### PR TITLE
fix: library shows only user's books + chat privacy + early key reminder

### DIFF
--- a/frontend/e2e/home.spec.ts
+++ b/frontend/e2e/home.spec.ts
@@ -2,7 +2,7 @@
  * E2E: Home page user flows
  */
 import { test, expect } from "@playwright/test";
-import { mockBackend } from "./fixtures";
+import { mockBackend, MOCK_BOOK } from "./fixtures";
 
 test.beforeEach(async ({ page }) => {
   await mockBackend(page);
@@ -14,34 +14,51 @@ test("home page renders header and search input", async ({ page }) => {
   await expect(page.getByPlaceholder(/Search by title or author/)).toBeVisible();
 });
 
-test("shows cached library from backend", async ({ page }) => {
+test("Your Library shows books from localStorage recentBooks", async ({ page }) => {
+  // Seed a recent book in localStorage (simulates a book the user has opened)
   await page.goto("/");
+  await page.evaluate((book) => {
+    localStorage.setItem("recent_books", JSON.stringify([
+      { ...book, lastRead: Date.now(), lastChapter: 2 },
+    ]));
+  }, MOCK_BOOK);
+  await page.reload();
+
   await expect(page.getByText("Your Library")).toBeVisible();
   await expect(page.getByText("Pride and Prejudice").first()).toBeVisible();
+  await expect(page.getByText(/Ch\. 3/)).toBeVisible(); // badge with chapter
+});
+
+test("Your Library is hidden when no recent books", async ({ page }) => {
+  await page.goto("/");
+  // No recent books in localStorage → library section should not appear
+  await expect(page.getByText("Your Library")).not.toBeVisible();
 });
 
 test("search for Faust returns result and displays it", async ({ page }) => {
   await page.goto("/");
   await page.getByPlaceholder(/Search by title or author/).fill("Faust");
   await page.getByRole("button", { name: "Search" }).click();
-  // Book title appears in search results
   await expect(page.getByText("Faust").first()).toBeVisible();
 });
 
 test("quick search pill triggers search", async ({ page }) => {
   await page.goto("/");
-  // Use Faust — not in the cached library, so clicking the pill really does
-  // trigger a search (instead of matching a pre-existing BookCard).
   await page.getByRole("button", { name: "Faust" }).click();
-  // Mocked search returns Goethe as the author
   await expect(page.getByText(/Goethe/)).toBeVisible();
 });
 
-test("clicking a book navigates to reader page", async ({ page }) => {
+test("clicking a library book navigates to reader page", async ({ page }) => {
+  // Seed a recent book so the library shows up
   await page.goto("/");
-  // Scope to buttons that contain the author text — BookCards wrap both
-  // title and author, while quick-search pills only contain the title.
-  // This avoids ambiguity between the "Pride and Prejudice" pill and card.
+  await page.evaluate((book) => {
+    localStorage.setItem("recent_books", JSON.stringify([
+      { ...book, lastRead: Date.now(), lastChapter: 0 },
+    ]));
+  }, MOCK_BOOK);
+  await page.reload();
+
+  // Click the BookCard (contains author text, unlike search pills)
   await page.getByRole("button").filter({ hasText: "Jane Austen" }).first().click();
   await page.waitForURL(/\/reader\/1342/);
   expect(page.url()).toContain("/reader/1342");

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { searchBooks, getCachedBooks, BookMeta } from "@/lib/api";
+import { searchBooks, BookMeta } from "@/lib/api";
 import { getRecentBooks, RecentBook } from "@/lib/recentBooks";
 import BookCard from "@/components/BookCard";
 import { useRouter } from "next/navigation";
@@ -37,19 +37,15 @@ export default function Home() {
   const [searchedQuery, setSearchedQuery] = useState(""); // tracks what was searched (for "no results" message)
 
   const [recentBooks, setRecentBooks] = useState<RecentBook[]>([]);
-  const [cachedBooks, setCachedBooks] = useState<BookMeta[]>([]);
-  const [cachedLoading, setCachedLoading] = useState(true);
 
   // Race-condition guard: drop responses from stale searches
   const searchGenRef = useRef(0);
 
-  // Load recent books from localStorage and cached books from backend on mount
+  // Load recent books from localStorage on mount. These are books the user
+  // has actually opened — NOT the full server cache (which includes 100+
+  // seeded books the user has never touched).
   useEffect(() => {
     setRecentBooks(getRecentBooks());
-    getCachedBooks()
-      .then(setCachedBooks)
-      .catch(() => {})
-      .finally(() => setCachedLoading(false));
   }, []);
 
   async function handleSearch(q = query, l = lang) {
@@ -76,20 +72,8 @@ export default function Home() {
     router.push(`/reader/${id}`);
   }
 
-  // Merge cached books (server-side) with recent-read info (client-side localStorage).
-  // Recent books carry lastChapter + lastRead timestamps; cached books are the
-  // canonical server list. We enhance cached books with the recent info and
-  // sort so recently-read books appear first.
-  const recentMap = new Map(recentBooks.map((b) => [b.id, b]));
-  const libraryBooks = [...cachedBooks]
-    .sort((a, b) => {
-      const ra = recentMap.get(a.id)?.lastRead ?? 0;
-      const rb = recentMap.get(b.id)?.lastRead ?? 0;
-      return rb - ra; // most recently read first
-    });
-
-  const showLibrary = libraryBooks.length > 0;
-  const showEmpty = !showLibrary && !cachedLoading && searchResults.length === 0;
+  const showLibrary = recentBooks.length > 0;
+  const showEmpty = !showLibrary && searchResults.length === 0;
 
   return (
     <main className="min-h-screen bg-parchment">
@@ -119,38 +103,23 @@ export default function Home() {
 
       <div className="max-w-4xl mx-auto px-6 py-8 space-y-10">
 
-        {/* ── Your Library (merged: server-cached books + client-side read progress) ── */}
+        {/* ── Your Library (books the user has actually opened) ── */}
         {showLibrary && (
           <section>
             <h2 className="font-serif font-semibold text-ink text-lg mb-3">
               Your Library
             </h2>
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-              {libraryBooks.map((book) => {
-                const recent = recentMap.get(book.id);
-                return (
-                  <BookCard
-                    key={book.id}
-                    book={book}
-                    onClick={() => openBook(book.id)}
-                    badge={recent ? `Ch. ${recent.lastChapter + 1} · ${timeAgo(recent.lastRead)}` : undefined}
-                  />
-                );
-              })}
+              {recentBooks.map((book) => (
+                <BookCard
+                  key={book.id}
+                  book={book}
+                  onClick={() => openBook(book.id)}
+                  badge={`Ch. ${book.lastChapter + 1} · ${timeAgo(book.lastRead)}`}
+                />
+              ))}
             </div>
           </section>
-        )}
-
-        {cachedLoading && (
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <div key={i} className="rounded-xl border border-amber-200 bg-white p-3 animate-pulse">
-                <div className="w-full h-40 bg-amber-100 rounded-lg mb-2" />
-                <div className="h-3 bg-amber-100 rounded w-3/4 mb-1" />
-                <div className="h-3 bg-amber-100 rounded w-1/2" />
-              </div>
-            ))}
-          </div>
         )}
 
         {/* ── Discover Books (Search) ────────────────────────────────── */}

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -557,6 +557,8 @@ export default function ReaderPage() {
           {/* Keep mounted so chat history persists across open/close */}
           <InsightChat
             bookId={bookId}
+            userId={session?.backendUser?.id ?? null}
+            hasGeminiKey={hasGeminiKey}
             isVisible={sidebarOpen}
             chapterText={current?.text ?? ""}
             chapterTitle={current?.title || `Chapter ${chapterIndex + 1}`}

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -21,7 +21,10 @@ export const LANGUAGES = [
   { code: "ja", label: "日本語" },
 ];
 
-const HISTORY_KEY = (id: string) => `chat-history:${id}`;
+// Chat history is scoped per user + book so different users on the same
+// browser don't see each other's conversations. The userId comes from
+// the backend session (passed as a prop).
+const HISTORY_KEY = (userId: number | string, bookId: string) => `chat-history:${userId}:${bookId}`;
 const INITIAL_DISPLAY = 30; // messages shown on first load
 const LOAD_BATCH = 20;      // messages revealed per "load earlier" click
 const MAX_STORED = 200;     // cap localStorage to last N messages
@@ -38,6 +41,8 @@ interface Message {
 
 interface Props {
   bookId: string;
+  userId: number | null;    // current user's ID — scopes chat history per user
+  hasGeminiKey: boolean;    // whether the user has a Gemini key — shows early reminder if not
   isVisible: boolean;       // true when the sidebar is open — gates insight fetching
   chapterText: string;
   chapterTitle: string;
@@ -51,6 +56,8 @@ interface Props {
 
 export default function InsightChat({
   bookId,
+  userId,
+  hasGeminiKey,
   isVisible,
   chapterText,
   chapterTitle,
@@ -96,7 +103,7 @@ export default function InsightChat({
     setChatLoading(false);
 
     try {
-      const raw = localStorage.getItem(HISTORY_KEY(bookId));
+      const raw = localStorage.getItem(HISTORY_KEY(userId ?? "anon", bookId));
       if (raw) {
         const stored: Message[] = JSON.parse(raw);
         setMessages(stored);
@@ -120,7 +127,7 @@ export default function InsightChat({
     try {
       const toStore = messages.slice(-MAX_STORED);
       if (toStore.length > 0)
-        localStorage.setItem(HISTORY_KEY(bookId), JSON.stringify(toStore));
+        localStorage.setItem(HISTORY_KEY(userId ?? "anon", bookId), JSON.stringify(toStore));
     } catch {} // ignore quota errors
   }, [messages, bookId]);
 
@@ -422,13 +429,25 @@ export default function InsightChat({
               </div>
             )}
 
+            {/* Early Gemini key reminder — shown before the user even types */}
+            {!hasGeminiKey && (
+              <div className="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 mb-2 text-xs text-amber-800">
+                Chat requires a{" "}
+                <a href="/profile" target="_blank" className="underline font-medium">
+                  Gemini API key
+                </a>{" "}
+                (free from Google AI Studio). Add one in your profile to start chatting.
+              </div>
+            )}
+
             <div className="flex gap-2 items-end">
               <textarea
                 className="flex-1 rounded-xl border border-amber-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 resize-none font-serif leading-snug"
                 rows={2}
-                placeholder="Ask about this chapter…"
+                placeholder={hasGeminiKey ? "Ask about this chapter…" : "Gemini API key required to chat"}
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
+                disabled={!hasGeminiKey}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" && !e.shiftKey) {
                     e.preventDefault();
@@ -438,14 +457,14 @@ export default function InsightChat({
               />
               <button
                 onClick={sendMessage}
-                disabled={chatLoading || !input.trim()}
+                disabled={chatLoading || !input.trim() || !hasGeminiKey}
                 className="rounded-xl bg-amber-700 p-2.5 text-white text-base hover:bg-amber-800 disabled:opacity-40 shrink-0"
                 title="Send (Enter)"
               >
                 ↑
               </button>
             </div>
-            <p className="text-xs text-amber-400 mt-1.5">Enter · Shift+Enter for newline</p>
+            {hasGeminiKey && <p className="text-xs text-amber-400 mt-1.5">Enter · Shift+Enter for newline</p>}
           </div>
         </div>
       )}


### PR DESCRIPTION
Three fixes: (1) Your Library shows only books from localStorage recentBooks, not the full server cache. (2) Chat history scoped per user ID. (3) Chat shows early Gemini key reminder before the user types. E2E tests updated + new test for empty library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)