### PR TITLE
feat(db): honour DB_PATH env var so SQLite can live on a Railway volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,17 @@ See `backend/.env.example` and `frontend/.env.example` for the full list of envi
 
 1. **New Project → Deploy from GitHub → select this repo**
 2. Railway reads `railway.json` automatically (Dockerfile build, health check at `/api/health`).
-3. **Add environment variables** from `backend/.env.example`:
+3. **Attach a persistent volume** so the SQLite file survives redeploys. In the Railway service settings:
+   - Click **Volumes → Add Volume**
+   - **Mount path:** `/app/data`
+   - Size: 1 GB is plenty for this app
+4. **Add environment variables** from `backend/.env.example`:
+   - `DB_PATH` — `/app/data/books.db` ← **must be inside the volume mount path** from step 3
    - `JWT_SECRET` — `openssl rand -hex 32`
    - `GOOGLE_CLIENT_ID` — from Google Cloud Console OAuth credentials
    - `FRONTEND_URL` — `https://<your-vercel-url>` (after the frontend is deployed)
    - `ENCRYPTION_KEY` — optional, derived from `JWT_SECRET` if unset
    - `YOUTUBE_API_KEY` — optional, only for the "find related videos" feature
-4. **⚠ Data persistence** (important — see "known limitation" below).
 
 ### Frontend — Vercel
 
@@ -147,15 +151,11 @@ See `backend/.env.example` and `frontend/.env.example` for the full list of envi
    - `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET` — same OAuth credentials as the backend
 4. **Google OAuth setup**: in Google Cloud Console, add the Vercel domain to **Authorized JavaScript origins** and add `https://<your-vercel-url>/api/auth/callback/google` to **Authorized redirect URIs**.
 
-### Known limitation: SQLite data persistence on Railway
+### Notes on data persistence
 
-By default, Railway containers have an **ephemeral filesystem** — every redeploy wipes the SQLite file at `/app/books.db`. This means:
+The backend reads `DB_PATH` from the environment and falls back to `backend/books.db` for local development. **In production you must point this at a path inside a persistent volume** — Railway containers have an ephemeral filesystem, and any file outside a mounted volume gets wiped on every redeploy.
 
-- Cached book text and translations are lost
-- User accounts and encrypted Gemini keys are lost
-- Audiobook → LibriVox links are lost
-
-The minimum fix is to attach a Railway **volume** mounted at `/app` (or wherever the SQLite file lives), so the file survives redeploys. The longer-term fix is to migrate to managed Postgres (Railway, Neon, Supabase). Both are tracked as future work.
+The Railway setup steps above (volume at `/app/data` + `DB_PATH=/app/data/books.db`) are the minimum viable fix. The longer-term option is to migrate to managed Postgres (Railway Postgres, Neon, Supabase), which removes the volume entirely.
 
 ---
 
@@ -202,6 +202,7 @@ book-reader-ai/
 | `JWT_SECRET` | Yes | Secret for signing backend JWTs (32+ chars). Generate with `openssl rand -hex 32`. |
 | `GOOGLE_CLIENT_ID` | Yes | OAuth client ID for verifying Google ID tokens |
 | `FRONTEND_URL` | Prod only | Frontend origin added to CORS allow-list |
+| `DB_PATH` | Prod | SQLite file path. **On Railway must point inside a mounted volume** (e.g. `/app/data/books.db`), otherwise data is lost on every redeploy. |
 | `ENCRYPTION_KEY` | Prod recommended | Fernet key for encrypting stored Gemini keys (derived from JWT_SECRET if unset) |
 | `YOUTUBE_API_KEY` | Optional | Enables the "find related videos" feature |
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -23,5 +23,11 @@ ENCRYPTION_KEY=
 # feature in the reader. Without this, video search returns empty.
 YOUTUBE_API_KEY=
 
+# Path to the SQLite database file. Defaults to backend/books.db (relative
+# to services/db.py). On Railway, set this to a path inside a mounted
+# persistent volume — otherwise every redeploy wipes your data.
+# Example: DB_PATH=/app/data/books.db
+DB_PATH=
+
 # ── Injected by Railway at runtime ───────────────────────────────────────
 # PORT — Railway sets this; the Dockerfile honours it via uvicorn --port

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -11,10 +11,25 @@ import json
 import os
 import aiosqlite
 
-DB_PATH = os.path.join(os.path.dirname(__file__), "..", "books.db")
+# DB file location. In local dev, defaults to backend/books.db (relative to
+# this file). In production (e.g. Railway), set DB_PATH to a path inside a
+# persistent volume so the file survives container redeploys — otherwise
+# every redeploy starts with an empty database. See README "Deployment".
+DB_PATH = os.environ.get(
+    "DB_PATH",
+    os.path.join(os.path.dirname(__file__), "..", "books.db"),
+)
 
 
 async def init_db() -> None:
+    # Make sure the parent directory exists. Important on first run after
+    # mounting a Railway volume at e.g. /app/data — the mount point exists
+    # but no books.db file does yet, and SQLite needs the directory to be
+    # present before it can create the file.
+    db_dir = os.path.dirname(DB_PATH)
+    if db_dir:
+        os.makedirs(db_dir, exist_ok=True)
+
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute("""
             CREATE TABLE IF NOT EXISTS books (

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -199,3 +199,39 @@ async def test_delete_audiobook():
 
 async def test_delete_audiobook_nonexistent_does_not_raise():
     await delete_audiobook(99999)  # should not raise
+
+
+# ── DB_PATH env var + parent directory handling ──────────────────────────────
+
+def test_db_path_honors_env_var(monkeypatch, tmp_path):
+    """Setting DB_PATH env var before module import should override the default."""
+    custom_path = str(tmp_path / "custom" / "books.db")
+    monkeypatch.setenv("DB_PATH", custom_path)
+    # Reload the module so it picks up the env var
+    import importlib
+    import services.db as db_module
+    importlib.reload(db_module)
+    try:
+        assert db_module.DB_PATH == custom_path
+    finally:
+        # Reload again so subsequent tests get a clean state
+        monkeypatch.delenv("DB_PATH", raising=False)
+        importlib.reload(db_module)
+
+
+async def test_init_db_creates_parent_directory(monkeypatch, tmp_path):
+    """init_db() should create the parent directory if it doesn't exist —
+    important for first-run after mounting a Railway volume at a fresh path."""
+    nested_path = str(tmp_path / "data" / "subdir" / "books.db")
+    monkeypatch.setattr(db_module, "DB_PATH", nested_path)
+
+    # Parent directory does NOT exist before init_db runs
+    assert not os.path.exists(os.path.dirname(nested_path))
+
+    await init_db()
+
+    # Parent dir exists, file exists, schema is in place
+    assert os.path.exists(nested_path)
+    # Sanity-check the schema by running a real query
+    user = await get_or_create_user(google_id="x", email="a@b.com", name="A", picture="")
+    assert user["id"] is not None


### PR DESCRIPTION
## What

Backend now reads its SQLite file path from \`DB_PATH\`, defaulting to \`backend/books.db\` for local development. Production deployments on Railway should set it to a path inside a mounted persistent volume — fixing the data-loss-on-redeploy problem from earlier in this session.

## Why

Railway containers have an ephemeral filesystem. With \`DB_PATH\` hardcoded inside the container, every redeploy wipes the SQLite file and the user starts over. We hit this in real life today: lost users, encrypted Gemini keys, audiobook links, and cached translations. Fixing the persistence story is a prerequisite for a deployable app.

This is **PR A** of the two-step plan I laid out: persistence first, then migrations. Migrations only matter once data actually survives between runs.

## Changes

- **\`services/db.py\`**: \`DB_PATH = os.environ.get(\"DB_PATH\", <local default>)\`. Also calls \`os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)\` inside \`init_db()\` so the first run after mounting a fresh Railway volume succeeds without a manual \`mkdir\`.
- **\`tests/test_db.py\`**: two new tests
  - \`test_db_path_honors_env_var\` — set \`DB_PATH\`, reload \`services.db\`, confirm the override is picked up.
  - \`test_init_db_creates_parent_directory\` — point \`DB_PATH\` at a nested path with no parent dir, run \`init_db()\`, confirm the directory was created and the schema works.
- **\`backend/.env.example\`**: documents \`DB_PATH\` with the Railway example.
- **\`README.md\` Deployment section**: now lists the **Volume → Add Volume → Mount path \`/app/data\`** step *before* the env var list, then \`DB_PATH=/app/data/books.db\` as required.
- **\`README.md\` \"Known limitation\" callout** → renamed to **\"Notes on data persistence\"** and rewritten as a setup step instead of a known issue.
- **\`README.md\` env vars reference table**: \`DB_PATH\` added with the \"Prod required, must be inside volume mount path\" note.

## What this PR does NOT include

- **A migration system.** Migrations only matter once data persists; they are the right *next* step after this PR is shipped. Tracked separately.
- **A managed Postgres migration.** Larger scope, longer-term option. Tracked separately.

## Test plan

- [x] All 146 backend tests pass (was 144, +2 new for DB_PATH behaviour)
- [x] Existing test fixture (\`monkeypatch.setattr(db_module, \"DB_PATH\", path)\`) still works because \`DB_PATH\` remains a module-level variable.
- [x] Frontend tests unchanged (no frontend code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)