### PR TITLE
feat(admin): spinner + 'Stopping…' feedback on worker toggle

### DIFF
--- a/frontend/src/__tests__/QueueTab.workerToggle.test.tsx
+++ b/frontend/src/__tests__/QueueTab.workerToggle.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Tests for the Worker Start / Stop button loading feedback.
+ *
+ * The backend /admin/queue/stop PUT can take up to 20 seconds because the
+ * worker waits for the in-flight batch to wind down. Without a spinner the
+ * button looks broken. This verifies the button swaps to "Stopping…" while
+ * the PUT is in flight and "Starting…" during the start call.
+ */
+
+import React from "react";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import QueueTab from "@/components/QueueTab";
+
+function makeStatus(running: boolean) {
+  return {
+    running,
+    state: {
+      enabled: true,
+      idle: true,
+      current_book_id: null,
+      current_book_title: "",
+      current_target_language: "",
+      current_batch_size: 0,
+      current_model: "",
+      last_completed_at: null,
+      last_error: "",
+      started_at: null,
+      requests_made: 0,
+      chapters_done: 0,
+      chapters_failed: 0,
+      waiting_reason: "",
+      log: [],
+    },
+    counts: {},
+  };
+}
+
+const SETTINGS = {
+  enabled: true,
+  has_api_key: true,
+  auto_translate_languages: [],
+  rpm: null,
+  rpd: null,
+  model: null,
+  model_chain: ["gemini-2.5-flash"],
+  max_output_tokens: null,
+};
+
+const COST = {
+  pending_items: 0,
+  pending_books: 0,
+  estimated_input_tokens: 0,
+  estimated_output_tokens: 0,
+  per_model: [],
+};
+
+describe("QueueTab worker start/stop button", () => {
+  beforeEach(() => {
+    window.confirm = jest.fn(() => true);
+  });
+
+  it('shows "Stopping…" while the stop PUT is in flight', async () => {
+    let workerRunning = true;
+    let resolveStop: (v: unknown) => void = () => {};
+    const stopPending = new Promise((resolve) => {
+      resolveStop = resolve;
+    });
+
+    const adminFetch = jest.fn((path: string, opts?: RequestInit) => {
+      if (path === "/admin/queue/status") return Promise.resolve(makeStatus(workerRunning));
+      if (path === "/admin/queue/settings") return Promise.resolve(SETTINGS);
+      if (path.startsWith("/admin/queue/items")) return Promise.resolve([]);
+      if (path === "/admin/queue/cost-estimate") return Promise.resolve(COST);
+      if (path === "/admin/queue/stop" && opts?.method === "POST") return stopPending;
+      return Promise.resolve({});
+    });
+
+    render(<QueueTab adminFetch={adminFetch} />);
+    const stopBtn = await screen.findByRole("button", { name: /^stop$/i });
+    await userEvent.click(stopBtn);
+
+    // While the PUT is in flight we should see "Stopping…" and the button
+    // should be disabled.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /stopping…/i })).toBeDisabled(),
+    );
+
+    // Let the PUT resolve and verify the button recovers.
+    workerRunning = false;
+    await act(async () => {
+      resolveStop({ ok: true });
+      await stopPending;
+    });
+    await waitFor(() =>
+      expect(screen.queryByText(/stopping…/i)).not.toBeInTheDocument(),
+    );
+  });
+
+  it('shows "Starting…" while the start POST is in flight', async () => {
+    let workerRunning = false;
+    let resolveStart: (v: unknown) => void = () => {};
+    const startPending = new Promise((resolve) => {
+      resolveStart = resolve;
+    });
+
+    const adminFetch = jest.fn((path: string, opts?: RequestInit) => {
+      if (path === "/admin/queue/status") return Promise.resolve(makeStatus(workerRunning));
+      if (path === "/admin/queue/settings") return Promise.resolve(SETTINGS);
+      if (path.startsWith("/admin/queue/items")) return Promise.resolve([]);
+      if (path === "/admin/queue/cost-estimate") return Promise.resolve(COST);
+      if (path === "/admin/queue/start" && opts?.method === "POST") return startPending;
+      return Promise.resolve({});
+    });
+
+    render(<QueueTab adminFetch={adminFetch} />);
+    const startBtn = await screen.findByRole("button", { name: /^start$/i });
+    await userEvent.click(startBtn);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /starting…/i })).toBeDisabled(),
+    );
+
+    workerRunning = true;
+    await act(async () => {
+      resolveStart({ ok: true });
+      await startPending;
+    });
+    await waitFor(() =>
+      expect(screen.queryByText(/starting…/i)).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -134,6 +134,10 @@ export default function QueueTab({ adminFetch }: Props) {
   // the corresponding fetch and false on completion (success or error).
   const [loadingItems, setLoadingItems] = useState(false);
   const [loadingCost, setLoadingCost] = useState(false);
+  // Worker start/stop PUTs can take up to ~20s because the backend waits
+  // for the in-flight batch to wind down gracefully. Without a spinner
+  // the button just looks broken.
+  const [togglingWorker, setTogglingWorker] = useState<"start" | "stop" | null>(null);
   // Track whether the first load has completed — subsequent polls keep
   // prior data visible, but the very first render needs a clear loading
   // indicator so the panels don't pop in one-by-one looking broken.
@@ -292,14 +296,27 @@ export default function QueueTab({ adminFetch }: Props) {
   }
 
   async function startWorker() {
-    await adminFetch("/admin/queue/start", { method: "POST" });
-    await refresh();
+    setTogglingWorker("start");
+    try {
+      await adminFetch("/admin/queue/start", { method: "POST" });
+      refreshCore();
+    } finally {
+      setTogglingWorker(null);
+    }
   }
 
   async function stopWorker() {
     if (!confirm("Stop the translation queue worker? Pending items stay in the queue.")) return;
-    await adminFetch("/admin/queue/stop", { method: "POST" });
-    await refresh();
+    setTogglingWorker("stop");
+    try {
+      // Backend waits up to ~20s for the in-flight batch to finish, so
+      // this PUT can hang for a while. The button shows a spinner +
+      // "Stopping…" during the wait.
+      await adminFetch("/admin/queue/stop", { method: "POST" });
+      refreshCore();
+    } finally {
+      setTogglingWorker(null);
+    }
   }
 
   async function enqueueAll() {
@@ -422,16 +439,32 @@ export default function QueueTab({ adminFetch }: Props) {
           {status?.running ? (
             <button
               onClick={stopWorker}
-              className="text-xs px-3 py-1 rounded border border-red-200 text-red-600 hover:bg-red-50"
+              disabled={togglingWorker !== null}
+              className="text-xs px-3 py-1 rounded border border-red-200 text-red-600 hover:bg-red-50 disabled:opacity-50 inline-flex items-center gap-1.5"
             >
-              Stop
+              {togglingWorker === "stop" && (
+                <span
+                  className="inline-block border-2 border-red-300 border-t-red-600 rounded-full animate-spin"
+                  style={{ width: 10, height: 10 }}
+                  aria-label="stopping"
+                />
+              )}
+              {togglingWorker === "stop" ? "Stopping…" : "Stop"}
             </button>
           ) : (
             <button
               onClick={startWorker}
-              className="text-xs px-3 py-1 rounded border border-emerald-300 text-emerald-700 hover:bg-emerald-50"
+              disabled={togglingWorker !== null}
+              className="text-xs px-3 py-1 rounded border border-emerald-300 text-emerald-700 hover:bg-emerald-50 disabled:opacity-50 inline-flex items-center gap-1.5"
             >
-              Start
+              {togglingWorker === "start" && (
+                <span
+                  className="inline-block border-2 border-emerald-300 border-t-emerald-700 rounded-full animate-spin"
+                  style={{ width: 10, height: 10 }}
+                  aria-label="starting"
+                />
+              )}
+              {togglingWorker === "start" ? "Starting…" : "Start"}
             </button>
           )}
         </div>


### PR DESCRIPTION
**/admin/queue/stop** can take up to ~20s because the backend waits for the in-flight batch to wind down. Before this PR the button just sat there — looked broken.

Both **Start** and **Stop** buttons now:
- disable during the PUT round-trip
- show a small circular spinner
- swap label to *Starting…* or *Stopping…*
- recover when the PUT resolves

## Test plan
- [x] New test `QueueTab.workerToggle.test.tsx` defers the adminFetch Promise for the respective endpoint and asserts both button states
- [x] Frontend: 132 tests pass (2 new)
- [x] `next build` passes

Generated with [Claude Code](https://claude.com/claude-code)