### PR TITLE
feat: dictionary lookup on double-click

### DIFF
--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -11,6 +11,7 @@ import TranslationView from "@/components/TranslationView";
 import AudiobookPlayer from "@/components/AudiobookPlayer";
 import AudiobookSearch from "@/components/AudiobookSearch";
 import SentenceReader from "@/components/SentenceReader";
+import WordLookup from "@/components/WordLookup";
 
 // In-memory cache: bookId → chapters (survives client-side navigation)
 const chaptersCache = new Map<string, BookChapter[]>();
@@ -28,6 +29,7 @@ export default function ReaderPage() {
   const [error, setError] = useState("");
 
   const [selectedText, setSelectedText] = useState("");
+  const [lookupWord, setLookupWord] = useState<{ word: string; x: number; y: number } | null>(null);
 
   // Audiobook
   const [audiobookEnabled, setAudiobookEnabled] = useState(true);
@@ -459,6 +461,12 @@ export default function ReaderPage() {
             className="flex-1 overflow-y-auto px-8 py-8"
             onMouseUp={handleSelection}
             onTouchEnd={handleSelection}
+            onDoubleClick={(e) => {
+              const sel = window.getSelection()?.toString().trim();
+              if (sel && sel.length > 1 && sel.length < 30 && !/\s/.test(sel)) {
+                setLookupWord({ word: sel, x: e.clientX, y: e.clientY });
+              }
+            }}
           >
             {loading ? (
               <div className="max-w-prose mx-auto space-y-3 animate-pulse">
@@ -522,6 +530,15 @@ export default function ReaderPage() {
               </>
             )}
           </div>
+
+          {/* Dictionary lookup popup */}
+          {lookupWord && (
+            <WordLookup
+              word={lookupWord.word}
+              position={{ x: lookupWord.x, y: lookupWord.y }}
+              onClose={() => setLookupWord(null)}
+            />
+          )}
 
           {/* Audiobook player */}
           {audiobookEnabled && audiobook && (

--- a/frontend/src/components/WordLookup.tsx
+++ b/frontend/src/components/WordLookup.tsx
@@ -1,0 +1,115 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+interface Definition {
+  partOfSpeech: string;
+  definitions: { definition: string }[];
+}
+
+interface LookupResult {
+  word: string;
+  phonetic?: string;
+  meanings: Definition[];
+}
+
+interface Props {
+  word: string;
+  position: { x: number; y: number };
+  onClose: () => void;
+}
+
+export default function WordLookup({ word, position, onClose }: Props) {
+  const [result, setResult] = useState<LookupResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError("");
+    setResult(null);
+
+    fetch(`https://api.dictionaryapi.dev/api/v2/entries/en/${encodeURIComponent(word.toLowerCase())}`)
+      .then((r) => {
+        if (!r.ok) throw new Error("Not found");
+        return r.json();
+      })
+      .then((data) => {
+        const entry = data[0];
+        setResult({
+          word: entry.word,
+          phonetic: entry.phonetic || entry.phonetics?.[0]?.text,
+          meanings: entry.meanings?.slice(0, 3).map((m: any) => ({
+            partOfSpeech: m.partOfSpeech,
+            definitions: m.definitions?.slice(0, 2),
+          })) ?? [],
+        });
+      })
+      .catch(() => setError("No definition found"))
+      .finally(() => setLoading(false));
+  }, [word]);
+
+  // Close on click outside
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [onClose]);
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  // Position the popup near the word, but keep it within viewport
+  const style: React.CSSProperties = {
+    position: "fixed",
+    left: Math.min(position.x, window.innerWidth - 320),
+    top: Math.min(position.y + 20, window.innerHeight - 300),
+    zIndex: 50,
+  };
+
+  return (
+    <div ref={ref} style={style} className="w-72 max-h-64 overflow-y-auto rounded-xl border border-amber-300 bg-white shadow-lg p-3 text-sm">
+      {loading && (
+        <div className="flex items-center gap-2 text-amber-600">
+          <span className="w-3 h-3 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+          Looking up &ldquo;{word}&rdquo;...
+        </div>
+      )}
+
+      {error && (
+        <p className="text-amber-600 italic">{error} for &ldquo;{word}&rdquo;</p>
+      )}
+
+      {result && (
+        <>
+          <div className="flex items-baseline gap-2 mb-2">
+            <span className="font-serif font-bold text-ink text-base">{result.word}</span>
+            {result.phonetic && (
+              <span className="text-xs text-amber-500">{result.phonetic}</span>
+            )}
+          </div>
+          {result.meanings.map((m, i) => (
+            <div key={i} className="mb-2 last:mb-0">
+              <span className="text-xs font-medium text-amber-700 italic">{m.partOfSpeech}</span>
+              <ol className="list-decimal list-inside ml-1 mt-0.5 space-y-0.5">
+                {m.definitions.map((d, j) => (
+                  <li key={j} className="text-ink text-xs leading-relaxed">{d.definition}</li>
+                ))}
+              </ol>
+            </div>
+          ))}
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Double-click any word in the reader to see its English definition
- Uses the free dictionaryapi.dev API (no key required)
- Shows part of speech, phonetic transcription, and definitions
- Popup closes on click outside or Escape key
- Only triggers for single words (no spaces, 2-29 chars)

## Test plan
- [x] Frontend: 108 tests pass
- [x] Backend: 234 tests pass
- [x] E2E: 11 tests pass

Generated with [Claude Code](https://claude.com/claude-code)
