### PR TITLE
fix(gemini): diagnose + recover from 'no <chapter> blocks' errors

### DIFF
--- a/backend/services/gemini.py
+++ b/backend/services/gemini.py
@@ -200,10 +200,47 @@ async def translate_chapters_batch(
     except ValueError:
         raw = ""
 
+    # Gemini tells us why generation stopped — MAX_TOKENS means we
+    # truncated the output (often mid-chapter, so `</chapter>` is
+    # missing). SAFETY / RECITATION means content was blocked. Other
+    # finish reasons usually mean the response was empty for some
+    # benign reason. We surface the reason in the error so the queue
+    # worker's chain-advance logs point at a concrete problem.
+    finish_reason = ""
+    try:
+        finish_reason = str(response.candidates[0].finish_reason or "")
+    except (AttributeError, IndexError, TypeError):
+        pass
+
     # Parse <chapter> blocks out of the response
     matches = _CHAPTER_BLOCK_RE.findall(raw)
     if not matches:
-        raise ValueError("Gemini response contained no <chapter> blocks")
+        # Fallback: when we sent exactly one chapter and the model
+        # produced non-empty prose without the `<chapter>` wrapping,
+        # trust it — it's almost certainly just that chapter's
+        # translation (common on flash-lite with short inputs). Only
+        # do this when the finish reason is a clean STOP; truncated
+        # output isn't a complete translation.
+        if (
+            len(chapters) == 1
+            and raw.strip()
+            and finish_reason.upper().endswith("STOP")
+        ):
+            idx = chapters[0][0]
+            paragraphs = [p.strip() for p in raw.split("\n\n") if p.strip()]
+            if paragraphs:
+                return {idx: paragraphs}
+
+        # Diagnostic error: include the finish reason and a preview
+        # of the raw output so admins can see whether the model
+        # truncated, was blocked, or simply returned the wrong
+        # format.
+        preview = raw.strip()[:160].replace("\n", "\\n")
+        reason = f" (finish_reason={finish_reason})" if finish_reason else ""
+        raise ValueError(
+            f"Gemini response contained no <chapter> blocks{reason} — "
+            f"raw preview: {preview!r}"
+        )
 
     result: dict[int, list[str]] = {}
     for idx_str, body in matches:

--- a/backend/tests/test_gemini.py
+++ b/backend/tests/test_gemini.py
@@ -120,18 +120,31 @@ async def test_translate_text_chunks_large_input():
 
 # ── translate_chapters_batch ─────────────────────────────────────────────────
 
-def _mock_gemini_response(text: str):
-    """Build a Gemini-style response object whose .text returns `text`."""
+def _mock_gemini_response(text: str, finish_reason: str | None = "STOP"):
+    """Build a Gemini-style response object whose .text returns `text`.
+
+    Supplies a minimal `candidates[0].finish_reason` too so the parser
+    can detect MAX_TOKENS truncation / SAFETY blocks the way the real
+    client reports them.
+    """
+    class _Candidate:
+        pass
+
     class _Resp:
         pass
+
+    cand = _Candidate()
+    cand.finish_reason = finish_reason
+
     r = _Resp()
     r.text = text
+    r.candidates = [cand]
     return r
 
 
-def _patch_gemini_generate(return_text: str):
+def _patch_gemini_generate(return_text: str, finish_reason: str | None = "STOP"):
     """Patch the underlying google-genai client used by translate_chapters_batch."""
-    async_mock = AsyncMock(return_value=_mock_gemini_response(return_text))
+    async_mock = AsyncMock(return_value=_mock_gemini_response(return_text, finish_reason))
 
     class _Models:
         generate_content = async_mock
@@ -200,10 +213,59 @@ async def test_translate_chapters_batch_includes_prior_context():
 
 
 async def test_translate_chapters_batch_raises_on_unparseable_response():
-    """If the model returns no <chapter> tags, we raise so caller can fall back."""
+    """If the model returns no <chapter> tags in a multi-chapter batch,
+    we raise so caller can fall back — ambiguous which chapter is which."""
     patcher, _ = _patch_gemini_generate("Just some text with no tags.")
     with patcher:
         with pytest.raises(ValueError, match="no <chapter> blocks"):
             await gemini.translate_chapters_batch(
+                "key", [(0, "text"), (1, "text")], "en", "zh",
+            )
+
+
+async def test_translate_chapters_batch_single_chapter_plain_text_fallback():
+    """Flash-lite sometimes drops the <chapter> wrapping on small inputs.
+    When we sent exactly ONE chapter and Gemini finished cleanly (STOP),
+    treat the whole plain-text response as that chapter's translation
+    instead of failing the batch."""
+    patcher, _ = _patch_gemini_generate(
+        "Erster Absatz der Übersetzung.\n\nZweiter Absatz.",
+        finish_reason="STOP",
+    )
+    with patcher:
+        result = await gemini.translate_chapters_batch(
+            "key", [(7, "One-chapter payload.")], "en", "de",
+        )
+    assert result == {7: ["Erster Absatz der Übersetzung.", "Zweiter Absatz."]}
+
+
+async def test_translate_chapters_batch_does_not_fallback_when_truncated():
+    """If finish_reason=MAX_TOKENS the response is incomplete and we
+    should NOT trust plain text as the translation — the chain advance
+    has to pick it up so a bigger-context model can retry."""
+    patcher, _ = _patch_gemini_generate(
+        "Partial translation that got c",
+        finish_reason="MAX_TOKENS",
+    )
+    with patcher:
+        with pytest.raises(ValueError, match="MAX_TOKENS"):
+            await gemini.translate_chapters_batch(
                 "key", [(0, "text")], "en", "zh",
+            )
+
+
+async def test_translate_chapters_batch_error_includes_raw_preview():
+    """The error message must include a preview of what the model
+    actually returned so admins can tell truncation apart from a
+    format-ignored response without re-running the call with extra
+    logging."""
+    patcher, _ = _patch_gemini_generate(
+        "I am sorry, I cannot translate this content.",
+        finish_reason="STOP",
+    )
+    with patcher:
+        # Multi-chapter batch so the single-chapter fallback doesn't apply.
+        with pytest.raises(ValueError, match="I am sorry"):
+            await gemini.translate_chapters_batch(
+                "key", [(0, "t"), (1, "t")], "en", "zh",
             )


### PR DESCRIPTION
## Context

The user reported repeated queue errors of the form:

```
! retry — Gemini response contained no <chapter> blocks
! chain_advance — Gemini response contained no <chapter> blocks
! chain_advance — Gemini response contained no <chapter> blocks
```

— looping across every model in the chain without useful information.

Two real causes stacked:
1. For long chapters the batch's estimated output exceeds the 7500-token cap; Gemini truncates mid-chapter and the closing `</chapter>` tag never appears. Every model in the chain hits the same truncation.
2. Small models (`flash-lite` especially) sometimes drop the XML wrapping on short single-chapter inputs and just return the plain translated text.

## Fix

- Capture `response.candidates[0].finish_reason` and include it in the raised error so the queue log distinguishes `MAX_TOKENS` (truncation) from `STOP` (format ignored) from `SAFETY` (content blocked).
- Include the first 160 chars of the raw response in the error preview so admins can tell at a glance what the model actually returned.
- When we sent exactly ONE chapter AND Gemini finished cleanly (`STOP`) with non-empty text, trust the raw response as that chapter's translation instead of failing. Multi-chapter ambiguity still fails.

## Test plan
- [x] New tests: single-chapter plain-text fallback accepted; MAX_TOKENS truncation NOT fallback-accepted; error message carries raw preview + finish_reason.
- [x] Existing test updated — multi-chapter is the only case where pure-text response raises.
- [x] 377 backend passes.
- [ ] Manual: re-run a Faust chapter that was hitting this loop, confirm either the fallback rescues it (for flash-lite short inputs) or the failure message now shows `finish_reason=MAX_TOKENS` + preview so we can see which chapters are genuinely too big.

Generated with [Claude Code](https://claude.com/claude-code)
