### PR TITLE
feat(queue): worker is passive — no auto-rescan on startup or idle

### DIFF
--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -641,27 +641,22 @@ class TranslationQueueWorker:
         assert self._stop_event is not None
         stop_event = self._stop_event
 
-        # Startup housekeeping: reset any rows left 'running' from a prior
-        # crash, and rescan the book library so newly-cached books or
-        # newly-configured languages are picked up immediately. Both
-        # phases are surfaced to the UI via state.startup_phase so the
-        # admin sees what's happening instead of a silent "Starting…".
+        # Startup housekeeping: only reset rows left 'running' from a
+        # prior crash. The worker is now PASSIVE — it does NOT scan the
+        # library to enqueue missing translations. Translation work is
+        # only added to the queue when:
+        #   - a user imports a book with target_language (save_book
+        #     auto-enqueue for configured auto-translate languages)
+        #   - a reader clicks Translate on a chapter (POST /translation)
+        #   - the admin manually enqueues via the queue panel
+        # Admins who want a blanket rescan can still use the "Queue every
+        # book" button in the admin panel.
         try:
             self._state.startup_phase = "reset_stale"
             self._state.startup_progress = "Resetting stale running rows…"
             stale = await reset_stale_running_rows()
             if stale:
                 self._append_log({"event": "startup_reset_stale", "count": stale})
-
-            self._state.startup_phase = "rescan"
-            self._state.startup_progress = "Scanning book library…"
-
-            def _on_progress(i: int, total: int, title: str) -> None:
-                self._state.startup_progress = f"Checking {i}/{total}: {title}"
-
-            added = await rescan_for_missing_translations(progress=_on_progress)
-            if added:
-                self._append_log({"event": "startup_rescan", "enqueued": added})
         except Exception:
             logger.exception("Startup housekeeping failed (non-fatal)")
         finally:
@@ -701,19 +696,6 @@ class TranslationQueueWorker:
         # rebuild prior_context per chapter, which loses the cross-batch
         # consistency benefit.
         items = await self._claim_next_batch()
-        if not items:
-            # Before idling, rescan the library for work that's been added
-            # since the last tick — new books via save_book, or new languages
-            # added to auto_translate_languages. This makes "Queue every
-            # book" largely unnecessary: the worker finds missing work on
-            # its own within one idle poll cycle.
-            try:
-                added = await rescan_for_missing_translations()
-                if added:
-                    self._append_log({"event": "rescan_enqueued", "count": added})
-                    items = await self._claim_next_batch()
-            except Exception:
-                logger.exception("Idle rescan failed (non-fatal)")
 
         if not items:
             self._state.idle = True

--- a/backend/tests/test_translation_queue.py
+++ b/backend/tests/test_translation_queue.py
@@ -190,23 +190,20 @@ async def test_worker_creates_per_model_limiter_with_correct_rates(tmp_db):
     assert (lim.rpm, lim.rpd) == (150, 1000)
 
 
-async def test_rescan_adds_newly_configured_language_without_admin_click(tmp_db):
-    """Admin adds a new target language to auto_translate_languages AFTER
-    books are already saved. The rescan helper should enqueue the missing
-    (book, new_lang) pairs on the next idle tick — no manual
-    'Queue every book' click required."""
+async def test_rescan_helper_enqueues_missing_translations_for_admin_button(tmp_db):
+    """The worker is PASSIVE — it no longer auto-rescans the library on
+    startup or idle. But the helper is still exposed so the admin's
+    'Queue every book' button can manually backfill older books for a
+    newly-added language."""
     from services.translation_queue import rescan_for_missing_translations
-    # Library exists, but no language configured yet.
     await save_book(1, BOOK_META, BOOK_TEXT)
     await save_book(2, BOOK_META, BOOK_TEXT)
     assert len(await list_queue()) == 0
 
-    # Admin picks zh + de as auto-translate languages.
     await set_setting(SETTING_AUTO_LANGS, json.dumps(["zh", "de"]))
 
     added = await rescan_for_missing_translations()
-    # 2 books × 2 langs × 2 chapters = 8 queue rows.
-    assert added == 8
+    assert added == 8  # 2 books × 2 langs × 2 chapters
     all_langs = {r["target_language"] for r in await list_queue()}
     assert all_langs == {"zh", "de"}
 
@@ -221,6 +218,35 @@ async def test_rescan_is_idempotent(tmp_db):
     second = await rescan_for_missing_translations()
     assert first > 0
     assert second == 0
+
+
+async def test_worker_does_not_auto_rescan_library_on_idle(tmp_db):
+    """Worker is passive now — an idle tick must NOT enqueue missing
+    translations on its own. Only explicit triggers (save_book, reader
+    request, admin button) add work to the queue."""
+    from services.auth import encrypt_api_key
+    await set_setting(SETTING_API_KEY, encrypt_api_key("fake-key"))
+    await set_setting(SETTING_ENABLED, "1")
+    await set_setting(SETTING_AUTO_LANGS, json.dumps(["zh", "de"]))
+    # Library has an untranslated book but the queue is empty — a rescan
+    # would pick these up. We want to verify an idle tick does NOT.
+    async with aiosqlite.connect(tmp_db) as db:
+        # Bypass save_book's auto-enqueue by inserting the book row
+        # directly.
+        await db.execute(
+            """INSERT INTO books (id, title, authors, languages, subjects,
+                                  download_count, cover, text, images)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (1, "Test", "[]", '["en"]', "[]", 0, "", BOOK_TEXT, "[]"),
+        )
+        await db.commit()
+    assert len(await list_queue()) == 0
+
+    w = TranslationQueueWorker()
+    w._stop_event = __import__("asyncio").Event()
+    await w._tick()
+    # No rescan should have happened — queue still empty.
+    assert len(await list_queue()) == 0
 
 
 async def test_reset_stale_running_rows_flips_to_pending(tmp_db):


### PR DESCRIPTION
Per admin direction: translation work only enters the queue when **explicitly** triggered. Removed both automatic rescan paths.

### Removed
- **Startup rescan**: the worker used to walk every cached book on boot and enqueue any missing `(book, lang)` pairs. Gone. Only stale-`running` rows from a crashed prior process are still reset on boot.
- **Idle-tick rescan**: the worker used to re-walk the library whenever the queue went empty. Gone. Empty queue now simply idles.

### Triggers that still enqueue (unchanged)
| When | How |
|---|---|
| User imports a book via import-stream with `target_language` | `save_book` auto-enqueues for configured `auto_translate_languages` |
| Reader clicks Translate on a chapter | `POST /books/{id}/chapters/{idx}/translation` enqueues at priority 10 |
| Admin clicks "Queue every book" or "Queue a language for this book" | Existing admin endpoints |

The `rescan_for_missing_translations` helper stays for the admin button. The `rescan` phase is removed from `WorkerState.startup_phase` — only `reset_stale` and `ready` remain.

## Test plan
- [x] New test `test_worker_does_not_auto_rescan_library_on_idle` — asserts the queue stays empty after an idle tick even with an untranslated book + configured langs
- [x] Renamed `test_rescan_adds_newly_configured_language_without_admin_click` → `test_rescan_helper_enqueues_missing_translations_for_admin_button` to reflect the manual-only trigger
- [x] Backend: 356 tests pass
- [x] Frontend: 130 tests pass

Generated with [Claude Code](https://claude.com/claude-code)