### PR TITLE
fix(splitter): strip bracket artifacts from chapter titles

### DIFF
--- a/backend/services/splitter.py
+++ b/backend/services/splitter.py
@@ -101,6 +101,15 @@ def strip_boilerplate(text: str) -> tuple[str, int]:
     return text[offset:end], offset
 
 
+def _clean_title(title: str) -> str:
+    """Remove Gutenberg bracket artifacts from chapter titles."""
+    # Strip trailing brackets/parens that aren't balanced (e.g. "Chapter I.]")
+    title = re.sub(r'[\]\)}>]+\s*$', '', title)
+    # Strip leading brackets that aren't balanced
+    title = re.sub(r'^[\[\({<]+', '', title)
+    return title.strip()
+
+
 def _validate(chapters: list[Chapter]) -> bool:
     """Return True if the chapter list looks reasonable."""
     if len(chapters) < 2:
@@ -152,7 +161,7 @@ def _chapters_from_keywords(body: str, offset: int, full_text: str) -> list[Chap
     for i, (title, start) in enumerate(entries):
         end = entries[i + 1][1] if i + 1 < len(entries) else len(full_text)
         text = full_text[start:end].strip()
-        chapters.append(Chapter(title=title, text=text))
+        chapters.append(Chapter(title=_clean_title(title), text=text))
 
     return _merge_tiny_first(chapters)
 
@@ -179,7 +188,7 @@ def _chapters_from_roman(body: str, offset: int, full_text: str) -> list[Chapter
     for i, (title, start) in enumerate(entries):
         end = entries[i + 1][1] if i + 1 < len(entries) else len(full_text)
         text = full_text[start:end].strip()
-        chapters.append(Chapter(title=title, text=text))
+        chapters.append(Chapter(title=_clean_title(title), text=text))
 
     return _merge_tiny_first(chapters)
 
@@ -227,7 +236,7 @@ def _chapters_from_toc(body: str, offset: int, full_text: str) -> list[Chapter]:
         end = positions[i + 1][1] if i + 1 < len(positions) else len(full_text)
         text = full_text[start:end].strip()
         if len(text) > 150:
-            chapters.append(Chapter(title=title, text=text))
+            chapters.append(Chapter(title=_clean_title(title), text=text))
 
     return _merge_tiny_first(chapters)
 
@@ -249,7 +258,7 @@ def _chapters_from_paragraphs(body: str) -> list[Chapter]:
         w = len(stripped.split())
         if word_count + w > WORDS_PER_SECTION and word_count > 0:
             chapters.append(Chapter(
-                title=section_title,
+                title=_clean_title(section_title),
                 text="\n\n".join(current),
             ))
             current = []
@@ -261,7 +270,7 @@ def _chapters_from_paragraphs(body: str) -> list[Chapter]:
         word_count += w
 
     if current:
-        chapters.append(Chapter(title=section_title, text="\n\n".join(current)))
+        chapters.append(Chapter(title=_clean_title(section_title), text="\n\n".join(current)))
     return [c for c in chapters if c.text.strip()]
 
 

--- a/backend/tests/test_splitter.py
+++ b/backend/tests/test_splitter.py
@@ -3,7 +3,7 @@ Tests for services/splitter.py — chapter splitting for Project Gutenberg books
 """
 
 import pytest
-from services.splitter import build_chapters, strip_boilerplate, _validate, Chapter
+from services.splitter import build_chapters, strip_boilerplate, _validate, _clean_title, Chapter
 
 
 def test_strip_boilerplate_removes_header_and_footer():
@@ -108,3 +108,19 @@ def test_chapter_at_start_of_body():
     chs = build_chapters(text)
     assert len(chs) >= 2
     assert "CHAPTER" in chs[0].title
+
+
+def test_clean_title_strips_trailing_bracket():
+    assert _clean_title("Chapter I.]") == "Chapter I."
+
+
+def test_clean_title_strips_trailing_parens():
+    assert _clean_title("CHAPTER II.)") == "CHAPTER II."
+
+
+def test_clean_title_no_change_on_clean_title():
+    assert _clean_title("CHAPTER III") == "CHAPTER III"
+
+
+def test_clean_title_strips_leading_bracket():
+    assert _clean_title("[Chapter IV") == "Chapter IV"


### PR DESCRIPTION
## Summary
- Gutenberg texts sometimes have stray brackets in chapter headings (e.g. `Chapter I.]`)
- Added `_clean_title()` to strip unbalanced trailing `]`, `)`, `}`, `>` and leading `[`, `(`, `{`, `<` from titles
- Applied across all 4 splitting strategies (keyword, roman numeral, TOC, paragraph fallback)

## Test plan
- [x] Backend: 226 tests pass (4 new for `_clean_title`)
- [x] Verified book 1342 now shows `Chapter I.` instead of `Chapter I.]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)