### PR TITLE
fix(e2e): inline auth bypass inside auth() wrapper

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -2,9 +2,10 @@ import { defineConfig, devices } from "@playwright/test";
 
 /**
  * Playwright config for E2E tests.
- * - Starts Next.js dev server with PLAYWRIGHT_TEST=1 so middleware bypasses auth
- * - Uses a stub API base URL so all requests are intercepted and mocked
- * - Chromium only (enough for our flows; add more browsers if needed)
+ *
+ * Auth bypass is done inline in src/middleware.ts via a PLAYWRIGHT_TEST=1
+ * check inside the auth() handler. No file swap, no disruption to any
+ * other dev server watching the same source tree.
  */
 export default defineConfig({
   testDir: "./e2e",
@@ -39,10 +40,9 @@ export default defineConfig({
     env: {
       PLAYWRIGHT_TEST: "1",
       NEXT_PUBLIC_API_URL: "http://stub.test/api",
-      // NextAuth v5 requires a secret at module load even if we never call auth().
-      // This is a throwaway value used only to boot the dev server for E2E.
+      // NextAuth v5 validates config at module load, so the dev server
+      // needs these even though our middleware bypass skips the auth call.
       AUTH_SECRET: "e2e-test-secret-do-not-use-in-prod",
-      // Dummy OAuth values so the provider config validates.
       AUTH_GOOGLE_ID: "e2e-dummy-id",
       AUTH_GOOGLE_SECRET: "e2e-dummy-secret",
     },

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,17 +1,18 @@
 import { auth } from "@/auth";
-import { NextResponse, NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
-// E2E test mode: bypass auth redirect when explicitly enabled via env var.
-// Never set PLAYWRIGHT_TEST=1 in production.
-const E2E_BYPASS = process.env.PLAYWRIGHT_TEST === "1";
-
-export default E2E_BYPASS
-  ? (_req: NextRequest) => NextResponse.next()
-  : auth((req) => {
-      if (!req.auth) {
-        return NextResponse.redirect(new URL("/login", req.url));
-      }
-    });
+export default auth((req) => {
+  // E2E test mode: bypass auth redirect when explicitly enabled via env var.
+  // Never set PLAYWRIGHT_TEST=1 in production. This lives inside the auth()
+  // wrapper (not a ternary on the default export) so hot-reload behaves.
+  if (process.env.PLAYWRIGHT_TEST === "1") {
+    return NextResponse.next();
+  }
+  // Redirect unauthenticated users to /login
+  if (!req.auth) {
+    return NextResponse.redirect(new URL("/login", req.url));
+  }
+});
 
 export const config = {
   // Protect everything except the login page, NextAuth API routes, and static assets


### PR DESCRIPTION
## What

Replaces the previous file-swap E2E middleware bypass with a single inline conditional inside the existing \`auth()\` wrapper. Keeps \`middleware.ts\` cleanly hot-reloadable while still allowing Playwright to hit protected routes.

## Why

Two earlier approaches each had a problem:

**Ternary default export** (\`export default CHECK ? fn1 : fn2\`) broke Next.js middleware hot-reload when introduced, because the structural shape of the default export changed. Required a dev server restart to recover.

**File swap** (\`globalSetup\`/\`globalTeardown\` copying a no-op middleware over \`src/middleware.ts\`) kept the production file clean, but could not avoid affecting any *other* dev server watching the same source tree. In practice it crashed the developer's port-3000 dev server during rapid swap/restore cycles.

## Fix

Keep the default export exactly as it was — \`auth((req) => ...)\` — and move the bypass to the **first line inside the handler body**:

\`\`\`ts
export default auth((req) => {
  if (process.env.PLAYWRIGHT_TEST === \"1\") {
    return NextResponse.next();
  }
  if (!req.auth) {
    return NextResponse.redirect(new URL(\"/login\", req.url));
  }
});
\`\`\`

Why this works where the ternary didn't: the exported function identity and shape never change — only a conditional inside it. Hot-reload is happy. No file swap needed. No disruption to any other dev server.

## Changes

- \`src/middleware.ts\`: inline \`PLAYWRIGHT_TEST\` check at top of the auth() callback
- \`playwright.config.ts\`: removed \`globalSetup\` / \`globalTeardown\`, restored \`PLAYWRIGHT_TEST=1\` + dummy \`AUTH_SECRET\` / Google env vars (needed because @/auth is still imported and NextAuth validates config at module load), reverted \`reuseExistingServer\` to \`!CI\`
- Deleted \`e2e/support/\` directory (swap machinery no longer needed)
- \`.gitignore\`: dropped \`middleware.ts.bak\` entry

## Test plan

- [x] Jest + pytest pass locally (pre-push hook)
- [ ] E2E verified in CI — not run locally to avoid any risk of disturbing a running dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)