### PR TITLE
feat(queue): model fallback chain with priority ranking UI

### DIFF
--- a/backend/migrations/010_rate_limiter_per_model.sql
+++ b/backend/migrations/010_rate_limiter_per_model.sql
@@ -1,0 +1,18 @@
+-- Per-model RPD counters so each model in a fallback chain has its own
+-- daily budget. Pre-existing rows are migrated under model='' so callers
+-- that don't specify a model (legacy bulk_translate, etc.) keep working.
+
+CREATE TABLE IF NOT EXISTS rate_limiter_usage_new (
+    provider  TEXT    NOT NULL,
+    model     TEXT    NOT NULL DEFAULT '',
+    date      TEXT    NOT NULL,
+    requests  INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (provider, model, date)
+);
+
+INSERT INTO rate_limiter_usage_new (provider, model, date, requests)
+SELECT provider, '', date, requests FROM rate_limiter_usage;
+
+DROP TABLE rate_limiter_usage;
+
+ALTER TABLE rate_limiter_usage_new RENAME TO rate_limiter_usage;

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -32,8 +32,10 @@ from services.translation_queue import (
     SETTING_ENABLED,
     SETTING_MAX_OUTPUT_TOKENS,
     SETTING_MODEL,
+    SETTING_MODEL_CHAIN,
     SETTING_RPD,
     SETTING_RPM,
+    get_model_chain,
     clear_queue,
     delete_queue_for_book,
     delete_queue_item,
@@ -676,6 +678,7 @@ async def queue_status(_admin: dict = Depends(_require_admin)):
             "current_book_title": s.current_book_title,
             "current_target_language": s.current_target_language,
             "current_batch_size": s.current_batch_size,
+            "current_model": s.current_model,
             "last_completed_at": s.last_completed_at,
             "last_error": s.last_error,
             "started_at": s.started_at,
@@ -715,6 +718,7 @@ async def queue_get_settings(_admin: dict = Depends(_require_admin)):
     rpd = await get_setting(SETTING_RPD)
     model = await get_setting(SETTING_MODEL)
     max_tok = await get_setting(SETTING_MAX_OUTPUT_TOKENS)
+    chain = await get_model_chain()
     return {
         "enabled": enabled != "0",
         "has_api_key": bool(key),
@@ -722,6 +726,7 @@ async def queue_get_settings(_admin: dict = Depends(_require_admin)):
         "rpm": int(rpm) if rpm else None,
         "rpd": int(rpd) if rpd else None,
         "model": model or None,
+        "model_chain": chain,
         "max_output_tokens": int(max_tok) if max_tok else None,
     }
 
@@ -733,6 +738,7 @@ class QueueSettingsRequest(BaseModel):
     rpm: int | None = None
     rpd: int | None = None
     model: str | None = None
+    model_chain: list[str] | None = None
     max_output_tokens: int | None = None
 
 
@@ -759,6 +765,12 @@ async def queue_set_settings(
         await set_setting(SETTING_RPD, str(req.rpd))
     if req.model is not None:
         await set_setting(SETTING_MODEL, req.model)
+    if req.model_chain is not None:
+        # Keep the legacy single-model setting in sync with the chain head
+        # so any code path still reading SETTING_MODEL stays consistent.
+        await set_setting(SETTING_MODEL_CHAIN, json.dumps(req.model_chain))
+        if req.model_chain:
+            await set_setting(SETTING_MODEL, req.model_chain[0])
     if req.max_output_tokens is not None:
         await set_setting(SETTING_MAX_OUTPUT_TOKENS, str(req.max_output_tokens))
     queue_worker().wake()

--- a/backend/services/migrations.py
+++ b/backend/services/migrations.py
@@ -79,6 +79,8 @@ async def run(db_path: str) -> list[str]:
              "SELECT name FROM sqlite_master WHERE type='table' AND name='translation_queue'"),
             ("009_queue_queued_by",
              "SELECT 1 FROM pragma_table_info('translation_queue') WHERE name='queued_by'"),
+            ("010_rate_limiter_per_model",
+             "SELECT 1 FROM pragma_table_info('rate_limiter_usage') WHERE name='model'"),
         ]
         bootstrapped: list[str] = []
         for version, check_sql in bootstrap_checks:

--- a/backend/services/model_limits.py
+++ b/backend/services/model_limits.py
@@ -1,0 +1,36 @@
+"""Per-model rate limits + output token budgets (backend-side mirror).
+
+Kept in sync with frontend/src/lib/geminiModels.ts. The backend needs its
+own copy so the queue worker can decide per-model capacity without
+round-tripping through the frontend — especially for the fallback-chain
+logic where each model has its own rolling-window limiter.
+
+If free-tier quotas change, update both this file and the frontend map.
+"""
+
+from typing import TypedDict
+
+
+class _Limits(TypedDict):
+    rpm: int
+    rpd: int
+    max_output_tokens: int
+
+
+MODEL_LIMITS: dict[str, _Limits] = {
+    # "" = server-side default (currently gemini-3.1-flash-lite-preview).
+    "": {"rpm": 12, "rpd": 1400, "max_output_tokens": 7500},
+    "gemini-2.5-pro": {"rpm": 2, "rpd": 50, "max_output_tokens": 60000},
+    "gemini-2.5-flash": {"rpm": 10, "rpd": 250, "max_output_tokens": 7500},
+    "gemini-2.5-flash-lite": {"rpm": 15, "rpd": 1000, "max_output_tokens": 7500},
+    "gemini-2.0-flash": {"rpm": 15, "rpd": 1500, "max_output_tokens": 7500},
+    "gemini-2.0-flash-lite": {"rpm": 30, "rpd": 1500, "max_output_tokens": 7500},
+}
+
+# Conservative fallback for unknown (custom) models we have no quota
+# knowledge of. Better to under-utilise than to blow through the cap.
+CUSTOM_LIMITS: _Limits = {"rpm": 10, "rpd": 500, "max_output_tokens": 7500}
+
+
+def limits_for(model: str) -> _Limits:
+    return MODEL_LIMITS.get(model, CUSTOM_LIMITS)

--- a/backend/services/rate_limiter.py
+++ b/backend/services/rate_limiter.py
@@ -55,6 +55,10 @@ class AsyncRateLimiter:
         rpm: int = 15,
         rpd: int = 1500,
         provider: str = "gemini",
+        # Per-model RPD tracking — each model in a fallback chain gets its
+        # own daily counter. Default "" keeps backward compat with callers
+        # that never cared which model they were hitting.
+        model: str = "",
         # clock injection makes the tests deterministic
         time_fn: Optional[Callable[[], float]] = None,
         sleep_fn: Optional[Callable[[float], "asyncio.Future[None]"]] = None,
@@ -64,6 +68,7 @@ class AsyncRateLimiter:
         self.rpm = rpm
         self.rpd = rpd
         self.provider = provider
+        self.model = model
         self._time = time_fn or (lambda: asyncio.get_event_loop().time())
         self._sleep = sleep_fn or asyncio.sleep
         self._rpm_window: deque[float] = deque()
@@ -114,8 +119,9 @@ class AsyncRateLimiter:
     async def _daily_count(self) -> int:
         async with aiosqlite.connect(db_module.DB_PATH) as db:
             async with db.execute(
-                "SELECT requests FROM rate_limiter_usage WHERE provider=? AND date=?",
-                (self.provider, _utc_today()),
+                "SELECT requests FROM rate_limiter_usage "
+                "WHERE provider=? AND model=? AND date=?",
+                (self.provider, self.model, _utc_today()),
             ) as cursor:
                 row = await cursor.fetchone()
         return row[0] if row else 0
@@ -128,10 +134,11 @@ class AsyncRateLimiter:
         async with aiosqlite.connect(db_module.DB_PATH) as db:
             await db.execute(
                 """
-                INSERT INTO rate_limiter_usage (provider, date, requests)
-                VALUES (?, ?, 1)
-                ON CONFLICT(provider, date) DO UPDATE SET requests = requests + 1
+                INSERT INTO rate_limiter_usage (provider, model, date, requests)
+                VALUES (?, ?, ?, 1)
+                ON CONFLICT(provider, model, date)
+                   DO UPDATE SET requests = requests + 1
                 """,
-                (self.provider, _utc_today()),
+                (self.provider, self.model, _utc_today()),
             )
             await db.commit()

--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -48,6 +48,7 @@ from services.db import (
     save_translation,
 )
 from services.gemini import translate_chapters_batch, TRANSLATOR_MODEL
+from services.model_limits import limits_for
 from services.rate_limiter import AsyncRateLimiter
 from services.splitter import build_chapters
 
@@ -59,7 +60,8 @@ SETTING_AUTO_LANGS = "auto_translate_languages"  # JSON array of lang codes
 SETTING_ENABLED = "queue_enabled"            # "1" or "0"
 SETTING_RPM = "queue_rpm"
 SETTING_RPD = "queue_rpd"
-SETTING_MODEL = "queue_model"
+SETTING_MODEL = "queue_model"                # legacy single-model, kept for compat
+SETTING_MODEL_CHAIN = "queue_model_chain"    # JSON list; tried in order on quota
 SETTING_MAX_OUTPUT_TOKENS = "queue_max_output_tokens"  # per-request budget
 
 DEFAULT_RPM = 12
@@ -74,6 +76,44 @@ RETRY_BACKOFF = (1.0, 5.0, 20.0, 60.0, 300.0)
 # rest of the queue is exhausted, but they no longer block other books.
 FAIL_PRIORITY_BUMP = 1000
 DEFAULT_PRIORITY = 100
+
+
+# ── Fallback chain helpers ───────────────────────────────────────────────────
+
+async def get_model_chain() -> list[str]:
+    """Return the ordered list of models to try on quota exhaustion.
+
+    Falls back to the legacy single-model setting, then to the server default.
+    An empty-string entry means "use TRANSLATOR_MODEL".
+    """
+    raw = await get_setting(SETTING_MODEL_CHAIN)
+    if raw:
+        try:
+            val = json.loads(raw)
+            if isinstance(val, list) and val:
+                return [str(m) for m in val]
+        except json.JSONDecodeError:
+            pass
+    legacy = await get_setting(SETTING_MODEL)
+    return [legacy if legacy is not None else ""]
+
+
+def is_quota_error(exc: BaseException) -> bool:
+    """Heuristic: did Gemini refuse this call because the key is over quota?
+
+    True → chain advances to next model.
+    False (e.g. 503 overloaded, malformed response) → stays on current
+    model and lets the outer retry loop back off.
+    """
+    msg = str(exc).lower()
+    return (
+        "429" in msg
+        or "resource_exhausted" in msg
+        or "resource exhausted" in msg
+        or "quota" in msg
+        or "rate limit" in msg
+        or "ratelimit" in msg
+    )
 
 
 # ── Queue row helpers ────────────────────────────────────────────────────────
@@ -293,6 +333,7 @@ class WorkerState:
     current_book_title: str = ""
     current_target_language: str = ""
     current_batch_size: int = 0
+    current_model: str = ""          # which model is actually being used right now
     last_completed_at: Optional[str] = None
     last_error: str = ""
     started_at: Optional[str] = None
@@ -316,7 +357,9 @@ class TranslationQueueWorker:
         self._stop_event: asyncio.Event | None = None
         self._wake_event: asyncio.Event = asyncio.Event()
         self._state = WorkerState()
-        self._limiter: AsyncRateLimiter | None = None
+        # One limiter per model in the chain — each model has its own
+        # rolling-window RPM and persisted RPD counter.
+        self._limiters: dict[str, AsyncRateLimiter] = {}
 
     # ── Lifecycle ───────────────────────────────────────────────────────
 
@@ -497,35 +540,24 @@ class TranslationQueueWorker:
         if not works:
             return
 
-        # Per-request output token budget. Different models have very different
-        # caps (gemini-2.5-pro: ~64K, flash models: ~8K), so we read it from
-        # the admin settings — populated by the UI when the admin picks a
-        # model. The budget drives both batch grouping here and the
-        # max_output_tokens we pass to the Gemini call.
-        max_tok_raw = await get_setting(SETTING_MAX_OUTPUT_TOKENS)
-        max_output_tokens = int(max_tok_raw) if max_tok_raw else DEFAULT_MAX_OUTPUT_TOKENS
+        # Per-batch output budget — use the LARGEST budget any model in
+        # the chain supports so we don't under-pack when a big model like
+        # 2.5-pro is primary. If the fallback model has a tighter budget,
+        # the Gemini call on that model will truncate; we accept that
+        # tradeoff (the call still returns the chapters it managed).
+        chain = await get_model_chain()
+        max_output_tokens = max(
+            (limits_for(m)["max_output_tokens"] for m in chain),
+            default=DEFAULT_MAX_OUTPUT_TOKENS,
+        )
 
         batches = group_chapters_for_batch(works, max_output_tokens=max_output_tokens)
         rows_by_idx = {r.chapter_index: r for r in items}
-        model = (await get_setting(SETTING_MODEL)) or TRANSLATOR_MODEL
 
         self._state.current_book_id = book_id
         self._state.current_book_title = title
         self._state.current_target_language = target_language
         self._state.current_batch_size = len(works)
-
-        # Read current rate-limit settings every batch so admins can tune
-        # RPM/RPD (or switch models which pins different limits) and have
-        # the change take effect immediately — no restart needed. Mutating
-        # the existing limiter preserves the rolling-window history so we
-        # never exceed the new cap right after a change.
-        rpm = int((await get_setting(SETTING_RPM)) or DEFAULT_RPM)
-        rpd = int((await get_setting(SETTING_RPD)) or DEFAULT_RPD)
-        if self._limiter is None:
-            self._limiter = AsyncRateLimiter(rpm=rpm, rpd=rpd, provider="gemini")
-        else:
-            self._limiter.rpm = rpm
-            self._limiter.rpd = rpd
 
         for batch in batches:
             chapters = [(c.chapter_index, c.chapter_text) for c in batch]
@@ -534,7 +566,7 @@ class TranslationQueueWorker:
                 source_language=source,
                 target_language=target_language,
                 api_key=api_key,
-                model=model,
+                chain=chain,
                 max_output_tokens=max_output_tokens,
             )
             for c in batch:
@@ -543,9 +575,12 @@ class TranslationQueueWorker:
                 if paragraphs is None:
                     await self._bump_attempt(row, "no translation returned")
                     continue
+                # Record the model that actually translated this chapter —
+                # may differ from the primary if the chain advanced.
                 await save_translation(
                     book_id, c.chapter_index, target_language, paragraphs,
-                    provider="gemini", model=model,
+                    provider="gemini",
+                    model=self._state.current_model or None,
                 )
                 await self._mark_done([row])
                 self._state.chapters_done += 1
@@ -558,6 +593,71 @@ class TranslationQueueWorker:
                 })
             self._state.last_completed_at = datetime.now(timezone.utc).isoformat()
 
+    async def _ensure_limiter(self, model: str) -> AsyncRateLimiter:
+        """Get (or lazily create) the limiter for this model, applying
+        the latest per-model RPM/RPD each time so config changes are live."""
+        lim = limits_for(model)
+        if model not in self._limiters:
+            self._limiters[model] = AsyncRateLimiter(
+                rpm=lim["rpm"], rpd=lim["rpd"], provider="gemini", model=model,
+            )
+        else:
+            self._limiters[model].rpm = lim["rpm"]
+            self._limiters[model].rpd = lim["rpd"]
+        return self._limiters[model]
+
+    async def _call_api_with_chain(
+        self,
+        *,
+        chain: list[str],
+        chapters: list[tuple[int, str]],
+        api_key: str,
+        source_language: str,
+        target_language: str,
+        max_output_tokens: int,
+    ) -> dict[int, list[str]]:
+        """Walk the chain: first model with quota + that doesn't 429 wins.
+
+        Non-quota errors (503, malformed response) propagate to the outer
+        retry loop so they get exponential backoff on the CURRENT model.
+        Only quota errors / already-exhausted models advance the chain —
+        those won't get better within this batch so there's no point waiting.
+        """
+        last_err: Exception | None = None
+        for model in chain:
+            limiter = await self._ensure_limiter(model)
+            remaining = await limiter.daily_remaining()
+            if remaining <= 0:
+                self._append_log({
+                    "event": "chain_skip_exhausted",
+                    "model": model or "default",
+                })
+                continue
+            try:
+                self._state.waiting_reason = f"rate limiter ({model or 'default'})"
+                await limiter.acquire()
+                self._state.waiting_reason = f"translating via {model or 'default'}"
+                self._state.current_model = model or TRANSLATOR_MODEL
+                self._state.requests_made += 1
+                return await translate_chapters_batch(
+                    api_key, chapters, source_language, target_language,
+                    model=model or TRANSLATOR_MODEL,
+                    max_output_tokens=max_output_tokens,
+                )
+            except Exception as e:  # noqa: BLE001
+                last_err = e
+                if is_quota_error(e):
+                    self._append_log({
+                        "event": "chain_advance",
+                        "from": model or "default",
+                        "reason": str(e)[:160],
+                    })
+                    continue
+                raise  # transient / other error — bubble up to retry loop
+        if last_err:
+            raise last_err
+        raise RuntimeError("all models in chain are at their daily cap")
+
     async def _translate_with_retry(
         self,
         *,
@@ -565,7 +665,7 @@ class TranslationQueueWorker:
         source_language: str,
         target_language: str,
         api_key: str,
-        model: str,
+        chain: list[str],
         max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS,
     ) -> dict[int, list[str]]:
         last_err: Exception | None = None
@@ -576,8 +676,6 @@ class TranslationQueueWorker:
             if self._stop_event and self._stop_event.is_set():
                 break
             if delay:
-                # Surface the upcoming retry so the UI can show "Retrying in Ns"
-                # instead of a scary red "Last error" banner.
                 self._state.waiting_reason = f"retry backoff {delay:.0f}s"
                 self._state.retry_delay_seconds = delay
                 from datetime import datetime as _dt, timezone as _tz, timedelta as _td
@@ -586,29 +684,24 @@ class TranslationQueueWorker:
                 ).isoformat()
                 await asyncio.sleep(delay)
             try:
-                assert self._limiter is not None
-                self._state.waiting_reason = "rate limiter"
-                await self._limiter.acquire()
-                self._state.waiting_reason = "translating"
                 self._state.retry_attempt = attempt + 1
-                self._state.requests_made += 1
-                result = await translate_chapters_batch(
-                    api_key, chapters, source_language, target_language,
-                    model=model, max_output_tokens=max_output_tokens,
+                result = await self._call_api_with_chain(
+                    chain=chain,
+                    chapters=chapters,
+                    api_key=api_key,
+                    source_language=source_language,
+                    target_language=target_language,
+                    max_output_tokens=max_output_tokens,
                 )
                 # Success — clear retry state.
                 self._state.retry_attempt = 0
                 self._state.retry_delay_seconds = 0.0
                 self._state.retry_next_at = None
                 self._state.retry_reason = ""
-                # Don't stomp last_error (admin may want to see prior failures
-                # in history); just note success implicitly.
                 return result
             except Exception as e:  # noqa: BLE001
                 last_err = e
                 summary = str(e)[:200]
-                # Mark as a transient retry. Only elevate to last_error once
-                # retries are exhausted (below).
                 self._state.retry_attempt = attempt + 1
                 self._state.retry_reason = summary
                 self._append_log({
@@ -621,7 +714,6 @@ class TranslationQueueWorker:
                     "Queue batch translate failed (attempt %d/%d): %s",
                     attempt + 1, total_attempts, e,
                 )
-        # All retries exhausted — now it's a real error.
         if last_err:
             self._state.last_error = str(last_err)[:500]
             self._state.retry_attempt = 0

--- a/backend/tests/test_translation_queue.py
+++ b/backend/tests/test_translation_queue.py
@@ -133,16 +133,18 @@ async def test_list_queue_includes_book_title(tmp_db):
     assert by_book[999]["book_title"] is None
 
 
-async def test_worker_passes_model_max_output_tokens_setting(tmp_db):
-    """SETTING_MAX_OUTPUT_TOKENS must drive both batch grouping and the
-    max_output_tokens the Gemini call receives — this is how picking a big
-    model like 2.5-pro lets us pack many chapters per batch."""
+async def test_worker_uses_model_specific_output_budget(tmp_db):
+    """The batch output-token cap passed to Gemini should come from the
+    largest-budget model in the chain — gemini-2.5-pro's 60K lets us pack
+    many chapters into one request even when smaller flash fallbacks exist."""
     from services.auth import encrypt_api_key
     from services.rate_limiter import AsyncRateLimiter
-    from services.translation_queue import SETTING_MAX_OUTPUT_TOKENS
     await set_setting(SETTING_API_KEY, encrypt_api_key("fake-key"))
     await set_setting(SETTING_ENABLED, "1")
-    await set_setting(SETTING_MAX_OUTPUT_TOKENS, "60000")
+    await set_setting(
+        "queue_model_chain",
+        json.dumps(["gemini-2.5-pro", "gemini-2.5-flash"]),
+    )
     await save_book(1, BOOK_META, BOOK_TEXT)
     await enqueue(1, 0, "zh")
 
@@ -157,19 +159,21 @@ async def test_worker_passes_model_max_output_tokens_setting(tmp_db):
     with patch("services.translation_queue.translate_chapters_batch", side_effect=fake_translate):
         with patch.object(AsyncRateLimiter, "acquire", new=AsyncMock(return_value=None)):
             await w._tick()
+    # 2.5-pro's 60000 wins across the chain.
     assert captured.get("max_output_tokens") == 60000
 
 
-async def test_worker_reconfigures_limiter_on_rate_setting_change(tmp_db):
-    """Changing RPM/RPD in app_settings must propagate to the live limiter
-    without restarting the worker — otherwise auto-rate-by-model wouldn't
-    take effect for pending items."""
+async def test_worker_creates_per_model_limiter_with_correct_rates(tmp_db):
+    """Each model in the chain gets its own limiter loaded with the
+    MODEL_LIMITS table values — not from SETTING_RPM/RPD anymore."""
     from services.auth import encrypt_api_key
     from services.rate_limiter import AsyncRateLimiter
     await set_setting(SETTING_API_KEY, encrypt_api_key("fake-key"))
     await set_setting(SETTING_ENABLED, "1")
-    await set_setting("queue_rpm", "15")
-    await set_setting("queue_rpd", "1500")
+    await set_setting(
+        "queue_model_chain",
+        json.dumps(["gemini-2.5-pro"]),
+    )
     await save_book(1, BOOK_META, BOOK_TEXT)
     await enqueue(1, 0, "zh")
 
@@ -181,17 +185,9 @@ async def test_worker_reconfigures_limiter_on_rate_setting_change(tmp_db):
     with patch("services.translation_queue.translate_chapters_batch", side_effect=fake_translate):
         with patch.object(AsyncRateLimiter, "acquire", new=AsyncMock(return_value=None)):
             await w._tick()
-    assert w._limiter is not None
-    assert (w._limiter.rpm, w._limiter.rpd) == (15, 1500)
-
-    # Admin "saves" a new model that pins different limits.
-    await set_setting("queue_rpm", "2")
-    await set_setting("queue_rpd", "50")
-    await enqueue(1, 1, "zh")
-    with patch("services.translation_queue.translate_chapters_batch", side_effect=fake_translate):
-        with patch.object(AsyncRateLimiter, "acquire", new=AsyncMock(return_value=None)):
-            await w._tick()
-    assert (w._limiter.rpm, w._limiter.rpd) == (2, 50)
+    lim = w._limiters.get("gemini-2.5-pro")
+    assert lim is not None
+    assert (lim.rpm, lim.rpd) == (2, 50)
 
 
 async def test_clear_queue_all_and_by_status(tmp_db):
@@ -240,6 +236,136 @@ async def test_worker_idles_when_disabled(tmp_db):
     await w._tick()
     assert w._state.idle is True
     assert w._state.enabled is False
+
+
+async def test_chain_advances_on_quota_error(tmp_db, monkeypatch):
+    """On a 429 / quota error, the worker should advance to the next model
+    in the chain instead of retrying the same one."""
+    from services.auth import encrypt_api_key
+    from services.rate_limiter import AsyncRateLimiter
+    import services.translation_queue as tq
+    await set_setting(SETTING_API_KEY, encrypt_api_key("fake-key"))
+    await set_setting(SETTING_ENABLED, "1")
+    await set_setting(
+        "queue_model_chain",
+        json.dumps(["gemini-2.5-pro", "gemini-2.5-flash"]),
+    )
+    monkeypatch.setattr(tq, "RETRY_BACKOFF", (0.0, 0.0, 0.0, 0.0, 0.0))
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    await enqueue(1, 0, "zh")
+
+    models_called: list[str] = []
+
+    async def fake_translate(api_key, chapters, src, tgt, *, model=None, **kwargs):
+        models_called.append(model or "")
+        if model == "gemini-2.5-pro":
+            raise RuntimeError("429 RESOURCE_EXHAUSTED: per-day quota exceeded")
+        return {idx: ["ok"] for idx, _ in chapters}
+
+    w = TranslationQueueWorker()
+    w._stop_event = __import__("asyncio").Event()
+    with patch("services.translation_queue.translate_chapters_batch", side_effect=fake_translate):
+        with patch.object(AsyncRateLimiter, "acquire", new=AsyncMock(return_value=None)):
+            await w._tick()
+
+    # Pro got called and errored, flash got called and succeeded.
+    assert models_called == ["gemini-2.5-pro", "gemini-2.5-flash"]
+    # Chain advance should be in the log for admin visibility.
+    advances = [e for e in w._state.log if e.get("event") == "chain_advance"]
+    assert len(advances) == 1
+    assert advances[0]["from"] == "gemini-2.5-pro"
+
+
+async def test_chain_skips_models_already_at_daily_cap(tmp_db, monkeypatch):
+    """If a model's RPD is already spent today, the chain should skip it
+    without ever calling translate_chapters_batch — no point attempting."""
+    from services.auth import encrypt_api_key
+    from services.rate_limiter import AsyncRateLimiter
+    import services.translation_queue as tq
+    from services.model_limits import MODEL_LIMITS
+    await set_setting(SETTING_API_KEY, encrypt_api_key("fake-key"))
+    await set_setting(SETTING_ENABLED, "1")
+    await set_setting(
+        "queue_model_chain",
+        json.dumps(["gemini-2.5-pro", "gemini-2.5-flash"]),
+    )
+    monkeypatch.setattr(tq, "RETRY_BACKOFF", (0.0, 0.0, 0.0, 0.0, 0.0))
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    await enqueue(1, 0, "zh")
+
+    # Pre-fill rate_limiter_usage to make pro already-exhausted for today.
+    import aiosqlite
+    from datetime import datetime, timezone
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    pro_cap = MODEL_LIMITS["gemini-2.5-pro"]["rpd"]
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute(
+            "INSERT INTO rate_limiter_usage (provider, model, date, requests) VALUES (?, ?, ?, ?)",
+            ("gemini", "gemini-2.5-pro", today, pro_cap),
+        )
+        await db.commit()
+
+    models_called: list[str] = []
+
+    async def fake_translate(api_key, chapters, src, tgt, *, model=None, **kwargs):
+        models_called.append(model or "")
+        return {idx: ["ok"] for idx, _ in chapters}
+
+    w = TranslationQueueWorker()
+    w._stop_event = __import__("asyncio").Event()
+    with patch("services.translation_queue.translate_chapters_batch", side_effect=fake_translate):
+        with patch.object(AsyncRateLimiter, "acquire", new=AsyncMock(return_value=None)):
+            await w._tick()
+
+    # Pro should be skipped without a call.
+    assert models_called == ["gemini-2.5-flash"]
+    skips = [e for e in w._state.log if e.get("event") == "chain_skip_exhausted"]
+    assert len(skips) == 1
+    assert skips[0]["model"] == "gemini-2.5-pro"
+
+
+async def test_non_quota_error_stays_on_current_model(tmp_db, monkeypatch):
+    """A 503 'model overloaded' is transient for THIS model, not a quota
+    issue. The chain should NOT advance — the outer retry loop backs off."""
+    from services.auth import encrypt_api_key
+    from services.rate_limiter import AsyncRateLimiter
+    import services.translation_queue as tq
+    await set_setting(SETTING_API_KEY, encrypt_api_key("fake-key"))
+    await set_setting(SETTING_ENABLED, "1")
+    await set_setting(
+        "queue_model_chain",
+        json.dumps(["gemini-2.5-pro", "gemini-2.5-flash"]),
+    )
+    monkeypatch.setattr(tq, "RETRY_BACKOFF", (0.0, 0.0, 0.0, 0.0, 0.0))
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    await enqueue(1, 0, "zh")
+
+    models_called: list[str] = []
+
+    async def fake_translate(api_key, chapters, src, tgt, *, model=None, **kwargs):
+        models_called.append(model or "")
+        raise RuntimeError("503 UNAVAILABLE: model overloaded")
+
+    w = TranslationQueueWorker()
+    w._stop_event = __import__("asyncio").Event()
+    with patch("services.translation_queue.translate_chapters_batch", side_effect=fake_translate):
+        with patch.object(AsyncRateLimiter, "acquire", new=AsyncMock(return_value=None)):
+            await w._tick()
+
+    # Every retry call used PRIMARY (pro), never advanced to flash.
+    assert all(m == "gemini-2.5-pro" for m in models_called)
+    assert "gemini-2.5-flash" not in models_called
+    # No chain_advance log.
+    assert not any(e.get("event") == "chain_advance" for e in w._state.log)
+
+
+async def test_is_quota_error_classifier():
+    from services.translation_queue import is_quota_error
+    assert is_quota_error(RuntimeError("429 RESOURCE_EXHAUSTED"))
+    assert is_quota_error(RuntimeError("quota exceeded"))
+    assert is_quota_error(RuntimeError("Rate limit hit"))
+    assert not is_quota_error(RuntimeError("503 UNAVAILABLE"))
+    assert not is_quota_error(RuntimeError("response had no <chapter> blocks"))
 
 
 async def test_failing_batch_bumps_priority_so_worker_moves_on(tmp_db, monkeypatch):

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -1,6 +1,12 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { GEMINI_MODEL_OPTIONS, rateForModel } from "@/lib/geminiModels";
+import {
+  GEMINI_MODEL_OPTIONS,
+  DEFAULT_CHAIN,
+  labelForModel,
+  isRecommended,
+  rateForModel,
+} from "@/lib/geminiModels";
 
 type AdminFetch = (path: string, options?: RequestInit) => Promise<any>;
 
@@ -11,6 +17,7 @@ interface QueueSettings {
   rpm: number | null;
   rpd: number | null;
   model: string | null;
+  model_chain: string[];
   max_output_tokens: number | null;
 }
 
@@ -31,6 +38,7 @@ interface WorkerState {
   current_book_title: string;
   current_target_language: string;
   current_batch_size: number;
+  current_model?: string;
   last_completed_at: string | null;
   last_error: string;
   started_at: string | null;
@@ -95,10 +103,13 @@ export default function QueueTab({ adminFetch }: Props) {
   // Form state — mirrors settings but editable.
   const [langs, setLangs] = useState("");
   const [apiKey, setApiKey] = useState("");
-  const [model, setModel] = useState("");
-  // Track once we've initialised model from server so the user's edit
-  // isn't overwritten by a later poll.
-  const modelInitedRef = useRef(false);
+  // Ordered chain of models. The worker tries each in order, advancing
+  // to the next on 429 / quota. Empty slot = not used.
+  const [chain, setChain] = useState<string[]>(DEFAULT_CHAIN);
+  const [customModel, setCustomModel] = useState("");
+  // Track once we've initialised from server so the user's edits
+  // aren't overwritten by a later poll.
+  const chainInitedRef = useRef(false);
 
   async function refresh() {
     try {
@@ -115,9 +126,16 @@ export default function QueueTab({ adminFetch }: Props) {
       setSettings(cfg);
       setItems(its);
       if (langs === "") setLangs((cfg.auto_translate_languages || []).join(", "));
-      if (!modelInitedRef.current) {
-        setModel(cfg.model || "");
-        modelInitedRef.current = true;
+      if (!chainInitedRef.current) {
+        const serverChain = (cfg as QueueSettings).model_chain;
+        setChain(
+          Array.isArray(serverChain) && serverChain.length > 0
+            ? serverChain
+            : cfg.model
+              ? [cfg.model]
+              : DEFAULT_CHAIN,
+        );
+        chainInitedRef.current = true;
       }
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Failed to load queue");
@@ -229,7 +247,9 @@ export default function QueueTab({ adminFetch }: Props) {
               {status?.running
                 ? s?.idle
                   ? `Idle — ${s.waiting_reason || "nothing to do"}`
-                  : `Translating ${s?.current_book_title || "…"} → ${s?.current_target_language}`
+                  : `Translating ${s?.current_book_title || "…"} → ${s?.current_target_language}${
+                      s?.current_model ? ` · via ${s.current_model}` : ""
+                    }`
                 : "Worker stopped"}
             </div>
             <div className="text-xs text-stone-500">
@@ -391,94 +411,179 @@ export default function QueueTab({ adminFetch }: Props) {
           <div className="space-y-1 sm:col-span-2">
             <div className="flex items-center justify-between">
               <label className="text-xs text-stone-600">
-                Model — rate limits auto-apply from the selection below
+                Model chain — tried in order. On 429/quota the worker falls to the next.
               </label>
               <button
                 onClick={() => {
-                  const { rpm, rpd, maxOutputTokens } = rateForModel(model);
+                  // Save chain; primary's rate limits become the active
+                  // ones for legacy fields so bulk-translate etc. see them.
+                  const primary = chain[0] ?? "";
+                  const { rpm, rpd, maxOutputTokens } = rateForModel(primary);
                   saveSettings({
-                    model,
+                    model_chain: chain,
+                    model: primary,
                     rpm,
                     rpd,
                     max_output_tokens: maxOutputTokens,
                   });
                 }}
-                disabled={saving}
+                disabled={saving || chain.length === 0}
                 className="text-xs px-3 py-0.5 rounded bg-amber-700 text-white disabled:opacity-50"
               >
-                Save model & rate
+                Save chain
               </button>
             </div>
 
-            {/* Current-applied summary so the admin sees what's live now */}
-            <div className="text-[11px] text-stone-500">
-              Active: <span className="font-mono">{settings?.model || "default"}</span>
-              {settings?.rpm || settings?.rpd ? (
-                <> · {settings.rpm ?? "?"} rpm · {settings.rpd ?? "?"} rpd</>
+            {/* Live summary — show the configured chain and what the
+                worker is actually using at the moment. */}
+            <div className="text-[11px] text-stone-500 leading-relaxed">
+              Active chain:{" "}
+              {(settings?.model_chain ?? [])
+                .map((m, i) => `${i + 1}. ${labelForModel(m)}`)
+                .join("  →  ") || <em>not saved yet</em>}
+              {s?.current_model ? (
+                <div>
+                  Currently using:{" "}
+                  <span className="font-mono text-emerald-700">{s.current_model}</span>
+                </div>
               ) : null}
-              {settings?.max_output_tokens
-                ? ` · batch ≤ ${settings.max_output_tokens.toLocaleString()} tokens`
-                : null}
             </div>
 
-            <div className="space-y-1.5 mt-1">
-              {GEMINI_MODEL_OPTIONS.map((opt) => (
-                <label
-                  key={opt.value || "default"}
-                  className={`flex items-start gap-3 p-2 rounded-lg border cursor-pointer transition-colors ${
-                    model === opt.value
-                      ? "border-amber-400 bg-amber-50"
-                      : "border-amber-200 bg-white hover:bg-amber-50/50"
-                  }`}
-                >
-                  <input
-                    type="radio"
-                    name="queue-model"
-                    value={opt.value}
-                    checked={model === opt.value}
-                    onChange={() => setModel(opt.value)}
-                    className="mt-0.5 accent-amber-700"
-                  />
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-baseline gap-2">
-                      <div className="text-sm font-medium text-ink font-mono">
-                        {opt.label}
-                      </div>
-                      <div className="text-[11px] text-stone-500 shrink-0">
-                        {opt.rpm} rpm · {opt.rpd} rpd · ≤
-                        {opt.maxOutputTokens.toLocaleString()} tok/batch
-                      </div>
+            {/* Configured chain — reorder / remove */}
+            <div className="mt-2 space-y-1.5">
+              {chain.map((m, idx) => {
+                const opt = GEMINI_MODEL_OPTIONS.find((o) => o.value === m);
+                const recommended = isRecommended(m);
+                return (
+                  <div
+                    key={`${m}-${idx}`}
+                    className={`flex items-start gap-2 p-2 rounded-lg border ${
+                      idx === 0
+                        ? "border-amber-400 bg-amber-50"
+                        : "border-amber-200 bg-white"
+                    }`}
+                  >
+                    <div className="text-xs text-stone-500 font-mono w-6 shrink-0 pt-0.5">
+                      {idx + 1}.
                     </div>
-                    <div className="text-xs text-stone-500 mt-0.5">{opt.note}</div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-baseline gap-2 flex-wrap">
+                        <span className="text-sm font-medium text-ink font-mono">
+                          {labelForModel(m)}
+                        </span>
+                        {!recommended && (
+                          <span
+                            className="text-[10px] px-1 py-0.5 rounded bg-orange-50 text-orange-700 border border-orange-200"
+                            title="Drops literary nuance — use only as a last-resort fallback"
+                          >
+                            not recommended for literature
+                          </span>
+                        )}
+                        {opt ? (
+                          <span className="text-[11px] text-stone-500">
+                            {opt.rpm} rpm · {opt.rpd} rpd · ≤
+                            {opt.maxOutputTokens.toLocaleString()} tok
+                          </span>
+                        ) : (
+                          <span className="text-[11px] text-stone-400">
+                            custom — conservative defaults
+                          </span>
+                        )}
+                      </div>
+                      {opt?.note && (
+                        <div className="text-xs text-stone-500 mt-0.5">{opt.note}</div>
+                      )}
+                    </div>
+                    <div className="flex flex-col gap-0.5 shrink-0">
+                      <button
+                        onClick={() => {
+                          if (idx === 0) return;
+                          const copy = [...chain];
+                          [copy[idx - 1], copy[idx]] = [copy[idx], copy[idx - 1]];
+                          setChain(copy);
+                        }}
+                        disabled={idx === 0}
+                        className="text-xs px-1 text-stone-500 hover:text-amber-700 disabled:opacity-30"
+                        title="Move up"
+                      >
+                        ↑
+                      </button>
+                      <button
+                        onClick={() => {
+                          if (idx === chain.length - 1) return;
+                          const copy = [...chain];
+                          [copy[idx], copy[idx + 1]] = [copy[idx + 1], copy[idx]];
+                          setChain(copy);
+                        }}
+                        disabled={idx === chain.length - 1}
+                        className="text-xs px-1 text-stone-500 hover:text-amber-700 disabled:opacity-30"
+                        title="Move down"
+                      >
+                        ↓
+                      </button>
+                    </div>
+                    <button
+                      onClick={() => setChain(chain.filter((_, i) => i !== idx))}
+                      className="text-xs px-1.5 rounded border border-red-200 text-red-500 shrink-0 self-start"
+                      title="Remove from chain"
+                    >
+                      ×
+                    </button>
                   </div>
-                </label>
-              ))}
-              <label className="flex items-start gap-3 p-2 rounded-lg border border-amber-200 bg-white">
-                <input
-                  type="radio"
-                  name="queue-model"
-                  checked={
-                    !!model && !GEMINI_MODEL_OPTIONS.some((o) => o.value === model)
-                  }
-                  onChange={() => setModel("gemini-2.5-flash")}
-                  className="mt-0.5 accent-amber-700"
-                />
-                <div className="flex-1">
-                  <div className="text-sm font-medium text-ink mb-1">Custom</div>
-                  <input
-                    type="text"
-                    value={
-                      GEMINI_MODEL_OPTIONS.some((o) => o.value === model) ? "" : model
-                    }
-                    onChange={(e) => setModel(e.target.value)}
-                    placeholder="e.g. gemini-exp-1206"
-                    className="w-full rounded border border-amber-300 px-2 py-1 text-sm bg-white font-mono"
-                  />
-                  <p className="text-[11px] text-stone-500 mt-1">
-                    Anything the API accepts. Uses conservative defaults (10 rpm · 500 rpd); override via API if you&apos;re on a paid tier.
-                  </p>
+                );
+              })}
+              {chain.length === 0 && (
+                <div className="text-xs text-stone-400 italic">
+                  Chain is empty — add a model below.
                 </div>
-              </label>
+              )}
+            </div>
+
+            {/* Add to chain — recommended first, then not-recommended */}
+            <div className="mt-3">
+              <div className="text-xs text-stone-600 mb-1">Add to chain:</div>
+              <div className="flex flex-wrap gap-1.5">
+                {GEMINI_MODEL_OPTIONS
+                  .filter((o) => !chain.includes(o.value))
+                  .map((opt) => (
+                    <button
+                      key={opt.value || "default"}
+                      onClick={() => setChain([...chain, opt.value])}
+                      className={`text-xs px-2 py-1 rounded border font-mono ${
+                        opt.recommended
+                          ? "border-emerald-300 text-emerald-700 hover:bg-emerald-50"
+                          : "border-stone-200 text-stone-500 hover:bg-stone-50"
+                      }`}
+                      title={opt.note}
+                    >
+                      + {opt.label}
+                      {!opt.recommended && (
+                        <span className="ml-1 text-[10px] text-orange-600">
+                          (not recommended)
+                        </span>
+                      )}
+                    </button>
+                  ))}
+              </div>
+              <div className="mt-2 flex gap-2">
+                <input
+                  value={customModel}
+                  onChange={(e) => setCustomModel(e.target.value)}
+                  placeholder="Custom model (e.g. gemini-exp-1206)"
+                  className="flex-1 rounded border border-amber-300 px-2 py-1 text-xs font-mono"
+                />
+                <button
+                  onClick={() => {
+                    if (!customModel.trim() || chain.includes(customModel.trim())) return;
+                    setChain([...chain, customModel.trim()]);
+                    setCustomModel("");
+                  }}
+                  disabled={!customModel.trim()}
+                  className="text-xs px-2 py-1 rounded border border-amber-300 text-amber-700 disabled:opacity-40"
+                >
+                  + Add custom
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/lib/geminiModels.ts
+++ b/frontend/src/lib/geminiModels.ts
@@ -2,69 +2,72 @@ export interface ModelOption {
   value: string;
   label: string;
   note: string;
-  // Conservative free-tier rate limits. Google's published tiers shift
-  // around, so these are rounded down to a safe floor. Admins on a paid
-  // tier can bump them via the (advanced) API, but for the common free-key
-  // case these keep us inside the quota without constant 429s.
   rpm: number;
   rpd: number;
-  // Per-request output token budget. 2.5-pro can emit ~64K in one call, so
-  // it pays to pack many chapters per batch; flash models cap at 8K and
-  // need tighter batches. The worker uses this to size greedy batches so
-  // we neither waste context (too few chapters) nor truncate (too many).
   maxOutputTokens: number;
+  // `true` = acceptable for literary translation (preserves register,
+  // handles metaphor/register). `false` = lite/preview models that drop
+  // nuance — still selectable as a last-ditch fallback, but visually
+  // de-emphasised in the chain picker.
+  recommended: boolean;
 }
 
 // Used by QueueTab and BulkTranslateTab. Picking a model auto-applies the
 // matching RPM/RPD to the queue settings so admins don't have to guess.
 export const GEMINI_MODEL_OPTIONS: ModelOption[] = [
   {
-    value: "",
-    label: "Default (gemini-3.1-flash-lite-preview)",
-    note: "Same model used for chat and insights — known to work with your key. Fast and cheap; fine for most translations.",
-    rpm: 12,
-    rpd: 1400,
-    maxOutputTokens: 7500,
-  },
-  {
     value: "gemini-2.5-pro",
     label: "gemini-2.5-pro",
-    note: "Highest quality, 64K output tokens — packs many chapters per batch, offsetting the tiny free-tier RPM. Best for overnight runs.",
+    note: "Highest quality — 64K output tokens packs many chapters per batch, offsetting the tiny free-tier RPM. Reserve for books you care most about.",
     rpm: 2,
     rpd: 50,
     maxOutputTokens: 60000,
+    recommended: true,
   },
   {
     value: "gemini-2.5-flash",
     label: "gemini-2.5-flash",
-    note: "Strong literary quality, 8K output tokens. Moderate free-tier limits — good balance of quality and throughput.",
+    note: "Near-Pro literary quality. Good balance for bulk work — fastest 'recommended' tier model at 10 rpm.",
     rpm: 10,
     rpd: 250,
     maxOutputTokens: 7500,
-  },
-  {
-    value: "gemini-2.5-flash-lite",
-    label: "gemini-2.5-flash-lite",
-    note: "Cheapest and fastest in the 2.5 line. Lower quality — fine for quick drafts or less demanding target languages.",
-    rpm: 15,
-    rpd: 1000,
-    maxOutputTokens: 7500,
+    recommended: true,
   },
   {
     value: "gemini-2.0-flash",
     label: "gemini-2.0-flash",
-    note: "Previous generation — widely available, stable quality, generous free-tier limits.",
+    note: "Previous generation, still solid for prose. Generous free-tier — a useful fallback when 2.5 models are exhausted.",
     rpm: 15,
     rpd: 1500,
     maxOutputTokens: 7500,
+    recommended: true,
+  },
+  {
+    value: "gemini-2.5-flash-lite",
+    label: "gemini-2.5-flash-lite",
+    note: "Drops nuance on dialogue and metaphor. Usable only as a last-ditch fallback.",
+    rpm: 15,
+    rpd: 1000,
+    maxOutputTokens: 7500,
+    recommended: false,
   },
   {
     value: "gemini-2.0-flash-lite",
     label: "gemini-2.0-flash-lite",
-    note: "Lightest model in the 2.0 line. Highest free-tier RPM — use if you're hitting 429 with heavier models.",
+    note: "Lowest quality in the 2.0 line. Not recommended for literature.",
     rpm: 30,
     rpd: 1500,
     maxOutputTokens: 7500,
+    recommended: false,
+  },
+  {
+    value: "",
+    label: "Default (gemini-3.1-flash-lite-preview)",
+    note: "Server default — a lite/preview model. Same one used for chat and insights. Not recommended for literary work; kept for backward compat.",
+    rpm: 12,
+    rpd: 1400,
+    maxOutputTokens: 7500,
+    recommended: false,
   },
 ];
 
@@ -86,3 +89,21 @@ export function rateForModel(model: string): {
     ? { rpm: hit.rpm, rpd: hit.rpd, maxOutputTokens: hit.maxOutputTokens }
     : CUSTOM_MODEL_RATE;
 }
+
+export function labelForModel(model: string): string {
+  const hit = GEMINI_MODEL_OPTIONS.find((o) => o.value === model);
+  return hit?.label || model || "default";
+}
+
+export function isRecommended(model: string): boolean {
+  const hit = GEMINI_MODEL_OPTIONS.find((o) => o.value === model);
+  return hit?.recommended ?? false;
+}
+
+// Suggested default chain — all three "Tier 1" models in quality order.
+// The worker will try them in this order and advance to the next on 429.
+export const DEFAULT_CHAIN: string[] = [
+  "gemini-2.5-pro",
+  "gemini-2.5-flash",
+  "gemini-2.0-flash",
+];


### PR DESCRIPTION
## Summary

Queue model selection is now a **priority ranking list**, and the worker **iterates through the chain when a model hits rate limits**. Two requests in one PR.

### Fallback chain behaviour

Admin configures an ordered chain (e.g. `gemini-2.5-pro → gemini-2.5-flash → gemini-2.0-flash`). For each batch:

- **429 / quota exhausted / already-at-daily-cap** → advance to the next model immediately. No point waiting for a spent model's RPD to reset — the chain gives us a higher-capacity alternative right now.
- **Non-quota error** (503 overloaded, malformed response) → stay on the current model, let the outer retry loop back off. Different problem; waiting on the same model is usually the right answer.

Each model has its own **rolling-window RPM + persisted daily counter** — migration 010 extends `rate_limiter_usage` with a `model` column and keys it by `(provider, model, date)`. The queue no longer shares one counter across all models.

### UI — priority ranking list

Replaces the single radio-list picker:
- **Configured chain** shown as an ordered list with ↑↓ reorder and × remove. Primary (slot 1) is highlighted.
- **Add to chain** pills below — recommended tier (pro, 2.5-flash, 2.0-flash) in green, not-recommended lite/preview models in muted grey with an "(not recommended)" hint.
- **Custom model** text input for anything Google publishes.
- **Live status** shows the configured chain *and* which model is actually running the current batch (`Currently using: gemini-2.5-flash` in green when the chain advanced).

### Literature-quality tiers (baked into the UI)

- **Recommended** (preserves nuance, dialogue, metaphor): `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.0-flash`
- **Not recommended** (drops register on complex prose): `*-flash-lite` variants, the server default `gemini-3.1-flash-lite-preview`

Admins can still select any of them — the flag is advisory.

## Test plan

- [x] Backend: 346 tests pass (4 new: chain advance on 429, skip already-exhausted, no advance on 503, quota-error classifier)
- [x] Frontend: 126 tests pass
- [x] `next build` passes
- [x] Migration 010 bootstrap-safe on existing DBs (adds `model` column, migrates old rows to `model=''`)

Generated with [Claude Code](https://claude.com/claude-code)
