### PR TITLE
fix(e2e): eliminate ambiguous selectors causing flaky home test

### DIFF
--- a/frontend/e2e/home.spec.ts
+++ b/frontend/e2e/home.spec.ts
@@ -30,14 +30,19 @@ test("search for Faust returns result and displays it", async ({ page }) => {
 
 test("quick search pill triggers search", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("button", { name: "Pride and Prejudice" }).first().click();
-  await expect(page.getByText("Jane Austen").first()).toBeVisible();
+  // Use Faust — not in the cached library, so clicking the pill really does
+  // trigger a search (instead of matching a pre-existing BookCard).
+  await page.getByRole("button", { name: "Faust" }).click();
+  // Mocked search returns Goethe as the author
+  await expect(page.getByText(/Goethe/)).toBeVisible();
 });
 
 test("clicking a book navigates to reader page", async ({ page }) => {
   await page.goto("/");
-  // Click first book card in the library
-  await page.getByText("Pride and Prejudice").first().click();
+  // Scope to buttons that contain the author text — BookCards wrap both
+  // title and author, while quick-search pills only contain the title.
+  // This avoids ambiguity between the "Pride and Prejudice" pill and card.
+  await page.getByRole("button").filter({ hasText: "Jane Austen" }).first().click();
   await page.waitForURL(/\/reader\/1342/);
   expect(page.url()).toContain("/reader/1342");
 });


### PR DESCRIPTION
## What

Fixes the flaky E2E test (\"1 flaky\" shown in the coverage comment on PR #8) by eliminating ambiguous selectors in \`home.spec.ts\`.

## Why

Two tests used selectors that matched multiple elements:

- \`getByText(\"Pride and Prejudice\")\`
- \`getByRole(\"button\", { name: \"Pride and Prejudice\" })\`

Both hit **two** elements on the home page:
1. The **BookCard** in the Your Library section
2. The **\"Pride and Prejudice\" pill** in the FEATURED quick-search list

On my Mac the library section always rendered first, so \`.first()\` consistently picked the BookCard and tests passed. On the CI runner there was a timing window where the library hadn't loaded yet — \`.first()\` picked the pill, clicking it triggered a search instead of navigation, and \`waitForURL\` timed out. Playwright's 2 CI retries masked the race as \"1 flaky\", which GitHub's required checks accept as pass, so PR #8 auto-merged while still flaky.

## Fix

Scope by text that only appears **inside BookCards** (author name), never in pills (title only):

- **\"clicking a book navigates to reader page\"** → \`getByRole(\"button\").filter({ hasText: \"Jane Austen\" })\`
- **\"quick search pill triggers search\"** → click the Faust pill, which is not in the cached library, so the search flow is actually exercised

## Verification

Ran locally with \`--repeat-each=5\` per the new E2E stability rule: **25 / 25 runs passed**, no flakes.

## Test plan

- [x] Reproduced the ambiguity locally by inspecting the DOM
- [x] All E2E tests pass 25/25 runs with \`--repeat-each=5\`
- [x] Jest and pytest unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)