### PR TITLE
chore: block git push to a branch whose PR already auto-merged

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -19,6 +19,28 @@ if [ "$CURRENT_BRANCH" = "$PROTECTED" ]; then
   exit 1
 fi
 
+# Auto-merge race guard: if this branch already has a PR that auto-merged,
+# pushing more commits would silently orphan them on a dead branch. Refuse
+# the push and point the developer at cherry-picking onto a fresh branch.
+if command -v gh >/dev/null 2>&1; then
+  PR_STATE="$(gh pr list --head "$CURRENT_BRANCH" --state all --json state -q '.[0].state' 2>/dev/null || true)"
+  if [ "$PR_STATE" = "MERGED" ]; then
+    echo "✗ The PR for branch '$CURRENT_BRANCH' is already MERGED."
+    echo "  Pushing more commits here orphans them on a closed branch."
+    echo ""
+    echo "  Move your new work to a fresh branch:"
+    echo "    git log -1 --format=%H                    # copy this SHA"
+    echo "    git checkout main && git pull"
+    echo "    git checkout -b fix/descriptive-name"
+    echo "    git cherry-pick <sha>"
+    echo "    git push -u origin fix/descriptive-name"
+    echo "    gh pr create"
+    echo ""
+    echo "  To bypass in an emergency: git push --no-verify"
+    exit 1
+  fi
+fi
+
 ROOT="$(git rev-parse --show-toplevel)"
 
 echo "▶ Running frontend tests…"


### PR DESCRIPTION
## What

Closes a concrete CI/CD gap that caused two lost-commit incidents in a single working session. The pre-push hook now refuses to push to a branch whose PR is already MERGED, preventing commits from being orphaned on a closed branch.

## The gap

Auto-merge is enabled on this repo, so the moment CI goes green, GitHub merges the PR. The developer's view of the world lags the actual state:

1. Developer pushes commit X → CI starts → CI green → auto-merge fires → PR MERGED
2. Developer keeps iterating, makes commit Y on the same branch
3. Developer pushes Y → git happily updates the (now dead) remote branch
4. Y is orphaned — not on main, not in any open PR

This has happened twice in the current session:
- **PR #8** auto-merged while still showing \`⚠ 1 flaky\`. The selector fix for the flake was pushed after merge and had to be cherry-picked to PR #9.
- **PR #12** (remove Claude fallback) auto-merged while I was writing the follow-up reminder fix. That fix was pushed after merge and had to be cherry-picked to PR #13.

Nothing in the pipeline currently warns you when this happens. You only notice when you try to view the PR and see it's closed.

## The fix

New check in \`.githooks/pre-push\`, run before tests:

\`\`\`bash
if command -v gh >/dev/null 2>&1; then
  PR_STATE=\"$(gh pr list --head \"$CURRENT_BRANCH\" --state all --json state -q '.[0].state' 2>/dev/null || true)\"
  if [ \"$PR_STATE\" = \"MERGED\" ]; then
    echo \"✗ The PR for branch '$CURRENT_BRANCH' is already MERGED.\"
    ...
    exit 1
  fi
fi
\`\`\`

When triggered, the hook prints a ready-to-copy recipe for cherry-picking onto a fresh branch:

\`\`\`
✗ The PR for branch 'feat/foo' is already MERGED.
  Pushing more commits here orphans them on a closed branch.

  Move your new work to a fresh branch:
    git log -1 --format=%H                    # copy this SHA
    git checkout main && git pull
    git checkout -b fix/descriptive-name
    git cherry-pick <sha>
    git push -u origin fix/descriptive-name
    gh pr create
\`\`\`

## Graceful degradation

- If \`gh\` is not installed → skip the check, still run tests
- If \`gh pr list\` fails (network, auth) → skip the check, still run tests
- Emergency bypass: \`git push --no-verify\`

## Verified

Manually verified the \`gh pr list --head <branch> --state all --json state -q '.[0].state'\` query against real repo state:
- Merged PR #12 branch → returns \`MERGED\` ✓
- A branch with no PR → returns empty string ✓

The push of this very PR exercised the new hook on an empty-state branch and proceeded normally.

## Other gaps worth noting (not fixed here)

- **Auto-merge has no grace period.** If you push commit X and then quickly push commit Y *before* auto-merge fires on X, GitHub re-evaluates status checks on HEAD and includes Y. But if Y lands *after* the merge, it's orphaned. We could introduce a grace period (e.g. \"wait N minutes after checks pass before merging\"), but it adds complexity. The pre-push hook is a simpler, sharper fix.
- **No notification when a PR merges.** GitHub can email or notify you but it's easy to miss. Not addressed here.
- **Draft PR workflow** could also prevent this (auto-merge doesn't fire on drafts), but requires changing a habit. The hook works regardless of whether you remember to use drafts.

## Test plan

- [x] Manual verification of the \`gh\` query against open, merged, and nonexistent branches
- [x] Hook ran on this very push (no PR → empty state → proceeded)
- [x] Existing test suite runs unchanged (Jest 86, pytest 144)

🤖 Generated with [Claude Code](https://claude.com/claude-code)