### PR TITLE
fix(splitter): strip inline [Illustration] tags from text

### DIFF
--- a/backend/services/splitter.py
+++ b/backend/services/splitter.py
@@ -89,7 +89,7 @@ TOC_HEADING_RE = re.compile(
 # ── Helpers ──────────────────────────────────────────────────────────────
 
 def strip_boilerplate(text: str) -> tuple[str, int]:
-    """Remove PG header/footer, return (body, offset_of_body_in_original)."""
+    """Remove PG header/footer and illustration tags, return (body, offset_of_body_in_original)."""
     start_m = re.search(
         r'\*{3}\s*START OF THE PROJECT GUTENBERG[^\n]*\n', text, re.IGNORECASE
     )
@@ -98,7 +98,12 @@ def strip_boilerplate(text: str) -> tuple[str, int]:
     )
     offset = start_m.end() if start_m else 0
     end = end_m.start() if end_m else len(text)
-    return text[offset:end], offset
+    body = text[offset:end]
+    # Remove single-line [Illustration] and [Illustration: short desc] tags.
+    # Multi-line illustration blocks (which can wrap chapter headings) are
+    # left alone — only the short inline markers are noise.
+    body = re.sub(r'\[Illustration(?:: [^\]\n]{0,80})?\]', '', body)
+    return body, offset
 
 
 def _clean_title(title: str) -> str:

--- a/backend/tests/test_splitter.py
+++ b/backend/tests/test_splitter.py
@@ -110,6 +110,14 @@ def test_chapter_at_start_of_body():
     assert "CHAPTER" in chs[0].title
 
 
+def test_strip_boilerplate_removes_illustration_tags():
+    text = "*** START OF THE PROJECT GUTENBERG EBOOK ***\n[Illustration: cover]\n\nCHAPTER I\n\n[Illustration]\n\nSome text.\n*** END OF THE PROJECT GUTENBERG EBOOK ***"
+    body, _ = strip_boilerplate(text)
+    assert "[Illustration" not in body
+    assert "Some text." in body
+    assert "CHAPTER I" in body
+
+
 def test_clean_title_strips_trailing_bracket():
     assert _clean_title("Chapter I.]") == "Chapter I."
 


### PR DESCRIPTION
## Summary
- Strip bare `[Illustration]` and single-line `[Illustration: desc]` tags during boilerplate removal
- Multi-line illustration blocks (which can wrap chapter headings) are preserved to avoid losing structure
- Follows up on #46 which fixed bracket artifacts in chapter titles

## Test plan
- [x] Backend: 227 tests pass (1 new for illustration stripping)
- [x] Verified book 1342 chapters no longer show bare `[Illustration]` markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)