### PR TITLE
fix(translate): translate verse line-by-line and render with whitespace-pre-wrap

### DIFF
--- a/backend/services/translate.py
+++ b/backend/services/translate.py
@@ -104,16 +104,34 @@ async def _google_translate(text: str, source: str, target: str) -> list[str]:
     loop = asyncio.get_event_loop()
     results = []
     for para in paragraphs:
-        unwrapped = _unwrap_paragraph(para)
         # Skip chapter headings — translating "I" or "Chapter XIV" produces
         # nonsense like "我" (Chinese for the pronoun "I").
-        if _is_heading(unwrapped):
-            results.append(unwrapped)
+        if _is_heading(para):
+            results.append(para)
             continue
-        translated = await loop.run_in_executor(
-            None, _google_translate_chunk, unwrapped, source, target
-        )
-        results.append(translated)
+
+        if _is_verse(para):
+            # Verse: translate line by line to preserve the line structure.
+            # Google Translate merges lines if sent together.
+            lines = para.split("\n")
+            translated_lines = []
+            for line in lines:
+                stripped = line.strip()
+                if not stripped:
+                    translated_lines.append("")
+                    continue
+                t = await loop.run_in_executor(
+                    None, _google_translate_chunk, stripped, source, target
+                )
+                translated_lines.append(t)
+            results.append("\n".join(translated_lines))
+        else:
+            # Prose: unwrap Gutenberg hard wraps, translate as a block.
+            unwrapped = _unwrap_paragraph(para)
+            translated = await loop.run_in_executor(
+                None, _google_translate_chunk, unwrapped, source, target
+            )
+            results.append(translated)
 
     return results
 

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -355,7 +355,7 @@ export default function SentenceReader({
               {originalContent}
               <div className="border-l border-amber-200 pl-6">
                 {translationText ? (
-                  <p className="font-serif text-base text-amber-800 leading-relaxed italic">
+                  <p className="font-serif text-base text-amber-800 leading-relaxed italic whitespace-pre-wrap">
                     {translationText}
                   </p>
                 ) : translationLoading ? (
@@ -381,7 +381,7 @@ export default function SentenceReader({
               </div>
             )}
             {translationText && (
-              <p className="mt-1 font-serif text-sm text-amber-700 italic border-l-2 border-amber-300 pl-3">
+              <p className="mt-1 font-serif text-sm text-amber-700 italic border-l-2 border-amber-300 pl-3 whitespace-pre-wrap">
                 {translationText}
               </p>
             )}

--- a/frontend/src/components/TranslationView.tsx
+++ b/frontend/src/components/TranslationView.tsx
@@ -22,7 +22,7 @@ export default function TranslationView({ paragraphs, translations, displayMode,
             <p className="font-serif text-base text-ink leading-relaxed">{unwrap(para)}</p>
             <div className="border-l border-amber-200 pl-6">
               {translations[i] ? (
-                <p className="font-serif text-base text-amber-800 leading-relaxed italic">
+                <p className="font-serif text-base text-amber-800 leading-relaxed italic whitespace-pre-wrap">
                   {translations[i]}
                 </p>
               ) : loading ? (
@@ -52,7 +52,7 @@ export default function TranslationView({ paragraphs, translations, displayMode,
             </div>
           )}
           {translations[i] && (
-            <p className="mt-1 font-serif text-sm text-amber-700 italic border-l-2 border-amber-300 pl-3">
+            <p className="mt-1 font-serif text-sm text-amber-700 italic border-l-2 border-amber-300 pl-3 whitespace-pre-wrap">
               {translations[i]}
             </p>
           )}


### PR DESCRIPTION
## Summary
Follows up on #54 — verse detection was correct but two issues remained:

1. **Backend**: Google Translate merges lines even when `\n` is included in the input. Fix: translate each verse line separately and rejoin with `\n`.
2. **Frontend**: Translation text `<p>` tags had `whitespace-pre-wrap` removed in #43. Re-added it so `\n` in verse translations renders as actual line breaks.

## Test plan
- [x] Backend: 238 tests pass
- [x] Frontend: 108 tests pass
- [x] E2E: 11 tests pass
- [x] Cleared Faust translation cache for re-generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)