### PR TITLE
chore(deploy): smallest viable deployment pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Backend
 backend/.env
 backend/.env.*
+!backend/.env.example
 backend/__pycache__/
 backend/**/__pycache__/
 backend/**/*.pyc
@@ -18,6 +19,7 @@ frontend/.next/
 frontend/out/
 frontend/.env.local
 frontend/.env.*
+!frontend/.env.example
 frontend/tsconfig.tsbuildinfo
 frontend/coverage/
 frontend/playwright-report/

--- a/README.md
+++ b/README.md
@@ -121,36 +121,41 @@ Tests run automatically on every push and pull request via GitHub Actions.
 
 ## Deployment
 
-The app is deployed on **Vercel** (frontend) + **Railway** (backend). Every push to `main` triggers a re-deploy.
+The app is deployed on **Vercel** (frontend) + **Railway** (backend). Every push to `main` triggers an auto-deploy on both platforms — no GitHub Actions wiring required, both connect natively to the GitHub repo.
+
+See `backend/.env.example` and `frontend/.env.example` for the full list of environment variables and how to generate each one.
 
 ### Backend — Railway
 
-1. New Project → Deploy from GitHub → select this repo
-2. Set the root to `/` (Railway reads `railway.json` automatically)
-3. Add environment variables:
-
-```env
-ANTHROPIC_API_KEY=sk-ant-...
-GOOGLE_CLIENT_ID=<your-oauth-client-id>
-JWT_SECRET=<random-32+-chars>
-ENCRYPTION_KEY=<generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())">
-FRONTEND_URL=https://<your-vercel-url>
-```
+1. **New Project → Deploy from GitHub → select this repo**
+2. Railway reads `railway.json` automatically (Dockerfile build, health check at `/api/health`).
+3. **Add environment variables** from `backend/.env.example`:
+   - `JWT_SECRET` — `openssl rand -hex 32`
+   - `GOOGLE_CLIENT_ID` — from Google Cloud Console OAuth credentials
+   - `FRONTEND_URL` — `https://<your-vercel-url>` (after the frontend is deployed)
+   - `ENCRYPTION_KEY` — optional, derived from `JWT_SECRET` if unset
+   - `YOUTUBE_API_KEY` — optional, only for the "find related videos" feature
+4. **⚠ Data persistence** (important — see "known limitation" below).
 
 ### Frontend — Vercel
 
-1. New Project → Import from GitHub → select this repo
+1. **New Project → Import from GitHub → select this repo**
 2. Set **Root Directory** to `frontend`
-3. Add environment variables:
+3. **Add environment variables** from `frontend/.env.example`:
+   - `NEXT_PUBLIC_API_URL` — `https://<your-railway-url>/api`
+   - `AUTH_SECRET` — `openssl rand -base64 32`
+   - `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET` — same OAuth credentials as the backend
+4. **Google OAuth setup**: in Google Cloud Console, add the Vercel domain to **Authorized JavaScript origins** and add `https://<your-vercel-url>/api/auth/callback/google` to **Authorized redirect URIs**.
 
-```env
-NEXT_PUBLIC_API_URL=https://<your-railway-url>/api
-AUTH_GOOGLE_ID=<your-oauth-client-id>
-AUTH_GOOGLE_SECRET=<your-oauth-client-secret>
-AUTH_SECRET=<random-string>
-```
+### Known limitation: SQLite data persistence on Railway
 
-4. In your Google OAuth app, add the Vercel domain to authorised origins and redirect URIs.
+By default, Railway containers have an **ephemeral filesystem** — every redeploy wipes the SQLite file at `/app/books.db`. This means:
+
+- Cached book text and translations are lost
+- User accounts and encrypted Gemini keys are lost
+- Audiobook → LibriVox links are lost
+
+The minimum fix is to attach a Railway **volume** mounted at `/app` (or wherever the SQLite file lives), so the file survives redeploys. The longer-term fix is to migrate to managed Postgres (Railway, Neon, Supabase). Both are tracked as future work.
 
 ---
 
@@ -194,20 +199,20 @@ book-reader-ai/
 
 | Variable | Required | Description |
 |---|---|---|
-| `ANTHROPIC_API_KEY` | Yes* | Claude API key (* not needed if all users have Gemini keys) |
+| `JWT_SECRET` | Yes | Secret for signing backend JWTs (32+ chars). Generate with `openssl rand -hex 32`. |
 | `GOOGLE_CLIENT_ID` | Yes | OAuth client ID for verifying Google ID tokens |
-| `JWT_SECRET` | Yes | Secret for signing backend JWTs (32+ chars) |
-| `ENCRYPTION_KEY` | Prod only | Fernet key for encrypting stored Gemini keys |
 | `FRONTEND_URL` | Prod only | Frontend origin added to CORS allow-list |
+| `ENCRYPTION_KEY` | Prod recommended | Fernet key for encrypting stored Gemini keys (derived from JWT_SECRET if unset) |
+| `YOUTUBE_API_KEY` | Optional | Enables the "find related videos" feature |
 
 ### Frontend
 
 | Variable | Required | Description |
 |---|---|---|
-| `NEXT_PUBLIC_API_URL` | Yes | Backend API base URL |
-| `AUTH_GOOGLE_ID` | Yes | Google OAuth client ID |
+| `NEXT_PUBLIC_API_URL` | Yes | Backend API base URL (include `/api` suffix) |
+| `AUTH_SECRET` | Yes | NextAuth signing secret. Generate with `openssl rand -base64 32`. |
+| `AUTH_GOOGLE_ID` | Yes | Google OAuth client ID (same as backend) |
 | `AUTH_GOOGLE_SECRET` | Yes | Google OAuth client secret |
-| `AUTH_SECRET` | Yes | NextAuth signing secret |
 
 ---
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,27 @@
-ANTHROPIC_API_KEY=your_claude_api_key_here
-YOUTUBE_API_KEY=your_youtube_data_api_key_here
+# ── Required in production ───────────────────────────────────────────────
+# Random 32-char secret used to sign JWTs (and to derive the Fernet key
+# that encrypts user-provided Gemini API keys, unless ENCRYPTION_KEY is
+# set explicitly). Generate one with:  openssl rand -hex 32
+JWT_SECRET=
+
+# Google OAuth client ID — must match the one configured in Google Cloud
+# Console for the OAuth consent screen. The backend uses this to verify
+# that ID tokens received from the frontend were issued for this app.
+GOOGLE_CLIENT_ID=
+
+# URL of the deployed frontend. Used for CORS allowed-origins.
+# Example: https://book-reader-ai.vercel.app
+FRONTEND_URL=
+
+# ── Optional ─────────────────────────────────────────────────────────────
+# Explicit Fernet key for encrypting Gemini API keys at rest. If unset,
+# one is derived from JWT_SECRET. Generate one with:
+#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+ENCRYPTION_KEY=
+
+# YouTube Data API v3 key — only needed for the "find related videos"
+# feature in the reader. Without this, video search returns empty.
+YOUTUBE_API_KEY=
+
+# ── Injected by Railway at runtime ───────────────────────────────────────
+# PORT — Railway sets this; the Dockerfile honours it via uvicorn --port

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,19 @@
+# ── Required in production ───────────────────────────────────────────────
+# Public URL of the deployed backend, including /api suffix.
+# Example: https://book-reader-ai-backend.up.railway.app/api
+NEXT_PUBLIC_API_URL=
+
+# NextAuth signing secret — used to encrypt the session cookie.
+# Generate one with:  openssl rand -base64 32
+AUTH_SECRET=
+
+# Google OAuth credentials — same client ID/secret you set in the backend
+# (the backend verifies the audience claim on ID tokens against its own
+# GOOGLE_CLIENT_ID, which must match these).
+AUTH_GOOGLE_ID=
+AUTH_GOOGLE_SECRET=
+
+# ── Injected by Vercel at runtime ────────────────────────────────────────
+# NEXTAUTH_URL — Vercel sets this automatically from the deployment URL.
+# Only set it manually if you have a custom domain that Vercel doesn't
+# detect.


### PR DESCRIPTION
## What

Documents and configures the smallest viable deployment pipeline:
**Vercel** for the frontend, **Railway** for the backend, both auto-deploying from GitHub on push to \`main\`. No GitHub Actions wiring — both platforms connect natively to the GitHub repo.

## Why

You asked for the smallest viable thing — the actual smallest path is just config files + setup docs, since both Railway and Vercel handle the GitHub-push trigger natively. No custom CI/CD machinery needed.

## Changes

- **\`backend/.env.example\`**: rewritten as a complete reference for every env var the backend reads (\`JWT_SECRET\`, \`GOOGLE_CLIENT_ID\`, \`FRONTEND_URL\`, \`ENCRYPTION_KEY\`, \`YOUTUBE_API_KEY\`). Removed \`ANTHROPIC_API_KEY\` since the Claude fallback was deleted in PR #12.
- **\`frontend/.env.example\`** (new): documents \`NEXT_PUBLIC_API_URL\`, \`AUTH_SECRET\`, \`AUTH_GOOGLE_ID\`, \`AUTH_GOOGLE_SECRET\`.
- **\`.gitignore\`**: \`!backend/.env.example\` + \`!frontend/.env.example\` exceptions so the example files aren't filtered by the \`.env.*\` glob.
- **\`README.md\` Deployment section**: rewritten with step-by-step Railway + Vercel wiring, env-var generation hints (\`openssl rand ...\`), and the Google OAuth redirect-URI setup that's easy to forget.
- **\`README.md\` Known limitation callout**: explains that Railway's filesystem is ephemeral and the SQLite file at \`/app/books.db\` gets wiped on every redeploy. Recommends attaching a Railway volume as the minimum fix.
- **\`README.md\` env-var reference table**: updated to drop \`ANTHROPIC_API_KEY\` and add \`YOUTUBE_API_KEY\` as optional.

## Setup steps for you (after this merges)

1. **Railway:** New Project → Deploy from GitHub → select this repo. Add the env vars from \`backend/.env.example\` (use \`openssl rand -hex 32\` for \`JWT_SECRET\`). Health check at \`/api/health\` is already configured in \`railway.json\`.
2. **Vercel:** New Project → Import from GitHub → select this repo, set Root Directory to \`frontend\`. Add the env vars from \`frontend/.env.example\`. Update \`FRONTEND_URL\` on Railway with the resulting Vercel URL.
3. **Google OAuth:** Add the Vercel domain to **Authorized JavaScript origins** and \`https://<vercel-url>/api/auth/callback/google\` to **Authorized redirect URIs** in Google Cloud Console.
4. **(Recommended)** Attach a Railway volume mounted at \`/app\` so SQLite data survives redeploys.

## Intentionally not in scope (smallest viable)

- Railway volume / persistent disk migration
- Managed Postgres migration
- Staging environment
- Post-deploy smoke tests
- Custom GitHub Actions deploy workflow
- Slack/email deploy notifications

Each can be a separate PR when there's a concrete need.

## Test plan

- [x] No code changes — just config files and docs
- [x] All Jest / pytest / E2E unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)