### PR TITLE
fix(home): merge Continue Reading + Your Library into one section

### DIFF
--- a/frontend/e2e/reader.spec.ts
+++ b/frontend/e2e/reader.spec.ts
@@ -78,7 +78,7 @@ test("shows Gemini reminder banner when translate fails without a key", async ({
   await expect(page.getByRole("button", { name: /Add your free Gemini API key/ })).toBeVisible();
 });
 
-test("home page shows Continue Reading badge with chapter number", async ({ page }) => {
+test("Your Library shows chapter badge from recent-read data", async ({ page }) => {
   // Seed a recent book with lastChapter = 4
   await page.goto("/");
   await page.evaluate(() => {
@@ -101,7 +101,8 @@ test("home page shows Continue Reading badge with chapter number", async ({ page
   });
   await page.reload();
 
-  await expect(page.getByText("Continue Reading")).toBeVisible();
+  // The merged "Your Library" section shows the chapter badge
+  await expect(page.getByText("Your Library")).toBeVisible();
   // Badge format: "Ch. 5 · just now" (1-indexed display)
   await expect(page.getByText(/Ch\. 5/)).toBeVisible();
 });

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -76,9 +76,20 @@ export default function Home() {
     router.push(`/reader/${id}`);
   }
 
-  const showLibrary = cachedBooks.length > 0;
-  const showRecent = recentBooks.length > 0;
-  const showEmpty = !showRecent && !showLibrary && !cachedLoading && searchResults.length === 0;
+  // Merge cached books (server-side) with recent-read info (client-side localStorage).
+  // Recent books carry lastChapter + lastRead timestamps; cached books are the
+  // canonical server list. We enhance cached books with the recent info and
+  // sort so recently-read books appear first.
+  const recentMap = new Map(recentBooks.map((b) => [b.id, b]));
+  const libraryBooks = [...cachedBooks]
+    .sort((a, b) => {
+      const ra = recentMap.get(a.id)?.lastRead ?? 0;
+      const rb = recentMap.get(b.id)?.lastRead ?? 0;
+      return rb - ra; // most recently read first
+    });
+
+  const showLibrary = libraryBooks.length > 0;
+  const showEmpty = !showLibrary && !cachedLoading && searchResults.length === 0;
 
   return (
     <main className="min-h-screen bg-parchment">
@@ -108,45 +119,29 @@ export default function Home() {
 
       <div className="max-w-4xl mx-auto px-6 py-8 space-y-10">
 
-        {/* ── Recently Read ─────────────────────────────────────────── */}
-        {showRecent && (
-          <section>
-            <h2 className="font-serif font-semibold text-ink text-lg mb-3">Continue Reading</h2>
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-              {recentBooks.map((book) => (
-                <BookCard
-                  key={book.id}
-                  book={book}
-                  onClick={() => openBook(book.id)}
-                  badge={`Ch. ${book.lastChapter + 1} · ${timeAgo(book.lastRead)}`}
-                />
-              ))}
-            </div>
-          </section>
-        )}
-
-        {/* ── Cached Library ────────────────────────────────────────── */}
+        {/* ── Your Library (merged: server-cached books + client-side read progress) ── */}
         {showLibrary && (
           <section>
             <h2 className="font-serif font-semibold text-ink text-lg mb-3">
               Your Library
-              <span className="ml-2 text-sm font-normal text-amber-600">
-                ({cachedBooks.length} book{cachedBooks.length !== 1 ? "s" : ""} saved locally)
-              </span>
             </h2>
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-              {cachedBooks.map((book) => (
-                <BookCard
-                  key={book.id}
-                  book={book}
-                  onClick={() => openBook(book.id)}
-                />
-              ))}
+              {libraryBooks.map((book) => {
+                const recent = recentMap.get(book.id);
+                return (
+                  <BookCard
+                    key={book.id}
+                    book={book}
+                    onClick={() => openBook(book.id)}
+                    badge={recent ? `Ch. ${recent.lastChapter + 1} · ${timeAgo(recent.lastRead)}` : undefined}
+                  />
+                );
+              })}
             </div>
           </section>
         )}
 
-        {cachedLoading && !showRecent && (
+        {cachedLoading && (
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
             {Array.from({ length: 4 }).map((_, i) => (
               <div key={i} className="rounded-xl border border-amber-200 bg-white p-3 animate-pulse">


### PR DESCRIPTION
## What

Merges the two repetitive home page sections into one unified "Your Library".

## Why

Opening a book both caches it server-side (showed in "Your Library") AND records it in localStorage (showed in "Continue Reading"). The same book appeared in both sections with slightly different info — confusing.

Also, "saved locally" was misleading — on the deployed version, books are saved on Railway (server-side).

## After

One "Your Library" section that:
- Shows server-cached books (canonical list)
- Enhances with chapter + time badges from localStorage when available ("Ch. 3 · 2h ago")
- Sorts by last-read time (recently-read books first)
- No misleading "saved locally" text

E2E test updated: "Continue Reading" → "Your Library shows chapter badge from recent-read data".

🤖 Generated with [Claude Code](https://claude.com/claude-code)