### PR TITLE
fix(tts): TTSControls Read button now honours provider preference

### DIFF
--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -202,9 +202,35 @@ test("synthesizeSpeech includes Authorization header when token is set", async (
   expect(headers.Authorization).toBe("Bearer my-jwt");
 });
 
+test("synthesizeSpeech forwards an AbortSignal to fetch", async () => {
+  global.URL.createObjectURL = jest.fn().mockReturnValue("blob:fake");
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    blob: jest.fn().mockResolvedValue(new Blob(["x"])),
+  });
+  const abort = new AbortController();
+  await synthesizeSpeech("Hello", "en", 1.0, "auto", abort.signal);
+  const opts = (global.fetch as jest.Mock).mock.calls[0][1];
+  expect(opts.signal).toBe(abort.signal);
+});
+
 test("synthesizeSpeech throws on non-ok response", async () => {
-  global.fetch = jest.fn().mockResolvedValue({ ok: false });
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    statusText: "Bad Request",
+    json: jest.fn().mockResolvedValue({}),
+  });
   await expect(synthesizeSpeech("Hello", "en")).rejects.toThrow("TTS failed");
+});
+
+test("synthesizeSpeech surfaces backend error detail", async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    statusText: "Bad Request",
+    json: jest.fn().mockResolvedValue({ detail: "Gemini API key required. Please add it in your profile." }),
+  });
+  await expect(synthesizeSpeech("Hello", "en", 1.0, "google"))
+    .rejects.toThrow(/Gemini API key required/);
 });
 
 // ── Audiobooks ────────────────────────────────────────────────────────────────

--- a/frontend/src/components/TTSControls.tsx
+++ b/frontend/src/components/TTSControls.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
 import { synthesizeSpeech } from "@/lib/api";
+import { getSettings } from "@/lib/settings";
 
 interface Props {
   text: string;
@@ -46,20 +47,19 @@ export default function TTSControls({ text, language }: Props) {
     setStatus("loading");
 
     try {
-      // Pass signal so the fetch is cancelled when stop is clicked
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api"}/ai/tts`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text, language, rate }),
-        signal: abort.signal,
-      });
-      if (!res.ok) throw new Error("TTS failed");
-      const blob = await res.blob();
+      // Use the shared synthesizeSpeech helper so auth header and the
+      // user's TTS-provider preference are both honoured. Pass the
+      // AbortSignal so clicking Stop cancels the in-flight request
+      // (important for cost control on Gemini TTS).
+      const provider = getSettings().ttsProvider;
+      const url = await synthesizeSpeech(text, language, rate, provider, abort.signal);
 
       // Bail out if stop was pressed while we were fetching
-      if (gen !== genRef.current) return;
+      if (gen !== genRef.current) {
+        URL.revokeObjectURL(url);
+        return;
+      }
 
-      const url = URL.createObjectURL(blob);
       blobUrlRef.current = url;
       const audio = new Audio(url);
       audioRef.current = audio;
@@ -71,7 +71,9 @@ export default function TTSControls({ text, language }: Props) {
     } catch (e: unknown) {
       if (gen !== genRef.current) return;
       if (e instanceof Error && e.name === "AbortError") return;
-      // Fallback to Web Speech API
+      // Fallback to the browser's Web Speech API. This is intentionally
+      // a "last resort" — quality is poor and provider preference can't
+      // be honoured. Most failures here are network/auth issues.
       const utter = new SpeechSynthesisUtterance(text);
       utter.lang = language;
       utter.rate = rate;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -111,7 +111,8 @@ export async function synthesizeSpeech(
   text: string,
   language: string,
   rate = 1.0,
-  provider: "auto" | "edge" | "google" = "auto"
+  provider: "auto" | "edge" | "google" = "auto",
+  signal?: AbortSignal
 ): Promise<string> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -121,8 +122,14 @@ export async function synthesizeSpeech(
     method: "POST",
     headers,
     body: JSON.stringify({ text, language, rate, provider }),
+    signal,
   });
-  if (!res.ok) throw new Error("TTS failed");
+  if (!res.ok) {
+    // Surface the backend's error detail when available so users see e.g.
+    // "Gemini API key required" instead of a generic "TTS failed".
+    const err = await res.json().catch(() => ({ detail: res.statusText }));
+    throw new Error(err.detail || "TTS failed");
+  }
   const blob = await res.blob();
   return URL.createObjectURL(blob);
 }


### PR DESCRIPTION
## What

Fixes a bug from PR #23: the reader's **▶ Read button** (in \`TTSControls.tsx\`) was completely bypassing the new pluggable TTS system. The user reported \"highlighting works, but Read button still uses the old voice\" — turns out it was even worse than that.

## Cause

\`TTSControls\` had its own raw \`fetch()\` to \`/api/ai/tts\` that:

1. **Did not include the \`Authorization\` header** — so the backend was returning 401 in production
2. **Did not pass the new \`provider\` field** — so the user's TTS-provider preference was completely ignored
3. **Was duplicating the work** of \`synthesizeSpeech()\` in \`lib/api.ts\` — which was *already* updated in PR #23 to handle auth + provider correctly

The combination of (1) + (3) explains why the Read button \"used the old voice\": the raw fetch was failing with 401, the catch block was falling back to \`window.speechSynthesis\` (the **browser's built-in TTS**), and that's the voice the user was actually hearing the whole time — not Edge TTS, and definitely not the new Gemini TTS.

In contrast, the **sentence-click / highlighting path** goes through \`synthesizeSpeech()\` directly (the call site I updated in PR #23), which is why *that* path works correctly. The two TTS entry points were silently using different code paths.

## Fix

Two small changes:

### \`lib/api.ts\` — \`synthesizeSpeech\` improvements

1. **Optional \`AbortSignal\` parameter** so callers can cancel in-flight requests. Important for Gemini TTS specifically: aborting an in-flight call saves tokens you'd otherwise pay for.
2. **Surface backend error details** — if the backend returns \`{\"detail\": \"Gemini API key required...\"}\`, throw that as the error message instead of the generic \`\"TTS failed\"\`. Users now see actionable errors.

### \`components/TTSControls.tsx\` — use the shared helper

- Replaced the raw \`fetch()\` with a call to \`synthesizeSpeech(text, language, rate, getSettings().ttsProvider, abort.signal)\`
- The user's TTS provider preference now flows through correctly
- AbortSignal threading preserved (Stop button still cancels)
- Web Speech API fallback path **kept** as a true last resort for genuine network failures, with a clearer code comment about its purpose

## Tests (93 total, was 91 — +2)

- \`api.test.ts\`: \`synthesizeSpeech forwards AbortSignal to fetch\`
- \`api.test.ts\`: \`synthesizeSpeech surfaces backend error detail\` (verifies the new \"Gemini API key required\" error path)

## Verified locally

- ✅ \`npm test\` — 93 pass
- ✅ \`env -i ... npm run build\` — production build succeeds

## After this merges

Try it on \`book-reader-ai.vercel.app\`:

1. Open Faust → click ▶ Read at the bottom of the reader
2. Should hear **Charon** (Gemini's German voice), not the browser's built-in TTS
3. Click ⏹ mid-generation — should cancel cleanly without burning extra tokens

If the **Read** button now sounds the same as the **sentence click** path, the fix worked. If it still sounds different, something deeper is wrong and we should investigate further.

## Meta-observation

This is the third instance this session where two near-identical code paths drifted apart silently:
- PR #18: CI Docker context vs Railway Docker context
- PR #21: \`next dev\` vs \`next build\` type-checking
- **This PR**: TTSControls raw fetch vs \`synthesizeSpeech\` helper

The shared lesson: **never have two ways to do the same thing in the same codebase.** Whenever there's a reusable helper, every caller should use it. The duplication in TTSControls existed because the original raw fetch needed an \`AbortSignal\`, which \`synthesizeSpeech\` didn't support. Now that \`synthesizeSpeech\` supports signals, the duplication is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)