### PR TITLE
fix(splitter): HTML verse — stanza lines got split into separate paragraphs

### DIFF
--- a/backend/services/splitter.py
+++ b/backend/services/splitter.py
@@ -475,7 +475,26 @@ def _html_body_text(elem, *, skip_first_heading: bool = False) -> str:
 
 
 def _html_inline_text(elem) -> str:
-    """Flatten a <p> (or similar) to plain text, turning <br> into newlines."""
+    """Flatten a <p> (or similar) to plain text, turning <br> into newlines.
+
+    Gutenberg HTML for verse indents each line after `<br>` so the raw text
+    for a stanza like::
+
+        <p>
+        Line 1<br>
+        Line 2<br>
+        Line 3
+        </p>
+
+    contains sequences of `\\n` (from <br>) + indentation whitespace + `\\n`
+    (from source formatting). Without cleanup, that leaves `\\n\\n` between
+    every line — and downstream `split('\\n\\n')` turns each verse line
+    into its own paragraph, flattening stanzas.
+
+    We collapse any run of whitespace-containing newlines back to a single
+    `\\n` so stanzas stay intact.
+    """
+    import re
     chunks: list[str] = []
     if elem.text:
         chunks.append(elem.text)
@@ -489,7 +508,13 @@ def _html_inline_text(elem) -> str:
                 chunks.append(inner)
         if child.tail:
             chunks.append(child.tail)
-    return "".join(chunks)
+    text = "".join(chunks)
+    # Collapse any sequence containing a newline (and surrounding spaces/tabs)
+    # to a single newline. Preserves stanza-internal line breaks while
+    # removing the indentation artifacts that would otherwise look like
+    # paragraph boundaries to the reader's paragraph-splitter.
+    text = re.sub(r"[ \t]*\n[ \t\n]*", "\n", text)
+    return text.strip()
 
 
 # ── Public API ───────────────────────────────────────────────────────────

--- a/backend/tests/test_splitter.py
+++ b/backend/tests/test_splitter.py
@@ -224,6 +224,47 @@ def test_looks_like_book_heading():
     assert _looks_like_book_heading("Chapter 42") is False
 
 
+def test_build_chapters_from_html_preserves_verse_stanzas():
+    """Gutenberg verse HTML: each stanza is a <p> with <br>-separated lines.
+    The extractor must produce one paragraph per stanza with lines joined by
+    single \\n (not \\n\\n). Regression for Faust book 2229 where every verse
+    line was becoming its own paragraph because formatting whitespace after
+    each <br> was leaving a blank-line artifact."""
+    # Enough stanzas to exceed the 50-word threshold that marks a div as a
+    # section divider. Matches Gutenberg's actual Faust Zueignung markup.
+    stanza1 = """<p>
+    Ihr naht euch wieder, schwankende Gestalten,<br>
+    Die früh sich einst dem trüben Blick gezeigt.<br>
+    Versuch ich wohl, euch diesmal festzuhalten?<br>
+    Fühl ich mein Herz noch jenem Wahn geneigt?<br>
+    Ihr drängt euch zu! nun gut, so mögt ihr walten,<br>
+    Wie ihr aus Dunst und Nebel um mich steigt;<br>
+    Mein Busen fühlt sich jugendlich erschüttert<br>
+    Vom Zauberhauch, der euren Zug umwittert.
+    </p>"""
+    stanza2 = """<p>
+    Ihr bringt mit euch die Bilder froher Tage,<br>
+    Und manche liebe Schatten steigen auf;<br>
+    Gleich einer alten, halbverklungnen Sage<br>
+    Kommt erste Lieb und Freundschaft mit herauf;<br>
+    Der Schmerz wird neu, es wiederholt die Klage<br>
+    Des Lebens labyrinthisch irren Lauf,<br>
+    Und nennt die Guten, die, um schöne Stunden<br>
+    Vom Glück getäuscht, vor mir hinweggeschwunden.
+    </p>"""
+    html = f'<div class="chapter"><h2>Zueignung</h2>{stanza1}{stanza2}</div>'
+    chapters = build_chapters_from_html(html)
+    assert len(chapters) == 1
+    text = chapters[0].text
+    stanzas = [p for p in text.split("\n\n") if p.strip()]
+    # Exactly two stanza-paragraphs, not one-per-line.
+    assert len(stanzas) == 2, f"Expected 2 stanzas, got {len(stanzas)}: {stanzas!r}"
+    # Each stanza retains its internal \n-separated lines.
+    for s in stanzas:
+        lines = [l for l in s.split("\n") if l.strip()]
+        assert len(lines) == 8, f"Expected 8 lines in stanza, got {len(lines)}: {s!r}"
+
+
 def test_build_chapters_from_html_handles_malformed_html():
     # lxml is lenient — should not raise, just return best effort
     html = "<div class='chapter'><h2>A</h2><p>x</p></unclosed>"


### PR DESCRIPTION
Reported on Faust (Gutenberg book 2229). Every verse line was rendering as its own paragraph with blank lines between, instead of grouped into stanzas.

### Cause
Gutenberg HTML for verse looks like this:
```html
<p>
Ihr naht euch wieder, schwankende Gestalten,<br>
Die früh sich einst dem trüben Blick gezeigt.<br>
Versuch ich wohl, euch diesmal festzuhalten?
</p>
```

The source formatting leaves **indentation whitespace + newline after each `<br>`**. My `_html_inline_text` turned `<br>` into `\n` and also preserved the tail whitespace — leaving `\n\n` between every line. Downstream `text.split('\n\n+')` in the reader then split each line into its own paragraph.

### Fix
Collapse any run of whitespace that contains a newline back to a single `\n` in `_html_inline_text`. Stanza-internal line breaks are preserved; `<p>`-level stanzas are still joined with `\n\n` by `_html_body_text`.

### Note on caching
HTML source is NOT stored in the DB. We fetch Gutenberg HTML on-demand at chapter-split time and cache the resulting `Chapter` list in memory. So a running backend needs a restart to re-split book 2229 with the new logic.

## Test plan
- [x] New test `test_build_chapters_from_html_preserves_verse_stanzas` uses Gutenberg's actual Faust Zueignung markup (2 × 8-line stanzas) and asserts exactly 2 paragraphs, each with 8 \n-separated lines
- [x] Backend: 358 tests pass

Generated with [Claude Code](https://claude.com/claude-code)