### PR TITLE
fix(translate): preserve verse/poetry line breaks

### DIFF
--- a/backend/services/translate.py
+++ b/backend/services/translate.py
@@ -44,15 +44,33 @@ def _google_translate_chunk(text: str, source: str, target: str) -> str:
     ).translate(text)
 
 
+def _is_verse(text: str) -> bool:
+    """Detect verse/poetry/drama by checking line length distribution.
+
+    Gutenberg prose wraps at ~65-75 chars, producing lines that are
+    mostly long with a short final line. Verse lines are consistently
+    short (under ~55 chars). We check that most lines (not just the
+    average) are short — this avoids false positives from prose
+    paragraphs that happen to have few lines.
+    """
+    lines = [l for l in text.split("\n") if l.strip()]
+    if len(lines) < 3:
+        return False
+    # Count lines shorter than typical prose wrap width
+    short = sum(1 for l in lines if len(l.strip()) < 55)
+    return short / len(lines) > 0.7
+
+
 def _unwrap_paragraph(text: str) -> str:
     """Join hard-wrapped lines within a paragraph into flowing text.
 
     Gutenberg texts wrap at ~70 chars, inserting \\n mid-sentence.
     Google Translate treats each line independently, so we must unwrap
-    before translating.  Preserves intentional breaks (e.g. verse or
-    dialogue) by only joining when the previous line doesn't end with
-    punctuation that suggests a deliberate break.
+    before translating.  Skips verse/poetry/drama where line breaks
+    are intentional.
     """
+    if _is_verse(text):
+        return text
     return re.sub(r"(?<![.!?:;\"'\u201d])\n(?!\n)", " ", text)
 
 

--- a/backend/tests/test_translate.py
+++ b/backend/tests/test_translate.py
@@ -1,7 +1,7 @@
 """Tests for services/translate.py — paragraph unwrapping, heading detection, and language mapping."""
 
 import pytest
-from services.translate import _unwrap_paragraph, _normalize_google_lang, _is_heading
+from services.translate import _unwrap_paragraph, _is_verse, _normalize_google_lang, _is_heading
 
 
 class TestUnwrapParagraph:
@@ -55,6 +55,29 @@ class TestUnwrapParagraph:
 
     def test_no_newlines(self):
         assert _unwrap_paragraph("Just one line.") == "Just one line."
+
+    def test_verse_not_unwrapped(self):
+        verse = "Ihr naht euch wieder,\nschwankende Gestalten,\nDie früh sich einst\ndem trüben Blick gezeigt.\nVersuch ich wohl,\neuch diesmal festzuhalten?"
+        assert _unwrap_paragraph(verse) == verse
+
+
+class TestIsVerse:
+    def test_short_lines_are_verse(self):
+        text = "Ihr naht euch wieder,\nschwankende Gestalten,\nDie früh sich einst\ndem trüben Blick gezeigt.\nVersuch ich wohl,\neuch diesmal festzuhalten?"
+        assert _is_verse(text) is True
+
+    def test_long_lines_are_prose(self):
+        text = ("I am by birth a Genevese, and my family is one of the most distinguished\n"
+                "of that republic. My ancestors had been for many years counsellors and\n"
+                "syndics; and my father had filled several public situations with honour\n"
+                "and reputation.")
+        assert _is_verse(text) is False
+
+    def test_single_line_is_not_verse(self):
+        assert _is_verse("Just one line.") is False
+
+    def test_two_lines_is_not_verse(self):
+        assert _is_verse("Line one.\nLine two.") is False
 
 
 class TestNormalizeGoogleLang:


### PR DESCRIPTION
## Summary
The line-unwrapping logic was joining ALL lines into prose, destroying the verse structure of poetry and drama (e.g. Faust). Google Translate then returned a dense block instead of matching the verse layout.

Added `_is_verse()` detection: if >70% of lines in a paragraph are shorter than 55 chars, the text is treated as verse and line breaks are preserved. Gutenberg prose with hard wraps (~70 chars) is still unwrapped as before.

## Test plan
- [x] Backend: 238 tests pass (5 new for `_is_verse` + verse unwrap behavior)
- [x] Verified Faust verse structure preserved in translation output

🤖 Generated with [Claude Code](https://claude.com/claude-code)