### PR TITLE
feat(admin): retranslate button for cached translations

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -6,7 +6,7 @@ Full CRUD where applicable.
 import aiosqlite
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from services.auth import get_current_user
+from services.auth import get_current_user, decrypt_api_key
 from services.db import (
     DB_PATH,
     list_users,
@@ -16,9 +16,12 @@ from services.db import (
     list_cached_books,
     get_cached_book,
     save_book,
+    save_translation,
     delete_chapter_audio_cache,
 )
 from services.gutenberg import get_book_meta, get_book_text
+from services.splitter import build_chapters
+from services.translate import translate_text as do_translate
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -221,6 +224,69 @@ async def delete_translation(
         )
         await db.commit()
         return {"ok": True, "deleted": cursor.rowcount}
+
+
+@router.post("/translations/{book_id}/{chapter_index}/{target_language}/retranslate")
+async def retranslate(
+    book_id: int,
+    chapter_index: int,
+    target_language: str,
+    admin: dict = Depends(_require_admin),
+):
+    """Delete cached translation and re-translate the chapter."""
+    # 1. Get the book text
+    book = await get_cached_book(book_id)
+    if not book or not book.get("text"):
+        raise HTTPException(status_code=404, detail="Book not found in cache")
+
+    chapters = build_chapters(book["text"])
+    if chapter_index < 0 or chapter_index >= len(chapters):
+        raise HTTPException(status_code=400, detail=f"Chapter index {chapter_index} out of range (0–{len(chapters) - 1})")
+
+    chapter_text = chapters[chapter_index].text
+
+    # 2. Delete old cached translation
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "DELETE FROM translations WHERE book_id=? AND chapter_index=? AND target_language=?",
+            (book_id, chapter_index, target_language),
+        )
+        await db.commit()
+
+    # 3. Detect source language from book metadata
+    source_language = (book.get("languages") or ["en"])[0]
+
+    # 4. Resolve provider — use admin's Gemini key if available, else Google
+    raw_key = admin.get("gemini_key")
+    decrypted_key: str | None = decrypt_api_key(raw_key) if raw_key else None
+    provider = "gemini" if decrypted_key else "google"
+
+    # 5. Translate
+    try:
+        paragraphs = await do_translate(
+            chapter_text,
+            source_language,
+            target_language,
+            provider=provider,
+            gemini_key=decrypted_key,
+        )
+    except Exception:
+        if provider == "gemini":
+            paragraphs = await do_translate(
+                chapter_text, source_language, target_language, provider="google",
+            )
+            provider = "google"
+        else:
+            raise
+
+    # 6. Cache the new translation
+    await save_translation(book_id, chapter_index, target_language, paragraphs)
+
+    return {
+        "ok": True,
+        "provider": provider,
+        "paragraphs_count": len(paragraphs),
+    }
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -4,6 +4,7 @@ import json
 import pytest
 from unittest.mock import patch, AsyncMock
 import services.db as db_module
+import routers.admin as admin_module
 from services.db import init_db, get_or_create_user, get_user_by_id, save_book, save_translation
 from services.auth import get_current_user
 from main import app
@@ -35,6 +36,8 @@ BOOK_TEXT = "CHAPTER I\n\nErster Absatz des ersten Kapitels.\n\nZweiter Absatz.\
 async def admin_db(monkeypatch, tmp_path):
     path = str(tmp_path / "admin-test.db")
     monkeypatch.setattr(db_module, "DB_PATH", path)
+    # admin.py imports DB_PATH as a local binding — patch it too
+    monkeypatch.setattr(admin_module, "DB_PATH", path)
     await init_db()
     return path
 

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -1,0 +1,110 @@
+"""Tests for admin endpoints — retranslate."""
+
+import json
+import pytest
+from unittest.mock import patch, AsyncMock
+import services.db as db_module
+from services.db import init_db, get_or_create_user, get_user_by_id, save_book, save_translation
+from services.auth import get_current_user
+from main import app
+from httpx import AsyncClient, ASGITransport
+
+
+ADMIN_USER = {
+    "google_id": "admin-google-id",
+    "email": "admin@example.com",
+    "name": "Admin",
+    "picture": "",
+}
+
+BOOK_META = {
+    "id": 100,
+    "title": "Test Book",
+    "authors": ["Author"],
+    "languages": ["de"],
+    "subjects": [],
+    "download_count": 0,
+    "cover": "",
+}
+
+# Two short chapters separated by a heading
+BOOK_TEXT = "CHAPTER I\n\nErster Absatz des ersten Kapitels.\n\nZweiter Absatz.\n\nCHAPTER II\n\nErstes Kapitel zwei."
+
+
+@pytest.fixture
+async def admin_db(monkeypatch, tmp_path):
+    path = str(tmp_path / "admin-test.db")
+    monkeypatch.setattr(db_module, "DB_PATH", path)
+    await init_db()
+    return path
+
+
+@pytest.fixture
+async def admin_user(admin_db):
+    """First user is auto-admin."""
+    return await get_or_create_user(**ADMIN_USER)
+
+
+@pytest.fixture
+async def admin_client(admin_user):
+    async def _override():
+        return await get_user_by_id(admin_user["id"])
+
+    app.dependency_overrides[get_current_user] = _override
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+async def test_retranslate_creates_new_translation(admin_client, admin_user):
+    """Retranslate deletes old cache and produces a fresh translation."""
+    # Seed a book
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    # Seed an old translation for chapter 0
+    await save_translation(100, 0, "en", ["Old stale translation."])
+
+    with patch(
+        "routers.admin.do_translate",
+        new_callable=AsyncMock,
+        return_value=["Fresh paragraph one.", "Fresh paragraph two."],
+    ) as mock_translate:
+        res = await admin_client.post("/api/admin/translations/100/0/en/retranslate")
+
+    assert res.status_code == 200
+    data = res.json()
+    assert data["ok"] is True
+    assert data["paragraphs_count"] == 2
+    assert data["provider"] in ("gemini", "google")
+    mock_translate.assert_awaited_once()
+
+
+async def test_retranslate_book_not_found(admin_client):
+    res = await admin_client.post("/api/admin/translations/999/0/en/retranslate")
+    assert res.status_code == 404
+
+
+async def test_retranslate_chapter_out_of_range(admin_client):
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    res = await admin_client.post("/api/admin/translations/100/99/en/retranslate")
+    assert res.status_code == 400
+    assert "out of range" in res.json()["detail"]
+
+
+async def test_retranslate_non_admin_forbidden(admin_db, admin_user):
+    """A non-admin user cannot access the retranslate endpoint."""
+    from services.db import set_user_approved
+    # Create a second (non-admin) user and approve them
+    user2 = await get_or_create_user(
+        google_id="user2", email="user2@example.com", name="User 2", picture=""
+    )
+    await set_user_approved(user2["id"], True)
+
+    async def _override():
+        return await get_user_by_id(user2["id"])
+
+    app.dependency_overrides[get_current_user] = _override
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        res = await c.post("/api/admin/translations/100/0/en/retranslate")
+    app.dependency_overrides.clear()
+
+    assert res.status_code == 403

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -44,6 +44,7 @@ export default function AdminPage() {
   const [translations, setTranslations] = useState<TranslationEntry[]>([]);
   const [importId, setImportId] = useState("");
   const [importing, setImporting] = useState(false);
+  const [retranslating, setRetranslating] = useState<string | null>(null);
 
   useEffect(() => {
     getMe().then((me) => {
@@ -89,6 +90,21 @@ export default function AdminPage() {
       alert(e instanceof Error ? e.message : "Import failed");
     } finally {
       setImporting(false);
+    }
+  }
+
+  async function handleRetranslate(t: TranslationEntry) {
+    const key = `${t.book_id}:${t.chapter_index}:${t.target_language}`;
+    if (!confirm(`Retranslate Book ${t.book_id}, Ch. ${t.chapter_index + 1} → ${t.target_language}?\nThis will delete the cached version and generate a fresh translation.`)) return;
+    setRetranslating(key);
+    try {
+      const res = await adminFetch(`/admin/translations/${t.book_id}/${t.chapter_index}/${t.target_language}/retranslate`, { method: "POST" });
+      alert(`Retranslated via ${res.provider}: ${res.paragraphs_count} paragraphs`);
+      await loadAll();
+    } catch (e: unknown) {
+      alert(e instanceof Error ? e.message : "Retranslation failed");
+    } finally {
+      setRetranslating(null);
     }
   }
 
@@ -246,6 +262,12 @@ export default function AdminPage() {
                   <div className="text-sm text-ink">Book {t.book_id}, Ch. {t.chapter_index + 1} → {t.target_language}</div>
                   <div className="text-xs text-stone-400">{(t.size_chars / 1000).toFixed(1)}K chars</div>
                 </div>
+                <button
+                  onClick={() => handleRetranslate(t)}
+                  disabled={retranslating === `${t.book_id}:${t.chapter_index}:${t.target_language}`}
+                  className="text-xs px-2 py-1 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-50">
+                  {retranslating === `${t.book_id}:${t.chapter_index}:${t.target_language}` ? "Translating…" : "Retranslate"}
+                </button>
                 <button onClick={() => act(() => adminFetch(`/admin/translations/${t.book_id}/${t.chapter_index}/${t.target_language}`, { method: "DELETE" }))}
                   className="text-xs px-2 py-1 rounded border border-red-200 text-red-500">Delete</button>
               </div>


### PR DESCRIPTION
## Summary
- Add `POST /api/admin/translations/{book_id}/{chapter_index}/{target_language}/retranslate` endpoint
- Deletes old cached translation, re-fetches chapter text from the book, translates (Gemini with Google fallback), saves fresh result
- Admin UI gets a "Retranslate" button next to each translation entry with loading state
- 4 new backend tests (happy path, book not found, chapter out of range, non-admin forbidden)

## Test plan
- [x] Backend: 219 tests pass
- [x] Frontend: 105 tests pass
- [x] E2E: 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)