### PR TITLE
ci: verify Next.js production build before merging frontend changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,22 @@ jobs:
           name: frontend-coverage-summary
           path: frontend/coverage/coverage-summary.json
 
+      # `next dev` is lenient about TypeScript errors and skips the strict
+      # type-check that `next build` runs. Without this step, things like
+      # "regex flag requires es2018+" or stale imports only fail when Vercel
+      # tries to build, after the PR has already merged. Run the same
+      # invocation Vercel runs so we catch it before merge instead.
+      - name: Verify Next.js production build
+        if: always()
+        run: npm run build
+        env:
+          # next-auth v5 validates config at module load. Provide throwaway
+          # values so the build can boot the auth() factory without crashing.
+          AUTH_SECRET: ci-build-dummy-secret-do-not-use-in-prod
+          AUTH_GOOGLE_ID: ci-build-dummy-id
+          AUTH_GOOGLE_SECRET: ci-build-dummy-secret
+          NEXT_PUBLIC_API_URL: http://stub.test/api
+
   test-e2e:
     name: Frontend E2E (Playwright)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds a \`Verify Next.js production build\` step to the existing \`Frontend tests (Jest)\` CI job. The step runs the same \`npm run build\` invocation that Vercel runs, with throwaway env vars, and turns the job red if the build fails.

## Why

Today's PR #21 fixed a Vercel build failure caused by a regex \`s\` flag that the TS \`target\` didn't allow. The root issue wasn't the regex — it was that **\`next build\` had never been invoked anywhere in CI**. \`jest\` and \`playwright\` use \`jest-environment-jsdom\` and the \`next dev\` server respectively, both of which are lenient about TypeScript errors. The first time the production build ran was on Vercel, after the PR was merged, after auto-merge had already shipped the broken code to main.

This is the **third time today** a production-only invocation slipped past CI:

| | Failure | What CI was missing |
|---|---|---|
| PR #18 | Railway Docker build couldn't find \`requirements.txt\` | CI built with \`context: backend\`, Railway uses \`context: .\` |
| PR #19 | Railway exec'd startup without a shell, broke \`\$PORT\` expansion | No CI test exercised the actual container startup |
| **PR #21** | **\`next build\` rejected the regex \`s\` flag** | **CI only ran \`jest\` / \`playwright\`, never \`next build\`** |

The fix pattern is always the same: **CI must invoke the production command, not a convenient near-equivalent.** This PR is the frontend half of that fix (PR #18 was the backend half).

## How

One new step inside the existing \`test-frontend\` job:

\`\`\`yaml
- name: Verify Next.js production build
  if: always()
  run: npm run build
  env:
    AUTH_SECRET: ci-build-dummy-secret-do-not-use-in-prod
    AUTH_GOOGLE_ID: ci-build-dummy-id
    AUTH_GOOGLE_SECRET: ci-build-dummy-secret
    NEXT_PUBLIC_API_URL: http://stub.test/api
\`\`\`

Notes:

- **Inside the existing job**, not a new one — reuses the cached \`npm ci\`, saves ~30s versus a separate job
- **\`if: always()\`** so it runs even when Jest fails. We want both signals on every PR.
- **Throwaway env vars** because next-auth v5 validates config at module load, same pattern as the Playwright config that already works in the \`test-e2e\` job
- **No new tests, no new dependencies** — just an extra step on the existing job

## Verified locally

Ran the build under a stripped environment to make sure it doesn't depend on anything in \`.env.local\`:

\`\`\`bash
env -i HOME=\$HOME PATH=\$PATH \\
  AUTH_SECRET=test AUTH_GOOGLE_ID=test AUTH_GOOGLE_SECRET=test \\
  NEXT_PUBLIC_API_URL=http://stub.test/api \\
  npm run build
# → ✓ Compiled successfully, all 7 routes
\`\`\`

If you'd intentionally introduced today's regex bug at the same time, this exact invocation would have failed with the same error Vercel showed — proving the new CI step would have caught it.

## What this PR does NOT include

- Adding the new step as a **required status check** on the branch protection rule. After this PR merges and the next CI run shows it passing, you should add \`Frontend tests (Jest)\` (which is what hosts this step) to required checks if it isn't already. (It already is per the branch protection I set earlier in this session — so nothing to do.)
- Caching the \`.next\` build directory between runs. Possible future optimization but not necessary at this scale.

## Test plan

- [x] Local stripped-env build works (\`env -i ... npm run build\`) — proves no dependence on \`.env.local\`
- [x] All 86 Jest tests still pass
- [x] All 144 backend tests untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)