### PR TITLE
chore: auto-merge PRs when all CI checks pass

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,19 @@
+name: Auto-merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Enable auto-merge (squash)
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Configures the repo to automatically merge PRs once all required CI checks pass.

## Why

Removes the manual merge step — push a branch, open a PR, and it merges itself when green.

## Changes

- Repository setting `allow_auto_merge` enabled
- `.github/workflows/auto-merge.yml`: enables squash auto-merge on every opened/updated PR via `gh pr merge --auto --squash`

## Test plan

- [x] New tests added for changed behaviour — N/A (tooling only)
- [x] All tests pass locally
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)