### PR TITLE
feat(queue): retry failed chapter from reader + admin book row

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -871,6 +871,45 @@ async def queue_retry_item(
     return {"ok": True, "updated": cursor.rowcount}
 
 
+class RetryFailedRequest(BaseModel):
+    book_id: int | None = None
+    target_language: str | None = None
+
+
+@router.post("/queue/retry-failed")
+async def queue_retry_failed(
+    req: RetryFailedRequest,
+    _admin: dict = Depends(_require_admin),
+):
+    """Revive every failed queue row matching the filters.
+
+    Shortcut for the admin books list's "Retry N failed" button when a
+    book/language pair has a stack of failures. Without filters this retries
+    every failed row in the whole queue.
+    """
+    clauses = ["status='failed'"]
+    params: list[int | str] = []
+    if req.book_id is not None:
+        clauses.append("book_id=?")
+        params.append(req.book_id)
+    if req.target_language is not None:
+        clauses.append("target_language=?")
+        params.append(req.target_language)
+    where = " AND ".join(clauses)
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            f"""UPDATE translation_queue
+                   SET status='pending', attempts=0, last_error=NULL,
+                       priority=100,
+                       updated_at=CURRENT_TIMESTAMP
+                   WHERE {where}""",
+            params,
+        )
+        await db.commit()
+    queue_worker().wake()
+    return {"ok": True, "updated": cursor.rowcount}
+
+
 @router.get("/queue/cost-estimate")
 async def queue_cost_estimate(_admin: dict = Depends(_require_admin)):
     """Ballpark USD to drain every pending queue item, per model.

--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -218,6 +218,40 @@ async def request_chapter_translation(
     }
 
 
+@router.post("/{book_id}/chapters/{chapter_index}/translation/retry")
+async def retry_chapter_translation(
+    book_id: int,
+    chapter_index: int,
+    req: RequestTranslationBody,
+    user: dict = Depends(get_current_user),
+):
+    """Re-queue a single chapter whose queue row is in 'failed' state.
+
+    Distinct from `request_chapter_translation` because that endpoint uses
+    INSERT OR IGNORE — a failed row would stay failed forever. Retry is an
+    explicit action: admin or reader clicks a button. Resets the queue row
+    to pending + attempts=0 and bumps priority to 10 (reader-initiated).
+    """
+    from services.translation_queue import enqueue, queue_status_for_chapter, worker
+
+    queued_by = user.get("email") or user.get("name") or f"user#{user.get('id')}"
+    await enqueue(
+        book_id, chapter_index, req.target_language,
+        priority=10,
+        reset_failed=True,
+        queued_by=queued_by,
+    )
+    worker().wake()
+    fresh = await queue_status_for_chapter(
+        book_id, chapter_index, req.target_language,
+    )
+    return {
+        "status": fresh["status"],
+        "position": fresh["position"],
+        "attempts": 0,
+    }
+
+
 @router.get("/{book_id}")
 async def book_meta(book_id: int):
     cached = await get_cached_book(book_id)

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -431,3 +431,70 @@ async def test_seed_popular_refuses_concurrent_start(admin_client, admin_db, mon
 
         # Clean up — stop the job
         await admin_client.post("/api/admin/books/seed-popular/stop")
+
+
+# ── Retry-failed bulk endpoint ───────────────────────────────────────────────
+
+async def _seed_failed(book_id: int, chapter_index: int, target_language: str):
+    """Helper: insert a failed queue row for retry-failed tests."""
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        await conn.execute(
+            """INSERT INTO translation_queue
+                   (book_id, chapter_index, target_language, priority,
+                    status, attempts, last_error)
+               VALUES (?, ?, ?, ?, 'failed', 3, 'boom')""",
+            (book_id, chapter_index, target_language, 100),
+        )
+        await conn.commit()
+
+
+async def test_admin_retry_failed_by_book_and_lang(admin_client, admin_db):
+    """POST /admin/queue/retry-failed with {book_id, target_language}
+    revives only failed rows matching both filters — other failed rows
+    stay failed."""
+    await _seed_failed(100, 0, "zh")
+    await _seed_failed(100, 1, "zh")
+    await _seed_failed(100, 0, "fr")   # different language
+    await _seed_failed(200, 0, "zh")   # different book
+
+    res = await admin_client.post(
+        "/api/admin/queue/retry-failed",
+        json={"book_id": 100, "target_language": "zh"},
+    )
+    assert res.status_code == 200
+    assert res.json()["updated"] == 2
+
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        conn.row_factory = aiosqlite.Row
+        async with conn.execute(
+            "SELECT book_id, chapter_index, target_language, status, attempts "
+            "FROM translation_queue ORDER BY book_id, chapter_index, target_language",
+        ) as cursor:
+            rows = [dict(r) for r in await cursor.fetchall()]
+
+    by_key = {
+        (r["book_id"], r["chapter_index"], r["target_language"]): r for r in rows
+    }
+    # Matched rows reset.
+    assert by_key[(100, 0, "zh")]["status"] == "pending"
+    assert by_key[(100, 0, "zh")]["attempts"] == 0
+    assert by_key[(100, 1, "zh")]["status"] == "pending"
+    # Non-matching stay failed.
+    assert by_key[(100, 0, "fr")]["status"] == "failed"
+    assert by_key[(200, 0, "zh")]["status"] == "failed"
+
+
+async def test_admin_retry_failed_without_filters_retries_all(admin_client, admin_db):
+    await _seed_failed(100, 0, "zh")
+    await _seed_failed(200, 0, "fr")
+
+    res = await admin_client.post("/api/admin/queue/retry-failed", json={})
+    assert res.status_code == 200
+    assert res.json()["updated"] == 2
+
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        async with conn.execute(
+            "SELECT COUNT(*) FROM translation_queue WHERE status='failed'",
+        ) as cursor:
+            (count,) = await cursor.fetchone()
+    assert count == 0

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -191,3 +191,72 @@ async def test_import_stream_done_event_on_uncached_book(client):
     assert resp.status_code == 200
     events = _parse_sse(resp.text)
     assert any(e["event"] == "done" for e in events)
+
+
+# ── Retry-failed-chapter endpoint ────────────────────────────────────────────
+
+async def test_retry_chapter_translation_revives_failed_row(client):
+    """POST /chapters/{idx}/translation/retry resets a 'failed' queue row
+    to 'pending' with attempts=0 so the worker picks it up again. Without
+    this endpoint the reader's normal translation request (INSERT OR IGNORE)
+    would leave the row failed forever."""
+    import aiosqlite
+    import services.db as db_module
+
+    await save_book(1342, MOCK_META, "text")
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        await conn.execute(
+            """INSERT INTO translation_queue
+                   (book_id, chapter_index, target_language, priority,
+                    status, attempts, last_error)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (1342, 0, "zh", 100, "failed", 3, "boom"),
+        )
+        await conn.commit()
+
+    resp = await client.post(
+        "/api/books/1342/chapters/0/translation/retry",
+        json={"target_language": "zh"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "pending"
+    assert data["attempts"] == 0
+
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        conn.row_factory = aiosqlite.Row
+        async with conn.execute(
+            "SELECT status, attempts, last_error, priority "
+            "FROM translation_queue WHERE book_id=1342 AND chapter_index=0 AND target_language='zh'",
+        ) as cursor:
+            row = await cursor.fetchone()
+    assert row["status"] == "pending"
+    assert row["attempts"] == 0
+    assert row["last_error"] is None
+    # Reader-initiated retry uses priority=10 (matches request_chapter_translation)
+    assert row["priority"] == 10
+
+
+async def test_retry_chapter_translation_inserts_if_no_row(client):
+    """If no queue row exists yet (e.g. failed row was deleted), retry
+    still succeeds and creates a pending row."""
+    import aiosqlite
+    import services.db as db_module
+
+    await save_book(1342, MOCK_META, "text")
+    resp = await client.post(
+        "/api/books/1342/chapters/2/translation/retry",
+        json={"target_language": "fr"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "pending"
+
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        conn.row_factory = aiosqlite.Row
+        async with conn.execute(
+            "SELECT status, priority FROM translation_queue "
+            "WHERE book_id=1342 AND chapter_index=2 AND target_language='fr'",
+        ) as cursor:
+            row = await cursor.fetchone()
+    assert row["status"] == "pending"
+    assert row["priority"] == 10

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -26,6 +26,7 @@ import {
   getMe,
   saveGeminiKey,
   deleteGeminiKey,
+  retryChapterTranslation,
 } from "@/lib/api";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -379,4 +380,18 @@ test("deleteGeminiKey sends DELETE", async () => {
   mockFetch({ ok: true });
   await deleteGeminiKey();
   expect((global.fetch as jest.Mock).mock.calls[0][1].method).toBe("DELETE");
+});
+
+// ── Chapter translation retry ────────────────────────────────────────────────
+
+test("retryChapterTranslation POSTs to the explicit retry URL", async () => {
+  // Distinct from requestChapterTranslation: the normal request uses
+  // INSERT OR IGNORE on the queue, which silently no-ops on failed rows.
+  // Retry hits a separate endpoint that resets the row to pending.
+  mockFetch({ status: "pending", position: 1, attempts: 0 });
+  await retryChapterTranslation(1342, 5, "zh");
+  const [url, opts] = (global.fetch as jest.Mock).mock.calls[0];
+  expect(url).toContain("/books/1342/chapters/5/translation/retry");
+  expect(opts.method).toBe("POST");
+  expect(JSON.parse(opts.body).target_language).toBe("zh");
 });

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -53,6 +53,7 @@ export default function BooksPage() {
   const [queueingLangFor, setQueueingLangFor] = useState<string | null>(null);
   const [retranslating, setRetranslating] = useState<string | null>(null);
   const [bulkRetranslating, setBulkRetranslating] = useState<string | null>(null);
+  const [retryingFailed, setRetryingFailed] = useState<string | null>(null);
 
   const load = useCallback(async ({ silent = false }: { silent?: boolean } = {}) => {
     if (!silent) setLoading(true);
@@ -145,6 +146,24 @@ export default function BooksPage() {
       alert(e instanceof Error ? e.message : "Enqueue failed");
     } finally {
       setQueueingLangFor(null);
+    }
+  }
+
+  async function retryFailedForLang(book: Book, lang: string, failedCount: number) {
+    const key = `${book.id}:${lang}`;
+    if (!confirm(`Retry ${failedCount} failed chapter(s) of "${book.title}" → ${lang}?`)) return;
+    setRetryingFailed(key);
+    try {
+      const res = await adminFetch("/admin/queue/retry-failed", {
+        method: "POST",
+        body: JSON.stringify({ book_id: book.id, target_language: lang }),
+      });
+      alert(`Re-queued ${res.updated} failed chapter(s) of "${book.title}" → ${lang}.`);
+      await load({ silent: true });
+    } catch (e: unknown) {
+      alert(e instanceof Error ? e.message : "Retry failed");
+    } finally {
+      setRetryingFailed(null);
     }
   }
 
@@ -242,19 +261,31 @@ export default function BooksPage() {
                             : pending > 0
                               ? "bg-stone-50 border-stone-200 text-stone-600"
                               : "bg-amber-50 border-amber-200 text-amber-700";
+                      const retryKey = `${b.id}:${lang}`;
                       return (
-                        <span
-                          key={lang}
-                          className={`text-[10px] px-1.5 py-0.5 rounded-full border ${tone}`}
-                          title={pieces.join(" · ")}
-                        >
-                          {lang} · {count}
-                          {pending + running + failed > 0 && (
-                            <span className="ml-1 opacity-70">
-                              {running > 0 && `▶${running}`}
-                              {pending > 0 && `⏳${pending}`}
-                              {failed > 0 && `!${failed}`}
-                            </span>
+                        <span key={lang} className="inline-flex items-center gap-0.5">
+                          <span
+                            className={`text-[10px] px-1.5 py-0.5 rounded-full border ${tone}`}
+                            title={pieces.join(" · ")}
+                          >
+                            {lang} · {count}
+                            {pending + running + failed > 0 && (
+                              <span className="ml-1 opacity-70">
+                                {running > 0 && `▶${running}`}
+                                {pending > 0 && `⏳${pending}`}
+                                {failed > 0 && `!${failed}`}
+                              </span>
+                            )}
+                          </span>
+                          {failed > 0 && (
+                            <button
+                              onClick={() => retryFailedForLang(b, lang, failed)}
+                              disabled={retryingFailed === retryKey}
+                              title={`Retry ${failed} failed ${lang} chapter${failed === 1 ? "" : "s"}`}
+                              className="text-[10px] px-1 rounded border border-red-300 text-red-600 hover:bg-red-50 disabled:opacity-50"
+                            >
+                              {retryingFailed === retryKey ? "…" : "↻"}
+                            </button>
                           )}
                         </span>
                       );

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { getBookChapters, deleteTranslationCache, getAudiobook, deleteAudiobook, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, TranslationStatus, BookMeta, BookChapter, Audiobook } from "@/lib/api";
+import { getBookChapters, deleteTranslationCache, getAudiobook, deleteAudiobook, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, retryChapterTranslation, TranslationStatus, BookMeta, BookChapter, Audiobook } from "@/lib/api";
 import { recordRecentBook, saveLastChapter, getLastChapter } from "@/lib/recentBooks";
 import { getSettings, saveSettings, FontSize, Theme } from "@/lib/settings";
 import InsightChat, { LANGUAGES } from "@/components/InsightChat";
@@ -338,6 +338,25 @@ export default function ReaderPage() {
     setTimeout(() => setTranslationEnabled(true), 50);
   }
 
+  async function handleRetryFailed() {
+    // Different from handleRetranslate: there is no cached translation to
+    // delete (the chapter failed), we just need to revive the failed queue
+    // row so the worker picks it up again. Clearing frontend state + the
+    // toggle dance re-starts polling once the row is pending.
+    const bid = Number(bookId);
+    const cacheKey = `${bookId}-${chapterIndex}-${translationLang}`;
+    try {
+      await retryChapterTranslation(bid, chapterIndex, translationLang);
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "Retry failed");
+      return;
+    }
+    translationCache.current.delete(cacheKey);
+    setTranslatedParagraphs([]);
+    setTranslationEnabled(false);
+    setTimeout(() => setTranslationEnabled(true), 50);
+  }
+
   const handleSelection = useCallback(() => {
     const sel = window.getSelection()?.toString().trim() || "";
     if (sel.length > 10) setSelectedText(sel);
@@ -611,6 +630,21 @@ export default function ReaderPage() {
                   Retranslate
                 </button>
               )}
+
+              {/* Any user can retry their own failed chapter — the queue row
+                  is in 'failed' state, a fresh request is idempotent, and
+                  priority=10 means the worker picks it up ahead of background
+                  auto-enqueued items. */}
+              {!translationLoading &&
+                translationUsedProvider.startsWith("queue failed") && (
+                  <button
+                    onClick={handleRetryFailed}
+                    className="text-xs px-2 py-1 rounded border border-red-300 text-red-600 hover:bg-red-50 ml-auto"
+                    title="Re-queue this chapter for the background worker"
+                  >
+                    Retry
+                  </button>
+                )}
             </>
           )}
         </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -284,6 +284,21 @@ export function requestChapterTranslation(
   );
 }
 
+export function retryChapterTranslation(
+  bookId: number,
+  chapterIndex: number,
+  targetLanguage: string,
+): Promise<ChapterTranslationResponse> {
+  return request<ChapterTranslationResponse>(
+    `/books/${bookId}/chapters/${chapterIndex}/translation/retry`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ target_language: targetLanguage }),
+    },
+  );
+}
+
 /** Save a completed progressive translation to the backend cache. */
 export function saveTranslationCache(
   bookId: number,


### PR DESCRIPTION
## Summary

Before: when a queue row flipped to `failed` after exhausting retries, the reader showed "queue failed · N attempts" with no way forward, and the admin saw a red `!N` chip on the book row with no one-click retry. The only path was the admin Queue tab's per-item list.

This PR surfaces retry in both places the user hits the failure.

**Backend**
- `POST /books/{id}/chapters/{idx}/translation/retry` — authenticated user; resets a failed queue row to pending with attempts=0 at priority=10. Separate endpoint because the normal translation request uses `INSERT OR IGNORE` and silently no-ops on failed rows.
- `POST /admin/queue/retry-failed` — admin; bulk revives every failed row, optionally filtered by `book_id` and/or `target_language`.

**Frontend**
- Reader: red `Retry` button next to the translation status line when `queue failed` is shown. One click re-enqueues and the polling loop resumes.
- Admin Books: each language chip with `!N failed` now has a `↻` button that bulk-retries just that (book, language) pair.

## Test plan

- [x] 4 new backend tests: revive failed row, insert if absent, bulk retry with filters, bulk retry without filters.
- [x] 1 new frontend test covers the `retryChapterTranslation` helper URL + shape.
- [x] Full suites green: 364 backend, 141 frontend.
- [ ] Manual on Faust (2229): confirm a failed chapter shows Retry in the reader, and admin's book row shows ↻ next to the language chip.
- [ ] Note for `/reader/2229`: already-cached wrong-index translations from before PR #107 still serve from cache. Hit "Retranslate all" on Faust in admin to regenerate, or delete and re-import — this PR only covers the retry-failed path.

Generated with [Claude Code](https://claude.com/claude-code)
