### PR TITLE
fix(translate): unwrap hard line breaks for Google Translate

### DIFF
--- a/backend/services/translate.py
+++ b/backend/services/translate.py
@@ -13,6 +13,7 @@ Public API: translate_text(text, source, target, provider, gemini_key)
 """
 
 import asyncio
+import re
 from typing import Literal
 
 Provider = Literal["gemini", "google"]
@@ -43,6 +44,18 @@ def _google_translate_chunk(text: str, source: str, target: str) -> str:
     ).translate(text)
 
 
+def _unwrap_paragraph(text: str) -> str:
+    """Join hard-wrapped lines within a paragraph into flowing text.
+
+    Gutenberg texts wrap at ~70 chars, inserting \\n mid-sentence.
+    Google Translate treats each line independently, so we must unwrap
+    before translating.  Preserves intentional breaks (e.g. verse or
+    dialogue) by only joining when the previous line doesn't end with
+    punctuation that suggests a deliberate break.
+    """
+    return re.sub(r"(?<![.!?:;\"'\u201d])\n(?!\n)", " ", text)
+
+
 async def _google_translate(text: str, source: str, target: str) -> list[str]:
     """Split text into paragraphs and translate each via Google Translate."""
     paragraphs = [p for p in text.split("\n\n") if p.strip()]
@@ -54,8 +67,9 @@ async def _google_translate(text: str, source: str, target: str) -> list[str]:
     loop = asyncio.get_event_loop()
     results = []
     for para in paragraphs:
+        unwrapped = _unwrap_paragraph(para)
         translated = await loop.run_in_executor(
-            None, _google_translate_chunk, para, source, target
+            None, _google_translate_chunk, unwrapped, source, target
         )
         results.append(translated)
 

--- a/backend/tests/test_translate.py
+++ b/backend/tests/test_translate.py
@@ -1,0 +1,73 @@
+"""Tests for services/translate.py — paragraph unwrapping and language mapping."""
+
+import pytest
+from services.translate import _unwrap_paragraph, _normalize_google_lang
+
+
+class TestUnwrapParagraph:
+    def test_joins_hard_wrapped_prose(self):
+        text = "I am by birth a Genevese, and my family is one of the most\ndistinguished of that republic."
+        assert _unwrap_paragraph(text) == (
+            "I am by birth a Genevese, and my family is one of the most "
+            "distinguished of that republic."
+        )
+
+    def test_double_newline_not_joined(self):
+        # In practice _unwrap_paragraph only sees single paragraphs (split
+        # upstream by \n\n), but if it did see \n\n the first \n is kept
+        # because '.' is in the lookbehind set, and the second \n is kept
+        # because the negative lookahead (?!\n) blocks it.
+        text = "First paragraph.\n\nSecond paragraph."
+        result = _unwrap_paragraph(text)
+        assert "First paragraph." in result
+        assert "Second paragraph." in result
+
+    def test_preserves_line_after_sentence_end(self):
+        text = "He spoke.\nShe replied."
+        assert _unwrap_paragraph(text) == "He spoke.\nShe replied."
+
+    def test_preserves_line_after_exclamation(self):
+        text = "Stop!\nDo not go."
+        assert _unwrap_paragraph(text) == "Stop!\nDo not go."
+
+    def test_preserves_line_after_question(self):
+        text = "Why?\nBecause I said so."
+        assert _unwrap_paragraph(text) == "Why?\nBecause I said so."
+
+    def test_preserves_line_after_colon(self):
+        text = "He said:\nNothing at all."
+        assert _unwrap_paragraph(text) == "He said:\nNothing at all."
+
+    def test_preserves_line_after_closing_quote(self):
+        text = 'He said "hello."\nShe waved.'
+        assert _unwrap_paragraph(text) == 'He said "hello."\nShe waved.'
+
+    def test_preserves_line_after_curly_quote(self):
+        text = "He said \u201chello.\u201d\nShe waved."
+        assert _unwrap_paragraph(text) == "He said \u201chello.\u201d\nShe waved."
+
+    def test_multiple_hard_wraps(self):
+        text = "one two three four five six seven eight nine ten eleven\ntwelve thirteen fourteen fifteen sixteen seventeen\neighteen nineteen twenty"
+        assert "\n" not in _unwrap_paragraph(text)
+
+    def test_empty_string(self):
+        assert _unwrap_paragraph("") == ""
+
+    def test_no_newlines(self):
+        assert _unwrap_paragraph("Just one line.") == "Just one line."
+
+
+class TestNormalizeGoogleLang:
+    def test_chinese(self):
+        assert _normalize_google_lang("zh") == "zh-CN"
+
+    def test_portuguese(self):
+        assert _normalize_google_lang("pt") == "pt-BR"
+
+    def test_hebrew(self):
+        assert _normalize_google_lang("he") == "iw"
+
+    def test_passthrough(self):
+        assert _normalize_google_lang("de") == "de"
+        assert _normalize_google_lang("en") == "en"
+        assert _normalize_google_lang("fr") == "fr"

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -355,7 +355,7 @@ export default function SentenceReader({
               {originalContent}
               <div className="border-l border-amber-200 pl-6">
                 {translationText ? (
-                  <p className="font-serif text-base text-amber-800 leading-relaxed italic whitespace-pre-wrap">
+                  <p className="font-serif text-base text-amber-800 leading-relaxed italic">
                     {translationText}
                   </p>
                 ) : translationLoading ? (
@@ -381,7 +381,7 @@ export default function SentenceReader({
               </div>
             )}
             {translationText && (
-              <p className="mt-1 font-serif text-sm text-amber-700 italic border-l-2 border-amber-300 pl-3 whitespace-pre-wrap">
+              <p className="mt-1 font-serif text-sm text-amber-700 italic border-l-2 border-amber-300 pl-3">
                 {translationText}
               </p>
             )}

--- a/frontend/src/components/TranslationView.tsx
+++ b/frontend/src/components/TranslationView.tsx
@@ -1,5 +1,11 @@
 "use client";
 
+/** Join Gutenberg hard wraps (single \n mid-sentence) into flowing text.
+ *  Keeps intentional breaks after sentence-ending punctuation. */
+function unwrap(text: string): string {
+  return text.replace(/(?<![.!?:;\"'\u201d])\n(?!\n)/g, " ");
+}
+
 interface Props {
   paragraphs: string[];
   translations: string[];
@@ -13,10 +19,10 @@ export default function TranslationView({ paragraphs, translations, displayMode,
       <div className="max-w-5xl mx-auto divide-y divide-amber-100">
         {paragraphs.map((para, i) => (
           <div key={i} className="grid grid-cols-2 gap-6 py-4 first:pt-0 last:pb-0">
-            <p className="font-serif text-base text-ink leading-relaxed whitespace-pre-wrap">{para}</p>
+            <p className="font-serif text-base text-ink leading-relaxed">{unwrap(para)}</p>
             <div className="border-l border-amber-200 pl-6">
               {translations[i] ? (
-                <p className="font-serif text-base text-amber-800 leading-relaxed italic whitespace-pre-wrap">
+                <p className="font-serif text-base text-amber-800 leading-relaxed italic">
                   {translations[i]}
                 </p>
               ) : loading ? (
@@ -38,7 +44,7 @@ export default function TranslationView({ paragraphs, translations, displayMode,
     <div className="prose-reader mx-auto space-y-6">
       {paragraphs.map((para, i) => (
         <div key={i}>
-          <p className="font-serif text-base text-ink leading-relaxed whitespace-pre-wrap">{para}</p>
+          <p className="font-serif text-base text-ink leading-relaxed">{unwrap(para)}</p>
           {loading && i === 0 && !translations.length && (
             <div className="mt-1 space-y-1 animate-pulse">
               <div className="h-3 bg-amber-100 rounded w-full" />
@@ -46,7 +52,7 @@ export default function TranslationView({ paragraphs, translations, displayMode,
             </div>
           )}
           {translations[i] && (
-            <p className="mt-1 font-serif text-sm text-amber-700 italic border-l-2 border-amber-300 pl-3 whitespace-pre-wrap">
+            <p className="mt-1 font-serif text-sm text-amber-700 italic border-l-2 border-amber-300 pl-3">
               {translations[i]}
             </p>
           )}


### PR DESCRIPTION
## Summary
- **Backend**: Gutenberg texts have hard wraps at ~70 chars within paragraphs. Google Translate treats each line independently, producing broken translations that cut mid-sentence. Added `_unwrap_paragraph()` to join single `\n` into spaces before translating, preserving intentional breaks after sentence-ending punctuation.
- **Frontend**: Removed `whitespace-pre-wrap` from translation text in both `TranslationView` and `SentenceReader` — the side-by-side view was rendering Gutenberg's hard wraps as actual line breaks, creating choppy short lines in the narrow column. Added `unwrap()` helper in `TranslationView` for the original text column too.

## Test plan
- [x] 15 new unit tests for `_unwrap_paragraph` and `_normalize_google_lang`
- [x] Backend: 215 tests pass
- [x] Frontend: 105 tests pass
- [x] E2E: 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)