### PR TITLE
feat(ai): require user's Gemini key — remove Claude fallback

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -3,13 +3,6 @@ from fastapi.responses import Response
 from pydantic import BaseModel
 from services.auth import get_current_user, decrypt_api_key
 from services.db import get_cached_translation, save_translation
-from services.claude import (
-    generate_insight as claude_insight,
-    answer_question as claude_qa,
-    check_pronunciation as claude_pronunciation,
-    suggest_youtube_query as claude_youtube,
-    translate_text as claude_translate,
-)
 from services import gemini
 from services.youtube import search_videos
 from services.tts import synthesize
@@ -19,11 +12,14 @@ router = APIRouter(prefix="/ai", tags=["ai"])
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
-def _gemini_key(user: dict) -> str | None:
-    """Return decrypted Gemini API key if the user has one, else None."""
+def _require_gemini_key(user: dict) -> str:
+    """Return the decrypted Gemini API key or raise 400 if the user has none."""
     raw = user.get("gemini_key")
     if not raw:
-        return None
+        raise HTTPException(
+            status_code=400,
+            detail="Gemini API key required. Please add it in your profile.",
+        )
     return decrypt_api_key(raw)
 
 
@@ -74,16 +70,11 @@ class TTSRequest(BaseModel):
 
 @router.post("/insight")
 async def insight(req: InsightRequest, user: dict = Depends(get_current_user)):
+    key = _require_gemini_key(user)
     try:
-        key = _gemini_key(user)
-        if key:
-            result = await gemini.generate_insight(
-                key, req.chapter_text, req.book_title, req.author, req.response_language
-            )
-        else:
-            result = await claude_insight(
-                req.chapter_text, req.book_title, req.author, req.response_language
-            )
+        result = await gemini.generate_insight(
+            key, req.chapter_text, req.book_title, req.author, req.response_language
+        )
         return {"insight": result}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
@@ -91,16 +82,11 @@ async def insight(req: InsightRequest, user: dict = Depends(get_current_user)):
 
 @router.post("/qa")
 async def qa(req: QARequest, user: dict = Depends(get_current_user)):
+    key = _require_gemini_key(user)
     try:
-        key = _gemini_key(user)
-        if key:
-            result = await gemini.answer_question(
-                key, req.question, req.passage, req.book_title, req.author, req.response_language
-            )
-        else:
-            result = await claude_qa(
-                req.question, req.passage, req.book_title, req.author, req.response_language
-            )
+        result = await gemini.answer_question(
+            key, req.question, req.passage, req.book_title, req.author, req.response_language
+        )
         return {"answer": result}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
@@ -108,16 +94,11 @@ async def qa(req: QARequest, user: dict = Depends(get_current_user)):
 
 @router.post("/pronunciation")
 async def pronunciation(req: PronunciationRequest, user: dict = Depends(get_current_user)):
+    key = _require_gemini_key(user)
     try:
-        key = _gemini_key(user)
-        if key:
-            result = await gemini.check_pronunciation(
-                key, req.original_text, req.spoken_text, req.language
-            )
-        else:
-            result = await claude_pronunciation(
-                req.original_text, req.spoken_text, req.language
-            )
+        result = await gemini.check_pronunciation(
+            key, req.original_text, req.spoken_text, req.language
+        )
         return {"feedback": result}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
@@ -125,14 +106,11 @@ async def pronunciation(req: PronunciationRequest, user: dict = Depends(get_curr
 
 @router.post("/videos")
 async def videos(req: VideoRequest, user: dict = Depends(get_current_user)):
+    key = _require_gemini_key(user)
     try:
-        key = _gemini_key(user)
-        if key:
-            query = await gemini.suggest_youtube_query(
-                key, req.passage, req.book_title, req.author
-            )
-        else:
-            query = await claude_youtube(req.passage, req.book_title, req.author)
+        query = await gemini.suggest_youtube_query(
+            key, req.passage, req.book_title, req.author
+        )
         results = await search_videos(query)
         return {"query": query, "videos": results}
     except Exception as e:
@@ -142,27 +120,24 @@ async def videos(req: VideoRequest, user: dict = Depends(get_current_user)):
 @router.post("/translate")
 async def translate(req: TranslateRequest, user: dict = Depends(get_current_user)):
     try:
-        # Check shared DB cache first
+        # Check shared DB cache first — cache hits don't need a Gemini key
         if req.book_id is not None and req.chapter_index is not None:
             cached = await get_cached_translation(req.book_id, req.chapter_index, req.target_language)
             if cached:
                 return {"paragraphs": cached, "cached": True}
 
-        key = _gemini_key(user)
-        if key:
-            paragraphs = await gemini.translate_text(
-                key, req.text, req.source_language, req.target_language
-            )
-        else:
-            paragraphs = await claude_translate(
-                req.text, req.source_language, req.target_language
-            )
+        key = _require_gemini_key(user)
+        paragraphs = await gemini.translate_text(
+            key, req.text, req.source_language, req.target_language
+        )
 
         # Save to shared cache
         if req.book_id is not None and req.chapter_index is not None:
             await save_translation(req.book_id, req.chapter_index, req.target_language, paragraphs)
 
         return {"paragraphs": paragraphs, "cached": False}
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -1,30 +1,36 @@
 """
 Tests for routers/ai.py
 
-All Claude / Gemini / TTS calls are mocked.
+All Gemini / TTS calls are mocked.
 Focuses on:
-  - Translation cache hit (no AI call made)
-  - Translation cache miss (AI called, result stored)
-  - Gemini key path vs Claude fallback path
-  - Insight, QA, TTS, pronunciation endpoints
+  - Translation cache hit (no AI call made, works without a Gemini key)
+  - Translation cache miss: 400 without a key, Gemini + cache write with a key
+  - Insight / QA / Pronunciation / Videos: require a Gemini key (400 without)
+  - TTS: unchanged (uses edge-tts, no key required)
+  - Error paths: upstream Gemini failure → 500
 """
 
 import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
-from services.db import save_translation, get_cached_translation
+from unittest.mock import AsyncMock, patch
+from services.db import save_translation, get_cached_translation, set_user_gemini_key
+from services.auth import encrypt_api_key
 
 
 CHAPTER_TEXT = "Es war einmal ein König."
 TRANSLATED = ["Once upon a time there was a king."]
 
 
+async def _set_key(test_user):
+    await set_user_gemini_key(test_user["id"], encrypt_api_key("my-gemini-key"))
+
+
 # ── Translation ───────────────────────────────────────────────────────────────
 
-async def test_translate_cache_hit_skips_ai(client):
+async def test_translate_cache_hit_works_without_key(client):
+    """Cache hits return the stored result without hitting Gemini at all."""
     await save_translation(1342, 0, "en", TRANSLATED)
 
-    with patch("routers.ai.claude_translate") as mock_claude, \
-         patch("routers.ai.gemini") as mock_gemini:
+    with patch("routers.ai.gemini") as mock_gemini:
         resp = await client.post("/api/ai/translate", json={
             "text": CHAPTER_TEXT,
             "source_language": "de",
@@ -37,12 +43,26 @@ async def test_translate_cache_hit_skips_ai(client):
     data = resp.json()
     assert data["cached"] is True
     assert data["paragraphs"] == TRANSLATED
-    mock_claude.assert_not_called()
     mock_gemini.translate_text.assert_not_called()
 
 
-async def test_translate_cache_miss_calls_claude_and_stores(client):
-    with patch("routers.ai.claude_translate", new_callable=AsyncMock, return_value=TRANSLATED):
+async def test_translate_cache_miss_without_key_returns_400(client):
+    resp = await client.post("/api/ai/translate", json={
+        "text": CHAPTER_TEXT,
+        "source_language": "de",
+        "target_language": "en",
+        "book_id": 1342,
+        "chapter_index": 0,
+    })
+    assert resp.status_code == 400
+    assert "Gemini" in resp.json()["detail"]
+
+
+async def test_translate_cache_miss_with_key_uses_gemini_and_stores(client, test_user):
+    await _set_key(test_user)
+
+    with patch("routers.ai.gemini") as mock_gemini:
+        mock_gemini.translate_text = AsyncMock(return_value=TRANSLATED)
         resp = await client.post("/api/ai/translate", json={
             "text": CHAPTER_TEXT,
             "source_language": "de",
@@ -54,31 +74,17 @@ async def test_translate_cache_miss_calls_claude_and_stores(client):
     assert resp.status_code == 200
     assert resp.json()["cached"] is False
     assert resp.json()["paragraphs"] == TRANSLATED
+    mock_gemini.translate_text.assert_called_once()
 
     # Result should now be in the DB
     cached = await get_cached_translation(1342, 0, "en")
     assert cached == TRANSLATED
 
 
-async def test_translate_uses_gemini_when_user_has_key(client, test_user):
-    from services.db import set_user_gemini_key
-    from services.auth import encrypt_api_key
-    await set_user_gemini_key(test_user["id"], encrypt_api_key("my-gemini-key"))
-
+async def test_translate_without_book_id_skips_cache(client, test_user):
+    await _set_key(test_user)
     with patch("routers.ai.gemini") as mock_gemini:
         mock_gemini.translate_text = AsyncMock(return_value=TRANSLATED)
-        resp = await client.post("/api/ai/translate", json={
-            "text": CHAPTER_TEXT,
-            "source_language": "de",
-            "target_language": "en",
-        })
-
-    assert resp.status_code == 200
-    mock_gemini.translate_text.assert_called_once()
-
-
-async def test_translate_without_book_id_skips_cache(client):
-    with patch("routers.ai.claude_translate", new_callable=AsyncMock, return_value=TRANSLATED):
         resp = await client.post("/api/ai/translate", json={
             "text": CHAPTER_TEXT,
             "source_language": "de",
@@ -90,22 +96,18 @@ async def test_translate_without_book_id_skips_cache(client):
 
 # ── Insight ───────────────────────────────────────────────────────────────────
 
-async def test_insight_returns_text(client):
-    with patch("routers.ai.claude_insight", new_callable=AsyncMock, return_value="A deep insight."):
-        resp = await client.post("/api/ai/insight", json={
-            "chapter_text": "Some text",
-            "book_title": "Faust",
-            "author": "Goethe",
-        })
-    assert resp.status_code == 200
-    assert resp.json()["insight"] == "A deep insight."
+async def test_insight_without_key_returns_400(client):
+    resp = await client.post("/api/ai/insight", json={
+        "chapter_text": "Some text",
+        "book_title": "Faust",
+        "author": "Goethe",
+    })
+    assert resp.status_code == 400
+    assert "Gemini" in resp.json()["detail"]
 
 
-async def test_insight_uses_gemini_when_user_has_key(client, test_user):
-    from services.db import set_user_gemini_key
-    from services.auth import encrypt_api_key
-    await set_user_gemini_key(test_user["id"], encrypt_api_key("my-gemini-key"))
-
+async def test_insight_with_key_returns_text(client, test_user):
+    await _set_key(test_user)
     with patch("routers.ai.gemini") as mock_gemini:
         mock_gemini.generate_insight = AsyncMock(return_value="Gemini insight.")
         resp = await client.post("/api/ai/insight", json={
@@ -113,15 +115,24 @@ async def test_insight_uses_gemini_when_user_has_key(client, test_user):
             "book_title": "Faust",
             "author": "Goethe",
         })
-
     assert resp.status_code == 200
+    assert resp.json()["insight"] == "Gemini insight."
     mock_gemini.generate_insight.assert_called_once()
 
 
 # ── QA ────────────────────────────────────────────────────────────────────────
 
-async def test_qa_returns_answer(client):
-    with patch("routers.ai.claude_qa", new_callable=AsyncMock, return_value="42"):
+async def test_qa_without_key_returns_400(client):
+    resp = await client.post("/api/ai/qa", json={
+        "question": "?", "passage": "text", "book_title": "Book", "author": "Author",
+    })
+    assert resp.status_code == 400
+
+
+async def test_qa_with_key_returns_answer(client, test_user):
+    await _set_key(test_user)
+    with patch("routers.ai.gemini") as mock_gemini:
+        mock_gemini.answer_question = AsyncMock(return_value="42")
         resp = await client.post("/api/ai/qa", json={
             "question": "What is the meaning?",
             "passage": "Some passage",
@@ -134,8 +145,18 @@ async def test_qa_returns_answer(client):
 
 # ── Pronunciation ─────────────────────────────────────────────────────────────
 
-async def test_pronunciation_returns_feedback(client):
-    with patch("routers.ai.claude_pronunciation", new_callable=AsyncMock, return_value="Good job!"):
+async def test_pronunciation_without_key_returns_400(client):
+    resp = await client.post("/api/ai/pronunciation", json={
+        "original_text": "Hello world",
+        "spoken_text": "Helo world",
+    })
+    assert resp.status_code == 400
+
+
+async def test_pronunciation_with_key_returns_feedback(client, test_user):
+    await _set_key(test_user)
+    with patch("routers.ai.gemini") as mock_gemini:
+        mock_gemini.check_pronunciation = AsyncMock(return_value="Good job!")
         resp = await client.post("/api/ai/pronunciation", json={
             "original_text": "Hello world",
             "spoken_text": "Helo world",
@@ -148,6 +169,7 @@ async def test_pronunciation_returns_feedback(client):
 # ── TTS ───────────────────────────────────────────────────────────────────────
 
 async def test_tts_returns_audio_bytes(client):
+    """TTS uses edge-tts and does not require a Gemini key."""
     fake_audio = b"FAKE_MP3_BYTES"
     with patch("routers.ai.synthesize", new_callable=AsyncMock, return_value=fake_audio):
         resp = await client.post("/api/ai/tts", json={
@@ -162,10 +184,21 @@ async def test_tts_returns_audio_bytes(client):
 
 # ── Videos ────────────────────────────────────────────────────────────────────
 
-async def test_videos_returns_results(client):
+async def test_videos_without_key_returns_400(client):
+    resp = await client.post("/api/ai/videos", json={
+        "passage": "Faust sells his soul.",
+        "book_title": "Faust",
+        "author": "Goethe",
+    })
+    assert resp.status_code == 400
+
+
+async def test_videos_with_key_returns_results(client, test_user):
+    await _set_key(test_user)
     fake_videos = [{"id": "abc", "title": "Faust Film", "url": "https://youtube.com/watch?v=abc"}]
-    with patch("routers.ai.claude_youtube", new_callable=AsyncMock, return_value="Faust opera film"), \
+    with patch("routers.ai.gemini") as mock_gemini, \
          patch("routers.ai.search_videos", new_callable=AsyncMock, return_value=fake_videos):
+        mock_gemini.suggest_youtube_query = AsyncMock(return_value="Faust opera film")
         resp = await client.post("/api/ai/videos", json={
             "passage": "Faust sells his soul.",
             "book_title": "Faust",
@@ -177,26 +210,12 @@ async def test_videos_returns_results(client):
     assert len(data["videos"]) == 1
 
 
-async def test_videos_uses_gemini_when_key_set(client, test_user):
-    from services.db import set_user_gemini_key
-    from services.auth import encrypt_api_key
-    await set_user_gemini_key(test_user["id"], encrypt_api_key("my-gemini-key"))
+# ── Error paths (upstream Gemini failure → 500) ───────────────────────────────
 
-    with patch("routers.ai.gemini") as mock_gemini, \
-         patch("routers.ai.search_videos", new_callable=AsyncMock, return_value=[]):
-        mock_gemini.suggest_youtube_query = AsyncMock(return_value="Faust opera")
-        resp = await client.post("/api/ai/videos", json={
-            "passage": "text", "book_title": "Faust", "author": "Goethe",
-        })
-
-    assert resp.status_code == 200
-    mock_gemini.suggest_youtube_query.assert_called_once()
-
-
-# ── Error paths ───────────────────────────────────────────────────────────────
-
-async def test_insight_error_returns_500(client):
-    with patch("routers.ai.claude_insight", new_callable=AsyncMock, side_effect=RuntimeError("AI down")):
+async def test_insight_gemini_error_returns_500(client, test_user):
+    await _set_key(test_user)
+    with patch("routers.ai.gemini") as mock_gemini:
+        mock_gemini.generate_insight = AsyncMock(side_effect=RuntimeError("AI down"))
         resp = await client.post("/api/ai/insight", json={
             "chapter_text": "text", "book_title": "Book", "author": "Author",
         })
@@ -204,24 +223,30 @@ async def test_insight_error_returns_500(client):
     assert "AI down" in resp.json()["detail"]
 
 
-async def test_qa_error_returns_500(client):
-    with patch("routers.ai.claude_qa", new_callable=AsyncMock, side_effect=RuntimeError("fail")):
+async def test_qa_gemini_error_returns_500(client, test_user):
+    await _set_key(test_user)
+    with patch("routers.ai.gemini") as mock_gemini:
+        mock_gemini.answer_question = AsyncMock(side_effect=RuntimeError("fail"))
         resp = await client.post("/api/ai/qa", json={
             "question": "?", "passage": "text", "book_title": "Book", "author": "Author",
         })
     assert resp.status_code == 500
 
 
-async def test_pronunciation_error_returns_500(client):
-    with patch("routers.ai.claude_pronunciation", new_callable=AsyncMock, side_effect=RuntimeError("fail")):
+async def test_pronunciation_gemini_error_returns_500(client, test_user):
+    await _set_key(test_user)
+    with patch("routers.ai.gemini") as mock_gemini:
+        mock_gemini.check_pronunciation = AsyncMock(side_effect=RuntimeError("fail"))
         resp = await client.post("/api/ai/pronunciation", json={
             "original_text": "Hello", "spoken_text": "Helo",
         })
     assert resp.status_code == 500
 
 
-async def test_translate_error_returns_500(client):
-    with patch("routers.ai.claude_translate", new_callable=AsyncMock, side_effect=RuntimeError("fail")):
+async def test_translate_gemini_error_returns_500(client, test_user):
+    await _set_key(test_user)
+    with patch("routers.ai.gemini") as mock_gemini:
+        mock_gemini.translate_text = AsyncMock(side_effect=RuntimeError("fail"))
         resp = await client.post("/api/ai/translate", json={
             "text": "text", "source_language": "de", "target_language": "en",
         })
@@ -234,41 +259,11 @@ async def test_tts_error_returns_500(client):
     assert resp.status_code == 500
 
 
-async def test_videos_error_returns_500(client):
-    with patch("routers.ai.claude_youtube", new_callable=AsyncMock, side_effect=RuntimeError("fail")):
+async def test_videos_gemini_error_returns_500(client, test_user):
+    await _set_key(test_user)
+    with patch("routers.ai.gemini") as mock_gemini:
+        mock_gemini.suggest_youtube_query = AsyncMock(side_effect=RuntimeError("fail"))
         resp = await client.post("/api/ai/videos", json={
             "passage": "text", "book_title": "Book", "author": "Author",
         })
     assert resp.status_code == 500
-
-
-# ── Gemini paths for QA and pronunciation ─────────────────────────────────────
-
-async def test_qa_uses_gemini_when_key_set(client, test_user):
-    from services.db import set_user_gemini_key
-    from services.auth import encrypt_api_key
-    await set_user_gemini_key(test_user["id"], encrypt_api_key("my-gemini-key"))
-
-    with patch("routers.ai.gemini") as mock_gemini:
-        mock_gemini.answer_question = AsyncMock(return_value="Gemini answer")
-        resp = await client.post("/api/ai/qa", json={
-            "question": "?", "passage": "text", "book_title": "Book", "author": "Author",
-        })
-
-    assert resp.status_code == 200
-    mock_gemini.answer_question.assert_called_once()
-
-
-async def test_pronunciation_uses_gemini_when_key_set(client, test_user):
-    from services.db import set_user_gemini_key
-    from services.auth import encrypt_api_key
-    await set_user_gemini_key(test_user["id"], encrypt_api_key("my-gemini-key"))
-
-    with patch("routers.ai.gemini") as mock_gemini:
-        mock_gemini.check_pronunciation = AsyncMock(return_value="Gemini feedback")
-        resp = await client.post("/api/ai/pronunciation", json={
-            "original_text": "Hello", "spoken_text": "Helo",
-        })
-
-    assert resp.status_code == 200
-    mock_gemini.check_pronunciation.assert_called_once()


### PR DESCRIPTION
## What

Removes the automatic Claude fallback from all five AI endpoints. Users must now set their own Gemini API key in their profile; if they don't, the endpoints return \`400 Gemini API key required. Please add it in your profile.\`

Affected endpoints: \`/ai/insight\`, \`/ai/qa\`, \`/ai/pronunciation\`, \`/ai/videos\`, \`/ai/translate\`.

Unaffected:
- \`/ai/tts\` — uses edge-tts, never needed a key
- \`/ai/translate\` cache hits — pure DB read, no AI call, no key required

## Why

The old behaviour silently fell back to Claude using the server-side \`ANTHROPIC_API_KEY\` when a user had no Gemini key. That meant:

- AI cost shifted from the user to whoever paid for the Anthropic key
- Users never felt the pressure to configure their own key
- The BYOK-style UX (existing Gemini reminder banner on translate click) was misleading because the app would still work without a key

This makes the BYOK model explicit: users must bring their own Gemini key.

## UX flow

The existing frontend Gemini reminder banner already fires when translate is clicked, so the flow is:

1. User clicks translate without a key
2. Gemini reminder banner appears ('Please add your Gemini key to continue')
3. If they proceed anyway, API returns 400 with a clear error

## Test plan

- [x] All 144 backend tests pass
- [x] Rewrote \`test_router_ai.py\` — 19 tests:
  - Cache-hit works without a key
  - All five AI endpoints return 400 without a key
  - Same endpoints return 200 + Gemini-generated result with a key
  - Error paths: Gemini upstream failure → 500
- [x] Pytest branch coverage unchanged (91%)

## Follow-up

\`services/claude.py\` is now dead code — still imported nowhere after this PR. Leaving in place for this PR to keep the change scoped, can be deleted in a follow-up once you're confident no hidden caller remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)