### PR TITLE
fix(reader): show Gemini reminder when translate fails without a key

### DIFF
--- a/frontend/e2e/reader.spec.ts
+++ b/frontend/e2e/reader.spec.ts
@@ -49,6 +49,35 @@ test("continue-reading: reopening a book restores the last-read chapter", async 
   await expect(page.getByText(MOCK_CHAPTERS[2].text.slice(0, 30), { exact: false })).toBeVisible({ timeout: 5000 });
 });
 
+test("shows Gemini reminder banner when translate fails without a key", async ({ page }) => {
+  // Override the default mocks from fixtures.ts:
+  //   - user has no Gemini key
+  //   - translate returns 400 like the real backend now does
+  await page.route("**/api/user/me", (route) =>
+    route.fulfill({
+      json: { id: 1, email: "test@example.com", name: "Test", picture: "", hasGeminiKey: false },
+    })
+  );
+  await page.route("**/api/ai/translate", (route) =>
+    route.fulfill({
+      status: 400,
+      json: { detail: "Gemini API key required. Please add it in your profile." },
+    })
+  );
+
+  await page.goto("/reader/1342");
+
+  // Wait for chapters to render before toggling translation
+  await expect(page.getByText(/truth universally acknowledged/)).toBeVisible();
+
+  // Click the Translate toggle — triggers the translation effect
+  await page.getByRole("button", { name: /Translate/ }).first().click();
+
+  // Banner must appear because notifyAIUsed() now runs in the catch handler
+  await expect(page.getByText(/AI features require your own Gemini API key/)).toBeVisible();
+  await expect(page.getByRole("button", { name: /Add your free Gemini API key/ })).toBeVisible();
+});
+
 test("home page shows Continue Reading badge with chapter number", async ({ page }) => {
   // Seed a recent book with lastChapter = 4
   await page.goto("/");

--- a/frontend/src/__tests__/GeminiReminder.test.tsx
+++ b/frontend/src/__tests__/GeminiReminder.test.tsx
@@ -39,8 +39,9 @@ function ReminderHarness({ initialHasKey = true }: HarnessProps) {
     <div>
       {geminiReminderVisible && (
         <div role="alert" data-testid="gemini-banner">
-          AI features are using the app&apos;s shared quota.{" "}
+          AI features require your own Gemini API key.{" "}
           <a href="/profile">Add your free Gemini API key</a>
+          {" "}to enable them.
           <button
             onClick={() => setGeminiReminderVisible(false)}
             aria-label="Dismiss"

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -83,7 +83,10 @@ export default function ReaderPage() {
   const geminiReminderShown = useRef(false);
 
   useEffect(() => {
-    if (!session?.backendToken) return;
+    // Fetch live Gemini-key status. When the session has no token yet (initial
+    // render before hydration, or E2E with auth bypass) the backend will 401
+    // and we silently keep the optimistic default. Once session?.backendToken
+    // changes, the effect re-runs and picks up the real answer.
     getMe().then((me) => setHasGeminiKey(me.hasGeminiKey)).catch(() => {});
   }, [session?.backendToken]);
 
@@ -164,7 +167,13 @@ export default function ReaderPage() {
           setTranslatedParagraphs(r.paragraphs);
         }
       })
-      .catch((e) => console.error("Translation failed:", e))
+      .catch((e) => {
+        // Backend returns 400 "Gemini API key required" when the user has no key.
+        // notifyAIUsed() is guarded by !hasGeminiKey, so it's a no-op for users
+        // who do have a key (in which case the error is some real Gemini failure).
+        console.error("Translation failed:", e);
+        notifyAIUsed();
+      })
       .finally(() => {
         if (currentChapterKey.current === cacheKey) {
           setTranslationLoading(false);
@@ -211,14 +220,14 @@ export default function ReaderPage() {
       {geminiReminderVisible && (
         <div className="shrink-0 bg-amber-50 border-b border-amber-300 px-4 py-2 flex items-center justify-between gap-4 text-sm text-amber-800">
           <span>
-            AI features are using the app&apos;s shared quota.{" "}
+            AI features require your own Gemini API key.{" "}
             <button
               onClick={() => { window.open("/profile", "_blank"); }}
               className="underline font-medium hover:text-amber-900"
             >
               Add your free Gemini API key
             </button>{" "}
-            to use your own quota instead.
+            to enable them.
           </span>
           <button
             onClick={() => setGeminiReminderVisible(false)}


### PR DESCRIPTION
## What

Follow-up to PR #12 (remove Claude fallback). After that PR merged, users without a Gemini key who tried to translate saw **nothing** — no result, no banner, no error message. Silent failure.

## Why

Three bugs compounded:

**1. The reminder only fired on success.**
\`notifyAIUsed()\` was called inside \`translateText.then()\`. With the old Claude fallback, translation without a key *succeeded*, so \`.then()\` ran and the banner appeared. After PR #12 the call fails with 400 and \`.catch()\` runs — but \`.catch()\` was only doing \`console.error()\`.

**2. The banner text was stale.**
It still said \"AI features are using the app's shared quota\" — but after PR #12 there is no shared quota. It's BYOK-only.

**3. Live \`hasGeminiKey\` never fetched in some cases.**
The \`getMe()\` effect was guarded by \`if (!session?.backendToken) return\`. That meant \`hasGeminiKey\` stayed stuck at its optimistic \`true\` during the pre-hydration window, and the reminder (which is guarded by \`!hasGeminiKey\`) was always a no-op. A real production user might not notice because hydration is fast, but it was still a latent bug — and it made E2E testing of this flow impossible.

## Fix

- \`reader/page.tsx\`: \`notifyAIUsed()\` added to the catch handler. Safe — the function itself is guarded by \`!hasGeminiKey\` so it's a no-op for users who do have a key.
- \`reader/page.tsx\`: banner text → \"AI features require your own Gemini API key. Add your free Gemini API key to enable them.\"
- \`reader/page.tsx\`: removed the premature \`session?.backendToken\` guard on \`getMe()\`. Tokenless calls just 401 silently, and the effect re-runs once the session hydrates.
- \`GeminiReminder.test.tsx\`: harness text updated to match the new banner (all 9 existing tests still pass unchanged).
- \`e2e/reader.spec.ts\`: **new E2E test** that mocks \`/user/me → hasGeminiKey:false\` + \`/ai/translate → 400\`, clicks the Translate toggle, and asserts the banner appears. This would have caught the bug in PR #12 before merge.

## Test plan

- [x] New E2E test passes locally (10 E2E total, all green)
- [x] All 86 Jest tests pass
- [x] All 144 pytest tests pass

## Meta

The original fix commit landed on the already-merged branch for PR #12 because PR #12 auto-merged while I was still working. I've cherry-picked it onto a fresh branch here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)