### PR TITLE
ci: fail E2E job if any test was flaky

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,13 @@ jobs:
       - name: Run E2E tests
         run: npm run test:e2e
 
+      - name: Upload E2E results summary
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-results
+          path: frontend/e2e-results.json
+
       - name: Upload Playwright report on failure
         uses: actions/upload-artifact@v4
         if: failure()
@@ -78,12 +85,41 @@ jobs:
           path: frontend/playwright-report/
           retention-days: 7
 
-      - name: Upload E2E results summary
-        uses: actions/upload-artifact@v4
+      # Retries are kept at 2 to absorb genuine infra blips (cold dev server,
+      # network timeouts, etc.), but a flake that recovers on retry is almost
+      # always a real bug — an ambiguous selector, a race, or timing drift.
+      # Fail the job so flakes can't silently ship to main via auto-merge.
+      - name: Fail if any E2E test was flaky
         if: always()
-        with:
-          name: e2e-results
-          path: frontend/e2e-results.json
+        run: |
+          node -e '
+            const fs = require("fs");
+            let r;
+            try { r = JSON.parse(fs.readFileSync("e2e-results.json", "utf8")); }
+            catch (e) { console.error("Could not read e2e-results.json:", e.message); process.exit(0); }
+            const flaky = (r.stats && r.stats.flaky) || 0;
+            if (flaky === 0) { console.log("✓ No flakes detected."); process.exit(0); }
+            console.error(`::error::${flaky} E2E test(s) were flaky. Flakes must be fixed before merging.`);
+            // Walk the suite tree to print flaky test titles
+            const flakyTitles = [];
+            const walk = (suite, path = "") => {
+              for (const spec of (suite.specs || [])) {
+                for (const t of (spec.tests || [])) {
+                  const statuses = (t.results || []).map(x => x.status);
+                  const hadFail = statuses.includes("failed") || statuses.includes("timedOut");
+                  const hadPass = statuses.includes("passed");
+                  if (hadFail && hadPass) flakyTitles.push(`${path}${spec.title}`);
+                }
+              }
+              for (const sub of (suite.suites || [])) walk(sub, path + (suite.title ? suite.title + " > " : ""));
+            };
+            for (const suite of (r.suites || [])) walk(suite);
+            if (flakyTitles.length) {
+              console.error("Flaky tests:");
+              for (const t of flakyTitles) console.error("  - " + t);
+            }
+            process.exit(1);
+          '
 
   test-backend:
     name: Backend tests (pytest)


### PR DESCRIPTION
## What

Adds a post-test step to the \`test-e2e\` job that fails the job if Playwright reports any flaky tests. Retries are kept at 2 to absorb genuine infra noise, but flakes that recover on retry are now loud instead of silent.

## Why

PR #8 auto-merged with \`⚠️ 1 flaky\` visible in the coverage comment. The underlying bug was a real race condition (ambiguous selector that hit the wrong element on slow CI), but since Playwright's retry recovered it, GitHub's required status checks accepted it and auto-merge fired. The flake shipped to main and had to be fixed in a follow-up (PR #9).

This was option #2 from the discussion: **keep retries, but fail loudly on flake**. It preserves CI stability for genuine infra blips (cold-start dev server, network timeouts) while ensuring real flakes can't silently ship.

## How

New step in \`test-e2e\` after \`Run E2E tests\`:

1. Parses \`frontend/e2e-results.json\` (already produced by Playwright JSON reporter)
2. Exits 0 if \`stats.flaky == 0\`
3. Otherwise walks the suite tree, prints each flaky test title with \`::error::\` annotation, and exits 1

The \`coverage-comment\` job still runs (\`if: always()\`) so the flake count and test list stay visible on the PR for triage.

## Verification

Tested both paths locally against the flake-detection script:

| Scenario | Exit | Output |
|---|---|---|
| Real \`e2e-results.json\` (9/9 passed, 0 flaky) | 0 | \`✓ No flakes detected.\` |
| Simulated \`{flaky: 1}\` | 1 | \`::error::1 E2E test(s) were flaky\` + titles |

## Test plan

- [x] Script verified locally for both happy path and flake scenarios
- [x] No change to Jest / pytest suites
- [x] \`coverage-comment\` still runs on failure (via \`always()\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)