### PR TITLE
fix(reader): render verse line breaks from the HTML splitter

### DIFF
--- a/backend/services/splitter.py
+++ b/backend/services/splitter.py
@@ -590,11 +590,12 @@ def _html_inline_text(elem) -> str:
         if child.tail:
             chunks.append(child.tail)
     text = "".join(chunks)
-    # Collapse any sequence containing a newline (and surrounding spaces/tabs)
-    # to a single newline. Preserves stanza-internal line breaks while
-    # removing the indentation artifacts that would otherwise look like
-    # paragraph boundaries to the reader's paragraph-splitter.
-    text = re.sub(r"[ \t]*\n[ \t\n]*", "\n", text)
+    # Collapse any sequence containing a newline (and surrounding
+    # whitespace, incl. `\r` from Windows-style HTML source line
+    # endings) to a single newline. Preserves stanza-internal line
+    # breaks while removing indentation artifacts that would otherwise
+    # leave `\n\r\n` between verses (reader then renders them glued).
+    text = re.sub(r"[ \t\r]*\n[ \t\r\n]*", "\n", text)
     return text.strip()
 
 

--- a/backend/tests/test_splitter.py
+++ b/backend/tests/test_splitter.py
@@ -351,6 +351,38 @@ def test_build_chapters_from_html_keeps_regular_first_paragraph():
     assert paragraphs[0].startswith("Faust mit dem Pudel")
 
 
+def test_html_inline_text_normalises_crlf_between_verse_lines():
+    """Gutenberg HTML ships with Windows-style `\\r\\n` line endings, so
+    after converting `<br>` to `\\n` the verse lines end up separated by
+    `\\n\\r\\n`. Without stripping `\\r`, the reader's whitespace-pre-wrap
+    rendered the `\\r` as a second segment break (or the `\\n` was lost
+    in CSS collapse in non-pre mode), gluing verse lines together."""
+    from services.splitter import build_chapters_from_html
+
+    padding = "<br>".join("Word" for _ in range(200))
+    # <br> followed by \r\n + indentation in the HTML source
+    html = (
+        '<div class="chapter">'
+        '<h2>Hexenküche</h2>'
+        '<p>\r\n'
+        'FAUST.<br>\r\n'
+        '    Line one,<br>\r\n'
+        '    Line two,<br>\r\n'
+        '    Line three.\r\n'
+        '</p>'
+        f'<p>{padding}</p>'
+        '</div>'
+    )
+    chapters = build_chapters_from_html(html)
+    assert len(chapters) == 1
+    paragraphs = [p for p in chapters[0].text.split("\n\n") if p.strip()]
+    first = paragraphs[0]
+    # After the splitter there must be NO carriage returns between
+    # verse lines — just single `\n`.
+    assert "\r" not in first, repr(first)
+    assert first == "FAUST.\nLine one,\nLine two,\nLine three."
+
+
 def test_build_chapters_from_html_splits_multi_speaker_cue():
     """Faust's Walpurgisnacht packs an IRRLICHT solo AND a 3-way choral
     stanza into one <p>: the cue for the choral piece is

--- a/frontend/src/__tests__/TranslationView.test.tsx
+++ b/frontend/src/__tests__/TranslationView.test.tsx
@@ -139,3 +139,62 @@ describe("inline mode", () => {
     expect(container.querySelector(".animate-pulse")).not.toBeInTheDocument();
   });
 });
+
+// ── Verse / prose rendering ─────────────────────────────────────────────────
+//
+// Faust's dramatic verse (lines ≤ 60 chars, each ending a metrical unit)
+// was being glued by the old `unwrap` that replaced `\n` between verse
+// lines with a space. Regression tests for both the verse path and the
+// prose path live here.
+
+describe("source text rendering", () => {
+  const VERSE = [
+    "FAUST.",
+    "O Liebe, leihe mir den schnellsten deiner Flügel,",
+    "Und führe mich in ihr Gefild!",
+  ].join("\n");
+
+  // Matches Gutenberg's 72–80 char plain-text wrap. Multiple lines
+  // exceed the 60-char verse threshold, so this paragraph is classified
+  // as prose and its mid-sentence breaks are joined.
+  const PROSE_HARDWRAPPED = [
+    "Call me Ishmael. Some years ago—never mind how long precisely—having",
+    "little or no money in my purse, and nothing particular to interest me",
+    "on shore, I thought I would sail about a little and see the watery",
+    "part of the world.",
+  ].join("\n");
+
+  it("preserves verse line breaks on the source side", () => {
+    const { container } = render(
+      <TranslationView
+        paragraphs={[VERSE]}
+        translations={["stub"]}
+        displayMode="parallel"
+        loading={false}
+      />,
+    );
+    const sourceP = container.querySelector("p.whitespace-pre-wrap");
+    expect(sourceP).not.toBeNull();
+    // The \n's must survive into the rendered text so CSS pre-wrap
+    // turns them into line breaks.
+    expect(sourceP!.textContent).toContain("FAUST.\nO Liebe");
+    expect(sourceP!.textContent).toContain("Flügel,\nUnd führe");
+  });
+
+  it("joins prose hard-wraps into flowing text", () => {
+    const { container } = render(
+      <TranslationView
+        paragraphs={[PROSE_HARDWRAPPED]}
+        translations={["stub"]}
+        displayMode="parallel"
+        loading={false}
+      />,
+    );
+    const sourceP = container.querySelector("p.whitespace-pre-wrap");
+    expect(sourceP).not.toBeNull();
+    // Every mid-sentence \n (not right after a sentence-ending char)
+    // should have been collapsed to a space.
+    expect(sourceP!.textContent).not.toContain("\n");
+    expect(sourceP!.textContent).toContain("how long precisely");
+  });
+});

--- a/frontend/src/components/TranslationView.tsx
+++ b/frontend/src/components/TranslationView.tsx
@@ -1,9 +1,29 @@
 "use client";
 
-/** Join Gutenberg hard wraps (single \n mid-sentence) into flowing text.
- *  Keeps intentional breaks after sentence-ending punctuation. */
-function unwrap(text: string): string {
-  return text.replace(/(?<![.!?:;\"'\u201d])\n(?!\n)/g, " ");
+/**
+ * Per-paragraph text preparation for the reader's left column.
+ *
+ * Two different line-break semantics in our data:
+ *  - HTML-sourced chapters (Faust etc.): `\n` is an intentional verse
+ *    break from `<br>`. Must be preserved visually.
+ *  - Plain-text-sourced chapters: `\n` is Gutenberg's 72–80 char hard
+ *    wrap in the middle of prose. Must be joined back so the line
+ *    flows naturally.
+ *
+ * Classify per paragraph using the same heuristic as SentenceReader:
+ * a multi-line paragraph where EVERY line is ≤ 60 chars looks like
+ * verse (dramatic metre rarely exceeds 60). Anything longer is prose,
+ * and `\n` mid-sentence is joined with a space — except after
+ * sentence-ending punctuation where the break was clearly intentional.
+ */
+function renderSource(text: string): string {
+  const lines = text.split("\n");
+  if (lines.length >= 2 && lines.every((l) => l.trim().length <= 60)) {
+    // Verse: keep the `\n` so pre-wrap renders line breaks.
+    return text;
+  }
+  // Prose: join mid-sentence hard-wraps.
+  return text.replace(/(?<![.!?:;"'\u201d])\n(?!\n)/g, " ");
 }
 
 interface Props {
@@ -19,7 +39,9 @@ export default function TranslationView({ paragraphs, translations, displayMode,
       <div className="max-w-5xl mx-auto divide-y divide-amber-100">
         {paragraphs.map((para, i) => (
           <div key={i} className="grid grid-cols-2 gap-6 py-4 first:pt-0 last:pb-0">
-            <p className="font-serif text-base text-ink leading-relaxed">{unwrap(para)}</p>
+            <p className="font-serif text-base text-ink leading-relaxed whitespace-pre-wrap">
+              {renderSource(para)}
+            </p>
             <div className="border-l border-amber-200 pl-6">
               {translations[i] ? (
                 <p className="font-serif text-base text-amber-800 leading-relaxed italic whitespace-pre-wrap">
@@ -44,7 +66,9 @@ export default function TranslationView({ paragraphs, translations, displayMode,
     <div className="prose-reader mx-auto space-y-6">
       {paragraphs.map((para, i) => (
         <div key={i}>
-          <p className="font-serif text-base text-ink leading-relaxed">{unwrap(para)}</p>
+          <p className="font-serif text-base text-ink leading-relaxed whitespace-pre-wrap">
+            {renderSource(para)}
+          </p>
           {loading && i === 0 && !translations.length && (
             <div className="mt-1 space-y-1 animate-pulse">
               <div className="h-3 bg-amber-100 rounded w-full" />


### PR DESCRIPTION
## Summary

Faust ch. 9 (Hexenküche) verse paragraphs rendered as one glued block on the source (left) side while the translation (right) kept proper line breaks. Two bugs stacked:

1. **Backend** — `_html_inline_text` normalised `<br>` to `\n` but only stripped `[ \t]` around newlines. Gutenberg HTML uses Windows-style line endings, so verse lines ended up with `\n\r\n` between them. The `\r` survived into the paragraph text.
2. **Frontend** — `TranslationView` called `unwrap()` on the source paragraph, which replaces any `\n` not preceded by sentence-ending punctuation (`.!?:;"'"`) with a space. Goethe's verse lines almost all end with commas, so every break was collapsed. The source `<p>` also lacked `whitespace-pre-wrap`, which would have at least preserved surviving `\n`s.

## Fix

- Backend: extend the collapse regex to include `\r`, so `\n\r\n` becomes a single `\n`.
- Frontend: replace `unwrap` with a per-paragraph classifier. A paragraph where every line is ≤ 60 chars is treated as verse and its `\n`s survive. Longer-line paragraphs are still unwrapped so plain-text hard-wraps flow naturally. The source `<p>` now uses `whitespace-pre-wrap` so preserved `\n`s render as line breaks.

## Test plan

- [x] Backend: new `test_html_inline_text_normalises_crlf_between_verse_lines` + 373 pass.
- [x] Frontend: 2 new tests in `TranslationView.test.tsx` for verse / prose rendering + 152 pass.
- [ ] Manual: reload Faust ch. 9 (Hexenküche), confirm FAUST and MEPHISTOPHELES verse stanzas render line-by-line on the left and align with the right. Note: cached translations of this chapter were built against the old source breakpoints — delete/retranslate if alignment also looks wrong.

Generated with [Claude Code](https://claude.com/claude-code)
