### PR TITLE
fix(queue): sqlite lock 500s + balanced default + per-book cost + log wrap

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -21,6 +21,33 @@ DB_PATH = os.environ.get(
 )
 
 
+# ── Global aiosqlite tuning for concurrent writes ────────────────────────────
+#
+# By default sqlite3.connect uses `timeout=5.0` as its busy_timeout. Under the
+# always-on translation queue we have MANY overlapping writers:
+#   - worker writing translations + queue updates + rate_limiter_usage
+#   - admin PUT /queue/settings updating app_settings
+#   - save_book auto-enqueueing
+# A 5s window isn't always enough — admins were seeing
+# "database is locked" 500s on /admin/queue/settings. We monkey-patch
+# aiosqlite.connect to apply a 30-second busy timeout globally, which makes
+# SQLite retry the busy writer instead of failing fast. Combined with WAL
+# mode (set persistently in init_db), this eliminates the contention we
+# actually see in practice.
+
+_BUSY_TIMEOUT_ATTR = "_book_reader_ai_busy_timeout_patched"
+
+if not getattr(aiosqlite.connect, _BUSY_TIMEOUT_ATTR, False):
+    _original_aiosqlite_connect = aiosqlite.connect
+
+    def _aiosqlite_connect_with_busy_timeout(database, **kwargs):
+        kwargs.setdefault("timeout", 30)
+        return _original_aiosqlite_connect(database, **kwargs)
+
+    setattr(_aiosqlite_connect_with_busy_timeout, _BUSY_TIMEOUT_ATTR, True)
+    aiosqlite.connect = _aiosqlite_connect_with_busy_timeout
+
+
 async def init_db() -> None:
     """Ensure the database schema is up-to-date by running any pending
     versioned migrations from backend/migrations/*.sql.
@@ -44,6 +71,19 @@ async def init_db() -> None:
     if applied:
         import logging
         logging.getLogger(__name__).info("Applied %d migration(s): %s", len(applied), ", ".join(applied))
+
+    # Enable WAL journaling — concurrent readers don't block a writer, which
+    # is what our queue worker + admin settings + save_book paths constantly
+    # do. Persists across restarts once set on the file.
+    try:
+        async with aiosqlite.connect(DB_PATH) as db:
+            await db.execute("PRAGMA journal_mode=WAL")
+            await db.commit()
+    except Exception:
+        import logging
+        logging.getLogger(__name__).warning(
+            "Failed to enable WAL mode (non-fatal)", exc_info=True,
+        )
 
 
 async def get_or_create_user(google_id: str, email: str, name: str, picture: str) -> dict:

--- a/backend/services/model_limits.py
+++ b/backend/services/model_limits.py
@@ -22,12 +22,11 @@ class _Limits(TypedDict):
     output_usd_per_m: float
 
 
-# Curated default chain for first-time admins: frontier quality first, then
-# descending to highest-RPD model as a catch-all safety net. Overridable
-# via the Queue settings UI.
+# Curated default chain for first-time admins: the "Balanced" preset —
+# strong literary quality without the frontier pricing. Overridable via the
+# Queue settings UI; admins who want Premium (3.1-pro leading) or Budget
+# (flash-only) can one-click switch via the preset buttons.
 DEFAULT_CHAIN: list[str] = [
-    "gemini-3.1-pro-preview",
-    "gemini-2.5-pro",
     "gemini-2.5-flash",
     "gemini-2.0-flash",
 ]

--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -1003,7 +1003,7 @@ class TranslationQueueWorker:
         except asyncio.TimeoutError:
             pass
 
-    def _append_log(self, entry: dict, max_len: int = 30) -> None:
+    def _append_log(self, entry: dict, max_len: int = 100) -> None:
         entry["at"] = datetime.now(timezone.utc).isoformat()
         self._state.log.append(entry)
         if len(self._state.log) > max_len:

--- a/backend/tests/test_translation_queue.py
+++ b/backend/tests/test_translation_queue.py
@@ -323,8 +323,7 @@ async def test_default_chain_applied_when_no_setting(tmp_db):
     a sensible chain out of the box."""
     from services.translation_queue import get_model_chain
     chain = await get_model_chain()
-    assert chain[0] == "gemini-3.1-pro-preview"
-    assert "gemini-2.5-pro" in chain
+    assert chain[0] == "gemini-2.5-flash"
     assert "gemini-2.0-flash" in chain
 
 

--- a/frontend/src/__tests__/chainPresets.test.ts
+++ b/frontend/src/__tests__/chainPresets.test.ts
@@ -13,11 +13,11 @@ describe("chain presets", () => {
     ]);
   });
 
-  it("premium preset matches the app-wide DEFAULT_CHAIN", () => {
-    // Keeping the default in sync with the "premium" preset is what makes a
-    // fresh admin see "premium" highlighted without having to save anything.
-    const premium = CHAIN_PRESETS.find((p) => p.id === "premium")!;
-    expect(premium.chain).toEqual(DEFAULT_CHAIN);
+  it("balanced preset matches the app-wide DEFAULT_CHAIN", () => {
+    // Keeping the default in sync with the "balanced" preset is what makes a
+    // fresh admin see "balanced" highlighted without having to save anything.
+    const balanced = CHAIN_PRESETS.find((p) => p.id === "balanced")!;
+    expect(balanced.chain).toEqual(DEFAULT_CHAIN);
   });
 
   it("presetMatchingChain returns the preset id when chain matches exactly", () => {

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -106,6 +106,10 @@ export default function QueueTab({ adminFetch }: Props) {
   const [settings, setSettings] = useState<QueueSettings | null>(null);
   const [items, setItems] = useState<QueueItem[]>([]);
   const [cost, setCost] = useState<CostEstimate | null>(null);
+  // Flashes "Saved ✓" briefly after any successful setting save so the admin
+  // sees confirmation instead of wondering whether their click did anything.
+  // Maps a label ("chain", "api_key", etc.) → timestamp of last save.
+  const [lastSaved, setLastSaved] = useState<{ key: string; at: number } | null>(null);
   const [itemFilter, setItemFilter] = useState<"pending" | "running" | "failed" | "all">("pending");
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
@@ -164,7 +168,10 @@ export default function QueueTab({ adminFetch }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [itemFilter]);
 
-  async function saveSettings(patch: Record<string, unknown>) {
+  async function saveSettings(
+    patch: Record<string, unknown>,
+    label: string = "settings",
+  ) {
     setSaving(true);
     setError("");
     try {
@@ -172,12 +179,29 @@ export default function QueueTab({ adminFetch }: Props) {
         method: "PUT",
         body: JSON.stringify(patch),
       });
-      await refresh();
+      // Mark saved the moment the PUT succeeds — don't wait for refresh.
+      // If a periodic-poll or post-save refresh 500s, we'd otherwise
+      // misattribute that as a save failure.
+      setLastSaved({ key: label, at: Date.now() });
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Save failed");
-    } finally {
       setSaving(false);
+      return;
     }
+    // Refresh is best-effort — a transient 500 here shouldn't mask a
+    // successful save. The next 3s poll will pick up fresh state.
+    try {
+      await refresh();
+    } catch {
+      /* swallow — periodic poll will recover */
+    }
+    setSaving(false);
+  }
+
+  function wasJustSaved(label: string): boolean {
+    return (
+      lastSaved?.key === label && Date.now() - lastSaved.at < 3000
+    );
   }
 
   async function startWorker() {
@@ -316,14 +340,14 @@ export default function QueueTab({ adminFetch }: Props) {
             <summary className="text-xs text-amber-700 cursor-pointer">
               Activity log ({s.log.length})
             </summary>
-            <ul className="mt-1 text-xs space-y-0.5 max-h-40 overflow-y-auto">
+            <ul className="mt-1 text-xs space-y-1 max-h-60 overflow-y-auto">
               {s.log
                 .slice()
                 .reverse()
                 .map((e, i) => (
                   <li
                     key={i}
-                    className={`font-mono truncate ${
+                    className={`font-mono break-words whitespace-pre-wrap leading-snug ${
                       e.event.includes("error") || e.event === "tick_error"
                         ? "text-red-600"
                         : "text-stone-600"
@@ -426,25 +450,33 @@ export default function QueueTab({ adminFetch }: Props) {
               <label className="text-xs text-stone-600">
                 Model chain — tried in order. On 429/quota the worker falls to the next.
               </label>
-              <button
-                onClick={() => {
-                  // Save chain; primary's rate limits become the active
-                  // ones for legacy fields so bulk-translate etc. see them.
-                  const primary = chain[0] ?? "";
-                  const { rpm, rpd, maxOutputTokens } = rateForModel(primary);
-                  saveSettings({
-                    model_chain: chain,
-                    model: primary,
-                    rpm,
-                    rpd,
-                    max_output_tokens: maxOutputTokens,
-                  });
-                }}
-                disabled={saving || chain.length === 0}
-                className="text-xs px-3 py-0.5 rounded bg-amber-700 text-white disabled:opacity-50"
-              >
-                Save chain
-              </button>
+              <div className="flex items-center gap-2">
+                {wasJustSaved("chain") && (
+                  <span className="text-xs text-emerald-700">Saved ✓</span>
+                )}
+                <button
+                  onClick={() => {
+                    // Save chain; primary's rate limits become the active
+                    // ones for legacy fields so bulk-translate etc. see them.
+                    const primary = chain[0] ?? "";
+                    const { rpm, rpd, maxOutputTokens } = rateForModel(primary);
+                    saveSettings(
+                      {
+                        model_chain: chain,
+                        model: primary,
+                        rpm,
+                        rpd,
+                        max_output_tokens: maxOutputTokens,
+                      },
+                      "chain",
+                    );
+                  }}
+                  disabled={saving || chain.length === 0}
+                  className="text-xs px-3 py-0.5 rounded bg-amber-700 text-white disabled:opacity-50"
+                >
+                  Save chain
+                </button>
+              </div>
             </div>
 
             {/* Live summary — show the configured chain and what the
@@ -654,39 +686,116 @@ export default function QueueTab({ adminFetch }: Props) {
 
       {/* Cost analysis — back-of-envelope estimate of draining the pending queue
           across each model. Helps decide whether to route through pro vs flash. */}
-      {cost && cost.pending_items > 0 && (
-        <div className="bg-white rounded-xl border border-amber-200 p-4 space-y-2">
-          <div className="flex items-baseline justify-between">
-            <h3 className="font-medium text-ink">Cost estimate (to drain queue)</h3>
-            <span className="text-[11px] text-stone-500">
-              {cost.pending_items} pending across {cost.pending_books} book
-              {cost.pending_books === 1 ? "" : "s"} ·{" "}
-              ~{(cost.estimated_input_tokens / 1_000_000).toFixed(1)}M in /{" "}
-              ~{(cost.estimated_output_tokens / 1_000_000).toFixed(1)}M out tokens
-            </span>
-          </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-            {cost.per_model.map((row) => (
-              <div
-                key={row.model}
-                className="rounded-lg border border-amber-100 p-2 text-center"
-              >
-                <div className="text-[11px] text-stone-500 font-mono truncate">
-                  {row.model}
+      {cost && cost.pending_items > 0 && (() => {
+        const books = Math.max(1, cost.pending_books);
+        // Map the model rows by name so we can highlight what's in the
+        // configured chain vs. the full comparison grid.
+        const byModel: Record<string, number> = Object.fromEntries(
+          cost.per_model.map((r) => [r.model, r.usd]),
+        );
+        // The saved active chain (what the worker is actually going to use).
+        const activeChain = settings?.model_chain ?? [];
+        return (
+          <div className="bg-white rounded-xl border border-amber-200 p-4 space-y-3">
+            <div className="flex items-baseline justify-between flex-wrap gap-2">
+              <h3 className="font-medium text-ink">Cost estimate (to drain queue)</h3>
+              <span className="text-[11px] text-stone-500">
+                {cost.pending_items} pending across {cost.pending_books} book
+                {cost.pending_books === 1 ? "" : "s"} ·{" "}
+                ~{(cost.estimated_input_tokens / 1_000_000).toFixed(1)}M in /{" "}
+                ~{(cost.estimated_output_tokens / 1_000_000).toFixed(1)}M out tokens
+              </span>
+            </div>
+
+            {/* Chain-aware view: if the active chain's primary stays in
+                quota, this is the expected bill. Followed by per-book so
+                admins can reason about cost to translate one more title. */}
+            {activeChain.length > 0 && (
+              <div className="rounded-lg border border-emerald-200 bg-emerald-50/50 p-3">
+                <div className="text-[11px] text-emerald-700 font-medium mb-1">
+                  Active chain · {activeChain.map(labelForModel).join(" → ")}
                 </div>
-                <div className="text-sm font-semibold text-ink">
-                  ${row.usd.toFixed(2)}
+                <div className="flex flex-wrap gap-4 items-baseline">
+                  <div>
+                    <div className="text-[10px] text-stone-500">if primary handles all</div>
+                    <div className="text-lg font-semibold text-emerald-800">
+                      ${(
+                        byModel[activeChain[0]] ??
+                        byModel[activeChain[0] || ""] ??
+                        0
+                      ).toFixed(2)}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-[10px] text-stone-500">per book (avg)</div>
+                    <div className="text-lg font-semibold text-emerald-800">
+                      ${(
+                        (byModel[activeChain[0]] ??
+                          byModel[activeChain[0] || ""] ??
+                          0) / books
+                      ).toFixed(2)}
+                    </div>
+                  </div>
+                  {activeChain.length > 1 && (
+                    <div>
+                      <div className="text-[10px] text-stone-500">
+                        fallback min · {labelForModel(activeChain[activeChain.length - 1])}
+                      </div>
+                      <div className="text-lg font-semibold text-emerald-800">
+                        ${(
+                          byModel[activeChain[activeChain.length - 1]] ?? 0
+                        ).toFixed(2)}
+                      </div>
+                    </div>
+                  )}
                 </div>
               </div>
-            ))}
+            )}
+
+            {/* Grid: all models, with total + per-book so admins can
+                compare any alternative to their current chain. */}
+            <div>
+              <div className="text-[11px] text-stone-500 mb-1">
+                All models — total / per-book
+              </div>
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                {cost.per_model.map((row) => {
+                  const inChain = activeChain.includes(row.model)
+                    || (row.model === "default" && activeChain.includes(""));
+                  return (
+                    <div
+                      key={row.model}
+                      className={`rounded-lg border p-2 text-center ${
+                        inChain
+                          ? "border-emerald-300 bg-emerald-50/40"
+                          : "border-amber-100"
+                      }`}
+                    >
+                      <div className="text-[11px] text-stone-500 font-mono truncate">
+                        {row.model}
+                      </div>
+                      <div className="text-sm font-semibold text-ink">
+                        ${row.usd.toFixed(2)}
+                      </div>
+                      <div className="text-[10px] text-stone-400">
+                        ${(row.usd / books).toFixed(3)}/book
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            <p className="text-[11px] text-stone-400">
+              Rough estimate — assumes ~3 chars/token and 1:1 input-to-output ratio.
+              Actual cost depends on tokenizer, chapter lengths, and batching.
+              Chain advance on 429/quota means multiple models may contribute — the
+              &quot;fallback min&quot; shows the floor if every batch runs on the cheapest
+              chain member.
+            </p>
           </div>
-          <p className="text-[11px] text-stone-400">
-            Rough estimate — assumes ~3 chars/token and 1:1 input-to-output ratio.
-            Actual cost depends on tokenizer, chapter lengths, and batching.
-            Chain advance on 429 means multiple models may contribute.
-          </p>
-        </div>
-      )}
+        );
+      })()}
 
       {/* Queue items */}
       <div className="bg-white rounded-xl border border-amber-200 overflow-hidden">

--- a/frontend/src/lib/geminiModels.ts
+++ b/frontend/src/lib/geminiModels.ts
@@ -118,16 +118,11 @@ export function isRecommended(model: string): boolean {
   return hit?.recommended ?? false;
 }
 
-// Suggested default chain — recommended models in quality order. The worker
-// tries them in order and advances on 429/quota. Starts frontier (3.1-pro)
-// and descends to the highest-RPD model as a catch-all.
-//   3.1-pro  → 250/day  at top quality
-//   2.5-pro  → 1K/day  near-frontier
-//   2.5-flash → 10K/day strong literary
-//   2.0-flash → unlimited safety net
+// Suggested default chain — matches the "Balanced" preset. Strong literary
+// quality without the frontier pricing, cascades to unlimited-RPD 2.0-flash
+// as a safety net. Admins who want Premium or Budget can one-click switch
+// via the preset buttons in the Queue tab.
 export const DEFAULT_CHAIN: string[] = [
-  "gemini-3.1-pro-preview",
-  "gemini-2.5-pro",
   "gemini-2.5-flash",
   "gemini-2.0-flash",
 ];
@@ -165,7 +160,7 @@ export const CHAIN_PRESETS: ChainPreset[] = [
     label: "Premium",
     tagline: "Frontier top, graceful degradation",
     description:
-      "Start with 3.1-pro for the most faithful literary rendering; cascade to 2.5-pro, 2.5-flash, then 2.0-flash as daily quotas are spent. The default chain — best overall quality.",
+      "Start with 3.1-pro for the most faithful literary rendering; cascade to 2.5-pro, 2.5-flash, then 2.0-flash as daily quotas are spent. Expensive but produces the best output.",
     chain: [
       "gemini-3.1-pro-preview",
       "gemini-2.5-pro",


### PR DESCRIPTION
Four items from your screenshot + activity log, one PR.

### 1. Root cause of *Save chain not working*: SQLite 'database is locked'
Console showed `PUT /admin/queue/settings → 500` and your activity log showed `! retry — database is locked`. Cause: overlapping writers — the queue worker and the admin PUT both hitting the same DB. Two fixes:

- **Global aiosqlite busy_timeout=30s** (up from sqlite's default 5s) so writers wait instead of fail fast. Applied once via a guarded monkey-patch in `services/db.py`.
- **WAL journal mode** enabled in `init_db` — persists across restarts; readers no longer block writers. This is the structural fix.

Plus: `saveSettings` no longer conflates *PUT failed* with *refresh-after-PUT failed*. A transient 500 on the post-save poll stops masking a successful save. A green **Saved ✓** flash confirms the write landed.

### 2. Default chain = Balanced
Frontier quality shouldn't be the out-of-the-box spend. New default: `gemini-2.5-flash → gemini-2.0-flash`. The Balanced preset now matches DEFAULT_CHAIN, so fresh admins see it highlighted as *selected*. Premium is one click away.

### 3. Cost estimate — active-chain highlight + per-book
The cost panel now has a prominent **Active chain** row showing three numbers:
- Total cost if primary handles everything
- Per-book cost (total / pending_books)
- Fallback floor (every batch on the cheapest chain member)

Below, the model grid now shows **total + per-book** for each model, with chain members tinted emerald so the alternative-cost comparison is obvious.

### 4. Activity log shows full entries
Was truncated with CSS `truncate` — long 503 JSON payloads got clipped at the edge. Now wraps with `whitespace-pre-wrap`. Backend log cap bumped 30 → 100.

## Test plan

- [x] Backend: 354 tests pass (test asserting old default chain updated to match balanced)
- [x] Frontend: 130 tests pass (preset-matching test updated)
- [x] `next build` passes

Generated with [Claude Code](https://claude.com/claude-code)