### PR TITLE
feat(admin): fuzzy filter on the Books tab

### DIFF
--- a/frontend/src/__tests__/fuzzyMatch.test.ts
+++ b/frontend/src/__tests__/fuzzyMatch.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for the admin books filter. The matcher has to handle:
+ *   - diacritics (Faust/Goethe have ö, ü)
+ *   - case insensitive
+ *   - substring hits (the common case, fastest)
+ *   - subsequence hits ("wap" → "War and Peace")
+ *   - empty query means "everything matches"
+ */
+
+import { fuzzyMatch, fuzzyMatchAny } from "@/lib/fuzzyMatch";
+
+describe("fuzzyMatch", () => {
+  it("matches substring case-insensitively", () => {
+    expect(fuzzyMatch("faust", "Faust — Der Tragödie erster Teil")).toBe(true);
+    expect(fuzzyMatch("FAUST", "Faust")).toBe(true);
+  });
+
+  it("strips combining diacritics so plain ascii matches accented text", () => {
+    // ä/ö/ü decompose to a+combining-umlaut / o+combining-umlaut etc.,
+    // so stripping marks turns the accented char into the plain one.
+    expect(fuzzyMatch("tragodie", "Tragödie")).toBe(true);
+    expect(fuzzyMatch("uber", "Über")).toBe(true);
+    // And accented queries still match accented targets.
+    expect(fuzzyMatch("ödi", "Tragödie")).toBe(true);
+  });
+
+  it("matches subsequences when substring fails", () => {
+    expect(fuzzyMatch("wap", "War and Peace")).toBe(true);
+    expect(fuzzyMatch("fst", "Faust")).toBe(true);
+  });
+
+  it("rejects when no subsequence match", () => {
+    expect(fuzzyMatch("xyz", "Faust")).toBe(false);
+    expect(fuzzyMatch("peacewar", "War and Peace")).toBe(false);
+  });
+
+  it("treats empty query as a pass", () => {
+    expect(fuzzyMatch("", "Faust")).toBe(true);
+    expect(fuzzyMatch("   ", "Faust")).toBe(true);
+  });
+});
+
+describe("fuzzyMatchAny", () => {
+  it("matches if any of the target fields matches", () => {
+    expect(fuzzyMatchAny("goethe", ["Faust", "Johann Wolfgang von Goethe", 2229])).toBe(true);
+  });
+
+  it("matches against numeric book IDs", () => {
+    expect(fuzzyMatchAny("2229", ["Faust", "Goethe", 2229])).toBe(true);
+  });
+
+  it("skips null/undefined fields without crashing", () => {
+    expect(fuzzyMatchAny("faust", [null, undefined, "Faust"])).toBe(true);
+    expect(fuzzyMatchAny("zzz", [null, undefined])).toBe(false);
+  });
+
+  it("returns true on empty query (doesn't filter anything out)", () => {
+    expect(fuzzyMatchAny("", ["Faust"])).toBe(true);
+  });
+});

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { adminFetch } from "@/lib/adminFetch";
 import SeedPopularButton from "@/components/SeedPopularButton";
+import { fuzzyMatchAny } from "@/lib/fuzzyMatch";
 
 interface TranslationStat {
   chapters: number;
@@ -58,6 +59,7 @@ export default function BooksPage() {
   // `${book_id}:${chapter_index}:${lang}` so two open books don't share state.
   const [moveInput, setMoveInput] = useState<Record<string, string>>({});
   const [moving, setMoving] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
 
   const load = useCallback(async ({ silent = false }: { silent?: boolean } = {}) => {
     if (!silent) setLoading(true);
@@ -241,8 +243,32 @@ export default function BooksPage() {
 
       <SeedPopularButton adminFetch={adminFetch} onComplete={() => load({ silent: true })} />
 
+      {/* Fuzzy filter — matches against title + authors + book ID. Stays
+          client-side since the admin endpoint already returns the full
+          books list. Preserves existing expansion state while typing. */}
+      <div className="flex items-center gap-2">
+        <input
+          type="search"
+          placeholder="Search books by title, author, or ID…"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="flex-1 rounded-lg border border-amber-300 px-3 py-2 text-sm"
+          aria-label="Filter books"
+        />
+        {searchQuery && (
+          <span className="text-xs text-stone-500">
+            {books.filter((b) =>
+              fuzzyMatchAny(searchQuery, [b.title, ...(b.authors || []), b.id]),
+            ).length}{" "}
+            / {books.length}
+          </span>
+        )}
+      </div>
+
       <div className="bg-white rounded-xl border border-amber-200 divide-y divide-amber-100 overflow-hidden">
-        {books.map((b) => {
+        {books
+          .filter((b) => fuzzyMatchAny(searchQuery, [b.title, ...(b.authors || []), b.id]))
+          .map((b) => {
           const isExpanded = expandedBookId === b.id;
           const translatedLangs = Object.keys(b.translations || {});
           const queuedLangs = Object.keys(b.queue || {});
@@ -531,8 +557,16 @@ export default function BooksPage() {
             </div>
           );
         })}
-        {books.length === 0 && (
+        {books.length === 0 ? (
           <div className="px-4 py-8 text-center text-amber-600 text-sm">No books cached.</div>
+        ) : (
+          books.filter((b) =>
+            fuzzyMatchAny(searchQuery, [b.title, ...(b.authors || []), b.id]),
+          ).length === 0 && (
+            <div className="px-4 py-8 text-center text-amber-600 text-sm">
+              No books match &ldquo;{searchQuery}&rdquo;.
+            </div>
+          )
         )}
       </div>
     </div>

--- a/frontend/src/lib/fuzzyMatch.ts
+++ b/frontend/src/lib/fuzzyMatch.ts
@@ -1,0 +1,41 @@
+/**
+ * Lightweight fuzzy matcher for admin list filtering.
+ *
+ * Two tiers — a substring hit is preferred, a subsequence hit is a
+ * fallback. Both sides are lowercased + stripped of Unicode marks so
+ * "Gœthe" matches "goethe", "Faust — der Tragödie" matches "faust".
+ *
+ * Intentionally does not rank or fuzzy-edit — this is a filter, not a
+ * search-engine. The admin's book list rarely exceeds a few hundred
+ * rows, so correctness + zero deps beat Fuse.js-grade accuracy.
+ */
+
+function normalize(s: string): string {
+  return s.normalize("NFKD").replace(/\p{M}+/gu, "").toLowerCase();
+}
+
+function isSubsequence(query: string, target: string): boolean {
+  let i = 0;
+  for (const ch of target) {
+    if (ch === query[i]) i++;
+    if (i === query.length) return true;
+  }
+  return i === query.length;
+}
+
+export function fuzzyMatch(query: string, target: string): boolean {
+  const q = normalize(query.trim());
+  if (!q) return true;
+  const t = normalize(target);
+  if (t.includes(q)) return true;
+  return isSubsequence(q, t);
+}
+
+export function fuzzyMatchAny(query: string, targets: (string | number | null | undefined)[]): boolean {
+  const q = query.trim();
+  if (!q) return true;
+  return targets.some((t) => {
+    if (t === null || t === undefined) return false;
+    return fuzzyMatch(q, String(t));
+  });
+}


### PR DESCRIPTION
## Summary
Long cached-books lists (40+ imports) were hard to scan. Adds a search input above the admin Books list that client-side filters on **title + authors + ID**.

- New helper `lib/fuzzyMatch.ts` — NFKD-normalised, case-insensitive, strips combining marks so `tragodie` matches `Tragödie`. Substring first (fast path), subsequence fallback (`wap` → `War and Peace`). Zero runtime deps.
- Admin Books tab gets a `<input type="search">` + a "N / M" count that shows how many rows survived the filter.
- Empty-after-filter state renders "No books match '…'" instead of an empty panel.

## Test plan
- [x] 9 new unit tests cover substring, subsequence, diacritic stripping, numeric IDs, null/undefined fields, empty-query bypass.
- [x] Full frontend suite: 150 passed.
- [ ] Manual: admin Books tab, type "faust"/"goet"/"2229" — confirm counts + filtered list. Type gibberish — confirm empty state.

Generated with [Claude Code](https://claude.com/claude-code)
