### PR TITLE
fix(translate): skip chapter headings in Google Translate

### DIFF
--- a/backend/services/translate.py
+++ b/backend/services/translate.py
@@ -56,6 +56,25 @@ def _unwrap_paragraph(text: str) -> str:
     return re.sub(r"(?<![.!?:;\"'\u201d])\n(?!\n)", " ", text)
 
 
+_HEADING_RE = re.compile(
+    r'^(?:'
+    r'(?:CHAPTER|CHAPITRE|KAPITEL|BOOK|PART|ACT|SCENE|PROLOGUE?|EPILOGUE?)'
+    r'[\s.:\-]*'
+    r'(?:[IVXLCDM]+|[0-9]+)?'
+    r'[.\s]*'
+    r'|[IVXLCDM]+\.?\s*'  # bare roman numeral like "I" or "XIV."
+    r'|[0-9]+\.?\s*'      # bare number like "1" or "14."
+    r')$',
+    re.IGNORECASE,
+)
+
+
+def _is_heading(text: str) -> bool:
+    """Return True if text looks like a chapter heading (not worth translating)."""
+    stripped = text.strip()
+    return bool(_HEADING_RE.match(stripped))
+
+
 async def _google_translate(text: str, source: str, target: str) -> list[str]:
     """Split text into paragraphs and translate each via Google Translate."""
     paragraphs = [p for p in text.split("\n\n") if p.strip()]
@@ -68,6 +87,11 @@ async def _google_translate(text: str, source: str, target: str) -> list[str]:
     results = []
     for para in paragraphs:
         unwrapped = _unwrap_paragraph(para)
+        # Skip chapter headings — translating "I" or "Chapter XIV" produces
+        # nonsense like "我" (Chinese for the pronoun "I").
+        if _is_heading(unwrapped):
+            results.append(unwrapped)
+            continue
         translated = await loop.run_in_executor(
             None, _google_translate_chunk, unwrapped, source, target
         )

--- a/backend/tests/test_translate.py
+++ b/backend/tests/test_translate.py
@@ -1,7 +1,7 @@
-"""Tests for services/translate.py — paragraph unwrapping and language mapping."""
+"""Tests for services/translate.py — paragraph unwrapping, heading detection, and language mapping."""
 
 import pytest
-from services.translate import _unwrap_paragraph, _normalize_google_lang
+from services.translate import _unwrap_paragraph, _normalize_google_lang, _is_heading
 
 
 class TestUnwrapParagraph:
@@ -71,3 +71,31 @@ class TestNormalizeGoogleLang:
         assert _normalize_google_lang("de") == "de"
         assert _normalize_google_lang("en") == "en"
         assert _normalize_google_lang("fr") == "fr"
+
+
+class TestIsHeading:
+    def test_roman_numeral(self):
+        assert _is_heading("I") is True
+        assert _is_heading("XIV.") is True
+        assert _is_heading("III") is True
+
+    def test_chapter_keyword(self):
+        assert _is_heading("CHAPTER I.") is True
+        assert _is_heading("Chapter XIV") is True
+        assert _is_heading("CHAPITRE II") is True
+        assert _is_heading("KAPITEL 3") is True
+        assert _is_heading("BOOK III") is True
+        assert _is_heading("PART 2") is True
+
+    def test_bare_number(self):
+        assert _is_heading("1") is True
+        assert _is_heading("14.") is True
+
+    def test_prologue_epilogue(self):
+        assert _is_heading("PROLOGUE") is True
+        assert _is_heading("Epilogue") is True
+
+    def test_normal_text_not_heading(self):
+        assert _is_heading("It is a truth universally acknowledged") is False
+        assert _is_heading("I went to the store") is False
+        assert _is_heading("Chapter one of many adventures") is False


### PR DESCRIPTION
## Summary
- Chapter headings like "I", "Chapter XIV", "PROLOGUE" are now passed through untranslated
- Google Translate was turning Roman numeral "I" into "我" (Chinese pronoun) — nonsensical
- Added `_is_heading()` with regex matching chapter keywords, roman numerals, and bare numbers

## Test plan
- [x] Backend: 232 tests pass (5 new for `_is_heading`)
- [x] Frontend: 108 tests pass
- [x] E2E: 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)