### PR TITLE
fix(queue): items filter stale-closure + drop deprecated 2.0 models from defaults

### DIFF
--- a/backend/services/model_limits.py
+++ b/backend/services/model_limits.py
@@ -28,7 +28,7 @@ class _Limits(TypedDict):
 # (flash-only) can one-click switch via the preset buttons.
 DEFAULT_CHAIN: list[str] = [
     "gemini-2.5-flash",
-    "gemini-2.0-flash",
+    "gemini-2.5-flash-lite",
 ]
 
 

--- a/backend/tests/test_translation_queue.py
+++ b/backend/tests/test_translation_queue.py
@@ -324,7 +324,7 @@ async def test_default_chain_applied_when_no_setting(tmp_db):
     from services.translation_queue import get_model_chain
     chain = await get_model_chain()
     assert chain[0] == "gemini-2.5-flash"
-    assert "gemini-2.0-flash" in chain
+    assert "gemini-2.5-flash-lite" in chain
 
 
 async def test_clear_queue_all_and_by_status(tmp_db):

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -123,6 +123,10 @@ export default function QueueTab({ adminFetch }: Props) {
   // Maps a label ("chain", "api_key", etc.) → timestamp of last save.
   const [lastSaved, setLastSaved] = useState<{ key: string; at: number } | null>(null);
   const [itemFilter, setItemFilter] = useState<"pending" | "running" | "failed" | "all">("pending");
+  // Ref mirrors itemFilter so the long-lived poll interval (set up once
+  // with empty deps) reads the current filter on every tick instead of
+  // the initial "pending" captured in its closure.
+  const itemFilterRef = useRef(itemFilter);
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
   // Per-section loading flags so a slow fetch spins only its own panel
@@ -230,10 +234,13 @@ export default function QueueTab({ adminFetch }: Props) {
     refreshCost();
     // Core (status/settings) + items poll every 3s. Items polls are
     // SILENT so the spinner doesn't flicker every few seconds (which
-    // made the filter pills shift around).
+    // made the filter pills shift around). Read the filter via ref so
+    // the interval sees user changes instead of its stale initial
+    // closure — without this the poll overwrote the selected filter
+    // back to "pending" every 3s.
     const fastPoll = setInterval(() => {
       refreshCore();
-      refreshItems(itemFilter, { silent: true });
+      refreshItems(itemFilterRef.current, { silent: true });
     }, 3000);
     // Cost is heavier — poll on a 30s cadence to avoid blocking the UI.
     const slowPoll = setInterval(refreshCost, 30000);
@@ -244,10 +251,9 @@ export default function QueueTab({ adminFetch }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Filter pills: fire ONLY the items fetch, not the whole tab. Previously
-  // clicking a filter triggered refresh() which waited on 4 parallel
-  // fetches — visibly laggy. Spinner visible for user-initiated clicks.
+  // Filter pills: keep the ref in sync AND fire a fresh items fetch.
   useEffect(() => {
+    itemFilterRef.current = itemFilter;
     if (!chainInitedRef.current) return; // initial load handles it
     refreshItems(itemFilter);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/lib/geminiModels.ts
+++ b/frontend/src/lib/geminiModels.ts
@@ -43,18 +43,9 @@ export const GEMINI_MODEL_OPTIONS: ModelOption[] = [
     recommended: true,
   },
   {
-    value: "gemini-2.0-flash",
-    label: "gemini-2.0-flash",
-    note: "Solid for prose, unlimited daily requests. Best choice when upstream 2.5/3.1 tiers are spent.",
-    rpm: 2000,
-    rpd: 999999,
-    maxOutputTokens: 7500,
-    recommended: true,
-  },
-  {
     value: "gemini-3.1-flash-lite-preview",
     label: "gemini-3.1-flash-lite-preview",
-    note: "Newest lite model — 150K daily requests. Drops nuance on dialogue but very high capacity.",
+    note: "Newest lite model — 150K daily requests. Drops nuance on dialogue but very high capacity. Good capacity fallback.",
     rpm: 4000,
     rpd: 150000,
     maxOutputTokens: 7500,
@@ -64,15 +55,6 @@ export const GEMINI_MODEL_OPTIONS: ModelOption[] = [
     value: "gemini-2.5-flash-lite",
     label: "gemini-2.5-flash-lite",
     note: "Fast & cheap, unlimited daily requests. Usable only as a last-ditch fallback for literature.",
-    rpm: 4000,
-    rpd: 999999,
-    maxOutputTokens: 7500,
-    recommended: false,
-  },
-  {
-    value: "gemini-2.0-flash-lite",
-    label: "gemini-2.0-flash-lite",
-    note: "Lowest-quality flash-lite. Unlimited daily requests — use as a volume fallback.",
     rpm: 4000,
     rpd: 999999,
     maxOutputTokens: 7500,
@@ -119,12 +101,13 @@ export function isRecommended(model: string): boolean {
 }
 
 // Suggested default chain — matches the "Balanced" preset. Strong literary
-// quality without the frontier pricing, cascades to unlimited-RPD 2.0-flash
-// as a safety net. Admins who want Premium or Budget can one-click switch
-// via the preset buttons in the Queue tab.
+// quality with a capacity fallback. Admins who want Premium or Budget can
+// one-click switch via the preset buttons in the Queue tab.
+// Note: gemini-2.0-flash and gemini-2.0-flash-lite are deprecated for new
+// accounts (Google returns 404 for those). Defaults now avoid them.
 export const DEFAULT_CHAIN: string[] = [
   "gemini-2.5-flash",
-  "gemini-2.0-flash",
+  "gemini-2.5-flash-lite",
 ];
 
 // Named presets that map admin intent ("cheap drafts" / "quality without
@@ -142,30 +125,30 @@ export const CHAIN_PRESETS: ChainPreset[] = [
   {
     id: "budget",
     label: "Budget",
-    tagline: "Cheap, unlimited capacity",
+    tagline: "Cheap, high capacity",
     description:
-      "Flash-class models only. Good for first-pass drafts or non-literary target languages where nuance matters less. Unlimited daily requests — drain a whole library in one run.",
-    chain: ["gemini-2.0-flash", "gemini-2.0-flash-lite"],
+      "Flash-lite only. Good for first-pass drafts or non-literary target languages where nuance matters less. Very high daily request limits — drain a whole library in one run.",
+    chain: ["gemini-2.5-flash-lite", "gemini-3.1-flash-lite-preview"],
   },
   {
     id: "balanced",
     label: "Balanced",
     tagline: "Strong prose, affordable",
     description:
-      "2.5-flash leads for its near-pro literary quality; 2.0-flash catches overflow. The sweet spot for most libraries — clearly better than lite, a fraction of the pro cost.",
-    chain: ["gemini-2.5-flash", "gemini-2.0-flash"],
+      "2.5-flash leads for its near-pro literary quality; 2.5-flash-lite catches overflow. The sweet spot for most libraries — clearly better than lite-only, a fraction of the pro cost.",
+    chain: ["gemini-2.5-flash", "gemini-2.5-flash-lite"],
   },
   {
     id: "premium",
     label: "Premium",
     tagline: "Frontier top, graceful degradation",
     description:
-      "Start with 3.1-pro for the most faithful literary rendering; cascade to 2.5-pro, 2.5-flash, then 2.0-flash as daily quotas are spent. Expensive but produces the best output.",
+      "Start with 3.1-pro for the most faithful literary rendering; cascade to 2.5-pro, 2.5-flash, then 2.5-flash-lite as daily quotas are spent. Expensive but produces the best output.",
     chain: [
       "gemini-3.1-pro-preview",
       "gemini-2.5-pro",
       "gemini-2.5-flash",
-      "gemini-2.0-flash",
+      "gemini-2.5-flash-lite",
     ],
   },
 ];


### PR DESCRIPTION
Two bugs from your latest feedback.

### 1. Items filter snapped back to *pending* every 3s
The background poll interval was set up once with empty deps, so it captured the **initial** `itemFilter` ("pending") in its closure. Every 3s it overwrote whatever the user selected.

**Fix**: `itemFilterRef` mirrors the state via a secondary useEffect; the interval reads `itemFilterRef.current` on each tick instead of the stale closure value.

### 2. `gemini-2.0-flash` 404 on new accounts
`{'error': {'code': 404, 'message': 'This model models/gemini-2.0-flash is no longer available to new users. Please update your code to use a newer model.'}}`. Google has deprecated 2.0-flash and 2.0-flash-lite for accounts created after a cutoff. The fail-fast chain-advance from PR #94 handled the 404 gracefully but the log filled with `chain_advance` events every batch.

Defaults rotated away from 2.0 models:
- **Budget**: `2.5-flash-lite → 3.1-flash-lite-preview`
- **Balanced** (= DEFAULT_CHAIN): `2.5-flash → 2.5-flash-lite`
- **Premium**: `3.1-pro-preview → 2.5-pro → 2.5-flash → 2.5-flash-lite`

Backend `MODEL_LIMITS` keeps the 2.0-* entries so existing admin chains that reference them still have a valid lookup (the chain-advance still handles the 404 gracefully, no stall).

## Test plan
- [x] Backend: 354 tests pass
- [x] Frontend: 130 tests pass
- [x] `next build` passes

Generated with [Claude Code](https://claude.com/claude-code)