### PR TITLE
fix(splitter): split multi-speaker choral cues in drama paragraphs

### DIFF
--- a/backend/services/splitter.py
+++ b/backend/services/splitter.py
@@ -479,10 +479,16 @@ def _html_body_text(elem, *, skip_first_heading: bool = False) -> str:
 
 # Dramatic speaker cue: an all-caps label that introduces a speaker's
 # lines in plays (BÜRGERMÄDCHEN., ZWEITER SCHÜLER (zum ersten).,
-# ANDRER BÜRGER., …). Used by `_split_dramatic_speakers` to break
-# paragraphs that contain more than one speaker's speech.
+# ANDRER BÜRGER., FAUST, MEPHISTOPHELES, IRRLICHT (im Wechselgesang).
+# , …). Used by `_split_dramatic_speakers` to break paragraphs that
+# contain more than one speaker's speech.
+#
+# The character class includes `,` so Faust's multi-speaker "choral"
+# cues ("FAUST, MEPHISTOPHELES, IRRLICHT …") also break a stanza. Pure
+# prose sentences like "Hello, world." are rejected by the all-caps
+# start + period-terminator constraint.
 _SPEAKER_CUE_RE = re.compile(
-    r"^[A-ZÄÖÜ][A-ZÄÖÜß\s]{1,}"       # all-caps letters (Latin + German)
+    r"^[A-ZÄÖÜ][A-ZÄÖÜß\s,]{1,}"      # all-caps letters (Latin + German), commas between names
     r"(?:\s*\([^)]{0,60}\))?"          # optional parenthetical stage dir
     r"\.$"                              # terminated by period
 )

--- a/backend/tests/test_splitter.py
+++ b/backend/tests/test_splitter.py
@@ -301,3 +301,39 @@ def test_build_chapters_from_html_splits_dramatic_speakers():
     assert any(p.startswith("ZWEITER SCHÜLER") for p in paragraphs), paragraphs
     burger = next(p for p in paragraphs if p.startswith("BÜRGERMÄDCHEN."))
     assert "ZWEITER SCHÜLER" not in burger
+
+
+def test_build_chapters_from_html_splits_multi_speaker_cue():
+    """Faust's Walpurgisnacht packs an IRRLICHT solo AND a 3-way choral
+    stanza into one <p>: the cue for the choral piece is
+    'FAUST, MEPHISTOPHELES, IRRLICHT (im Wechselgesang).' — the commas
+    between names blocked the previous speaker-cue regex and the two
+    stanzas were rendering as one paragraph."""
+    fake_block = """<p>
+    IRRLICHT.<br>
+    Ich merke wohl, Ihr seid der Herr vom Haus,<br>
+    Und will mich gern nach Euch bequemen.<br>
+    Allein bedenkt! der Berg ist heute zaubertoll<br>
+    Und wenn ein Irrlicht Euch die Wege weisen soll<br>
+    So müßt Ihr's so genau nicht nehmen.<br>
+    FAUST, MEPHISTOPHELES, IRRLICHT (im Wechselgesang).<br>
+    In die Traum- und Zaubersphäre<br>
+    Sind wir, scheint es, eingegangen.<br>
+    Führ uns gut und mach dir Ehre<br>
+    Daß wir vorwärts bald gelangen
+    </p>"""
+    padding = "Word " * 200
+    html = (
+        '<div class="chapter"><h2>Walpurgisnacht</h2>'
+        f'{fake_block}<p>{padding}</p></div>'
+    )
+    chapters = build_chapters_from_html(html)
+    assert len(chapters) == 1
+    paragraphs = [p for p in chapters[0].text.split("\n\n") if p.strip()]
+    assert any(p.startswith("IRRLICHT.") for p in paragraphs), paragraphs
+    assert any(
+        p.startswith("FAUST, MEPHISTOPHELES, IRRLICHT") for p in paragraphs
+    ), paragraphs
+    # The solo and the choral stanza must be distinct paragraphs.
+    irrlicht = next(p for p in paragraphs if p.startswith("IRRLICHT."))
+    assert "FAUST, MEPHISTOPHELES" not in irrlicht


### PR DESCRIPTION
## Summary

Faust Walpurgisnacht packs an IRRLICHT solo + a 3-way choral stanza into a single `<p>`. The cue for the choral piece — `FAUST, MEPHISTOPHELES, IRRLICHT (im Wechselgesang).` — was rejected by the speaker-cue regex because the character class only allowed all-caps letters and spaces between the leading letter and the terminating period. Commas between speaker names blocked the match, so the two stanzas rendered as one glued paragraph.

Fix: add `,` to the character class. False-positive risk stays low — pure prose like `Hello, world.` is still rejected because the all-caps start and period-terminator constraints reject it.

## Test plan
- [x] New `test_build_chapters_from_html_splits_multi_speaker_cue` covers the IRRLICHT / choral stanza from Faust Ch. 21.
- [x] Existing `test_build_chapters_from_html_splits_dramatic_speakers` (single-speaker cue) still passes.
- [x] Full backend suite: 370 passed.
- [ ] Manual: reload Faust Ch. 21 (Walpurgisnacht), confirm IRRLICHT and the choral stanza render as separate paragraphs. Note — this only helps **new** translations; cached translations of Ch. 21 still use the old split, so either retranslate the chapter or delete the cache first.

Generated with [Claude Code](https://claude.com/claude-code)
