### PR TITLE
fix(queue): add 'done' filter pill + rescue running rows on batch exception

### DIFF
--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -777,11 +777,40 @@ class TranslationQueueWorker:
         ]
 
     async def _process_batch(self, items: list[QueueRow], api_key: str) -> None:
+        # Safety net: any row still marked 'running' at the end of this
+        # batch — whether via unhandled exception or logic bug — must be
+        # bumped back to pending/failed. Otherwise rows leak in 'running'
+        # status until the next worker restart. Tracks ids we've already
+        # transitioned so we don't double-bump.
+        handled_ids: set[int] = set()
+
+        def mark_handled(rows: list[QueueRow]) -> None:
+            for r in rows:
+                handled_ids.add(r.id)
+
+        try:
+            await self._process_batch_inner(items, api_key, mark_handled)
+        except Exception as e:  # noqa: BLE001
+            logger.exception("process_batch crashed")
+            self._state.last_error = str(e)[:500]
+            self._append_log({"event": "batch_error", "error": str(e)[:200]})
+            # Rescue any still-running rows so they don't leak.
+            unhandled = [r for r in items if r.id not in handled_ids]
+            for row in unhandled:
+                await self._bump_attempt(row, f"batch crashed: {str(e)[:200]}")
+
+    async def _process_batch_inner(
+        self,
+        items: list[QueueRow],
+        api_key: str,
+        mark_handled,
+    ) -> None:
         book_id = items[0].book_id
         target_language = items[0].target_language
         book = await get_cached_book(book_id)
         if not book or not book.get("text"):
             await self._mark_skipped(items, reason="book not in cache")
+            mark_handled(items)
             return
         source = (book.get("languages") or ["en"])[0]
         all_chapters = await asyncio.to_thread(build_chapters, book["text"])
@@ -791,20 +820,19 @@ class TranslationQueueWorker:
         for row in items:
             if row.chapter_index >= len(all_chapters):
                 await self._mark_failed([row], "chapter index out of range")
+                mark_handled([row])
                 continue
             text = all_chapters[row.chapter_index].text
             if not text.strip():
                 await self._mark_done([row])
+                mark_handled([row])
                 continue
-            # Defensive: skip re-translating if a cached translation already
-            # landed between enqueue and now (e.g. the reader triggered an
-            # on-demand translation, or a bulk job ran). No sense spending
-            # Gemini tokens on work that's already done.
             existing = await get_cached_translation(
                 book_id, row.chapter_index, target_language,
             )
             if existing:
                 await self._mark_done([row])
+                mark_handled([row])
                 self._append_log({
                     "event": "skipped_cached",
                     "book_id": book_id,
@@ -854,6 +882,7 @@ class TranslationQueueWorker:
                 paragraphs = translations.get(c.chapter_index)
                 if paragraphs is None:
                     await self._bump_attempt(row, "no translation returned")
+                    mark_handled([row])
                     continue
                 # Record the model that actually translated this chapter —
                 # may differ from the primary if the chain advanced.
@@ -863,6 +892,7 @@ class TranslationQueueWorker:
                     model=self._state.current_model or None,
                 )
                 await self._mark_done([row])
+                mark_handled([row])
                 self._state.chapters_done += 1
                 self._append_log({
                     "event": "translated",

--- a/backend/tests/test_translation_queue.py
+++ b/backend/tests/test_translation_queue.py
@@ -510,6 +510,39 @@ async def test_is_quota_error_classifier():
     assert not is_quota_error(RuntimeError("response had no <chapter> blocks"))
 
 
+async def test_process_batch_does_not_leak_running_rows_on_exception(tmp_db, monkeypatch):
+    """If the splitter or any other step crashes mid-batch, claimed rows
+    must NOT stay in 'running' forever. The inner try/except bumps each
+    un-handled row back to pending/failed so the queue keeps moving
+    without needing a worker restart."""
+    from services.auth import encrypt_api_key
+    from services.rate_limiter import AsyncRateLimiter
+    import services.translation_queue as tq
+    await set_setting(SETTING_API_KEY, encrypt_api_key("fake-key"))
+    await set_setting(SETTING_ENABLED, "1")
+    monkeypatch.setattr(tq, "RETRY_BACKOFF", (0.0, 0.0, 0.0))
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    await enqueue(1, 0, "zh")
+    await enqueue(1, 1, "zh")
+
+    # Force build_chapters to blow up — this runs via asyncio.to_thread
+    # inside _process_batch_inner so the exception propagates back.
+    def kaboom(_text):
+        raise RuntimeError("simulated splitter crash")
+
+    w = TranslationQueueWorker()
+    w._stop_event = __import__("asyncio").Event()
+    with patch("services.translation_queue.build_chapters", side_effect=kaboom):
+        with patch.object(AsyncRateLimiter, "acquire", new=AsyncMock(return_value=None)):
+            await w._tick()
+
+    # No row may be left in 'running' — all must be pending or failed.
+    running = await list_queue(status="running")
+    assert running == []
+    # The batch_error event should be in the log.
+    assert any(e.get("event") == "batch_error" for e in w._state.log)
+
+
 async def test_failing_batch_bumps_priority_so_worker_moves_on(tmp_db, monkeypatch):
     """A book that keeps failing must not block other books. The worker
     should bump failing rows' priority so they drop behind fresh work."""

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -124,7 +124,7 @@ export default function QueueTab({ adminFetch }: Props) {
   // sees confirmation instead of wondering whether their click did anything.
   // Maps a label ("chain", "api_key", etc.) → timestamp of last save.
   const [lastSaved, setLastSaved] = useState<{ key: string; at: number } | null>(null);
-  const [itemFilter, setItemFilter] = useState<"pending" | "running" | "failed" | "all">("pending");
+  const [itemFilter, setItemFilter] = useState<"pending" | "running" | "done" | "failed" | "all">("pending");
   // Ref mirrors itemFilter so the long-lived poll interval (set up once
   // with empty deps) reads the current filter on every tick instead of
   // the initial "pending" captured in its closure.
@@ -1007,7 +1007,7 @@ export default function QueueTab({ adminFetch }: Props) {
               {loadingItems && <Spinner />}
             </span>
           </span>
-          {(["pending", "running", "failed", "all"] as const).map((f) => (
+          {(["pending", "running", "done", "failed", "all"] as const).map((f) => (
             <button
               key={f}
               onClick={() => setItemFilter(f)}


### PR DESCRIPTION
Your hunch was right — two bugs.

### 1. No way to see 'done' items in the UI
Filter options were `pending / running / failed / all`. No 'done' pill. With 4K+ pending rows, even *all* filled the 100-item limit before any done rows surfaced. **Added a 'done' pill.**

### 2. Running-row leak on unhandled exception
If `_process_batch` raised *after* claiming rows but *before* `_mark_done`/`_bump_attempt` ran (splitter crash, DB hiccup, anything), those rows stayed in 'running' forever — only recovered on the next worker restart via `reset_stale_running_rows`.

**Fix**: Split into `_process_batch` (try/except wrapper) and `_process_batch_inner`. Each successful transition (`_mark_done`, `_mark_failed`, `_mark_skipped`, `_bump_attempt`) registers the row id in a `handled_ids` set. On unhandled exception, the outer catcher bumps every un-registered row back to pending/failed — no leaks.

New test `test_process_batch_does_not_leak_running_rows_on_exception` simulates a splitter crash and asserts zero rows remain in 'running'.

## Test plan
- [x] Backend: 355 tests pass (1 new)
- [x] Frontend: 132 tests pass
- [x] `next build` passes

Generated with [Claude Code](https://claude.com/claude-code)