### PR TITLE
fix(queue): add Clear queue / Clear failed buttons

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -33,6 +33,7 @@ from services.translation_queue import (
     SETTING_MODEL,
     SETTING_RPD,
     SETTING_RPM,
+    clear_queue,
     delete_queue_for_book,
     delete_queue_item,
     enqueue_for_book,
@@ -790,6 +791,20 @@ async def queue_delete_item(
     item_id: int, _admin: dict = Depends(_require_admin),
 ):
     deleted = await delete_queue_item(item_id)
+    return {"ok": True, "deleted": deleted}
+
+
+@router.delete("/queue")
+async def queue_clear(
+    status: str | None = None,
+    _admin: dict = Depends(_require_admin),
+):
+    """Delete every queue row (optionally filtered by status).
+
+    ?status=failed  → wipe just the failed rows (safe to retry clean).
+    No filter       → clear the entire queue (admin confirms in the UI).
+    """
+    deleted = await clear_queue(status)
     return {"ok": True, "deleted": deleted}
 
 

--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -212,6 +212,22 @@ async def queue_summary() -> dict:
     return {"counts": counts, "by_book": by_book}
 
 
+async def clear_queue(status: str | None = None) -> int:
+    """Delete ALL queue rows, or only rows matching a specific status.
+
+    Handy for the admin "Clear queue" / "Clear failed" buttons.
+    """
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        if status:
+            cursor = await db.execute(
+                "DELETE FROM translation_queue WHERE status=?", (status,),
+            )
+        else:
+            cursor = await db.execute("DELETE FROM translation_queue")
+        await db.commit()
+        return cursor.rowcount
+
+
 async def delete_queue_item(item_id: int) -> int:
     async with aiosqlite.connect(db_module.DB_PATH) as db:
         cursor = await db.execute(

--- a/backend/tests/test_translation_queue.py
+++ b/backend/tests/test_translation_queue.py
@@ -8,6 +8,7 @@ import aiosqlite
 import services.db as db_module
 from services.db import init_db, save_book, get_cached_translation, set_setting
 from services.translation_queue import (
+    clear_queue,
     enqueue,
     enqueue_for_book,
     list_queue,
@@ -104,6 +105,28 @@ async def test_queue_summary_counts(tmp_db):
     assert summary["counts"].get("pending") == 2
     assert 7 in summary["by_book"]
     assert summary["by_book"][7]["zh"]["pending"] == 2
+
+
+async def test_clear_queue_all_and_by_status(tmp_db):
+    """clear_queue() wipes everything; clear_queue(status='failed') only wipes failed rows."""
+    await enqueue(1, 0, "zh")
+    await enqueue(1, 1, "zh")
+    await enqueue(2, 0, "de")
+    # Mark one as failed so we can test status filtering.
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute(
+            "UPDATE translation_queue SET status='failed' WHERE book_id=2",
+        )
+        await db.commit()
+
+    removed = await clear_queue(status="failed")
+    assert removed == 1
+    remaining = await list_queue()
+    assert [(i["book_id"], i["chapter_index"]) for i in remaining] == [(1, 0), (1, 1)]
+
+    removed_all = await clear_queue()
+    assert removed_all == 2
+    assert await list_queue() == []
 
 
 async def test_worker_idles_without_api_key(tmp_db):

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -159,6 +159,21 @@ export default function QueueTab({ adminFetch }: Props) {
     await refresh();
   }
 
+  async function clearAll() {
+    const scope = itemFilter === "all" ? "ALL" : itemFilter;
+    if (!confirm(`Delete ${scope} queue items? This is irreversible (but you can re-enqueue via the Books tab).`)) return;
+    try {
+      const path = itemFilter === "all"
+        ? "/admin/queue"
+        : `/admin/queue?status=${itemFilter}`;
+      const res = await adminFetch(path, { method: "DELETE" });
+      alert(`Deleted ${res.deleted} queue item(s).`);
+      await refresh();
+    } catch (e: unknown) {
+      alert(e instanceof Error ? e.message : "Clear failed");
+    }
+  }
+
   const s = status?.state;
   const counts = status?.counts || {};
   const totalPending = counts.pending || 0;
@@ -463,6 +478,14 @@ export default function QueueTab({ adminFetch }: Props) {
             </button>
           ))}
           <span className="ml-auto text-xs text-stone-500">{items.length} shown</span>
+          <button
+            onClick={clearAll}
+            disabled={items.length === 0}
+            className="text-xs px-2 py-0.5 rounded border border-red-200 text-red-500 hover:bg-red-50 disabled:opacity-40"
+            title={itemFilter === "all" ? "Clear entire queue" : `Clear all ${itemFilter}`}
+          >
+            {itemFilter === "all" ? "Clear queue" : `Clear ${itemFilter}`}
+          </button>
         </div>
         {items.length === 0 ? (
           <div className="px-4 py-8 text-center text-stone-400 text-sm">


### PR DESCRIPTION
## Summary

Fix: admins had no way to clear the translation queue. Rows could pile up (leftover `done`, stale `failed`, or just test data) and the UI only supported per-item delete.

- New `DELETE /admin/queue` endpoint. Optional `?status=pending|running|done|failed|skipped` filter — pass a status to wipe just that subset, omit for a full wipe.
- QueueTab "Clear queue" / "Clear pending" / "Clear failed" button next to the filter pills. It follows the current filter so the action matches what you see.

## Test plan

- [x] Backend: 336 tests pass (1 new: `test_clear_queue_all_and_by_status` covers both paths)
- [x] Frontend: 126 tests pass
- [x] `next build` passes

Generated with [Claude Code](https://claude.com/claude-code)
