### PR TITLE
fix(frontend): set tsconfig target to es2020 so Vercel build passes

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "es2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## What

Adds \`\"target\": \"es2020\"\` to \`frontend/tsconfig.json\`. Fixes the Vercel build failure:

\`\`\`
./src/components/SentenceReader.tsx:62:56
Type error: This regular expression flag is only available when
targeting 'es2018' or later.
> 62 | const ILLUS_RE = /^\\[Illustration(?::\\s*(.+?))?\\s*\\]\$/is;
                                                                ^
\`\`\`

## Cause

\`tsconfig.json\` never set a \`target\`, so TypeScript fell back to its default — ES3/ES5 — which predates the dotAll regex flag (\`s\`) added in ES2018. The \`SentenceReader\` component uses \`/.../is\` to parse \`[Illustration: caption]\` markers across line breaks, and the type checker rejects it under the old target.

**Why it worked locally but failed on Vercel:** \`next dev\` is lenient about TypeScript errors (warnings only). \`next build\` runs the strict type checker. We never ran \`next build\` in CI — only \`jest\` and \`playwright\`. The first time the build was actually run was on Vercel.

## Fix

One line in \`tsconfig.json\`:

\`\`\`json
\"target\": \"es2020\"
\`\`\`

ES2020 is the right modern baseline:
- Next.js 14 already targets ES2020+ for its supported browsers
- Includes the \`s\` regex flag, plus optional chaining (\`?.\`), nullish coalescing (\`??\`), \`BigInt\`, \`Promise.allSettled\` — all of which we already use
- With \`noEmit: true\` in our config, this only affects the **type checker**. Actual runtime code is compiled by Next.js's SWC, which already targets a modern baseline. **Zero runtime impact.**

## Verified locally

- ✅ \`cd frontend && npm run build\` succeeds (the exact command Vercel runs)
- ✅ All 86 Jest tests still pass

## Pattern: same class of bug as earlier today

This is the third time today a production-only build/runtime path slipped past local CI:

1. PR #18 — Railway Docker build context didn't match CI's Docker context
2. PR #19 — Railway exec'd \`startCommand\` without a shell, broke \`\$PORT\` expansion
3. **This PR** — \`next build\` (the production build) wasn't part of CI; only \`next dev\` was exercised via Jest

The lesson is the same as PR #18: **CI should exercise the same invocation production runs.** A short follow-up PR could add a \`next build\` step to the existing \`Frontend tests (Jest)\` job — about 3 lines of YAML — and would catch every future tsconfig/import/typing bug before it reaches Vercel. Want me to do that next?

## Test plan

- [x] Local \`npm run build\` succeeds (the exact Vercel invocation)
- [x] All 86 Jest tests still pass
- [x] No code changes — just the tsconfig target

🤖 Generated with [Claude Code](https://claude.com/claude-code)