### PR TITLE
feat(queue): auto-rescan on idle + startup self-heal

### DIFF
--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -146,7 +146,7 @@ async def enqueue(
     priority: int = 100,
     reset_failed: bool = False,
     queued_by: str | None = None,
-) -> None:
+) -> int:
     """Insert (or no-op) a single queue item.
 
     If `reset_failed=True`, an existing row whose status is 'failed' or 'done'
@@ -154,10 +154,14 @@ async def enqueue(
 
     `queued_by` is a free-form label — usually the admin's email. NULL
     means the row was auto-enqueued by save_book and no admin is attributable.
+
+    Returns rowcount from the underlying write (1 if a new row was
+    inserted or an existing row was revived; 0 if the INSERT OR IGNORE
+    path no-op'd because a non-stale row already exists).
     """
     async with aiosqlite.connect(db_module.DB_PATH) as db:
         if reset_failed:
-            await db.execute(
+            cursor = await db.execute(
                 """INSERT INTO translation_queue
                        (book_id, chapter_index, target_language, priority, status, queued_by)
                    VALUES (?, ?, ?, ?, 'pending', ?)
@@ -171,13 +175,14 @@ async def enqueue(
                 (book_id, chapter_index, target_language, priority, queued_by),
             )
         else:
-            await db.execute(
+            cursor = await db.execute(
                 """INSERT OR IGNORE INTO translation_queue
                        (book_id, chapter_index, target_language, priority, queued_by)
                    VALUES (?, ?, ?, ?, ?)""",
                 (book_id, chapter_index, target_language, priority, queued_by),
             )
         await db.commit()
+        return cursor.rowcount
 
 
 async def enqueue_for_book(
@@ -215,13 +220,12 @@ async def enqueue_for_book(
                 continue
             if not reset_failed and await get_cached_translation(book_id, idx, lang):
                 continue
-            await enqueue(
+            inserted += await enqueue(
                 book_id, idx, lang,
                 priority=priority,
                 reset_failed=reset_failed,
                 queued_by=queued_by,
             )
-            inserted += 1
     return inserted
 
 
@@ -356,6 +360,44 @@ async def queue_summary() -> dict:
     for book_id, lang, status, n in rows:
         by_book.setdefault(book_id, {}).setdefault(lang, {})[status] = n
     return {"counts": counts, "by_book": by_book}
+
+
+async def rescan_for_missing_translations() -> int:
+    """Walk every cached book and enqueue (book, lang) pairs that are
+    configured for auto-translation but have untranslated chapters.
+
+    Idempotent — `enqueue_for_book` already skips chapters with existing
+    translations AND skips duplicate pending rows (unique index). Safe to
+    run on every idle tick.
+
+    Returns the number of newly-enqueued rows.
+    """
+    langs = await get_auto_languages()
+    if not langs:
+        return 0
+    # Lazy import to avoid cycle with services.db
+    from services.db import list_cached_books
+    books = await list_cached_books()
+    total = 0
+    for b in books:
+        total += await enqueue_for_book(b["id"], target_languages=langs)
+    return total
+
+
+async def reset_stale_running_rows() -> int:
+    """Any row still marked 'running' when the worker starts is stale —
+    the previous process crashed or was killed mid-batch. Reset them to
+    'pending' so the next claim picks them up. Priority-bumps and
+    attempt counts from prior failures are preserved.
+    """
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        cursor = await db.execute(
+            """UPDATE translation_queue
+               SET status='pending', updated_at=CURRENT_TIMESTAMP
+               WHERE status='running'""",
+        )
+        await db.commit()
+        return cursor.rowcount
 
 
 async def mark_queue_row_done(
@@ -543,6 +585,19 @@ class TranslationQueueWorker:
         assert self._stop_event is not None
         stop_event = self._stop_event
 
+        # Startup housekeeping: reset any rows left 'running' from a prior
+        # crash, and rescan the book library so newly-cached books or
+        # newly-configured languages are picked up immediately.
+        try:
+            stale = await reset_stale_running_rows()
+            if stale:
+                self._append_log({"event": "startup_reset_stale", "count": stale})
+            added = await rescan_for_missing_translations()
+            if added:
+                self._append_log({"event": "startup_rescan", "enqueued": added})
+        except Exception:
+            logger.exception("Startup housekeeping failed (non-fatal)")
+
         while not stop_event.is_set():
             try:
                 await self._tick()
@@ -576,6 +631,20 @@ class TranslationQueueWorker:
         # rebuild prior_context per chapter, which loses the cross-batch
         # consistency benefit.
         items = await self._claim_next_batch()
+        if not items:
+            # Before idling, rescan the library for work that's been added
+            # since the last tick — new books via save_book, or new languages
+            # added to auto_translate_languages. This makes "Queue every
+            # book" largely unnecessary: the worker finds missing work on
+            # its own within one idle poll cycle.
+            try:
+                added = await rescan_for_missing_translations()
+                if added:
+                    self._append_log({"event": "rescan_enqueued", "count": added})
+                    items = await self._claim_next_batch()
+            except Exception:
+                logger.exception("Idle rescan failed (non-fatal)")
+
         if not items:
             self._state.idle = True
             self._state.waiting_reason = "queue empty"

--- a/backend/tests/test_translation_queue.py
+++ b/backend/tests/test_translation_queue.py
@@ -190,6 +190,54 @@ async def test_worker_creates_per_model_limiter_with_correct_rates(tmp_db):
     assert (lim.rpm, lim.rpd) == (150, 1000)
 
 
+async def test_rescan_adds_newly_configured_language_without_admin_click(tmp_db):
+    """Admin adds a new target language to auto_translate_languages AFTER
+    books are already saved. The rescan helper should enqueue the missing
+    (book, new_lang) pairs on the next idle tick — no manual
+    'Queue every book' click required."""
+    from services.translation_queue import rescan_for_missing_translations
+    # Library exists, but no language configured yet.
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    await save_book(2, BOOK_META, BOOK_TEXT)
+    assert len(await list_queue()) == 0
+
+    # Admin picks zh + de as auto-translate languages.
+    await set_setting(SETTING_AUTO_LANGS, json.dumps(["zh", "de"]))
+
+    added = await rescan_for_missing_translations()
+    # 2 books × 2 langs × 2 chapters = 8 queue rows.
+    assert added == 8
+    all_langs = {r["target_language"] for r in await list_queue()}
+    assert all_langs == {"zh", "de"}
+
+
+async def test_rescan_is_idempotent(tmp_db):
+    """Calling rescan twice shouldn't stack duplicate rows — relies on the
+    unique (book, chapter, lang) index."""
+    from services.translation_queue import rescan_for_missing_translations
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    await set_setting(SETTING_AUTO_LANGS, json.dumps(["zh"]))
+    first = await rescan_for_missing_translations()
+    second = await rescan_for_missing_translations()
+    assert first > 0
+    assert second == 0
+
+
+async def test_reset_stale_running_rows_flips_to_pending(tmp_db):
+    """A process crash can leave rows stuck in 'running'. Startup cleanup
+    resets them so the next claim picks them up."""
+    from services.translation_queue import reset_stale_running_rows
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    await enqueue(1, 0, "zh")
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute("UPDATE translation_queue SET status='running'")
+        await db.commit()
+    n = await reset_stale_running_rows()
+    assert n == 1
+    pending = await list_queue(status="pending")
+    assert len(pending) == 1
+
+
 async def test_save_translation_auto_clears_pending_queue_row(tmp_db):
     """save_translation must mark any matching pending/running queue row as
     done so the worker doesn't claim+skip it later."""


### PR DESCRIPTION
Admins shouldn't have to click **Queue every book** when they add a new language or a new book lands. The worker now handles both cases automatically.

### Auto-rescan on idle
Every time the worker is about to sleep (queue appears empty), it walks the book library and enqueues any missing `(book, lang)` pairs for the currently-configured auto-translate languages. `enqueue_for_book` is idempotent thanks to the unique index, so repeated calls are safe.

**Effect**: admin adds "ja" to the configured languages → within ~10s the worker's next idle tick enqueues every book × ja → work starts immediately.

### Startup self-heal
When the worker starts (backend boot or Start button click), it does two housekeeping passes:

1. **Reset stale `running` rows** to `pending` — leftovers from a crashed prior process. Priority bumps and attempt counts preserved.
2. **Immediate rescan** so work that piled up while the worker was down gets picked up on the first tick.

### Idempotency fix
`enqueue()` now returns rowcount so `enqueue_for_book` counts actual inserts instead of attempted ones. Without this, the second identical rescan was reporting non-zero enqueues even though SQLite no-op'd via `INSERT OR IGNORE`.

### Settings changes still apply live
No queue wipe needed on restart — the per-model limiter logic from a prior PR already reads RPM/RPD/model fresh each batch.

## Test plan

- [x] Backend: 354 tests pass (3 new — auto-rescan picks up newly-configured language, rescan idempotency, stale-running reset)
- [x] Frontend: 130 tests pass

Generated with [Claude Code](https://claude.com/claude-code)