### PR TITLE
feat: translation provider setting and provider notice

### DIFF
--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -34,6 +34,7 @@ export default function ProfilePage() {
     translationLang: "en",
     audiobookEnabled: true,
     ttsProvider: "auto",
+    translationProvider: "auto",
     fontSize: "base",
     theme: "light",
   });
@@ -298,6 +299,42 @@ export default function ProfilePage() {
                 .
               </p>
             )}
+          </div>
+
+          {/* Translation provider */}
+          <div>
+            <label className="block text-sm font-medium text-ink mb-1.5">
+              Translation provider
+            </label>
+            <div className="space-y-2">
+              {([
+                { value: "auto", label: "Auto", hint: "Use Gemini if a key is set, otherwise Google Translate (free)." },
+                { value: "google", label: "Google Translate", hint: "Free, no API key required. Good enough for casual reading." },
+                { value: "gemini", label: "Gemini", hint: "Best quality for literary text — preserves style, tone, and poetic structure. Requires a Gemini API key." },
+              ] as const).map((opt) => (
+                <label
+                  key={opt.value}
+                  className={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                    settings.translationProvider === opt.value
+                      ? "border-amber-400 bg-amber-50"
+                      : "border-amber-200 bg-white hover:bg-amber-50/50"
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="translationProvider"
+                    value={opt.value}
+                    checked={settings.translationProvider === opt.value}
+                    onChange={() => updatePref("translationProvider", opt.value)}
+                    className="mt-0.5 accent-amber-700"
+                  />
+                  <div className="flex-1">
+                    <div className="text-sm font-medium text-ink">{opt.label}</div>
+                    <div className="text-xs text-stone-500 mt-0.5">{opt.hint}</div>
+                  </div>
+                </label>
+              ))}
+            </div>
           </div>
 
           {/* LibriVox audiobook */}

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -4,7 +4,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { getBookChapters, translateText, getTranslationCache, saveTranslationCache, deleteTranslationCache, getAudiobook, deleteAudiobook, synthesizeSpeech, getMe, BookMeta, BookChapter, Audiobook } from "@/lib/api";
 import { recordRecentBook, saveLastChapter, getLastChapter } from "@/lib/recentBooks";
-import { getSettings, saveSettings, FontSize, Theme } from "@/lib/settings";
+import { getSettings, saveSettings, FontSize, Theme, TranslationProvider } from "@/lib/settings";
 import InsightChat, { LANGUAGES } from "@/components/InsightChat";
 import TTSControls from "@/components/TTSControls";
 import TranslationView from "@/components/TranslationView";
@@ -109,9 +109,11 @@ export default function ReaderPage() {
   const currentChapterKey = useRef<string>(""); // tracks which chapter is currently displayed
   const [translationEnabled, setTranslationEnabled] = useState(false);
   const [translationLang, setTranslationLang] = useState("en");
+  const [translationProvider, setTranslationProvider] = useState<TranslationProvider>("auto");
   const [displayMode, setDisplayMode] = useState<"parallel" | "inline">("parallel");
   const [translatedParagraphs, setTranslatedParagraphs] = useState<string[]>([]);
   const [translationLoading, setTranslationLoading] = useState(false);
+  const [translationUsedProvider, setTranslationUsedProvider] = useState<string>("");
 
   // Reader display settings
   const [fontSize, setFontSize] = useState<FontSize>("base");
@@ -122,6 +124,7 @@ export default function ReaderPage() {
   useEffect(() => {
     const s = getSettings();
     setTranslationLang(s.translationLang);
+    setTranslationProvider(s.translationProvider);
     setAudiobookEnabled(s.audiobookEnabled);
     setFontSize(s.fontSize);
     setTheme(s.theme);
@@ -204,12 +207,14 @@ export default function ReaderPage() {
 
     if (translationCache.current.has(cacheKey)) {
       setTranslatedParagraphs(translationCache.current.get(cacheKey)!);
+      setTranslationUsedProvider("cached");
       return;
     }
 
     let cancelled = false;
     setTranslationLoading(true);
     setTranslatedParagraphs([]);
+    setTranslationUsedProvider("");
 
     const bid = Number(bookId);
 
@@ -220,6 +225,7 @@ export default function ReaderPage() {
       if (cached) {
         translationCache.current.set(cacheKey, cached);
         setTranslatedParagraphs(cached);
+        setTranslationUsedProvider("cached");
         setTranslationLoading(false);
         return;
       }
@@ -234,13 +240,17 @@ export default function ReaderPage() {
       }
 
       const accumulated: string[] = [];
+      let usedProvider = "";
       for (const batch of batches) {
         if (cancelled || currentChapterKey.current !== cacheKey) return;
         try {
-          const r = await translateText(batch.join("\n\n"), bookLanguage, translationLang);
+          const r = await translateText(batch.join("\n\n"), bookLanguage, translationLang, undefined, undefined, translationProvider);
           accumulated.push(...r.paragraphs);
+          if (r.provider) usedProvider = r.provider;
+          if (r.fallback) usedProvider += " (fallback)";
           if (!cancelled && currentChapterKey.current === cacheKey) {
             setTranslatedParagraphs([...accumulated]);
+            setTranslationUsedProvider(usedProvider);
           }
         } catch (e) {
           console.error("Translation batch failed:", e);
@@ -257,7 +267,7 @@ export default function ReaderPage() {
 
     return () => { cancelled = true; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [translationEnabled, translationLang, chapterIndex, bookId]);
+  }, [translationEnabled, translationLang, translationProvider, chapterIndex, bookId]);
 
   async function handleRetranslate() {
     const bid = Number(bookId);
@@ -517,8 +527,31 @@ export default function ReaderPage() {
                 </button>
               </div>
 
+              {/* Provider selector */}
+              <select
+                className="text-xs rounded border border-amber-300 px-2 py-1 text-ink bg-white"
+                value={translationProvider}
+                onChange={(e) => {
+                  const v = e.target.value as TranslationProvider;
+                  setTranslationProvider(v);
+                  saveSettings({ translationProvider: v });
+                  // Clear cache so re-translation uses the new provider
+                  translationCache.current.clear();
+                }}
+              >
+                <option value="auto">Auto</option>
+                <option value="google">Google (free)</option>
+                <option value="gemini">Gemini (key)</option>
+              </select>
+
               {translationLoading && (
                 <span className="text-xs text-amber-500 animate-pulse">Translating…</span>
+              )}
+
+              {!translationLoading && translationUsedProvider && (
+                <span className="text-[10px] text-amber-400">
+                  via {translationUsedProvider}
+                </span>
               )}
 
               {isAdmin && !translationLoading && translatedParagraphs.length > 0 && (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -66,11 +66,12 @@ export function translateText(
   target_language: string,
   book_id?: number,
   chapter_index?: number,
+  provider: "auto" | "gemini" | "google" = "auto",
 ) {
-  return request<{ paragraphs: string[]; cached: boolean }>("/ai/translate", {
+  return request<{ paragraphs: string[]; cached: boolean; provider?: string; fallback?: boolean }>("/ai/translate", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ text, source_language, target_language, book_id, chapter_index }),
+    body: JSON.stringify({ text, source_language, target_language, book_id, chapter_index, provider }),
   });
 }
 

--- a/frontend/src/lib/settings.ts
+++ b/frontend/src/lib/settings.ts
@@ -1,4 +1,5 @@
 export type TTSProvider = "auto" | "edge" | "google";
+export type TranslationProvider = "auto" | "gemini" | "google";
 export type FontSize = "sm" | "base" | "lg" | "xl";
 export type Theme = "light" | "dark" | "sepia";
 
@@ -7,6 +8,7 @@ export interface AppSettings {
   translationLang: string;
   audiobookEnabled: boolean;
   ttsProvider: TTSProvider;
+  translationProvider: TranslationProvider;
   fontSize: FontSize;
   theme: Theme;
 }
@@ -16,6 +18,7 @@ const DEFAULTS: AppSettings = {
   translationLang: "en",
   audiobookEnabled: true,
   ttsProvider: "auto",
+  translationProvider: "auto",
   fontSize: "base",
   theme: "light",
 };


### PR DESCRIPTION
## Summary
- New **translation provider** setting: Auto / Google Translate (free) / Gemini (key required)
- **Provider selector** in the reader translation toolbar for quick switching
- **Provider notice** shown after translation completes: "via google", "via gemini", "via gemini (fallback)", or "cached"
- Setting configurable in profile page with radio buttons and descriptions
- Provider persists in localStorage across sessions

## Test plan
- [x] Frontend: 108 tests pass
- [x] Backend: 249 tests pass
- [x] E2E: 11 tests pass

Generated with [Claude Code](https://claude.com/claude-code)
