### PR TITLE
chore: remove illustration/image feature — plain text only

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException, Query
-from services.gutenberg import search_books, get_book_meta, get_book_text, get_book_images
+from services.gutenberg import search_books, get_book_meta, get_book_text
 from services.db import get_cached_book, save_book, list_cached_books
 from services.splitter import build_chapters
 
@@ -26,7 +26,7 @@ async def cached_books():
 async def book_meta(book_id: int):
     cached = await get_cached_book(book_id)
     if cached:
-        return {k: v for k, v in cached.items() if k not in ("text", "cached_at")}
+        return {k: v for k, v in cached.items() if k not in ("text", "cached_at", "images")}
     try:
         return await get_book_meta(book_id)
     except Exception as e:
@@ -43,16 +43,10 @@ async def book_chapters(book_id: int):
 
     if cached and cached.get("text"):
         text = cached["text"]
-        images = cached.get("images") or []
         meta = {k: v for k, v in cached.items() if k not in ("text", "cached_at", "images")}
-        # Back-fill images for books cached before this feature was added
-        if not images:
-            images = await get_book_images(book_id)
-            if images:
-                await save_book(book_id, meta, text, images)
     else:
         try:
-            meta, text, images = await _fetch_and_cache(book_id)
+            meta, text = await _fetch_and_cache(book_id)
         except Exception as e:
             msg = str(e) or type(e).__name__
             raise HTTPException(status_code=404, detail=msg)
@@ -61,14 +55,12 @@ async def book_chapters(book_id: int):
     return {
         "book_id": book_id,
         "meta": meta,
-        "images": images,
         "chapters": [{"title": c.title, "text": c.text} for c in chapters],
     }
 
 
-async def _fetch_and_cache(book_id: int) -> tuple[dict, str, list]:
+async def _fetch_and_cache(book_id: int) -> tuple[dict, str]:
     meta = await get_book_meta(book_id)
     text = await get_book_text(book_id)
-    images = await get_book_images(book_id)
-    await save_book(book_id, meta, text, images)
-    return meta, text, images
+    await save_book(book_id, meta, text)
+    return meta, text

--- a/backend/services/gutenberg.py
+++ b/backend/services/gutenberg.py
@@ -1,6 +1,4 @@
 import httpx
-from bs4 import BeautifulSoup
-from typing import Optional
 
 GUTENBERG_SEARCH = "https://gutendex.com/books"
 GUTENBERG_BASE = "https://www.gutenberg.org"
@@ -95,44 +93,6 @@ async def get_book_text(book_id: int) -> str:
                 last_error = f"{type(e).__name__} fetching {url}: {e}"
                 continue
     raise ValueError(f"Could not fetch text for book {book_id}. Last error: {last_error}")
-
-
-async def get_book_images(book_id: int) -> list[dict]:
-    """
-    Fetch the Gutenberg HTML version and extract all illustration images
-    in document order.  Returns [{url, caption}, ...].
-    Returns [] if the HTML page is unavailable or has no images.
-    """
-    html_url = f"https://www.gutenberg.org/cache/epub/{book_id}/pg{book_id}-images.html"
-    base_url = f"https://www.gutenberg.org/cache/epub/{book_id}/"
-    try:
-        async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
-            resp = await client.get(html_url)
-            if resp.status_code != 200:
-                return []
-        soup = BeautifulSoup(resp.text, "html.parser")
-        images = []
-        for img in soup.find_all("img"):
-            src = img.get("src", "")
-            if not src:
-                continue
-            # Make absolute
-            if src.startswith("http"):
-                abs_url = src
-            else:
-                abs_url = base_url + src.lstrip("./")
-            # Caption: try alt, then nearest figcaption / p.caption sibling
-            caption = img.get("alt", "").strip()
-            if not caption:
-                parent = img.find_parent(["figure", "div"])
-                if parent:
-                    cap_el = parent.find(["figcaption", "p"])
-                    if cap_el:
-                        caption = cap_el.get_text(" ", strip=True)
-            images.append({"url": abs_url, "caption": caption})
-        return images
-    except Exception:
-        return []
 
 
 def _get_text_url(formats: dict) -> str:

--- a/backend/tests/test_gutenberg.py
+++ b/backend/tests/test_gutenberg.py
@@ -7,7 +7,7 @@ All HTTP calls are mocked with respx.
 import pytest
 import respx
 import httpx
-from services.gutenberg import search_books, get_book_meta, get_book_text, get_book_images, _format_book_meta
+from services.gutenberg import search_books, get_book_meta, get_book_text, _format_book_meta
 
 
 RAW_BOOK = {
@@ -154,42 +154,3 @@ async def test_get_book_text_normalizes_line_endings():
     assert result == "Line1\nLine2\nLine3"
 
 
-# ── get_book_images ───────────────────────────────────────────────────────────
-
-async def test_get_book_images_parses_html():
-    html = """<html><body>
-        <figure>
-            <img src="images/cover.jpg" alt="Cover illustration">
-            <figcaption>The cover</figcaption>
-        </figure>
-    </body></html>"""
-
-    with respx.mock:
-        respx.get("https://www.gutenberg.org/cache/epub/1342/pg1342-images.html").mock(
-            return_value=httpx.Response(200, text=html)
-        )
-        result = await get_book_images(1342)
-
-    assert len(result) == 1
-    assert "cover.jpg" in result[0]["url"]
-    assert result[0]["caption"] == "Cover illustration"
-
-
-async def test_get_book_images_returns_empty_on_404():
-    with respx.mock:
-        respx.get("https://www.gutenberg.org/cache/epub/1342/pg1342-images.html").mock(
-            return_value=httpx.Response(404)
-        )
-        result = await get_book_images(1342)
-
-    assert result == []
-
-
-async def test_get_book_images_returns_empty_on_error():
-    with respx.mock:
-        respx.get("https://www.gutenberg.org/cache/epub/1342/pg1342-images.html").mock(
-            side_effect=httpx.ConnectError("connection refused")
-        )
-        result = await get_book_images(1342)
-
-    assert result == []

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -75,7 +75,6 @@ async def test_book_chapters_fetches_and_caches(client):
     with (
         patch("routers.books.get_book_meta", new_callable=AsyncMock, return_value=MOCK_META),
         patch("routers.books.get_book_text", new_callable=AsyncMock, return_value=text),
-        patch("routers.books.get_book_images", new_callable=AsyncMock, return_value=[]),
     ):
         resp = await client.get("/api/books/1342/chapters")
     assert resp.status_code == 200

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { getBookChapters, translateText, getAudiobook, deleteAudiobook, synthesizeSpeech, getMe, BookMeta, BookChapter, BookImage, Audiobook } from "@/lib/api";
+import { getBookChapters, translateText, getAudiobook, deleteAudiobook, synthesizeSpeech, getMe, BookMeta, BookChapter, Audiobook } from "@/lib/api";
 import { recordRecentBook, saveLastChapter, getLastChapter } from "@/lib/recentBooks";
 import { getSettings } from "@/lib/settings";
 import InsightChat, { LANGUAGES } from "@/components/InsightChat";
@@ -16,7 +16,6 @@ import SentenceReader from "@/components/SentenceReader";
 // In-memory cache: bookId → chapters (survives client-side navigation)
 const chaptersCache = new Map<string, BookChapter[]>();
 const metaCache = new Map<string, BookMeta>();
-const imagesCache = new Map<string, BookImage[]>();
 
 export default function ReaderPage() {
   const { bookId } = useParams<{ bookId: string }>();
@@ -25,7 +24,6 @@ export default function ReaderPage() {
 
   const [meta, setMeta] = useState<BookMeta | null>(metaCache.get(bookId) ?? null);
   const [chapters, setChapters] = useState<BookChapter[]>(chaptersCache.get(bookId) ?? []);
-  const [bookImages, setBookImages] = useState<BookImage[]>(imagesCache.get(bookId) ?? []);
   const [chapterIndex, setChapterIndex] = useState(() => getLastChapter(Number(bookId)));
   const [loading, setLoading] = useState(!chaptersCache.has(bookId));
   const [error, setError] = useState("");
@@ -130,10 +128,8 @@ export default function ReaderPage() {
       .then((data) => {
         chaptersCache.set(bookId, data.chapters);
         metaCache.set(bookId, data.meta);
-        imagesCache.set(bookId, data.images ?? []);
         setChapters(data.chapters);
         setMeta(data.meta);
-        setBookImages(data.images ?? []);
         const savedChapter = getLastChapter(Number(bookId));
         setChapterIndex(Math.min(savedChapter, data.chapters.length - 1));
         recordRecentBook(data.meta, savedChapter);
@@ -430,7 +426,6 @@ export default function ReaderPage() {
                   duration={audiobook ? audioDuration : ttsDuration}
                   currentTime={audiobook ? audioCurrentTime : ttsCurrentTime}
                   isPlaying={audiobook ? audioIsPlaying : ttsIsPlaying}
-                  images={bookImages}
                   chunks={!audiobook && ttsChunks.length > 0 ? ttsChunks : undefined}
                   disabled={!audiobook && ttsIsLoading}
                   // Translation props: SentenceReader renders both original

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useEffect, useMemo, useRef } from "react";
-import { BookImage } from "@/lib/api";
 
 // ── Text parsing ────────────────────────────────────────────────────────────
 
@@ -14,7 +13,6 @@ interface Segment {
 interface Paragraph {
   segments: Segment[];
   isVerse: boolean;      // true = poetry (newlines between lines), false = prose
-  illustration: BookImage | null; // non-null = render as image, not text
 }
 
 /** Optional chunk metadata for accurate timing + per-chunk visual coloring. */
@@ -65,49 +63,34 @@ function isVerse(lines: string[]): boolean {
   return !lines.some((l) => l.length > 60);
 }
 
-/** Match a [Illustration...] marker and extract the caption. */
-const ILLUS_RE = /^\[Illustration(?::\s*(.+?))?\s*\]$/is;
-
 function parseIntoSegments(
   text: string,
   duration: number,
-  images: BookImage[],
   chunks?: ChunkInfo[],
 ): Paragraph[] {
   // Step 1: collect all segment texts and classify paragraphs
   const rawParas = text.split(/\n\n+/);
-  const paraData: { texts: string[]; isVerse: boolean; illustrationIdx: number | null }[] = [];
+  const paraData: { texts: string[]; isVerse: boolean }[] = [];
   const allTexts: string[] = [];
-  let illustrationCount = 0;
 
   for (const raw of rawParas) {
     const trimmed = raw.trim();
     if (!trimmed) continue;
 
-    // Detect illustration marker
-    const illusMatch = trimmed.match(ILLUS_RE);
-    if (illusMatch) {
-      paraData.push({ texts: [], isVerse: false, illustrationIdx: illustrationCount++ });
-      continue;
-    }
-
     if (trimmed.includes("\n")) {
       const lines = trimmed.split("\n").map((l) => l.trim()).filter(Boolean);
       if (isVerse(lines)) {
-        // Real poetry — each line is its own segment
-        paraData.push({ texts: lines, isVerse: true, illustrationIdx: null });
+        paraData.push({ texts: lines, isVerse: true });
         allTexts.push(...lines);
       } else {
-        // Soft-wrapped prose — join lines then split into sentences
         const joined = lines.join(" ");
         const sents = splitSentences(joined);
-        paraData.push({ texts: sents, isVerse: false, illustrationIdx: null });
+        paraData.push({ texts: sents, isVerse: false });
         allTexts.push(...sents);
       }
     } else {
-      // Single-line paragraph — split into sentences
       const sents = splitSentences(trimmed);
-      paraData.push({ texts: sents, isVerse: false, illustrationIdx: null });
+      paraData.push({ texts: sents, isVerse: false });
       allTexts.push(...sents);
     }
   }
@@ -178,25 +161,18 @@ function parseIntoSegments(
 
   // Step 3: map back to paragraph structure
   let flat = 0;
-  return paraData.map(({ texts, isVerse: verse, illustrationIdx }) => {
-    if (illustrationIdx !== null) {
-      const img = images[illustrationIdx] ?? null;
-      return { isVerse: false, illustration: img, segments: [] };
-    }
-    return {
-      isVerse: verse,
-      illustration: null,
-      segments: texts.map((text) => {
-        const here = flat++;
-        return {
-          text,
-          flatIdx: here,
-          startTime: startTimes[here],
-          chunkIdx: segmentChunkIdx[here],
-        };
-      }),
-    };
-  });
+  return paraData.map(({ texts, isVerse: verse }) => ({
+    isVerse: verse,
+    segments: texts.map((text) => {
+      const here = flat++;
+      return {
+        text,
+        flatIdx: here,
+        startTime: startTimes[here],
+        chunkIdx: segmentChunkIdx[here],
+      };
+    }),
+  }));
 }
 
 // ── Component ───────────────────────────────────────────────────────────────
@@ -206,7 +182,6 @@ interface Props {
   duration: number;      // audio duration in seconds (0 = no audio linked)
   currentTime: number;   // audio currentTime in seconds
   isPlaying: boolean;
-  images?: BookImage[];
   onSegmentClick: (startTime: number, text: string) => void;
   /**
    * Per-chunk metadata for chunked TTS playback. When provided, segment
@@ -238,7 +213,6 @@ export default function SentenceReader({
   duration,
   currentTime,
   isPlaying,
-  images = [],
   onSegmentClick,
   chunks,
   disabled = false,
@@ -252,8 +226,8 @@ export default function SentenceReader({
   // comes from text.split(/\n\n+/) which doesn't include illustration markers.
   let textParaIdx = -1;
   const paragraphs = useMemo(
-    () => parseIntoSegments(text, Math.max(duration, 1), images, chunks),
-    [text, duration, images, chunks]
+    () => parseIntoSegments(text, Math.max(duration, 1), chunks),
+    [text, duration, chunks]
   );
 
   // For coloring: which chunk indices have actually loaded (duration > 0)
@@ -299,28 +273,7 @@ export default function SentenceReader({
   return (
     <div className={isParallel ? "max-w-5xl mx-auto divide-y divide-amber-100" : "prose-reader mx-auto space-y-4"}>
       {paragraphs.map((para, pIdx) => {
-        // ── Illustration ──
-        if (para.illustration) {
-          const { url, caption } = para.illustration;
-          return (
-            <figure key={pIdx} className="my-6 flex flex-col items-center gap-2">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={url}
-                alt={caption}
-                className="max-w-full rounded shadow-sm"
-                loading="lazy"
-              />
-              {caption && (
-                <figcaption className="text-center text-sm text-stone-500 italic">
-                  {caption}
-                </figcaption>
-              )}
-            </figure>
-          );
-        }
-
-        // Track the text paragraph index (excluding illustrations) so we
+        // Track the text paragraph index so we
         // can pair with the right entry in translations[].
         textParaIdx++;
         const translationText = translations?.[textParaIdx];

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -35,17 +35,12 @@ export function getBookMeta(id: number) {
 }
 
 export function getBookChapters(id: number) {
-  return request<{ book_id: number; meta: BookMeta; chapters: BookChapter[]; images: BookImage[] }>(`/books/${id}/chapters`);
+  return request<{ book_id: number; meta: BookMeta; chapters: BookChapter[] }>(`/books/${id}/chapters`);
 }
 
 export interface BookChapter {
   title: string;
   text: string;
-}
-
-export interface BookImage {
-  url: string;
-  caption: string;
 }
 
 // AI


### PR DESCRIPTION
Removes the HTML-based illustration extraction. The app now downloads and renders plain text only. get_book_images(), BookImage, ILLUS_RE, and all image rendering code removed. The images DB column stays (SQLite can't drop it) but is no longer read or written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)