### PR TITLE
feat(library): remove a book from the user library

### DIFF
--- a/frontend/src/__tests__/recentBooks.test.ts
+++ b/frontend/src/__tests__/recentBooks.test.ts
@@ -5,6 +5,7 @@
 import {
   getRecentBooks,
   recordRecentBook,
+  removeRecentBook,
   saveLastChapter,
   getLastChapter,
   RecentBook,
@@ -113,5 +114,27 @@ test("getRecentBooks returns empty array when localStorage is empty", () => {
 
 test("getRecentBooks returns empty array when localStorage contains invalid JSON", () => {
   localStorage.setItem("recent_books", "not-json");
+  expect(getRecentBooks()).toEqual([]);
+});
+
+// ── removeRecentBook ─────────────────────────────────────────────────────────
+
+test("removeRecentBook drops the matching book from the list", () => {
+  recordRecentBook({ ...BOOK, id: 1, title: "A" });
+  recordRecentBook({ ...BOOK, id: 2, title: "B" });
+  recordRecentBook({ ...BOOK, id: 3, title: "C" });
+  removeRecentBook(2);
+  const books = getRecentBooks();
+  expect(books.map((b: RecentBook) => b.id).sort()).toEqual([1, 3]);
+});
+
+test("removeRecentBook is a no-op for an unknown book id", () => {
+  recordRecentBook({ ...BOOK, id: 1 });
+  removeRecentBook(9999);
+  expect(getRecentBooks()).toHaveLength(1);
+});
+
+test("removeRecentBook does not throw on empty library", () => {
+  expect(() => removeRecentBook(1)).not.toThrow();
   expect(getRecentBooks()).toEqual([]);
 });

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
 import { searchBooks, getPopularBooks, getMe, BookMeta } from "@/lib/api";
-import { getRecentBooks, RecentBook } from "@/lib/recentBooks";
+import { getRecentBooks, removeRecentBook, RecentBook } from "@/lib/recentBooks";
 import BookCard from "@/components/BookCard";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
@@ -203,6 +203,11 @@ export default function Home() {
                     book={book}
                     onClick={() => openBook(book.id)}
                     badge={`Ch. ${book.lastChapter + 1} · ${timeAgo(book.lastRead)}`}
+                    onRemove={() => {
+                      if (!confirm(`Remove "${book.title}" from your library?`)) return;
+                      removeRecentBook(book.id);
+                      setRecentBooks(getRecentBooks());
+                    }}
                   />
                 ))}
               </div>

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -5,34 +5,53 @@ interface Props {
   book: BookMeta;
   onClick: () => void;
   badge?: string; // e.g. "Last read 2h ago"
+  /** When provided, a small × button appears in the card corner that
+   *  calls this handler without navigating. Used on the "Your Library"
+   *  tab to let users remove books from their local recent list. */
+  onRemove?: () => void;
 }
 
-export default function BookCard({ book, onClick, badge }: Props) {
+export default function BookCard({ book, onClick, badge, onRemove }: Props) {
   return (
-    <button
-      onClick={onClick}
-      className="text-left rounded-xl border border-amber-200 bg-white shadow-sm hover:shadow-md transition-shadow p-3 flex flex-col w-full"
-    >
-      {book.cover ? (
-        <img
-          src={book.cover}
-          alt={book.title}
-          className="w-full h-40 object-cover rounded-lg mb-2"
-        />
-      ) : (
-        <div className="w-full h-40 bg-amber-50 rounded-lg mb-2 flex items-center justify-center text-4xl border border-amber-100">
-          📖
-        </div>
+    <div className="relative">
+      {onRemove && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          title="Remove from library"
+          aria-label="Remove from library"
+          className="absolute top-1 right-1 z-10 w-6 h-6 rounded-full bg-white/80 text-stone-500 border border-amber-200 text-xs hover:bg-red-50 hover:text-red-600 hover:border-red-200"
+        >
+          ×
+        </button>
       )}
-      <p className="font-serif font-semibold text-sm text-ink line-clamp-2 flex-1">
-        {book.title}
-      </p>
-      <p className="text-xs text-amber-700 mt-1 line-clamp-1">
-        {book.authors.join(", ")}
-      </p>
-      {badge && (
-        <span className="mt-1.5 text-xs text-amber-500">{badge}</span>
-      )}
-    </button>
+      <button
+        onClick={onClick}
+        className="text-left rounded-xl border border-amber-200 bg-white shadow-sm hover:shadow-md transition-shadow p-3 flex flex-col w-full"
+      >
+        {book.cover ? (
+          <img
+            src={book.cover}
+            alt={book.title}
+            className="w-full h-40 object-cover rounded-lg mb-2"
+          />
+        ) : (
+          <div className="w-full h-40 bg-amber-50 rounded-lg mb-2 flex items-center justify-center text-4xl border border-amber-100">
+            📖
+          </div>
+        )}
+        <p className="font-serif font-semibold text-sm text-ink line-clamp-2 flex-1">
+          {book.title}
+        </p>
+        <p className="text-xs text-amber-700 mt-1 line-clamp-1">
+          {book.authors.join(", ")}
+        </p>
+        {badge && (
+          <span className="mt-1.5 text-xs text-amber-500">{badge}</span>
+        )}
+      </button>
+    </div>
   );
 }

--- a/frontend/src/lib/recentBooks.ts
+++ b/frontend/src/lib/recentBooks.ts
@@ -50,3 +50,19 @@ export function getLastChapter(bookId: number): number {
     return 0;
   }
 }
+
+/** Remove a book from the user's local library list.
+ *
+ * Only touches localStorage — the book stays cached on the backend for
+ * other readers. If the user opens it again from Discover/Search it will
+ * re-appear in the library automatically.
+ */
+export function removeRecentBook(bookId: number) {
+  try {
+    const existing = getRecentBooks();
+    const filtered = existing.filter((b) => b.id !== bookId);
+    if (filtered.length !== existing.length) {
+      localStorage.setItem(KEY, JSON.stringify(filtered));
+    }
+  } catch {}
+}


### PR DESCRIPTION
Users had no way to clear a book from the **Your Library** list. Added a small × button in the top-right corner of each BookCard on the library tab. Click → confirm → the book is dropped from the local `recent_books` list in localStorage. The book stays cached on the backend for other readers.

### Scope

- New `removeRecentBook(bookId)` helper in `lib/recentBooks.ts`
- `BookCard` gets an optional `onRemove` prop; when set, renders an absolutely-positioned × button that uses `stopPropagation` so clicking it doesn't navigate to the book
- Library tab wires `onRemove` → `removeRecentBook` + refresh state

Books can be added back simply by opening them from Discover/Search again — no backend action needed.

## Test plan
- [x] Frontend: 135 tests pass (3 new covering remove: drop match, no-op on unknown id, no-op on empty library)
- [x] `next build` passes

Generated with [Claude Code](https://claude.com/claude-code)