### PR TITLE
feat(queue): self-cleaning + reader-page queue awareness + fix 3.1 model IDs

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -101,6 +101,23 @@ async def translation_status(book_id: int, target_language: str):
     }
 
 
+@router.get("/{book_id}/chapters/{chapter_index}/queue-status")
+async def chapter_queue_status(
+    book_id: int,
+    chapter_index: int,
+    target_language: str,
+    _user: dict = Depends(get_current_user),
+):
+    """Per-chapter queue lookup for the reader page.
+
+    Any logged-in user can call this — the reader needs it before firing an
+    on-demand translate to avoid duplicating work the background worker is
+    already scheduled to do.
+    """
+    from services.translation_queue import queue_status_for_chapter
+    return await queue_status_for_chapter(book_id, chapter_index, target_language)
+
+
 @router.get("/{book_id}")
 async def book_meta(book_id: int):
     cached = await get_cached_book(book_id)

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -286,6 +286,20 @@ async def save_translation(
         )
         await db.commit()
 
+    # Self-cleaning queue: any pending/running row for this (book, chapter,
+    # lang) gets marked 'done' so the worker doesn't claim and skip-cache
+    # later. Works for all save paths: reader on-demand, bulk job, manual
+    # retranslate, and even the worker's own save (no-op in that case).
+    # Lazy import for cycle safety; non-fatal on error.
+    try:
+        from services.translation_queue import mark_queue_row_done
+        await mark_queue_row_done(book_id, chapter_index, target_language)
+    except Exception:
+        import logging
+        logging.getLogger(__name__).warning(
+            "Queue cleanup after save_translation failed", exc_info=True,
+        )
+
 
 async def count_translations_for_book(book_id: int, target_language: str) -> int:
     """Count how many chapters of a book have a translation cached."""

--- a/backend/services/model_limits.py
+++ b/backend/services/model_limits.py
@@ -26,7 +26,7 @@ class _Limits(TypedDict):
 # descending to highest-RPD model as a catch-all safety net. Overridable
 # via the Queue settings UI.
 DEFAULT_CHAIN: list[str] = [
-    "gemini-3.1-pro",
+    "gemini-3.1-pro-preview",
     "gemini-2.5-pro",
     "gemini-2.5-flash",
     "gemini-2.0-flash",
@@ -50,11 +50,11 @@ MODEL_LIMITS: dict[str, _Limits] = {
         "input_usd_per_m": 0.10, "output_usd_per_m": 0.40,
     },
     # Frontier 3.1 family
-    "gemini-3.1-pro": {
+    "gemini-3.1-pro-preview": {
         "rpm": 25, "rpd": 250, "max_output_tokens": 60000,
         "input_usd_per_m": 1.25, "output_usd_per_m": 10.00,
     },
-    "gemini-3.1-flash-lite": {
+    "gemini-3.1-flash-lite-preview": {
         "rpm": 4000, "rpd": 150000, "max_output_tokens": 7500,
         "input_usd_per_m": 0.10, "output_usd_per_m": 0.40,
     },

--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -358,6 +358,69 @@ async def queue_summary() -> dict:
     return {"counts": counts, "by_book": by_book}
 
 
+async def mark_queue_row_done(
+    book_id: int, chapter_index: int, target_language: str,
+) -> int:
+    """Mark any pending/running row for this (book, chapter, lang) as done.
+
+    Called from save_translation so that when a translation lands from ANY
+    source — reader on-demand, bulk job, manual retranslate, queue worker
+    itself — any queued duplicate is retired immediately and the worker
+    doesn't waste a claim-then-skip tick on it.
+
+    Returns the number of rows updated (usually 0 or 1).
+    """
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        cursor = await db.execute(
+            """UPDATE translation_queue
+               SET status='done', updated_at=CURRENT_TIMESTAMP
+               WHERE book_id=? AND chapter_index=? AND target_language=?
+                 AND status IN ('pending', 'running')""",
+            (book_id, chapter_index, target_language),
+        )
+        await db.commit()
+        return cursor.rowcount
+
+
+async def queue_status_for_chapter(
+    book_id: int, chapter_index: int, target_language: str,
+) -> dict:
+    """User-facing view of one chapter's queue state.
+
+    Used by the reader page to decide whether to fire an on-demand
+    translate (not queued) or wait for the background worker (queued).
+    """
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            """SELECT id, status, priority, attempts FROM translation_queue
+               WHERE book_id=? AND chapter_index=? AND target_language=?""",
+            (book_id, chapter_index, target_language),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if not row:
+            return {
+                "queued": False, "status": None,
+                "position": None, "attempts": 0,
+            }
+        # Rough position: how many pending rows are ahead of this one in the
+        # (priority, id) ordering the worker uses.
+        async with db.execute(
+            """SELECT COUNT(*) FROM translation_queue
+               WHERE status='pending' AND (
+                  priority < ? OR (priority = ? AND id < ?)
+               )""",
+            (row["priority"], row["priority"], row["id"]),
+        ) as cursor:
+            (ahead,) = await cursor.fetchone()
+    return {
+        "queued": row["status"] in ("pending", "running"),
+        "status": row["status"],
+        "position": (ahead + 1) if row["status"] == "pending" else 0,
+        "attempts": row["attempts"],
+    }
+
+
 async def clear_queue(status: str | None = None) -> int:
     """Delete ALL queue rows, or only rows matching a specific status.
 

--- a/backend/tests/test_translation_queue.py
+++ b/backend/tests/test_translation_queue.py
@@ -190,6 +190,61 @@ async def test_worker_creates_per_model_limiter_with_correct_rates(tmp_db):
     assert (lim.rpm, lim.rpd) == (150, 1000)
 
 
+async def test_save_translation_auto_clears_pending_queue_row(tmp_db):
+    """save_translation must mark any matching pending/running queue row as
+    done so the worker doesn't claim+skip it later."""
+    from services.db import save_translation
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    await enqueue(1, 0, "zh")
+    # Sanity: row starts as pending.
+    rows = await list_queue(status="pending")
+    assert len(rows) == 1
+
+    await save_translation(1, 0, "zh", ["done"], provider="gemini")
+
+    # Post-condition: the queue row is now 'done', not pending.
+    pending = await list_queue(status="pending")
+    assert pending == []
+    done = await list_queue(status="done")
+    assert len(done) == 1
+    assert done[0]["book_id"] == 1
+
+
+async def test_save_translation_ignores_unrelated_queue_rows(tmp_db):
+    """A save for (1, 0, zh) must not touch (1, 1, zh) or (1, 0, de)."""
+    from services.db import save_translation
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    await enqueue(1, 0, "zh")
+    await enqueue(1, 1, "zh")
+    await enqueue(1, 0, "de")
+
+    await save_translation(1, 0, "zh", ["x"])
+
+    remaining_pending = {(r["chapter_index"], r["target_language"])
+                         for r in await list_queue(status="pending")}
+    assert remaining_pending == {(1, "zh"), (0, "de")}
+
+
+async def test_queue_status_for_chapter_reports_position(tmp_db):
+    """The reader-page status lookup returns the right position + status."""
+    from services.translation_queue import queue_status_for_chapter
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    # No row yet → not queued.
+    none = await queue_status_for_chapter(1, 0, "zh")
+    assert none == {"queued": False, "status": None, "position": None, "attempts": 0}
+
+    # Enqueue three; (1, 0, zh) is second in line because it's enqueued
+    # second but shares priority 100 with the first row.
+    await enqueue(2, 0, "zh", priority=100)   # id=1, ahead
+    await enqueue(1, 0, "zh", priority=100)   # id=2, ours
+    await enqueue(3, 0, "zh", priority=100)   # id=3, behind
+
+    status = await queue_status_for_chapter(1, 0, "zh")
+    assert status["queued"] is True
+    assert status["status"] == "pending"
+    assert status["position"] == 2
+
+
 async def test_estimate_queue_cost_returns_per_model_breakdown(tmp_db):
     """Cost estimate must give a non-zero USD figure per model when there's
     pending work, and zero when there's none."""
@@ -220,7 +275,7 @@ async def test_default_chain_applied_when_no_setting(tmp_db):
     a sensible chain out of the box."""
     from services.translation_queue import get_model_chain
     chain = await get_model_chain()
-    assert chain[0] == "gemini-3.1-pro"
+    assert chain[0] == "gemini-3.1-pro-preview"
     assert "gemini-2.5-pro" in chain
     assert "gemini-2.0-flash" in chain
 

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { getBookChapters, translateText, getTranslationCache, saveTranslationCache, deleteTranslationCache, getAudiobook, deleteAudiobook, synthesizeSpeech, getMe, getBookTranslationStatus, TranslationStatus, BookMeta, BookChapter, Audiobook } from "@/lib/api";
+import { getBookChapters, translateText, getTranslationCache, saveTranslationCache, deleteTranslationCache, getAudiobook, deleteAudiobook, synthesizeSpeech, getMe, getBookTranslationStatus, getChapterQueueStatus, TranslationStatus, BookMeta, BookChapter, Audiobook } from "@/lib/api";
 import { recordRecentBook, saveLastChapter, getLastChapter } from "@/lib/recentBooks";
 import { getSettings, saveSettings, FontSize, Theme, TranslationProvider } from "@/lib/settings";
 import InsightChat, { LANGUAGES } from "@/components/InsightChat";
@@ -236,8 +236,48 @@ export default function ReaderPage() {
         return;
       }
 
-      // 2. No cache — translate progressively in batches of ~3 paragraphs.
-      //    Each batch appears as soon as it's done.
+      // 2. No cache — before firing fresh API calls, check if the queue
+      //    worker is already scheduled to translate this chapter. If so,
+      //    wait for it (poll cache) instead of duplicating the call.
+      try {
+        const q = await getChapterQueueStatus(bid, chapterIndex, translationLang);
+        if (q.queued) {
+          setTranslationUsedProvider(
+            q.status === "running"
+              ? "queued · translating now"
+              : `queued · position ${q.position ?? "?"}`,
+          );
+          // Poll for cache landing, up to ~90s. Background worker advances
+          // ~1 batch/6s typically; if it's further out, fall through to
+          // on-demand translate rather than blocking the reader forever.
+          const POLL_MS = 3000;
+          const MAX_POLLS = 30;
+          for (let i = 0; i < MAX_POLLS; i++) {
+            await new Promise((r) => setTimeout(r, POLL_MS));
+            if (cancelled || currentChapterKey.current !== cacheKey) return;
+            const latest = await getTranslationCache(bid, chapterIndex, translationLang);
+            if (latest) {
+              translationCache.current.set(cacheKey, latest.paragraphs);
+              setTranslatedParagraphs(latest.paragraphs);
+              const providerLabel = latest.provider
+                ? (latest.model ? `${latest.provider} (${latest.model})` : latest.provider)
+                : "queue · cached";
+              setTranslationUsedProvider(providerLabel);
+              setTranslationLoading(false);
+              return;
+            }
+          }
+          // Timeout — fall through to on-demand translate below.
+          setTranslationUsedProvider("queue timeout · translating now");
+        }
+      } catch {
+        // If the queue-status lookup fails, just do on-demand as before.
+      }
+
+      if (cancelled || currentChapterKey.current !== cacheKey) return;
+
+      // 3. Still nothing cached — translate progressively in batches of ~3
+      //    paragraphs. Each batch appears as soon as it's done.
       const BATCH_SIZE = 3;
       const paragraphs = current.text.split(/\n\n+/).filter((p: string) => p.trim());
       const batches: string[][] = [];

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -228,6 +228,28 @@ export function getBookTranslationStatus(
   );
 }
 
+/** Is a specific chapter queued for background translation?
+ * Returned by the reader page before it fires an on-demand translate —
+ * if the chapter is already pending/running, we wait for the worker
+ * instead of duplicating the call.
+ */
+export interface ChapterQueueStatus {
+  queued: boolean;
+  status: "pending" | "running" | "done" | "failed" | "skipped" | null;
+  position: number | null; // 1-based position among pending rows
+  attempts: number;
+}
+
+export function getChapterQueueStatus(
+  bookId: number,
+  chapterIndex: number,
+  targetLanguage: string,
+): Promise<ChapterQueueStatus> {
+  return request<ChapterQueueStatus>(
+    `/books/${bookId}/chapters/${chapterIndex}/queue-status?target_language=${encodeURIComponent(targetLanguage)}`,
+  );
+}
+
 /** Save a completed progressive translation to the backend cache. */
 export function saveTranslationCache(
   bookId: number,

--- a/frontend/src/lib/geminiModels.ts
+++ b/frontend/src/lib/geminiModels.ts
@@ -16,8 +16,8 @@ export interface ModelOption {
 // matching RPM/RPD to the queue settings so admins don't have to guess.
 export const GEMINI_MODEL_OPTIONS: ModelOption[] = [
   {
-    value: "gemini-3.1-pro",
-    label: "gemini-3.1-pro",
+    value: "gemini-3.1-pro-preview",
+    label: "gemini-3.1-pro-preview",
     note: "Frontier quality (3.1 family). Low RPD — reserve for the most important books. Packs up to 60K output tokens per batch.",
     rpm: 25,
     rpd: 250,
@@ -52,8 +52,8 @@ export const GEMINI_MODEL_OPTIONS: ModelOption[] = [
     recommended: true,
   },
   {
-    value: "gemini-3.1-flash-lite",
-    label: "gemini-3.1-flash-lite",
+    value: "gemini-3.1-flash-lite-preview",
+    label: "gemini-3.1-flash-lite-preview",
     note: "Newest lite model — 150K daily requests. Drops nuance on dialogue but very high capacity.",
     rpm: 4000,
     rpd: 150000,
@@ -126,7 +126,7 @@ export function isRecommended(model: string): boolean {
 //   2.5-flash → 10K/day strong literary
 //   2.0-flash → unlimited safety net
 export const DEFAULT_CHAIN: string[] = [
-  "gemini-3.1-pro",
+  "gemini-3.1-pro-preview",
   "gemini-2.5-pro",
   "gemini-2.5-flash",
   "gemini-2.0-flash",
@@ -167,7 +167,7 @@ export const CHAIN_PRESETS: ChainPreset[] = [
     description:
       "Start with 3.1-pro for the most faithful literary rendering; cascade to 2.5-pro, 2.5-flash, then 2.0-flash as daily quotas are spent. The default chain — best overall quality.",
     chain: [
-      "gemini-3.1-pro",
+      "gemini-3.1-pro-preview",
       "gemini-2.5-pro",
       "gemini-2.5-flash",
       "gemini-2.0-flash",


### PR DESCRIPTION
Three interlocking fixes so the reader and the queue stop doing duplicate work.

### 1. `save_translation` auto-cleans matching queue rows
Whenever a translation lands from ANY source — reader on-demand, bulk job, manual retranslate, worker itself — any pending/running queue row for the same `(book, chapter, lang)` is marked `done`. The worker no longer wastes a claim+skip-cache tick. Lazy-imported, non-fatal on error.

### 2. Reader page checks the queue before firing on-demand translate
New **user-facing** endpoint `GET /books/{id}/chapters/{idx}/queue-status` returns `{queued, status, position, attempts}`. The reader calls it between the cache-check and the fresh-translate fallback. If queued, shows `queued · position N` and polls the cache (3s interval, 90s cap). On timeout it falls through to on-demand so the reader is never blocked indefinitely.

### 3. Correct Gemini 3.x API identifiers
The AI Studio dashboard label "Gemini 3.1 Pro" maps to the API id `gemini-3.1-pro-preview` (not `gemini-3.1-pro`); same for `gemini-3.1-flash-lite-preview`. Picking pro from the UI was returning 404. Both `MODEL_LIMITS`, `GEMINI_MODEL_OPTIONS`, `DEFAULT_CHAIN`, and the Premium preset are updated.

## Test plan

- [x] Backend: 351 tests pass (3 new — self-cleaning happy path + unrelated-row isolation + queue-status positional lookup)
- [x] Frontend: 130 tests pass
- [x] `next build` passes

Generated with [Claude Code](https://claude.com/claude-code)