### PR TITLE
feat(queue): one-click chain presets (Budget / Balanced / Premium)

### DIFF
--- a/frontend/src/__tests__/chainPresets.test.ts
+++ b/frontend/src/__tests__/chainPresets.test.ts
@@ -1,0 +1,36 @@
+import {
+  CHAIN_PRESETS,
+  DEFAULT_CHAIN,
+  presetMatchingChain,
+} from "@/lib/geminiModels";
+
+describe("chain presets", () => {
+  it("exposes exactly the three intent-named presets", () => {
+    expect(CHAIN_PRESETS.map((p) => p.id)).toEqual([
+      "budget",
+      "balanced",
+      "premium",
+    ]);
+  });
+
+  it("premium preset matches the app-wide DEFAULT_CHAIN", () => {
+    // Keeping the default in sync with the "premium" preset is what makes a
+    // fresh admin see "premium" highlighted without having to save anything.
+    const premium = CHAIN_PRESETS.find((p) => p.id === "premium")!;
+    expect(premium.chain).toEqual(DEFAULT_CHAIN);
+  });
+
+  it("presetMatchingChain returns the preset id when chain matches exactly", () => {
+    for (const p of CHAIN_PRESETS) {
+      expect(presetMatchingChain(p.chain)).toBe(p.id);
+    }
+  });
+
+  it("returns null for chains that don't match any preset", () => {
+    expect(presetMatchingChain(["gemini-3.1-pro"])).toBeNull();
+    expect(presetMatchingChain([])).toBeNull();
+    expect(
+      presetMatchingChain(["gemini-2.5-flash", "gemini-2.5-pro"]),
+    ).toBeNull(); // right models, wrong order
+  });
+});

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -1,10 +1,12 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
 import {
-  GEMINI_MODEL_OPTIONS,
+  CHAIN_PRESETS,
   DEFAULT_CHAIN,
-  labelForModel,
+  GEMINI_MODEL_OPTIONS,
   isRecommended,
+  labelForModel,
+  presetMatchingChain,
   rateForModel,
 } from "@/lib/geminiModels";
 
@@ -458,6 +460,47 @@ export default function QueueTab({ adminFetch }: Props) {
                   <span className="font-mono text-emerald-700">{s.current_model}</span>
                 </div>
               ) : null}
+            </div>
+
+            {/* Preset strip — one-click chains that map admin intent to a
+                concrete model ordering. Clicking applies to form state;
+                admin still saves explicitly via "Save chain". */}
+            <div className="mt-2 rounded-lg border border-amber-100 bg-amber-50/30 p-2">
+              <div className="text-xs text-stone-600 mb-1">
+                Quick presets (click to load a chain):
+              </div>
+              <div className="grid sm:grid-cols-3 gap-2">
+                {CHAIN_PRESETS.map((p) => {
+                  const active = presetMatchingChain(chain) === p.id;
+                  return (
+                    <button
+                      key={p.id}
+                      onClick={() => setChain([...p.chain])}
+                      className={`text-left p-2 rounded-lg border transition-colors ${
+                        active
+                          ? "border-amber-500 bg-amber-100/60"
+                          : "border-amber-200 bg-white hover:bg-amber-50"
+                      }`}
+                    >
+                      <div className="flex items-baseline justify-between gap-2">
+                        <span className="text-sm font-medium text-ink">
+                          {p.label}
+                        </span>
+                        {active && (
+                          <span className="text-[10px] text-amber-700">selected</span>
+                        )}
+                      </div>
+                      <div className="text-[11px] text-amber-700">{p.tagline}</div>
+                      <div className="text-[11px] text-stone-500 mt-1 leading-snug">
+                        {p.description}
+                      </div>
+                      <div className="text-[10px] font-mono text-stone-400 mt-1 truncate">
+                        {p.chain.join(" → ")}
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
             </div>
 
             {/* Configured chain — reorder / remove */}

--- a/frontend/src/lib/geminiModels.ts
+++ b/frontend/src/lib/geminiModels.ts
@@ -131,3 +131,60 @@ export const DEFAULT_CHAIN: string[] = [
   "gemini-2.5-flash",
   "gemini-2.0-flash",
 ];
+
+// Named presets that map admin intent ("cheap drafts" / "quality without
+// breaking the bank" / "best money can buy") to a concrete chain. Picking a
+// preset populates the chain picker; admin still saves explicitly.
+export interface ChainPreset {
+  id: "budget" | "balanced" | "premium";
+  label: string;
+  tagline: string;
+  description: string;
+  chain: string[];
+}
+
+export const CHAIN_PRESETS: ChainPreset[] = [
+  {
+    id: "budget",
+    label: "Budget",
+    tagline: "Cheap, unlimited capacity",
+    description:
+      "Flash-class models only. Good for first-pass drafts or non-literary target languages where nuance matters less. Unlimited daily requests — drain a whole library in one run.",
+    chain: ["gemini-2.0-flash", "gemini-2.0-flash-lite"],
+  },
+  {
+    id: "balanced",
+    label: "Balanced",
+    tagline: "Strong prose, affordable",
+    description:
+      "2.5-flash leads for its near-pro literary quality; 2.0-flash catches overflow. The sweet spot for most libraries — clearly better than lite, a fraction of the pro cost.",
+    chain: ["gemini-2.5-flash", "gemini-2.0-flash"],
+  },
+  {
+    id: "premium",
+    label: "Premium",
+    tagline: "Frontier top, graceful degradation",
+    description:
+      "Start with 3.1-pro for the most faithful literary rendering; cascade to 2.5-pro, 2.5-flash, then 2.0-flash as daily quotas are spent. The default chain — best overall quality.",
+    chain: [
+      "gemini-3.1-pro",
+      "gemini-2.5-pro",
+      "gemini-2.5-flash",
+      "gemini-2.0-flash",
+    ],
+  },
+];
+
+export function presetMatchingChain(
+  chain: readonly string[],
+): ChainPreset["id"] | null {
+  for (const p of CHAIN_PRESETS) {
+    if (
+      p.chain.length === chain.length &&
+      p.chain.every((m, i) => m === chain[i])
+    ) {
+      return p.id;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
Admins were building the fallback chain model-by-model, which didn't map to the intents they actually had. Three named presets now cover the common cases:

| Preset | Chain | Intent |
|---|---|---|
| **Budget** | `2.0-flash → 2.0-flash-lite` | Unlimited RPD, cheap drafts, non-literary languages |
| **Balanced** | `2.5-flash → 2.0-flash` | Near-pro literary quality at a fraction of the pro cost |
| **Premium** | `3.1-pro → 2.5-pro → 2.5-flash → 2.0-flash` | Frontier at top, graceful degradation (same as `DEFAULT_CHAIN`) |

Rendered in the Queue tab as a 3-card strip above the chain list. Clicking a preset populates the form; admin still has to hit **Save chain** to persist. A "selected" badge appears when the current form chain matches a preset exactly.

## Test plan
- [x] Backend: 348 tests pass
- [x] Frontend: 130 tests pass (4 new covering preset match + default-chain sync)
- [x] `next build` passes

Generated with [Claude Code](https://claude.com/claude-code)