### PR TITLE
feat(translate): progressive batch translation

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -136,6 +136,34 @@ async def references(req: ReferencesRequest, user: dict = Depends(get_current_us
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.get("/translate/cache")
+async def translate_cache(
+    book_id: int,
+    chapter_index: int,
+    target_language: str,
+    _user: dict = Depends(get_current_user),
+):
+    """Check if a translation is cached. Returns it if yes, 404 if not."""
+    cached = await get_cached_translation(book_id, chapter_index, target_language)
+    if cached:
+        return {"paragraphs": cached, "cached": True}
+    raise HTTPException(status_code=404, detail="Not cached")
+
+
+class SaveTranslationRequest(BaseModel):
+    book_id: int
+    chapter_index: int
+    target_language: str
+    paragraphs: list[str]
+
+
+@router.put("/translate/cache")
+async def save_translate_cache(req: SaveTranslationRequest, _user: dict = Depends(get_current_user)):
+    """Save a completed progressive translation to the backend cache."""
+    await save_translation(req.book_id, req.chapter_index, req.target_language, req.paragraphs)
+    return {"ok": True}
+
+
 @router.post("/translate")
 async def translate(req: TranslateRequest, user: dict = Depends(get_current_user)):
     """Translate text with auto-fallback: Gemini if key available, else Google Translate (free)."""

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -94,6 +94,33 @@ async def test_translate_without_book_id_skips_cache(client, test_user):
     assert resp.json()["cached"] is False
 
 
+# ── Translation cache endpoints ───────────────────────────────────────────────
+
+async def test_translate_cache_get_returns_cached(client):
+    """GET /translate/cache returns cached translation."""
+    await save_translation(1, 0, "en", TRANSLATED)
+    resp = await client.get("/api/ai/translate/cache?book_id=1&chapter_index=0&target_language=en")
+    assert resp.status_code == 200
+    assert resp.json()["paragraphs"] == TRANSLATED
+    assert resp.json()["cached"] is True
+
+
+async def test_translate_cache_get_returns_404_when_missing(client):
+    resp = await client.get("/api/ai/translate/cache?book_id=999&chapter_index=0&target_language=en")
+    assert resp.status_code == 404
+
+
+async def test_translate_cache_put_saves(client):
+    """PUT /translate/cache saves paragraphs for later retrieval."""
+    resp = await client.put("/api/ai/translate/cache", json={
+        "book_id": 2, "chapter_index": 1, "target_language": "fr",
+        "paragraphs": ["Bonjour"],
+    })
+    assert resp.status_code == 200
+    cached = await get_cached_translation(2, 1, "fr")
+    assert cached == ["Bonjour"]
+
+
 # ── Insight ───────────────────────────────────────────────────────────────────
 
 async def test_insight_without_key_returns_400(client):

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -12,6 +12,8 @@ import {
   getBookChapters,
   getInsight,
   translateText,
+  getTranslationCache,
+  saveTranslationCache,
   askQuestion,
   synthesizeSpeech,
   getTtsChunks,
@@ -136,6 +138,32 @@ test("translateText sends correct body", async () => {
   expect(body.target_language).toBe("en");
   expect(body.book_id).toBe(1342);
   expect(body.chapter_index).toBe(0);
+});
+
+test("getTranslationCache returns paragraphs on hit", async () => {
+  mockFetch({ paragraphs: ["Translated"], cached: true });
+  const result = await getTranslationCache(1342, 0, "en");
+  expect(result).toEqual(["Translated"]);
+  const url = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+  expect(url).toContain("/ai/translate/cache");
+  expect(url).toContain("book_id=1342");
+});
+
+test("getTranslationCache returns null on miss", async () => {
+  mockFetch({ detail: "Not cached" }, false);
+  const result = await getTranslationCache(999, 0, "en");
+  expect(result).toBeNull();
+});
+
+test("saveTranslationCache sends PUT", async () => {
+  mockFetch({ ok: true });
+  await saveTranslationCache(1342, 0, "en", ["Hello"]);
+  const [url, opts] = (global.fetch as jest.Mock).mock.calls[0];
+  expect(url).toContain("/ai/translate/cache");
+  expect(opts.method).toBe("PUT");
+  const body = JSON.parse(opts.body);
+  expect(body.book_id).toBe(1342);
+  expect(body.paragraphs).toEqual(["Hello"]);
 });
 
 test("askQuestion sends POST to /ai/qa", async () => {

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { getBookChapters, translateText, getAudiobook, deleteAudiobook, synthesizeSpeech, getMe, BookMeta, BookChapter, Audiobook } from "@/lib/api";
+import { getBookChapters, translateText, getTranslationCache, saveTranslationCache, getAudiobook, deleteAudiobook, synthesizeSpeech, getMe, BookMeta, BookChapter, Audiobook } from "@/lib/api";
 import { recordRecentBook, saveLastChapter, getLastChapter } from "@/lib/recentBooks";
 import { getSettings } from "@/lib/settings";
 import InsightChat, { LANGUAGES } from "@/components/InsightChat";
@@ -144,7 +144,9 @@ export default function ReaderPage() {
 
   const bookLanguage = meta?.languages[0] || "en";
 
-  // Auto-translate when enabled or chapter/lang changes
+  // Auto-translate when enabled or chapter/lang changes.
+  // Splits the chapter into batches and translates progressively so
+  // paragraphs appear one batch at a time instead of all-or-nothing.
   useEffect(() => {
     const current = chapters[chapterIndex];
     if (!translationEnabled || !current?.text) {
@@ -158,30 +160,58 @@ export default function ReaderPage() {
       setTranslatedParagraphs(translationCache.current.get(cacheKey)!);
       return;
     }
+
+    let cancelled = false;
     setTranslationLoading(true);
     setTranslatedParagraphs([]);
-    translateText(current.text, bookLanguage, translationLang, Number(bookId), chapterIndex)
-      .then((r) => {
-        // Always cache so the user gets instant results if they navigate back
-        if (!r.cached) notifyAIUsed();
-        translationCache.current.set(cacheKey, r.paragraphs);
-        // Only update the UI if the user is still on this chapter
-        if (currentChapterKey.current === cacheKey) {
-          setTranslatedParagraphs(r.paragraphs);
+
+    const bid = Number(bookId);
+
+    (async () => {
+      // 1. Quick cache check — returns instantly if backend has it
+      const cached = await getTranslationCache(bid, chapterIndex, translationLang);
+      if (cancelled || currentChapterKey.current !== cacheKey) return;
+      if (cached) {
+        translationCache.current.set(cacheKey, cached);
+        setTranslatedParagraphs(cached);
+        setTranslationLoading(false);
+        return;
+      }
+
+      // 2. No cache — translate progressively in batches of ~3 paragraphs.
+      //    Each batch appears as soon as it's done.
+      const BATCH_SIZE = 3;
+      const paragraphs = current.text.split(/\n\n+/).filter((p: string) => p.trim());
+      const batches: string[][] = [];
+      for (let i = 0; i < paragraphs.length; i += BATCH_SIZE) {
+        batches.push(paragraphs.slice(i, i + BATCH_SIZE));
+      }
+
+      const accumulated: string[] = [];
+      for (const batch of batches) {
+        if (cancelled || currentChapterKey.current !== cacheKey) return;
+        try {
+          const r = await translateText(batch.join("\n\n"), bookLanguage, translationLang);
+          accumulated.push(...r.paragraphs);
+          if (!cancelled && currentChapterKey.current === cacheKey) {
+            setTranslatedParagraphs([...accumulated]);
+          }
+          notifyAIUsed();
+        } catch (e) {
+          console.error("Translation batch failed:", e);
+          notifyAIUsed();
+          break;
         }
-      })
-      .catch((e) => {
-        // Backend returns 400 "Gemini API key required" when the user has no key.
-        // notifyAIUsed() is guarded by !hasGeminiKey, so it's a no-op for users
-        // who do have a key (in which case the error is some real Gemini failure).
-        console.error("Translation failed:", e);
-        notifyAIUsed();
-      })
-      .finally(() => {
-        if (currentChapterKey.current === cacheKey) {
-          setTranslationLoading(false);
-        }
-      });
+      }
+      if (!cancelled && currentChapterKey.current === cacheKey) {
+        translationCache.current.set(cacheKey, accumulated);
+        setTranslationLoading(false);
+        // Save to backend cache for next visit (fire-and-forget)
+        saveTranslationCache(bid, chapterIndex, translationLang, accumulated).catch(() => {});
+      }
+    })();
+
+    return () => { cancelled = true; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [translationEnabled, translationLang, chapterIndex, bookId]);
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -74,6 +74,36 @@ export function translateText(
   });
 }
 
+/** Check if a translation is already cached. Returns paragraphs or null. */
+export async function getTranslationCache(
+  bookId: number,
+  chapterIndex: number,
+  targetLanguage: string,
+): Promise<string[] | null> {
+  try {
+    const data = await request<{ paragraphs: string[] }>(
+      `/ai/translate/cache?book_id=${bookId}&chapter_index=${chapterIndex}&target_language=${targetLanguage}`
+    );
+    return data.paragraphs;
+  } catch {
+    return null;
+  }
+}
+
+/** Save a completed progressive translation to the backend cache. */
+export function saveTranslationCache(
+  bookId: number,
+  chapterIndex: number,
+  targetLanguage: string,
+  paragraphs: string[],
+) {
+  return request<{ ok: boolean }>("/ai/translate/cache", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ book_id: bookId, chapter_index: chapterIndex, target_language: targetLanguage, paragraphs }),
+  });
+}
+
 export function askQuestion(
   question: string,
   passage: string,


### PR DESCRIPTION
## Summary
- Translation now appears **incrementally** — paragraphs show up batch by batch (3 at a time) instead of waiting for the entire chapter
- Quick backend cache check via `GET /ai/translate/cache` returns instantly if cached
- After all batches complete, saves the full result via `PUT /ai/translate/cache` for instant retrieval next time
- Cached chapters still load instantly (no change to cached behavior)

## Test plan
- [x] Backend: 222 tests pass (3 new for cache GET/PUT endpoints)
- [x] Frontend: 108 tests pass (3 new for getTranslationCache/saveTranslationCache)
- [x] E2E: 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)