### PR TITLE
feat(queue): per-book language enqueue UI + user-import auto-enqueue

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -269,6 +269,28 @@ async def import_stream(
                 and len(chapters) > 0
             )
             if should_translate:
+                # Enqueue this book for the user's target language BEFORE the
+                # inline stream runs. Rationale: if the user closes their tab
+                # or the connection drops, the background worker picks up
+                # whatever chapters the stream didn't finish. The save_translation
+                # -> mark-queue-row-done hook clears rows as the inline stream
+                # completes them, so there's no double work in the happy path.
+                try:
+                    from services.translation_queue import enqueue_for_book, worker
+                    queued_by = user.get("email") or user.get("name") or f"user#{user.get('id')}"
+                    added = await enqueue_for_book(
+                        book_id,
+                        target_languages=[target_language],
+                        queued_by=queued_by,
+                    )
+                    if added:
+                        worker().wake()
+                except Exception:
+                    logger.warning(
+                        "Failed to pre-enqueue user import for book %s → %s",
+                        book_id, target_language, exc_info=True,
+                    )
+
                 # Resolve provider: prefer Gemini if user has a key, else Google (free)
                 provider = "gemini" if decrypted_key else "google"
                 yield _sse("stage", {

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -66,6 +66,9 @@ export default function AdminPage() {
   // can be further expanded to show per-chapter rows.
   const [expandedBookId, setExpandedBookId] = useState<number | null>(null);
   const [expandedLang, setExpandedLang] = useState<string | null>(null);
+  // One text input per-book, keyed by book id, for "Queue a new language"
+  const [newLangInput, setNewLangInput] = useState<Record<number, string>>({});
+  const [queueingLangFor, setQueueingLangFor] = useState<string | null>(null);
 
   useEffect(() => {
     getMe().then((me) => {
@@ -345,9 +348,59 @@ export default function AdminPage() {
                     {/* Expanded translation panel */}
                     {isExpanded && (
                       <div className="px-4 pb-4 pt-1 bg-amber-50/40 border-t border-amber-100">
+                        {/* Queue a new language for this book — short-circuits
+                            "add to auto_translate_languages + wait for rescan"
+                            when the admin wants just one book in one language. */}
+                        <div className="mb-3 flex items-center gap-2 text-xs">
+                          <span className="text-stone-500">Queue a language for this book:</span>
+                          <input
+                            placeholder="e.g. ja, fr, zh"
+                            value={newLangInput[b.id] ?? ""}
+                            onChange={(e) => setNewLangInput({ ...newLangInput, [b.id]: e.target.value })}
+                            onKeyDown={async (e) => {
+                              if (e.key === "Enter") (e.currentTarget.nextSibling as HTMLButtonElement | null)?.click();
+                            }}
+                            className="flex-1 max-w-[160px] rounded border border-amber-300 px-2 py-0.5 font-mono"
+                          />
+                          <button
+                            onClick={async () => {
+                              const raw = (newLangInput[b.id] ?? "").trim().toLowerCase();
+                              if (!raw) return;
+                              const key = `${b.id}:${raw}`;
+                              setQueueingLangFor(key);
+                              try {
+                                const res = await adminFetch("/admin/queue/enqueue-book", {
+                                  method: "POST",
+                                  body: JSON.stringify({
+                                    book_id: b.id,
+                                    target_languages: [raw],
+                                    // higher than auto-enqueue default of 100
+                                    // so this specific request jumps the line.
+                                    priority: 50,
+                                  }),
+                                });
+                                alert(`Queued ${res.enqueued} chapter(s) of "${b.title}" → ${raw}.`);
+                                setNewLangInput({ ...newLangInput, [b.id]: "" });
+                                await loadAll({ silent: true });
+                              } catch (e: unknown) {
+                                alert(e instanceof Error ? e.message : "Enqueue failed");
+                              } finally {
+                                setQueueingLangFor(null);
+                              }
+                            }}
+                            disabled={queueingLangFor === `${b.id}:${(newLangInput[b.id] ?? "").trim().toLowerCase()}`}
+                            className="text-xs px-2 py-0.5 rounded bg-amber-700 text-white disabled:opacity-50"
+                          >
+                            {queueingLangFor?.startsWith(`${b.id}:`) ? "Queueing…" : "Queue"}
+                          </button>
+                          <span className="text-[10px] text-stone-400">
+                            (worker processes according to the configured chain)
+                          </span>
+                        </div>
+
                         {translatedLangs.length === 0 ? (
                           <p className="text-xs text-stone-500 italic">
-                            No translations cached yet. Run a bulk translation job or open the book to trigger on-demand translation.
+                            No translations cached yet. Use the input above to queue a language, or wait for the auto-translate languages to cover this book.
                           </p>
                         ) : (
                           <div className="space-y-2">


### PR DESCRIPTION
Two queue UX gaps, fixed in one PR.

### Admin Books tab: *Queue a language for this book*
Inside each expanded book row, a small input + button lets the admin queue one specific `(book, language)` pair **without** adding the language to `auto_translate_languages`. Short-circuits the "configure langs → wait for the next idle rescan" loop when the admin just wants one book translated into one extra language. Priority 50 so these admin-initiated requests jump ahead of the priority-100 auto-enqueue rows.

### User import → auto-enqueue for their target language
Answering *"when a user adds a book, does their target language get queued too?"* — previously **no**; `save_book` only enqueued for the admin's `auto_translate_languages`. Now when a user imports via `/books/{id}/import-stream` with a `target_language`, the backend enqueues that `(book, language)` pair right at the top of the stream.

**Why before the inline translate, not after**: if the user closes the tab or the connection drops mid-stream, the background worker picks up whatever chapters the stream didn't finish. The `save_translation → mark-queue-row-done` hook (prior PR) clears queue rows as the inline stream completes them, so the happy-path case has **no double work**. `queued_by` is set to the user's email for attribution in the admin queue panel.

## Test plan

- [x] Backend: 354 tests pass
- [x] Frontend: 130 tests pass
- [x] `next build` passes

Generated with [Claude Code](https://claude.com/claude-code)