### PR TITLE
feat(translate): chunk oversized chapters + widen parallel reader

### DIFF
--- a/backend/services/gemini.py
+++ b/backend/services/gemini.py
@@ -139,6 +139,51 @@ _CHAPTER_BLOCK_RE = re.compile(
 )
 
 
+# Rough estimate: how many output tokens a chapter of N source words
+# will consume. Mirrors bulk_translate.WORDS_TO_OUTPUT_TOKENS so the
+# batch-grouper and the chunker agree on "oversized".
+_WORDS_TO_OUTPUT_TOKENS = 1.4
+
+
+def _estimate_output_tokens(text: str) -> int:
+    """Approx output tokens for a source text, with a small wrapper
+    allowance for the `<chapter>` tags the model echoes back."""
+    return int(len(text.split()) * _WORDS_TO_OUTPUT_TOKENS) + 100
+
+
+def _split_paragraphs_into_budget_chunks(
+    paragraphs: list[str], max_output_tokens: int,
+) -> list[list[str]]:
+    """Group consecutive paragraphs so each sub-chunk stays under the
+    model's output budget. Used to translate one oversized chapter via
+    several API calls while preserving paragraph order and count.
+
+    Leaves a 10% headroom so the model still fits its reply inside
+    max_output_tokens even when our per-word estimate under-counts
+    (CJK targets, dense verse)."""
+    if not paragraphs:
+        return []
+    # If even a single paragraph on its own exceeds the budget we still
+    # put it in its own chunk — splitting mid-paragraph would lose
+    # paragraph alignment downstream. The caller has to accept the risk
+    # of mid-paragraph truncation on that one call.
+    budget = int(max_output_tokens * 0.9)
+    chunks: list[list[str]] = []
+    current: list[str] = []
+    current_tokens = 0
+    for para in paragraphs:
+        est = _estimate_output_tokens(para)
+        if current and current_tokens + est > budget:
+            chunks.append(current)
+            current = []
+            current_tokens = 0
+        current.append(para)
+        current_tokens += est
+    if current:
+        chunks.append(current)
+    return chunks
+
+
 async def translate_chapters_batch(
     api_key: str,
     chapters: list[tuple[int, str]],  # list of (chapter_index, chapter_text)
@@ -159,11 +204,31 @@ async def translate_chapters_batch(
     cross-batch consistency (character/place names, style). It should be
     a plain text snippet of previously-translated material.
 
+    Oversized-chapter handling: if the batch has a single chapter whose
+    estimated output tokens exceed `max_output_tokens`, the chapter is
+    split into paragraph-aligned sub-chunks and translated across
+    multiple API calls. Each sub-chunk uses the previous sub-chunk's
+    tail as `prior_context` for cross-cut style consistency.
+
     Raises ValueError if the response can't be parsed into at least one
     chapter block — callers can fall back to per-chapter translation.
     """
     if not chapters:
         return {}
+
+    # Single oversized chapter — translate in sub-chunks, preserving
+    # paragraph order, so we stop dead-ending at MAX_TOKENS for long
+    # chapters on flash-tier models.
+    if len(chapters) == 1:
+        idx, text = chapters[0]
+        if _estimate_output_tokens(text) > max_output_tokens:
+            return await _translate_chapter_in_chunks(
+                api_key, idx, text,
+                source_language, target_language,
+                prior_context=prior_context,
+                model=model,
+                max_output_tokens=max_output_tokens,
+            )
 
     system = SYSTEM_LITERARY_TRANSLATOR.format(
         source=source_language, target=target_language,
@@ -253,6 +318,56 @@ async def translate_chapters_batch(
         if paragraphs:
             result[idx] = paragraphs
     return result
+
+
+async def _translate_chapter_in_chunks(
+    api_key: str,
+    chapter_index: int,
+    chapter_text: str,
+    source_language: str,
+    target_language: str,
+    *,
+    prior_context: str,
+    model: str,
+    max_output_tokens: int,
+) -> dict[int, list[str]]:
+    """Translate a single oversized chapter across several API calls.
+
+    Splits the chapter's paragraphs into budget-sized sub-chunks,
+    translates each as its own batch of one, and concatenates the
+    paragraphs in order. Each call after the first passes a small tail
+    of the previous translation as `prior_context` so the model keeps
+    names and style consistent across the cut.
+
+    Returns the same shape as `translate_chapters_batch`:
+    `{chapter_index: [paragraph, ...]}`.
+    """
+    paragraphs = [p.strip() for p in chapter_text.split("\n\n") if p.strip()]
+    if not paragraphs:
+        return {chapter_index: []}
+    sub_chunks = _split_paragraphs_into_budget_chunks(paragraphs, max_output_tokens)
+    out: list[str] = []
+    carry = prior_context
+    for chunk_paragraphs in sub_chunks:
+        chunk_text = "\n\n".join(chunk_paragraphs)
+        # IMPORTANT: recurse into translate_chapters_batch but with the
+        # sub-chunk small enough that the top-level "oversized" branch
+        # does NOT fire — otherwise we'd loop. The split guarantees
+        # each sub-chunk fits in budget, so the single-call path runs.
+        sub = await translate_chapters_batch(
+            api_key, [(chapter_index, chunk_text)],
+            source_language, target_language,
+            prior_context=carry,
+            model=model,
+            max_output_tokens=max_output_tokens,
+        )
+        translated = sub.get(chapter_index, [])
+        out.extend(translated)
+        # Carry the last 1–2 translated paragraphs as context for the
+        # next sub-chunk. Keeps character names etc. consistent.
+        if translated:
+            carry = "\n\n".join(translated[-2:])
+    return {chapter_index: out}
 
 
 async def translate_text(

--- a/backend/tests/test_gemini.py
+++ b/backend/tests/test_gemini.py
@@ -254,6 +254,75 @@ async def test_translate_chapters_batch_does_not_fallback_when_truncated():
             )
 
 
+async def test_translate_chapters_batch_splits_oversized_single_chapter():
+    """A single chapter whose estimated output exceeds max_output_tokens
+    must be split into paragraph-aligned sub-chunks, each translated
+    via its own API call. Prevents mid-chapter MAX_TOKENS truncation
+    on flash-tier models for long dramatic scenes."""
+    # 6 source paragraphs, 50 words each → ~420 est output tokens total
+    # with our 1.4 words/token heuristic. With max_output_tokens=200
+    # and 10% headroom = 180 target, we expect the splitter to make
+    # 3–4 sub-chunks.
+    words = " ".join(["word"] * 50)
+    source_paragraphs = [f"Source paragraph {i}. {words}" for i in range(6)]
+    source_text = "\n\n".join(source_paragraphs)
+
+    call_count = {"n": 0}
+
+    def fake_response_for(prompt: str) -> str:
+        # Return one <chapter> block per call, with two translated
+        # paragraphs per sub-chunk — enough to verify concatenation order.
+        call_count["n"] += 1
+        n = call_count["n"]
+        return (
+            f'<chapter index="5">\n'
+            f'Chunk {n} translated paragraph A.\n\n'
+            f'Chunk {n} translated paragraph B.\n'
+            f'</chapter>'
+        )
+
+    async def fake_generate(*, model, contents, config):
+        return _mock_gemini_response(fake_response_for(contents))
+
+    class _Models:
+        generate_content = AsyncMock(side_effect=fake_generate)
+
+    class _Aio:
+        models = _Models()
+
+    class _Client:
+        aio = _Aio()
+
+    with patch("services.gemini._client", return_value=_Client()):
+        result = await gemini.translate_chapters_batch(
+            "key", [(5, source_text)], "en", "zh",
+            max_output_tokens=200,
+        )
+
+    # Multiple API calls happened — the chapter was chunked.
+    assert call_count["n"] >= 2
+    # Result aggregates paragraphs from every sub-chunk in order.
+    paragraphs = result[5]
+    assert len(paragraphs) == 2 * call_count["n"]
+    assert paragraphs[0].startswith("Chunk 1")
+    assert paragraphs[-1].startswith(f"Chunk {call_count['n']}")
+
+
+async def test_translate_chapters_batch_under_budget_does_not_split():
+    """Regression guard: normally-sized chapters still go out as a
+    single API call (no accidental over-splitting)."""
+    patcher, mock = _patch_gemini_generate(
+        '<chapter index="0">Only one paragraph.</chapter>',
+    )
+    with patcher:
+        result = await gemini.translate_chapters_batch(
+            "key", [(0, "Short text.")], "en", "zh",
+            max_output_tokens=8192,
+        )
+    assert result == {0: ["Only one paragraph."]}
+    assert mock.await_count == 1
+
+
 async def test_translate_chapters_batch_error_includes_raw_preview():
     """The error message must include a preview of what the model
     actually returned so admins can tell truncation apart from a

--- a/frontend/src/__tests__/TranslationView.test.tsx
+++ b/frontend/src/__tests__/TranslationView.test.tsx
@@ -42,6 +42,26 @@ describe("parallel mode", () => {
     TRANSLATIONS.forEach((t) => expect(screen.getByText(t)).toBeInTheDocument());
   });
 
+  it("uses the wide parallel container so source + translation each get ~prose width", () => {
+    // Regression guard: previously the parallel container was
+    // max-w-5xl (1024px) which split into two ~500px columns — the
+    // source column was narrower than the single-column 68ch prose
+    // width. Wider (max-w-7xl, 1280px) gives each column ~620px,
+    // roughly matching single-column prose.
+    const { container } = render(
+      <TranslationView
+        paragraphs={PARAGRAPHS}
+        translations={TRANSLATIONS}
+        displayMode="parallel"
+        loading={false}
+      />,
+    );
+    const outer = container.querySelector("div.grid")?.parentElement;
+    expect(outer).not.toBeNull();
+    expect(outer!.className).toContain("max-w-7xl");
+    expect(outer!.className).not.toContain("max-w-5xl");
+  });
+
   it("renders original and translation in the same row (shared grid cell)", () => {
     const { container } = render(
       <TranslationView

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -835,7 +835,7 @@ export default function ReaderPage() {
                       });
                   }}
                 />
-                <div className={`mt-10 flex justify-between ${translationEnabled && displayMode === "parallel" ? "max-w-5xl mx-auto" : "prose-reader mx-auto"}`}>
+                <div className={`mt-10 flex justify-between ${translationEnabled && displayMode === "parallel" ? "max-w-7xl mx-auto" : "prose-reader mx-auto"}`}>
                   <button
                     onClick={() => goToChapter(Math.max(0, chapterIndex - 1))}
                     disabled={chapterIndex === 0}

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -271,7 +271,7 @@ export default function SentenceReader({
   const isParallel = hasTranslations && translationDisplayMode === "parallel";
 
   return (
-    <div className={isParallel ? "max-w-5xl mx-auto divide-y divide-amber-100" : "prose-reader mx-auto space-y-4"}>
+    <div className={isParallel ? "max-w-7xl mx-auto divide-y divide-amber-100" : "prose-reader mx-auto space-y-4"}>
       {paragraphs.map((para, pIdx) => {
         // Track the text paragraph index so we
         // can pair with the right entry in translations[].

--- a/frontend/src/components/TranslationView.tsx
+++ b/frontend/src/components/TranslationView.tsx
@@ -36,7 +36,7 @@ interface Props {
 export default function TranslationView({ paragraphs, translations, displayMode, loading }: Props) {
   if (displayMode === "parallel") {
     return (
-      <div className="max-w-5xl mx-auto divide-y divide-amber-100">
+      <div className="max-w-7xl mx-auto divide-y divide-amber-100">
         {paragraphs.map((para, i) => (
           <div key={i} className="grid grid-cols-2 gap-6 py-4 first:pt-0 last:pb-0">
             <p className="font-serif text-base text-ink leading-relaxed whitespace-pre-wrap">


### PR DESCRIPTION
## Summary

Two independent fixes bundled:

### 1. Long chapters no longer dead-end at MAX_TOKENS

`translate_chapters_batch` now detects a single chapter whose estimated output exceeds `max_output_tokens` and splits its paragraphs into budget-sized sub-chunks, translating each in a separate Gemini call.

- Paragraph order and count are preserved.
- Each sub-chunk after the first gets the previous sub-chunk's tail as `prior_context`, so character names and style stay consistent across the cut.
- Replaces option (a) — adding a pro-tier model — so the Balanced chain (flash + flash-lite) can handle every chapter regardless of length.

### 2. Wider parallel reader

Source column was only ~500 px wide because the outer container was `max-w-5xl` (1024 px), narrower than single-column prose (68ch ≈ 610 px). Raised to `max-w-7xl` (1280 px) so each column gets ~620 px — roughly the same reading density as single-column mode.

## Test plan

- [x] Backend: new test `test_translate_chapters_batch_splits_oversized_single_chapter` fakes an oversized chapter with a 200-token budget, asserts ≥ 2 API calls and paragraphs concatenated in order. Regression guard `test_translate_chapters_batch_under_budget_does_not_split` keeps the normal single-call path.
- [x] Frontend: `TranslationView.test.tsx` locks the parallel container to `max-w-7xl`.
- [x] Full suites: 379 backend, 154 frontend.
- [ ] Manual: retry the Faust chapter that was looping on `no <chapter> blocks`, confirm it translates across multiple sub-calls. Also open a translated chapter in side-by-side mode and confirm both columns are ~620px wide.

Generated with [Claude Code](https://claude.com/claude-code)
