### PR TITLE
fix(queue): delete queue row on success — fixes orphan-done no-op enqueue

### DIFF
--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -453,24 +453,48 @@ async def reset_stale_running_rows() -> int:
         return cursor.rowcount
 
 
-async def mark_queue_row_done(
-    book_id: int, chapter_index: int, target_language: str,
-) -> int:
-    """Mark any pending/running row for this (book, chapter, lang) as done.
-
-    Called from save_translation so that when a translation lands from ANY
-    source — reader on-demand, bulk job, manual retranslate, queue worker
-    itself — any queued duplicate is retired immediately and the worker
-    doesn't waste a claim-then-skip tick on it.
-
-    Returns the number of rows updated (usually 0 or 1).
+async def cleanup_orphan_done_rows() -> int:
+    """Delete stale 'done' queue rows left behind by the previous
+    behaviour (UPDATE SET status='done' on completion). If a done
+    row lingers after the cache is deleted, `enqueue()`'s
+    INSERT OR IGNORE treats the chapter as already queued and
+    silently no-ops every future re-enqueue attempt. With the new
+    delete-on-success semantics these rows are redundant regardless
+    of cache state — clear them on worker startup so deployments
+    with pre-existing orphans self-heal without manual intervention.
     """
     async with aiosqlite.connect(db_module.DB_PATH) as db:
         cursor = await db.execute(
-            """UPDATE translation_queue
-               SET status='done', updated_at=CURRENT_TIMESTAMP
-               WHERE book_id=? AND chapter_index=? AND target_language=?
-                 AND status IN ('pending', 'running')""",
+            "DELETE FROM translation_queue WHERE status='done'",
+        )
+        await db.commit()
+        return cursor.rowcount
+
+
+async def mark_queue_row_done(
+    book_id: int, chapter_index: int, target_language: str,
+) -> int:
+    """Delete any queue row for this (book, chapter, lang) once a
+    translation has been cached.
+
+    Called from save_translation so every path that produces a
+    translation — reader on-demand, bulk job, manual retranslate,
+    queue worker itself — retires the queue row immediately.
+
+    Why delete instead of UPDATE SET status='done'? Previously a
+    'done' row stayed in the table after success. If the cache was
+    ever deleted afterwards (admin retranslate, DB restore, bug),
+    the row survived but the cache didn't — and `enqueue()`'s
+    INSERT OR IGNORE silently no-op'd forever, blocking re-translation.
+    The `translations` table is the source of truth for what's
+    translated; a queue row only makes sense for work still to do.
+
+    Returns the number of rows removed (usually 0 or 1).
+    """
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        cursor = await db.execute(
+            """DELETE FROM translation_queue
+               WHERE book_id=? AND chapter_index=? AND target_language=?""",
             (book_id, chapter_index, target_language),
         )
         await db.commit()
@@ -665,6 +689,11 @@ class TranslationQueueWorker:
             stale = await reset_stale_running_rows()
             if stale:
                 self._append_log({"event": "startup_reset_stale", "count": stale})
+            orphans = await cleanup_orphan_done_rows()
+            if orphans:
+                self._append_log(
+                    {"event": "startup_cleanup_done_rows", "count": orphans},
+                )
         except Exception:
             logger.exception("Startup housekeeping failed (non-fatal)")
         finally:
@@ -1030,7 +1059,19 @@ class TranslationQueueWorker:
     # ── Status mutations ────────────────────────────────────────────────
 
     async def _mark_done(self, rows: list[QueueRow]) -> None:
-        await self._update_status(rows, "done")
+        # Delete on success so no 'done' row lingers to block a future
+        # re-enqueue via INSERT OR IGNORE. The translations table is
+        # the source of truth for completed work.
+        if not rows:
+            return
+        ids = [r.id for r in rows]
+        placeholders = ",".join("?" for _ in ids)
+        async with aiosqlite.connect(db_module.DB_PATH) as db:
+            await db.execute(
+                f"DELETE FROM translation_queue WHERE id IN ({placeholders})",
+                ids,
+            )
+            await db.commit()
 
     async def _mark_skipped(self, rows: list[QueueRow], *, reason: str) -> None:
         await self._update_status(rows, "skipped", error=reason)

--- a/backend/tests/test_translation_queue.py
+++ b/backend/tests/test_translation_queue.py
@@ -275,23 +275,58 @@ async def test_reset_stale_running_rows_flips_to_pending(tmp_db):
 
 
 async def test_save_translation_auto_clears_pending_queue_row(tmp_db):
-    """save_translation must mark any matching pending/running queue row as
-    done so the worker doesn't claim+skip it later."""
+    """save_translation must retire any matching queue row so the worker
+    doesn't claim+skip it later AND so a future re-enqueue isn't blocked
+    by an orphan 'done' row.
+
+    Post PR: rows are DELETED on success (not UPDATE SET status='done').
+    The translations table is the source of truth for what's translated;
+    lingering 'done' queue rows caused INSERT OR IGNORE to silently
+    no-op on future enqueue attempts when the cache later got deleted.
+    """
     from services.db import save_translation
     await save_book(1, BOOK_META, BOOK_TEXT)
     await enqueue(1, 0, "zh")
-    # Sanity: row starts as pending.
     rows = await list_queue(status="pending")
     assert len(rows) == 1
 
     await save_translation(1, 0, "zh", ["done"], provider="gemini")
 
-    # Post-condition: the queue row is now 'done', not pending.
+    # Row is gone — no 'pending', no 'done', nothing.
+    assert await list_queue(status="pending") == []
+    assert await list_queue(status="done") == []
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute(
+            "SELECT COUNT(*) FROM translation_queue WHERE book_id=1",
+        ) as cursor:
+            (count,) = await cursor.fetchone()
+    assert count == 0
+
+
+async def test_enqueue_after_cache_deleted_succeeds(tmp_db):
+    """Regression: if a 'done' row lingers from the old behaviour and
+    the cache is deleted, a fresh enqueue must insert a new pending row
+    (not silently no-op via INSERT OR IGNORE)."""
+    import services.db as db_module
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    # Seed a legacy orphan 'done' row — cache row deliberately absent.
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        await conn.execute(
+            """INSERT INTO translation_queue
+                   (book_id, chapter_index, target_language, priority, status)
+               VALUES (1, 0, 'zh', 100, 'done')""",
+        )
+        await conn.commit()
+
+    from services.translation_queue import cleanup_orphan_done_rows
+    removed = await cleanup_orphan_done_rows()
+    assert removed == 1
+
+    # Now enqueue succeeds.
+    inserted = await enqueue(1, 0, "zh")
+    assert inserted == 1
     pending = await list_queue(status="pending")
-    assert pending == []
-    done = await list_queue(status="done")
-    assert len(done) == 1
-    assert done[0]["book_id"] == 1
+    assert len(pending) == 1
 
 
 async def test_save_translation_ignores_unrelated_queue_rows(tmp_db):
@@ -717,9 +752,19 @@ async def test_worker_skips_already_cached_chapter(tmp_db):
     # Cached translation for chapter 0 is untouched
     existing = await get_cached_translation(1, 0, "zh")
     assert existing == ["already done"]
-    # Both queue items are marked done (chapter 0 skipped, chapter 1 translated)
-    done = await list_queue(status="done")
-    assert len(done) == 2
+    # Both queue rows are retired — chapter 0 because it was already
+    # cached (skipped), chapter 1 because the worker translated it.
+    # Rows are DELETED on success so no 'done' row lingers to block
+    # a future re-enqueue via INSERT OR IGNORE.
+    import aiosqlite as _aio
+    import services.db as _dbmod
+    async with _aio.connect(_dbmod.DB_PATH) as conn:
+        async with conn.execute(
+            "SELECT COUNT(*) FROM translation_queue WHERE book_id=1",
+        ) as cursor:
+            (count,) = await cursor.fetchone()
+    assert count == 0
+    assert await list_queue(status="done") == []
 
 
 async def test_worker_processes_batch(tmp_db):
@@ -748,10 +793,17 @@ async def test_worker_processes_batch(tmp_db):
         ):
             await w._tick()
 
-    # Both chapters should now be cached and queue rows marked done
+    # Both chapters are now cached; queue rows are deleted on success
+    # so no 'done' row lingers to block a future re-enqueue.
     t0 = await get_cached_translation(1, 0, "zh")
     t1 = await get_cached_translation(1, 1, "zh")
     assert t0 == ["翻译段落一", "翻译段落二"]
     assert t1 == ["翻译章节二"]
-    items = await list_queue(status="done")
-    assert len(items) == 2
+    import aiosqlite as _aio
+    import services.db as _dbmod
+    async with _aio.connect(_dbmod.DB_PATH) as conn:
+        async with conn.execute(
+            "SELECT COUNT(*) FROM translation_queue WHERE book_id=1",
+        ) as cursor:
+            (count,) = await cursor.fetchone()
+    assert count == 0

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -275,6 +275,19 @@ export default function ReaderPage() {
 
       setTranslationUsedProvider(describeStatus(res));
 
+      // Kick the whole-book banner immediately so "N not started" doesn't
+      // misreport the chapter we just enqueued — users clicking "Translate
+      // all N remaining" next would otherwise see a stale count and a
+      // confusing no-op ("enqueued=0" because we already enqueued this).
+      (async () => {
+        try {
+          const status = await getBookTranslationStatus(bid, translationLang);
+          if (!cancelled && currentChapterKey.current === cacheKey) {
+            setBookTranslationStatus(status);
+          }
+        } catch { /* ignore */ }
+      })();
+
       const POLL_MS = 3000;
       while (!cancelled && currentChapterKey.current === cacheKey) {
         await new Promise((r) => setTimeout(r, POLL_MS));
@@ -346,16 +359,37 @@ export default function ReaderPage() {
     try {
       const res = await enqueueBookTranslation(bid, translationLang);
       // Refresh whole-book status immediately so the banner updates
-      // without waiting for the 15s poll tick.
+      // without waiting for the 15s poll tick — the banner may have
+      // been showing stale "not started" counts because a chapter
+      // was on-demand-queued by the reader between polls.
+      let fresh: TranslationStatus | null = null;
       try {
-        const status = await getBookTranslationStatus(bid, translationLang);
-        setBookTranslationStatus(status);
+        fresh = await getBookTranslationStatus(bid, translationLang);
+        setBookTranslationStatus(fresh);
       } catch { /* ignore */ }
-      alert(
-        res.enqueued === 0
-          ? `All chapters are already translated or already queued.`
-          : `Queued ${res.enqueued} chapter${res.enqueued === 1 ? "" : "s"} for translation into ${translationLang}.`,
-      );
+
+      // Distinguish "nothing to queue because everything's done" from
+      // "nothing to queue because everything's already queued" — the
+      // button disappearing + a vague 'already queued' message used
+      // to look like the click was a no-op even when the worker was
+      // actively translating.
+      let msg;
+      if (res.enqueued > 0) {
+        msg = `Queued ${res.enqueued} chapter${res.enqueued === 1 ? "" : "s"} for translation into ${translationLang}.`;
+      } else if (fresh) {
+        const queued = (fresh.queue_pending ?? 0) + (fresh.queue_running ?? 0);
+        const failed = fresh.queue_failed ?? 0;
+        if (queued > 0) {
+          msg = `Nothing new to queue — ${queued} chapter${queued === 1 ? " is" : "s are"} already in the queue and being processed.`;
+        } else if (failed > 0) {
+          msg = `Nothing new to queue — ${failed} chapter${failed === 1 ? "" : "s"} previously failed. Use the Retry button to revive them.`;
+        } else {
+          msg = `All chapters are already translated.`;
+        }
+      } else {
+        msg = `All chapters are already translated or already queued.`;
+      }
+      alert(msg);
     } catch (e) {
       alert(e instanceof Error ? e.message : "Failed to queue book");
     } finally {


### PR DESCRIPTION
## Context

User clicked "Translate all 1 remaining" — nothing queued. Admin Queue tab showed the queue was empty with the worker running. Yet the click returned `enqueued=0` and the banner didn't update.

## Root cause

`enqueue()` uses `INSERT OR IGNORE INTO translation_queue` keyed on `(book_id, chapter_index, target_language)`. `mark_queue_row_done` and the worker's `_mark_done` both set the row's status to `'done'` after success rather than deleting it. The admin's Queue tab hides 'done' rows so it looks empty, but the row is still in the table. Any future enqueue attempt for that chapter silently no-ops.

How it happens in practice: a translation succeeds → row flips to `'done'`. Later the cache gets deleted (admin Retranslate, DB restore, bug). Cache is gone, but the 'done' row survives — and it blocks every future re-enqueue.

## Fix

- `mark_queue_row_done` now `DELETE`s the row.
- Worker's `_mark_done` also `DELETE`s instead of setting `status='done'`.
- New `cleanup_orphan_done_rows()` runs at worker startup, wiping any lingering 'done' rows from the old behaviour so existing deployments self-heal without manual DB surgery.

## Test plan
- [x] Updated existing `save_translation` test + worker tests — assert row is deleted, not marked 'done'.
- [x] New `test_enqueue_after_cache_deleted_succeeds` — seeds an orphan 'done' row, confirms cleanup + enqueue works.
- [x] 380 backend passes.
- [ ] Manual: try "Translate all N remaining" on book 22367 after Railway deploys this PR. The startup cleanup clears the orphan done rows on the next worker restart.

Generated with [Claude Code](https://claude.com/claude-code)
