### PR TITLE
fix(gemini): permissive safety settings for literary translation

### DIFF
--- a/backend/services/gemini.py
+++ b/backend/services/gemini.py
@@ -15,6 +15,35 @@ MODEL = "gemini-3.1-flash-lite-preview"
 TRANSLATOR_MODEL = MODEL
 
 
+# Permissive safety settings for literary translation. Classic books (Faust
+# is the concrete case) routinely trigger default mid-level filters on
+# sexuality / violence / occultism, causing finish_reason=PROHIBITED_CONTENT
+# with no translation returned. The queue worker then burns through the
+# whole fallback chain because every model shares the same safety layer.
+# We push the thresholds to BLOCK_NONE on the four categories that
+# literature commonly trips: harassment, hate speech, sexually explicit,
+# dangerous content. Civic-integrity / image categories are unrelated to
+# prose translation and left at defaults.
+_LITERARY_SAFETY_SETTINGS: list[types.SafetySetting] = [
+    types.SafetySetting(
+        category=types.HarmCategory.HARM_CATEGORY_HARASSMENT,
+        threshold=types.HarmBlockThreshold.BLOCK_NONE,
+    ),
+    types.SafetySetting(
+        category=types.HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+        threshold=types.HarmBlockThreshold.BLOCK_NONE,
+    ),
+    types.SafetySetting(
+        category=types.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+        threshold=types.HarmBlockThreshold.BLOCK_NONE,
+    ),
+    types.SafetySetting(
+        category=types.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+        threshold=types.HarmBlockThreshold.BLOCK_NONE,
+    ),
+]
+
+
 def _client(api_key: str) -> genai.Client:
     return genai.Client(api_key=api_key)
 
@@ -256,6 +285,7 @@ async def translate_chapters_batch(
     config = types.GenerateContentConfig(
         system_instruction=system,
         max_output_tokens=max_output_tokens,
+        safety_settings=_LITERARY_SAFETY_SETTINGS,
     )
     response = await client.aio.models.generate_content(
         model=model, contents=prompt, config=config,

--- a/backend/tests/test_gemini.py
+++ b/backend/tests/test_gemini.py
@@ -323,6 +323,37 @@ async def test_translate_chapters_batch_under_budget_does_not_split():
     assert mock.await_count == 1
 
 
+async def test_translate_chapters_batch_sends_permissive_safety_settings():
+    """Classic literature (Faust) hits default safety filters and comes back
+    with finish_reason=PROHIBITED_CONTENT. The batch call must pass
+    BLOCK_NONE thresholds on the four content categories that actually
+    matter for prose translation so the whole model chain doesn't dead-
+    end on safety blocks."""
+    from google.genai import types as g_types
+
+    patcher, mock = _patch_gemini_generate('<chapter index="0">x</chapter>')
+    with patcher:
+        await gemini.translate_chapters_batch(
+            "key", [(0, "text")], "en", "zh",
+        )
+    config = mock.call_args.kwargs["config"]
+    categories = {str(s.category) for s in config.safety_settings}
+    thresholds = {str(s.threshold) for s in config.safety_settings}
+    # All four literary-relevant categories present.
+    assert any("HARASSMENT" in c for c in categories)
+    assert any("HATE_SPEECH" in c for c in categories)
+    assert any("SEXUALLY_EXPLICIT" in c for c in categories)
+    assert any("DANGEROUS_CONTENT" in c for c in categories)
+    # All thresholds are the permissive BLOCK_NONE — if one slipped back
+    # to default/unset we'd get mid-level blocks on literary content.
+    assert all("BLOCK_NONE" in t for t in thresholds)
+    # Sanity: unrelated harm block category was not configured (we don't
+    # want to accidentally disable civic-integrity filtering for no reason).
+    assert not any("CIVIC_INTEGRITY" in c for c in categories)
+    # Type check: the SDK expects a list of SafetySetting objects.
+    assert all(isinstance(s, g_types.SafetySetting) for s in config.safety_settings)
+
+
 async def test_translate_chapters_batch_error_includes_raw_preview():
     """The error message must include a preview of what the model
     actually returned so admins can tell truncation apart from a


### PR DESCRIPTION
## Summary

Follow-up to PR #116's diagnostic errors. With the improved error message, a new failure mode surfaced:

```
! chain_advance — Gemini response contained no <chapter> blocks (finish_reason=FinishReason.PROHIBITED_CONTENT)
```

Classic literature (Faust concretely — devil pacts, Gretchen tragedy, Walpurgisnacht) keeps tripping Gemini's default **mid-level** safety filters on harassment / hate speech / sexually explicit / dangerous content categories. The response comes back empty with `PROHIBITED_CONTENT`. Since every model in the fallback chain shares the same safety layer, the whole chain dead-ends.

## Fix

Attach explicit `BLOCK_NONE` thresholds for the four literary-relevant harm categories on every `translate_chapters_batch` call. Civic-integrity and image categories are left at defaults — they never misfire on prose translation.

## Test plan
- [x] New `test_translate_chapters_batch_sends_permissive_safety_settings` asserts the config carries four `BLOCK_NONE` `SafetySetting` objects for the four categories.
- [x] Full backend suite: 380 passed.
- [ ] Manual: queue a Faust chapter that was previously hitting `PROHIBITED_CONTENT`, confirm the translation completes.

Generated with [Claude Code](https://claude.com/claude-code)
