### PR TITLE
feat: keyboard shortcuts for chapter navigation

### DIFF
--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -277,6 +277,25 @@ export default function ReaderPage() {
     if (sel.length > 10) setSelectedText(sel);
   }, []);
 
+  // Keyboard shortcuts
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      // Skip if user is typing in an input/select/textarea
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+
+      if (e.key === "ArrowLeft" && chapterIndex > 0) {
+        e.preventDefault();
+        goToChapter(chapterIndex - 1);
+      } else if (e.key === "ArrowRight" && chapterIndex < chapters.length - 1) {
+        e.preventDefault();
+        goToChapter(chapterIndex + 1);
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  });
+
   function goToChapter(index: number) {
     setChapterIndex(index);
     saveLastChapter(Number(bookId), index);


### PR DESCRIPTION
## Summary
Arrow left/right keys navigate between chapters in the reader. Shortcuts are disabled when focus is in input/textarea/select elements.

## Test plan
- [x] Frontend: 108 tests pass
- [x] Backend: 249 tests pass
- [x] E2E: 11 tests pass

Generated with [Claude Code](https://claude.com/claude-code)
