### PR TITLE
feat: Sign in with Apple OAuth support

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,6 +9,11 @@ JWT_SECRET=
 # that ID tokens received from the frontend were issued for this app.
 GOOGLE_CLIENT_ID=
 
+# Apple Services ID — used to verify the audience (aud) claim in Apple ID
+# tokens. Must match AUTH_APPLE_ID in the frontend .env.
+# Example: com.yourapp.web
+APPLE_CLIENT_ID=
+
 # URL of the deployed frontend. Used for CORS allowed-origins.
 # Example: https://book-reader-ai.vercel.app
 FRONTEND_URL=

--- a/backend/migrations/006_add_apple_id.sql
+++ b/backend/migrations/006_add_apple_id.sql
@@ -1,0 +1,3 @@
+-- Add Apple OAuth support: users can sign in via Apple in addition to Google and GitHub.
+ALTER TABLE users ADD COLUMN apple_id TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_apple_id ON users(apple_id) WHERE apple_id IS NOT NULL;

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-from services.auth import verify_google_id_token, create_jwt
-from services.db import get_or_create_user, get_or_create_user_github
+from services.auth import verify_google_id_token, verify_apple_id_token, create_jwt
+from services.db import get_or_create_user, get_or_create_user_github, get_or_create_user_apple
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -60,5 +60,30 @@ async def github_login(req: GitHubAuthRequest):
         email=req.email,
         name=req.name,
         picture=req.picture,
+    )
+    return _user_response(user)
+
+
+class AppleAuthRequest(BaseModel):
+    id_token: str
+    name: str = ""
+
+
+@router.post("/apple")
+async def apple_login(req: AppleAuthRequest):
+    """Exchange an Apple ID token for our own backend JWT."""
+    try:
+        payload = await verify_apple_id_token(req.id_token)
+    except Exception as e:
+        raise HTTPException(status_code=401, detail=str(e))
+
+    apple_id = payload.get("sub", "")
+    if not apple_id:
+        raise HTTPException(status_code=401, detail="Apple ID token missing sub claim")
+
+    user = await get_or_create_user_apple(
+        apple_id=apple_id,
+        email=payload.get("email", ""),
+        name=req.name,
     )
     return _user_response(user)

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -19,6 +19,7 @@ JWT_ALGORITHM = "HS256"
 JWT_EXPIRE_DAYS = 30
 
 GOOGLE_CLIENT_ID = os.environ.get("GOOGLE_CLIENT_ID", "")
+APPLE_CLIENT_ID = os.environ.get("APPLE_CLIENT_ID", "")
 
 # Fernet key must be 32 url-safe base64-encoded bytes.
 # In dev we derive one from the JWT_SECRET; in prod set ENCRYPTION_KEY explicitly.
@@ -79,6 +80,68 @@ async def verify_google_id_token(id_token: str) -> dict:
     if GOOGLE_CLIENT_ID and data.get("aud") != GOOGLE_CLIENT_ID:
         raise HTTPException(status_code=401, detail="Token audience mismatch")
     return data
+
+
+# ── Apple ID token verification ──────────────────────────────────────────────
+
+APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys"
+_apple_jwks_cache: dict | None = None
+
+
+async def _get_apple_jwks() -> dict:
+    global _apple_jwks_cache
+    if _apple_jwks_cache is not None:
+        return _apple_jwks_cache
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(APPLE_JWKS_URL)
+    if resp.status_code != 200:
+        raise HTTPException(status_code=503, detail="Could not fetch Apple public keys")
+    _apple_jwks_cache = resp.json()
+    return _apple_jwks_cache
+
+
+async def verify_apple_id_token(id_token: str) -> dict:
+    """
+    Verify an Apple ID token using Apple's JWKS public keys.
+    Returns the decoded payload (sub, email, ...).
+    """
+    from jose import jwk as jose_jwk
+    from jose.utils import base64url_decode
+    import json as _json
+
+    jwks = await _get_apple_jwks()
+
+    # Decode header to find the right key
+    header_segment = id_token.split(".")[0]
+    try:
+        header = _json.loads(base64url_decode(header_segment.encode()))
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid Apple ID token format")
+
+    kid = header.get("kid")
+    key_data = next((k for k in jwks.get("keys", []) if k.get("kid") == kid), None)
+    if key_data is None:
+        # Key not in cache — try refreshing once
+        global _apple_jwks_cache
+        _apple_jwks_cache = None
+        jwks = await _get_apple_jwks()
+        key_data = next((k for k in jwks.get("keys", []) if k.get("kid") == kid), None)
+    if key_data is None:
+        raise HTTPException(status_code=401, detail="Apple signing key not found")
+
+    public_key = jose_jwk.construct(key_data)
+    try:
+        payload = jwt.decode(
+            id_token,
+            public_key,
+            algorithms=["RS256"],
+            audience=APPLE_CLIENT_ID if APPLE_CLIENT_ID else None,
+            issuer="https://appleid.apple.com",
+            options={"verify_aud": bool(APPLE_CLIENT_ID)},
+        )
+    except JWTError as e:
+        raise HTTPException(status_code=401, detail=f"Invalid Apple ID token: {e}")
+    return payload
 
 
 # ── FastAPI dependency ────────────────────────────────────────────────────────

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -129,6 +129,58 @@ async def get_or_create_user_github(github_id: str, email: str, name: str, pictu
         return dict(row)
 
 
+async def get_or_create_user_apple(apple_id: str, email: str, name: str) -> dict:
+    """Return existing user (by apple_id or email) or create a new one for Apple OAuth.
+
+    Apple only returns name/email on the first login; subsequent logins only
+    provide the subject (apple_id). We therefore only update name/email when
+    they are non-empty.
+    """
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        # Try finding by apple_id first
+        async with db.execute("SELECT * FROM users WHERE apple_id = ?", (apple_id,)) as cursor:
+            row = await cursor.fetchone()
+        if row:
+            if email or name:
+                await db.execute(
+                    "UPDATE users SET email=COALESCE(NULLIF(?,''), email), name=COALESCE(NULLIF(?,''), name) WHERE apple_id=?",
+                    (email, name, apple_id),
+                )
+                await db.commit()
+            async with db.execute("SELECT * FROM users WHERE apple_id = ?", (apple_id,)) as cursor:
+                row = await cursor.fetchone()
+            return dict(row)
+
+        # Try linking to existing account by email
+        if email:
+            async with db.execute("SELECT * FROM users WHERE email = ?", (email,)) as cursor:
+                row = await cursor.fetchone()
+            if row:
+                await db.execute(
+                    "UPDATE users SET apple_id=? WHERE id=?",
+                    (apple_id, row["id"]),
+                )
+                await db.commit()
+                return dict(row)
+
+        # New user
+        async with db.execute("SELECT COUNT(*) FROM users") as cursor:
+            count = (await cursor.fetchone())[0]
+        is_first = count == 0
+
+        await db.execute(
+            "INSERT INTO users (google_id, apple_id, email, name, role, approved) VALUES (?,?,?,?,?,?)",
+            (f"apple:{apple_id}", apple_id, email, name,
+             "admin" if is_first else "user",
+             1 if is_first else 0),
+        )
+        await db.commit()
+        async with db.execute("SELECT * FROM users WHERE apple_id = ?", (apple_id,)) as cursor:
+            row = await cursor.fetchone()
+        return dict(row)
+
+
 async def get_user_by_id(user_id: int) -> dict | None:
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row

--- a/backend/tests/test_apple_auth.py
+++ b/backend/tests/test_apple_auth.py
@@ -1,0 +1,252 @@
+"""
+Tests for Apple OAuth: service (verify_apple_id_token), db (get_or_create_user_apple),
+and router (/auth/apple).
+
+Service tests use a real RSA key pair so we can sign test tokens and verify the full
+decode path without hitting Apple's servers.
+"""
+
+import json
+import time
+import pytest
+import httpx
+import respx
+from unittest.mock import AsyncMock, patch
+
+from cryptography.hazmat.primitives.asymmetric import rsa, padding
+from cryptography.hazmat.primitives import hashes, serialization
+import base64
+
+from fastapi import HTTPException
+import services.auth as auth_module
+from services.auth import verify_apple_id_token
+from services.db import get_or_create_user_apple, get_or_create_user, init_db
+import services.db as db_module
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_rsa_keypair():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+    return private_key, public_key
+
+
+def _int_to_base64url(n: int) -> str:
+    length = (n.bit_length() + 7) // 8
+    return base64.urlsafe_b64encode(n.to_bytes(length, "big")).rstrip(b"=").decode()
+
+
+def _public_key_to_jwk(public_key, kid: str = "test-key-id") -> dict:
+    pub_numbers = public_key.public_numbers()
+    return {
+        "kty": "RSA",
+        "kid": kid,
+        "use": "sig",
+        "alg": "RS256",
+        "n": _int_to_base64url(pub_numbers.n),
+        "e": _int_to_base64url(pub_numbers.e),
+    }
+
+
+def _make_apple_id_token(private_key, kid: str = "test-key-id", sub: str = "apple-user-123",
+                          email: str = "user@privaterelay.appleid.com",
+                          issuer: str = "https://appleid.apple.com",
+                          audience: str = "com.yourapp.web",
+                          exp_offset: int = 3600) -> str:
+    from jose import jwt as jose_jwt
+    private_pem = private_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    )
+    payload = {
+        "iss": issuer,
+        "aud": audience,
+        "exp": int(time.time()) + exp_offset,
+        "iat": int(time.time()),
+        "sub": sub,
+        "email": email,
+    }
+    return jose_jwt.encode(payload, private_pem, algorithm="RS256", headers={"kid": kid})
+
+
+# ── verify_apple_id_token ─────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def reset_jwks_cache():
+    """Clear the module-level JWKS cache before each test."""
+    auth_module._apple_jwks_cache = None
+    yield
+    auth_module._apple_jwks_cache = None
+
+
+async def test_verify_apple_id_token_happy_path(monkeypatch):
+    private_key, public_key = _make_rsa_keypair()
+    jwk = _public_key_to_jwk(public_key)
+    token = _make_apple_id_token(private_key)
+
+    monkeypatch.setattr(auth_module, "APPLE_CLIENT_ID", "com.yourapp.web")
+
+    with respx.mock:
+        respx.get(auth_module.APPLE_JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [jwk]})
+        )
+        payload = await verify_apple_id_token(token)
+
+    assert payload["sub"] == "apple-user-123"
+    assert payload["email"] == "user@privaterelay.appleid.com"
+
+
+async def test_verify_apple_id_token_wrong_key_raises_401(monkeypatch):
+    """Token signed with one key, JWKS returns a different key → should fail."""
+    private_key, _ = _make_rsa_keypair()
+    _, other_public = _make_rsa_keypair()
+    jwk = _public_key_to_jwk(other_public)
+    token = _make_apple_id_token(private_key)
+
+    monkeypatch.setattr(auth_module, "APPLE_CLIENT_ID", "")
+
+    with respx.mock:
+        # Return wrong key both times (initial fetch + cache-bust retry)
+        respx.get(auth_module.APPLE_JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [jwk]})
+        )
+        with pytest.raises(HTTPException) as exc:
+            await verify_apple_id_token(token)
+    assert exc.value.status_code == 401
+
+
+async def test_verify_apple_id_token_jwks_unavailable_raises_503():
+    with respx.mock:
+        respx.get(auth_module.APPLE_JWKS_URL).mock(
+            return_value=httpx.Response(503, text="unavailable")
+        )
+        with pytest.raises(HTTPException) as exc:
+            await verify_apple_id_token("any.token.here")
+    assert exc.value.status_code == 503
+
+
+async def test_verify_apple_id_token_unknown_kid_raises_401(monkeypatch):
+    """JWKS doesn't contain the kid from the token."""
+    private_key, public_key = _make_rsa_keypair()
+    jwk = _public_key_to_jwk(public_key, kid="other-kid")
+    token = _make_apple_id_token(private_key, kid="test-key-id")
+
+    monkeypatch.setattr(auth_module, "APPLE_CLIENT_ID", "")
+
+    with respx.mock:
+        respx.get(auth_module.APPLE_JWKS_URL).mock(
+            return_value=httpx.Response(200, json={"keys": [jwk]})
+        )
+        with pytest.raises(HTTPException) as exc:
+            await verify_apple_id_token(token)
+    assert exc.value.status_code == 401
+
+
+# ── get_or_create_user_apple ──────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+async def tmp_db(monkeypatch, tmp_path):
+    path = str(tmp_path / "test.db")
+    monkeypatch.setattr(db_module, "DB_PATH", path)
+    await init_db()
+
+
+async def test_create_apple_user():
+    user = await get_or_create_user_apple("apple-001", "alice@example.com", "Alice")
+    assert user["apple_id"] == "apple-001"
+    assert user["email"] == "alice@example.com"
+    assert user["name"] == "Alice"
+    assert user["id"] is not None
+
+
+async def test_apple_login_idempotent():
+    u1 = await get_or_create_user_apple("apple-001", "alice@example.com", "Alice")
+    u2 = await get_or_create_user_apple("apple-001", "alice@example.com", "Alice")
+    assert u1["id"] == u2["id"]
+
+
+async def test_apple_subsequent_login_no_name_keeps_existing_name():
+    """Apple only sends name on first login — blank name must not overwrite stored name."""
+    await get_or_create_user_apple("apple-002", "bob@example.com", "Bob Smith")
+    user2 = await get_or_create_user_apple("apple-002", "", "")
+    assert user2["name"] == "Bob Smith"
+
+
+async def test_apple_links_to_existing_google_user():
+    """If a Google user with matching email exists, Apple login should link to that account."""
+    google_user = await get_or_create_user("g-123", "shared@example.com", "Carol", "")
+    apple_user = await get_or_create_user_apple("apple-003", "shared@example.com", "Carol Apple")
+    assert apple_user["id"] == google_user["id"]
+
+
+async def test_apple_first_user_gets_admin():
+    user = await get_or_create_user_apple("apple-004", "first@example.com", "First")
+    assert user["role"] == "admin"
+    assert user["approved"] == 1
+
+
+async def test_apple_second_user_pending():
+    await get_or_create_user_apple("apple-005", "first@example.com", "First")
+    user2 = await get_or_create_user_apple("apple-006", "second@example.com", "Second")
+    assert user2["role"] == "user"
+    assert user2["approved"] == 0
+
+
+# ── /auth/apple router ────────────────────────────────────────────────────────
+
+FAKE_APPLE_PAYLOAD = {
+    "sub": "apple-user-999",
+    "email": "test@privaterelay.appleid.com",
+    "iss": "https://appleid.apple.com",
+    "aud": "com.yourapp.web",
+}
+
+
+async def test_apple_login_returns_token_and_user(client):
+    with patch("routers.auth.verify_apple_id_token", new_callable=AsyncMock, return_value=FAKE_APPLE_PAYLOAD):
+        resp = await client.post("/api/auth/apple", json={"id_token": "valid-token", "name": "Test User"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "token" in data
+    assert data["user"]["email"] == "test@privaterelay.appleid.com"
+    assert "hasGeminiKey" in data["user"]
+
+
+async def test_apple_login_invalid_token_returns_401(client):
+    with patch(
+        "routers.auth.verify_apple_id_token",
+        new_callable=AsyncMock,
+        side_effect=ValueError("bad apple token"),
+    ):
+        resp = await client.post("/api/auth/apple", json={"id_token": "bad-token"})
+
+    assert resp.status_code == 401
+    assert "bad apple token" in resp.json()["detail"]
+
+
+async def test_apple_login_missing_sub_returns_401(client):
+    """Payload without 'sub' claim must be rejected."""
+    with patch("routers.auth.verify_apple_id_token", new_callable=AsyncMock, return_value={}):
+        resp = await client.post("/api/auth/apple", json={"id_token": "token-no-sub"})
+
+    assert resp.status_code == 401
+
+
+async def test_apple_login_name_optional(client):
+    """name field is optional — omitting it should still succeed."""
+    with patch("routers.auth.verify_apple_id_token", new_callable=AsyncMock, return_value=FAKE_APPLE_PAYLOAD):
+        resp = await client.post("/api/auth/apple", json={"id_token": "valid-token"})
+
+    assert resp.status_code == 200
+
+
+async def test_apple_login_idempotent_via_router(client):
+    """Two logins with same apple sub return the same user id."""
+    with patch("routers.auth.verify_apple_id_token", new_callable=AsyncMock, return_value=FAKE_APPLE_PAYLOAD):
+        r1 = await client.post("/api/auth/apple", json={"id_token": "token"})
+        r2 = await client.post("/api/auth/apple", json={"id_token": "token"})
+
+    assert r1.json()["user"]["id"] == r2.json()["user"]["id"]

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -18,6 +18,23 @@ AUTH_GOOGLE_SECRET=
 AUTH_GITHUB_ID=
 AUTH_GITHUB_SECRET=
 
+# Apple OAuth (optional — enables "Continue with Apple" on login page)
+# Setup steps:
+#   1. In Apple Developer → Certificates, Identifiers & Profiles, create a
+#      Services ID (e.g. com.yourapp.web) with Sign In with Apple enabled.
+#      Add your domain and redirect URL:
+#        https://<your-domain>/api/auth/callback/apple
+#   2. Create a Key with Sign In with Apple enabled, download the .p8 file.
+#   3. Generate the client secret JWT (valid up to 6 months) with:
+#        npx auth apple-secret \
+#          --teamId TEAM_ID \
+#          --keyId KEY_ID \
+#          --clientId com.yourapp.web \
+#          --keyFile /path/to/key.p8
+#      Paste the output as AUTH_APPLE_SECRET below.
+AUTH_APPLE_ID=com.yourapp.web
+AUTH_APPLE_SECRET=
+
 # ── Injected by Vercel at runtime ────────────────────────────────────────
 # NEXTAUTH_URL — Vercel sets this automatically from the deployment URL.
 # Only set it manually if you have a custom domain that Vercel doesn't

--- a/frontend/src/__tests__/LoginPage.test.tsx
+++ b/frontend/src/__tests__/LoginPage.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Tests for the login page — verifies all three OAuth buttons (Google, GitHub, Apple)
+ * are rendered and call signIn with the correct provider.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mock next-auth/react so signIn is controllable
+const mockSignIn = jest.fn();
+jest.mock("next-auth/react", () => ({
+  signIn: (...args: unknown[]) => mockSignIn(...args),
+}));
+
+// Mock next/navigation for useSearchParams
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// Dynamic import of the component after mocks are set up
+let LoginForm: React.ComponentType;
+beforeAll(async () => {
+  // We import the inner LoginForm by importing the default export (LoginPage wraps it
+  // in Suspense; we test the inner logic by rendering the full page with Suspense)
+  const mod = await import("@/app/login/page");
+  LoginForm = mod.default;
+});
+
+beforeEach(() => {
+  mockSignIn.mockClear();
+});
+
+describe("LoginPage", () => {
+  it("renders Google sign-in button", () => {
+    render(<LoginForm />);
+    expect(screen.getByText("Continue with Google")).toBeInTheDocument();
+  });
+
+  it("renders GitHub sign-in button", () => {
+    render(<LoginForm />);
+    expect(screen.getByText("Continue with GitHub")).toBeInTheDocument();
+  });
+
+  it("renders Apple sign-in button", () => {
+    render(<LoginForm />);
+    expect(screen.getByText("Continue with Apple")).toBeInTheDocument();
+  });
+
+  it("clicking Apple button calls signIn with 'apple'", async () => {
+    const user = userEvent.setup();
+    render(<LoginForm />);
+    await user.click(screen.getByText("Continue with Apple"));
+    expect(mockSignIn).toHaveBeenCalledWith("apple", expect.objectContaining({ callbackUrl: "/" }));
+  });
+
+  it("clicking Google button calls signIn with 'google'", async () => {
+    const user = userEvent.setup();
+    render(<LoginForm />);
+    await user.click(screen.getByText("Continue with Google"));
+    expect(mockSignIn).toHaveBeenCalledWith("google", expect.objectContaining({ callbackUrl: "/" }));
+  });
+
+  it("clicking GitHub button calls signIn with 'github'", async () => {
+    const user = userEvent.setup();
+    render(<LoginForm />);
+    await user.click(screen.getByText("Continue with GitHub"));
+    expect(mockSignIn).toHaveBeenCalledWith("github", expect.objectContaining({ callbackUrl: "/" }));
+  });
+});

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -47,6 +47,16 @@ function LoginForm() {
               </svg>
               Continue with GitHub
             </button>
+
+            <button
+              onClick={() => signIn("apple", { callbackUrl })}
+              className="w-full flex items-center justify-center gap-3 bg-black text-white rounded-lg px-4 py-3 text-sm font-medium hover:bg-stone-900 transition-colors shadow-sm"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="white" aria-hidden="true">
+                <path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.54 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701"/>
+              </svg>
+              Continue with Apple
+            </button>
           </div>
         </div>
 

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -1,6 +1,7 @@
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 import GitHub from "next-auth/providers/github";
+import Apple from "next-auth/providers/apple";
 
 const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api";
 
@@ -13,6 +14,10 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     GitHub({
       clientId: process.env.GITHUB_CLIENT_ID ?? process.env.AUTH_GITHUB_ID,
       clientSecret: process.env.GITHUB_CLIENT_SECRET ?? process.env.AUTH_GITHUB_SECRET,
+    }),
+    Apple({
+      clientId: process.env.AUTH_APPLE_ID ?? "",
+      clientSecret: process.env.AUTH_APPLE_SECRET ?? "",
     }),
   ],
   pages: {
@@ -41,6 +46,16 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
                 name: ghProfile?.name ?? ghProfile?.login ?? "",
                 picture: ghProfile?.avatar_url ?? "",
               }),
+            });
+          } else if (account.provider === "apple" && account.id_token) {
+            const appleProfile = profile as { name?: { firstName?: string; lastName?: string } } | undefined;
+            const name = [appleProfile?.name?.firstName, appleProfile?.name?.lastName]
+              .filter(Boolean)
+              .join(" ");
+            res = await fetch(`${API}/auth/apple`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ id_token: account.id_token, name }),
             });
           } else {
             return token;


### PR DESCRIPTION
## Summary

- Add Sign in with Apple as a third OAuth login method alongside Google and GitHub
- Backend verifies Apple ID tokens via JWKS/RS256 (fetches Apple's public keys, caches them), then issues our own JWT
- New DB migration adds `apple_id` column; new users get `google_id = 'apple:{apple_id}'` as placeholder to satisfy the NOT NULL constraint
- Frontend: NextAuth Apple provider + login button on `/login`
- Apple only sends name/email on first login — subsequent logins only provide `sub`; `get_or_create_user_apple` handles this gracefully

## Test plan

- [x] 15 backend tests: `verify_apple_id_token` (happy path, wrong key, JWKS unavailable, unknown kid), `get_or_create_user_apple` (create, idempotent, name preserved on re-login, email linking, first-user admin, second-user pending), router `/auth/apple` (success, 401, missing sub, name optional, idempotent)
- [x] 6 frontend tests: all three buttons render, each calls `signIn` with correct provider
- [x] Full suite: backend 264 passed, frontend 114 passed, E2E 11 passed

## User config required after merge

See `frontend/.env.example` and `backend/.env.example` for full instructions.

**Apple Developer Portal:**
1. Enable Sign In with Apple on your App ID
2. Create a **Services ID** (e.g. `com.yourapp.web`) — this is the OAuth Client ID
3. Add redirect URL: `https://<your-domain>/api/auth/callback/apple`
4. Create a **Key** with Sign In with Apple, download the `.p8` file

**Generate client secret JWT** (valid up to 6 months):
```bash
npx auth apple-secret --teamId TEAM_ID --keyId KEY_ID --clientId com.yourapp.web --keyFile /path/to/key.p8
```

**Frontend `.env`:**
```
AUTH_APPLE_ID=com.yourapp.web
AUTH_APPLE_SECRET=<output from above command>
```

**Backend `.env`:**
```
APPLE_CLIENT_ID=com.yourapp.web
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
