### PR TITLE
feat(audio): chunked chapter audio with cache, lazy load, and live UI

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,7 @@ pydantic==2.7.1
 aiosqlite==0.20.0
 pytest==8.2.0
 pytest-asyncio==0.23.6
-edge-tts==6.1.10
+edge-tts>=7.2.0
 google-genai>=1.0.0
 python-jose[cryptography]==3.3.0
 cryptography>=42.0.0

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -4,10 +4,16 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import Response
 from pydantic import BaseModel
 from services.auth import get_current_user, decrypt_api_key
-from services.db import get_cached_translation, save_translation
+from services.db import (
+    get_cached_translation,
+    save_translation,
+    get_cached_audio,
+    save_audio,
+    delete_chapter_audio_cache,
+)
 from services import gemini
 from services.youtube import search_videos
-from services.tts import synthesize
+from services.tts import synthesize, resolve_voice, chunk_text
 
 router = APIRouter(prefix="/ai", tags=["ai"])
 
@@ -69,6 +75,17 @@ class TTSRequest(BaseModel):
     # "auto" → resolves to "google" when the user has a Gemini key,
     #          otherwise falls back to "edge".
     provider: Literal["auto", "edge", "google"] = "auto"
+    # Optional cache keys. When book_id + chapter_index are present, the
+    # response is served from / written to the persistent audio cache.
+    # Snippet calls (sentence clicks, ad-hoc TTS) omit them and bypass.
+    # chunk_index defaults to 0 — chunked clients pass it explicitly.
+    book_id: int | None = None
+    chapter_index: int | None = None
+    chunk_index: int = 0
+
+
+class ChunkTextRequest(BaseModel):
+    text: str
 
 
 # ── Endpoints ─────────────────────────────────────────────────────────────────
@@ -156,6 +173,12 @@ async def tts(req: TTSRequest, user: dict = Depends(get_current_user)):
       - "edge"   Microsoft Edge TTS — free, no API key, MP3 output
       - "google" Google Gemini TTS — uses the user's Gemini key, WAV output
       - "auto"   (default) → google if the user has a Gemini key, else edge
+
+    When `book_id` and `chapter_index` are both provided, the response is
+    served from / written to a persistent audio cache keyed by
+    (book, chapter, provider, voice). Without those fields the call is
+    treated as a one-off snippet and never touches the cache (used for
+    sentence-click playback).
     """
     # Resolve "auto" to a concrete backend
     raw_key = user.get("gemini_key")
@@ -172,6 +195,22 @@ async def tts(req: TTSRequest, user: dict = Depends(get_current_user)):
             detail="Google TTS requires a Gemini API key. Please add one in your profile.",
         )
 
+    # Cache lookup — only when this is a real chapter request, not a snippet.
+    cache_eligible = req.book_id is not None and req.chapter_index is not None
+    voice = resolve_voice(chosen, req.language)
+
+    if cache_eligible:
+        cached = await get_cached_audio(
+            req.book_id, req.chapter_index, chosen, voice, req.chunk_index
+        )
+        if cached is not None:
+            audio, content_type = cached
+            return Response(
+                content=audio,
+                media_type=content_type,
+                headers={"X-TTS-Cache": "hit"},
+            )
+
     try:
         audio, content_type = await synthesize(
             req.text,
@@ -180,8 +219,48 @@ async def tts(req: TTSRequest, user: dict = Depends(get_current_user)):
             provider=chosen,
             gemini_key=decrypted_key,
         )
-        return Response(content=audio, media_type=content_type)
     except HTTPException:
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+    # Persist on cache miss so the next request (and the next page reload,
+    # and the next session, and the next device) returns instantly.
+    if cache_eligible:
+        await save_audio(
+            req.book_id, req.chapter_index, chosen, voice, audio, content_type, req.chunk_index
+        )
+
+    return Response(
+        content=audio,
+        media_type=content_type,
+        headers={"X-TTS-Cache": "miss"} if cache_eligible else {},
+    )
+
+
+@router.delete("/tts/cache")
+async def delete_tts_cache(
+    book_id: int,
+    chapter_index: int,
+    _user: dict = Depends(get_current_user),
+):
+    """Delete all cached audio chunks for a chapter (any provider/voice).
+
+    Used by the Regenerate button — the next call to /api/ai/tts will be a
+    cache miss and will hit the TTS provider fresh.
+    """
+    deleted = await delete_chapter_audio_cache(book_id, chapter_index)
+    return {"deleted": deleted}
+
+
+@router.post("/tts/chunks")
+async def tts_chunks(req: ChunkTextRequest, _user: dict = Depends(get_current_user)):
+    """Return the chunk list the backend would feed to the TTS provider.
+
+    The frontend calls this once per chapter before fetching audio, so it
+    can drive a per-chunk progress UI and key the audio cache by chunk_index.
+    Single source of truth — the frontend never has to replicate the
+    chunking algorithm in TypeScript.
+    """
+    chunks = chunk_text(req.text)
+    return {"chunks": chunks}

--- a/backend/routers/audiobooks.py
+++ b/backend/routers/audiobooks.py
@@ -18,11 +18,13 @@ class SaveRequest(BaseModel):
 
 @router.get("/{book_id}")
 async def get(book_id: int):
-    """Return the saved audiobook for a Gutenberg book (or 404)."""
-    ab = await get_audiobook(book_id)
-    if ab is None:
-        raise HTTPException(status_code=404, detail="No audiobook linked")
-    return ab
+    """Return the saved audiobook for a Gutenberg book, or null if none.
+
+    We return 200+null (rather than 404) so the frontend can fetch this on
+    every reader page load without producing red 404s in the browser console
+    — "no audiobook linked" is a perfectly normal state, not an error.
+    """
+    return await get_audiobook(book_id)
 
 
 @router.get("/{book_id}/search")

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -83,6 +83,36 @@ async def init_db() -> None:
                 saved_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         """)
+        # Cached per-chunk chapter audio. We store one row per text chunk
+        # (the frontend chunks the chapter via /api/ai/tts/chunks before
+        # synthesizing) so the cache is finer-grained: replays are free,
+        # partial generation cost is sunk per-chunk on cancel, and the cache
+        # key includes provider+voice so switching voices misses cleanly.
+        #
+        # Migration: SQLite cannot ALTER the primary key on an existing table,
+        # so if the audio_cache table exists with the OLD PK (no chunk_index),
+        # we drop it and recreate. The cache is regeneratable so losing it on
+        # this one-time upgrade is acceptable.
+        async with db.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='audio_cache'"
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row and "chunk_index" not in row[0]:
+            await db.execute("DROP TABLE audio_cache")
+
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS audio_cache (
+                book_id       INTEGER NOT NULL,
+                chapter_index INTEGER NOT NULL,
+                chunk_index   INTEGER NOT NULL DEFAULT 0,
+                provider      TEXT NOT NULL,
+                voice         TEXT NOT NULL,
+                content_type  TEXT NOT NULL,
+                audio         BLOB NOT NULL,
+                created_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (book_id, chapter_index, chunk_index, provider, voice)
+            )
+        """)
         await db.commit()
 
 
@@ -153,6 +183,67 @@ async def save_translation(book_id: int, chapter_index: int, target_language: st
             (book_id, chapter_index, target_language, json.dumps(paragraphs)),
         )
         await db.commit()
+
+
+# ── Audio cache (whole-chapter TTS output) ────────────────────────────────────
+
+async def get_cached_audio(
+    book_id: int,
+    chapter_index: int,
+    provider: str,
+    voice: str,
+    chunk_index: int = 0,
+) -> tuple[bytes, str] | None:
+    """Return (audio_bytes, content_type) for a cached chunk, or None on miss."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            """
+            SELECT audio, content_type FROM audio_cache
+            WHERE book_id=? AND chapter_index=? AND chunk_index=? AND provider=? AND voice=?
+            """,
+            (book_id, chapter_index, chunk_index, provider, voice),
+        ) as cursor:
+            row = await cursor.fetchone()
+    if not row:
+        return None
+    return row[0], row[1]
+
+
+async def save_audio(
+    book_id: int,
+    chapter_index: int,
+    provider: str,
+    voice: str,
+    audio: bytes,
+    content_type: str,
+    chunk_index: int = 0,
+) -> None:
+    """Insert or replace one cached audio chunk."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            """
+            INSERT OR REPLACE INTO audio_cache
+                (book_id, chapter_index, chunk_index, provider, voice, content_type, audio)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (book_id, chapter_index, chunk_index, provider, voice, content_type, audio),
+        )
+        await db.commit()
+
+
+async def delete_chapter_audio_cache(book_id: int, chapter_index: int) -> int:
+    """Delete all cached audio chunks for one chapter (across all providers/voices).
+
+    Returns the number of rows deleted. Used by the Regenerate button to
+    force a fresh TTS generation pass on the next Read click.
+    """
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "DELETE FROM audio_cache WHERE book_id=? AND chapter_index=?",
+            (book_id, chapter_index),
+        )
+        await db.commit()
+        return cursor.rowcount
 
 
 async def get_cached_book(book_id: int) -> dict | None:

--- a/backend/services/tts.py
+++ b/backend/services/tts.py
@@ -138,9 +138,125 @@ def _pcm_to_wav(pcm_data: bytes, sample_rate: int = 24000, channels: int = 1, bi
     return header + pcm_data
 
 
+# Gemini TTS has an output cap of roughly ~30 seconds of audio per call.
+# When the input text is longer than that, the model stops generating speech
+# but the response still contains silent PCM padding to fill its output
+# buffer. The result is a long WAV with 30s of speech and 5+ minutes of
+# silence — useless for chapter-length text. To work around this we chunk
+# the input by paragraph/line, synthesize each chunk separately, trim the
+# trailing silence from each chunk's PCM, and concatenate.
+GEMINI_TTS_CHUNK_CHARS = 400
+
+
+def _chunk_text_for_tts(text: str, max_chars: int = GEMINI_TTS_CHUNK_CHARS) -> list[str]:
+    """Split text into chunks of at most max_chars, respecting paragraph and line boundaries.
+
+    Strategy: prefer to keep paragraphs whole. If a single paragraph is too
+    long, split it on line breaks. Empty chunks are dropped.
+    """
+    paragraphs = [p for p in text.split("\n\n") if p.strip()]
+    chunks: list[str] = []
+    current: list[str] = []
+    current_len = 0
+
+    def flush_current():
+        nonlocal current, current_len
+        if current:
+            chunks.append("\n\n".join(current))
+            current = []
+            current_len = 0
+
+    for para in paragraphs:
+        para_len = len(para)
+
+        # Paragraph fits inside the current chunk
+        if current_len + para_len + 2 <= max_chars:
+            current.append(para)
+            current_len += para_len + 2
+            continue
+
+        # Current chunk has stuff, flush it before handling this paragraph
+        flush_current()
+
+        # Single paragraph is small enough on its own
+        if para_len <= max_chars:
+            current.append(para)
+            current_len = para_len
+            continue
+
+        # Single paragraph is too long → split on line breaks
+        line_buf: list[str] = []
+        line_buf_len = 0
+        for line in para.split("\n"):
+            line_with_break = len(line) + 1
+            if line_buf_len + line_with_break > max_chars and line_buf:
+                chunks.append("\n".join(line_buf))
+                line_buf = []
+                line_buf_len = 0
+            line_buf.append(line)
+            line_buf_len += line_with_break
+        if line_buf:
+            chunks.append("\n".join(line_buf))
+
+    flush_current()
+    return chunks
+
+
+def _trim_trailing_silence(
+    pcm: bytes,
+    sample_rate: int = 24000,
+    rms_threshold: float = 200.0,
+    tail_ms: int = 250,
+) -> bytes:
+    """Trim trailing silence from raw 16-bit mono PCM.
+
+    Walks 100 ms windows from the end of the buffer toward the start, finds
+    the last window whose RMS is above `rms_threshold`, and keeps everything
+    up to that window plus a small `tail_ms` cushion. Internal pauses are
+    preserved (we only cut from the very end).
+
+    `rms_threshold=200` is well below normal speech (typically RMS 1000–8000
+    for Gemini's voices) but well above the silence floor (~5–15 RMS).
+    """
+    if not pcm:
+        return pcm
+    n_samples = len(pcm) // 2  # 16-bit = 2 bytes/sample
+    if n_samples == 0:
+        return pcm
+
+    window = max(1, sample_rate // 10)  # 100 ms
+    samples = struct.unpack(f"<{n_samples}h", pcm)
+
+    # Walk windows from the end
+    last_loud_end = 0
+    i = n_samples - window
+    while i >= 0:
+        chunk = samples[i : i + window]
+        # RMS — avoid sqrt for speed; threshold the squared value
+        sq_sum = sum(s * s for s in chunk)
+        rms_sq = sq_sum / len(chunk)
+        if rms_sq > rms_threshold * rms_threshold:
+            last_loud_end = i + window
+            break
+        i -= window
+
+    if last_loud_end == 0:
+        # All silent — return unchanged so the caller can decide what to do
+        return pcm
+
+    keep_samples = min(n_samples, last_loud_end + (sample_rate * tail_ms // 1000))
+    return pcm[: keep_samples * 2]
+
+
 async def _gemini_synthesize(text: str, language: str, api_key: str) -> tuple[bytes, str]:
     """
-    Synthesize via Google Gemini TTS. Returns (wav_bytes, content_type).
+    Synthesize a single chunk via Google Gemini TTS. Returns (wav_bytes, content_type).
+
+    Gemini's TTS preview model has an output cap (~30 sec of audio per call)
+    and pads truncated outputs with silence. The CALLER is responsible for
+    splitting longer text into chunks and concatenating the results — see
+    `_chunk_text_for_tts`. We trim the per-chunk trailing silence here so
+    callers don't have to worry about the padding.
 
     Note: Gemini TTS does not support a rate parameter — playback speed is
     a client-side concern (audio.playbackRate on the <audio> element).
@@ -165,11 +281,33 @@ async def _gemini_synthesize(text: str, language: str, api_key: str) -> tuple[by
         ),
     )
 
-    pcm_data = response.candidates[0].content.parts[0].inline_data.data
-    return _pcm_to_wav(pcm_data, sample_rate=24000), "audio/wav"
+    pcm = response.candidates[0].content.parts[0].inline_data.data
+    trimmed = _trim_trailing_silence(pcm)
+    return _pcm_to_wav(trimmed, sample_rate=24000), "audio/wav"
 
 
 # ── Public dispatch ──────────────────────────────────────────────────────────
+
+def chunk_text(text: str, max_chars: int = GEMINI_TTS_CHUNK_CHARS) -> list[str]:
+    """Public wrapper around _chunk_text_for_tts so the router can expose it.
+
+    The frontend calls this via POST /api/ai/tts/chunks before fetching audio,
+    and uses the resulting list to drive per-chunk progress UI and per-chunk
+    audio caching.
+    """
+    return _chunk_text_for_tts(text, max_chars=max_chars)
+
+
+def resolve_voice(provider: Provider, language: str) -> str:
+    """Return the concrete voice name a synthesize() call would use.
+
+    Exposed so the router can use (provider, voice) as part of the audio cache key —
+    switching from one voice to another should miss the cache and re-generate.
+    """
+    if provider == "google":
+        return _pick_gemini_voice(language)
+    return _pick_edge_voice(language)
+
 
 async def synthesize(
     text: str,

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -22,6 +22,9 @@ from services.db import (
     save_audiobook,
     get_audiobook,
     delete_audiobook,
+    save_audio,
+    get_cached_audio,
+    delete_chapter_audio_cache,
 )
 
 
@@ -199,6 +202,114 @@ async def test_delete_audiobook():
 
 async def test_delete_audiobook_nonexistent_does_not_raise():
     await delete_audiobook(99999)  # should not raise
+
+
+# ── Audio cache ───────────────────────────────────────────────────────────────
+
+async def test_get_cached_audio_miss_returns_none():
+    result = await get_cached_audio(2229, 0, "google", "Charon")
+    assert result is None
+
+
+async def test_save_and_get_audio_roundtrip():
+    audio_bytes = b"\x00\x01\x02\x03" * 10
+    await save_audio(2229, 0, "google", "Charon", audio_bytes, "audio/wav")
+    result = await get_cached_audio(2229, 0, "google", "Charon")
+    assert result is not None
+    cached_bytes, content_type = result
+    assert cached_bytes == audio_bytes
+    assert content_type == "audio/wav"
+
+
+async def test_save_audio_replaces_existing():
+    await save_audio(2229, 0, "google", "Charon", b"old", "audio/wav")
+    await save_audio(2229, 0, "google", "Charon", b"new", "audio/wav")
+    cached_bytes, _ = await get_cached_audio(2229, 0, "google", "Charon")
+    assert cached_bytes == b"new"
+
+
+async def test_audio_cache_keyed_by_provider_and_voice():
+    """Different providers / voices for the same chapter must not collide."""
+    await save_audio(2229, 0, "google", "Charon", b"google-charon", "audio/wav")
+    await save_audio(2229, 0, "google", "Leda", b"google-leda", "audio/wav")
+    await save_audio(2229, 0, "edge", "de-DE-FlorianMultilingualNeural", b"edge", "audio/mpeg")
+
+    a, _ = await get_cached_audio(2229, 0, "google", "Charon")
+    b, _ = await get_cached_audio(2229, 0, "google", "Leda")
+    c, _ = await get_cached_audio(2229, 0, "edge", "de-DE-FlorianMultilingualNeural")
+    assert a == b"google-charon"
+    assert b == b"google-leda"
+    assert c == b"edge"
+
+
+async def test_audio_cache_keyed_by_chapter():
+    await save_audio(2229, 0, "google", "Charon", b"chapter-0", "audio/wav")
+    await save_audio(2229, 1, "google", "Charon", b"chapter-1", "audio/wav")
+
+    a, _ = await get_cached_audio(2229, 0, "google", "Charon")
+    b, _ = await get_cached_audio(2229, 1, "google", "Charon")
+    assert a == b"chapter-0"
+    assert b == b"chapter-1"
+
+
+async def test_audio_cache_keyed_by_chunk_index():
+    """Different chunks of the same chapter must be cached independently."""
+    await save_audio(2229, 0, "google", "Charon", b"chunk-0", "audio/wav", chunk_index=0)
+    await save_audio(2229, 0, "google", "Charon", b"chunk-1", "audio/wav", chunk_index=1)
+    await save_audio(2229, 0, "google", "Charon", b"chunk-2", "audio/wav", chunk_index=2)
+
+    a, _ = await get_cached_audio(2229, 0, "google", "Charon", chunk_index=0)
+    b, _ = await get_cached_audio(2229, 0, "google", "Charon", chunk_index=1)
+    c, _ = await get_cached_audio(2229, 0, "google", "Charon", chunk_index=2)
+    assert a == b"chunk-0"
+    assert b == b"chunk-1"
+    assert c == b"chunk-2"
+
+
+async def test_delete_chapter_audio_cache_removes_all_chunks_for_chapter():
+    # Save 3 chunks for chapter 0 (Faust) plus one for chapter 1 (Pride & Prejudice)
+    await save_audio(2229, 0, "google", "Charon", b"c0", "audio/wav", chunk_index=0)
+    await save_audio(2229, 0, "google", "Charon", b"c1", "audio/wav", chunk_index=1)
+    await save_audio(2229, 0, "google", "Charon", b"c2", "audio/wav", chunk_index=2)
+    await save_audio(1342, 0, "google", "Charon", b"other", "audio/wav", chunk_index=0)
+
+    deleted = await delete_chapter_audio_cache(2229, 0)
+    assert deleted == 3
+
+    # All chunks for the deleted chapter are gone
+    assert await get_cached_audio(2229, 0, "google", "Charon", chunk_index=0) is None
+    assert await get_cached_audio(2229, 0, "google", "Charon", chunk_index=1) is None
+    assert await get_cached_audio(2229, 0, "google", "Charon", chunk_index=2) is None
+    # The unrelated chapter is untouched
+    other = await get_cached_audio(1342, 0, "google", "Charon")
+    assert other is not None and other[0] == b"other"
+
+
+async def test_delete_chapter_audio_cache_removes_across_voices_and_providers():
+    """Regenerate should clear ALL voices/providers for the chapter, not just one."""
+    await save_audio(2229, 0, "google", "Charon", b"a", "audio/wav", chunk_index=0)
+    await save_audio(2229, 0, "google", "Leda", b"b", "audio/wav", chunk_index=0)
+    await save_audio(2229, 0, "edge", "de-DE-FlorianMultilingualNeural", b"c", "audio/mpeg", chunk_index=0)
+
+    deleted = await delete_chapter_audio_cache(2229, 0)
+    assert deleted == 3
+
+    assert await get_cached_audio(2229, 0, "google", "Charon") is None
+    assert await get_cached_audio(2229, 0, "google", "Leda") is None
+    assert await get_cached_audio(2229, 0, "edge", "de-DE-FlorianMultilingualNeural") is None
+
+
+async def test_delete_chapter_audio_cache_returns_zero_when_empty():
+    deleted = await delete_chapter_audio_cache(9999, 99)
+    assert deleted == 0
+
+
+async def test_get_cached_audio_default_chunk_index_is_zero():
+    """Backwards compat: callers that don't pass chunk_index get chunk 0."""
+    await save_audio(2229, 0, "google", "Charon", b"first", "audio/wav")  # default chunk=0
+    result = await get_cached_audio(2229, 0, "google", "Charon")  # default chunk=0
+    assert result is not None
+    assert result[0] == b"first"
 
 
 # ── DB_PATH env var + parent directory handling ──────────────────────────────

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -256,6 +256,242 @@ async def test_tts_explicit_google_with_key(client, test_user):
     assert mock_synth.call_args.kwargs["provider"] == "google"
 
 
+# ── TTS audio cache ───────────────────────────────────────────────────────────
+
+async def test_tts_cache_miss_then_hit(client):
+    """First chapter request synthesizes + caches; second is served from cache."""
+    fake_audio = b"FAKE_MP3_BYTES"
+    with patch(
+        "routers.ai.synthesize",
+        new_callable=AsyncMock,
+        return_value=(fake_audio, "audio/mpeg"),
+    ) as mock_synth:
+        # First call: cache miss → synthesize is invoked
+        resp1 = await client.post("/api/ai/tts", json={
+            "text": "Chapter text here.",
+            "language": "en",
+            "rate": 1.0,
+            "book_id": 1342,
+            "chapter_index": 0,
+            "provider": "edge",
+        })
+
+    assert resp1.status_code == 200
+    assert resp1.content == fake_audio
+    assert resp1.headers["x-tts-cache"] == "miss"
+    assert mock_synth.call_count == 1
+
+    # Second call: cache hit → synthesize must NOT be invoked
+    with patch(
+        "routers.ai.synthesize",
+        new_callable=AsyncMock,
+    ) as mock_synth2:
+        resp2 = await client.post("/api/ai/tts", json={
+            "text": "Chapter text here.",
+            "language": "en",
+            "rate": 1.0,
+            "book_id": 1342,
+            "chapter_index": 0,
+            "provider": "edge",
+        })
+
+    assert resp2.status_code == 200
+    assert resp2.content == fake_audio
+    assert resp2.headers["x-tts-cache"] == "hit"
+    mock_synth2.assert_not_called()
+
+
+async def test_tts_without_book_id_skips_cache(client):
+    """Snippet calls (no book_id/chapter_index) never touch the cache."""
+    with patch(
+        "routers.ai.synthesize",
+        new_callable=AsyncMock,
+        return_value=(b"snippet1", "audio/mpeg"),
+    ) as mock_synth:
+        resp1 = await client.post("/api/ai/tts", json={
+            "text": "Hello",
+            "language": "en",
+            "rate": 1.0,
+            "provider": "edge",
+        })
+
+    assert resp1.status_code == 200
+    # No X-TTS-Cache header on snippet calls (cache not consulted)
+    assert "x-tts-cache" not in resp1.headers
+    assert mock_synth.call_count == 1
+
+    # Same request again — synthesize should be called again, no caching
+    with patch(
+        "routers.ai.synthesize",
+        new_callable=AsyncMock,
+        return_value=(b"snippet2", "audio/mpeg"),
+    ) as mock_synth2:
+        resp2 = await client.post("/api/ai/tts", json={
+            "text": "Hello",
+            "language": "en",
+            "rate": 1.0,
+            "provider": "edge",
+        })
+
+    assert resp2.status_code == 200
+    assert resp2.content == b"snippet2"
+    assert mock_synth2.call_count == 1
+
+
+# ── /api/ai/tts/chunks endpoint ───────────────────────────────────────────────
+
+async def test_delete_tts_cache_removes_chapter_chunks(client):
+    """The Regenerate button calls DELETE /api/ai/tts/cache to clear the
+    cached audio so the next play triggers fresh generation."""
+    from services.db import save_audio
+    await save_audio(1342, 0, "edge", "voice-x", b"chunk0", "audio/mpeg", chunk_index=0)
+    await save_audio(1342, 0, "edge", "voice-x", b"chunk1", "audio/mpeg", chunk_index=1)
+
+    resp = await client.delete("/api/ai/tts/cache?book_id=1342&chapter_index=0")
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] == 2
+
+    # Subsequent /tts request must miss the cache
+    with patch(
+        "routers.ai.synthesize",
+        new_callable=AsyncMock,
+        return_value=(b"fresh", "audio/mpeg"),
+    ):
+        resp2 = await client.post("/api/ai/tts", json={
+            "text": "x", "language": "en", "rate": 1.0,
+            "book_id": 1342, "chapter_index": 0, "chunk_index": 0,
+            "provider": "edge",
+        })
+    assert resp2.headers["x-tts-cache"] == "miss"
+
+
+async def test_delete_tts_cache_zero_when_nothing_cached(client):
+    resp = await client.delete("/api/ai/tts/cache?book_id=9999&chapter_index=99")
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] == 0
+
+
+async def test_tts_chunks_returns_chunk_list(client):
+    """Frontend calls this once per chapter to know how to slice the text."""
+    resp = await client.post("/api/ai/tts/chunks", json={"text": "Just one short paragraph."})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "chunks" in data
+    assert data["chunks"] == ["Just one short paragraph."]
+
+
+async def test_tts_chunks_splits_long_text(client):
+    long_text = "\n\n".join([f"Paragraph {i}: " + ("x" * 200) for i in range(5)])
+    resp = await client.post("/api/ai/tts/chunks", json={"text": long_text})
+    assert resp.status_code == 200
+    chunks = resp.json()["chunks"]
+    assert len(chunks) > 1
+    # Concat of chunks should contain the same content (whitespace preserved or not)
+    rejoined = " ".join(chunks)
+    assert "Paragraph 0:" in rejoined
+    assert "Paragraph 4:" in rejoined
+
+
+async def test_tts_chunks_requires_auth(client):
+    """The chunks endpoint goes through get_current_user. With the test
+    fixture overriding it, the call succeeds — this just confirms the
+    dependency wiring is in place."""
+    resp = await client.post("/api/ai/tts/chunks", json={"text": "x"})
+    assert resp.status_code == 200
+
+
+async def test_tts_chunk_index_keys_cache_separately(client):
+    """Two requests for the same chapter but different chunk_index produce
+    independent cache entries — neither hit if the other is set."""
+    with patch(
+        "routers.ai.synthesize",
+        new_callable=AsyncMock,
+        return_value=(b"chunk-0-audio", "audio/mpeg"),
+    ):
+        resp0 = await client.post("/api/ai/tts", json={
+            "text": "Chunk zero text.",
+            "language": "en",
+            "rate": 1.0,
+            "book_id": 1342,
+            "chapter_index": 0,
+            "chunk_index": 0,
+            "provider": "edge",
+        })
+    assert resp0.headers["x-tts-cache"] == "miss"
+
+    with patch(
+        "routers.ai.synthesize",
+        new_callable=AsyncMock,
+        return_value=(b"chunk-1-audio", "audio/mpeg"),
+    ):
+        resp1 = await client.post("/api/ai/tts", json={
+            "text": "Chunk one text.",
+            "language": "en",
+            "rate": 1.0,
+            "book_id": 1342,
+            "chapter_index": 0,
+            "chunk_index": 1,
+            "provider": "edge",
+        })
+    # Different chunk_index → independent cache miss, NOT a hit on chunk 0
+    assert resp1.headers["x-tts-cache"] == "miss"
+    assert resp1.content == b"chunk-1-audio"
+
+    # Refetch chunk 0 → should be a cache hit
+    with patch("routers.ai.synthesize") as never_called:
+        resp0_again = await client.post("/api/ai/tts", json={
+            "text": "Chunk zero text.",
+            "language": "en",
+            "rate": 1.0,
+            "book_id": 1342,
+            "chapter_index": 0,
+            "chunk_index": 0,
+            "provider": "edge",
+        })
+    assert resp0_again.headers["x-tts-cache"] == "hit"
+    assert resp0_again.content == b"chunk-0-audio"
+    never_called.assert_not_called()
+
+
+async def test_tts_cache_keyed_by_provider(client, test_user):
+    """Same chapter, different provider → different cache entries."""
+    await _set_key(test_user)
+
+    with patch(
+        "routers.ai.synthesize",
+        new_callable=AsyncMock,
+        return_value=(b"edge-audio", "audio/mpeg"),
+    ):
+        resp_edge = await client.post("/api/ai/tts", json={
+            "text": "Hello",
+            "language": "en",
+            "rate": 1.0,
+            "book_id": 1342,
+            "chapter_index": 0,
+            "provider": "edge",
+        })
+    assert resp_edge.headers["x-tts-cache"] == "miss"
+
+    with patch(
+        "routers.ai.synthesize",
+        new_callable=AsyncMock,
+        return_value=(b"google-audio", "audio/wav"),
+    ) as mock_google:
+        resp_google = await client.post("/api/ai/tts", json={
+            "text": "Hello",
+            "language": "en",
+            "rate": 1.0,
+            "book_id": 1342,
+            "chapter_index": 0,
+            "provider": "google",
+        })
+
+    # Google must be a separate cache miss — the edge entry doesn't satisfy it
+    assert resp_google.headers["x-tts-cache"] == "miss"
+    assert resp_google.content == b"google-audio"
+    mock_google.assert_called_once()
+
+
 # ── Videos ────────────────────────────────────────────────────────────────────
 
 async def test_videos_without_key_returns_400(client):

--- a/backend/tests/test_router_audiobooks.py
+++ b/backend/tests/test_router_audiobooks.py
@@ -16,9 +16,12 @@ AUDIOBOOK = {
 }
 
 
-async def test_get_audiobook_404_when_not_linked(client):
+async def test_get_audiobook_returns_null_when_not_linked(client):
+    """No audiobook linked → 200 with null body (not 404), so the reader
+    page can call this on every load without producing console noise."""
     resp = await client.get("/api/audiobooks/2229")
-    assert resp.status_code == 404
+    assert resp.status_code == 200
+    assert resp.json() is None
 
 
 async def test_get_audiobook_returns_saved(client):
@@ -45,7 +48,8 @@ async def test_delete_audiobook(client):
     assert resp.json()["ok"] is True
 
     get_resp = await client.get("/api/audiobooks/2229")
-    assert get_resp.status_code == 404
+    assert get_resp.status_code == 200
+    assert get_resp.json() is None
 
 
 async def test_search_audiobooks(client):

--- a/backend/tests/test_tts.py
+++ b/backend/tests/test_tts.py
@@ -6,15 +6,20 @@ External SDKs (edge_tts.Communicate, google.genai.Client) are mocked.
 
 import pytest
 from unittest.mock import MagicMock, patch
+import struct
+
 from services.tts import (
     _pick_edge_voice,
     _pick_gemini_voice,
     _rate_str,
     _pcm_to_wav,
+    _chunk_text_for_tts,
+    _trim_trailing_silence,
     synthesize,
     EDGE_VOICE_MAP,
     GEMINI_VOICE_MAP,
     GEMINI_DEFAULT_VOICE,
+    GEMINI_TTS_CHUNK_CHARS,
 )
 
 
@@ -148,6 +153,138 @@ async def test_edge_synthesize_uses_correct_voice_and_rate():
     mock_cls.assert_called_once_with("Test", EDGE_VOICE_MAP["de"], rate="+50%")
 
 
+# ── _chunk_text_for_tts ───────────────────────────────────────────────────────
+
+def test_chunk_short_text_returns_single_chunk():
+    text = "Just a short paragraph."
+    chunks = _chunk_text_for_tts(text)
+    assert chunks == ["Just a short paragraph."]
+
+
+def test_chunk_drops_empty_paragraphs():
+    text = "\n\n\n\nFirst.\n\n\n\nSecond.\n\n"
+    chunks = _chunk_text_for_tts(text)
+    # All paragraphs fit in one chunk
+    assert len(chunks) == 1
+    assert "First." in chunks[0]
+    assert "Second." in chunks[0]
+
+
+def test_chunk_groups_paragraphs_under_limit():
+    text = "A" * 100 + "\n\n" + "B" * 100 + "\n\n" + "C" * 100
+    chunks = _chunk_text_for_tts(text, max_chars=400)
+    # All three paragraphs fit (100+2+100+2+100 = 304 chars)
+    assert len(chunks) == 1
+
+
+def test_chunk_splits_when_over_limit():
+    text = "A" * 200 + "\n\n" + "B" * 200 + "\n\n" + "C" * 200
+    chunks = _chunk_text_for_tts(text, max_chars=300)
+    # Each paragraph is 200 chars, two would be 400+ → split into 3 chunks
+    assert len(chunks) == 3
+
+
+def test_chunk_splits_oversized_paragraph_on_lines():
+    # One long paragraph, much bigger than max_chars
+    long_para = "\n".join([f"Line {i} of this poem about ocean waves." for i in range(20)])
+    chunks = _chunk_text_for_tts(long_para, max_chars=100)
+    assert len(chunks) > 1
+    # Each chunk should be under or near the limit
+    for c in chunks:
+        # Allow ~one line over since we add lines greedily
+        assert len(c) <= 200, f"Chunk too big: {len(c)}"
+    # And the original content should be reconstructable
+    rejoined = " ".join(chunks)
+    assert "Line 0" in rejoined
+    assert "Line 19" in rejoined
+
+
+def test_chunk_real_faust_text():
+    """Faust Zueignung is ~1400 chars — should chunk into a handful of pieces."""
+    faust = """Zueignung
+
+
+Ihr naht euch wieder, schwankende Gestalten,
+Die früh sich einst dem trüben Blick gezeigt.
+Versuch ich wohl, euch diesmal festzuhalten?
+
+Ihr drängt euch zu! nun gut, so mögt ihr walten,
+Wie ihr aus Dunst und Nebel um mich steigt;
+Mein Busen fühlt sich jugendlich erschüttert.
+
+Vom Zauberhauch, der euren Zug umwittert.
+Ihr bringt mit euch die Bilder froher Tage,
+Und manche liebe Schatten steigen auf;
+"""
+    chunks = _chunk_text_for_tts(faust, max_chars=GEMINI_TTS_CHUNK_CHARS)
+    assert len(chunks) >= 1
+    # Every chunk respects the size cap (with line-split slack)
+    for c in chunks:
+        assert len(c) <= GEMINI_TTS_CHUNK_CHARS + 100
+
+
+def test_chunk_empty_input():
+    assert _chunk_text_for_tts("") == []
+    assert _chunk_text_for_tts("\n\n  \n\n") == []
+
+
+# ── _trim_trailing_silence ────────────────────────────────────────────────────
+
+def _make_silence(samples: int) -> bytes:
+    return struct.pack(f"<{samples}h", *([0] * samples))
+
+
+def _make_loud(samples: int, amplitude: int = 5000) -> bytes:
+    """A simple loud waveform — alternating samples."""
+    return struct.pack(f"<{samples}h", *([amplitude, -amplitude] * (samples // 2)))
+
+
+def test_trim_silence_keeps_pure_speech_intact():
+    speech = _make_loud(24000)  # 1 second of loud audio
+    trimmed = _trim_trailing_silence(speech, sample_rate=24000)
+    # Should keep all of it (allowing for the small tail cushion)
+    assert len(trimmed) >= len(speech) * 0.9
+
+
+def test_trim_silence_removes_long_trailing_silence():
+    # 1 second of speech followed by 5 seconds of silence
+    speech = _make_loud(24000)
+    silence = _make_silence(5 * 24000)
+    pcm = speech + silence
+    trimmed = _trim_trailing_silence(pcm, sample_rate=24000, tail_ms=250)
+
+    # Trimmed result should be approximately 1.25s (speech + tail), not 6s
+    n_samples = len(trimmed) // 2
+    assert n_samples < 24000 * 2, f"Expected < 2s of audio, got {n_samples / 24000:.2f}s"
+    assert n_samples > 24000 * 0.9, f"Expected > 0.9s of audio, got {n_samples / 24000:.2f}s"
+
+
+def test_trim_silence_preserves_internal_silence():
+    """A natural pause in the middle of speech should NOT be cut."""
+    speech1 = _make_loud(24000)             # 1 sec speech
+    pause = _make_silence(int(24000 * 0.5)) # 0.5 sec pause
+    speech2 = _make_loud(24000)             # 1 sec speech
+    trailing = _make_silence(5 * 24000)     # 5 sec trailing silence
+    pcm = speech1 + pause + speech2 + trailing
+
+    trimmed = _trim_trailing_silence(pcm, sample_rate=24000, tail_ms=250)
+    n_samples = len(trimmed) // 2
+    # Should keep ~2.75s (1 + 0.5 + 1 + 0.25 tail), not the 7.5s total
+    assert n_samples > 24000 * 2.4, f"Lost the second speech segment: {n_samples / 24000:.2f}s"
+    assert n_samples < 24000 * 3.5, f"Did not trim trailing: {n_samples / 24000:.2f}s"
+
+
+def test_trim_silence_all_silence_returns_unchanged():
+    silence = _make_silence(24000)
+    trimmed = _trim_trailing_silence(silence)
+    # Falls back to returning input unchanged when nothing is loud
+    assert trimmed == silence
+
+
+def test_trim_silence_empty_input():
+    assert _trim_trailing_silence(b"") == b""
+
+
 # ── Gemini backend ────────────────────────────────────────────────────────────
 
 class _FakeInlineData:
@@ -201,6 +338,38 @@ async def test_gemini_synthesize_returns_wav_bytes_and_wav_content_type():
     assert audio[:4] == b"RIFF"
     assert audio[8:12] == b"WAVE"
     assert audio.endswith(pcm)
+
+
+async def test_gemini_synthesize_calls_generate_content_once_per_request():
+    """The synthesize() function is single-chunk — chunking is now the
+    caller's responsibility (frontend uses /api/ai/tts/chunks for that).
+    A long input should still result in exactly ONE API call here."""
+    long_text = "\n\n".join([f"Paragraph number {i}. " + ("x" * 200) for i in range(5)])
+
+    call_count = {"n": 0}
+    pcm_per_call = b"\x00\x10" * 100
+
+    fake_genai = MagicMock()
+    fake_types = MagicMock()
+
+    async def counting_generate_content(model, contents, config):  # noqa: ARG001
+        call_count["n"] += 1
+        return _FakeResponse(pcm_per_call)
+
+    fake_genai.Client.return_value.aio.models.generate_content = counting_generate_content
+
+    with patch.dict("sys.modules", {
+        "google": MagicMock(genai=fake_genai),
+        "google.genai": fake_genai,
+        "google.genai.types": fake_types,
+    }):
+        audio, ct = await synthesize(
+            long_text, "en", 1.0, provider="google", gemini_key="dummy-key"
+        )
+
+    assert call_count["n"] == 1, f"Expected exactly 1 API call, got {call_count['n']}"
+    assert ct == "audio/wav"
+    assert audio[:4] == b"RIFF"
 
 
 async def test_gemini_synthesize_requires_api_key():

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -15,6 +15,8 @@ import {
   askQuestion,
   checkPronunciation,
   synthesizeSpeech,
+  getTtsChunks,
+  deleteAudioCache,
   findVideos,
   searchAudiobooks,
   getAudiobook,
@@ -209,9 +211,65 @@ test("synthesizeSpeech forwards an AbortSignal to fetch", async () => {
     blob: jest.fn().mockResolvedValue(new Blob(["x"])),
   });
   const abort = new AbortController();
-  await synthesizeSpeech("Hello", "en", 1.0, "auto", abort.signal);
+  await synthesizeSpeech("Hello", "en", 1.0, "auto", { signal: abort.signal });
   const opts = (global.fetch as jest.Mock).mock.calls[0][1];
   expect(opts.signal).toBe(abort.signal);
+});
+
+test("synthesizeSpeech includes chunk_index when provided", async () => {
+  global.URL.createObjectURL = jest.fn().mockReturnValue("blob:fake");
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    blob: jest.fn().mockResolvedValue(new Blob(["x"])),
+  });
+  await synthesizeSpeech("Hello", "en", 1.0, "auto", { bookId: 1, chapterIndex: 2, chunkIndex: 5 });
+  const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+  expect(body.chunk_index).toBe(5);
+});
+
+test("getTtsChunks calls /ai/tts/chunks and returns the chunk list", async () => {
+  mockFetch({ chunks: ["first chunk", "second chunk", "third chunk"] });
+  const chunks = await getTtsChunks("the full chapter text");
+  expect(chunks).toEqual(["first chunk", "second chunk", "third chunk"]);
+  const [url, opts] = (global.fetch as jest.Mock).mock.calls[0];
+  expect(url).toContain("/ai/tts/chunks");
+  expect(opts.method).toBe("POST");
+  expect(JSON.parse(opts.body).text).toBe("the full chapter text");
+});
+
+test("deleteAudioCache sends DELETE with book_id and chapter_index", async () => {
+  mockFetch({ deleted: 5 });
+  const result = await deleteAudioCache(1342, 3);
+  expect(result.deleted).toBe(5);
+  const [url, opts] = (global.fetch as jest.Mock).mock.calls[0];
+  expect(url).toContain("/ai/tts/cache");
+  expect(url).toContain("book_id=1342");
+  expect(url).toContain("chapter_index=3");
+  expect(opts.method).toBe("DELETE");
+});
+
+test("synthesizeSpeech includes book_id and chapter_index when provided", async () => {
+  global.URL.createObjectURL = jest.fn().mockReturnValue("blob:fake");
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    blob: jest.fn().mockResolvedValue(new Blob(["x"])),
+  });
+  await synthesizeSpeech("Hello", "en", 1.0, "auto", { bookId: 1342, chapterIndex: 3 });
+  const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+  expect(body.book_id).toBe(1342);
+  expect(body.chapter_index).toBe(3);
+});
+
+test("synthesizeSpeech omits book_id when not provided", async () => {
+  global.URL.createObjectURL = jest.fn().mockReturnValue("blob:fake");
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    blob: jest.fn().mockResolvedValue(new Blob(["x"])),
+  });
+  await synthesizeSpeech("Hello", "en");
+  const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+  expect(body.book_id).toBeUndefined();
+  expect(body.chapter_index).toBeUndefined();
 });
 
 test("synthesizeSpeech throws on non-ok response", async () => {

--- a/frontend/src/__tests__/audio.test.ts
+++ b/frontend/src/__tests__/audio.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for lib/audio.ts — persistent playback positions per (book, chapter).
+ */
+
+import {
+  getAudioPosition,
+  saveAudioPosition,
+  clearAudioPosition,
+} from "@/lib/audio";
+
+beforeEach(() => localStorage.clear());
+
+test("getAudioPosition returns 0 for an unknown chapter", () => {
+  expect(getAudioPosition(1342, 0)).toBe(0);
+});
+
+test("saveAudioPosition then getAudioPosition round-trips", () => {
+  saveAudioPosition(1342, 0, 42.5);
+  expect(getAudioPosition(1342, 0)).toBe(42.5);
+});
+
+test("positions are independent per chapter", () => {
+  saveAudioPosition(1342, 0, 10);
+  saveAudioPosition(1342, 1, 20);
+  expect(getAudioPosition(1342, 0)).toBe(10);
+  expect(getAudioPosition(1342, 1)).toBe(20);
+});
+
+test("positions are independent per book", () => {
+  saveAudioPosition(1342, 0, 10);
+  saveAudioPosition(2229, 0, 30);
+  expect(getAudioPosition(1342, 0)).toBe(10);
+  expect(getAudioPosition(2229, 0)).toBe(30);
+});
+
+test("clearAudioPosition removes a saved position", () => {
+  saveAudioPosition(1342, 0, 10);
+  clearAudioPosition(1342, 0);
+  expect(getAudioPosition(1342, 0)).toBe(0);
+});
+
+test("clearAudioPosition does not throw for an unknown chapter", () => {
+  expect(() => clearAudioPosition(9999, 99)).not.toThrow();
+});
+
+test("getAudioPosition ignores invalid stored values", () => {
+  localStorage.setItem("audio_position:1342:0", "not-a-number");
+  expect(getAudioPosition(1342, 0)).toBe(0);
+});
+
+test("getAudioPosition ignores negative stored values", () => {
+  localStorage.setItem("audio_position:1342:0", "-5");
+  expect(getAudioPosition(1342, 0)).toBe(0);
+});
+
+test("saveAudioPosition silently ignores invalid input", () => {
+  saveAudioPosition(1342, 0, NaN);
+  saveAudioPosition(1342, 0, -1);
+  expect(getAudioPosition(1342, 0)).toBe(0);
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -43,6 +43,16 @@ export default function ReaderPage() {
   const [audioIsPlaying, setAudioIsPlaying] = useState(false);
   const seekAudioRef = useRef<(t: number) => void>(() => {});
 
+  // TTS Read-button playback state — fed by TTSControls via callback props.
+  // When no LibriVox audiobook is linked, these drive the SentenceReader's
+  // sentence highlighting and click-to-seek.
+  const [ttsCurrentTime, setTtsCurrentTime] = useState(0);
+  const [ttsDuration, setTtsDuration] = useState(0);
+  const [ttsIsPlaying, setTtsIsPlaying] = useState(false);
+  const [ttsIsLoading, setTtsIsLoading] = useState(false);
+  const [ttsChunks, setTtsChunks] = useState<{ text: string; duration: number }[]>([]);
+  const ttsSeekRef = useRef<(t: number) => void>(() => {});
+
   // Sidebar (insight chat) — hidden by default, resizable
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(320);
@@ -441,22 +451,51 @@ export default function ReaderPage() {
               <>
                 <SentenceReader
                   text={current?.text ?? ""}
-                  duration={audioDuration}
-                  currentTime={audioCurrentTime}
-                  isPlaying={audioIsPlaying}
+                  // SentenceReader's source of truth: prefer the LibriVox audiobook
+                  // if one is linked, otherwise fall back to the TTS Read-button
+                  // playback. Either way the SentenceReader does the same
+                  // sentence segmentation + word-proportion timing math.
+                  duration={audiobook ? audioDuration : ttsDuration}
+                  currentTime={audiobook ? audioCurrentTime : ttsCurrentTime}
+                  isPlaying={audiobook ? audioIsPlaying : ttsIsPlaying}
                   images={bookImages}
-                  onSegmentClick={(_startTime, segText) => {
-                    synthesizeSpeech(segText, bookLanguage, 1.0, getSettings().ttsProvider).then((url) => {
-                      const audio = new Audio(url);
-                      audio.onended = () => URL.revokeObjectURL(url);
-                      audio.play().catch(() => URL.revokeObjectURL(url));
-                    }).catch(() => {
-                      // Fallback to Web Speech API
-                      window.speechSynthesis.cancel();
-                      const utter = new SpeechSynthesisUtterance(segText);
-                      utter.lang = bookLanguage;
-                      window.speechSynthesis.speak(utter);
-                    });
+                  // Pass the chunk metadata only when using TTS (not LibriVox).
+                  // SentenceReader uses it for accurate per-chunk timing AND
+                  // for muted/loaded color of segments in unloaded chunks.
+                  chunks={!audiobook && ttsChunks.length > 0 ? ttsChunks : undefined}
+                  // Block sentence clicks while TTS is generating to prevent
+                  // accidentally firing one-off snippets that conflict with
+                  // the in-flight chapter generation.
+                  disabled={!audiobook && ttsIsLoading}
+                  onSegmentClick={(startTime, segText) => {
+                    // Priority 1: LibriVox audiobook is linked → seek it
+                    if (audiobook) {
+                      seekAudioRef.current(startTime);
+                      return;
+                    }
+                    // Priority 2: TTS chapter audio is already loaded → seek
+                    // it to the clicked sentence and play. Reuses the same
+                    // cached audio that the Read button uses.
+                    if (ttsDuration > 0) {
+                      ttsSeekRef.current(startTime);
+                      return;
+                    }
+                    // Priority 3: nothing loaded yet → one-off snippet TTS,
+                    // same fallback as before. Doesn't trigger chapter audio
+                    // generation (preserves the lazy-load contract).
+                    synthesizeSpeech(segText, bookLanguage, 1.0, getSettings().ttsProvider)
+                      .then((url) => {
+                        const audio = new Audio(url);
+                        audio.onended = () => URL.revokeObjectURL(url);
+                        audio.play().catch(() => URL.revokeObjectURL(url));
+                      })
+                      .catch(() => {
+                        // Web Speech API as final fallback (network or auth failure)
+                        window.speechSynthesis.cancel();
+                        const utter = new SpeechSynthesisUtterance(segText);
+                        utter.lang = bookLanguage;
+                        window.speechSynthesis.speak(utter);
+                      });
                   }}
                 />
                 <div className="max-w-prose mx-auto mt-10 flex justify-between">
@@ -500,7 +539,22 @@ export default function ReaderPage() {
 
           {/* TTS + Recorder */}
           <div className="border-t border-amber-200 shrink-0">
-            <TTSControls text={current?.text ?? ""} language={bookLanguage} />
+            <TTSControls
+              text={current?.text ?? ""}
+              language={bookLanguage}
+              bookId={Number(bookId)}
+              chapterIndex={chapterIndex}
+              onPlaybackUpdate={(currentTime, duration, isPlaying) => {
+                setTtsCurrentTime(currentTime);
+                setTtsDuration(duration);
+                setTtsIsPlaying(isPlaying);
+              }}
+              onLoadingChange={setTtsIsLoading}
+              onChunksUpdate={setTtsChunks}
+              onSeekRegister={(seekFn) => {
+                ttsSeekRef.current = seekFn;
+              }}
+            />
             <div className="px-3 pb-3">
               <button
                 onClick={() => setShowRecorder((v) => !v)}

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -7,13 +7,20 @@ import { BookImage } from "@/lib/api";
 interface Segment {
   text: string;
   flatIdx: number;
-  startTime: number; // estimated, seconds
+  startTime: number;  // estimated, seconds
+  chunkIdx: number;   // which chunk this segment belongs to (-1 if no chunks given)
 }
 
 interface Paragraph {
   segments: Segment[];
   isVerse: boolean;      // true = poetry (newlines between lines), false = prose
   illustration: BookImage | null; // non-null = render as image, not text
+}
+
+/** Optional chunk metadata for accurate timing + per-chunk visual coloring. */
+export interface ChunkInfo {
+  text: string;
+  duration: number;  // 0 if not yet loaded; positive once the chunk's audio loads
 }
 
 // Common abbreviations that should not trigger a sentence split
@@ -61,7 +68,12 @@ function isVerse(lines: string[]): boolean {
 /** Match a [Illustration...] marker and extract the caption. */
 const ILLUS_RE = /^\[Illustration(?::\s*(.+?))?\s*\]$/is;
 
-function parseIntoSegments(text: string, duration: number, images: BookImage[]): Paragraph[] {
+function parseIntoSegments(
+  text: string,
+  duration: number,
+  images: BookImage[],
+  chunks?: ChunkInfo[],
+): Paragraph[] {
   // Step 1: collect all segment texts and classify paragraphs
   const rawParas = text.split(/\n\n+/);
   const paraData: { texts: string[]; isVerse: boolean; illustrationIdx: number | null }[] = [];
@@ -100,14 +112,68 @@ function parseIntoSegments(text: string, duration: number, images: BookImage[]):
     }
   }
 
-  // Step 2: build time map (word-proportion estimate)
+  // Step 2a: figure out which chunk each segment belongs to (when chunks present)
+  // The chunker splits the chapter at paragraph boundaries; the segmenter
+  // splits at sentences/lines. So a segment never spans chunk boundaries —
+  // we just walk both lists in chapter order and assign.
+  const segmentChunkIdx: number[] = new Array(allTexts.length).fill(-1);
+  if (chunks && chunks.length > 0) {
+    let chunkIdx = 0;
+    let cursor = 0;            // index into the current chunk's text
+    for (let s = 0; s < allTexts.length; s++) {
+      const seg = allTexts[s];
+      // Find this segment within the remaining chunk text
+      while (chunkIdx < chunks.length) {
+        const chunkText = chunks[chunkIdx].text;
+        const pos = chunkText.indexOf(seg, cursor);
+        if (pos >= 0) {
+          segmentChunkIdx[s] = chunkIdx;
+          cursor = pos + seg.length;
+          break;
+        }
+        // Not in this chunk — move to the next
+        chunkIdx++;
+        cursor = 0;
+      }
+      // Out of chunks → leave -1 (won't get a startTime, won't be coloured-as-loaded)
+    }
+  }
+
+  // Step 2b: build time map.
+  // Two paths:
+  //   a) chunks given → distribute segments within each chunk by word count,
+  //      using the chunk's MEASURED duration. This is much more accurate
+  //      than linear interpolation across the whole chapter because it
+  //      accounts for varying speech rate per chunk.
+  //   b) no chunks → fall back to linear word-proportion across `duration`.
   const wordCounts = allTexts.map((s) => Math.max(1, s.split(/\s+/).filter(Boolean).length));
-  const totalWords = wordCounts.reduce((a, b) => a + b, 0) || 1;
-  const startTimes: number[] = [];
-  let elapsed = 0;
-  for (const wc of wordCounts) {
-    startTimes.push((elapsed / totalWords) * duration);
-    elapsed += wc;
+  const startTimes: number[] = new Array(allTexts.length).fill(0);
+
+  if (chunks && chunks.length > 0) {
+    let chunkStartTime = 0;
+    for (let ci = 0; ci < chunks.length; ci++) {
+      const chunk = chunks[ci];
+      // Indices of segments in this chunk
+      const segIndices: number[] = [];
+      for (let s = 0; s < allTexts.length; s++) {
+        if (segmentChunkIdx[s] === ci) segIndices.push(s);
+      }
+      const chunkWords = segIndices.reduce((sum, idx) => sum + wordCounts[idx], 0) || 1;
+      let elapsed = 0;
+      for (const idx of segIndices) {
+        startTimes[idx] = chunkStartTime + (elapsed / chunkWords) * chunk.duration;
+        elapsed += wordCounts[idx];
+      }
+      chunkStartTime += chunk.duration;
+    }
+  } else {
+    // Linear fallback (used by the LibriVox audiobook path)
+    const totalWords = wordCounts.reduce((a, b) => a + b, 0) || 1;
+    let elapsed = 0;
+    for (let i = 0; i < allTexts.length; i++) {
+      startTimes[i] = (elapsed / totalWords) * duration;
+      elapsed += wordCounts[i];
+    }
   }
 
   // Step 3: map back to paragraph structure
@@ -120,11 +186,15 @@ function parseIntoSegments(text: string, duration: number, images: BookImage[]):
     return {
       isVerse: verse,
       illustration: null,
-      segments: texts.map((text) => ({
-        text,
-        flatIdx: flat,
-        startTime: startTimes[flat++],
-      })),
+      segments: texts.map((text) => {
+        const here = flat++;
+        return {
+          text,
+          flatIdx: here,
+          startTime: startTimes[here],
+          chunkIdx: segmentChunkIdx[here],
+        };
+      }),
     };
   });
 }
@@ -138,6 +208,19 @@ interface Props {
   isPlaying: boolean;
   images?: BookImage[];
   onSegmentClick: (startTime: number, text: string) => void;
+  /**
+   * Per-chunk metadata for chunked TTS playback. When provided, segment
+   * timings are computed per-chunk (much more accurate than linear), and
+   * segments in not-yet-loaded chunks (duration === 0) are visually muted.
+   */
+  chunks?: ChunkInfo[];
+  /**
+   * When true, sentence clicks are ignored and segments are visually
+   * deemphasized. Used while TTS audio is generating, so the user can't
+   * accidentally trigger a one-off snippet that conflicts with the
+   * in-flight chapter generation.
+   */
+  disabled?: boolean;
 }
 
 export default function SentenceReader({
@@ -147,11 +230,26 @@ export default function SentenceReader({
   isPlaying,
   images = [],
   onSegmentClick,
+  chunks,
+  disabled = false,
 }: Props) {
   const paragraphs = useMemo(
-    () => parseIntoSegments(text, Math.max(duration, 1), images),
-    [text, duration, images]
+    () => parseIntoSegments(text, Math.max(duration, 1), images, chunks),
+    [text, duration, images, chunks]
   );
+
+  // For coloring: which chunk indices have actually loaded (duration > 0)
+  const loadedChunkIndices = useMemo(() => {
+    if (!chunks) return null;
+    const set = new Set<number>();
+    chunks.forEach((c, i) => { if (c.duration > 0) set.add(i); });
+    return set;
+  }, [chunks]);
+
+  function isSegmentLoaded(seg: { chunkIdx: number }): boolean {
+    if (loadedChunkIndices === null) return true;  // no chunks given → always rendered normally
+    return seg.chunkIdx >= 0 && loadedChunkIndices.has(seg.chunkIdx);
+  }
 
   const allSegments = useMemo(
     () => paragraphs.flatMap((p) => p.segments),
@@ -201,6 +299,31 @@ export default function SentenceReader({
           );
         }
 
+        // Helper: pick the className for a segment span based on:
+        //   - whether it's the currently-playing one (active)
+        //   - whether its chunk has finished loading (loaded)
+        //   - whether sentence clicks are blocked (disabled)
+        const segClass = (seg: { flatIdx: number; chunkIdx: number }): string => {
+          const active = seg.flatIdx === currentIdx;
+          const loaded = isSegmentLoaded(seg);
+          if (active) return "bg-amber-300 text-amber-950 cursor-pointer";
+          if (disabled) {
+            // Loading state: muted text, no hover, not clickable
+            return loaded
+              ? "text-stone-500 cursor-default"
+              : "text-stone-400/70 cursor-default";
+          }
+          return loaded
+            ? "cursor-pointer hover:bg-amber-100"
+            : "text-stone-400 cursor-default";
+        };
+
+        const handleSegClick = (seg: { startTime: number; text: string; chunkIdx: number }) => {
+          if (disabled) return;
+          if (!isSegmentLoaded(seg)) return;
+          onSegmentClick(seg.startTime, seg.text);
+        };
+
         if (para.isVerse) {
           // Poetry: each segment on its own line
           return (
@@ -212,12 +335,8 @@ export default function SentenceReader({
                     <span
                       ref={active ? (el) => { activeRef.current = el; } : undefined}
                       data-seg={seg.flatIdx}
-                      onClick={() => onSegmentClick(seg.startTime, seg.text)}
-                      className={`cursor-pointer rounded px-0.5 -mx-0.5 transition-colors duration-150 ${
-                        active
-                          ? "bg-amber-300 text-amber-950"
-                          : "hover:bg-amber-100"
-                      }`}
+                      onClick={() => handleSegClick(seg)}
+                      className={`rounded px-0.5 -mx-0.5 transition-colors duration-200 ${segClass(seg)}`}
                     >
                       {seg.text}
                     </span>
@@ -238,12 +357,8 @@ export default function SentenceReader({
                   key={seg.flatIdx}
                   ref={active ? (el) => { activeRef.current = el; } : undefined}
                   data-seg={seg.flatIdx}
-                  onClick={() => onSegmentClick(seg.startTime, seg.text)}
-                  className={`cursor-pointer rounded px-0.5 -mx-0.5 transition-colors duration-150 ${
-                    active
-                      ? "bg-amber-300 text-amber-950"
-                      : "hover:bg-amber-100"
-                  }`}
+                  onClick={() => handleSegClick(seg)}
+                  className={`rounded px-0.5 -mx-0.5 transition-colors duration-200 ${segClass(seg)}`}
                 >
                   {seg.text}
                   {sIdx < para.segments.length - 1 ? " " : ""}

--- a/frontend/src/components/TTSControls.tsx
+++ b/frontend/src/components/TTSControls.tsx
@@ -1,152 +1,594 @@
 "use client";
-import { useEffect, useRef, useState } from "react";
-import { synthesizeSpeech } from "@/lib/api";
+import { useEffect, useRef, useState, useCallback } from "react";
+import { synthesizeSpeech, getTtsChunks, deleteAudioCache } from "@/lib/api";
 import { getSettings } from "@/lib/settings";
+import { getAudioPosition, saveAudioPosition, clearAudioPosition } from "@/lib/audio";
+
+export interface ChunkSnapshot {
+  text: string;
+  duration: number;  // 0 until the chunk's audio loads
+}
 
 interface Props {
   text: string;
   language: string;
+  bookId: number;
+  chapterIndex: number;
+  /**
+   * Lift live playback state to the parent so SentenceReader can highlight
+   * the currently-playing sentence. currentTime/duration are in *global*
+   * time across all chunks, not per-chunk.
+   */
+  onPlaybackUpdate?: (currentTime: number, duration: number, isPlaying: boolean) => void;
+  /** Notifies the parent whenever generation is in progress (true) or done. */
+  onLoadingChange?: (isLoading: boolean) => void;
+  /**
+   * Notifies the parent of the current chunks list — text + duration per
+   * chunk. Duration is 0 for chunks that haven't loaded yet. Used by
+   * SentenceReader for accurate per-chunk timing and visual loaded/unloaded
+   * coloring of segments.
+   */
+  onChunksUpdate?: (chunks: ChunkSnapshot[]) => void;
+  /**
+   * Register a seek-and-play function with the parent (SentenceReader uses
+   * it to jump to the start time of a clicked sentence). The seek time is
+   * in global chunk-aggregated seconds.
+   */
+  onSeekRegister?: (seekAndPlay: (time: number) => void) => void;
 }
 
-export default function TTSControls({ text, language }: Props) {
-  const [status, setStatus] = useState<"idle" | "loading" | "playing" | "paused">("idle");
-  const [rate, setRate] = useState(1.0);
+type Status =
+  | "idle"     // no chapter loaded yet
+  | "loading"  // fetching chunks (one per HTTP request, sequential)
+  | "paused"   // chapter ready (audio loaded OR not yet fetched) → "▶ Read"
+  | "playing"  // currently playing
+  | "error";
 
-  const audioRef = useRef<HTMLAudioElement | null>(null);
-  const blobUrlRef = useRef<string | null>(null);
+interface ChunkState {
+  index: number;
+  text: string;       // for the "Preparing chunk N: <preview>" UI
+  audio: HTMLAudioElement;
+  blobUrl: string;
+  duration: number;
+}
+
+interface LoadingState {
+  index: number;
+  total: number;
+  preview: string;    // first ~60 chars of the chunk currently being fetched
+}
+
+/**
+ * Chapter audio player with frontend-driven chunking.
+ *
+ * Flow:
+ * 1. User clicks ▶ Read for the first time on this chapter.
+ * 2. Frontend calls /api/ai/tts/chunks to ask the backend how it would slice
+ *    the text. Returns e.g. ["chunk 0 text", "chunk 1 text", ...].
+ * 3. Frontend fetches each chunk's audio sequentially via /api/ai/tts (with
+ *    chunk_index in the body so the backend caches per-chunk).
+ * 4. Chunk 0 starts playing as soon as it's loaded; chunks 1..N continue to
+ *    fetch in the background. When the playing chunk ends, the next one
+ *    starts immediately.
+ * 5. While loading, the UI shows "Preparing N/M: <preview>".
+ *
+ * Playback model:
+ * - Each chunk is its own <audio> element.
+ * - Global currentTime = sum of completed-chunk durations + currentTime of
+ *   the chunk currently playing.
+ * - Global duration = sum of all known chunk durations (grows as chunks load).
+ * - Seek bar values are in global seconds; seek translates to chunk + offset.
+ * - Pause / resume just toggle play/pause on the active chunk's audio.
+ * - Position is persisted as global seconds in localStorage per
+ *   (bookId, chapterIndex), so it survives reloads.
+ */
+export default function TTSControls({
+  text,
+  language,
+  bookId,
+  chapterIndex,
+  onPlaybackUpdate,
+  onLoadingChange,
+  onChunksUpdate,
+  onSeekRegister,
+}: Props) {
+  const [status, setStatus] = useState<Status>("idle");
+  const [rate, setRate] = useState(1.0);
+  const [errorMsg, setErrorMsg] = useState("");
+  const [loadingState, setLoadingState] = useState<LoadingState | null>(null);
+
+  // Global playback state (aggregated across chunks)
+  const [globalCurrentTime, setGlobalCurrentTime] = useState(0);
+  const [globalDuration, setGlobalDuration] = useState(0);
+
+  // Loaded chunks (in order). Mutated through state setters so React re-renders.
+  const [chunks, setChunks] = useState<ChunkState[]>([]);
+  const chunksRef = useRef<ChunkState[]>([]);
+  // Index of the chunk currently playing or paused at
+  const activeIndexRef = useRef<number>(0);
+
   const abortRef = useRef<AbortController | null>(null);
-  // Incremented on every stop/play — lets an in-flight play() detect it was cancelled
   const genRef = useRef(0);
 
-  useEffect(() => { stopAudio(); }, [text, language]); // eslint-disable-line react-hooks/exhaustive-deps
-  useEffect(() => () => stopAudio(), []); // eslint-disable-line react-hooks/exhaustive-deps
+  // Full chunk list (text from getTtsChunks + duration that gets filled in
+  // as each chunk loads). Distinct from `chunks` above which is only the
+  // ChunkState[] for chunks whose audio is actually loaded.
+  const [allChunks, setAllChunks] = useState<ChunkSnapshot[]>([]);
 
-  function stopAudio() {
-    genRef.current++;                          // invalidate any in-flight play()
-    abortRef.current?.abort();                 // cancel the fetch
-    abortRef.current = null;
+  // Latest callback refs — keep in refs so they don't trigger effect re-runs
+  const onPlaybackUpdateRef = useRef(onPlaybackUpdate);
+  const onLoadingChangeRef = useRef(onLoadingChange);
+  const onChunksUpdateRef = useRef(onChunksUpdate);
+  const onSeekRegisterRef = useRef(onSeekRegister);
+  useEffect(() => { onPlaybackUpdateRef.current = onPlaybackUpdate; }, [onPlaybackUpdate]);
+  useEffect(() => { onLoadingChangeRef.current = onLoadingChange; }, [onLoadingChange]);
+  useEffect(() => { onChunksUpdateRef.current = onChunksUpdate; }, [onChunksUpdate]);
+  useEffect(() => { onSeekRegisterRef.current = onSeekRegister; }, [onSeekRegister]);
 
-    if (audioRef.current) {
-      audioRef.current.pause();
-      audioRef.current.src = "";
-      audioRef.current = null;
+  // Notify parent whenever loading state or chunks change
+  useEffect(() => {
+    onLoadingChangeRef.current?.(status === "loading");
+  }, [status]);
+  useEffect(() => {
+    onChunksUpdateRef.current?.(allChunks);
+  }, [allChunks]);
+
+  // ── Chapter change: full reset ─────────────────────────────────────────────
+  useEffect(() => {
+    cleanupAll();
+    setGlobalCurrentTime(0);
+    setGlobalDuration(0);
+    setLoadingState(null);
+    setErrorMsg("");
+    setStatus(text ? "paused" : "idle");
+
+    return () => {
+      // Persist current playback position before tearing down
+      const t = computeGlobalCurrentTime();
+      if (t > 0 && t < globalDuration - 1) {
+        saveAudioPosition(bookId, chapterIndex, t);
+      }
+      genRef.current++;
+      abortRef.current?.abort();
+      abortRef.current = null;
+      cleanupAll();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [text, language, bookId, chapterIndex]);
+
+  function cleanupAll() {
+    for (const c of chunksRef.current) {
+      c.audio.pause();
+      c.audio.src = "";
+      URL.revokeObjectURL(c.blobUrl);
     }
-    if (blobUrlRef.current) {
-      URL.revokeObjectURL(blobUrlRef.current);
-      blobUrlRef.current = null;
-    }
-    window.speechSynthesis.cancel();           // stop fallback TTS if it was used
-    setStatus("idle");
+    chunksRef.current = [];
+    setChunks([]);
+    setAllChunks([]);
+    activeIndexRef.current = 0;
+    window.speechSynthesis.cancel();
   }
 
-  async function play() {
-    stopAudio();
-    const gen = ++genRef.current;
+  // ── Global time helpers ────────────────────────────────────────────────────
+  const computeGlobalCurrentTime = useCallback((): number => {
+    let sum = 0;
+    for (let i = 0; i < activeIndexRef.current; i++) {
+      sum += chunksRef.current[i]?.duration ?? 0;
+    }
+    const active = chunksRef.current[activeIndexRef.current];
+    if (active) sum += active.audio.currentTime;
+    return sum;
+  }, []);
+
+  const computeGlobalDuration = useCallback((): number => {
+    return chunksRef.current.reduce((sum, c) => sum + c.duration, 0);
+  }, []);
+
+  // Mirror state out to the parent on every change
+  useEffect(() => {
+    onPlaybackUpdateRef.current?.(
+      globalCurrentTime,
+      globalDuration,
+      status === "playing"
+    );
+  }, [globalCurrentTime, globalDuration, status]);
+
+  // ── Chunk loading ──────────────────────────────────────────────────────────
+  /** Load + play. Optionally seek to a global time after the relevant chunk loads. */
+  async function loadAndPlay(seekToGlobal?: number) {
+    // If chunks already exist, just play (or seek then play)
+    if (chunksRef.current.length > 0) {
+      if (seekToGlobal !== undefined) {
+        await seekTo(seekToGlobal);
+      } else {
+        const active = chunksRef.current[activeIndexRef.current];
+        active?.audio.play().then(() => setStatus("playing")).catch(() => setStatus("error"));
+      }
+      return;
+    }
+
+    setStatus("loading");
+    setErrorMsg("");
     const abort = new AbortController();
     abortRef.current = abort;
-    setStatus("loading");
+    const myGen = ++genRef.current;
+    const settings = getSettings();
+    const provider = settings.ttsProvider;
 
     try {
-      // Use the shared synthesizeSpeech helper so auth header and the
-      // user's TTS-provider preference are both honoured. Pass the
-      // AbortSignal so clicking Stop cancels the in-flight request
-      // (important for cost control on Gemini TTS).
-      const provider = getSettings().ttsProvider;
-      const url = await synthesizeSpeech(text, language, rate, provider, abort.signal);
-
-      // Bail out if stop was pressed while we were fetching
-      if (gen !== genRef.current) {
-        URL.revokeObjectURL(url);
+      // Step 1: ask the backend how to chunk this chapter
+      const chunkTexts = await getTtsChunks(text);
+      if (myGen !== genRef.current) return;
+      if (chunkTexts.length === 0) {
+        setStatus("error");
+        setErrorMsg("No text to read.");
         return;
       }
 
-      blobUrlRef.current = url;
-      const audio = new Audio(url);
-      audioRef.current = audio;
-      audio.playbackRate = rate;
-      audio.onended = () => { if (gen === genRef.current) setStatus("idle"); };
-      audio.onerror = () => { if (gen === genRef.current) setStatus("idle"); };
-      await audio.play();
-      if (gen === genRef.current) setStatus("playing");
+      // Seed the full chunk list with duration=0; SentenceReader uses
+      // this immediately to mute unloaded sentences in the text view.
+      setAllChunks(chunkTexts.map((t) => ({ text: t, duration: 0 })));
+
+      const savedPos = getAudioPosition(bookId, chapterIndex);
+      let cumulative = 0;
+      let started = false;
+
+      // Step 2: fetch each chunk sequentially. Start playback after chunk 0
+      // is loaded; subsequent chunks load in the background.
+      for (let i = 0; i < chunkTexts.length; i++) {
+        if (myGen !== genRef.current) return;
+
+        const chunkText = chunkTexts[i];
+        setLoadingState({
+          index: i,
+          total: chunkTexts.length,
+          preview: chunkText.replace(/\s+/g, " ").trim().slice(0, 60),
+        });
+
+        const url = await synthesizeSpeech(chunkText, language, 1.0, provider, {
+          bookId,
+          chapterIndex,
+          chunkIndex: i,
+          signal: abort.signal,
+        });
+
+        if (myGen !== genRef.current) {
+          URL.revokeObjectURL(url);
+          return;
+        }
+
+        // Build the <audio> element and wait for its metadata
+        const audio = new Audio(url);
+        audio.preload = "auto";
+        audio.playbackRate = rate;
+        await new Promise<void>((resolve, reject) => {
+          audio.addEventListener("loadedmetadata", () => resolve(), { once: true });
+          audio.addEventListener("error", () => reject(new Error(`chunk ${i} failed to load`)), { once: true });
+        });
+
+        if (myGen !== genRef.current) {
+          URL.revokeObjectURL(url);
+          return;
+        }
+
+        const duration = audio.duration || 0;
+        const newChunk: ChunkState = {
+          index: i,
+          text: chunkText,
+          audio,
+          blobUrl: url,
+          duration,
+        };
+        chunksRef.current = [...chunksRef.current, newChunk];
+        setChunks([...chunksRef.current]);
+        setGlobalDuration(computeGlobalDuration());
+        // Update the public chunks snapshot — this is what SentenceReader
+        // reads, and what triggers the "this segment is now loaded → switch
+        // to full color" visual transition.
+        setAllChunks((prev) => {
+          const next = [...prev];
+          next[i] = { text: chunkText, duration };
+          return next;
+        });
+
+        // Hook up cross-chunk transition: when this chunk ends, advance.
+        audio.addEventListener("ended", () => {
+          if (myGen !== genRef.current) return;
+          const next = i + 1;
+          if (next < chunksRef.current.length) {
+            activeIndexRef.current = next;
+            const nextAudio = chunksRef.current[next].audio;
+            nextAudio.playbackRate = rate;
+            nextAudio.currentTime = 0;
+            nextAudio.play().catch(() => {});
+            setGlobalCurrentTime(computeGlobalCurrentTime());
+          } else {
+            // Last chunk finished — playback complete
+            setStatus("paused");
+            activeIndexRef.current = 0;
+            // Reset all chunks to position 0
+            for (const c of chunksRef.current) c.audio.currentTime = 0;
+            setGlobalCurrentTime(0);
+            clearAudioPosition(bookId, chapterIndex);
+          }
+        });
+        audio.addEventListener("timeupdate", () => {
+          if (myGen !== genRef.current) return;
+          if (chunksRef.current[activeIndexRef.current]?.audio === audio) {
+            setGlobalCurrentTime(computeGlobalCurrentTime());
+          }
+        });
+
+        // Start playback as soon as the first chunk that contains the
+        // resume position (or chunk 0 if no resume) is ready.
+        if (!started) {
+          let targetGlobal = 0;
+          if (seekToGlobal !== undefined) {
+            targetGlobal = seekToGlobal;
+          } else if (savedPos > 0) {
+            targetGlobal = savedPos;
+          }
+
+          // Does this chunk contain the target time?
+          const chunkEnd = cumulative + duration;
+          if (chunkEnd >= targetGlobal || i === chunkTexts.length - 1) {
+            const offsetWithinChunk = Math.max(0, targetGlobal - cumulative);
+            audio.currentTime = Math.min(offsetWithinChunk, duration);
+            activeIndexRef.current = i;
+            audio.play().catch(() => {});
+            setStatus("playing");
+            setGlobalCurrentTime(targetGlobal);
+            started = true;
+          }
+        }
+
+        cumulative += duration;
+      }
+
+      setLoadingState(null);
     } catch (e: unknown) {
-      if (gen !== genRef.current) return;
-      if (e instanceof Error && e.name === "AbortError") return;
-      // Fallback to the browser's Web Speech API. This is intentionally
-      // a "last resort" — quality is poor and provider preference can't
-      // be honoured. Most failures here are network/auth issues.
-      const utter = new SpeechSynthesisUtterance(text);
-      utter.lang = language;
-      utter.rate = rate;
-      utter.onend = () => { if (gen === genRef.current) setStatus("idle"); };
-      window.speechSynthesis.speak(utter);
-      if (gen === genRef.current) setStatus("playing");
+      if (myGen !== genRef.current) return;
+      if (e instanceof Error && e.name === "AbortError") {
+        setStatus("paused");
+        setLoadingState(null);
+        return;
+      }
+      setStatus("error");
+      setErrorMsg(e instanceof Error ? e.message : "TTS failed");
+      setLoadingState(null);
     }
+  }
+
+  function play() {
+    loadAndPlay();
   }
 
   function pause() {
-    audioRef.current?.pause();
-    window.speechSynthesis.pause();
+    const active = chunksRef.current[activeIndexRef.current];
+    if (!active) return;
+    active.audio.pause();
+    saveAudioPosition(bookId, chapterIndex, computeGlobalCurrentTime());
     setStatus("paused");
   }
 
-  function resume() {
-    if (audioRef.current) {
-      audioRef.current.play();
-    } else {
-      window.speechSynthesis.resume();
-    }
-    setStatus("playing");
+  function cancelLoad() {
+    abortRef.current?.abort();
+    setStatus("paused");
+    setLoadingState(null);
   }
 
+  /** Seek to a global time (across all chunks). */
+  async function seekTo(globalTime: number) {
+    if (chunksRef.current.length === 0) {
+      // Audio not loaded yet — kick off load with a target seek time
+      await loadAndPlay(globalTime);
+      return;
+    }
+
+    let cumulative = 0;
+    for (let i = 0; i < chunksRef.current.length; i++) {
+      const chunk = chunksRef.current[i];
+      const chunkEnd = cumulative + chunk.duration;
+      if (chunkEnd >= globalTime || i === chunksRef.current.length - 1) {
+        // Pause the previously-active chunk
+        const previousActive = chunksRef.current[activeIndexRef.current];
+        if (previousActive && previousActive !== chunk) {
+          previousActive.audio.pause();
+        }
+        const offset = Math.max(0, globalTime - cumulative);
+        chunk.audio.currentTime = Math.min(offset, chunk.duration);
+        activeIndexRef.current = i;
+        chunk.audio.playbackRate = rate;
+        try {
+          await chunk.audio.play();
+          setStatus("playing");
+        } catch {
+          // ignore — user-gesture rules etc.
+        }
+        setGlobalCurrentTime(globalTime);
+        saveAudioPosition(bookId, chapterIndex, globalTime);
+        return;
+      }
+      cumulative = chunkEnd;
+    }
+  }
+
+  function changeRate(newRate: number) {
+    setRate(newRate);
+    for (const c of chunksRef.current) {
+      c.audio.playbackRate = newRate;
+    }
+  }
+
+  /**
+   * Regenerate: clears the server-side cache for this chapter, tears down
+   * any in-flight or loaded audio, then immediately re-triggers loadAndPlay
+   * so the new generation starts right away.
+   */
+  async function regenerate() {
+    abortRef.current?.abort();
+    genRef.current++;
+    cleanupAll();
+    setGlobalCurrentTime(0);
+    setGlobalDuration(0);
+    setLoadingState(null);
+    setErrorMsg("");
+    clearAudioPosition(bookId, chapterIndex);
+    try {
+      await deleteAudioCache(bookId, chapterIndex);
+    } catch (e: unknown) {
+      // Non-fatal — we'll still try to regenerate even if the delete fails
+      // (e.g. backend was already empty).
+      console.warn("Failed to clear audio cache:", e);
+    }
+    // Kick off a fresh load
+    loadAndPlay();
+  }
+
+  // Register seek function with parent so SentenceReader can drive playback
+  useEffect(() => {
+    onSeekRegisterRef.current?.((time: number) => {
+      seekTo(time);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bookId, chapterIndex]);
+
+  // ── Render helpers ─────────────────────────────────────────────────────────
+  function formatTime(seconds: number): string {
+    if (!Number.isFinite(seconds) || seconds < 0) return "0:00";
+    const m = Math.floor(seconds / 60);
+    const s = Math.floor(seconds % 60);
+    return `${m}:${s.toString().padStart(2, "0")}`;
+  }
+
+  // ── UI ─────────────────────────────────────────────────────────────────────
   return (
     <div className="flex flex-wrap items-center gap-3 p-3 bg-white border-t border-amber-200">
       <div className="flex gap-1">
         {status === "loading" ? (
           <button
-            onClick={stopAudio}
-            className="rounded-lg bg-amber-700 text-white px-4 py-1.5 text-sm hover:bg-amber-800 flex items-center gap-2"
+            onClick={cancelLoad}
+            className="rounded-lg bg-amber-300 text-amber-900 px-4 py-1.5 text-sm flex items-center gap-2 hover:bg-amber-400"
+            title="Click to cancel"
           >
-            <span className="w-3 h-3 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+            <span className="w-3 h-3 border-2 border-amber-700/40 border-t-amber-800 rounded-full animate-spin" />
             Preparing… ×
           </button>
         ) : status === "playing" ? (
-          <button onClick={pause} className="rounded-lg bg-amber-200 text-amber-900 px-4 py-1.5 text-sm hover:bg-amber-300">
+          <button
+            onClick={pause}
+            className="rounded-lg bg-amber-200 text-amber-900 px-4 py-1.5 text-sm hover:bg-amber-300"
+          >
             ⏸ Pause
           </button>
         ) : status === "paused" ? (
-          <button onClick={resume} className="rounded-lg bg-amber-700 text-white px-4 py-1.5 text-sm hover:bg-amber-800">
-            ▶ Resume
-          </button>
-        ) : (
-          <button onClick={play} className="rounded-lg bg-amber-700 text-white px-4 py-1.5 text-sm hover:bg-amber-800">
+          <button
+            onClick={play}
+            className="rounded-lg bg-amber-700 text-white px-4 py-1.5 text-sm hover:bg-amber-800"
+          >
             ▶ Read
           </button>
-        )}
-
-        {status !== "idle" && (
+        ) : status === "error" ? (
           <button
-            onClick={stopAudio}
-            className="rounded-lg border border-amber-300 px-3 py-1.5 text-sm text-amber-800 hover:bg-amber-100"
+            onClick={play}
+            className="rounded-lg bg-red-100 text-red-800 border border-red-300 px-3 py-1.5 text-sm hover:bg-red-200"
+            title={errorMsg || "Audio failed"}
           >
-            ⏹
+            ↻ Retry
+          </button>
+        ) : (
+          <button
+            disabled
+            className="rounded-lg bg-amber-100 text-amber-400 px-4 py-1.5 text-sm cursor-not-allowed"
+          >
+            ▶ Read
           </button>
         )}
       </div>
 
+      {/* Sound bar (visible whenever any chunk is loaded) */}
+      {chunks.length > 0 && globalDuration > 0 && (
+        <div className="flex items-center gap-2 flex-1 min-w-[200px]">
+          <span className="text-xs text-amber-700 tabular-nums w-10 text-right">
+            {formatTime(globalCurrentTime)}
+          </span>
+          <input
+            type="range"
+            min={0}
+            max={globalDuration}
+            step={0.1}
+            value={globalCurrentTime}
+            onChange={(e) => seekTo(Number(e.target.value))}
+            className="flex-1 accent-amber-700"
+            aria-label="Playback position"
+          />
+          <span className="text-xs text-amber-700 tabular-nums w-10">
+            {formatTime(globalDuration)}
+          </span>
+        </div>
+      )}
+
       <label className="flex items-center gap-1 text-xs text-amber-800">
         Speed
         <input
-          type="range" min="0.5" max="2" step="0.1"
+          type="range"
+          min="0.5"
+          max="2"
+          step="0.1"
           value={rate}
-          onChange={(e) => {
-            const v = Number(e.target.value);
-            setRate(v);
-            if (audioRef.current) audioRef.current.playbackRate = v;
-          }}
+          onChange={(e) => changeRate(Number(e.target.value))}
           className="w-20 accent-amber-700"
         />
         <span>{rate.toFixed(1)}×</span>
       </label>
+
+      {/* Regenerate button — only when there's something to regenerate */}
+      {(allChunks.length > 0 || status === "error") && status !== "loading" && (
+        <button
+          onClick={regenerate}
+          title="Clear cached audio and re-generate this chapter from scratch"
+          className="text-amber-600 hover:text-amber-900 text-base px-2 py-1 rounded hover:bg-amber-50 transition-colors"
+          aria-label="Regenerate audio"
+        >
+          ↻
+        </button>
+      )}
+
+      {/* Loud per-chunk progress bar while loading */}
+      {loadingState && (
+        <div className="w-full mt-1">
+          <div className="flex items-center justify-between text-xs text-amber-800 mb-1">
+            <span className="font-medium">
+              Generating chunk {loadingState.index + 1} of {loadingState.total}
+            </span>
+            <span className="text-amber-600">
+              {Math.round(((loadingState.index) / loadingState.total) * 100)}%
+            </span>
+          </div>
+          <div className="h-2 w-full bg-amber-100 rounded-full overflow-hidden relative">
+            {/* Filled portion = chunks already done */}
+            <div
+              className="absolute inset-y-0 left-0 bg-amber-600 transition-all duration-300"
+              style={{ width: `${(loadingState.index / loadingState.total) * 100}%` }}
+            />
+            {/* Currently-generating chunk: animated indeterminate stripe over the next slot */}
+            <div
+              className="absolute inset-y-0 bg-amber-400/60 animate-pulse"
+              style={{
+                left: `${(loadingState.index / loadingState.total) * 100}%`,
+                width: `${(1 / loadingState.total) * 100}%`,
+              }}
+            />
+          </div>
+          <p className="text-xs text-stone-500 mt-1 italic truncate">
+            &ldquo;{loadingState.preview}…&rdquo;
+          </p>
+        </div>
+      )}
+
+      {status === "error" && errorMsg && (
+        <p className="text-xs text-red-600 w-full">{errorMsg}</p>
+      )}
     </div>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -107,22 +107,36 @@ export function checkPronunciation(
  * Microsoft Edge TTS). Authorization is required, so the call goes
  * through `request`-style headers.
  */
+export interface SynthesizeOptions {
+  /** Backend caches the result when both bookId and chapterIndex are present. */
+  bookId?: number;
+  chapterIndex?: number;
+  /** Index of this chunk within the chapter (used as part of the cache key). */
+  chunkIndex?: number;
+  signal?: AbortSignal;
+}
+
 export async function synthesizeSpeech(
   text: string,
   language: string,
   rate = 1.0,
   provider: "auto" | "edge" | "google" = "auto",
-  signal?: AbortSignal
+  options: SynthesizeOptions = {}
 ): Promise<string> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     ...(_authToken ? { Authorization: `Bearer ${_authToken}` } : {}),
   };
+  const body: Record<string, unknown> = { text, language, rate, provider };
+  if (options.bookId !== undefined) body.book_id = options.bookId;
+  if (options.chapterIndex !== undefined) body.chapter_index = options.chapterIndex;
+  if (options.chunkIndex !== undefined) body.chunk_index = options.chunkIndex;
+
   const res = await fetch(`${BASE}/ai/tts`, {
     method: "POST",
     headers,
-    body: JSON.stringify({ text, language, rate, provider }),
-    signal,
+    body: JSON.stringify(body),
+    signal: options.signal,
   });
   if (!res.ok) {
     // Surface the backend's error detail when available so users see e.g.
@@ -132,6 +146,33 @@ export async function synthesizeSpeech(
   }
   const blob = await res.blob();
   return URL.createObjectURL(blob);
+}
+
+/**
+ * Ask the backend how it would chunk the given text. The frontend calls this
+ * once per chapter, then fetches one audio file per chunk via synthesizeSpeech
+ * — this way the chunking algorithm has exactly one implementation (Python)
+ * and the frontend can show per-chunk progress without replicating it.
+ */
+export async function getTtsChunks(text: string): Promise<string[]> {
+  const data = await request<{ chunks: string[] }>("/ai/tts/chunks", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+  return data.chunks;
+}
+
+/**
+ * Delete all cached audio chunks for a chapter, across providers and voices.
+ * Used by the Regenerate button so the next ▶ Read triggers a fresh
+ * generation pass instead of returning cached audio.
+ */
+export function deleteAudioCache(bookId: number, chapterIndex: number) {
+  return request<{ deleted: number }>(
+    `/ai/tts/cache?book_id=${bookId}&chapter_index=${chapterIndex}`,
+    { method: "DELETE" }
+  );
 }
 
 export function findVideos(passage: string, book_title: string, author: string) {

--- a/frontend/src/lib/audio.ts
+++ b/frontend/src/lib/audio.ts
@@ -1,0 +1,50 @@
+/**
+ * Persistent playback positions for the chapter Read button.
+ *
+ * Saves `audio.currentTime` to localStorage on pause/stop/unmount and restores
+ * it next time the user clicks Read on the same chapter. Per-(book, chapter).
+ *
+ * Backend audio cache (services/db.audio_cache) handles the *audio file*; this
+ * module handles only the *playback position* — they're independent.
+ */
+
+const KEY_PREFIX = "audio_position";
+
+function key(bookId: number, chapterIndex: number): string {
+  return `${KEY_PREFIX}:${bookId}:${chapterIndex}`;
+}
+
+export function getAudioPosition(bookId: number, chapterIndex: number): number {
+  if (typeof window === "undefined") return 0;
+  try {
+    const raw = localStorage.getItem(key(bookId, chapterIndex));
+    if (!raw) return 0;
+    const t = Number(raw);
+    return Number.isFinite(t) && t >= 0 ? t : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function saveAudioPosition(
+  bookId: number,
+  chapterIndex: number,
+  currentTime: number
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (!Number.isFinite(currentTime) || currentTime < 0) return;
+    localStorage.setItem(key(bookId, chapterIndex), String(currentTime));
+  } catch {
+    // ignore quota / private-mode errors
+  }
+}
+
+export function clearAudioPosition(bookId: number, chapterIndex: number): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(key(bookId, chapterIndex));
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## What

Restructures the chapter Read button into a real audiobook-style player with **frontend-driven chunking**, **per-chunk caching**, **live progress UI**, and **accurate chunk-aware highlighting**. Plus a critical fix for Edge TTS being broken by upstream Microsoft token rotation.

## Why

The previous "single TTS request, whole chapter" approach had three real problems on actual chapters:

1. **Gemini truncation** — Gemini's TTS preview model has a per-call output cap (~30 sec). Long inputs got 30 seconds of speech followed by ~5 minutes of silence padding. Useless for chapter-length text.
2. **No cancellation granularity** — abort meant losing everything that had been generated.
3. **No progress visibility** — the user clicked Read and stared at a spinner for 20–60 seconds with no idea what was happening.

The fix is to chunk the chapter text into small pieces, generate each piece independently, cache each piece, and play them back as a single virtual audio stream.

## Architecture

### Chunking lives in one place — the Python backend

Old: chunking was a hidden internal loop inside ``_gemini_synthesize``. The frontend had no idea it existed.

New:
- ``services.tts.chunk_text(text)`` is exposed via ``POST /api/ai/tts/chunks``
- Frontend calls it once per chapter to get the chunk list
- Frontend then fetches one audio file per chunk via ``POST /api/ai/tts`` (with ``chunk_index`` in the body)
- Single source of truth — no TypeScript port to keep in sync

### Per-chunk audio cache

\`audio_cache\` PRIMARY KEY is now ``(book_id, chapter_index, chunk_index, provider, voice)``. SQLite can't ALTER a primary key, so ``init_db()`` detects the old PK and DROPs+CREATEs the table on existing DBs. The cache is regeneratable so this one-time loss is acceptable. Future schema changes of this kind are exactly why a proper migration system is the next PR (still pending — see meta below).

### Frontend playback orchestration

\`TTSControls\` is now a multi-audio orchestrator:
- Lazy fetch — nothing happens until ▶ Read is clicked
- Sequential per-chunk fetching with chunk 0 starting playback as soon as it's loaded; chunks 1..N load in background
- Each chunk is its own ``HTMLAudioElement``
- Global currentTime/duration aggregated across chunks
- Seek bar shows global time and seeks across chunk boundaries
- Position persisted per ``(bookId, chapterIndex)`` in localStorage via the new \`lib/audio.ts\`

## Visible UX changes

| | Before | After |
|---|---|---|
| Click ▶ Read on a long chapter | Spinner for 20–60s, then plays (or worse, plays 30s of speech then 5min silence with Gemini) | Toolbar progress bar shows ``Generating chunk N of M``, audio starts playing as soon as chunk 0 is ready, rest loads in background |
| Sentence click during loading | Fired a one-off snippet TTS, raced with the chapter generation | **Blocked**. Sentences in unloaded chunks render muted-grey, click is a no-op |
| Sentence highlight while playing | Linear word-proportion across the whole chapter — drifted noticeably on long inputs | **Per-chunk timing** — each segment's startTime is computed within its own chunk's measured duration |
| Page text appearance during generation | Static | Sentences in unloaded chunks render in muted ``text-stone-400``; they **light up** to full ink as their chunk finishes loading |
| Want to re-listen with different voice / fix a bad generation | No way except to wait for cache eviction (none) | New ↻ **Regenerate** button: clears cache for this chapter, kicks off fresh load |
| Chapter audio cost | 1× full chapter per Gemini call (often truncated) | N× small chunk calls. Cancellable per chunk. Cached per chunk so partial replays are free |

## Edge TTS fix (urgent — bundled in)

The user reported Edge TTS was returning 500. Direct repro showed:

\`\`\`
WSServerHandshakeError: 403, message='Invalid response status',
  url='wss://speech.platform.bing.com/consumer/speech/synthesize/readaloud/edge/v1?...'
\`\`\`

Microsoft has rotated the Edge TTS auth tokens / handshake protocol since May 2024 (when ``edge-tts==6.1.10`` was released). The upstream fix is in ``edge-tts>=7.2.0``. Bumped the requirement; venv is now on ``7.2.8`` and verified working against Microsoft's live endpoint.

This is a recurring upstream issue — Microsoft does this every 6–12 months. The loosened range (\`>=\`) lets future Railway redeploys pick up new fixes automatically.

## Bundled small fix

\`GET /api/audiobooks/{id}\` now returns ``200 null`` when no audiobook is linked, instead of \`404\`. The reader page fetches this on every page load and the 404 was producing red console noise for a perfectly normal "not linked" state. Tests updated.

## Tests

| Suite | Before this PR | After |
|---|---|---|
| Backend pytest | 168 | **192** |
| Frontend Jest | 86 | **107** |
| Backend coverage | 92% | 93% |

New backend tests cover: ``chunk_text`` (single, group small, split oversize, drop empty, real Faust), \`_trim_trailing_silence\`, \`audio_cache\` chunk_index keying, cache key isolation across providers/voices/chunks, \`delete_chapter_audio_cache\` cross-voice/chunk behaviour, the new \`/api/ai/tts/chunks\` endpoint, the new \`DELETE /api/ai/tts/cache\` endpoint, single-chunk Gemini synthesize behaviour, and the audiobook 404→null change.

New frontend tests cover: \`lib/audio.ts\` (9 tests for position persistence — round-trip, per-chapter independence, per-book independence, clear, invalid input handling, NaN guards), \`getTtsChunks\`, \`deleteAudioCache\`, \`chunk_index\` in body, \`AbortSignal\` forwarding, \`Authorization\` header inclusion, and backend error-detail surfacing.

## What is NOT in this PR

- **Migration system.** \`init_db()\` still has ad-hoc table-create plus a custom "detect old audio_cache PK" check. The PK migration logic in this PR is exactly the kind of thing a proper migration runner should handle. Tracked as the next focused PR.
- **Streaming progress endpoint.** The current "show preview of the chunk being generated" works without streaming because the frontend knows the full chunk list from \`getTtsChunks\` and can show the in-flight chunk's text directly. A streaming SSE endpoint would let us show progress at sub-chunk granularity, but that's a separate refactor.

## Test plan

- [x] Edge TTS verified against Microsoft's live endpoint after upgrade
- [x] All 192 backend tests pass
- [x] All 107 frontend tests pass
- [x] Production build green
- [x] Manual: lazy fetch confirmed, no eager generation
- [x] Manual: Gemini chunked synthesis works for Faust Zueignung end-to-end
- [x] Manual: regenerate button clears cache and re-fetches
- [x] Manual: sentence highlight follows chunked audio (much more accurate than before)
- [x] Manual: muted-then-light-up colour transition as chunks load
- [x] Manual: sentence clicks blocked while loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)