### PR TITLE
fix(tts): retry failed chunks up to 3 times with backoff

### DIFF
--- a/frontend/src/components/TTSControls.tsx
+++ b/frontend/src/components/TTSControls.tsx
@@ -246,8 +246,7 @@ export default function TTSControls({
         });
 
         // Retry up to 2 times on failure (network glitches, transient errors)
-        let url: string;
-        let lastErr: Error | null = null;
+        let url = "";
         for (let attempt = 0; attempt < 3; attempt++) {
           try {
             url = await synthesizeSpeech(chunkText, language, 1.0, provider, {
@@ -256,15 +255,12 @@ export default function TTSControls({
               chunkIndex: i,
               signal: abort.signal,
             });
-            lastErr = null;
             break;
           } catch (e) {
-            lastErr = e instanceof Error ? e : new Error("TTS failed");
-            if (abort.signal.aborted) throw lastErr;
-            if (attempt < 2) await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
+            if (abort.signal.aborted || attempt === 2) throw e;
+            await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
           }
         }
-        if (lastErr) throw lastErr;
 
         if (myGen !== genRef.current) {
           URL.revokeObjectURL(url);

--- a/frontend/src/components/TTSControls.tsx
+++ b/frontend/src/components/TTSControls.tsx
@@ -245,12 +245,26 @@ export default function TTSControls({
           preview: chunkText.replace(/\s+/g, " ").trim().slice(0, 60),
         });
 
-        const url = await synthesizeSpeech(chunkText, language, 1.0, provider, {
-          bookId,
-          chapterIndex,
-          chunkIndex: i,
-          signal: abort.signal,
-        });
+        // Retry up to 2 times on failure (network glitches, transient errors)
+        let url: string;
+        let lastErr: Error | null = null;
+        for (let attempt = 0; attempt < 3; attempt++) {
+          try {
+            url = await synthesizeSpeech(chunkText, language, 1.0, provider, {
+              bookId,
+              chapterIndex,
+              chunkIndex: i,
+              signal: abort.signal,
+            });
+            lastErr = null;
+            break;
+          } catch (e) {
+            lastErr = e instanceof Error ? e : new Error("TTS failed");
+            if (abort.signal.aborted) throw lastErr;
+            if (attempt < 2) await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
+          }
+        }
+        if (lastErr) throw lastErr;
 
         if (myGen !== genRef.current) {
           URL.revokeObjectURL(url);


### PR DESCRIPTION
## Summary
TTS chunk synthesis now retries up to 2 additional times on failure with increasing delay (1s, 2s). Prevents the entire chapter audio from stalling due to a transient network error on a single chunk. Respects abort signal to avoid retrying cancelled requests.

## Test plan
- [x] Frontend: 108 tests pass
- [x] Backend: 249 tests pass
- [x] E2E: 11 tests pass

Generated with [Claude Code](https://claude.com/claude-code)
