### PR TITLE
fix(splitter): fold centered subtitle into the chapter title

### DIFF
--- a/backend/services/splitter.py
+++ b/backend/services/splitter.py
@@ -374,11 +374,38 @@ def build_chapters_from_html(html: str) -> list[Chapter]:
         # Extract title: first heading inside the block
         title_elems = div.xpath(".//h1 | .//h2 | .//h3")
         title = ""
+        title_elem = None
         if title_elems:
-            title = _html_text(title_elems[0])
+            title_elem = title_elems[0]
+            title = _html_text(title_elem)
+
+        # Subtitle: a `<p class="center">` immediately following the
+        # chapter heading is a semantic subtitle (Faust ch. 25 splits
+        # "Walpurgisnachtstraum" into an <h2> and a centered <p> for
+        # "oder / Oberons und Titanias goldne Hochzeit / Intermezzo").
+        # Fold it into the title so the body doesn't open with an
+        # orphaned "oder" line.
+        subtitle_elem = None
+        if title_elem is not None:
+            nxt = title_elem.getnext()
+            if (
+                nxt is not None
+                and isinstance(nxt.tag, str)
+                and nxt.tag == "p"
+                and "center" in (nxt.get("class") or "").split()
+            ):
+                subtitle_text = " ".join(
+                    line for line in _html_inline_text(nxt).splitlines() if line.strip()
+                ).strip()
+                if subtitle_text:
+                    title = f"{title} — {subtitle_text}" if title else subtitle_text
+                    subtitle_elem = nxt
 
         # Extract body text from all children except the title heading
-        body_text = _html_body_text(div, skip_first_heading=True)
+        # (and the subtitle paragraph, if any).
+        body_text = _html_body_text(
+            div, skip_first_heading=True, skip_elems=(subtitle_elem,) if subtitle_elem is not None else (),
+        )
         word_count = len(body_text.split())
 
         # Section divider detection. Gutenberg uses a flat structure where
@@ -437,19 +464,28 @@ def _html_text(elem) -> str:
     return " ".join(elem.itertext()).strip()
 
 
-def _html_body_text(elem, *, skip_first_heading: bool = False) -> str:
+def _html_body_text(
+    elem,
+    *,
+    skip_first_heading: bool = False,
+    skip_elems: tuple = (),
+) -> str:
     """Extract readable text from an HTML element, preserving paragraph breaks.
 
     Each `<p>` becomes one paragraph separated by blank lines. `<br>` becomes
     a single newline. Inline tags are flattened. The first `<h1>/<h2>/<h3>`
     is skipped when `skip_first_heading=True` (since the caller already used
-    it as the chapter title).
+    it as the chapter title). `skip_elems` lets the caller exclude specific
+    elements (e.g. a subtitle `<p>` already folded into the title).
     """
     parts: list[str] = []
     skipped_heading = not skip_first_heading
+    skip_set = {id(e) for e in skip_elems}
 
     for child in elem.iterchildren():
         tag = child.tag if isinstance(child.tag, str) else ""
+        if id(child) in skip_set:
+            continue
         if tag in ("h1", "h2", "h3") and not skipped_heading:
             skipped_heading = True
             continue

--- a/backend/tests/test_splitter.py
+++ b/backend/tests/test_splitter.py
@@ -303,6 +303,54 @@ def test_build_chapters_from_html_splits_dramatic_speakers():
     assert "ZWEITER SCHÜLER" not in burger
 
 
+def test_build_chapters_from_html_folds_centered_subtitle_into_title():
+    """Faust ch. 25 encodes 'Walpurgisnachtstraum' in <h2> and the rest
+    of the title ('oder / Oberons und Titanias goldne Hochzeit /
+    Intermezzo') in a <p class="center"> immediately after. Without
+    folding, the body opens with an orphan 'oder' line."""
+    body_padding = "<br>".join("Word" for _ in range(200))
+    html = (
+        '<div class="chapter">'
+        '<h2>Walpurgisnachtstraum</h2>'
+        '<p class="center">oder<br>Oberons und Titanias goldne Hochzeit<br>Intermezzo</p>'
+        f'<p>THEATERMEISTER.<br>{body_padding}</p>'
+        '</div>'
+    )
+    chapters = build_chapters_from_html(html)
+    assert len(chapters) == 1
+    ch = chapters[0]
+    # Subtitle is part of the title.
+    assert "Walpurgisnachtstraum" in ch.title
+    assert "Oberons und Titanias goldne Hochzeit" in ch.title
+    assert "Intermezzo" in ch.title
+    # Body no longer starts with a centered "oder …" paragraph.
+    paragraphs = [p for p in ch.text.split("\n\n") if p.strip()]
+    assert paragraphs
+    first = paragraphs[0]
+    assert not first.startswith("oder"), first
+    assert "Oberons und Titanias" not in first
+    assert first.startswith("THEATERMEISTER")
+
+
+def test_build_chapters_from_html_keeps_regular_first_paragraph():
+    """Regression guard: for chapters where the first <p> is ordinary
+    stage direction (not a centered subtitle), it must stay in the body."""
+    body_padding = "<br>".join("Word" for _ in range(200))
+    html = (
+        '<div class="chapter">'
+        '<h2>Studierzimmer</h2>'
+        '<p>Faust mit dem Pudel hereintretend.</p>'
+        f'<p>FAUST.<br>{body_padding}</p>'
+        '</div>'
+    )
+    chapters = build_chapters_from_html(html)
+    assert len(chapters) == 1
+    # Title is just the heading — stage direction stays in body.
+    assert chapters[0].title == "Studierzimmer"
+    paragraphs = [p for p in chapters[0].text.split("\n\n") if p.strip()]
+    assert paragraphs[0].startswith("Faust mit dem Pudel")
+
+
 def test_build_chapters_from_html_splits_multi_speaker_cue():
     """Faust's Walpurgisnacht packs an IRRLICHT solo AND a 3-way choral
     stanza into one <p>: the cue for the choral piece is


### PR DESCRIPTION
## Summary

The orphan `oder` you saw at the start of Faust ch. 25 is from Gutenberg's HTML structure: the chapter title `Walpurgisnachtstraum oder Oberons und Titanias goldne Hochzeit. Intermezzo.` is split across an `<h2>` (main word only) and a following `<p class="center">` (the rest). The previous splitter only used the `<h2>` for the title, so the centered subtitle fell into the body as an orphaned paragraph starting with `oder`.

Fix: when a `<p class="center">` immediately follows the chapter heading, fold its text into the title and exclude the element from the body. Only centered paragraphs qualify — ordinary opening stage directions like `Faust mit dem Pudel hereintretend.` still render as body text.

## Test plan
- [x] 2 new splitter tests cover the Faust ch. 25 fold and a regression guard for non-centered openings.
- [x] Full backend suite: 372 passed.
- [ ] Manual: reload Faust ch. 25 — title should read `Walpurgisnachtstraum — oder Oberons und Titanias goldne Hochzeit Intermezzo` and the first body paragraph should be `THEATERMEISTER.`. Cached translations from before this change still reflect the old split — delete that chapter's cache (or `Retranslate all`) to refresh.

Generated with [Claude Code](https://claude.com/claude-code)
