### PR TITLE
fix(admin): name the default Gemini model in the picker

### DIFF
--- a/frontend/src/lib/geminiModels.ts
+++ b/frontend/src/lib/geminiModels.ts
@@ -10,8 +10,8 @@ export interface ModelOption {
 export const GEMINI_MODEL_OPTIONS: ModelOption[] = [
   {
     value: "",
-    label: "Default (server-side)",
-    note: "Same model used for chat and insights — known to work with your key.",
+    label: "Default (gemini-3.1-flash-lite-preview)",
+    note: "Same model used for chat and insights — known to work with your key. Fast and cheap; fine for most translations.",
   },
   {
     value: "gemini-2.5-pro",


### PR DESCRIPTION
Replaces the opaque "Default (server-side)" label with the actual fallback model name: `gemini-3.1-flash-lite-preview`. Admins can now tell what they're getting without grepping the backend.

Also note on 503s: the queue worker already retries transient 5xx errors with exponential backoff (1s → 5s → 20s → 60s → 300s, up to 5 attempts), so those go away on their own.

## Test plan
- [x] Frontend: 126 tests pass
- [x] `next build` passes

Generated with [Claude Code](https://claude.com/claude-code)