### PR TITLE
feat(reader): default translation display to side-by-side

### DIFF
--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -102,7 +102,7 @@ export default function ReaderPage() {
   const currentChapterKey = useRef<string>(""); // tracks which chapter is currently displayed
   const [translationEnabled, setTranslationEnabled] = useState(false);
   const [translationLang, setTranslationLang] = useState("en");
-  const [displayMode, setDisplayMode] = useState<"parallel" | "inline">("inline");
+  const [displayMode, setDisplayMode] = useState<"parallel" | "inline">("parallel");
   const [translatedParagraphs, setTranslatedParagraphs] = useState<string[]>([]);
   const [translationLoading, setTranslationLoading] = useState(false);
 


### PR DESCRIPTION
## What

Changes the default translation display mode in the reader from \`inline\` to \`parallel\` (side-by-side). One-line change.

## Why

Side-by-side is more useful than inline as a starting point for language learners — the original and translation share horizontal space, so the eye can compare line-by-line without scrolling between paragraphs.

Users can still switch to inline via the existing toolbar toggle if they prefer it for any chapter.

## Test plan

- [x] All 86 Jest tests pass (no test asserted the default value)
- [x] All 144 pytest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)