### PR TITLE
fix(queue): fail-fast retry + stop items spinner flicker

### DIFF
--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -73,7 +73,12 @@ DEFAULT_RPM = 12
 DEFAULT_RPD = 1400
 IDLE_POLL_SECONDS = 10.0
 MAX_ATTEMPTS = 5
-RETRY_BACKOFF = (1.0, 5.0, 20.0, 60.0, 300.0)
+# Short outer-retry backoff. Rationale: the chain already tries every model
+# in order before the outer retry fires, so if we're here ALL models in the
+# chain just failed. Waiting 300s rarely helps — usually a transient burst
+# on Google's side recovers within 10-20s. Admins explicitly asked to
+# "fail faster" so they can see forward progress.
+RETRY_BACKOFF = (1.0, 5.0, 15.0)
 
 # Every time a batch fails, the rows' priority is bumped by this much so the
 # worker moves on to other (book, language) groups instead of spinning on
@@ -832,12 +837,14 @@ class TranslationQueueWorker:
         target_language: str,
         max_output_tokens: int,
     ) -> dict[int, list[str]]:
-        """Walk the chain: first model with quota + that doesn't 429 wins.
+        """Walk the chain: first model that answers successfully wins.
 
-        Non-quota errors (503, malformed response) propagate to the outer
-        retry loop so they get exponential backoff on the CURRENT model.
-        Only quota errors / already-exhausted models advance the chain —
-        those won't get better within this batch so there's no point waiting.
+        Any error from the API advances to the next model — 429, 503,
+        malformed response, network glitch, anything. Rationale: the
+        whole point of a fallback chain is to route around model-level
+        problems without sitting on long backoffs. If ALL models in the
+        chain fail, the exception bubbles up to the outer retry loop,
+        which waits briefly before re-trying the whole chain.
         """
         last_err: Exception | None = None
         for model in chain:
@@ -862,14 +869,14 @@ class TranslationQueueWorker:
                 )
             except Exception as e:  # noqa: BLE001
                 last_err = e
-                if is_quota_error(e):
-                    self._append_log({
-                        "event": "chain_advance",
-                        "from": model or "default",
-                        "reason": str(e)[:160],
-                    })
-                    continue
-                raise  # transient / other error — bubble up to retry loop
+                reason = "quota" if is_quota_error(e) else "error"
+                self._append_log({
+                    "event": "chain_advance",
+                    "from": model or "default",
+                    "reason": reason,
+                    "error": str(e)[:160],
+                })
+                continue
         if last_err:
             raise last_err
         raise RuntimeError("all models in chain are at their daily cap")

--- a/backend/tests/test_translation_queue.py
+++ b/backend/tests/test_translation_queue.py
@@ -461,9 +461,11 @@ async def test_chain_skips_models_already_at_daily_cap(tmp_db, monkeypatch):
     assert skips[0]["model"] == "gemini-2.5-pro"
 
 
-async def test_non_quota_error_stays_on_current_model(tmp_db, monkeypatch):
-    """A 503 'model overloaded' is transient for THIS model, not a quota
-    issue. The chain should NOT advance — the outer retry loop backs off."""
+async def test_503_also_advances_chain_for_fail_fast(tmp_db, monkeypatch):
+    """Historical behaviour waited up to 300s on a 503 before giving up.
+    Admins asked for fail-fast: on ANY API error (not just quota) the
+    chain should advance immediately so a sibling model gets a chance
+    without a long backoff."""
     from services.auth import encrypt_api_key
     from services.rate_limiter import AsyncRateLimiter
     import services.translation_queue as tq
@@ -473,7 +475,7 @@ async def test_non_quota_error_stays_on_current_model(tmp_db, monkeypatch):
         "queue_model_chain",
         json.dumps(["gemini-2.5-pro", "gemini-2.5-flash"]),
     )
-    monkeypatch.setattr(tq, "RETRY_BACKOFF", (0.0, 0.0, 0.0, 0.0, 0.0))
+    monkeypatch.setattr(tq, "RETRY_BACKOFF", (0.0, 0.0, 0.0))
     await save_book(1, BOOK_META, BOOK_TEXT)
     await enqueue(1, 0, "zh")
 
@@ -481,7 +483,9 @@ async def test_non_quota_error_stays_on_current_model(tmp_db, monkeypatch):
 
     async def fake_translate(api_key, chapters, src, tgt, *, model=None, **kwargs):
         models_called.append(model or "")
-        raise RuntimeError("503 UNAVAILABLE: model overloaded")
+        if model == "gemini-2.5-pro":
+            raise RuntimeError("503 UNAVAILABLE: model overloaded")
+        return {idx: ["ok"] for idx, _ in chapters}
 
     w = TranslationQueueWorker()
     w._stop_event = __import__("asyncio").Event()
@@ -489,11 +493,12 @@ async def test_non_quota_error_stays_on_current_model(tmp_db, monkeypatch):
         with patch.object(AsyncRateLimiter, "acquire", new=AsyncMock(return_value=None)):
             await w._tick()
 
-    # Every retry call used PRIMARY (pro), never advanced to flash.
-    assert all(m == "gemini-2.5-pro" for m in models_called)
-    assert "gemini-2.5-flash" not in models_called
-    # No chain_advance log.
-    assert not any(e.get("event") == "chain_advance" for e in w._state.log)
+    # Pro got called, threw 503, then flash was tried and succeeded.
+    assert models_called == ["gemini-2.5-pro", "gemini-2.5-flash"]
+    advances = [e for e in w._state.log if e.get("event") == "chain_advance"]
+    assert len(advances) == 1
+    assert advances[0]["reason"] == "error"
+    assert "503" in advances[0]["error"]
 
 
 async def test_is_quota_error_classifier():

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -178,8 +178,14 @@ export default function QueueTab({ adminFetch }: Props) {
     }
   }
 
-  async function refreshItems(filter: string = itemFilter) {
-    setLoadingItems(true);
+  async function refreshItems(
+    filter: string = itemFilter,
+    opts: { silent?: boolean } = {},
+  ) {
+    // The 3s background poll passes silent:true so the spinner doesn't
+    // flicker every few seconds. Initial load + user-initiated filter
+    // changes pass silent:false so the user gets visible feedback.
+    if (!opts.silent) setLoadingItems(true);
     try {
       const its = await adminFetch(
         `/admin/queue/items?limit=100${
@@ -191,7 +197,7 @@ export default function QueueTab({ adminFetch }: Props) {
     } catch {
       /* leave existing items visible if this poll fails */
     } finally {
-      setLoadingItems(false);
+      if (!opts.silent) setLoadingItems(false);
     }
   }
 
@@ -220,12 +226,14 @@ export default function QueueTab({ adminFetch }: Props) {
 
   useEffect(() => {
     refreshCore();
-    refreshItems();
+    refreshItems(); // initial items load — spinner visible
     refreshCost();
-    // Core (status/settings) + items poll every 3s.
+    // Core (status/settings) + items poll every 3s. Items polls are
+    // SILENT so the spinner doesn't flicker every few seconds (which
+    // made the filter pills shift around).
     const fastPoll = setInterval(() => {
       refreshCore();
-      refreshItems();
+      refreshItems(itemFilter, { silent: true });
     }, 3000);
     // Cost is heavier — poll on a 30s cadence to avoid blocking the UI.
     const slowPoll = setInterval(refreshCost, 30000);
@@ -238,7 +246,7 @@ export default function QueueTab({ adminFetch }: Props) {
 
   // Filter pills: fire ONLY the items fetch, not the whole tab. Previously
   // clicking a filter triggered refresh() which waited on 4 parallel
-  // fetches — visibly laggy.
+  // fetches — visibly laggy. Spinner visible for user-initiated clicks.
   useEffect(() => {
     if (!chainInitedRef.current) return; // initial load handles it
     refreshItems(itemFilter);
@@ -928,18 +936,21 @@ export default function QueueTab({ adminFetch }: Props) {
       {/* Queue items */}
       <div className="bg-white rounded-xl border border-amber-200 overflow-hidden">
         <div className="px-4 py-2 border-b border-amber-100 flex items-center gap-2 text-sm">
+          {/* Spinner slot has fixed width even when empty so the header
+              doesn't reflow and shift the filter pills. */}
           <span className="font-medium flex items-center gap-1.5">
             Items
-            {loadingItems && <Spinner />}
+            <span className="inline-block w-3 h-3 align-middle">
+              {loadingItems && <Spinner />}
+            </span>
           </span>
           {(["pending", "running", "failed", "all"] as const).map((f) => (
             <button
               key={f}
               onClick={() => setItemFilter(f)}
-              disabled={loadingItems && itemFilter !== f}
               className={`text-xs px-2 py-0.5 rounded ${
                 itemFilter === f ? "bg-amber-700 text-white" : "text-amber-700 hover:bg-amber-50"
-              } disabled:opacity-40`}
+              }`}
             >
               {f}
             </button>


### PR DESCRIPTION
Two annoyances from your last feedback.

### 1. Retry strategy was waiting up to 300s on 503s
The previous retry backoff was `(1, 5, 20, 60, 300)` seconds for non-quota errors — so a persistent 503 on the primary model made the worker sit glued to a single dead model for ~6 minutes before giving up, when a sibling model in the chain might have been healthy the whole time.

**Fix**: any error now advances the chain. 429, 503, malformed response, network glitch — all advance. The outer retry loop only kicks in when the *entire* chain fails, and its backoff is now `(1, 5, 15)` — 3 retries, 21s max.

Effect: worst-case wait drops from **~386s** (one model stuck) to **~21s + a few seconds per chain attempt**.

### 2. Items spinner flickered every 3s + pill layout shifted
The 3s background poll toggled `loadingItems` on/off, which:
- Showed the spinner every few seconds (visual flicker)
- Briefly disabled 3 of 4 filter pills (layout shifted, clicks could miss)

**Fix**: `refreshItems(filter, { silent: true })` for the periodic poll — no spinner toggle, no disabled state. Initial load and user filter clicks stay non-silent so the user still gets feedback. Spinner slot in the Items header also has a fixed 12×12 size so swapping in/out never reflows.

## Test plan
- [x] Backend: 29 queue tests pass (updated `test_503_also_advances_chain_for_fail_fast`)
- [x] Frontend: 130 tests pass
- [x] `next build` passes

Generated with [Claude Code](https://claude.com/claude-code)