### PR TITLE
feat(admin): always-on translation queue service

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,7 +18,32 @@ from services.db import init_db
 async def lifespan(app: FastAPI):
     await init_db()
     await _resume_bulk_translation_if_needed()
-    yield
+    await _start_translation_queue_worker()
+    try:
+        yield
+    finally:
+        await _stop_translation_queue_worker()
+
+
+async def _start_translation_queue_worker() -> None:
+    """Launch the always-on queue worker. It immediately idles if no API key
+    or languages are configured — admins can flip it on from the UI without
+    restarting the backend."""
+    import logging
+    try:
+        from services.translation_queue import worker
+        await worker().start()
+    except Exception:
+        logging.getLogger(__name__).exception("Failed to start translation queue worker")
+
+
+async def _stop_translation_queue_worker() -> None:
+    import logging
+    try:
+        from services.translation_queue import worker
+        await worker().stop()
+    except Exception:
+        logging.getLogger(__name__).exception("Failed to stop translation queue worker")
 
 
 async def _resume_bulk_translation_if_needed() -> None:

--- a/backend/migrations/008_translation_queue.sql
+++ b/backend/migrations/008_translation_queue.sql
@@ -1,0 +1,36 @@
+-- Always-on translation queue.
+--
+-- Each row represents "translate book B chapter C into target language L".
+-- The queue worker pulls pending rows in priority order and processes them,
+-- re-using the same per-batch translator the bulk job uses. Unlike a one-shot
+-- bulk job, the queue is permanent — newly-saved books are auto-enqueued and
+-- the worker just keeps draining.
+
+CREATE TABLE IF NOT EXISTS translation_queue (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    book_id           INTEGER NOT NULL,
+    chapter_index     INTEGER NOT NULL,
+    target_language   TEXT    NOT NULL,
+    status            TEXT    NOT NULL DEFAULT 'pending',
+    -- pending | running | done | failed | skipped
+    priority          INTEGER NOT NULL DEFAULT 100,
+    -- lower = sooner. auto-enqueued items default to 100
+    attempts          INTEGER NOT NULL DEFAULT 0,
+    last_error        TEXT,
+    created_at        TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at        TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (book_id, chapter_index, target_language)
+);
+
+CREATE INDEX IF NOT EXISTS idx_queue_status_priority
+    ON translation_queue(status, priority, id);
+
+CREATE INDEX IF NOT EXISTS idx_queue_book
+    ON translation_queue(book_id, target_language);
+
+-- Generic key/value config for the admin panel. First user is the
+-- list of languages to auto-enqueue when a new book is saved.
+CREATE TABLE IF NOT EXISTS app_settings (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -3,10 +3,11 @@ Admin-only endpoints for managing users, books, audio cache, and translations.
 Full CRUD where applicable.
 """
 
+import json
 import aiosqlite
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from services.auth import get_current_user, decrypt_api_key
+from services.auth import get_current_user, decrypt_api_key, encrypt_api_key
 from services.bulk_translate import manager as bulk_manager, plan_work, group_chapters_for_batch
 from services.db import (
     DB_PATH,
@@ -19,10 +20,27 @@ from services.db import (
     save_book,
     save_translation,
     delete_chapter_audio_cache,
+    get_setting,
+    set_setting,
 )
 from services.gutenberg import get_book_meta, get_book_text
 from services.splitter import build_chapters
 from services.translate import translate_text as do_translate
+from services.translation_queue import (
+    SETTING_API_KEY,
+    SETTING_AUTO_LANGS,
+    SETTING_ENABLED,
+    SETTING_MODEL,
+    SETTING_RPD,
+    SETTING_RPM,
+    delete_queue_for_book,
+    delete_queue_item,
+    enqueue_for_book,
+    get_auto_languages,
+    list_queue,
+    queue_summary,
+    worker as queue_worker,
+)
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -81,34 +99,82 @@ async def remove_user(user_id: int, admin: dict = Depends(_require_admin)):
 
 @router.get("/books")
 async def get_books(_admin: dict = Depends(_require_admin)):
-    """List all cached books, with text size + translation counts per language.
+    """List all cached books with rich stats for the admin UI.
 
-    The `translations` field is a map of `target_language → chapters_cached`
-    so the admin UI can show per-language summaries like "zh (22 chapters)"
-    directly on the book row.
+    Per-book payload:
+    - `text_length`, `word_count`, `chapter_count` — size stats.
+    - `translations`: map of `target_language → {chapters, size_chars}`.
+    - `queue`: map of `target_language → {pending, running, done, failed, ...}`
+      so the UI can show progress bars / status badges live.
     """
     books = await list_cached_books()
 
-    # One grouped query for all translations instead of N queries per book.
     async with aiosqlite.connect(DB_PATH) as db:
+        # Translation stats grouped per (book, language)
         async with db.execute(
-            """SELECT book_id, target_language, COUNT(*) AS n
+            """SELECT book_id, target_language,
+                      COUNT(*) AS chapters,
+                      SUM(LENGTH(paragraphs)) AS size_chars
                FROM translations
                GROUP BY book_id, target_language"""
         ) as cursor:
-            rows = await cursor.fetchall()
-    by_book: dict[int, dict[str, int]] = {}
-    for book_id, lang, n in rows:
-        by_book.setdefault(book_id, {})[lang] = n
+            trans_rows = await cursor.fetchall()
+
+        # Live queue stats grouped per (book, language, status)
+        async with db.execute(
+            """SELECT book_id, target_language, status, COUNT(*) AS n
+               FROM translation_queue
+               GROUP BY book_id, target_language, status"""
+        ) as cursor:
+            queue_rows = await cursor.fetchall()
+
+    translations: dict[int, dict[str, dict]] = {}
+    for book_id, lang, chapters, size_chars in trans_rows:
+        translations.setdefault(book_id, {})[lang] = {
+            "chapters": chapters,
+            "size_chars": size_chars or 0,
+        }
+
+    queue_by_book: dict[int, dict[str, dict[str, int]]] = {}
+    for book_id, lang, status, n in queue_rows:
+        queue_by_book.setdefault(book_id, {}).setdefault(lang, {})[status] = n
+
+    # Currently active (book, lang) from worker state — used by the UI to
+    # show a "working now" glow on the right row.
+    worker_state = queue_worker().state()
+    current = None
+    if worker_state.current_book_id:
+        current = {
+            "book_id": worker_state.current_book_id,
+            "target_language": worker_state.current_target_language,
+        }
 
     result = []
     for b in books:
         full = await get_cached_book(b["id"])
-        text_len = len(full["text"]) if full and full.get("text") else 0
+        text = full["text"] if full and full.get("text") else ""
+        text_len = len(text)
+        word_count = len(text.split()) if text else 0
+        # Avoid re-splitting chapters on every /admin/books hit — it's
+        # expensive for big books. The translations table gives us an
+        # upper bound; splitting can be done on-demand per book elsewhere.
         result.append({
             **b,
             "text_length": text_len,
-            "translations": by_book.get(b["id"], {}),
+            "word_count": word_count,
+            "translations": {
+                lang: v["chapters"] for lang, v in translations.get(b["id"], {}).items()
+            },
+            "translation_stats": translations.get(b["id"], {}),
+            "queue": queue_by_book.get(b["id"], {}),
+            "active": bool(
+                current and current["book_id"] == b["id"]
+            ),
+            "active_language": (
+                current["target_language"]
+                if current and current["book_id"] == b["id"]
+                else None
+            ),
         })
     return result
 
@@ -587,3 +653,186 @@ async def bulk_translate_history(_admin: dict = Depends(_require_admin)):
     for r in rows:
         r["dry_run"] = bool(r["dry_run"])
     return rows
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ALWAYS-ON TRANSLATION QUEUE
+# ══════════════════════════════════════════════════════════════════════════════
+
+@router.get("/queue/status")
+async def queue_status(_admin: dict = Depends(_require_admin)):
+    """Snapshot of the queue worker + overall queue counts."""
+    w = queue_worker()
+    s = w.state()
+    summary = await queue_summary()
+    return {
+        "running": w.is_running(),
+        "state": {
+            "enabled": s.enabled,
+            "idle": s.idle,
+            "current_book_id": s.current_book_id,
+            "current_book_title": s.current_book_title,
+            "current_target_language": s.current_target_language,
+            "current_batch_size": s.current_batch_size,
+            "last_completed_at": s.last_completed_at,
+            "last_error": s.last_error,
+            "started_at": s.started_at,
+            "requests_made": s.requests_made,
+            "chapters_done": s.chapters_done,
+            "chapters_failed": s.chapters_failed,
+            "waiting_reason": s.waiting_reason,
+            "log": list(s.log),
+        },
+        "counts": summary["counts"],
+    }
+
+
+@router.post("/queue/start")
+async def queue_start(_admin: dict = Depends(_require_admin)):
+    await queue_worker().start()
+    return {"ok": True}
+
+
+@router.post("/queue/stop")
+async def queue_stop(_admin: dict = Depends(_require_admin)):
+    await queue_worker().stop()
+    return {"ok": True}
+
+
+@router.get("/queue/settings")
+async def queue_get_settings(_admin: dict = Depends(_require_admin)):
+    enabled = await get_setting(SETTING_ENABLED)
+    key = await get_setting(SETTING_API_KEY)
+    langs = await get_auto_languages()
+    rpm = await get_setting(SETTING_RPM)
+    rpd = await get_setting(SETTING_RPD)
+    model = await get_setting(SETTING_MODEL)
+    return {
+        "enabled": enabled != "0",
+        "has_api_key": bool(key),
+        "auto_translate_languages": langs,
+        "rpm": int(rpm) if rpm else None,
+        "rpd": int(rpd) if rpd else None,
+        "model": model or None,
+    }
+
+
+class QueueSettingsRequest(BaseModel):
+    enabled: bool | None = None
+    api_key: str | None = None     # plaintext; empty string clears
+    auto_translate_languages: list[str] | None = None
+    rpm: int | None = None
+    rpd: int | None = None
+    model: str | None = None
+
+
+@router.put("/queue/settings")
+async def queue_set_settings(
+    req: QueueSettingsRequest,
+    _admin: dict = Depends(_require_admin),
+):
+    if req.enabled is not None:
+        await set_setting(SETTING_ENABLED, "1" if req.enabled else "0")
+    if req.api_key is not None:
+        if req.api_key == "":
+            await set_setting(SETTING_API_KEY, "")
+        else:
+            await set_setting(SETTING_API_KEY, encrypt_api_key(req.api_key))
+    if req.auto_translate_languages is not None:
+        await set_setting(
+            SETTING_AUTO_LANGS,
+            json.dumps([lang for lang in req.auto_translate_languages if lang]),
+        )
+    if req.rpm is not None:
+        await set_setting(SETTING_RPM, str(req.rpm))
+    if req.rpd is not None:
+        await set_setting(SETTING_RPD, str(req.rpd))
+    if req.model is not None:
+        await set_setting(SETTING_MODEL, req.model)
+    queue_worker().wake()
+    return {"ok": True}
+
+
+@router.get("/queue/items")
+async def queue_items(
+    status: str | None = None,
+    book_id: int | None = None,
+    limit: int = 200,
+    _admin: dict = Depends(_require_admin),
+):
+    return await list_queue(status=status, book_id=book_id, limit=limit)
+
+
+class EnqueueBookRequest(BaseModel):
+    book_id: int
+    target_languages: list[str] | None = None
+    priority: int = 50   # lower than default so admin enqueues jump the line
+    reset_failed: bool = False
+
+
+@router.post("/queue/enqueue-book")
+async def queue_enqueue_book(
+    req: EnqueueBookRequest,
+    _admin: dict = Depends(_require_admin),
+):
+    added = await enqueue_for_book(
+        req.book_id,
+        target_languages=req.target_languages,
+        priority=req.priority,
+        reset_failed=req.reset_failed,
+    )
+    queue_worker().wake()
+    return {"ok": True, "enqueued": added}
+
+
+@router.delete("/queue/items/{item_id}")
+async def queue_delete_item(
+    item_id: int, _admin: dict = Depends(_require_admin),
+):
+    deleted = await delete_queue_item(item_id)
+    return {"ok": True, "deleted": deleted}
+
+
+@router.delete("/queue/book/{book_id}")
+async def queue_delete_book(
+    book_id: int,
+    target_language: str | None = None,
+    _admin: dict = Depends(_require_admin),
+):
+    deleted = await delete_queue_for_book(book_id, target_language=target_language)
+    return {"ok": True, "deleted": deleted}
+
+
+@router.post("/queue/items/{item_id}/retry")
+async def queue_retry_item(
+    item_id: int, _admin: dict = Depends(_require_admin),
+):
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            """UPDATE translation_queue
+               SET status='pending', attempts=0, last_error=NULL,
+                   updated_at=CURRENT_TIMESTAMP
+               WHERE id=?""",
+            (item_id,),
+        )
+        await db.commit()
+    queue_worker().wake()
+    return {"ok": True, "updated": cursor.rowcount}
+
+
+@router.post("/queue/enqueue-all")
+async def queue_enqueue_all(_admin: dict = Depends(_require_admin)):
+    """Walk every cached book and enqueue missing translations for all
+    configured auto-translate languages."""
+    langs = await get_auto_languages()
+    if not langs:
+        raise HTTPException(
+            status_code=400,
+            detail="No auto_translate_languages configured in queue settings",
+        )
+    books = await list_cached_books()
+    total = 0
+    for b in books:
+        total += await enqueue_for_book(b["id"], target_languages=langs)
+    queue_worker().wake()
+    return {"ok": True, "enqueued": total, "books_scanned": len(books)}

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -379,7 +379,12 @@ async def get_cached_book(book_id: int) -> dict | None:
 
 
 async def save_book(book_id: int, meta: dict, text: str, images: list | None = None) -> None:
-    """Insert or replace a book record (meta + full text + images)."""
+    """Insert or replace a book record (meta + full text + images).
+
+    After saving, the translation queue is auto-seeded with this book's
+    chapters for every configured target language. The worker (if running)
+    will pick them up on its next tick.
+    """
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute(
             """
@@ -400,6 +405,20 @@ async def save_book(book_id: int, meta: dict, text: str, images: list | None = N
             ),
         )
         await db.commit()
+
+    # Auto-enqueue for translation. Lazy-imported to avoid a circular import
+    # (translation_queue → db → translation_queue). Failures are non-fatal:
+    # a book save must never be blocked by queue trouble.
+    try:
+        from services.translation_queue import enqueue_for_book, worker
+        added = await enqueue_for_book(book_id)
+        if added:
+            worker().wake()
+    except Exception:
+        import logging
+        logging.getLogger(__name__).warning(
+            "Auto-enqueue after save_book(%s) failed", book_id, exc_info=True,
+        )
 
 
 async def get_audiobook(book_id: int) -> dict | None:
@@ -445,6 +464,27 @@ async def delete_audiobook(book_id: int) -> None:
     """Remove the audiobook association for a book."""
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute("DELETE FROM audiobooks WHERE book_id = ?", (book_id,))
+        await db.commit()
+
+
+# ── App settings (key/value config used by the always-on queue, etc.) ────────
+
+async def get_setting(key: str) -> str | None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "SELECT value FROM app_settings WHERE key=?", (key,),
+        ) as cursor:
+            row = await cursor.fetchone()
+    return row[0] if row else None
+
+
+async def set_setting(key: str, value: str) -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            """INSERT INTO app_settings (key, value) VALUES (?, ?)
+               ON CONFLICT(key) DO UPDATE SET value=excluded.value""",
+            (key, value),
+        )
         await db.commit()
 
 

--- a/backend/services/migrations.py
+++ b/backend/services/migrations.py
@@ -75,6 +75,8 @@ async def run(db_path: str) -> list[str]:
              "SELECT name FROM sqlite_master WHERE type='table' AND name='bulk_translation_jobs'"),
             ("007_translation_provider_info",
              "SELECT 1 FROM pragma_table_info('translations') WHERE name='provider'"),
+            ("008_translation_queue",
+             "SELECT name FROM sqlite_master WHERE type='table' AND name='translation_queue'"),
         ]
         bootstrapped: list[str] = []
         for version, check_sql in bootstrap_checks:

--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -1,0 +1,592 @@
+"""
+Always-on translation queue.
+
+Unlike the one-shot bulk job, this service runs forever in the backend
+process. It pulls pending items from the `translation_queue` table, packs
+them into batches by (book_id, target_language), translates them through
+Gemini, and writes the result to the `translations` table.
+
+Key behaviours
+--------------
+- **Singleton worker**, launched once from the FastAPI lifespan.
+- Stops cleanly on shutdown via an asyncio.Event.
+- When the queue is empty, the worker idles for IDLE_POLL_SECONDS and re-checks.
+- Hitting the rate limiter just makes the worker wait — that's the limiter's
+  job. If a single batch fails, attempts are bumped and the row goes back to
+  pending; after MAX_ATTEMPTS it's marked failed (still re-tryable from the
+  admin UI by resetting status).
+- API key is read from `app_settings.queue_api_key` (encrypted). If no key is
+  configured, the worker logs once and idles — admins can set a key without
+  restarting the backend.
+- Auto-enqueue: `enqueue_for_book` is called from `save_book` to seed the
+  queue whenever a new book lands. The set of target languages comes from
+  `app_settings.auto_translate_languages` (JSON array of language codes).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+import aiosqlite
+
+from services import db as db_module
+from services.auth import decrypt_api_key
+from services.bulk_translate import (
+    ChapterWork,
+    DEFAULT_MAX_OUTPUT_TOKENS,
+    group_chapters_for_batch,
+)
+from services.db import (
+    get_cached_book,
+    get_cached_translation,
+    get_setting,
+    save_translation,
+)
+from services.gemini import translate_chapters_batch, TRANSLATOR_MODEL
+from services.rate_limiter import AsyncRateLimiter
+from services.splitter import build_chapters
+
+logger = logging.getLogger(__name__)
+
+
+SETTING_API_KEY = "queue_api_key"            # encrypted Gemini key
+SETTING_AUTO_LANGS = "auto_translate_languages"  # JSON array of lang codes
+SETTING_ENABLED = "queue_enabled"            # "1" or "0"
+SETTING_RPM = "queue_rpm"
+SETTING_RPD = "queue_rpd"
+SETTING_MODEL = "queue_model"
+
+DEFAULT_RPM = 12
+DEFAULT_RPD = 1400
+IDLE_POLL_SECONDS = 10.0
+MAX_ATTEMPTS = 5
+RETRY_BACKOFF = (1.0, 5.0, 20.0, 60.0, 300.0)
+
+
+# ── Queue row helpers ────────────────────────────────────────────────────────
+
+@dataclass
+class QueueRow:
+    id: int
+    book_id: int
+    chapter_index: int
+    target_language: str
+    status: str
+    priority: int
+    attempts: int
+    last_error: str = ""
+
+
+async def enqueue(
+    book_id: int,
+    chapter_index: int,
+    target_language: str,
+    *,
+    priority: int = 100,
+    reset_failed: bool = False,
+) -> None:
+    """Insert (or no-op) a single queue item.
+
+    If `reset_failed=True`, an existing row whose status is 'failed' or 'done'
+    will be revived to 'pending' (used when the admin clicks "Retranslate").
+    """
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        if reset_failed:
+            await db.execute(
+                """INSERT INTO translation_queue
+                       (book_id, chapter_index, target_language, priority, status)
+                   VALUES (?, ?, ?, ?, 'pending')
+                   ON CONFLICT(book_id, chapter_index, target_language) DO UPDATE
+                     SET status='pending',
+                         attempts=0,
+                         last_error=NULL,
+                         priority=MIN(priority, excluded.priority),
+                         updated_at=CURRENT_TIMESTAMP""",
+                (book_id, chapter_index, target_language, priority),
+            )
+        else:
+            await db.execute(
+                """INSERT OR IGNORE INTO translation_queue
+                       (book_id, chapter_index, target_language, priority)
+                   VALUES (?, ?, ?, ?)""",
+                (book_id, chapter_index, target_language, priority),
+            )
+        await db.commit()
+
+
+async def enqueue_for_book(
+    book_id: int,
+    *,
+    target_languages: list[str] | None = None,
+    priority: int = 100,
+    reset_failed: bool = False,
+) -> int:
+    """Enqueue every chapter of `book_id` for each target language.
+
+    Skips chapters that already have a cached translation (no point re-doing
+    work). Returns the number of newly-enqueued items.
+
+    `target_languages=None` → use the configured auto-translate languages.
+    """
+    if target_languages is None:
+        target_languages = await get_auto_languages()
+    if not target_languages:
+        return 0
+
+    book = await get_cached_book(book_id)
+    if not book or not book.get("text"):
+        return 0
+    source = (book.get("languages") or [None])[0]
+    chapters = build_chapters(book["text"])
+
+    inserted = 0
+    for lang in target_languages:
+        if not lang or lang == source:
+            continue
+        for idx, ch in enumerate(chapters):
+            if not ch.text.strip():
+                continue
+            if not reset_failed and await get_cached_translation(book_id, idx, lang):
+                continue
+            await enqueue(book_id, idx, lang, priority=priority, reset_failed=reset_failed)
+            inserted += 1
+    return inserted
+
+
+async def get_auto_languages() -> list[str]:
+    raw = await get_setting(SETTING_AUTO_LANGS)
+    if not raw:
+        return []
+    try:
+        value = json.loads(raw)
+        return [str(x) for x in value if x]
+    except json.JSONDecodeError:
+        return []
+
+
+async def list_queue(
+    *,
+    status: str | None = None,
+    book_id: int | None = None,
+    limit: int = 200,
+) -> list[dict]:
+    where = []
+    params: list = []
+    if status:
+        where.append("status = ?")
+        params.append(status)
+    if book_id is not None:
+        where.append("book_id = ?")
+        params.append(book_id)
+    sql = "SELECT * FROM translation_queue"
+    if where:
+        sql += " WHERE " + " AND ".join(where)
+    sql += " ORDER BY (status='running') DESC, priority ASC, id ASC LIMIT ?"
+    params.append(limit)
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(sql, params) as cursor:
+            return [dict(row) async for row in cursor]
+
+
+async def queue_summary() -> dict:
+    """Counts by status, plus per-(book, language) breakdowns for the UI."""
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        async with db.execute(
+            "SELECT status, COUNT(*) FROM translation_queue GROUP BY status"
+        ) as cursor:
+            counts = {row[0]: row[1] async for row in cursor}
+        async with db.execute(
+            """SELECT book_id, target_language, status, COUNT(*) AS n
+               FROM translation_queue GROUP BY book_id, target_language, status"""
+        ) as cursor:
+            rows = await cursor.fetchall()
+    by_book: dict[int, dict[str, dict[str, int]]] = {}
+    for book_id, lang, status, n in rows:
+        by_book.setdefault(book_id, {}).setdefault(lang, {})[status] = n
+    return {"counts": counts, "by_book": by_book}
+
+
+async def delete_queue_item(item_id: int) -> int:
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        cursor = await db.execute(
+            "DELETE FROM translation_queue WHERE id=?", (item_id,),
+        )
+        await db.commit()
+        return cursor.rowcount
+
+
+async def delete_queue_for_book(
+    book_id: int, *, target_language: str | None = None,
+) -> int:
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        if target_language:
+            cursor = await db.execute(
+                "DELETE FROM translation_queue WHERE book_id=? AND target_language=?",
+                (book_id, target_language),
+            )
+        else:
+            cursor = await db.execute(
+                "DELETE FROM translation_queue WHERE book_id=?", (book_id,),
+            )
+        await db.commit()
+        return cursor.rowcount
+
+
+# ── Worker ───────────────────────────────────────────────────────────────────
+
+@dataclass
+class WorkerState:
+    running: bool = False
+    enabled: bool = False
+    idle: bool = True
+    current_book_id: int | None = None
+    current_book_title: str = ""
+    current_target_language: str = ""
+    current_batch_size: int = 0
+    last_completed_at: Optional[str] = None
+    last_error: str = ""
+    started_at: Optional[str] = None
+    requests_made: int = 0
+    chapters_done: int = 0
+    chapters_failed: int = 0
+    waiting_reason: str = ""
+    log: list[dict] = field(default_factory=list)
+
+
+class TranslationQueueWorker:
+    def __init__(self) -> None:
+        self._task: asyncio.Task | None = None
+        self._stop_event: asyncio.Event | None = None
+        self._wake_event: asyncio.Event = asyncio.Event()
+        self._state = WorkerState()
+        self._limiter: AsyncRateLimiter | None = None
+
+    # ── Lifecycle ───────────────────────────────────────────────────────
+
+    def is_running(self) -> bool:
+        return self._task is not None and not self._task.done()
+
+    async def start(self) -> None:
+        if self.is_running():
+            return
+        self._stop_event = asyncio.Event()
+        self._wake_event = asyncio.Event()
+        self._state = WorkerState(
+            running=True,
+            started_at=datetime.now(timezone.utc).isoformat(),
+        )
+        self._task = asyncio.create_task(self._run(), name="translation-queue-worker")
+
+    async def stop(self) -> None:
+        if self._stop_event:
+            self._stop_event.set()
+        if self._task:
+            self._wake_event.set()
+            try:
+                await asyncio.wait_for(self._task, timeout=20)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                self._task.cancel()
+        self._state.running = False
+
+    def wake(self) -> None:
+        """Nudge the worker to re-check the queue immediately (used after
+        new items are enqueued)."""
+        self._wake_event.set()
+
+    def state(self) -> WorkerState:
+        return self._state
+
+    # ── Main loop ────────────────────────────────────────────────────────
+
+    async def _run(self) -> None:
+        assert self._stop_event is not None
+        stop_event = self._stop_event
+
+        while not stop_event.is_set():
+            try:
+                await self._tick()
+            except Exception as e:  # noqa: BLE001
+                logger.exception("Translation queue worker tick failed")
+                self._state.last_error = str(e)[:500]
+                self._append_log({"event": "tick_error", "error": str(e)[:200]})
+                await self._sleep_or_wake(IDLE_POLL_SECONDS)
+        self._state.running = False
+
+    async def _tick(self) -> None:
+        # Check enabled flag every tick — admins can flip the kill switch
+        # without restarting the backend.
+        enabled_raw = await get_setting(SETTING_ENABLED)
+        self._state.enabled = enabled_raw != "0"
+        if not self._state.enabled:
+            self._state.idle = True
+            self._state.waiting_reason = "service disabled"
+            await self._sleep_or_wake(IDLE_POLL_SECONDS)
+            return
+
+        api_key = await self._load_api_key()
+        if not api_key:
+            self._state.idle = True
+            self._state.waiting_reason = "no Gemini key configured"
+            await self._sleep_or_wake(IDLE_POLL_SECONDS)
+            return
+
+        # Pull one batch's worth of pending items, all sharing the same
+        # (book_id, target_language). Batching across books would force us to
+        # rebuild prior_context per chapter, which loses the cross-batch
+        # consistency benefit.
+        items = await self._claim_next_batch()
+        if not items:
+            self._state.idle = True
+            self._state.waiting_reason = "queue empty"
+            self._state.current_book_id = None
+            self._state.current_book_title = ""
+            self._state.current_target_language = ""
+            self._state.current_batch_size = 0
+            await self._sleep_or_wake(IDLE_POLL_SECONDS)
+            return
+
+        self._state.idle = False
+        self._state.waiting_reason = ""
+        await self._process_batch(items, api_key)
+
+    async def _claim_next_batch(self) -> list[QueueRow]:
+        """Atomically grab the next contiguous group of pending items for
+        the same (book, language) and mark them running."""
+        async with aiosqlite.connect(db_module.DB_PATH) as db:
+            db.row_factory = aiosqlite.Row
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                async with db.execute(
+                    """SELECT * FROM translation_queue
+                       WHERE status='pending'
+                       ORDER BY priority ASC, id ASC LIMIT 1"""
+                ) as cursor:
+                    head = await cursor.fetchone()
+                if head is None:
+                    await db.execute("COMMIT")
+                    return []
+                book_id = head["book_id"]
+                lang = head["target_language"]
+                async with db.execute(
+                    """SELECT * FROM translation_queue
+                       WHERE status='pending' AND book_id=? AND target_language=?
+                       ORDER BY chapter_index ASC LIMIT 50""",
+                    (book_id, lang),
+                ) as cursor:
+                    rows = await cursor.fetchall()
+                ids = [r["id"] for r in rows]
+                placeholders = ",".join("?" for _ in ids)
+                await db.execute(
+                    f"UPDATE translation_queue "
+                    f"SET status='running', updated_at=CURRENT_TIMESTAMP "
+                    f"WHERE id IN ({placeholders})",
+                    ids,
+                )
+                await db.execute("COMMIT")
+            except Exception:
+                await db.execute("ROLLBACK")
+                raise
+        return [
+            QueueRow(
+                id=r["id"], book_id=r["book_id"], chapter_index=r["chapter_index"],
+                target_language=r["target_language"], status="running",
+                priority=r["priority"], attempts=r["attempts"],
+                last_error=r["last_error"] or "",
+            )
+            for r in rows
+        ]
+
+    async def _process_batch(self, items: list[QueueRow], api_key: str) -> None:
+        book_id = items[0].book_id
+        target_language = items[0].target_language
+        book = await get_cached_book(book_id)
+        if not book or not book.get("text"):
+            await self._mark_skipped(items, reason="book not in cache")
+            return
+        source = (book.get("languages") or ["en"])[0]
+        all_chapters = build_chapters(book["text"])
+
+        works: list[ChapterWork] = []
+        title = book.get("title") or str(book_id)
+        for row in items:
+            if row.chapter_index >= len(all_chapters):
+                await self._mark_failed([row], "chapter index out of range")
+                continue
+            text = all_chapters[row.chapter_index].text
+            if not text.strip():
+                await self._mark_done([row])
+                continue
+            works.append(ChapterWork(
+                book_id=book_id, book_title=title, source_language=source,
+                chapter_index=row.chapter_index, chapter_text=text,
+            ))
+        if not works:
+            return
+
+        # Group into output-token-bounded batches. Usually 1 batch.
+        batches = group_chapters_for_batch(works, max_output_tokens=DEFAULT_MAX_OUTPUT_TOKENS)
+        rows_by_idx = {r.chapter_index: r for r in items}
+        model = (await get_setting(SETTING_MODEL)) or TRANSLATOR_MODEL
+
+        self._state.current_book_id = book_id
+        self._state.current_book_title = title
+        self._state.current_target_language = target_language
+        self._state.current_batch_size = len(works)
+
+        if self._limiter is None:
+            rpm = int((await get_setting(SETTING_RPM)) or DEFAULT_RPM)
+            rpd = int((await get_setting(SETTING_RPD)) or DEFAULT_RPD)
+            self._limiter = AsyncRateLimiter(rpm=rpm, rpd=rpd, provider="gemini")
+
+        for batch in batches:
+            chapters = [(c.chapter_index, c.chapter_text) for c in batch]
+            translations = await self._translate_with_retry(
+                chapters=chapters,
+                source_language=source,
+                target_language=target_language,
+                api_key=api_key,
+                model=model,
+            )
+            for c in batch:
+                row = rows_by_idx[c.chapter_index]
+                paragraphs = translations.get(c.chapter_index)
+                if paragraphs is None:
+                    await self._bump_attempt(row, "no translation returned")
+                    continue
+                await save_translation(
+                    book_id, c.chapter_index, target_language, paragraphs,
+                    provider="gemini", model=model,
+                )
+                await self._mark_done([row])
+                self._state.chapters_done += 1
+                self._append_log({
+                    "event": "translated",
+                    "book_id": book_id,
+                    "title": title,
+                    "lang": target_language,
+                    "chapter": c.chapter_index,
+                })
+            self._state.last_completed_at = datetime.now(timezone.utc).isoformat()
+
+    async def _translate_with_retry(
+        self,
+        *,
+        chapters: list[tuple[int, str]],
+        source_language: str,
+        target_language: str,
+        api_key: str,
+        model: str,
+    ) -> dict[int, list[str]]:
+        last_err: Exception | None = None
+        for attempt, delay in enumerate([0.0, *RETRY_BACKOFF]):
+            if self._stop_event and self._stop_event.is_set():
+                break
+            if delay:
+                self._state.waiting_reason = f"retry backoff {delay:.0f}s"
+                await asyncio.sleep(delay)
+            try:
+                assert self._limiter is not None
+                self._state.waiting_reason = "rate limiter"
+                await self._limiter.acquire()
+                self._state.waiting_reason = "translating"
+                self._state.requests_made += 1
+                return await translate_chapters_batch(
+                    api_key, chapters, source_language, target_language, model=model,
+                )
+            except Exception as e:  # noqa: BLE001
+                last_err = e
+                self._state.last_error = str(e)[:500]
+                logger.warning(
+                    "Queue batch translate failed (attempt %d): %s", attempt + 1, e,
+                )
+        if last_err:
+            logger.error("Queue batch failed permanently: %s", last_err)
+        return {}
+
+    # ── Status mutations ────────────────────────────────────────────────
+
+    async def _mark_done(self, rows: list[QueueRow]) -> None:
+        await self._update_status(rows, "done")
+
+    async def _mark_skipped(self, rows: list[QueueRow], *, reason: str) -> None:
+        await self._update_status(rows, "skipped", error=reason)
+
+    async def _mark_failed(self, rows: list[QueueRow], reason: str) -> None:
+        await self._update_status(rows, "failed", error=reason)
+        self._state.chapters_failed += len(rows)
+
+    async def _update_status(
+        self, rows: list[QueueRow], status: str, *, error: str | None = None,
+    ) -> None:
+        if not rows:
+            return
+        ids = [r.id for r in rows]
+        placeholders = ",".join("?" for _ in ids)
+        async with aiosqlite.connect(db_module.DB_PATH) as db:
+            await db.execute(
+                f"""UPDATE translation_queue
+                    SET status=?, last_error=?, updated_at=CURRENT_TIMESTAMP
+                    WHERE id IN ({placeholders})""",
+                [status, error, *ids],
+            )
+            await db.commit()
+
+    async def _bump_attempt(self, row: QueueRow, error: str) -> None:
+        new_attempts = row.attempts + 1
+        new_status = "failed" if new_attempts >= MAX_ATTEMPTS else "pending"
+        async with aiosqlite.connect(db_module.DB_PATH) as db:
+            await db.execute(
+                """UPDATE translation_queue
+                   SET attempts=?, status=?, last_error=?,
+                       updated_at=CURRENT_TIMESTAMP
+                   WHERE id=?""",
+                (new_attempts, new_status, error, row.id),
+            )
+            await db.commit()
+        if new_status == "failed":
+            self._state.chapters_failed += 1
+
+    # ── Helpers ──────────────────────────────────────────────────────────
+
+    async def _load_api_key(self) -> str | None:
+        encrypted = await get_setting(SETTING_API_KEY)
+        if not encrypted:
+            return None
+        try:
+            return decrypt_api_key(encrypted)
+        except Exception:
+            logger.exception("Failed to decrypt queue_api_key — clearing")
+            return None
+
+    async def _sleep_or_wake(self, seconds: float) -> None:
+        """Sleep until either `seconds` elapses, the wake event fires, or
+        the stop event fires."""
+        if self._stop_event is None:
+            await asyncio.sleep(seconds)
+            return
+        try:
+            self._wake_event.clear()
+            await asyncio.wait_for(self._wake_event.wait(), timeout=seconds)
+        except asyncio.TimeoutError:
+            pass
+
+    def _append_log(self, entry: dict, max_len: int = 30) -> None:
+        entry["at"] = datetime.now(timezone.utc).isoformat()
+        self._state.log.append(entry)
+        if len(self._state.log) > max_len:
+            self._state.log = self._state.log[-max_len:]
+
+
+# ── Module-level singleton ────────────────────────────────────────────────────
+
+_worker = TranslationQueueWorker()
+
+
+def worker() -> TranslationQueueWorker:
+    return _worker

--- a/backend/tests/test_translation_queue.py
+++ b/backend/tests/test_translation_queue.py
@@ -1,0 +1,167 @@
+"""Tests for the always-on translation queue service."""
+
+import json
+import pytest
+from unittest.mock import patch, AsyncMock
+import aiosqlite
+
+import services.db as db_module
+from services.db import init_db, save_book, get_cached_translation, set_setting
+from services.translation_queue import (
+    enqueue,
+    enqueue_for_book,
+    list_queue,
+    queue_summary,
+    TranslationQueueWorker,
+    SETTING_API_KEY,
+    SETTING_AUTO_LANGS,
+    SETTING_ENABLED,
+)
+
+
+BOOK_META = {
+    "title": "Test Book",
+    "authors": ["Author"],
+    "languages": ["en"],
+    "subjects": [],
+    "download_count": 0,
+    "cover": "",
+}
+
+# Long enough for the splitter to accept (MIN_AVG_WORDS=150 per chapter).
+_FILLER = " ".join(["filler"] * 200)
+BOOK_TEXT = (
+    f"CHAPTER I\n\n{_FILLER}.\n\nAnother paragraph here. {_FILLER}.\n\n"
+    f"CHAPTER II\n\n{_FILLER}.\n\nStill more content. {_FILLER}.\n"
+)
+
+
+@pytest.fixture
+async def tmp_db(monkeypatch, tmp_path):
+    path = str(tmp_path / "queue-test.db")
+    monkeypatch.setattr(db_module, "DB_PATH", path)
+    await init_db()
+    return path
+
+
+async def test_migration_creates_queue_tables(tmp_db):
+    """Migration 008 must produce both translation_queue and app_settings."""
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name IN ('translation_queue', 'app_settings')"
+        ) as cursor:
+            rows = [row async for row in cursor]
+    names = sorted(r[0] for r in rows)
+    assert names == ["app_settings", "translation_queue"]
+
+
+async def test_enqueue_idempotent(tmp_db):
+    """Duplicate enqueue() calls for the same (book, chapter, lang) don't stack."""
+    await enqueue(1, 0, "zh")
+    await enqueue(1, 0, "zh")
+    await enqueue(1, 0, "de")
+    items = await list_queue()
+    keys = [(i["book_id"], i["chapter_index"], i["target_language"]) for i in items]
+    assert keys == [(1, 0, "zh"), (1, 0, "de")]
+
+
+async def test_enqueue_for_book_skips_existing_translations(tmp_db):
+    """Chapters that already have a cached translation should NOT be enqueued."""
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    # Pre-cache chapter 0 → zh; enqueue_for_book should skip it.
+    from services.db import save_translation
+    await save_translation(1, 0, "zh", ["p1"])
+    added = await enqueue_for_book(1, target_languages=["zh"])
+    assert added == 1  # only chapter 1
+    items = await list_queue()
+    assert {(i["chapter_index"], i["target_language"]) for i in items} == {(1, "zh")}
+
+
+async def test_auto_enqueue_on_save_book(tmp_db):
+    """save_book should auto-enqueue chapters for every configured auto-translate language."""
+    await set_setting(SETTING_AUTO_LANGS, json.dumps(["zh", "de"]))
+    await save_book(42, BOOK_META, BOOK_TEXT)
+    items = await list_queue()
+    langs = {i["target_language"] for i in items}
+    assert langs == {"zh", "de"}
+    # 2 chapters × 2 langs = 4 items
+    assert len(items) == 4
+
+
+async def test_auto_enqueue_skips_source_language(tmp_db):
+    """Enqueuing for the book's own source language is a waste — skip it."""
+    await set_setting(SETTING_AUTO_LANGS, json.dumps(["en", "zh"]))
+    await save_book(42, BOOK_META, BOOK_TEXT)
+    items = await list_queue()
+    assert all(i["target_language"] == "zh" for i in items)
+
+
+async def test_queue_summary_counts(tmp_db):
+    await save_book(7, BOOK_META, BOOK_TEXT)
+    await enqueue_for_book(7, target_languages=["zh"])
+    summary = await queue_summary()
+    assert summary["counts"].get("pending") == 2
+    assert 7 in summary["by_book"]
+    assert summary["by_book"][7]["zh"]["pending"] == 2
+
+
+async def test_worker_idles_without_api_key(tmp_db):
+    """With no queue_api_key configured, the worker must idle — not crash."""
+    await set_setting(SETTING_ENABLED, "1")
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    await enqueue_for_book(1, target_languages=["zh"])
+    w = TranslationQueueWorker()
+    w._stop_event = __import__("asyncio").Event()
+    await w._tick()
+    assert w._state.idle is True
+    assert "key" in w._state.waiting_reason.lower()
+
+
+async def test_worker_idles_when_disabled(tmp_db):
+    """Flipping queue_enabled=0 pauses the worker without requiring a restart."""
+    from services.auth import encrypt_api_key
+    await set_setting(SETTING_API_KEY, encrypt_api_key("fake-key"))
+    await set_setting(SETTING_ENABLED, "0")
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    await enqueue_for_book(1, target_languages=["zh"])
+    w = TranslationQueueWorker()
+    w._stop_event = __import__("asyncio").Event()
+    await w._tick()
+    assert w._state.idle is True
+    assert w._state.enabled is False
+
+
+async def test_worker_processes_batch(tmp_db):
+    """With a (faked) API key and translator mocked, the worker translates and marks items done."""
+    from services.auth import encrypt_api_key
+    await set_setting(SETTING_API_KEY, encrypt_api_key("fake-key"))
+    await set_setting(SETTING_ENABLED, "1")
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    await enqueue_for_book(1, target_languages=["zh"])
+
+    fake_return = {0: ["翻译段落一", "翻译段落二"], 1: ["翻译章节二"]}
+
+    async def fake_translate(api_key, chapters, src, tgt, *, prior_context="", model=None):
+        return fake_return
+
+    w = TranslationQueueWorker()
+    w._stop_event = __import__("asyncio").Event()
+    with patch(
+        "services.translation_queue.translate_chapters_batch",
+        side_effect=fake_translate,
+    ):
+        with patch.object(
+            __import__("services.translation_queue", fromlist=["AsyncRateLimiter"]).AsyncRateLimiter,
+            "acquire",
+            new=AsyncMock(return_value=None),
+        ):
+            await w._tick()
+
+    # Both chapters should now be cached and queue rows marked done
+    t0 = await get_cached_translation(1, 0, "zh")
+    t1 = await get_cached_translation(1, 1, "zh")
+    assert t0 == ["翻译段落一", "翻译段落二"]
+    assert t1 == ["翻译章节二"]
+    items = await list_queue(status="done")
+    assert len(items) == 2

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { getMe, getAuthToken, awaitSession } from "@/lib/api";
 import BulkTranslateTab from "@/components/BulkTranslateTab";
 import SeedPopularButton from "@/components/SeedPopularButton";
+import QueueTab from "@/components/QueueTab";
 
 const BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api";
 
@@ -27,13 +28,19 @@ async function adminFetch(path: string, options?: RequestInit) {
   return res.json();
 }
 
-type Tab = "users" | "books" | "audio" | "bulk";
+type Tab = "users" | "books" | "audio" | "bulk" | "queue";
 
 interface User { id: number; email: string; name: string; picture: string; role: string; approved: number; created_at: string; }
+interface TranslationStat { chapters: number; size_chars: number; }
+type QueueBreakdown = Record<string, Record<string, number>>; // lang → {status → count}
 interface Book {
   id: number; title: string; authors: string[]; languages: string[];
-  download_count: number; text_length?: number; cached_at?: string;
+  download_count: number; text_length?: number; word_count?: number; cached_at?: string;
   translations?: Record<string, number>;
+  translation_stats?: Record<string, TranslationStat>;
+  queue?: QueueBreakdown;
+  active?: boolean;
+  active_language?: string | null;
 }
 interface AudioEntry { book_id: number; chapter_index: number; provider: string; voice: string; chunks: number; size_mb: number; created_at: string; }
 interface TranslationEntry { book_id: number; chapter_index: number; target_language: string; size_chars: number; created_at: string; }
@@ -135,6 +142,7 @@ export default function AdminPage() {
       // Translation info now lives inside each book row
     },
     { key: "audio", label: "Audio Cache", count: stats?.audio_chunks_cached },
+    { key: "queue", label: "Queue" },
     { key: "bulk", label: "Bulk Translate" },
   ];
 
@@ -246,11 +254,15 @@ export default function AdminPage() {
             <div className="bg-white rounded-xl border border-amber-200 divide-y divide-amber-100 overflow-hidden">
               {books.map((b) => {
                 const isExpanded = expandedBookId === b.id;
+                // Union of languages that have any translations OR any queue activity,
+                // so chips show in-progress work even before the first chapter lands.
                 const translatedLangs = Object.keys(b.translations || {});
+                const queuedLangs = Object.keys(b.queue || {});
+                const allLangs = Array.from(new Set([...translatedLangs, ...queuedLangs]));
 
                 return (
                   <div key={b.id}>
-                    <div className="px-4 py-3 flex items-center gap-3">
+                    <div className={`px-4 py-3 flex items-center gap-3 ${b.active ? "bg-emerald-50/60" : ""}`}>
                       <button
                         onClick={() => {
                           setExpandedBookId(isExpanded ? null : b.id);
@@ -263,27 +275,63 @@ export default function AdminPage() {
                       </button>
 
                       <div className="flex-1 min-w-0">
-                        <div className="font-medium text-ink text-sm truncate">{b.title}</div>
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium text-ink text-sm truncate">{b.title}</span>
+                          {b.active && (
+                            <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-emerald-100 text-emerald-700 animate-pulse">
+                              translating → {b.active_language}
+                            </span>
+                          )}
+                        </div>
                         <div className="text-xs text-stone-400">
-                          ID: {b.id} · {b.languages?.join(", ")} · {((b.text_length || 0) / 1000).toFixed(0)}K chars
+                          ID: {b.id} · {b.languages?.join(", ")}
+                          {" · "}{((b.text_length || 0) / 1000).toFixed(0)}K chars
+                          {b.word_count ? ` · ${b.word_count.toLocaleString()} words` : ""}
                           {b.authors?.length ? ` · ${b.authors.join(", ")}` : ""}
                         </div>
                       </div>
 
                       {/* Translation chips — compact summary, visible without expanding */}
                       <div className="flex flex-wrap gap-1 items-center">
-                        {translatedLangs.length === 0 ? (
+                        {allLangs.length === 0 ? (
                           <span className="text-[10px] text-stone-300">no translations</span>
                         ) : (
-                          translatedLangs.map((lang) => (
-                            <span
-                              key={lang}
-                              className="text-[10px] px-1.5 py-0.5 rounded-full bg-amber-50 border border-amber-200 text-amber-700"
-                              title={`${b.translations![lang]} chapters translated to ${lang}`}
-                            >
-                              {lang} · {b.translations![lang]}
-                            </span>
-                          ))
+                          allLangs.map((lang) => {
+                            const count = b.translations?.[lang] || 0;
+                            const q = b.queue?.[lang] || {};
+                            const pending = q.pending || 0;
+                            const running = q.running || 0;
+                            const failed = q.failed || 0;
+                            const pieces: string[] = [];
+                            if (count) pieces.push(`${count} done`);
+                            if (running) pieces.push(`${running} running`);
+                            if (pending) pieces.push(`${pending} pending`);
+                            if (failed) pieces.push(`${failed} failed`);
+                            const tone =
+                              running > 0
+                                ? "bg-emerald-50 border-emerald-200 text-emerald-700"
+                                : failed > 0
+                                  ? "bg-red-50 border-red-200 text-red-700"
+                                  : pending > 0
+                                    ? "bg-stone-50 border-stone-200 text-stone-600"
+                                    : "bg-amber-50 border-amber-200 text-amber-700";
+                            return (
+                              <span
+                                key={lang}
+                                className={`text-[10px] px-1.5 py-0.5 rounded-full border ${tone}`}
+                                title={pieces.join(" · ")}
+                              >
+                                {lang} · {count}
+                                {(pending || running || failed) > 0 && (
+                                  <span className="ml-1 opacity-70">
+                                    {running > 0 && `▶${running}`}
+                                    {pending > 0 && `⏳${pending}`}
+                                    {failed > 0 && `!${failed}`}
+                                  </span>
+                                )}
+                              </span>
+                            );
+                          })
                         )}
                       </div>
 
@@ -422,6 +470,9 @@ export default function AdminPage() {
         )}
 
         {/* Translations tab removed — info is now consolidated into the Books tab */}
+
+        {/* ── Queue Tab ── */}
+        {tab === "queue" && <QueueTab adminFetch={adminFetch} />}
 
         {/* ── Bulk Translate Tab ── */}
         {tab === "bulk" && <BulkTranslateTab adminFetch={adminFetch} />}

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -1,0 +1,476 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+type AdminFetch = (path: string, options?: RequestInit) => Promise<any>;
+
+interface QueueSettings {
+  enabled: boolean;
+  has_api_key: boolean;
+  auto_translate_languages: string[];
+  rpm: number | null;
+  rpd: number | null;
+  model: string | null;
+}
+
+interface WorkerLog {
+  event: string;
+  at: string;
+  book_id?: number;
+  title?: string;
+  lang?: string;
+  chapter?: number;
+  error?: string;
+}
+
+interface WorkerState {
+  enabled: boolean;
+  idle: boolean;
+  current_book_id: number | null;
+  current_book_title: string;
+  current_target_language: string;
+  current_batch_size: number;
+  last_completed_at: string | null;
+  last_error: string;
+  started_at: string | null;
+  requests_made: number;
+  chapters_done: number;
+  chapters_failed: number;
+  waiting_reason: string;
+  log: WorkerLog[];
+}
+
+interface QueueStatus {
+  running: boolean;
+  state: WorkerState;
+  counts: Record<string, number>;
+}
+
+interface QueueItem {
+  id: number;
+  book_id: number;
+  chapter_index: number;
+  target_language: string;
+  status: string;
+  priority: number;
+  attempts: number;
+  last_error: string | null;
+  created_at: string;
+}
+
+interface Props {
+  adminFetch: AdminFetch;
+}
+
+export default function QueueTab({ adminFetch }: Props) {
+  const [status, setStatus] = useState<QueueStatus | null>(null);
+  const [settings, setSettings] = useState<QueueSettings | null>(null);
+  const [items, setItems] = useState<QueueItem[]>([]);
+  const [itemFilter, setItemFilter] = useState<"pending" | "running" | "failed" | "all">("pending");
+  const [error, setError] = useState("");
+  const [saving, setSaving] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Form state — mirrors settings but editable.
+  const [langs, setLangs] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [rpm, setRpm] = useState("");
+  const [rpd, setRpd] = useState("");
+  const [model, setModel] = useState("");
+
+  async function refresh() {
+    try {
+      const [st, cfg, its] = await Promise.all([
+        adminFetch("/admin/queue/status"),
+        adminFetch("/admin/queue/settings"),
+        adminFetch(
+          `/admin/queue/items?limit=100${
+            itemFilter === "all" ? "" : `&status=${itemFilter}`
+          }`,
+        ),
+      ]);
+      setStatus(st);
+      setSettings(cfg);
+      setItems(its);
+      if (langs === "") setLangs((cfg.auto_translate_languages || []).join(", "));
+      if (rpm === "" && cfg.rpm) setRpm(String(cfg.rpm));
+      if (rpd === "" && cfg.rpd) setRpd(String(cfg.rpd));
+      if (model === "" && cfg.model) setModel(cfg.model);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to load queue");
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+    pollRef.current = setInterval(refresh, 3000);
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [itemFilter]);
+
+  async function saveSettings(patch: Record<string, unknown>) {
+    setSaving(true);
+    setError("");
+    try {
+      await adminFetch("/admin/queue/settings", {
+        method: "PUT",
+        body: JSON.stringify(patch),
+      });
+      await refresh();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function startWorker() {
+    await adminFetch("/admin/queue/start", { method: "POST" });
+    await refresh();
+  }
+
+  async function stopWorker() {
+    if (!confirm("Stop the translation queue worker? Pending items stay in the queue.")) return;
+    await adminFetch("/admin/queue/stop", { method: "POST" });
+    await refresh();
+  }
+
+  async function enqueueAll() {
+    if (!confirm("Queue EVERY cached book for translation into all configured languages?")) return;
+    try {
+      const res = await adminFetch("/admin/queue/enqueue-all", { method: "POST" });
+      alert(`Enqueued ${res.enqueued} chapter(s) across ${res.books_scanned} book(s).`);
+      await refresh();
+    } catch (e: unknown) {
+      alert(e instanceof Error ? e.message : "Failed");
+    }
+  }
+
+  async function retry(item: QueueItem) {
+    await adminFetch(`/admin/queue/items/${item.id}/retry`, { method: "POST" });
+    await refresh();
+  }
+
+  async function remove(item: QueueItem) {
+    if (!confirm(`Remove queue item #${item.id}?`)) return;
+    await adminFetch(`/admin/queue/items/${item.id}`, { method: "DELETE" });
+    await refresh();
+  }
+
+  const s = status?.state;
+  const counts = status?.counts || {};
+  const totalPending = counts.pending || 0;
+  const totalDone = counts.done || 0;
+  const totalFailed = counts.failed || 0;
+  const totalRunning = counts.running || 0;
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-2 text-sm">
+          {error}
+        </div>
+      )}
+
+      {/* Worker status */}
+      <div className="bg-white rounded-xl border border-amber-200 p-4 space-y-3">
+        <div className="flex items-center gap-3">
+          <div
+            className={`w-2.5 h-2.5 rounded-full ${
+              status?.running
+                ? s?.idle
+                  ? "bg-amber-400"
+                  : "bg-emerald-500 animate-pulse"
+                : "bg-stone-300"
+            }`}
+          />
+          <div className="flex-1">
+            <div className="text-sm font-medium text-ink">
+              {status?.running
+                ? s?.idle
+                  ? `Idle — ${s.waiting_reason || "nothing to do"}`
+                  : `Translating ${s?.current_book_title || "…"} → ${s?.current_target_language}`
+                : "Worker stopped"}
+            </div>
+            <div className="text-xs text-stone-500">
+              {totalPending} pending · {totalRunning} running · {totalDone} done · {totalFailed} failed
+              {s?.requests_made !== undefined && ` · ${s.requests_made} API calls this session`}
+            </div>
+          </div>
+          {status?.running ? (
+            <button
+              onClick={stopWorker}
+              className="text-xs px-3 py-1 rounded border border-red-200 text-red-600 hover:bg-red-50"
+            >
+              Stop
+            </button>
+          ) : (
+            <button
+              onClick={startWorker}
+              className="text-xs px-3 py-1 rounded border border-emerald-300 text-emerald-700 hover:bg-emerald-50"
+            >
+              Start
+            </button>
+          )}
+        </div>
+
+        {s?.last_error && (
+          <div className="text-xs text-red-600 bg-red-50 rounded px-2 py-1 truncate">
+            Last error: {s.last_error}
+          </div>
+        )}
+
+        {s?.log && s.log.length > 0 && (
+          <details>
+            <summary className="text-xs text-amber-700 cursor-pointer">
+              Activity log ({s.log.length})
+            </summary>
+            <ul className="mt-1 text-xs space-y-0.5 max-h-40 overflow-y-auto">
+              {s.log
+                .slice()
+                .reverse()
+                .map((e, i) => (
+                  <li
+                    key={i}
+                    className={`font-mono truncate ${
+                      e.event.includes("error") || e.event === "tick_error"
+                        ? "text-red-600"
+                        : "text-stone-600"
+                    }`}
+                  >
+                    {e.event === "translated" ? "✓" : "!"} {e.event}
+                    {e.title ? ` · ${e.title}` : ""}
+                    {e.chapter !== undefined ? ` · ch${e.chapter}` : ""}
+                    {e.lang ? ` → ${e.lang}` : ""}
+                    {e.error ? ` — ${e.error}` : ""}
+                  </li>
+                ))}
+            </ul>
+          </details>
+        )}
+      </div>
+
+      {/* Settings */}
+      <div className="bg-white rounded-xl border border-amber-200 p-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="font-medium text-ink">Service settings</h3>
+          <label className="flex items-center gap-2 text-sm">
+            <span className="text-stone-600">Enabled</span>
+            <input
+              type="checkbox"
+              checked={settings?.enabled ?? false}
+              disabled={saving}
+              onChange={(e) => saveSettings({ enabled: e.target.checked })}
+            />
+          </label>
+        </div>
+
+        <div className="grid sm:grid-cols-2 gap-3">
+          <div className="space-y-1">
+            <label className="text-xs text-stone-600">
+              Auto-translate languages (comma-separated, e.g. <code>zh, de, ja</code>)
+            </label>
+            <div className="flex gap-2">
+              <input
+                value={langs}
+                onChange={(e) => setLangs(e.target.value)}
+                className="flex-1 rounded border border-amber-300 px-2 py-1 text-sm"
+                placeholder="zh, de, ja"
+              />
+              <button
+                onClick={() =>
+                  saveSettings({
+                    auto_translate_languages: langs
+                      .split(",")
+                      .map((x) => x.trim())
+                      .filter(Boolean),
+                  })
+                }
+                disabled={saving}
+                className="text-xs px-3 py-1 rounded bg-amber-700 text-white disabled:opacity-50"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-xs text-stone-600">
+              Gemini API key {settings?.has_api_key && <span className="text-emerald-600">· configured</span>}
+            </label>
+            <div className="flex gap-2">
+              <input
+                type="password"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                className="flex-1 rounded border border-amber-300 px-2 py-1 text-sm"
+                placeholder={settings?.has_api_key ? "•••• (leave empty to keep)" : "Paste key"}
+              />
+              <button
+                onClick={() => {
+                  if (!apiKey) return;
+                  saveSettings({ api_key: apiKey });
+                  setApiKey("");
+                }}
+                disabled={saving || !apiKey}
+                className="text-xs px-3 py-1 rounded bg-amber-700 text-white disabled:opacity-50"
+              >
+                Save
+              </button>
+              {settings?.has_api_key && (
+                <button
+                  onClick={() => {
+                    if (confirm("Clear queue API key?")) saveSettings({ api_key: "" });
+                  }}
+                  className="text-xs px-2 py-1 rounded border border-red-200 text-red-500"
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-xs text-stone-600">RPM</label>
+            <div className="flex gap-2">
+              <input
+                value={rpm}
+                onChange={(e) => setRpm(e.target.value)}
+                className="flex-1 rounded border border-amber-300 px-2 py-1 text-sm"
+                placeholder="12"
+              />
+              <button
+                onClick={() => saveSettings({ rpm: Number(rpm) || 12 })}
+                disabled={saving}
+                className="text-xs px-3 py-1 rounded bg-amber-700 text-white disabled:opacity-50"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-xs text-stone-600">RPD (per-day cap)</label>
+            <div className="flex gap-2">
+              <input
+                value={rpd}
+                onChange={(e) => setRpd(e.target.value)}
+                className="flex-1 rounded border border-amber-300 px-2 py-1 text-sm"
+                placeholder="1400"
+              />
+              <button
+                onClick={() => saveSettings({ rpd: Number(rpd) || 1400 })}
+                disabled={saving}
+                className="text-xs px-3 py-1 rounded bg-amber-700 text-white disabled:opacity-50"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+
+          <div className="space-y-1 sm:col-span-2">
+            <label className="text-xs text-stone-600">Model (optional override)</label>
+            <div className="flex gap-2">
+              <input
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                className="flex-1 rounded border border-amber-300 px-2 py-1 text-sm"
+                placeholder="gemini-3.1-flash-lite-preview"
+              />
+              <button
+                onClick={() => saveSettings({ model })}
+                disabled={saving}
+                className="text-xs px-3 py-1 rounded bg-amber-700 text-white disabled:opacity-50"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex gap-2 pt-2 border-t border-amber-100">
+          <button
+            onClick={enqueueAll}
+            className="text-xs px-3 py-1.5 rounded border border-amber-300 text-amber-700 hover:bg-amber-50"
+          >
+            Queue every book for all configured languages
+          </button>
+        </div>
+      </div>
+
+      {/* Queue items */}
+      <div className="bg-white rounded-xl border border-amber-200 overflow-hidden">
+        <div className="px-4 py-2 border-b border-amber-100 flex items-center gap-2 text-sm">
+          <span className="font-medium">Items</span>
+          {(["pending", "running", "failed", "all"] as const).map((f) => (
+            <button
+              key={f}
+              onClick={() => setItemFilter(f)}
+              className={`text-xs px-2 py-0.5 rounded ${
+                itemFilter === f ? "bg-amber-700 text-white" : "text-amber-700 hover:bg-amber-50"
+              }`}
+            >
+              {f}
+            </button>
+          ))}
+          <span className="ml-auto text-xs text-stone-500">{items.length} shown</span>
+        </div>
+        {items.length === 0 ? (
+          <div className="px-4 py-8 text-center text-stone-400 text-sm">
+            No items in this view.
+          </div>
+        ) : (
+          <ul className="divide-y divide-amber-50 max-h-96 overflow-y-auto">
+            {items.map((it) => (
+              <li key={it.id} className="px-4 py-2 flex items-center gap-2 text-xs">
+                <span
+                  className={`px-1.5 py-0.5 rounded text-[10px] ${
+                    it.status === "pending"
+                      ? "bg-stone-100 text-stone-600"
+                      : it.status === "running"
+                        ? "bg-emerald-100 text-emerald-700"
+                        : it.status === "done"
+                          ? "bg-amber-100 text-amber-700"
+                          : it.status === "failed"
+                            ? "bg-red-100 text-red-700"
+                            : "bg-stone-100 text-stone-600"
+                  }`}
+                >
+                  {it.status}
+                </span>
+                <span className="text-stone-600 font-mono">
+                  book {it.book_id} · ch {it.chapter_index} → {it.target_language}
+                </span>
+                {it.attempts > 0 && (
+                  <span className="text-stone-400">· {it.attempts} attempts</span>
+                )}
+                {it.last_error && (
+                  <span className="text-red-500 truncate flex-1" title={it.last_error}>
+                    {it.last_error}
+                  </span>
+                )}
+                <div className="ml-auto flex gap-1">
+                  {it.status === "failed" && (
+                    <button
+                      onClick={() => retry(it)}
+                      className="px-1.5 py-0.5 rounded border border-amber-300 text-amber-700"
+                    >
+                      Retry
+                    </button>
+                  )}
+                  <button
+                    onClick={() => remove(it)}
+                    className="px-1.5 py-0.5 rounded border border-red-200 text-red-500"
+                  >
+                    Del
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Turn pre-translation into an **always-on service**. A singleton worker drains a persistent `translation_queue` table in the background, batching pending (book, language, chapter) items through Gemini via the existing rate limiter. Newly-saved books auto-enqueue into every configured target language — the queue keeps draining until everything is translated, no admin ceremony required.

### How it behaves

- **New book → auto-enqueued** for every language in `auto_translate_languages`.
- **Rate limit hit** (RPM/RPD) → worker just waits; the existing `AsyncRateLimiter` gates the API call.
- **Backend restart** → queue survives (it's in SQLite); worker is kicked off from the FastAPI lifespan.
- **Disabled or no API key** → worker idles; flip the switch in the Queue tab to resume without restarting.

### Admin UI

- **New "Queue" tab** — live worker status (idle/translating), controls to start/stop, service settings (enable, Gemini key, auto-translate languages, RPM, RPD, model), filterable items list with retry/delete, and a "Queue every book for all configured languages" button.
- **Books tab** — language chips now show live state: `zh · 10 ▶2 ⏳5 !1` (done / running / pending / failed). The actively-translating row glows green. Per-book word count added.

### Backend

- `migrations/008_translation_queue.sql` — `translation_queue` + `app_settings`.
- `services/translation_queue.py` — `TranslationQueueWorker` singleton + `enqueue_for_book` / `queue_summary` helpers.
- `services/db.py` — `get_setting`/`set_setting`; `save_book()` now auto-enqueues (lazy import, failure non-fatal).
- `routers/admin.py` — `/admin/queue/*` endpoints; `/admin/books` now returns `translation_stats`, `queue`, `active`, `word_count`.
- `main.py` — lifespan starts/stops the worker.

## Test plan

- [x] Backend: 334 tests pass (9 new, covering idempotent enqueue, auto-enqueue on save_book, source-language skip, worker idle paths, and a full batch translate → DB round-trip with Gemini mocked)
- [x] Frontend: 126 tests pass
- [x] `next build` passes
- [x] Manual: migration 008 bootstraps on existing DBs; worker idles when no key is configured; auto-enqueue creates the right rows.

Generated with [Claude Code](https://claude.com/claude-code)
