### PR TITLE
feat(reader): whole-book translation progress overview

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -69,12 +69,18 @@ async def popular_books(language: str = ""):
 
 @router.get("/{book_id}/translation-status")
 async def translation_status(book_id: int, target_language: str):
-    """Return how many chapters of a book have a cached translation.
+    """Return book-level translation progress for the reader banner.
 
-    Used by the reader to show a 'bulk translation in progress' banner when
-    the admin is running a background job. Cheap — just counts DB rows.
+    Includes:
+      - total_chapters (as split by the splitter)
+      - translated_chapters (cached in translations table)
+      - queue_pending / queue_running / queue_failed (per-book per-lang
+        counts from the translation_queue table) — lets the reader show
+        "3/21 chapters still processing" during a background run.
+      - bulk_active: legacy one-shot bulk job, kept for back-compat.
     """
-    from services.db import count_translations_for_book
+    import aiosqlite
+    from services.db import count_translations_for_book, DB_PATH
     from services.bulk_translate import manager as bulk_manager
 
     cached = await get_cached_book(book_id)
@@ -83,6 +89,18 @@ async def translation_status(book_id: int, target_language: str):
         total_chapters = len(build_chapters(cached["text"]))
 
     cached_translations = await count_translations_for_book(book_id, target_language)
+
+    # Pull queue stats for this (book, language) in one grouped query.
+    queue_counts: dict[str, int] = {}
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            """SELECT status, COUNT(*) FROM translation_queue
+               WHERE book_id=? AND target_language=?
+               GROUP BY status""",
+            (book_id, target_language),
+        ) as cursor:
+            async for row in cursor:
+                queue_counts[row[0]] = row[1]
 
     # Is a bulk job currently touching this book?
     bulk_active = False
@@ -98,6 +116,10 @@ async def translation_status(book_id: int, target_language: str):
         "target_language": target_language,
         "total_chapters": total_chapters,
         "translated_chapters": cached_translations,
+        "queue_pending": queue_counts.get("pending", 0),
+        "queue_running": queue_counts.get("running", 0),
+        "queue_failed": queue_counts.get("failed", 0),
+        "queue_done": queue_counts.get("done", 0),
         "bulk_active": bulk_active,
     }
 

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -635,18 +635,43 @@ export default function ReaderPage() {
           </div>
         )}
 
-      {/* Bulk translation banner — visible when a background job is translating this book */}
-      {translationEnabled && bookTranslationStatus && bookTranslationStatus.bulk_active && (
-        <div className="bg-amber-50 border-b border-amber-200 px-4 py-2 text-xs text-amber-800 flex items-center justify-between">
-          <span>
-            <span className="inline-block w-1.5 h-1.5 bg-amber-500 rounded-full animate-pulse mr-2" />
-            Bulk translation in progress —{" "}
-            <strong>{bookTranslationStatus.translated_chapters} / {bookTranslationStatus.total_chapters}</strong>{" "}
-            chapters ready for this book.
-          </span>
-          <span className="text-amber-500">Polls every 15s</span>
-        </div>
-      )}
+      {/* Book-level translation progress — shown whenever the queue is
+          holding at least one chapter of THIS book in THIS language,
+          even if a legacy bulk job isn't running. Gives the user a
+          whole-book view (e.g. "18/21 chapters ready · 3 processing")
+          in addition to the per-chapter banner above. */}
+      {translationEnabled && bookTranslationStatus && (() => {
+        const s = bookTranslationStatus;
+        const queued = (s.queue_pending ?? 0) + (s.queue_running ?? 0);
+        const anyQueueActivity = queued > 0 || (s.queue_failed ?? 0) > 0;
+        if (!s.bulk_active && !anyQueueActivity) return null;
+        const ready = s.translated_chapters;
+        const total = s.total_chapters;
+        return (
+          <div className="bg-amber-50 border-b border-amber-200 px-4 py-2 text-xs text-amber-800 flex items-center justify-between gap-3">
+            <span className="flex items-center gap-2">
+              <span className="inline-block w-1.5 h-1.5 bg-amber-500 rounded-full animate-pulse" />
+              <span>
+                <strong>{ready} / {total}</strong> chapters translated
+                {queued > 0 && (
+                  <>
+                    {" · "}
+                    <strong>{queued}</strong> still processing
+                    {s.queue_running ? ` (${s.queue_running} running)` : ""}
+                  </>
+                )}
+                {s.queue_failed ? (
+                  <>
+                    {" · "}
+                    <span className="text-red-600">{s.queue_failed} failed</span>
+                  </>
+                ) : null}
+              </span>
+            </span>
+            <span className="text-amber-500 shrink-0">Polls every 15s</span>
+          </div>
+        );
+      })()}
 
       {/* Reading progress bar — combines chapter position + scroll within chapter */}
       {chapters.length > 0 && (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -212,6 +212,10 @@ export async function getTranslationCache(
 
 /** Lightweight public endpoint — how many chapters of a book are translated? */
 export interface TranslationStatus {
+  queue_pending?: number;
+  queue_running?: number;
+  queue_failed?: number;
+  queue_done?: number;
   book_id: number;
   target_language: string;
   total_chapters: number;


### PR DESCRIPTION
Per-chapter banner only told the user about the current chapter. Reader now shows whole-book progress: **18 / 21 chapters translated · 3 still processing (1 running)**.

### Backend

Extended `GET /books/{id}/translation-status` with queue counts per `(book, target_language)` pair:
- `queue_pending`
- `queue_running`
- `queue_failed`
- `queue_done`

One grouped `SELECT status, COUNT(*) GROUP BY status` query so it stays cheap.

### Reader UI

Banner is now shown whenever the queue has *any* activity for this book+lang, not just during a legacy bulk run. Failed rows are flagged in red so users know to check with admin.

## Test plan
- [x] Backend: 359 tests pass
- [x] Frontend: 135 tests pass
- [x] `next build` passes

Generated with [Claude Code](https://claude.com/claude-code)