### PR TITLE
feat(reader): translate whole book + visible queued/not-started counts

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -218,6 +218,34 @@ async def request_chapter_translation(
     }
 
 
+@router.post("/{book_id}/translations/enqueue-all")
+async def enqueue_all_chapters(
+    book_id: int,
+    req: RequestTranslationBody,
+    user: dict = Depends(get_current_user),
+):
+    """Queue every not-yet-translated chapter of a book for one language.
+
+    Reader-side counterpart to the admin panel's per-book + Translate
+    button. Accepts any authenticated user; queued items use
+    priority=20 — above auto-enqueue (100) and admin per-book (50) so
+    the user who clicked is served ahead of background rescans, but
+    below the active reader's priority=10 so the chapter they're
+    currently staring at still wins.
+    """
+    from services.translation_queue import enqueue_for_book, worker
+
+    queued_by = user.get("email") or user.get("name") or f"user#{user.get('id')}"
+    enqueued = await enqueue_for_book(
+        book_id,
+        target_languages=[req.target_language],
+        priority=20,
+        queued_by=queued_by,
+    )
+    worker().wake()
+    return {"ok": True, "enqueued": enqueued}
+
+
 @router.post("/{book_id}/chapters/{chapter_index}/translation/retry")
 async def retry_chapter_translation(
     book_id: int,

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -237,6 +237,42 @@ async def test_retry_chapter_translation_revives_failed_row(client):
     assert row["priority"] == 10
 
 
+async def test_enqueue_all_chapters_for_user(client):
+    """POST /books/{id}/translations/enqueue-all queues every not-yet-
+    translated chapter of the book in the requested language at
+    priority=20 (between admin per-book 50 and reader on-demand 10)."""
+    import aiosqlite
+    import services.db as db_module
+    # Long enough text to split into 2 chapters under the plain-text splitter.
+    text = (
+        "CHAPTER I\n\n" + ("First chapter word. " * 40) + "\n\n"
+        + ("More first chapter text. " * 40) + "\n\n"
+        + "CHAPTER II\n\n" + ("Second chapter word. " * 40) + "\n\n"
+        + ("More second chapter text. " * 40)
+    )
+    await save_book(1342, MOCK_META, text)
+    resp = await client.post(
+        "/api/books/1342/translations/enqueue-all",
+        json={"target_language": "zh"},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["enqueued"] >= 1
+
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        conn.row_factory = aiosqlite.Row
+        async with conn.execute(
+            "SELECT chapter_index, priority, status FROM translation_queue "
+            "WHERE book_id=1342 AND target_language='zh' ORDER BY chapter_index",
+        ) as cursor:
+            rows = [dict(r) for r in await cursor.fetchall()]
+    assert rows
+    for row in rows:
+        assert row["status"] == "pending"
+        assert row["priority"] == 20
+
+
 async def test_retry_chapter_translation_inserts_if_no_row(client):
     """If no queue row exists yet (e.g. failed row was deleted), retry
     still succeeds and creates a pending row."""

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -27,6 +27,7 @@ import {
   saveGeminiKey,
   deleteGeminiKey,
   retryChapterTranslation,
+  enqueueBookTranslation,
 } from "@/lib/api";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -392,6 +393,19 @@ test("retryChapterTranslation POSTs to the explicit retry URL", async () => {
   await retryChapterTranslation(1342, 5, "zh");
   const [url, opts] = (global.fetch as jest.Mock).mock.calls[0];
   expect(url).toContain("/books/1342/chapters/5/translation/retry");
+  expect(opts.method).toBe("POST");
+  expect(JSON.parse(opts.body).target_language).toBe("zh");
+});
+
+test("enqueueBookTranslation POSTs to /books/{id}/translations/enqueue-all", async () => {
+  // Reader-side whole-book translate button. Body shape mirrors the
+  // per-chapter translation endpoint so the backend can reuse the
+  // RequestTranslationBody pydantic model.
+  mockFetch({ ok: true, enqueued: 3 });
+  const res = await enqueueBookTranslation(1342, "zh");
+  expect(res.enqueued).toBe(3);
+  const [url, opts] = (global.fetch as jest.Mock).mock.calls[0];
+  expect(url).toContain("/books/1342/translations/enqueue-all");
   expect(opts.method).toBe("POST");
   expect(JSON.parse(opts.body).target_language).toBe("zh");
 });

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { getBookChapters, deleteTranslationCache, getAudiobook, deleteAudiobook, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, retryChapterTranslation, TranslationStatus, BookMeta, BookChapter, Audiobook } from "@/lib/api";
+import { getBookChapters, deleteTranslationCache, getAudiobook, deleteAudiobook, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, retryChapterTranslation, enqueueBookTranslation, TranslationStatus, BookMeta, BookChapter, Audiobook } from "@/lib/api";
 import { recordRecentBook, saveLastChapter, getLastChapter } from "@/lib/recentBooks";
 import { getSettings, saveSettings, FontSize, Theme } from "@/lib/settings";
 import InsightChat, { LANGUAGES } from "@/components/InsightChat";
@@ -336,6 +336,31 @@ export default function ReaderPage() {
     // Re-trigger by toggling translation off then on
     setTranslationEnabled(false);
     setTimeout(() => setTranslationEnabled(true), 50);
+  }
+
+  const [enqueueingBook, setEnqueueingBook] = useState(false);
+
+  async function handleTranslateWholeBook() {
+    const bid = Number(bookId);
+    setEnqueueingBook(true);
+    try {
+      const res = await enqueueBookTranslation(bid, translationLang);
+      // Refresh whole-book status immediately so the banner updates
+      // without waiting for the 15s poll tick.
+      try {
+        const status = await getBookTranslationStatus(bid, translationLang);
+        setBookTranslationStatus(status);
+      } catch { /* ignore */ }
+      alert(
+        res.enqueued === 0
+          ? `All chapters are already translated or already queued.`
+          : `Queued ${res.enqueued} chapter${res.enqueued === 1 ? "" : "s"} for translation into ${translationLang}.`,
+      );
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "Failed to queue book");
+    } finally {
+      setEnqueueingBook(false);
+    }
   }
 
   async function handleRetryFailed() {
@@ -677,13 +702,18 @@ export default function ReaderPage() {
       {translationEnabled && bookTranslationStatus && (() => {
         const s = bookTranslationStatus;
         const queued = (s.queue_pending ?? 0) + (s.queue_running ?? 0);
-        const anyQueueActivity = queued > 0 || (s.queue_failed ?? 0) > 0;
-        if (!s.bulk_active && !anyQueueActivity) return null;
         const ready = s.translated_chapters;
         const total = s.total_chapters;
+        // Chapters that are neither done nor queued — the "nothing is
+        // happening for these" bucket the user can act on via the
+        // Translate-whole-book button.
+        const notStarted = Math.max(
+          0,
+          total - ready - queued - (s.queue_failed ?? 0),
+        );
         return (
-          <div className="bg-amber-50 border-b border-amber-200 px-4 py-2 text-xs text-amber-800 flex items-center justify-between gap-3">
-            <span className="flex items-center gap-2">
+          <div className="bg-amber-50 border-b border-amber-200 px-4 py-2 text-xs text-amber-800 flex items-center justify-between gap-3 flex-wrap">
+            <span className="flex items-center gap-2 min-w-0">
               <span className="inline-block w-1.5 h-1.5 bg-amber-500 rounded-full animate-pulse" />
               <span>
                 <strong>{ready} / {total}</strong> chapters translated
@@ -700,9 +730,31 @@ export default function ReaderPage() {
                     <span className="text-red-600">{s.queue_failed} failed</span>
                   </>
                 ) : null}
+                {notStarted > 0 && (
+                  <>
+                    {" · "}
+                    <span className="text-stone-500">{notStarted} not started</span>
+                  </>
+                )}
               </span>
             </span>
-            <span className="text-amber-500 shrink-0">Polls every 15s</span>
+            <span className="flex items-center gap-2 shrink-0">
+              {/* Any authenticated user can queue the whole book they're
+                  reading. Priority=20 (above admin auto, below active-
+                  reader on-demand) so the click is honored without
+                  starving whoever is currently waiting on a chapter. */}
+              {notStarted > 0 && (
+                <button
+                  onClick={handleTranslateWholeBook}
+                  disabled={enqueueingBook}
+                  className="text-xs px-3 py-1 rounded-full border border-amber-400 bg-white text-amber-800 hover:bg-amber-100 disabled:opacity-50"
+                  title={`Queue the remaining ${notStarted} chapters into ${translationLang}`}
+                >
+                  {enqueueingBook ? "Queueing…" : `Translate all ${notStarted} remaining`}
+                </button>
+              )}
+              <span className="text-amber-500">Polls every 15s</span>
+            </span>
           </div>
         );
       })()}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -299,6 +299,20 @@ export function retryChapterTranslation(
   );
 }
 
+export function enqueueBookTranslation(
+  bookId: number,
+  targetLanguage: string,
+): Promise<{ ok: boolean; enqueued: number }> {
+  return request<{ ok: boolean; enqueued: number }>(
+    `/books/${bookId}/translations/enqueue-all`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ target_language: targetLanguage }),
+    },
+  );
+}
+
 /** Save a completed progressive translation to the backend cache. */
 export function saveTranslationCache(
   bookId: number,


### PR DESCRIPTION
## Summary

The reader could only translate one chapter at a time. To get every chapter of a 21-chapter play translated you had to scroll through each one and wait, or ask an admin to use the admin Books tab's `+ Translate`.

This PR adds both pieces you asked for: a whole-book translate button on the reader, **and** visible counts for how many chapters are translated / queued / not yet started.

**Backend**
- `POST /books/{id}/translations/enqueue-all {target_language}` — any authenticated user. Calls `enqueue_for_book` at `priority=20` (above admin auto-enqueue `100` and admin per-book `50`, below the active reader's on-demand `10`, so clicking the button is honoured without starving whoever's currently waiting on a chapter).

**Frontend (reader)**
- The whole-book progress banner now renders whenever translation is enabled (previously hidden when there was no queue activity).
- Banner content: `X / Y chapters translated · Z still processing · Z2 failed · N not started`.
- When `N not started > 0`, a `Translate all N remaining` button appears on the right. After clicking it, the banner refreshes immediately so the counts update without waiting for the 15 s poll tick.

## Test plan
- [x] Backend: new `test_enqueue_all_chapters_for_user` — asserts priority=20 and status=pending for every queued row. 374 backend total.
- [x] Frontend: new `api.test.ts` case for `enqueueBookTranslation`. 153 frontend total.
- [ ] Manual: open Faust in the reader, enable Translate, confirm banner shows `translated · queued · failed · not started` and the `Translate all N remaining` button queues the rest.

Generated with [Claude Code](https://claude.com/claude-code)
