### PR TITLE
feat(queue): model picker + skip cached chapters

### DIFF
--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -422,6 +422,23 @@ class TranslationQueueWorker:
             if not text.strip():
                 await self._mark_done([row])
                 continue
+            # Defensive: skip re-translating if a cached translation already
+            # landed between enqueue and now (e.g. the reader triggered an
+            # on-demand translation, or a bulk job ran). No sense spending
+            # Gemini tokens on work that's already done.
+            existing = await get_cached_translation(
+                book_id, row.chapter_index, target_language,
+            )
+            if existing:
+                await self._mark_done([row])
+                self._append_log({
+                    "event": "skipped_cached",
+                    "book_id": book_id,
+                    "title": title,
+                    "lang": target_language,
+                    "chapter": row.chapter_index,
+                })
+                continue
             works.append(ChapterWork(
                 book_id=book_id, book_title=title, source_language=source,
                 chapter_index=row.chapter_index, chapter_text=text,

--- a/backend/tests/test_translation_queue.py
+++ b/backend/tests/test_translation_queue.py
@@ -132,6 +132,51 @@ async def test_worker_idles_when_disabled(tmp_db):
     assert w._state.enabled is False
 
 
+async def test_worker_skips_already_cached_chapter(tmp_db):
+    """If a translation lands between enqueue and claim, the worker must
+    NOT re-translate — that would waste tokens on work already done."""
+    from services.auth import encrypt_api_key
+    from services.db import save_translation
+    await set_setting(SETTING_API_KEY, encrypt_api_key("fake-key"))
+    await set_setting(SETTING_ENABLED, "1")
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    # Enqueue both chapters, but pretend chapter 0 got translated by another
+    # path (e.g. reader on-demand call) before the worker gets to it.
+    await enqueue(1, 0, "zh")
+    await enqueue(1, 1, "zh")
+    await save_translation(1, 0, "zh", ["already done"])
+
+    called_with: list = []
+
+    async def fake_translate(api_key, chapters, src, tgt, *, prior_context="", model=None):
+        called_with.append(chapters)
+        return {idx: [f"new-{idx}"] for idx, _ in chapters}
+
+    w = TranslationQueueWorker()
+    w._stop_event = __import__("asyncio").Event()
+    with patch(
+        "services.translation_queue.translate_chapters_batch",
+        side_effect=fake_translate,
+    ):
+        with patch.object(
+            __import__("services.translation_queue", fromlist=["AsyncRateLimiter"]).AsyncRateLimiter,
+            "acquire",
+            new=AsyncMock(return_value=None),
+        ):
+            await w._tick()
+
+    # Only chapter 1 should have been sent to Gemini
+    assert len(called_with) == 1
+    sent_chapter_indices = [idx for idx, _ in called_with[0]]
+    assert sent_chapter_indices == [1]
+    # Cached translation for chapter 0 is untouched
+    existing = await get_cached_translation(1, 0, "zh")
+    assert existing == ["already done"]
+    # Both queue items are marked done (chapter 0 skipped, chapter 1 translated)
+    done = await list_queue(status="done")
+    assert len(done) == 2
+
+
 async def test_worker_processes_batch(tmp_db):
     """With a (faked) API key and translator mocked, the worker translates and marks items done."""
     from services.auth import encrypt_api_key

--- a/frontend/src/components/BulkTranslateTab.tsx
+++ b/frontend/src/components/BulkTranslateTab.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
+import { GEMINI_MODEL_OPTIONS } from "@/lib/geminiModels";
 
 type FetchFn = (path: string, options?: RequestInit) => Promise<any>;
 
@@ -69,48 +70,7 @@ const LANGUAGES = [
   { code: "ja", label: "Japanese (ja)" },
 ];
 
-// Known Gemini models with free-tier hints + quality trade-offs.
-// "Default" leaves it unset so the backend uses its compiled-in default
-// (currently the same model powering chat/insight). These are suggestions —
-// the admin can type any model the API accepts in the custom field.
-interface ModelOption {
-  value: string;
-  label: string;
-  note: string;
-}
-
-const MODEL_OPTIONS: ModelOption[] = [
-  {
-    value: "",
-    label: "Default (server-side)",
-    note: "Same model used for chat and insights — known to work with your key.",
-  },
-  {
-    value: "gemini-2.5-pro",
-    label: "gemini-2.5-pro",
-    note: "Highest quality, 64K output tokens per request. Free-tier RPM is low (~2), best for overnight runs with fewer, bigger batches.",
-  },
-  {
-    value: "gemini-2.5-flash",
-    label: "gemini-2.5-flash",
-    note: "Strong literary quality, 8K output tokens per request. Free-tier has higher RPM than Pro — good balance for bulk work.",
-  },
-  {
-    value: "gemini-2.5-flash-lite",
-    label: "gemini-2.5-flash-lite",
-    note: "Cheapest and fastest. Lower quality — fine for quick drafts or less demanding target languages.",
-  },
-  {
-    value: "gemini-2.0-flash",
-    label: "gemini-2.0-flash",
-    note: "Previous generation — widely available, stable quality, generous free-tier limits.",
-  },
-  {
-    value: "gemini-2.0-flash-lite",
-    label: "gemini-2.0-flash-lite",
-    note: "Lightest model in the 2.0 line. Use if you're hitting rate limits with heavier models.",
-  },
-];
+const MODEL_OPTIONS = GEMINI_MODEL_OPTIONS;
 
 export default function BulkTranslateTab({ adminFetch }: { adminFetch: FetchFn }) {
   const [targetLang, setTargetLang] = useState("zh");

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
+import { GEMINI_MODEL_OPTIONS } from "@/lib/geminiModels";
 
 type AdminFetch = (path: string, options?: RequestInit) => Promise<any>;
 
@@ -370,21 +371,68 @@ export default function QueueTab({ adminFetch }: Props) {
           </div>
 
           <div className="space-y-1 sm:col-span-2">
-            <label className="text-xs text-stone-600">Model (optional override)</label>
-            <div className="flex gap-2">
-              <input
-                value={model}
-                onChange={(e) => setModel(e.target.value)}
-                className="flex-1 rounded border border-amber-300 px-2 py-1 text-sm"
-                placeholder="gemini-3.1-flash-lite-preview"
-              />
+            <div className="flex items-center justify-between">
+              <label className="text-xs text-stone-600">Model</label>
               <button
                 onClick={() => saveSettings({ model })}
                 disabled={saving}
-                className="text-xs px-3 py-1 rounded bg-amber-700 text-white disabled:opacity-50"
+                className="text-xs px-3 py-0.5 rounded bg-amber-700 text-white disabled:opacity-50"
               >
-                Save
+                Save model
               </button>
+            </div>
+            <div className="space-y-1.5">
+              {GEMINI_MODEL_OPTIONS.map((opt) => (
+                <label
+                  key={opt.value || "default"}
+                  className={`flex items-start gap-3 p-2 rounded-lg border cursor-pointer transition-colors ${
+                    model === opt.value
+                      ? "border-amber-400 bg-amber-50"
+                      : "border-amber-200 bg-white hover:bg-amber-50/50"
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="queue-model"
+                    value={opt.value}
+                    checked={model === opt.value}
+                    onChange={() => setModel(opt.value)}
+                    className="mt-0.5 accent-amber-700"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium text-ink font-mono">
+                      {opt.label}
+                    </div>
+                    <div className="text-xs text-stone-500 mt-0.5">{opt.note}</div>
+                  </div>
+                </label>
+              ))}
+              <label className="flex items-start gap-3 p-2 rounded-lg border border-amber-200 bg-white">
+                <input
+                  type="radio"
+                  name="queue-model"
+                  checked={
+                    !!model && !GEMINI_MODEL_OPTIONS.some((o) => o.value === model)
+                  }
+                  onChange={() => setModel("gemini-2.5-flash")}
+                  className="mt-0.5 accent-amber-700"
+                />
+                <div className="flex-1">
+                  <div className="text-sm font-medium text-ink mb-1">Custom</div>
+                  <input
+                    type="text"
+                    value={
+                      GEMINI_MODEL_OPTIONS.some((o) => o.value === model) ? "" : model
+                    }
+                    onChange={(e) => setModel(e.target.value)}
+                    placeholder="e.g. gemini-exp-1206"
+                    className="w-full rounded border border-amber-300 px-2 py-1 text-sm bg-white font-mono"
+                  />
+                  <p className="text-[11px] text-stone-500 mt-1">
+                    Anything the API accepts. If you see 404, the model isn&apos;t available for your key.
+                  </p>
+                </div>
+              </label>
             </div>
           </div>
         </div>

--- a/frontend/src/lib/geminiModels.ts
+++ b/frontend/src/lib/geminiModels.ts
@@ -1,0 +1,41 @@
+export interface ModelOption {
+  value: string;
+  label: string;
+  note: string;
+}
+
+// Shared between BulkTranslateTab and QueueTab. "Default" leaves model empty
+// so the backend picks its compiled-in default. Admins can always type a
+// custom model if they want to try something not listed.
+export const GEMINI_MODEL_OPTIONS: ModelOption[] = [
+  {
+    value: "",
+    label: "Default (server-side)",
+    note: "Same model used for chat and insights — known to work with your key.",
+  },
+  {
+    value: "gemini-2.5-pro",
+    label: "gemini-2.5-pro",
+    note: "Highest quality, 64K output tokens per request. Free-tier RPM is low (~2), best for overnight runs with fewer, bigger batches.",
+  },
+  {
+    value: "gemini-2.5-flash",
+    label: "gemini-2.5-flash",
+    note: "Strong literary quality, 8K output tokens per request. Free-tier has higher RPM than Pro — good balance for bulk work.",
+  },
+  {
+    value: "gemini-2.5-flash-lite",
+    label: "gemini-2.5-flash-lite",
+    note: "Cheapest and fastest. Lower quality — fine for quick drafts or less demanding target languages.",
+  },
+  {
+    value: "gemini-2.0-flash",
+    label: "gemini-2.0-flash",
+    note: "Previous generation — widely available, stable quality, generous free-tier limits.",
+  },
+  {
+    value: "gemini-2.0-flash-lite",
+    label: "gemini-2.0-flash-lite",
+    note: "Lightest model in the 2.0 line. Use if you're hitting rate limits with heavier models.",
+  },
+];


### PR DESCRIPTION
## Summary

Two small follow-ups to the always-on translation queue (#78):

### 1. Model picker in Queue settings
The Queue tab now has the same radio-list model picker as Bulk Translate — 2.5-pro / flash / flash-lite, 2.0-flash / flash-lite, or a custom free-text field. Each option carries a one-line note about RPM quota and quality trade-off, so admins don't have to remember which model is "cheap but low quality" vs. "high quality but slow". The list is shared between both tabs via `frontend/src/lib/geminiModels.ts`.

### 2. Skip chapters that were translated in the meantime
The worker now re-checks the `translations` table right before calling Gemini on a claimed queue row. If a cached translation exists (e.g. the reader triggered an on-demand translation, or a bulk job ran between enqueue and claim), the queue row is marked `done` and **no API call is made**. Before this, the enqueue-time check skipped already-translated chapters, but there was a small window where a row could still hit the API unnecessarily.

## Test plan

- [x] Backend: 335 tests pass (1 new: `test_worker_skips_already_cached_chapter` — patches `translate_chapters_batch` and asserts it's called only for the uncached chapter)
- [x] Frontend: 126 tests pass
- [x] `next build` passes

Generated with [Claude Code](https://claude.com/claude-code)
