### PR TITLE
feat: book-level progress bar and admin bulk retranslate

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -289,6 +289,57 @@ async def retranslate(
     }
 
 
+class BulkRetranslateRequest(BaseModel):
+    target_language: str
+
+
+@router.post("/translations/{book_id}/retranslate-all")
+async def retranslate_all(
+    book_id: int,
+    req: BulkRetranslateRequest,
+    admin: dict = Depends(_require_admin),
+):
+    """Delete and retranslate ALL chapters of a book for a target language."""
+    book = await get_cached_book(book_id)
+    if not book or not book.get("text"):
+        raise HTTPException(status_code=404, detail="Book not found in cache")
+
+    chapters = build_chapters(book["text"])
+    source_language = (book.get("languages") or ["en"])[0]
+
+    raw_key = admin.get("gemini_key")
+    decrypted_key: str | None = decrypt_api_key(raw_key) if raw_key else None
+    provider = "gemini" if decrypted_key else "google"
+
+    # Delete all existing translations for this language
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "DELETE FROM translations WHERE book_id=? AND target_language=?",
+            (book_id, req.target_language),
+        )
+        await db.commit()
+
+    results = []
+    for i, ch in enumerate(chapters):
+        try:
+            paragraphs = await do_translate(
+                ch.text, source_language, req.target_language,
+                provider=provider, gemini_key=decrypted_key,
+            )
+        except Exception:
+            if provider == "gemini":
+                paragraphs = await do_translate(
+                    ch.text, source_language, req.target_language, provider="google",
+                )
+            else:
+                results.append({"chapter": i, "status": "failed"})
+                continue
+        await save_translation(book_id, i, req.target_language, paragraphs)
+        results.append({"chapter": i, "status": "ok", "paragraphs": len(paragraphs)})
+
+    return {"ok": True, "chapters": len(results), "results": results}
+
+
 # ══════════════════════════════════════════════════════════════════════════════
 # STATS
 # ══════════════════════════════════════════════════════════════════════════════

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -45,6 +45,7 @@ export default function AdminPage() {
   const [importId, setImportId] = useState("");
   const [importing, setImporting] = useState(false);
   const [retranslating, setRetranslating] = useState<string | null>(null);
+  const [bulkRetranslating, setBulkRetranslating] = useState(false);
 
   useEffect(() => {
     getMe().then((me) => {
@@ -255,6 +256,43 @@ export default function AdminPage() {
 
         {/* ── Translations Tab ── */}
         {tab === "translations" && (
+          <div className="space-y-4">
+            {/* Bulk retranslate — pick a book that has translations */}
+            {translations.length > 0 && (
+              <div className="flex items-center gap-2">
+                <select id="bulk-book" className="text-sm rounded border border-amber-300 px-2 py-1.5">
+                  {[...new Set(translations.map(t => t.book_id))].map(bid => (
+                    <option key={bid} value={bid}>Book {bid}</option>
+                  ))}
+                </select>
+                <select id="bulk-lang" className="text-sm rounded border border-amber-300 px-2 py-1.5">
+                  {[...new Set(translations.map(t => t.target_language))].map(lang => (
+                    <option key={lang} value={lang}>{lang}</option>
+                  ))}
+                </select>
+                <button
+                  disabled={bulkRetranslating}
+                  onClick={async () => {
+                    const bid = (document.getElementById("bulk-book") as HTMLSelectElement)?.value;
+                    const lang = (document.getElementById("bulk-lang") as HTMLSelectElement)?.value;
+                    if (!bid || !lang || !confirm(`Retranslate ALL chapters of book ${bid} → ${lang}?`)) return;
+                    setBulkRetranslating(true);
+                    try {
+                      const res = await adminFetch(`/admin/translations/${bid}/retranslate-all`, {
+                        method: "POST", body: JSON.stringify({ target_language: lang }),
+                      });
+                      alert(`Retranslated ${res.chapters} chapters`);
+                      await loadAll();
+                    } catch (e: unknown) { alert(e instanceof Error ? e.message : "Failed"); }
+                    finally { setBulkRetranslating(false); }
+                  }}
+                  className="text-sm px-3 py-1.5 rounded bg-amber-700 text-white hover:bg-amber-800 disabled:opacity-50"
+                >
+                  {bulkRetranslating ? "Retranslating all…" : "Retranslate All"}
+                </button>
+              </div>
+            )}
+
           <div className="bg-white rounded-xl border border-amber-200 divide-y divide-amber-100 overflow-hidden">
             {translations.map((t, i) => (
               <div key={i} className="px-4 py-3 flex items-center gap-3">
@@ -273,6 +311,7 @@ export default function AdminPage() {
               </div>
             ))}
             {translations.length === 0 && <div className="px-4 py-8 text-center text-amber-600 text-sm">No translations cached.</div>}
+          </div>
           </div>
         )}
       </div>

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -534,13 +534,15 @@ export default function ReaderPage() {
         </div>
       </header>
 
-      {/* Reading progress bar */}
-      <div className="h-0.5 bg-amber-100">
-        <div
-          className="h-full bg-amber-600 transition-all duration-150"
-          style={{ width: `${scrollProgress}%` }}
-        />
-      </div>
+      {/* Reading progress bar — combines chapter position + scroll within chapter */}
+      {chapters.length > 0 && (
+        <div className="h-0.5 bg-amber-100" title={`${Math.round(((chapterIndex + scrollProgress / 100) / chapters.length) * 100)}% through book`}>
+          <div
+            className="h-full bg-amber-600 transition-all duration-150"
+            style={{ width: `${((chapterIndex + scrollProgress / 100) / chapters.length) * 100}%` }}
+          />
+        </div>
+      )}
 
       {/* ── Body ────────────────────────────────────────────────────────── */}
       <div className="flex flex-1 overflow-hidden">
@@ -609,7 +611,7 @@ export default function ReaderPage() {
                     className="text-sm text-amber-700 hover:text-amber-900 disabled:opacity-30"
                   >← Previous chapter</button>
                   <span className="text-xs text-amber-500 self-center">
-                    {chapterIndex + 1} / {chapters.length}
+                    {chapterIndex + 1} / {chapters.length} · {Math.round(((chapterIndex + 1) / chapters.length) * 100)}%
                   </span>
                   <button
                     onClick={() => goToChapter(Math.min(chapters.length - 1, chapterIndex + 1))}


### PR DESCRIPTION
## Summary
- **Reader**: Progress bar now shows position through the entire book (chapter + scroll), not just scroll within chapter. Bottom indicator shows "5 / 61 · 8%".
- **Admin**: New "Retranslate All" button retranslates every chapter of a book for a chosen language in one click. Backend endpoint: `POST /admin/translations/{book_id}/retranslate-all`.

## Test plan
- [x] Frontend: 108 tests pass
- [x] Backend: 249 tests pass
- [x] E2E: 11 tests pass

Generated with [Claude Code](https://claude.com/claude-code)
