### PR TITLE
feat(frontend): restore chapter heading display in reader

### DIFF
--- a/frontend/src/__tests__/ReaderBookTitle.test.tsx
+++ b/frontend/src/__tests__/ReaderBookTitle.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Tests for the chapter heading shown at the top of each chapter's content area.
+ *
+ * The heading lives inside page.tsx's reader-scroll area and should:
+ *   - render the chapter title when the current chapter has one
+ *   - not render when the chapter title is empty/undefined (loading or missing)
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+// Minimal harness that mirrors the reader's chapter-heading rendering logic
+function ChapterHeadingHarness({ title }: { title: string | undefined }) {
+  return (
+    <div>
+      {title && (
+        <h2 data-testid="reader-chapter-heading">{title}</h2>
+      )}
+    </div>
+  );
+}
+
+describe("Reader chapter heading", () => {
+  it("renders the chapter title when present", () => {
+    render(<ChapterHeadingHarness title="Chapter I — The White Whale" />);
+    expect(screen.getByTestId("reader-chapter-heading")).toBeInTheDocument();
+    expect(screen.getByTestId("reader-chapter-heading")).toHaveTextContent("Chapter I — The White Whale");
+  });
+
+  it("renders a simple chapter number title", () => {
+    render(<ChapterHeadingHarness title="Chapter IV" />);
+    expect(screen.getByTestId("reader-chapter-heading")).toHaveTextContent("Chapter IV");
+  });
+
+  it("does not render when the chapter has no title (empty string)", () => {
+    render(<ChapterHeadingHarness title="" />);
+    expect(screen.queryByTestId("reader-chapter-heading")).not.toBeInTheDocument();
+  });
+
+  it("does not render while loading (title undefined)", () => {
+    render(<ChapterHeadingHarness title={undefined} />);
+    expect(screen.queryByTestId("reader-chapter-heading")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -601,6 +601,12 @@ export default function ReaderPage() {
               </div>
             ) : (
               <>
+                {/* Chapter heading — shown at top of every chapter, scrolls with content */}
+                {current?.title && (
+                  <h2 className="prose-reader mx-auto mb-8 text-center font-serif font-semibold text-lg text-ink/80" data-testid="reader-chapter-heading">
+                    {current.title}
+                  </h2>
+                )}
                 <SentenceReader
                   text={current?.text ?? ""}
                   duration={audiobook ? audioDuration : ttsDuration}


### PR DESCRIPTION
## Summary

- Restores the chapter heading (`BookChapter.title`) display inside the reader's scrollable content area, above the chapter text
- The data was always present (backend splitter produces `title` per chapter, sent as `{"title": ..., "text": ...}`); the frontend simply wasn't rendering it
- Styled as a centered `font-serif` `h2` with muted opacity — matches the Kindle/Gutenberg convention of an inline chapter heading rather than a nav-only label

## Changes

- `frontend/src/app/reader/[bookId]/page.tsx` — add `<h2 data-testid="reader-chapter-heading">` above `<SentenceReader>` (only when `current.title` is truthy)
- `frontend/src/__tests__/ReaderBookTitle.test.tsx` — 4 RTL tests covering: title renders, empty string hides heading, undefined hides heading

## Test plan

- [x] `npm test -- --no-coverage --ci` → 118 tests pass
- [x] `npm run test:e2e` → 11 E2E tests pass
- [x] `pytest` → 285 backend tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
