### PR TITLE
feat(backend): add preseed_translations.py script

### DIFF
--- a/backend/scripts/preseed_translations.py
+++ b/backend/scripts/preseed_translations.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""
+Pre-populate the `translations` table for every cached book.
+
+Walks every book in the DB, splits it into chapters using the same
+`services.splitter.build_chapters` the reader uses, and writes a cached
+translation for every chapter into the shared cache. Users hit the cache
+instantly the first time they open a chapter — no API spend at runtime.
+
+Idempotent: chapters that already have a translation for the target
+language are skipped. Books that are already in the target language are
+skipped entirely.
+
+Usage:
+    # Default — free Google Translate, target Chinese
+    python scripts/preseed_translations.py
+
+    # Use Gemini with a key from env var (best literary quality, free tier)
+    GEMINI_API_KEY=AIza... python scripts/preseed_translations.py --provider gemini
+
+    # Different target language
+    python scripts/preseed_translations.py --target de
+
+    # Just one book (useful for testing)
+    python scripts/preseed_translations.py --book-id 2229
+
+    # See what would be done without calling any API
+    python scripts/preseed_translations.py --dry-run
+
+    # Bump concurrency (default 3 — Gemini free tier RPM is low)
+    python scripts/preseed_translations.py --concurrency 5
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+from dataclasses import dataclass
+from typing import Awaitable, Callable
+
+# Make `services.*` importable when this file is run as a script.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from services.db import (  # noqa: E402
+    init_db,
+    list_cached_books,
+    get_cached_book,
+    get_cached_translation,
+    save_translation,
+    DB_PATH,
+)
+from services.splitter import build_chapters  # noqa: E402
+from services.translate import translate_text  # noqa: E402
+
+
+Translator = Callable[[str, str, str], Awaitable[list[str]]]
+
+
+@dataclass
+class ChapterJob:
+    book_id: int
+    book_title: str
+    chapter_index: int
+    source_language: str
+    text: str
+
+
+def _resolve_source_language(book: dict) -> str | None:
+    """Return the first language code from book metadata, or None."""
+    langs = book.get("languages") or []
+    return langs[0] if langs else None
+
+
+async def plan_jobs(
+    books: list[dict],
+    target_language: str,
+    *,
+    book_id_filter: int | None = None,
+) -> list[ChapterJob]:
+    """Build the list of chapters that still need translating.
+
+    - Skips books already in `target_language`
+    - Skips books without a language or without cached text
+    - Skips individual chapters that already have a translation cached
+    - Optionally filters to a single book_id
+    """
+    jobs: list[ChapterJob] = []
+    for meta in books:
+        if book_id_filter is not None and meta["id"] != book_id_filter:
+            continue
+
+        source = _resolve_source_language(meta)
+        if source is None or source == target_language:
+            continue
+
+        book = await get_cached_book(meta["id"])
+        if book is None or not book.get("text"):
+            continue
+
+        chapters = build_chapters(book["text"])
+        for idx, ch in enumerate(chapters):
+            if not ch.text.strip():
+                continue
+            existing = await get_cached_translation(meta["id"], idx, target_language)
+            if existing:
+                continue
+            jobs.append(ChapterJob(
+                book_id=meta["id"],
+                book_title=book["title"],
+                chapter_index=idx,
+                source_language=source,
+                text=ch.text,
+            ))
+    return jobs
+
+
+async def run_jobs(
+    jobs: list[ChapterJob],
+    target_language: str,
+    translator: Translator,
+    *,
+    concurrency: int = 1,
+    on_result: Callable[[ChapterJob, bool, str], None] | None = None,
+) -> tuple[int, int]:
+    """Run every job through `translator`, persist results, return (ok, failed).
+
+    A single chapter failing never aborts the run — the error is reported
+    through `on_result` (if provided) and the next job continues. This
+    matters for long unattended overnight batches.
+    """
+    if concurrency < 1:
+        raise ValueError("concurrency must be >= 1")
+
+    sem = asyncio.Semaphore(concurrency)
+    ok = 0
+    failed = 0
+
+    async def _one(job: ChapterJob) -> None:
+        nonlocal ok, failed
+        async with sem:
+            try:
+                paragraphs = await translator(
+                    job.text, job.source_language, target_language
+                )
+                await save_translation(
+                    job.book_id, job.chapter_index, target_language, paragraphs
+                )
+                ok += 1
+                if on_result:
+                    on_result(job, True, "")
+            except Exception as e:  # noqa: BLE001 — deliberately broad
+                failed += 1
+                if on_result:
+                    on_result(job, False, str(e))
+
+    await asyncio.gather(*(_one(j) for j in jobs))
+    return ok, failed
+
+
+def _build_translator(provider: str, gemini_key: str | None) -> Translator:
+    """Return an async callable matching the `Translator` protocol."""
+    async def _t(text: str, source: str, target: str) -> list[str]:
+        return await translate_text(
+            text, source, target,
+            provider=provider,
+            gemini_key=gemini_key,
+        )
+    return _t
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Pre-populate chapter translations for every cached book.",
+    )
+    parser.add_argument("--target", default="zh",
+                        help="Target language code (default: zh)")
+    parser.add_argument("--provider", choices=("google", "gemini"), default="google",
+                        help="Translation backend (default: google — free, no key)")
+    parser.add_argument("--gemini-key", default=os.environ.get("GEMINI_API_KEY"),
+                        help="Gemini API key (or set GEMINI_API_KEY env var)")
+    parser.add_argument("--book-id", type=int, default=None,
+                        help="Only process this one book")
+    parser.add_argument("--concurrency", type=int, default=3,
+                        help="Max in-flight translations (default: 3)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print what would be done without calling any API")
+    return parser.parse_args(argv)
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    await init_db()
+
+    if args.provider == "gemini" and not args.gemini_key:
+        print("ERROR: --provider gemini requires --gemini-key or GEMINI_API_KEY env var.",
+              file=sys.stderr)
+        return 2
+
+    books = await list_cached_books()
+    print(f"Database: {DB_PATH}")
+    print(f"Books cached: {len(books)}")
+    print(f"Target language: {args.target}")
+    print(f"Provider: {args.provider}\n")
+
+    print("Planning work…")
+    jobs = await plan_jobs(books, args.target, book_id_filter=args.book_id)
+
+    if not jobs:
+        print("Nothing to do — all chapters already translated (or no books match).")
+        return 0
+
+    # Stats
+    by_book: dict[int, list[ChapterJob]] = {}
+    for j in jobs:
+        by_book.setdefault(j.book_id, []).append(j)
+    total_words = sum(len(j.text.split()) for j in jobs)
+    print(f"  Books to process: {len(by_book)}")
+    print(f"  Chapters to translate: {len(jobs)}")
+    print(f"  Total words: {total_words:,}\n")
+
+    if args.dry_run:
+        for bid, bjobs in by_book.items():
+            title = bjobs[0].book_title
+            words = sum(len(j.text.split()) for j in bjobs)
+            print(f"  [{bid:>6}] {title[:60]:<60} "
+                  f"{len(bjobs):>3} ch, {words:>7,} words")
+        print("\n(dry-run — no translations written)")
+        return 0
+
+    translator = _build_translator(args.provider, args.gemini_key)
+
+    total = len(jobs)
+    counter = {"n": 0}
+
+    def _log(job: ChapterJob, success: bool, err: str) -> None:
+        counter["n"] += 1
+        mark = "OK" if success else "!!"
+        suffix = "" if success else f"  ({err[:60]})"
+        print(f"  [{counter['n']:>4}/{total}] {mark} "
+              f"{job.book_id} ch{job.chapter_index}  "
+              f"{job.book_title[:40]}{suffix}")
+
+    ok, failed = await run_jobs(
+        jobs, args.target, translator,
+        concurrency=args.concurrency,
+        on_result=_log,
+    )
+
+    print(f"\nDone. Succeeded: {ok}, Failed: {failed}")
+    return 0 if failed == 0 else 1
+
+
+def main() -> int:
+    args = _parse_args()
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_preseed_translations.py
+++ b/backend/tests/test_preseed_translations.py
@@ -1,0 +1,317 @@
+"""
+Tests for scripts/preseed_translations.py
+
+The real translation backend is never invoked — we pass a stub translator
+into `run_jobs`, and `plan_jobs` reads from a temporary SQLite database
+seeded by the test.
+"""
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+# Make the scripts directory importable
+_SCRIPTS_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts"
+)
+sys.path.insert(0, _SCRIPTS_DIR)
+
+import preseed_translations as pre  # noqa: E402
+
+import services.db as db_module  # noqa: E402
+from services.db import (  # noqa: E402
+    init_db,
+    save_book,
+    save_translation,
+    get_cached_translation,
+    list_cached_books,
+)
+
+
+# ── Shared fixtures ──────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+async def tmp_db(monkeypatch, tmp_path):
+    path = str(tmp_path / "preseed.db")
+    monkeypatch.setattr(db_module, "DB_PATH", path)
+    await init_db()
+    yield
+
+
+# A minimal book body the splitter will accept. Two CHAPTER headings
+# keep the "keyword" strategy happy, and each body is long enough that
+# _validate() does not reject the split (MIN_AVG_WORDS = 150).
+_LONG_PARA = (" ".join(["word"] * 200)).strip()
+
+SAMPLE_EN_TEXT = (
+    "CHAPTER I\n\n" + _LONG_PARA + "\n\n"
+    "CHAPTER II\n\n" + _LONG_PARA + "\n"
+)
+
+
+def _meta(title: str, lang: str) -> dict:
+    return {
+        "title": title,
+        "authors": ["Someone"],
+        "languages": [lang],
+        "subjects": [],
+        "download_count": 0,
+        "cover": "",
+    }
+
+
+# ── _resolve_source_language ─────────────────────────────────────────────────
+
+def test_resolve_source_language_returns_first_language():
+    assert pre._resolve_source_language({"languages": ["en", "de"]}) == "en"
+
+
+def test_resolve_source_language_returns_none_for_empty():
+    assert pre._resolve_source_language({"languages": []}) is None
+
+
+def test_resolve_source_language_returns_none_when_missing():
+    assert pre._resolve_source_language({}) is None
+
+
+# ── plan_jobs ────────────────────────────────────────────────────────────────
+
+async def test_plan_jobs_emits_job_per_chapter():
+    await save_book(1, _meta("Sample", "en"), SAMPLE_EN_TEXT)
+    books = await list_cached_books()
+
+    jobs = await pre.plan_jobs(books, "zh")
+
+    # The sample text splits into 2 chapters, both need translation.
+    assert len(jobs) == 2
+    assert {j.chapter_index for j in jobs} == {0, 1}
+    assert all(j.book_id == 1 for j in jobs)
+    assert all(j.source_language == "en" for j in jobs)
+
+
+async def test_plan_jobs_skips_books_already_in_target_language():
+    await save_book(1, _meta("Chinese Book", "zh"), SAMPLE_EN_TEXT)
+    books = await list_cached_books()
+
+    jobs = await pre.plan_jobs(books, "zh")
+
+    assert jobs == []
+
+
+async def test_plan_jobs_skips_books_without_language():
+    await save_book(1, _meta("No lang", ""), SAMPLE_EN_TEXT)
+    # Empty-string language — simulate missing metadata
+    books = await list_cached_books()
+    books[0]["languages"] = []  # force the None path
+
+    jobs = await pre.plan_jobs(books, "zh")
+
+    assert jobs == []
+
+
+async def test_plan_jobs_skips_already_cached_chapters():
+    await save_book(1, _meta("Sample", "en"), SAMPLE_EN_TEXT)
+    # Pretend chapter 0 was already translated — only chapter 1 should remain.
+    await save_translation(1, 0, "zh", ["已翻译"])
+    books = await list_cached_books()
+
+    jobs = await pre.plan_jobs(books, "zh")
+
+    assert len(jobs) == 1
+    assert jobs[0].chapter_index == 1
+
+
+async def test_plan_jobs_filters_by_book_id():
+    await save_book(1, _meta("Book A", "en"), SAMPLE_EN_TEXT)
+    await save_book(2, _meta("Book B", "en"), SAMPLE_EN_TEXT)
+    books = await list_cached_books()
+
+    jobs = await pre.plan_jobs(books, "zh", book_id_filter=2)
+
+    assert jobs
+    assert {j.book_id for j in jobs} == {2}
+
+
+async def test_plan_jobs_uses_target_language_when_deciding_cached():
+    """A German translation cached for chapter 0 must not mask a missing
+    Chinese translation — cache lookup is keyed by target language."""
+    await save_book(1, _meta("Sample", "en"), SAMPLE_EN_TEXT)
+    await save_translation(1, 0, "de", ["Schon übersetzt"])
+    books = await list_cached_books()
+
+    jobs = await pre.plan_jobs(books, "zh")
+
+    # The German cache hit must not prevent the Chinese job from being emitted.
+    assert any(j.chapter_index == 0 for j in jobs)
+
+
+# ── run_jobs ─────────────────────────────────────────────────────────────────
+
+def _job(book_id: int, chapter_index: int, text: str = "hello") -> pre.ChapterJob:
+    return pre.ChapterJob(
+        book_id=book_id,
+        book_title="T",
+        chapter_index=chapter_index,
+        source_language="en",
+        text=text,
+    )
+
+
+async def test_run_jobs_saves_translations_for_every_job():
+    async def translator(text, src, tgt):
+        return [f"[{tgt}] {text}"]
+
+    jobs = [_job(1, 0, "a"), _job(1, 1, "b")]
+    ok, failed = await pre.run_jobs(jobs, "zh", translator)
+
+    assert (ok, failed) == (2, 0)
+    assert await get_cached_translation(1, 0, "zh") == ["[zh] a"]
+    assert await get_cached_translation(1, 1, "zh") == ["[zh] b"]
+
+
+async def test_run_jobs_counts_failures_and_keeps_going():
+    async def translator(text, src, tgt):
+        if text == "break":
+            raise RuntimeError("kaboom")
+        return ["ok"]
+
+    jobs = [_job(1, 0, "a"), _job(1, 1, "break"), _job(1, 2, "c")]
+    ok, failed = await pre.run_jobs(jobs, "zh", translator)
+
+    assert ok == 2
+    assert failed == 1
+    # The successful jobs are persisted, the failing one is not.
+    assert await get_cached_translation(1, 0, "zh") == ["ok"]
+    assert await get_cached_translation(1, 1, "zh") is None
+    assert await get_cached_translation(1, 2, "zh") == ["ok"]
+
+
+async def test_run_jobs_invokes_on_result_for_success_and_failure():
+    events: list[tuple[int, bool]] = []
+
+    async def translator(text, src, tgt):
+        if text == "fail":
+            raise ValueError("no")
+        return ["ok"]
+
+    def cb(job, success, err):
+        events.append((job.chapter_index, success))
+
+    jobs = [_job(1, 0, "ok"), _job(1, 1, "fail")]
+    await pre.run_jobs(jobs, "zh", translator, on_result=cb)
+
+    assert (0, True) in events
+    assert (1, False) in events
+
+
+async def test_run_jobs_respects_concurrency_limit():
+    """With concurrency=2, never more than 2 translations should be in flight."""
+    in_flight = 0
+    peak = 0
+    lock = asyncio.Lock()
+
+    async def translator(text, src, tgt):
+        nonlocal in_flight, peak
+        async with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        await asyncio.sleep(0.01)
+        async with lock:
+            in_flight -= 1
+        return ["ok"]
+
+    jobs = [_job(1, i) for i in range(6)]
+    await pre.run_jobs(jobs, "zh", translator, concurrency=2)
+
+    assert peak <= 2
+
+
+async def test_run_jobs_rejects_zero_concurrency():
+    async def translator(text, src, tgt):
+        return []
+
+    with pytest.raises(ValueError):
+        await pre.run_jobs([], "zh", translator, concurrency=0)
+
+
+# ── CLI arg parsing ──────────────────────────────────────────────────────────
+
+def test_parse_args_defaults():
+    args = pre._parse_args([])
+    assert args.target == "zh"
+    assert args.provider == "google"
+    assert args.concurrency == 3
+    assert args.dry_run is False
+    assert args.book_id is None
+
+
+def test_parse_args_overrides():
+    args = pre._parse_args([
+        "--target", "de",
+        "--provider", "gemini",
+        "--gemini-key", "AIza...",
+        "--book-id", "42",
+        "--concurrency", "5",
+        "--dry-run",
+    ])
+    assert args.target == "de"
+    assert args.provider == "gemini"
+    assert args.gemini_key == "AIza..."
+    assert args.book_id == 42
+    assert args.concurrency == 5
+    assert args.dry_run is True
+
+
+def test_parse_args_reads_gemini_key_from_env(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "from-env")
+    args = pre._parse_args([])
+    assert args.gemini_key == "from-env"
+
+
+# ── main_async integration ───────────────────────────────────────────────────
+
+async def test_main_async_dry_run_writes_nothing(monkeypatch, capsys):
+    await save_book(1, _meta("Sample", "en"), SAMPLE_EN_TEXT)
+
+    args = pre._parse_args(["--dry-run"])
+    rc = await pre.main_async(args)
+
+    assert rc == 0
+    captured = capsys.readouterr().out
+    assert "dry-run" in captured.lower()
+    # Nothing persisted — chapter 0 still uncached.
+    assert await get_cached_translation(1, 0, "zh") is None
+
+
+async def test_main_async_errors_when_gemini_provider_missing_key(monkeypatch, capsys):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    args = pre._parse_args(["--provider", "gemini"])
+    rc = await pre.main_async(args)
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "gemini" in err.lower()
+
+
+async def test_main_async_no_books_exits_cleanly():
+    args = pre._parse_args([])
+    rc = await pre.main_async(args)
+    assert rc == 0
+
+
+async def test_main_async_translates_via_injected_translator(monkeypatch):
+    """End-to-end: seeded book → real plan_jobs + run_jobs → rows in DB."""
+    await save_book(1, _meta("Sample", "en"), SAMPLE_EN_TEXT)
+
+    async def fake_translate(text, src, tgt, *, provider, gemini_key):
+        return [f"[{tgt}] chapter"]
+
+    monkeypatch.setattr(pre, "translate_text", fake_translate)
+
+    args = pre._parse_args([])
+    rc = await pre.main_async(args)
+
+    assert rc == 0
+    assert await get_cached_translation(1, 0, "zh") == ["[zh] chapter"]
+    assert await get_cached_translation(1, 1, "zh") == ["[zh] chapter"]


### PR DESCRIPTION
Walks every cached book, splits it into chapters via the existing
splitter, and populates the shared translations cache for a target
language. Idempotent (skips already-cached chapters) and supports
both the free Google Translate backend and Gemini (with a key).

Useful for pre-populating Chinese (or any other) translations during
development so users hit the cache on first open instead of waiting
for a round-trip to the translator.

https://claude.ai/code/session_01EaGzJ8nKeRiADoBc3hRaqj