### PR TITLE
feat(queue): auto rate/batch per model + row titles, attribution, skip stalled books

### DIFF
--- a/backend/migrations/009_queue_queued_by.sql
+++ b/backend/migrations/009_queue_queued_by.sql
@@ -1,0 +1,4 @@
+-- Track who (or what) put each item on the translation queue.
+-- NULL = auto-enqueued by save_book(). Otherwise the admin's email.
+
+ALTER TABLE translation_queue ADD COLUMN queued_by TEXT;

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -30,6 +30,7 @@ from services.translation_queue import (
     SETTING_API_KEY,
     SETTING_AUTO_LANGS,
     SETTING_ENABLED,
+    SETTING_MAX_OUTPUT_TOKENS,
     SETTING_MODEL,
     SETTING_RPD,
     SETTING_RPM,
@@ -713,6 +714,7 @@ async def queue_get_settings(_admin: dict = Depends(_require_admin)):
     rpm = await get_setting(SETTING_RPM)
     rpd = await get_setting(SETTING_RPD)
     model = await get_setting(SETTING_MODEL)
+    max_tok = await get_setting(SETTING_MAX_OUTPUT_TOKENS)
     return {
         "enabled": enabled != "0",
         "has_api_key": bool(key),
@@ -720,6 +722,7 @@ async def queue_get_settings(_admin: dict = Depends(_require_admin)):
         "rpm": int(rpm) if rpm else None,
         "rpd": int(rpd) if rpd else None,
         "model": model or None,
+        "max_output_tokens": int(max_tok) if max_tok else None,
     }
 
 
@@ -730,6 +733,7 @@ class QueueSettingsRequest(BaseModel):
     rpm: int | None = None
     rpd: int | None = None
     model: str | None = None
+    max_output_tokens: int | None = None
 
 
 @router.put("/queue/settings")
@@ -755,6 +759,8 @@ async def queue_set_settings(
         await set_setting(SETTING_RPD, str(req.rpd))
     if req.model is not None:
         await set_setting(SETTING_MODEL, req.model)
+    if req.max_output_tokens is not None:
+        await set_setting(SETTING_MAX_OUTPUT_TOKENS, str(req.max_output_tokens))
     queue_worker().wake()
     return {"ok": True}
 
@@ -779,13 +785,14 @@ class EnqueueBookRequest(BaseModel):
 @router.post("/queue/enqueue-book")
 async def queue_enqueue_book(
     req: EnqueueBookRequest,
-    _admin: dict = Depends(_require_admin),
+    admin: dict = Depends(_require_admin),
 ):
     added = await enqueue_for_book(
         req.book_id,
         target_languages=req.target_languages,
         priority=req.priority,
         reset_failed=req.reset_failed,
+        queued_by=admin.get("email") or admin.get("name") or f"admin#{admin.get('id')}",
     )
     queue_worker().wake()
     return {"ok": True, "enqueued": added}
@@ -827,10 +834,13 @@ async def queue_delete_book(
 async def queue_retry_item(
     item_id: int, _admin: dict = Depends(_require_admin),
 ):
+    # Reset priority too — without this, a row that was bumped to the back
+    # on failure would be retried but still sit behind everything else.
     async with aiosqlite.connect(DB_PATH) as db:
         cursor = await db.execute(
             """UPDATE translation_queue
                SET status='pending', attempts=0, last_error=NULL,
+                   priority=100,
                    updated_at=CURRENT_TIMESTAMP
                WHERE id=?""",
             (item_id,),
@@ -841,7 +851,7 @@ async def queue_retry_item(
 
 
 @router.post("/queue/enqueue-all")
-async def queue_enqueue_all(_admin: dict = Depends(_require_admin)):
+async def queue_enqueue_all(admin: dict = Depends(_require_admin)):
     """Walk every cached book and enqueue missing translations for all
     configured auto-translate languages."""
     langs = await get_auto_languages()
@@ -851,8 +861,9 @@ async def queue_enqueue_all(_admin: dict = Depends(_require_admin)):
             detail="No auto_translate_languages configured in queue settings",
         )
     books = await list_cached_books()
+    by = admin.get("email") or admin.get("name") or f"admin#{admin.get('id')}"
     total = 0
     for b in books:
-        total += await enqueue_for_book(b["id"], target_languages=langs)
+        total += await enqueue_for_book(b["id"], target_languages=langs, queued_by=by)
     queue_worker().wake()
     return {"ok": True, "enqueued": total, "books_scanned": len(books)}

--- a/backend/services/migrations.py
+++ b/backend/services/migrations.py
@@ -77,6 +77,8 @@ async def run(db_path: str) -> list[str]:
              "SELECT 1 FROM pragma_table_info('translations') WHERE name='provider'"),
             ("008_translation_queue",
              "SELECT name FROM sqlite_master WHERE type='table' AND name='translation_queue'"),
+            ("009_queue_queued_by",
+             "SELECT 1 FROM pragma_table_info('translation_queue') WHERE name='queued_by'"),
         ]
         bootstrapped: list[str] = []
         for version, check_sql in bootstrap_checks:

--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -60,12 +60,20 @@ SETTING_ENABLED = "queue_enabled"            # "1" or "0"
 SETTING_RPM = "queue_rpm"
 SETTING_RPD = "queue_rpd"
 SETTING_MODEL = "queue_model"
+SETTING_MAX_OUTPUT_TOKENS = "queue_max_output_tokens"  # per-request budget
 
 DEFAULT_RPM = 12
 DEFAULT_RPD = 1400
 IDLE_POLL_SECONDS = 10.0
 MAX_ATTEMPTS = 5
 RETRY_BACKOFF = (1.0, 5.0, 20.0, 60.0, 300.0)
+
+# Every time a batch fails, the rows' priority is bumped by this much so the
+# worker moves on to other (book, language) groups instead of spinning on
+# the same bad one. Rows stay pending and will be retried later when the
+# rest of the queue is exhausted, but they no longer block other books.
+FAIL_PRIORITY_BUMP = 1000
+DEFAULT_PRIORITY = 100
 
 
 # ── Queue row helpers ────────────────────────────────────────────────────────
@@ -89,32 +97,37 @@ async def enqueue(
     *,
     priority: int = 100,
     reset_failed: bool = False,
+    queued_by: str | None = None,
 ) -> None:
     """Insert (or no-op) a single queue item.
 
     If `reset_failed=True`, an existing row whose status is 'failed' or 'done'
     will be revived to 'pending' (used when the admin clicks "Retranslate").
+
+    `queued_by` is a free-form label — usually the admin's email. NULL
+    means the row was auto-enqueued by save_book and no admin is attributable.
     """
     async with aiosqlite.connect(db_module.DB_PATH) as db:
         if reset_failed:
             await db.execute(
                 """INSERT INTO translation_queue
-                       (book_id, chapter_index, target_language, priority, status)
-                   VALUES (?, ?, ?, ?, 'pending')
+                       (book_id, chapter_index, target_language, priority, status, queued_by)
+                   VALUES (?, ?, ?, ?, 'pending', ?)
                    ON CONFLICT(book_id, chapter_index, target_language) DO UPDATE
                      SET status='pending',
                          attempts=0,
                          last_error=NULL,
                          priority=MIN(priority, excluded.priority),
+                         queued_by=COALESCE(excluded.queued_by, queued_by),
                          updated_at=CURRENT_TIMESTAMP""",
-                (book_id, chapter_index, target_language, priority),
+                (book_id, chapter_index, target_language, priority, queued_by),
             )
         else:
             await db.execute(
                 """INSERT OR IGNORE INTO translation_queue
-                       (book_id, chapter_index, target_language, priority)
-                   VALUES (?, ?, ?, ?)""",
-                (book_id, chapter_index, target_language, priority),
+                       (book_id, chapter_index, target_language, priority, queued_by)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (book_id, chapter_index, target_language, priority, queued_by),
             )
         await db.commit()
 
@@ -125,6 +138,7 @@ async def enqueue_for_book(
     target_languages: list[str] | None = None,
     priority: int = 100,
     reset_failed: bool = False,
+    queued_by: str | None = None,
 ) -> int:
     """Enqueue every chapter of `book_id` for each target language.
 
@@ -153,7 +167,12 @@ async def enqueue_for_book(
                 continue
             if not reset_failed and await get_cached_translation(book_id, idx, lang):
                 continue
-            await enqueue(book_id, idx, lang, priority=priority, reset_failed=reset_failed)
+            await enqueue(
+                book_id, idx, lang,
+                priority=priority,
+                reset_failed=reset_failed,
+                queued_by=queued_by,
+            )
             inserted += 1
     return inserted
 
@@ -175,18 +194,27 @@ async def list_queue(
     book_id: int | None = None,
     limit: int = 200,
 ) -> list[dict]:
+    """Return queue rows joined with the book title.
+
+    The book_title field lets the admin UI show "Moby Dick · ch 14 → zh"
+    instead of raw IDs. LEFT JOIN so orphan rows (book deleted but queue
+    entry remains) still come back with book_title=None.
+    """
     where = []
     params: list = []
     if status:
-        where.append("status = ?")
+        where.append("q.status = ?")
         params.append(status)
     if book_id is not None:
-        where.append("book_id = ?")
+        where.append("q.book_id = ?")
         params.append(book_id)
-    sql = "SELECT * FROM translation_queue"
+    sql = (
+        "SELECT q.*, b.title AS book_title FROM translation_queue q "
+        "LEFT JOIN books b ON b.id = q.book_id"
+    )
     if where:
         sql += " WHERE " + " AND ".join(where)
-    sql += " ORDER BY (status='running') DESC, priority ASC, id ASC LIMIT ?"
+    sql += " ORDER BY (q.status='running') DESC, q.priority ASC, q.id ASC LIMIT ?"
     params.append(limit)
     async with aiosqlite.connect(db_module.DB_PATH) as db:
         db.row_factory = aiosqlite.Row
@@ -469,8 +497,15 @@ class TranslationQueueWorker:
         if not works:
             return
 
-        # Group into output-token-bounded batches. Usually 1 batch.
-        batches = group_chapters_for_batch(works, max_output_tokens=DEFAULT_MAX_OUTPUT_TOKENS)
+        # Per-request output token budget. Different models have very different
+        # caps (gemini-2.5-pro: ~64K, flash models: ~8K), so we read it from
+        # the admin settings — populated by the UI when the admin picks a
+        # model. The budget drives both batch grouping here and the
+        # max_output_tokens we pass to the Gemini call.
+        max_tok_raw = await get_setting(SETTING_MAX_OUTPUT_TOKENS)
+        max_output_tokens = int(max_tok_raw) if max_tok_raw else DEFAULT_MAX_OUTPUT_TOKENS
+
+        batches = group_chapters_for_batch(works, max_output_tokens=max_output_tokens)
         rows_by_idx = {r.chapter_index: r for r in items}
         model = (await get_setting(SETTING_MODEL)) or TRANSLATOR_MODEL
 
@@ -479,10 +514,18 @@ class TranslationQueueWorker:
         self._state.current_target_language = target_language
         self._state.current_batch_size = len(works)
 
+        # Read current rate-limit settings every batch so admins can tune
+        # RPM/RPD (or switch models which pins different limits) and have
+        # the change take effect immediately — no restart needed. Mutating
+        # the existing limiter preserves the rolling-window history so we
+        # never exceed the new cap right after a change.
+        rpm = int((await get_setting(SETTING_RPM)) or DEFAULT_RPM)
+        rpd = int((await get_setting(SETTING_RPD)) or DEFAULT_RPD)
         if self._limiter is None:
-            rpm = int((await get_setting(SETTING_RPM)) or DEFAULT_RPM)
-            rpd = int((await get_setting(SETTING_RPD)) or DEFAULT_RPD)
             self._limiter = AsyncRateLimiter(rpm=rpm, rpd=rpd, provider="gemini")
+        else:
+            self._limiter.rpm = rpm
+            self._limiter.rpd = rpd
 
         for batch in batches:
             chapters = [(c.chapter_index, c.chapter_text) for c in batch]
@@ -492,6 +535,7 @@ class TranslationQueueWorker:
                 target_language=target_language,
                 api_key=api_key,
                 model=model,
+                max_output_tokens=max_output_tokens,
             )
             for c in batch:
                 row = rows_by_idx[c.chapter_index]
@@ -522,6 +566,7 @@ class TranslationQueueWorker:
         target_language: str,
         api_key: str,
         model: str,
+        max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS,
     ) -> dict[int, list[str]]:
         last_err: Exception | None = None
         delays = [0.0, *RETRY_BACKOFF]
@@ -548,7 +593,8 @@ class TranslationQueueWorker:
                 self._state.retry_attempt = attempt + 1
                 self._state.requests_made += 1
                 result = await translate_chapters_batch(
-                    api_key, chapters, source_language, target_language, model=model,
+                    api_key, chapters, source_language, target_language,
+                    model=model, max_output_tokens=max_output_tokens,
                 )
                 # Success — clear retry state.
                 self._state.retry_attempt = 0
@@ -615,13 +661,17 @@ class TranslationQueueWorker:
     async def _bump_attempt(self, row: QueueRow, error: str) -> None:
         new_attempts = row.attempts + 1
         new_status = "failed" if new_attempts >= MAX_ATTEMPTS else "pending"
+        # Push the row to the back of the queue so the worker moves on to
+        # other books instead of spinning on this one. If the admin retries
+        # via the UI, priority is reset — see queue_retry_item.
+        new_priority = row.priority + FAIL_PRIORITY_BUMP
         async with aiosqlite.connect(db_module.DB_PATH) as db:
             await db.execute(
                 """UPDATE translation_queue
-                   SET attempts=?, status=?, last_error=?,
+                   SET attempts=?, status=?, last_error=?, priority=?,
                        updated_at=CURRENT_TIMESTAMP
                    WHERE id=?""",
-                (new_attempts, new_status, error, row.id),
+                (new_attempts, new_status, error, new_priority, row.id),
             )
             await db.commit()
         if new_status == "failed":

--- a/backend/tests/test_translation_queue.py
+++ b/backend/tests/test_translation_queue.py
@@ -107,6 +107,93 @@ async def test_queue_summary_counts(tmp_db):
     assert summary["by_book"][7]["zh"]["pending"] == 2
 
 
+async def test_queued_by_tracks_attribution(tmp_db):
+    """Admin-initiated enqueues record the admin label; auto-enqueues from
+    save_book leave queued_by = NULL."""
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    # Auto path (save_book with no languages configured) and manual path
+    # with an attributed user.
+    await enqueue(1, 0, "zh", queued_by="admin@example.com")
+    await enqueue(1, 1, "zh")  # no queued_by → NULL
+    rows = await list_queue()
+    by_idx = {r["chapter_index"]: r for r in rows}
+    assert by_idx[0]["queued_by"] == "admin@example.com"
+    assert by_idx[1]["queued_by"] is None
+
+
+async def test_list_queue_includes_book_title(tmp_db):
+    """Queue items must carry the book title so the admin UI can identify rows."""
+    await save_book(1, {**BOOK_META, "title": "Moby Dick"}, BOOK_TEXT)
+    await enqueue(1, 0, "zh")
+    # Orphan row — book never saved.
+    await enqueue(999, 0, "zh")
+    rows = await list_queue()
+    by_book = {r["book_id"]: r for r in rows}
+    assert by_book[1]["book_title"] == "Moby Dick"
+    assert by_book[999]["book_title"] is None
+
+
+async def test_worker_passes_model_max_output_tokens_setting(tmp_db):
+    """SETTING_MAX_OUTPUT_TOKENS must drive both batch grouping and the
+    max_output_tokens the Gemini call receives — this is how picking a big
+    model like 2.5-pro lets us pack many chapters per batch."""
+    from services.auth import encrypt_api_key
+    from services.rate_limiter import AsyncRateLimiter
+    from services.translation_queue import SETTING_MAX_OUTPUT_TOKENS
+    await set_setting(SETTING_API_KEY, encrypt_api_key("fake-key"))
+    await set_setting(SETTING_ENABLED, "1")
+    await set_setting(SETTING_MAX_OUTPUT_TOKENS, "60000")
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    await enqueue(1, 0, "zh")
+
+    captured: dict = {}
+
+    async def fake_translate(api_key, chapters, src, tgt, *, model=None, max_output_tokens=None, **kwargs):
+        captured["max_output_tokens"] = max_output_tokens
+        return {idx: ["ok"] for idx, _ in chapters}
+
+    w = TranslationQueueWorker()
+    w._stop_event = __import__("asyncio").Event()
+    with patch("services.translation_queue.translate_chapters_batch", side_effect=fake_translate):
+        with patch.object(AsyncRateLimiter, "acquire", new=AsyncMock(return_value=None)):
+            await w._tick()
+    assert captured.get("max_output_tokens") == 60000
+
+
+async def test_worker_reconfigures_limiter_on_rate_setting_change(tmp_db):
+    """Changing RPM/RPD in app_settings must propagate to the live limiter
+    without restarting the worker — otherwise auto-rate-by-model wouldn't
+    take effect for pending items."""
+    from services.auth import encrypt_api_key
+    from services.rate_limiter import AsyncRateLimiter
+    await set_setting(SETTING_API_KEY, encrypt_api_key("fake-key"))
+    await set_setting(SETTING_ENABLED, "1")
+    await set_setting("queue_rpm", "15")
+    await set_setting("queue_rpd", "1500")
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    await enqueue(1, 0, "zh")
+
+    async def fake_translate(*args, **kwargs):
+        return {0: ["ok"]}
+
+    w = TranslationQueueWorker()
+    w._stop_event = __import__("asyncio").Event()
+    with patch("services.translation_queue.translate_chapters_batch", side_effect=fake_translate):
+        with patch.object(AsyncRateLimiter, "acquire", new=AsyncMock(return_value=None)):
+            await w._tick()
+    assert w._limiter is not None
+    assert (w._limiter.rpm, w._limiter.rpd) == (15, 1500)
+
+    # Admin "saves" a new model that pins different limits.
+    await set_setting("queue_rpm", "2")
+    await set_setting("queue_rpd", "50")
+    await enqueue(1, 1, "zh")
+    with patch("services.translation_queue.translate_chapters_batch", side_effect=fake_translate):
+        with patch.object(AsyncRateLimiter, "acquire", new=AsyncMock(return_value=None)):
+            await w._tick()
+    assert (w._limiter.rpm, w._limiter.rpd) == (2, 50)
+
+
 async def test_clear_queue_all_and_by_status(tmp_db):
     """clear_queue() wipes everything; clear_queue(status='failed') only wipes failed rows."""
     await enqueue(1, 0, "zh")
@@ -155,6 +242,36 @@ async def test_worker_idles_when_disabled(tmp_db):
     assert w._state.enabled is False
 
 
+async def test_failing_batch_bumps_priority_so_worker_moves_on(tmp_db, monkeypatch):
+    """A book that keeps failing must not block other books. The worker
+    should bump failing rows' priority so they drop behind fresh work."""
+    from services.auth import encrypt_api_key
+    from services.rate_limiter import AsyncRateLimiter
+    import services.translation_queue as tq
+    await set_setting(SETTING_API_KEY, encrypt_api_key("fake-key"))
+    await set_setting(SETTING_ENABLED, "1")
+    monkeypatch.setattr(tq, "RETRY_BACKOFF", (0.0, 0.0, 0.0, 0.0, 0.0))
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    await enqueue(1, 0, "zh", priority=100)
+
+    async def always_fail(*args, **kwargs):
+        raise RuntimeError("safety blocked")
+
+    w = TranslationQueueWorker()
+    w._stop_event = __import__("asyncio").Event()
+    with patch("services.translation_queue.translate_chapters_batch", side_effect=always_fail):
+        with patch.object(AsyncRateLimiter, "acquire", new=AsyncMock(return_value=None)):
+            await w._tick()
+
+    rows = await list_queue()
+    # Still pending (attempts=1, not yet MAX_ATTEMPTS) but priority bumped
+    # from 100 to 1100 so it's behind anything freshly enqueued at 100.
+    assert len(rows) == 1
+    assert rows[0]["status"] == "pending"
+    assert rows[0]["attempts"] == 1
+    assert rows[0]["priority"] >= 1100
+
+
 async def test_worker_exposes_retry_state_on_transient_error(tmp_db, monkeypatch):
     """A transient 503 must surface as retry_attempt/retry_reason, not last_error.
     Only after retries are exhausted does it become last_error."""
@@ -170,6 +287,9 @@ async def test_worker_exposes_retry_state_on_transient_error(tmp_db, monkeypatch
 
     async def always_503(*args, **kwargs):
         raise RuntimeError("503 UNAVAILABLE. model overloaded")
+
+    # kwargs signature compatibility — translate_chapters_batch now receives
+    # max_output_tokens too.
 
     w = TranslationQueueWorker()
     w._stop_event = __import__("asyncio").Event()
@@ -206,7 +326,7 @@ async def test_worker_skips_already_cached_chapter(tmp_db):
 
     called_with: list = []
 
-    async def fake_translate(api_key, chapters, src, tgt, *, prior_context="", model=None):
+    async def fake_translate(api_key, chapters, src, tgt, *, prior_context="", model=None, **kwargs):
         called_with.append(chapters)
         return {idx: [f"new-{idx}"] for idx, _ in chapters}
 
@@ -245,7 +365,7 @@ async def test_worker_processes_batch(tmp_db):
 
     fake_return = {0: ["翻译段落一", "翻译段落二"], 1: ["翻译章节二"]}
 
-    async def fake_translate(api_key, chapters, src, tgt, *, prior_context="", model=None):
+    async def fake_translate(api_key, chapters, src, tgt, *, prior_context="", model=None, **kwargs):
         return fake_return
 
     w = TranslationQueueWorker()

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { GEMINI_MODEL_OPTIONS } from "@/lib/geminiModels";
+import { GEMINI_MODEL_OPTIONS, rateForModel } from "@/lib/geminiModels";
 
 type AdminFetch = (path: string, options?: RequestInit) => Promise<any>;
 
@@ -11,6 +11,7 @@ interface QueueSettings {
   rpm: number | null;
   rpd: number | null;
   model: string | null;
+  max_output_tokens: number | null;
 }
 
 interface WorkerLog {
@@ -54,6 +55,7 @@ interface QueueStatus {
 interface QueueItem {
   id: number;
   book_id: number;
+  book_title: string | null;
   chapter_index: number;
   target_language: string;
   status: string;
@@ -61,10 +63,24 @@ interface QueueItem {
   attempts: number;
   last_error: string | null;
   created_at: string;
+  queued_by: string | null;
 }
 
 interface Props {
   adminFetch: AdminFetch;
+}
+
+// SQLite returns "YYYY-MM-DD HH:MM:SS" in UTC. Render as a compact relative
+// age (e.g. "3m ago", "2h ago") — admins scan rows fastest that way.
+function relTime(ts: string | null | undefined): string {
+  if (!ts) return "";
+  const d = new Date(ts.includes("T") ? ts : ts.replace(" ", "T") + "Z");
+  const secs = Math.round((Date.now() - d.getTime()) / 1000);
+  if (secs < 5) return "now";
+  if (secs < 60) return `${secs}s ago`;
+  if (secs < 3600) return `${Math.round(secs / 60)}m ago`;
+  if (secs < 86400) return `${Math.round(secs / 3600)}h ago`;
+  return `${Math.round(secs / 86400)}d ago`;
 }
 
 export default function QueueTab({ adminFetch }: Props) {
@@ -79,9 +95,10 @@ export default function QueueTab({ adminFetch }: Props) {
   // Form state — mirrors settings but editable.
   const [langs, setLangs] = useState("");
   const [apiKey, setApiKey] = useState("");
-  const [rpm, setRpm] = useState("");
-  const [rpd, setRpd] = useState("");
   const [model, setModel] = useState("");
+  // Track once we've initialised model from server so the user's edit
+  // isn't overwritten by a later poll.
+  const modelInitedRef = useRef(false);
 
   async function refresh() {
     try {
@@ -98,9 +115,10 @@ export default function QueueTab({ adminFetch }: Props) {
       setSettings(cfg);
       setItems(its);
       if (langs === "") setLangs((cfg.auto_translate_languages || []).join(", "));
-      if (rpm === "" && cfg.rpm) setRpm(String(cfg.rpm));
-      if (rpd === "" && cfg.rpd) setRpd(String(cfg.rpd));
-      if (model === "" && cfg.model) setModel(cfg.model);
+      if (!modelInitedRef.current) {
+        setModel(cfg.model || "");
+        modelInitedRef.current = true;
+      }
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Failed to load queue");
     }
@@ -370,56 +388,40 @@ export default function QueueTab({ adminFetch }: Props) {
             </div>
           </div>
 
-          <div className="space-y-1">
-            <label className="text-xs text-stone-600">RPM</label>
-            <div className="flex gap-2">
-              <input
-                value={rpm}
-                onChange={(e) => setRpm(e.target.value)}
-                className="flex-1 rounded border border-amber-300 px-2 py-1 text-sm"
-                placeholder="12"
-              />
-              <button
-                onClick={() => saveSettings({ rpm: Number(rpm) || 12 })}
-                disabled={saving}
-                className="text-xs px-3 py-1 rounded bg-amber-700 text-white disabled:opacity-50"
-              >
-                Save
-              </button>
-            </div>
-          </div>
-
-          <div className="space-y-1">
-            <label className="text-xs text-stone-600">RPD (per-day cap)</label>
-            <div className="flex gap-2">
-              <input
-                value={rpd}
-                onChange={(e) => setRpd(e.target.value)}
-                className="flex-1 rounded border border-amber-300 px-2 py-1 text-sm"
-                placeholder="1400"
-              />
-              <button
-                onClick={() => saveSettings({ rpd: Number(rpd) || 1400 })}
-                disabled={saving}
-                className="text-xs px-3 py-1 rounded bg-amber-700 text-white disabled:opacity-50"
-              >
-                Save
-              </button>
-            </div>
-          </div>
-
           <div className="space-y-1 sm:col-span-2">
             <div className="flex items-center justify-between">
-              <label className="text-xs text-stone-600">Model</label>
+              <label className="text-xs text-stone-600">
+                Model — rate limits auto-apply from the selection below
+              </label>
               <button
-                onClick={() => saveSettings({ model })}
+                onClick={() => {
+                  const { rpm, rpd, maxOutputTokens } = rateForModel(model);
+                  saveSettings({
+                    model,
+                    rpm,
+                    rpd,
+                    max_output_tokens: maxOutputTokens,
+                  });
+                }}
                 disabled={saving}
                 className="text-xs px-3 py-0.5 rounded bg-amber-700 text-white disabled:opacity-50"
               >
-                Save model
+                Save model & rate
               </button>
             </div>
-            <div className="space-y-1.5">
+
+            {/* Current-applied summary so the admin sees what's live now */}
+            <div className="text-[11px] text-stone-500">
+              Active: <span className="font-mono">{settings?.model || "default"}</span>
+              {settings?.rpm || settings?.rpd ? (
+                <> · {settings.rpm ?? "?"} rpm · {settings.rpd ?? "?"} rpd</>
+              ) : null}
+              {settings?.max_output_tokens
+                ? ` · batch ≤ ${settings.max_output_tokens.toLocaleString()} tokens`
+                : null}
+            </div>
+
+            <div className="space-y-1.5 mt-1">
               {GEMINI_MODEL_OPTIONS.map((opt) => (
                 <label
                   key={opt.value || "default"}
@@ -438,8 +440,14 @@ export default function QueueTab({ adminFetch }: Props) {
                     className="mt-0.5 accent-amber-700"
                   />
                   <div className="flex-1 min-w-0">
-                    <div className="text-sm font-medium text-ink font-mono">
-                      {opt.label}
+                    <div className="flex items-baseline gap-2">
+                      <div className="text-sm font-medium text-ink font-mono">
+                        {opt.label}
+                      </div>
+                      <div className="text-[11px] text-stone-500 shrink-0">
+                        {opt.rpm} rpm · {opt.rpd} rpd · ≤
+                        {opt.maxOutputTokens.toLocaleString()} tok/batch
+                      </div>
                     </div>
                     <div className="text-xs text-stone-500 mt-0.5">{opt.note}</div>
                   </div>
@@ -467,7 +475,7 @@ export default function QueueTab({ adminFetch }: Props) {
                     className="w-full rounded border border-amber-300 px-2 py-1 text-sm bg-white font-mono"
                   />
                   <p className="text-[11px] text-stone-500 mt-1">
-                    Anything the API accepts. If you see 404, the model isn&apos;t available for your key.
+                    Anything the API accepts. Uses conservative defaults (10 rpm · 500 rpd); override via API if you&apos;re on a paid tier.
                   </p>
                 </div>
               </label>
@@ -519,7 +527,7 @@ export default function QueueTab({ adminFetch }: Props) {
             {items.map((it) => (
               <li key={it.id} className="px-4 py-2 flex items-center gap-2 text-xs">
                 <span
-                  className={`px-1.5 py-0.5 rounded text-[10px] ${
+                  className={`px-1.5 py-0.5 rounded text-[10px] shrink-0 ${
                     it.status === "pending"
                       ? "bg-stone-100 text-stone-600"
                       : it.status === "running"
@@ -533,18 +541,37 @@ export default function QueueTab({ adminFetch }: Props) {
                 >
                   {it.status}
                 </span>
-                <span className="text-stone-600 font-mono">
-                  book {it.book_id} · ch {it.chapter_index} → {it.target_language}
+                <span
+                  className="text-ink truncate max-w-[40%]"
+                  title={it.book_title || `book ${it.book_id}`}
+                >
+                  {it.book_title || `book ${it.book_id}`}
+                </span>
+                <span className="text-stone-500 font-mono shrink-0">
+                  · ch {it.chapter_index + 1} → {it.target_language}
+                </span>
+                <span
+                  className="text-stone-400 shrink-0"
+                  title={`Queued ${it.created_at} by ${it.queued_by || "auto (save_book)"}`}
+                >
+                  · {relTime(it.created_at)}
+                  {" by "}
+                  <span className={it.queued_by ? "text-stone-500" : "italic"}>
+                    {it.queued_by || "auto"}
+                  </span>
                 </span>
                 {it.attempts > 0 && (
-                  <span className="text-stone-400">· {it.attempts} attempts</span>
+                  <span className="text-stone-400 shrink-0">· {it.attempts} attempts</span>
                 )}
                 {it.last_error && (
-                  <span className="text-red-500 truncate flex-1" title={it.last_error}>
+                  <span
+                    className="text-red-500 truncate flex-1 min-w-0"
+                    title={it.last_error}
+                  >
                     {it.last_error}
                   </span>
                 )}
-                <div className="ml-auto flex gap-1">
+                <div className="ml-auto flex gap-1 shrink-0">
                   {it.status === "failed" && (
                     <button
                       onClick={() => retry(it)}

--- a/frontend/src/lib/geminiModels.ts
+++ b/frontend/src/lib/geminiModels.ts
@@ -2,40 +2,87 @@ export interface ModelOption {
   value: string;
   label: string;
   note: string;
+  // Conservative free-tier rate limits. Google's published tiers shift
+  // around, so these are rounded down to a safe floor. Admins on a paid
+  // tier can bump them via the (advanced) API, but for the common free-key
+  // case these keep us inside the quota without constant 429s.
+  rpm: number;
+  rpd: number;
+  // Per-request output token budget. 2.5-pro can emit ~64K in one call, so
+  // it pays to pack many chapters per batch; flash models cap at 8K and
+  // need tighter batches. The worker uses this to size greedy batches so
+  // we neither waste context (too few chapters) nor truncate (too many).
+  maxOutputTokens: number;
 }
 
-// Shared between BulkTranslateTab and QueueTab. "Default" leaves model empty
-// so the backend picks its compiled-in default. Admins can always type a
-// custom model if they want to try something not listed.
+// Used by QueueTab and BulkTranslateTab. Picking a model auto-applies the
+// matching RPM/RPD to the queue settings so admins don't have to guess.
 export const GEMINI_MODEL_OPTIONS: ModelOption[] = [
   {
     value: "",
     label: "Default (gemini-3.1-flash-lite-preview)",
     note: "Same model used for chat and insights — known to work with your key. Fast and cheap; fine for most translations.",
+    rpm: 12,
+    rpd: 1400,
+    maxOutputTokens: 7500,
   },
   {
     value: "gemini-2.5-pro",
     label: "gemini-2.5-pro",
-    note: "Highest quality, 64K output tokens per request. Free-tier RPM is low (~2), best for overnight runs with fewer, bigger batches.",
+    note: "Highest quality, 64K output tokens — packs many chapters per batch, offsetting the tiny free-tier RPM. Best for overnight runs.",
+    rpm: 2,
+    rpd: 50,
+    maxOutputTokens: 60000,
   },
   {
     value: "gemini-2.5-flash",
     label: "gemini-2.5-flash",
-    note: "Strong literary quality, 8K output tokens per request. Free-tier has higher RPM than Pro — good balance for bulk work.",
+    note: "Strong literary quality, 8K output tokens. Moderate free-tier limits — good balance of quality and throughput.",
+    rpm: 10,
+    rpd: 250,
+    maxOutputTokens: 7500,
   },
   {
     value: "gemini-2.5-flash-lite",
     label: "gemini-2.5-flash-lite",
-    note: "Cheapest and fastest. Lower quality — fine for quick drafts or less demanding target languages.",
+    note: "Cheapest and fastest in the 2.5 line. Lower quality — fine for quick drafts or less demanding target languages.",
+    rpm: 15,
+    rpd: 1000,
+    maxOutputTokens: 7500,
   },
   {
     value: "gemini-2.0-flash",
     label: "gemini-2.0-flash",
     note: "Previous generation — widely available, stable quality, generous free-tier limits.",
+    rpm: 15,
+    rpd: 1500,
+    maxOutputTokens: 7500,
   },
   {
     value: "gemini-2.0-flash-lite",
     label: "gemini-2.0-flash-lite",
-    note: "Lightest model in the 2.0 line. Use if you're hitting rate limits with heavier models.",
+    note: "Lightest model in the 2.0 line. Highest free-tier RPM — use if you're hitting 429 with heavier models.",
+    rpm: 30,
+    rpd: 1500,
+    maxOutputTokens: 7500,
   },
 ];
+
+// Conservative fallback when a custom model is typed in — we don't know
+// its quota, so we pick something safe.
+export const CUSTOM_MODEL_RATE: { rpm: number; rpd: number; maxOutputTokens: number } = {
+  rpm: 10,
+  rpd: 500,
+  maxOutputTokens: 7500,
+};
+
+export function rateForModel(model: string): {
+  rpm: number;
+  rpd: number;
+  maxOutputTokens: number;
+} {
+  const hit = GEMINI_MODEL_OPTIONS.find((o) => o.value === model);
+  return hit
+    ? { rpm: hit.rpm, rpd: hit.rpd, maxOutputTokens: hit.maxOutputTokens }
+    : CUSTOM_MODEL_RATE;
+}


### PR DESCRIPTION
## Summary

Five interlocking queue-UX improvements based on admin feedback.

### 1. Auto RPM/RPD from model choice
`GEMINI_MODEL_OPTIONS` now carries `rpm` / `rpd` per model — 2.5-pro: `2/50`, 2.5-flash: `10/250`, 3.1-flash-lite-preview (default): `12/1400`, etc. Admin picks a model, clicks **Save model & rate**, all three settings persist together. The manual RPM/RPD inputs are gone — one less knob to mis-configure.

### 2. Auto batch size per model
Same list carries `maxOutputTokens`. The worker reads the setting and uses it for both greedy batch grouping and the per-request `max_output_tokens` passed to Gemini. 2.5-pro's 60K output budget lets us pack ~8× more chapters per call, which offsets its very low free-tier RPM — exactly what big-model overnight runs want.

### 3. Live reconfigure without restart
Worker re-reads RPM/RPD every batch and mutates the existing `AsyncRateLimiter`'s attributes, preserving the rolling-window history so we never exceed the new cap right after a change. Admins can switch models mid-run.

### 4. Book titles + attribution on queue rows
- `list_queue` LEFT JOINs `books` so each item carries `book_title`.
- New `queued_by` column (migration 009) records the admin's email on manual enqueue; stays NULL for `save_book` auto-enqueues, which the UI labels *auto*.
- Row UI: `Moby Dick · ch 14 → zh · 3m ago by admin@example.com`.

### 5. Don't stall on a bad book
A book that keeps failing (content filter, model refusal, mangled XML response) used to block the whole queue. Now: on each batch failure, failed rows get their `priority` bumped by +1000 so the worker moves on to other books. Rows stay `pending` and will be retried later when nothing fresher is available. The retry endpoint resets priority so admins can re-prioritise a specific row manually.

## Test plan

- [x] Backend: 342 tests pass (4 new: `queued_by` attribution, `book_title` join, `max_output_tokens` plumbing, priority bump on failure)
- [x] Frontend: 126 tests pass
- [x] `next build` passes

Generated with [Claude Code](https://claude.com/claude-code)
