### PR TITLE
feat(admin): reassign cached translation to a different chapter

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -488,6 +488,95 @@ async def retranslate_all(
     return {"ok": True, "chapters": len(results), "results": results}
 
 
+class MoveTranslationRequest(BaseModel):
+    new_chapter_index: int
+
+
+@router.post("/translations/{book_id}/{chapter_index}/{target_language}/move")
+async def move_translation(
+    book_id: int,
+    chapter_index: int,
+    target_language: str,
+    req: MoveTranslationRequest,
+    _admin: dict = Depends(_require_admin),
+):
+    """Reassign a cached translation to a different chapter_index.
+
+    Use case: when the splitter indices change (PR #107 HTML/text
+    realignment), existing cached translations are at the wrong slot.
+    Rather than burn tokens re-translating, admins can shift each cached
+    translation to the chapter_index that now matches the source content.
+
+    Rejects with 409 if the target slot already has a translation —
+    the admin must delete it first. Rejects with 400 on out-of-range
+    indices. Clears any pending/failed queue row at the destination so
+    the worker doesn't later overwrite the moved translation.
+    """
+    book = await get_cached_book(book_id)
+    if not book or not book.get("text"):
+        raise HTTPException(status_code=404, detail="Book not found in cache")
+
+    from services.book_chapters import split_with_html_preference
+    chapters = await split_with_html_preference(book_id, book["text"])
+    new_idx = req.new_chapter_index
+    if new_idx < 0 or new_idx >= len(chapters):
+        raise HTTPException(
+            status_code=400,
+            detail=f"new_chapter_index {new_idx} out of range (0-{len(chapters) - 1})",
+        )
+    if new_idx == chapter_index:
+        raise HTTPException(
+            status_code=400, detail="new_chapter_index is the same as the source",
+        )
+
+    async with aiosqlite.connect(DB_PATH) as db:
+        # Source exists?
+        async with db.execute(
+            "SELECT 1 FROM translations "
+            "WHERE book_id=? AND chapter_index=? AND target_language=?",
+            (book_id, chapter_index, target_language),
+        ) as cursor:
+            if await cursor.fetchone() is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=(
+                        f"No translation at chapter {chapter_index} "
+                        f"for book {book_id} / {target_language}"
+                    ),
+                )
+        # Target slot must be empty — safer than silently overwriting.
+        async with db.execute(
+            "SELECT 1 FROM translations "
+            "WHERE book_id=? AND chapter_index=? AND target_language=?",
+            (book_id, new_idx, target_language),
+        ) as cursor:
+            if await cursor.fetchone() is not None:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"Chapter {new_idx} already has a {target_language} translation. "
+                        "Delete it first, then retry the move."
+                    ),
+                )
+        await db.execute(
+            "UPDATE translations "
+            "SET chapter_index=? "
+            "WHERE book_id=? AND chapter_index=? AND target_language=?",
+            (new_idx, book_id, chapter_index, target_language),
+        )
+        # A queue row at the destination (pending/running/failed) would
+        # let the worker later translate over the top. Clear it — the
+        # move means we're asserting this chapter is now done.
+        await db.execute(
+            "DELETE FROM translation_queue "
+            "WHERE book_id=? AND chapter_index=? AND target_language=?",
+            (book_id, new_idx, target_language),
+        )
+        await db.commit()
+
+    return {"ok": True, "from": chapter_index, "to": new_idx}
+
+
 # ══════════════════════════════════════════════════════════════════════════════
 # STATS
 # ══════════════════════════════════════════════════════════════════════════════

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -484,6 +484,97 @@ async def test_admin_retry_failed_by_book_and_lang(admin_client, admin_db):
     assert by_key[(200, 0, "zh")]["status"] == "failed"
 
 
+# The short BOOK_TEXT above collapses to a single chapter under the
+# splitter's minimum-length heuristic. Move tests need ≥2 real chapters
+# so the "new_chapter_index" range check has room to exercise both
+# success and out-of-range paths.
+MOVE_BOOK_TEXT = (
+    "CHAPTER I\n\n" + ("Paragraph one. " * 40) + "\n\n"
+    + ("Paragraph two. " * 40) + "\n\n"
+    + "CHAPTER II\n\n" + ("Paragraph three. " * 40) + "\n\n"
+    + ("Paragraph four. " * 40) + "\n\n"
+    + "CHAPTER III\n\n" + ("Paragraph five. " * 40) + "\n\n"
+    + ("Paragraph six. " * 40)
+)
+
+
+async def test_move_translation_shifts_chapter_index(admin_client, admin_db):
+    """POST /admin/translations/{id}/{idx}/{lang}/move reassigns an existing
+    cached translation to a different chapter_index without retranslating.
+    Used to rescue stale translations after a splitter change."""
+    await save_book(100, BOOK_META, MOVE_BOOK_TEXT)
+    await save_translation(100, 1, "en", ["Old chapter 2 text."])
+    res = await admin_client.post(
+        "/api/admin/translations/100/1/en/move",
+        json={"new_chapter_index": 0},
+    )
+    assert res.status_code == 200, res.text
+    assert res.json() == {"ok": True, "from": 1, "to": 0}
+
+    from services.db import get_cached_translation
+    assert await get_cached_translation(100, 0, "en") == ["Old chapter 2 text."]
+    assert await get_cached_translation(100, 1, "en") is None
+
+
+async def test_move_translation_rejects_when_target_occupied(admin_client, admin_db):
+    """Target collision returns 409 so the admin can't silently overwrite
+    a translation they meant to keep."""
+    await save_book(100, BOOK_META, MOVE_BOOK_TEXT)
+    await save_translation(100, 0, "en", ["First."])
+    await save_translation(100, 1, "en", ["Second."])
+    res = await admin_client.post(
+        "/api/admin/translations/100/1/en/move",
+        json={"new_chapter_index": 0},
+    )
+    assert res.status_code == 409
+
+    from services.db import get_cached_translation
+    assert await get_cached_translation(100, 0, "en") == ["First."]
+    assert await get_cached_translation(100, 1, "en") == ["Second."]
+
+
+async def test_move_translation_rejects_out_of_range(admin_client, admin_db):
+    await save_book(100, BOOK_META, MOVE_BOOK_TEXT)
+    await save_translation(100, 0, "en", ["First."])
+    res = await admin_client.post(
+        "/api/admin/translations/100/0/en/move",
+        json={"new_chapter_index": 99},
+    )
+    assert res.status_code == 400
+
+
+async def test_move_translation_404_when_source_missing(admin_client, admin_db):
+    await save_book(100, BOOK_META, MOVE_BOOK_TEXT)
+    res = await admin_client.post(
+        "/api/admin/translations/100/0/en/move",
+        json={"new_chapter_index": 1},
+    )
+    assert res.status_code == 404
+
+
+async def test_move_translation_clears_queue_at_destination(admin_client, admin_db):
+    """If a queue row exists at the destination (pending/failed/whatever),
+    it would later cause the worker to translate over the moved row.
+    The move must clean it up."""
+    await save_book(100, BOOK_META, MOVE_BOOK_TEXT)
+    await save_translation(100, 1, "en", ["From slot 1."])
+    await _seed_failed(100, 0, "en")
+
+    res = await admin_client.post(
+        "/api/admin/translations/100/1/en/move",
+        json={"new_chapter_index": 0},
+    )
+    assert res.status_code == 200
+
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        async with conn.execute(
+            "SELECT COUNT(*) FROM translation_queue "
+            "WHERE book_id=100 AND chapter_index=0 AND target_language='en'",
+        ) as cursor:
+            (count,) = await cursor.fetchone()
+    assert count == 0
+
+
 async def test_admin_retry_failed_without_filters_retries_all(admin_client, admin_db):
     await _seed_failed(100, 0, "zh")
     await _seed_failed(200, 0, "fr")

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -54,6 +54,10 @@ export default function BooksPage() {
   const [retranslating, setRetranslating] = useState<string | null>(null);
   const [bulkRetranslating, setBulkRetranslating] = useState<string | null>(null);
   const [retryingFailed, setRetryingFailed] = useState<string | null>(null);
+  // Per-row input for "Move to chapter N" action — keyed by
+  // `${book_id}:${chapter_index}:${lang}` so two open books don't share state.
+  const [moveInput, setMoveInput] = useState<Record<string, string>>({});
+  const [moving, setMoving] = useState<string | null>(null);
 
   const load = useCallback(async ({ silent = false }: { silent?: boolean } = {}) => {
     if (!silent) setLoading(true);
@@ -146,6 +150,44 @@ export default function BooksPage() {
       alert(e instanceof Error ? e.message : "Enqueue failed");
     } finally {
       setQueueingLangFor(null);
+    }
+  }
+
+  async function handleMove(t: TranslationEntry, rawInput: string) {
+    // User types a 1-based chapter number to match the visible "Ch. N"
+    // label; convert to 0-based for the backend.
+    const parsed = parseInt(rawInput.trim(), 10);
+    if (isNaN(parsed) || parsed < 1) {
+      alert("Enter a chapter number (1-based, e.g. 6).");
+      return;
+    }
+    const newIdx = parsed - 1;
+    if (newIdx === t.chapter_index) {
+      alert("Target chapter is the same as the source.");
+      return;
+    }
+    const rowKey = `${t.book_id}:${t.chapter_index}:${t.target_language}`;
+    if (
+      !confirm(
+        `Reassign translation from Ch. ${t.chapter_index + 1} to Ch. ${parsed} for ${t.target_language}?\nNo tokens are used — this only moves the existing cached paragraphs.`,
+      )
+    )
+      return;
+    setMoving(rowKey);
+    try {
+      await adminFetch(
+        `/admin/translations/${t.book_id}/${t.chapter_index}/${t.target_language}/move`,
+        {
+          method: "POST",
+          body: JSON.stringify({ new_chapter_index: newIdx }),
+        },
+      );
+      setMoveInput({ ...moveInput, [rowKey]: "" });
+      await load({ silent: true });
+    } catch (e: unknown) {
+      alert(e instanceof Error ? e.message : "Move failed");
+    } finally {
+      setMoving(null);
     }
   }
 
@@ -427,6 +469,32 @@ export default function BooksPage() {
                                           <span className="text-stone-400 flex-1">
                                             {(t.size_chars / 1000).toFixed(1)}K chars
                                           </span>
+                                          {/* Move-to: reassign the cached translation
+                                              to a different chapter index without
+                                              burning tokens. Used to fix splitter-
+                                              realignment cases where paragraphs are
+                                              correct but the chapter_index is wrong. */}
+                                          <input
+                                            type="number"
+                                            min={1}
+                                            placeholder="→Ch"
+                                            value={moveInput[rowKey] ?? ""}
+                                            onChange={(e) =>
+                                              setMoveInput({ ...moveInput, [rowKey]: e.target.value })
+                                            }
+                                            onKeyDown={(e) => {
+                                              if (e.key === "Enter") handleMove(t, moveInput[rowKey] ?? "");
+                                            }}
+                                            className="w-14 rounded border border-amber-300 px-1 py-0.5 text-xs"
+                                            title="Reassign this translation to another chapter number (1-based)"
+                                          />
+                                          <button
+                                            onClick={() => handleMove(t, moveInput[rowKey] ?? "")}
+                                            disabled={moving === rowKey || !(moveInput[rowKey] ?? "").trim()}
+                                            className="px-2 py-0.5 rounded border border-sky-300 text-sky-700 hover:bg-sky-50 disabled:opacity-50"
+                                          >
+                                            {moving === rowKey ? "…" : "Move"}
+                                          </button>
                                           <button
                                             onClick={() => handleRetranslate(t)}
                                             disabled={retranslating === rowKey}


### PR DESCRIPTION
## Summary

After PR #107 realigned the chapter splitter, cached translations for affected books (Faust is the concrete case — chapter 6 missing, 7+ off-by-one) sit at indices that no longer match the source paragraphs. Retranslating every chapter would burn a lot of tokens for work that's already done correctly — just attached to the wrong chapter number.

This PR lets the admin **reassign** a cached translation to a different chapter index without touching the LLM.

**Backend**
- `POST /admin/translations/{book_id}/{chapter_index}/{target_language}/move` with body `{new_chapter_index}`.
- Rejects with `400` on out-of-range or same-as-source, `404` if the source row doesn't exist, `409` if the target slot already has a translation (no silent overwrites — admin must delete first).
- Also clears any queue row at the destination so the worker doesn't later translate over the moved row.

**Frontend (Admin → Books tab)**
- Each per-chapter row in the expanded drill-down now has a `→Ch [N] [Move]` input next to Retranslate / Delete.
- User types the 1-based chapter number they want the translation to land at and hits Move (or Enter). Zero tokens consumed.

## Test plan
- [x] 5 new backend tests: happy-path shift, 409 collision, 400 out-of-range, 404 missing source, queue-cleanup on destination.
- [x] Full suites green: 369 backend, 141 frontend.
- [ ] Manual on Faust (2229): open admin Books, expand Faust → a language, reassign a chapter that shows wrong content to the correct index. Confirm reader now renders the right translation without touching LLM.

Generated with [Claude Code](https://claude.com/claude-code)
