### PR TITLE
fix(deploy): expand $PORT correctly in Railway deploy

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,4 +23,8 @@ ENV PORT=8000
 
 EXPOSE $PORT
 
-CMD uvicorn main:app --host 0.0.0.0 --port $PORT
+# Exec form with explicit `sh -c` so $PORT gets expanded by the shell.
+# Plain shell-form CMD also works in vanilla Docker, but some hosts
+# (Railway in particular) sometimes exec the CMD directly without a shell,
+# causing the literal string "$PORT" to be passed to uvicorn.
+CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port $PORT"]

--- a/railway.json
+++ b/railway.json
@@ -6,7 +6,6 @@
     "watchPatterns": ["backend/**"]
   },
   "deploy": {
-    "startCommand": "uvicorn main:app --host 0.0.0.0 --port $PORT",
     "healthcheckPath": "/api/health",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 3


### PR DESCRIPTION
## What

Fixes the Railway runtime crash that came right after PR #18 unblocked the build:

\`\`\`
Mounting volume on: /var/lib/containers/railwayapp/bind-mounts/...
Error: Invalid value for '--port': '\$PORT' is not a valid integer.
\`\`\`

## Cause

Two compounding bugs:

**1. \`railway.json\` was overriding the Dockerfile with a broken \`startCommand\`.**
\`\`\`json
\"startCommand\": \"uvicorn main:app --host 0.0.0.0 --port \$PORT\"
\`\`\`
When \`railway.json\` specifies a \`startCommand\`, Railway uses that *instead* of the Dockerfile's \`CMD\`. But Railway exec's the \`startCommand\` directly, **without** wrapping it in a shell — so \`\$PORT\` is passed to uvicorn as the literal four-character string \`\"\$PORT\"\` rather than being expanded to e.g. \`\"8080\"\`. uvicorn refuses to start.

**2. The Dockerfile \`CMD\` was in shell form, which is fragile.**
\`\`\`dockerfile
CMD uvicorn main:app --host 0.0.0.0 --port \$PORT
\`\`\`
In plain Docker this works fine — Docker runs the command via \`/bin/sh -c\`, which expands \`\$PORT\`. But it was being shadowed by the broken \`railway.json\` line anyway, and it's too implicit to rely on across different hosts.

## Fix

| File | Change |
|---|---|
| \`railway.json\` | **Removed** \`startCommand\` entirely. Let the Dockerfile own the startup command. \`railway.json\` keeps \`healthcheckPath\` and \`restartPolicy\` (the bits Railway actually needs). |
| \`backend/Dockerfile\` | \`CMD\` is now explicit exec-form with \`sh -c\`: <br>\`CMD [\"sh\", \"-c\", \"uvicorn main:app --host 0.0.0.0 --port \$PORT\"]\` <br>This guarantees \$PORT is expanded by the shell regardless of who invokes the container — Railway, plain \`docker run\`, docker-compose, etc. |

## Volume mount status (good news)

The Railway logs show:
\`\`\`
Mounting volume on: /var/lib/containers/railwayapp/bind-mounts/...
\`\`\`
That means **the volume from PR #17 is mounting correctly**. Once this PR unblocks startup, the persistent SQLite path (\`DB_PATH=/app/data/books.db\`) should work as designed and survive redeploys.

## Test plan

- [x] CI's \`Verify Docker build\` will catch any Dockerfile syntax issue (and now uses the same context as Railway, per PR #18)
- [x] No code changes — just config and the Dockerfile CMD line
- [x] All Python / JS / E2E tests untouched

## After this merges

Watch the next Railway redeploy. Three things to verify in the deploy logs:

1. **No more \`Invalid value for '--port'\` error.** uvicorn should start with the actual injected port number.
2. **\`Application startup complete\`** appears in the uvicorn log.
3. **Health check passes** (\`/api/health\` returns 200) — Railway will switch the deployment to \"Active\".

If any of those fail with a new error, paste it and I'll debug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)