### PR TITLE
feat: GitHub OAuth login support

### DIFF
--- a/backend/migrations/005_add_github_id.sql
+++ b/backend/migrations/005_add_github_id.sql
@@ -1,0 +1,3 @@
+-- Add GitHub OAuth support: users can sign in via GitHub in addition to Google.
+ALTER TABLE users ADD COLUMN github_id TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_github_id ON users(github_id) WHERE github_id IS NOT NULL;

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,33 +1,13 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from services.auth import verify_google_id_token, create_jwt
-from services.db import get_or_create_user
+from services.db import get_or_create_user, get_or_create_user_github
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
-class GoogleAuthRequest(BaseModel):
-    id_token: str
-
-
-@router.post("/google")
-async def google_login(req: GoogleAuthRequest):
-    """
-    Exchange a Google ID token for our own backend JWT.
-    Called by NextAuth during the OAuth flow.
-    """
-    try:
-        info = await verify_google_id_token(req.id_token)
-    except Exception as e:
-        raise HTTPException(status_code=401, detail=str(e))
-
-    user = await get_or_create_user(
-        google_id=info["sub"],
-        email=info.get("email", ""),
-        name=info.get("name", ""),
-        picture=info.get("picture", ""),
-    )
-
+def _user_response(user: dict) -> dict:
+    """Build the standard auth response from a user dict."""
     token = create_jwt(user["id"], user["email"])
     return {
         "token": token,
@@ -39,3 +19,46 @@ async def google_login(req: GoogleAuthRequest):
             "hasGeminiKey": bool(user.get("gemini_key")),
         },
     }
+
+
+class GoogleAuthRequest(BaseModel):
+    id_token: str
+
+
+@router.post("/google")
+async def google_login(req: GoogleAuthRequest):
+    """Exchange a Google ID token for our own backend JWT."""
+    try:
+        info = await verify_google_id_token(req.id_token)
+    except Exception as e:
+        raise HTTPException(status_code=401, detail=str(e))
+
+    user = await get_or_create_user(
+        google_id=info["sub"],
+        email=info.get("email", ""),
+        name=info.get("name", ""),
+        picture=info.get("picture", ""),
+    )
+    return _user_response(user)
+
+
+class GitHubAuthRequest(BaseModel):
+    github_id: str
+    email: str = ""
+    name: str = ""
+    picture: str = ""
+
+
+@router.post("/github")
+async def github_login(req: GitHubAuthRequest):
+    """Exchange GitHub profile info for our own backend JWT."""
+    if not req.github_id:
+        raise HTTPException(status_code=400, detail="github_id is required")
+
+    user = await get_or_create_user_github(
+        github_id=req.github_id,
+        email=req.email,
+        name=req.name,
+        picture=req.picture,
+    )
+    return _user_response(user)

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -85,6 +85,50 @@ async def get_or_create_user(google_id: str, email: str, name: str, picture: str
         return dict(row)
 
 
+async def get_or_create_user_github(github_id: str, email: str, name: str, picture: str) -> dict:
+    """Return existing user (by github_id or email) or create a new one for GitHub OAuth."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        # Try finding by github_id first
+        async with db.execute("SELECT * FROM users WHERE github_id = ?", (github_id,)) as cursor:
+            row = await cursor.fetchone()
+        if row:
+            await db.execute(
+                "UPDATE users SET email=?, name=?, picture=? WHERE github_id=?",
+                (email, name, picture, github_id),
+            )
+            await db.commit()
+            return dict(row)
+
+        # Try linking to existing account by email (user signed in via Google before)
+        if email:
+            async with db.execute("SELECT * FROM users WHERE email = ?", (email,)) as cursor:
+                row = await cursor.fetchone()
+            if row:
+                await db.execute(
+                    "UPDATE users SET github_id=?, name=?, picture=? WHERE id=?",
+                    (github_id, name, picture, row["id"]),
+                )
+                await db.commit()
+                return dict(row)
+
+        # New user
+        async with db.execute("SELECT COUNT(*) FROM users") as cursor:
+            count = (await cursor.fetchone())[0]
+        is_first = count == 0
+
+        await db.execute(
+            "INSERT INTO users (google_id, github_id, email, name, picture, role, approved) VALUES (?,?,?,?,?,?,?)",
+            (f"github:{github_id}", github_id, email, name, picture,
+             "admin" if is_first else "user",
+             1 if is_first else 0),
+        )
+        await db.commit()
+        async with db.execute("SELECT * FROM users WHERE github_id = ?", (github_id,)) as cursor:
+            row = await cursor.fetchone()
+        return dict(row)
+
+
 async def get_user_by_id(user_id: int) -> dict | None:
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row

--- a/backend/services/migrations.py
+++ b/backend/services/migrations.py
@@ -69,6 +69,8 @@ async def run(db_path: str) -> list[str]:
              "SELECT name FROM sqlite_master WHERE type='table' AND name='audio_cache'"),
             ("004_user_roles_and_approval",
              "SELECT 1 FROM pragma_table_info('users') WHERE name='role'"),
+            ("005_add_github_id",
+             "SELECT 1 FROM pragma_table_info('users') WHERE name='github_id'"),
         ]
         bootstrapped: list[str] = []
         for version, check_sql in bootstrap_checks:

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -171,12 +171,15 @@ async def test_partial_bootstrap_marks_missing_versions(tmp_db):
         """)
         await db.commit()
 
-    # This should NOT crash — the bootstrap should detect the missing 002/003
+    # This should NOT crash — the bootstrap should detect the missing 002/003/004
     # and mark them as applied before the migration loop tries to execute them.
+    # Newer migrations (005+) that add new columns will actually run.
     applied = await run_migrations(tmp_db)
-    assert applied == []  # nothing NEW applied (bootstrap marked them, not the loop)
+    assert "002_add_book_images" not in applied
+    assert "003_create_audio_cache" not in applied
+    assert "004_user_roles_and_approval" not in applied
 
-    # All three should now be in schema_migrations
+    # All bootstrapped versions should be in schema_migrations
     async with aiosqlite.connect(tmp_db) as db:
         async with db.execute("SELECT version FROM schema_migrations ORDER BY version") as cursor:
             versions = [row[0] async for row in cursor]
@@ -270,8 +273,12 @@ async def test_existing_db_bootstrap_marks_old_migrations_done(tmp_db):
         await db.commit()
 
     applied = await run_migrations(tmp_db)
-    # Bootstrap should have marked all 4 as done (DB has all features)
-    assert applied == []
+    # Bootstrap should have marked first 4 as done (DB has all features).
+    # Newer migrations (005+) that add new columns will actually run.
+    assert "001_initial_schema" not in applied
+    assert "002_add_book_images" not in applied
+    assert "003_create_audio_cache" not in applied
+    assert "004_user_roles_and_approval" not in applied
 
     # Verify schema_migrations contains the bootstrapped versions
     async with aiosqlite.connect(tmp_db) as db:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -13,6 +13,11 @@ AUTH_SECRET=
 AUTH_GOOGLE_ID=
 AUTH_GOOGLE_SECRET=
 
+# GitHub OAuth (optional — enables "Continue with GitHub" on login page)
+# Create an OAuth App at https://github.com/settings/developers
+AUTH_GITHUB_ID=
+AUTH_GITHUB_SECRET=
+
 # ── Injected by Vercel at runtime ────────────────────────────────────────
 # NEXTAUTH_URL — Vercel sets this automatically from the deployment URL.
 # Only set it manually if you have a custom domain that Vercel doesn't

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -23,20 +23,31 @@ function LoginForm() {
             Sign in to access your library and AI features.
           </p>
 
-          <button
-            onClick={() => signIn("google", { callbackUrl })}
-            className="w-full flex items-center justify-center gap-3 bg-white border border-stone-300 text-stone-700 rounded-lg px-4 py-3 text-sm font-medium hover:bg-stone-50 transition-colors shadow-sm"
-          >
-            {/* Google "G" logo */}
-            <svg width="18" height="18" viewBox="0 0 48 48" aria-hidden="true">
-              <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
-              <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
-              <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/>
-              <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
-              <path fill="none" d="M0 0h48v48H0z"/>
-            </svg>
-            Continue with Google
-          </button>
+          <div className="space-y-3">
+            <button
+              onClick={() => signIn("google", { callbackUrl })}
+              className="w-full flex items-center justify-center gap-3 bg-white border border-stone-300 text-stone-700 rounded-lg px-4 py-3 text-sm font-medium hover:bg-stone-50 transition-colors shadow-sm"
+            >
+              <svg width="18" height="18" viewBox="0 0 48 48" aria-hidden="true">
+                <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
+                <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
+                <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/>
+                <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
+                <path fill="none" d="M0 0h48v48H0z"/>
+              </svg>
+              Continue with Google
+            </button>
+
+            <button
+              onClick={() => signIn("github", { callbackUrl })}
+              className="w-full flex items-center justify-center gap-3 bg-[#24292f] text-white rounded-lg px-4 py-3 text-sm font-medium hover:bg-[#1b1f23] transition-colors shadow-sm"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="white" aria-hidden="true">
+                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
+              </svg>
+              Continue with GitHub
+            </button>
+          </div>
         </div>
 
         <p className="text-center text-xs text-stone-400 mt-6">

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -1,5 +1,6 @@
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
+import GitHub from "next-auth/providers/github";
 
 const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api";
 
@@ -9,20 +10,41 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       clientId: process.env.GOOGLE_CLIENT_ID ?? process.env.AUTH_GOOGLE_ID,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? process.env.AUTH_GOOGLE_SECRET,
     }),
+    GitHub({
+      clientId: process.env.GITHUB_CLIENT_ID ?? process.env.AUTH_GITHUB_ID,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET ?? process.env.AUTH_GITHUB_SECRET,
+    }),
   ],
   pages: {
     signIn: "/login",
   },
   callbacks: {
-    async jwt({ token, account }) {
+    async jwt({ token, account, profile }) {
       // Only runs on initial sign-in when account is present
-      if (account?.id_token) {
+      if (account) {
         try {
-          const res = await fetch(`${API}/auth/google`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ id_token: account.id_token }),
-          });
+          let res: Response;
+          if (account.provider === "google" && account.id_token) {
+            res = await fetch(`${API}/auth/google`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ id_token: account.id_token }),
+            });
+          } else if (account.provider === "github") {
+            const ghProfile = profile as { id?: number; login?: string; avatar_url?: string; email?: string; name?: string } | undefined;
+            res = await fetch(`${API}/auth/github`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                github_id: String(ghProfile?.id ?? account.providerAccountId),
+                email: ghProfile?.email ?? token.email ?? "",
+                name: ghProfile?.name ?? ghProfile?.login ?? "",
+                picture: ghProfile?.avatar_url ?? "",
+              }),
+            });
+          } else {
+            return token;
+          }
           if (res.ok) {
             const data = await res.json();
             token.backendToken = data.token;


### PR DESCRIPTION
## Summary
Add GitHub as a second login method alongside Google OAuth.

- **Migration 005**: adds `github_id` column to users table with unique index
- **Backend**: new `POST /auth/github` endpoint + `get_or_create_user_github` with email-based account linking (if you sign in with GitHub using the same email as your Google account, it links to the same user)
- **Frontend**: GitHub provider in NextAuth, JWT callback handles both providers, login page shows Google + GitHub buttons side by side
- **Bootstrap check** for migration 005 so existing databases auto-detect

To enable GitHub login, set `AUTH_GITHUB_ID` and `AUTH_GITHUB_SECRET` in your .env. Create an OAuth App at https://github.com/settings/developers.

## Test plan
- [x] Backend: 249 tests pass (migration tests updated for 005)
- [x] Frontend: 108 tests pass
- [x] E2E: 11 tests pass

Generated with [Claude Code](https://claude.com/claude-code)
