### PR TITLE
feat(queue): Tier 1 quotas + 3.1 models, curated default chain, cost estimate

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -35,6 +35,7 @@ from services.translation_queue import (
     SETTING_MODEL_CHAIN,
     SETTING_RPD,
     SETTING_RPM,
+    estimate_queue_cost,
     get_model_chain,
     clear_queue,
     delete_queue_for_book,
@@ -860,6 +861,16 @@ async def queue_retry_item(
         await db.commit()
     queue_worker().wake()
     return {"ok": True, "updated": cursor.rowcount}
+
+
+@router.get("/queue/cost-estimate")
+async def queue_cost_estimate(_admin: dict = Depends(_require_admin)):
+    """Ballpark USD to drain every pending queue item, per model.
+
+    Intended to help admins decide whether it's worth routing the queue
+    through the frontier models vs. cheaper flash variants.
+    """
+    return await estimate_queue_cost()
 
 
 @router.post("/queue/enqueue-all")

--- a/backend/services/model_limits.py
+++ b/backend/services/model_limits.py
@@ -15,22 +15,101 @@ class _Limits(TypedDict):
     rpm: int
     rpd: int
     max_output_tokens: int
+    # Tier 1 pay-as-you-go pricing, USD per 1M tokens (approximate — Google
+    # updates pricing periodically; verify at ai.google.dev/pricing before
+    # budgeting large runs). Used to surface cost estimates in the admin UI.
+    input_usd_per_m: float
+    output_usd_per_m: float
 
+
+# Curated default chain for first-time admins: frontier quality first, then
+# descending to highest-RPD model as a catch-all safety net. Overridable
+# via the Queue settings UI.
+DEFAULT_CHAIN: list[str] = [
+    "gemini-3.1-pro",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "gemini-2.0-flash",
+]
+
+
+# Tier 1 (paid / billing-enabled) limits, sourced from the admin's
+# aistudio.google.com/rate-limit dashboard. "Unlimited" RPD is encoded as
+# UNLIMITED_RPD so the rate limiter never blocks on daily cap.
+#
+# If Google changes quotas, update both this map and
+# frontend/src/lib/geminiModels.ts — both are read by the UI.
+
+UNLIMITED_RPD = 1_000_000  # treat as effectively unlimited
 
 MODEL_LIMITS: dict[str, _Limits] = {
     # "" = server-side default (currently gemini-3.1-flash-lite-preview).
-    "": {"rpm": 12, "rpd": 1400, "max_output_tokens": 7500},
-    "gemini-2.5-pro": {"rpm": 2, "rpd": 50, "max_output_tokens": 60000},
-    "gemini-2.5-flash": {"rpm": 10, "rpd": 250, "max_output_tokens": 7500},
-    "gemini-2.5-flash-lite": {"rpm": 15, "rpd": 1000, "max_output_tokens": 7500},
-    "gemini-2.0-flash": {"rpm": 15, "rpd": 1500, "max_output_tokens": 7500},
-    "gemini-2.0-flash-lite": {"rpm": 30, "rpd": 1500, "max_output_tokens": 7500},
+    # Same quota + pricing as gemini-3.1-flash-lite on Tier 1.
+    "": {
+        "rpm": 4000, "rpd": 150000, "max_output_tokens": 7500,
+        "input_usd_per_m": 0.10, "output_usd_per_m": 0.40,
+    },
+    # Frontier 3.1 family
+    "gemini-3.1-pro": {
+        "rpm": 25, "rpd": 250, "max_output_tokens": 60000,
+        "input_usd_per_m": 1.25, "output_usd_per_m": 10.00,
+    },
+    "gemini-3.1-flash-lite": {
+        "rpm": 4000, "rpd": 150000, "max_output_tokens": 7500,
+        "input_usd_per_m": 0.10, "output_usd_per_m": 0.40,
+    },
+    # 2.5 family
+    "gemini-2.5-pro": {
+        "rpm": 150, "rpd": 1000, "max_output_tokens": 60000,
+        "input_usd_per_m": 1.25, "output_usd_per_m": 10.00,
+    },
+    "gemini-2.5-flash": {
+        "rpm": 1000, "rpd": 10000, "max_output_tokens": 7500,
+        "input_usd_per_m": 0.30, "output_usd_per_m": 2.50,
+    },
+    "gemini-2.5-flash-lite": {
+        "rpm": 4000, "rpd": UNLIMITED_RPD, "max_output_tokens": 7500,
+        "input_usd_per_m": 0.10, "output_usd_per_m": 0.40,
+    },
+    # 2.0 family
+    "gemini-2.0-flash": {
+        "rpm": 2000, "rpd": UNLIMITED_RPD, "max_output_tokens": 7500,
+        "input_usd_per_m": 0.10, "output_usd_per_m": 0.40,
+    },
+    "gemini-2.0-flash-lite": {
+        "rpm": 4000, "rpd": UNLIMITED_RPD, "max_output_tokens": 7500,
+        "input_usd_per_m": 0.075, "output_usd_per_m": 0.30,
+    },
 }
 
 # Conservative fallback for unknown (custom) models we have no quota
 # knowledge of. Better to under-utilise than to blow through the cap.
-CUSTOM_LIMITS: _Limits = {"rpm": 10, "rpd": 500, "max_output_tokens": 7500}
+CUSTOM_LIMITS: _Limits = {
+    "rpm": 10, "rpd": 500, "max_output_tokens": 7500,
+    "input_usd_per_m": 1.25, "output_usd_per_m": 10.00,
+}
 
 
 def limits_for(model: str) -> _Limits:
     return MODEL_LIMITS.get(model, CUSTOM_LIMITS)
+
+
+# Token estimation heuristic: Gemini's tokenizer averages ~4 chars per token
+# for English prose, ~2 chars/token for CJK text. We pick a middle-of-the-road
+# 3 chars/token so the estimate works across source + target languages.
+CHARS_PER_TOKEN = 3.0
+
+
+def estimate_tokens_from_chars(char_count: int) -> int:
+    return int(char_count / CHARS_PER_TOKEN)
+
+
+def estimate_cost_usd(
+    model: str, input_tokens: int, output_tokens: int,
+) -> float:
+    """Back-of-envelope cost for a call. Prices are per 1M tokens."""
+    lim = limits_for(model)
+    return (
+        input_tokens / 1_000_000 * lim["input_usd_per_m"]
+        + output_tokens / 1_000_000 * lim["output_usd_per_m"]
+    )

--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -48,7 +48,12 @@ from services.db import (
     save_translation,
 )
 from services.gemini import translate_chapters_batch, TRANSLATOR_MODEL
-from services.model_limits import limits_for
+from services.model_limits import (
+    DEFAULT_CHAIN as _DEFAULT_CHAIN,
+    estimate_cost_usd,
+    estimate_tokens_from_chars,
+    limits_for,
+)
 from services.rate_limiter import AsyncRateLimiter
 from services.splitter import build_chapters
 
@@ -83,8 +88,9 @@ DEFAULT_PRIORITY = 100
 async def get_model_chain() -> list[str]:
     """Return the ordered list of models to try on quota exhaustion.
 
-    Falls back to the legacy single-model setting, then to the server default.
-    An empty-string entry means "use TRANSLATOR_MODEL".
+    Falls back to the legacy single-model setting, then to the curated
+    DEFAULT_CHAIN (so first-time admins get a sensible chain without
+    having to configure anything).
     """
     raw = await get_setting(SETTING_MODEL_CHAIN)
     if raw:
@@ -95,7 +101,9 @@ async def get_model_chain() -> list[str]:
         except json.JSONDecodeError:
             pass
     legacy = await get_setting(SETTING_MODEL)
-    return [legacy if legacy is not None else ""]
+    if legacy:
+        return [legacy]
+    return list(_DEFAULT_CHAIN)
 
 
 def is_quota_error(exc: BaseException) -> bool:
@@ -260,6 +268,76 @@ async def list_queue(
         db.row_factory = aiosqlite.Row
         async with db.execute(sql, params) as cursor:
             return [dict(row) async for row in cursor]
+
+
+async def estimate_queue_cost(models: list[str] | None = None) -> dict:
+    """Estimate what it will cost to drain every pending queue item on each model.
+
+    Methodology (deliberately rough — pricing and tokenization vary):
+    - Sum chapter-text chars across all pending queue rows.
+    - Translate that to tokens at CHARS_PER_TOKEN ≈ 3.
+    - Output tokens assumed ~= input tokens (literary translation is
+      roughly 1:1 in char count; CJK targets cancel out against Latin source).
+    - Per-model USD = input_tokens × input_price + output_tokens × output_price.
+
+    Return one row per model plus overall totals so the admin UI can show
+    a quick comparison table.
+    """
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        # Pull chapter-text lengths for every pending (book, chapter) pair,
+        # joined against the books table. We only need text_length proxy —
+        # use LENGTH(text) which is charcount for TEXT columns.
+        async with db.execute(
+            """SELECT q.book_id, q.chapter_index, LENGTH(b.text) AS total_chars
+               FROM translation_queue q
+               LEFT JOIN books b ON b.id = q.book_id
+               WHERE q.status='pending'"""
+        ) as cursor:
+            rows = await cursor.fetchall()
+
+    # Group by book to compute per-chapter share (book_total_chars / n_chapters)
+    # — we don't know each chapter's actual length without re-running the
+    # splitter, so approximate by equal share.
+    by_book: dict[int, dict] = {}
+    for book_id, _chap_idx, total_chars in rows:
+        if total_chars is None:
+            continue
+        entry = by_book.setdefault(book_id, {"total_chars": total_chars, "count": 0})
+        entry["count"] += 1
+
+    # Total chars of pending work across all books.
+    total_chars = 0
+    for entry in by_book.values():
+        # Heuristic: assume the pending rows are spread across ~50 chapters
+        # per book on average. That's a bit handwavy but matches typical novels.
+        CHAPTERS_PER_BOOK_GUESS = 50
+        per_chapter = max(1, entry["total_chars"] // CHAPTERS_PER_BOOK_GUESS)
+        total_chars += per_chapter * entry["count"]
+
+    input_tokens = estimate_tokens_from_chars(total_chars)
+    output_tokens = input_tokens  # 1:1 heuristic for translation
+
+    if models is None:
+        models = [""] + [m for m in (await get_model_chain()) if m]
+
+    # De-dupe while preserving order
+    seen = set()
+    models = [m for m in models if not (m in seen or seen.add(m))]
+
+    per_model = []
+    for m in models:
+        cost = estimate_cost_usd(m, input_tokens, output_tokens)
+        per_model.append({
+            "model": m or "default",
+            "usd": round(cost, 4),
+        })
+    return {
+        "pending_items": sum(e["count"] for e in by_book.values()),
+        "pending_books": len(by_book),
+        "estimated_input_tokens": input_tokens,
+        "estimated_output_tokens": output_tokens,
+        "per_model": per_model,
+    }
 
 
 async def queue_summary() -> dict:

--- a/backend/tests/test_translation_queue.py
+++ b/backend/tests/test_translation_queue.py
@@ -187,7 +187,42 @@ async def test_worker_creates_per_model_limiter_with_correct_rates(tmp_db):
             await w._tick()
     lim = w._limiters.get("gemini-2.5-pro")
     assert lim is not None
-    assert (lim.rpm, lim.rpd) == (2, 50)
+    assert (lim.rpm, lim.rpd) == (150, 1000)
+
+
+async def test_estimate_queue_cost_returns_per_model_breakdown(tmp_db):
+    """Cost estimate must give a non-zero USD figure per model when there's
+    pending work, and zero when there's none."""
+    from services.translation_queue import estimate_queue_cost
+    # Empty queue → zero across the board.
+    empty = await estimate_queue_cost()
+    assert empty["pending_items"] == 0
+    assert all(row["usd"] == 0 for row in empty["per_model"])
+
+    # With pending work the pro/flash models should differ in cost.
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    await enqueue(1, 0, "zh")
+    await enqueue(1, 1, "zh")
+    est = await estimate_queue_cost(
+        models=["gemini-2.5-pro", "gemini-2.0-flash"],
+    )
+    assert est["pending_items"] == 2
+    assert est["pending_books"] == 1
+    pro = next(r for r in est["per_model"] if r["model"] == "gemini-2.5-pro")
+    flash = next(r for r in est["per_model"] if r["model"] == "gemini-2.0-flash")
+    # pro is ~12x the price of flash, so estimates must differ markedly.
+    assert pro["usd"] > flash["usd"]
+    assert pro["usd"] > 0
+
+
+async def test_default_chain_applied_when_no_setting(tmp_db):
+    """First-time admin with no queue_model_chain saved should still get
+    a sensible chain out of the box."""
+    from services.translation_queue import get_model_chain
+    chain = await get_model_chain()
+    assert chain[0] == "gemini-3.1-pro"
+    assert "gemini-2.5-pro" in chain
+    assert "gemini-2.0-flash" in chain
 
 
 async def test_clear_queue_all_and_by_status(tmp_db):

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -60,6 +60,14 @@ interface QueueStatus {
   counts: Record<string, number>;
 }
 
+interface CostEstimate {
+  pending_items: number;
+  pending_books: number;
+  estimated_input_tokens: number;
+  estimated_output_tokens: number;
+  per_model: { model: string; usd: number }[];
+}
+
 interface QueueItem {
   id: number;
   book_id: number;
@@ -95,6 +103,7 @@ export default function QueueTab({ adminFetch }: Props) {
   const [status, setStatus] = useState<QueueStatus | null>(null);
   const [settings, setSettings] = useState<QueueSettings | null>(null);
   const [items, setItems] = useState<QueueItem[]>([]);
+  const [cost, setCost] = useState<CostEstimate | null>(null);
   const [itemFilter, setItemFilter] = useState<"pending" | "running" | "failed" | "all">("pending");
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
@@ -113,7 +122,7 @@ export default function QueueTab({ adminFetch }: Props) {
 
   async function refresh() {
     try {
-      const [st, cfg, its] = await Promise.all([
+      const [st, cfg, its, cst] = await Promise.all([
         adminFetch("/admin/queue/status"),
         adminFetch("/admin/queue/settings"),
         adminFetch(
@@ -121,10 +130,12 @@ export default function QueueTab({ adminFetch }: Props) {
             itemFilter === "all" ? "" : `&status=${itemFilter}`
           }`,
         ),
+        adminFetch("/admin/queue/cost-estimate"),
       ]);
       setStatus(st);
       setSettings(cfg);
       setItems(its);
+      setCost(cst);
       if (langs === "") setLangs((cfg.auto_translate_languages || []).join(", "));
       if (!chainInitedRef.current) {
         const serverChain = (cfg as QueueSettings).model_chain;
@@ -597,6 +608,42 @@ export default function QueueTab({ adminFetch }: Props) {
           </button>
         </div>
       </div>
+
+      {/* Cost analysis — back-of-envelope estimate of draining the pending queue
+          across each model. Helps decide whether to route through pro vs flash. */}
+      {cost && cost.pending_items > 0 && (
+        <div className="bg-white rounded-xl border border-amber-200 p-4 space-y-2">
+          <div className="flex items-baseline justify-between">
+            <h3 className="font-medium text-ink">Cost estimate (to drain queue)</h3>
+            <span className="text-[11px] text-stone-500">
+              {cost.pending_items} pending across {cost.pending_books} book
+              {cost.pending_books === 1 ? "" : "s"} ·{" "}
+              ~{(cost.estimated_input_tokens / 1_000_000).toFixed(1)}M in /{" "}
+              ~{(cost.estimated_output_tokens / 1_000_000).toFixed(1)}M out tokens
+            </span>
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+            {cost.per_model.map((row) => (
+              <div
+                key={row.model}
+                className="rounded-lg border border-amber-100 p-2 text-center"
+              >
+                <div className="text-[11px] text-stone-500 font-mono truncate">
+                  {row.model}
+                </div>
+                <div className="text-sm font-semibold text-ink">
+                  ${row.usd.toFixed(2)}
+                </div>
+              </div>
+            ))}
+          </div>
+          <p className="text-[11px] text-stone-400">
+            Rough estimate — assumes ~3 chars/token and 1:1 input-to-output ratio.
+            Actual cost depends on tokenizer, chapter lengths, and batching.
+            Chain advance on 429 means multiple models may contribute.
+          </p>
+        </div>
+      )}
 
       {/* Queue items */}
       <div className="bg-white rounded-xl border border-amber-200 overflow-hidden">

--- a/frontend/src/lib/geminiModels.ts
+++ b/frontend/src/lib/geminiModels.ts
@@ -16,56 +16,74 @@ export interface ModelOption {
 // matching RPM/RPD to the queue settings so admins don't have to guess.
 export const GEMINI_MODEL_OPTIONS: ModelOption[] = [
   {
+    value: "gemini-3.1-pro",
+    label: "gemini-3.1-pro",
+    note: "Frontier quality (3.1 family). Low RPD — reserve for the most important books. Packs up to 60K output tokens per batch.",
+    rpm: 25,
+    rpd: 250,
+    maxOutputTokens: 60000,
+    recommended: true,
+  },
+  {
     value: "gemini-2.5-pro",
     label: "gemini-2.5-pro",
-    note: "Highest quality — 64K output tokens packs many chapters per batch, offsetting the tiny free-tier RPM. Reserve for books you care most about.",
-    rpm: 2,
-    rpd: 50,
+    note: "Near-frontier quality. Higher RPD than 3.1-pro — good secondary when 3.1-pro is exhausted.",
+    rpm: 150,
+    rpd: 1000,
     maxOutputTokens: 60000,
     recommended: true,
   },
   {
     value: "gemini-2.5-flash",
     label: "gemini-2.5-flash",
-    note: "Near-Pro literary quality. Good balance for bulk work — fastest 'recommended' tier model at 10 rpm.",
-    rpm: 10,
-    rpd: 250,
+    note: "Strong literary quality, 10K daily requests. Sweet spot for bulk work that still needs nuance.",
+    rpm: 1000,
+    rpd: 10000,
     maxOutputTokens: 7500,
     recommended: true,
   },
   {
     value: "gemini-2.0-flash",
     label: "gemini-2.0-flash",
-    note: "Previous generation, still solid for prose. Generous free-tier — a useful fallback when 2.5 models are exhausted.",
-    rpm: 15,
-    rpd: 1500,
+    note: "Solid for prose, unlimited daily requests. Best choice when upstream 2.5/3.1 tiers are spent.",
+    rpm: 2000,
+    rpd: 999999,
     maxOutputTokens: 7500,
     recommended: true,
   },
   {
+    value: "gemini-3.1-flash-lite",
+    label: "gemini-3.1-flash-lite",
+    note: "Newest lite model — 150K daily requests. Drops nuance on dialogue but very high capacity.",
+    rpm: 4000,
+    rpd: 150000,
+    maxOutputTokens: 7500,
+    recommended: false,
+  },
+  {
     value: "gemini-2.5-flash-lite",
     label: "gemini-2.5-flash-lite",
-    note: "Drops nuance on dialogue and metaphor. Usable only as a last-ditch fallback.",
-    rpm: 15,
-    rpd: 1000,
+    note: "Fast & cheap, unlimited daily requests. Usable only as a last-ditch fallback for literature.",
+    rpm: 4000,
+    rpd: 999999,
     maxOutputTokens: 7500,
     recommended: false,
   },
   {
     value: "gemini-2.0-flash-lite",
     label: "gemini-2.0-flash-lite",
-    note: "Lowest quality in the 2.0 line. Not recommended for literature.",
-    rpm: 30,
-    rpd: 1500,
+    note: "Lowest-quality flash-lite. Unlimited daily requests — use as a volume fallback.",
+    rpm: 4000,
+    rpd: 999999,
     maxOutputTokens: 7500,
     recommended: false,
   },
   {
     value: "",
     label: "Default (gemini-3.1-flash-lite-preview)",
-    note: "Server default — a lite/preview model. Same one used for chat and insights. Not recommended for literary work; kept for backward compat.",
-    rpm: 12,
-    rpd: 1400,
+    note: "Server default — same model used for chat/insights. Not recommended for literary work; kept for backward compat.",
+    rpm: 4000,
+    rpd: 150000,
     maxOutputTokens: 7500,
     recommended: false,
   },
@@ -100,9 +118,15 @@ export function isRecommended(model: string): boolean {
   return hit?.recommended ?? false;
 }
 
-// Suggested default chain — all three "Tier 1" models in quality order.
-// The worker will try them in this order and advance to the next on 429.
+// Suggested default chain — recommended models in quality order. The worker
+// tries them in order and advances on 429/quota. Starts frontier (3.1-pro)
+// and descends to the highest-RPD model as a catch-all.
+//   3.1-pro  → 250/day  at top quality
+//   2.5-pro  → 1K/day  near-frontier
+//   2.5-flash → 10K/day strong literary
+//   2.0-flash → unlimited safety net
 export const DEFAULT_CHAIN: string[] = [
+  "gemini-3.1-pro",
   "gemini-2.5-pro",
   "gemini-2.5-flash",
   "gemini-2.0-flash",


### PR DESCRIPTION
## Summary

Paid Tier 1 is active — this PR picks up the real per-model quotas from the admin's `aistudio.google.com/rate-limit` dashboard, adds the two frontier **3.1** models now available, ships a curated default chain, and adds a **cost estimate panel** to the Queue tab.

### Tier 1 quotas (now live in `MODEL_LIMITS`)

| Model | RPM | RPD | Output budget | Notes |
|---|---|---|---|---|
| **gemini-3.1-pro** | 25 | 250 | 60K | Frontier — reserve for high-value books |
| gemini-2.5-pro | 150 | 1,000 | 60K | Near-frontier |
| **gemini-3.1-flash-lite** | 4,000 | 150K | 7.5K | Bulk lite |
| gemini-2.5-flash | 1,000 | 10K | 7.5K | Strong literary |
| gemini-2.5-flash-lite | 4,000 | ∞ | 7.5K | Volume |
| gemini-2.0-flash | 2,000 | ∞ | 7.5K | Safety-net |
| gemini-2.0-flash-lite | 4,000 | ∞ | 7.5K | Volume |

Per request: 3.1 family only — skipping 3.0/`gemini-3-flash`.

### Curated default chain

First-time admins with no `queue_model_chain` saved get:

```
gemini-3.1-pro → gemini-2.5-pro → gemini-2.5-flash → gemini-2.0-flash
```

Top quality → descends to the highest-RPD safety-net. Overridable from the UI.

### Cost estimate panel

New admin-only endpoint `GET /admin/queue/cost-estimate` returns ballpark USD to drain the pending queue on each model, plus total input/output token estimates. Rendered in the Queue tab as a grid of per-model prices so admins can decide whether to route through the frontier tier or save money with flash.

Pricing is hardcoded in `MODEL_LIMITS` (`input_usd_per_m`, `output_usd_per_m`) using Google's public Tier 1 rates. If Google changes pricing, updating one map is enough.

## Test plan

- [x] Backend: 348 tests pass (2 new: cost estimate per-model breakdown + default-chain fallback)
- [x] Frontend: 126 tests pass
- [x] `next build` passes

Generated with [Claude Code](https://claude.com/claude-code)
