### PR TITLE
feat(admin): offline translate-and-seed tooling for pre-translated books

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -440,6 +440,51 @@ class BulkRetranslateRequest(BaseModel):
     target_language: str
 
 
+class ImportTranslationEntry(BaseModel):
+    book_id: int
+    chapter_index: int
+    target_language: str
+    paragraphs: list[str]
+    provider: str | None = None
+    model: str | None = None
+
+
+class ImportTranslationsRequest(BaseModel):
+    entries: list[ImportTranslationEntry]
+
+
+@router.post("/translations/import")
+async def import_translations(
+    req: ImportTranslationsRequest,
+    _admin: dict = Depends(_require_admin),
+):
+    """Bulk-import pre-translated chapters from an offline run.
+
+    Companion to `scripts/translate_book.py` and `scripts/seed_translations.py`:
+    you translate a book locally (paying once on a dev machine), export
+    the rows to JSON, then POST them here to seed prod without paying
+    for Gemini a second time.
+
+    Overwrites existing cache entries — safer than silently skipping,
+    since the whole point of seeding is usually to replace bad
+    translations. Skips empty paragraphs arrays.
+    """
+    count = 0
+    for entry in req.entries:
+        if not entry.paragraphs:
+            continue
+        await save_translation(
+            entry.book_id,
+            entry.chapter_index,
+            entry.target_language,
+            entry.paragraphs,
+            provider=entry.provider,
+            model=entry.model,
+        )
+        count += 1
+    return {"ok": True, "imported": count}
+
+
 @router.post("/translations/{book_id}/retranslate-all")
 async def retranslate_all(
     book_id: int,

--- a/backend/scripts/seed_translations.py
+++ b/backend/scripts/seed_translations.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Upload a `translate_book.py` JSON export to the admin `translations/import`
+endpoint so production gets the pre-translated cache rows.
+
+Usage:
+  ADMIN_JWT=eyJ...  python scripts/seed_translations.py \\
+      --file translations_1342_zh.json \\
+      --api-url https://api.book-reader.railway.app/api
+
+The admin JWT comes from signing in to the admin panel and copying the
+Bearer token from a network request (or generating one via the auth
+service). Keep it short-lived.
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Seed a translate_book JSON export into production.",
+    )
+    parser.add_argument(
+        "--file", type=Path, required=True,
+        help="Path to the JSON file produced by translate_book.py --output",
+    )
+    parser.add_argument(
+        "--api-url", default=os.environ.get("BACKEND_URL"),
+        help="Prod API base URL, e.g. https://api.book-reader.railway.app/api "
+             "(or set BACKEND_URL env var)",
+    )
+    parser.add_argument(
+        "--token", default=os.environ.get("ADMIN_JWT"),
+        help="Admin Bearer JWT (or set ADMIN_JWT env var)",
+    )
+    parser.add_argument(
+        "--chunk", type=int, default=50,
+        help="Upload in chunks of N entries per request (default 50). "
+             "Keeps request bodies under proxy limits for big books.",
+    )
+    return parser.parse_args(argv)
+
+
+def main() -> int:
+    args = _parse_args()
+    if not args.api_url:
+        print("ERROR: set --api-url or BACKEND_URL env var", file=sys.stderr)
+        return 2
+    if not args.token:
+        print("ERROR: set --token or ADMIN_JWT env var", file=sys.stderr)
+        return 2
+    if not args.file.exists():
+        print(f"ERROR: file not found: {args.file}", file=sys.stderr)
+        return 2
+
+    entries = json.loads(args.file.read_text())
+    if not isinstance(entries, list) or not entries:
+        print("ERROR: file is empty or not a JSON array", file=sys.stderr)
+        return 2
+
+    url = args.api_url.rstrip("/") + "/admin/translations/import"
+    print(f"Uploading {len(entries)} entries to {url} in chunks of {args.chunk}")
+
+    total_imported = 0
+    for start in range(0, len(entries), args.chunk):
+        chunk = entries[start:start + args.chunk]
+        body = json.dumps({"entries": chunk}).encode()
+        req = urllib.request.Request(
+            url,
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {args.token}",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                payload = json.loads(resp.read().decode())
+        except urllib.error.HTTPError as e:
+            detail = e.read().decode()
+            print(f"HTTP {e.code}: {detail}", file=sys.stderr)
+            return 1
+        except urllib.error.URLError as e:
+            print(f"Network error: {e}", file=sys.stderr)
+            return 1
+        imported = payload.get("imported", 0)
+        total_imported += imported
+        print(
+            f"  [{start + 1}-{start + len(chunk)}/{len(entries)}] "
+            f"imported={imported}",
+        )
+
+    print(f"\nDone — {total_imported} rows imported into production.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/translate_book.py
+++ b/backend/scripts/translate_book.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""
+Translate a single cached book chapter-by-chapter via Gemini and either:
+
+  - write the translation rows to the local `translations` table (so the
+    reader shows it immediately), and/or
+  - export the rows to a JSON file for uploading to production via
+    `seed_translations.py`.
+
+Why this exists:
+  The queue worker is great for production throughput, but when you want
+  to pre-translate a book offline (Pride and Prejudice → zh, say) and
+  then seed the prod DB, a one-shot CLI is simpler: no queue to manage,
+  deterministic ordering, prior-context carried across chapters for
+  style consistency.
+
+Alignment discipline:
+  Uses the same `split_with_html_preference` the reader uses, so chapter
+  indices match what the user sees. Uses `translate_chapters_batch` so
+  we inherit its paragraph-preservation prompt, oversized-chapter
+  chunking, and BLOCK_NONE safety settings. After each chapter we
+  verify the translated paragraph count matches the source. Strict
+  mode (the default) fails the whole chapter on mismatch; pass
+  `--allow-misaligned` to save partial results anyway.
+
+Usage:
+
+  GEMINI_API_KEY=AIza... python scripts/translate_book.py \\
+      --book-id 1342 --lang zh \\
+      --output translations_1342_zh.json --write-local
+
+  # Seed prod from the exported JSON
+  ADMIN_JWT=eyJ... python scripts/seed_translations.py \\
+      --file translations_1342_zh.json \\
+      --api-url https://api.book-reader.railway.app/api
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+# Make `services.*` importable when run as a script from anywhere.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from services.book_chapters import split_with_html_preference  # noqa: E402
+from services.db import (  # noqa: E402
+    DB_PATH,
+    get_cached_book,
+    get_cached_translation,
+    init_db,
+    save_translation,
+)
+from services.gemini import translate_chapters_batch  # noqa: E402
+from services.model_limits import limits_for  # noqa: E402
+
+
+@dataclass
+class ChapterResult:
+    book_id: int
+    chapter_index: int
+    target_language: str
+    paragraphs: list[str]
+    provider: str
+    model: str
+
+
+def _source_paragraphs(text: str) -> list[str]:
+    """Paragraph split used to check alignment. Must match the reader's
+    split (see SentenceReader: `text.split(/\\n\\n+/)`)."""
+    return [p for p in text.split("\n\n") if p.strip()]
+
+
+async def translate_book(
+    book_id: int,
+    target_language: str,
+    *,
+    api_key: str,
+    model: str,
+    write_local: bool,
+    output: Path | None,
+    skip_cached: bool,
+    allow_misaligned: bool,
+    prior_context_paragraphs: int = 2,
+) -> list[ChapterResult]:
+    book = await get_cached_book(book_id)
+    if not book or not book.get("text"):
+        raise SystemExit(
+            f"Book {book_id} is not cached locally. Import it via the "
+            "reader first, or run `seed_books.py`.",
+        )
+    source = (book.get("languages") or ["en"])[0]
+    if source == target_language:
+        raise SystemExit(
+            f"Book {book_id} is already in {target_language}; nothing to translate.",
+        )
+    chapters = await split_with_html_preference(book_id, book["text"])
+
+    limits = limits_for(model)
+    max_tokens = limits["max_output_tokens"]
+
+    title = book.get("title") or f"book {book_id}"
+    print(f"Book:   {title} (id={book_id})")
+    print(f"Source: {source}  →  Target: {target_language}")
+    print(f"Model:  {model}  (max_output_tokens={max_tokens})")
+    print(f"Chapters: {len(chapters)}")
+    print()
+
+    results: list[ChapterResult] = []
+    prior_context = ""
+    started = time.monotonic()
+
+    for i, ch in enumerate(chapters):
+        src_paragraphs = _source_paragraphs(ch.text)
+        if not src_paragraphs:
+            print(f"[{i + 1:>3}/{len(chapters)}] empty — skipping")
+            continue
+
+        if skip_cached and await get_cached_translation(
+            book_id, i, target_language,
+        ):
+            print(f"[{i + 1:>3}/{len(chapters)}] already cached — skipping")
+            continue
+
+        words = sum(len(p.split()) for p in src_paragraphs)
+        print(
+            f"[{i + 1:>3}/{len(chapters)}] translating "
+            f"({len(src_paragraphs)} paragraphs, {words} words)…",
+            flush=True,
+        )
+
+        try:
+            response = await translate_chapters_batch(
+                api_key,
+                [(i, ch.text)],
+                source,
+                target_language,
+                prior_context=prior_context,
+                model=model,
+                max_output_tokens=max_tokens,
+            )
+        except Exception as exc:
+            print(f"    failed: {exc}", file=sys.stderr)
+            continue
+
+        paragraphs = response.get(i, [])
+        if not paragraphs:
+            print("    empty response — skipping", file=sys.stderr)
+            continue
+
+        if len(paragraphs) != len(src_paragraphs):
+            msg = (
+                f"    paragraph count mismatch: source={len(src_paragraphs)} "
+                f"translation={len(paragraphs)}"
+            )
+            if allow_misaligned:
+                print(msg + " (saving anyway, --allow-misaligned)", file=sys.stderr)
+            else:
+                print(msg + " (skipping, pass --allow-misaligned to save)",
+                      file=sys.stderr)
+                continue
+
+        result = ChapterResult(
+            book_id=book_id,
+            chapter_index=i,
+            target_language=target_language,
+            paragraphs=paragraphs,
+            provider="gemini",
+            model=model,
+        )
+        results.append(result)
+
+        if write_local:
+            await save_translation(
+                book_id, i, target_language, paragraphs,
+                provider="gemini", model=model,
+            )
+
+        # Carry the tail for cross-chapter consistency in character
+        # names / tone, same as the queue worker does.
+        if prior_context_paragraphs > 0:
+            tail = paragraphs[-prior_context_paragraphs:]
+            prior_context = "\n\n".join(tail)
+
+        elapsed = time.monotonic() - started
+        print(f"    done in {elapsed:.1f}s cumulative", flush=True)
+
+    if output:
+        payload = [
+            {
+                "book_id": r.book_id,
+                "chapter_index": r.chapter_index,
+                "target_language": r.target_language,
+                "paragraphs": r.paragraphs,
+                "provider": r.provider,
+                "model": r.model,
+            }
+            for r in results
+        ]
+        output.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+        print(f"\nWrote {len(results)} chapter translations to {output}")
+
+    return results
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Translate a cached book chapter-by-chapter via Gemini.",
+    )
+    parser.add_argument("--book-id", type=int, required=True)
+    parser.add_argument(
+        "--lang", required=True,
+        help="Target language code (e.g. zh, en, de, fr)",
+    )
+    parser.add_argument(
+        "--model", default="gemini-2.5-flash",
+        help="Gemini model ID (default: gemini-2.5-flash)",
+    )
+    parser.add_argument(
+        "--output", type=Path,
+        help="Export translations to this JSON file (for prod seeding)",
+    )
+    parser.add_argument(
+        "--write-local", action="store_true",
+        help="Also insert rows into the local DB's translations table",
+    )
+    parser.add_argument(
+        "--skip-cached", action="store_true", default=True,
+        help="Skip chapters that already have a cached translation (default)",
+    )
+    parser.add_argument(
+        "--force", action="store_false", dest="skip_cached",
+        help="Re-translate chapters that are already cached",
+    )
+    parser.add_argument(
+        "--allow-misaligned", action="store_true",
+        help="Save chapters even when paragraph counts don't match the "
+             "source (default: skip mismatched chapters)",
+    )
+    parser.add_argument(
+        "--gemini-key", default=os.environ.get("GEMINI_API_KEY"),
+        help="Gemini API key (or set GEMINI_API_KEY env var)",
+    )
+    return parser.parse_args(argv)
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    if not args.gemini_key:
+        print("ERROR: set --gemini-key or GEMINI_API_KEY env var",
+              file=sys.stderr)
+        return 2
+    if not args.output and not args.write_local:
+        print("ERROR: specify --output and/or --write-local — otherwise "
+              "the translation is thrown away", file=sys.stderr)
+        return 2
+
+    await init_db()
+    print(f"DB_PATH: {DB_PATH}\n")
+
+    results = await translate_book(
+        args.book_id,
+        args.lang,
+        api_key=args.gemini_key,
+        model=args.model,
+        write_local=args.write_local,
+        output=args.output,
+        skip_cached=args.skip_cached,
+        allow_misaligned=args.allow_misaligned,
+    )
+    print(f"\nDone — {len(results)} chapters translated successfully.")
+    return 0
+
+
+def main() -> None:
+    args = _parse_args()
+    sys.exit(asyncio.run(main_async(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -498,6 +498,101 @@ MOVE_BOOK_TEXT = (
 )
 
 
+async def test_import_translations_inserts_rows(admin_client, admin_db):
+    """POST /admin/translations/import writes pre-translated chapters into
+    the cache without going through Gemini. Companion to the offline
+    translate_book.py script used to seed prod from a dev-side run."""
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    res = await admin_client.post(
+        "/api/admin/translations/import",
+        json={
+            "entries": [
+                {
+                    "book_id": 100,
+                    "chapter_index": 0,
+                    "target_language": "zh",
+                    "paragraphs": ["第一段。", "第二段。"],
+                    "provider": "gemini",
+                    "model": "gemini-2.5-flash",
+                },
+            ],
+        },
+    )
+    assert res.status_code == 200, res.text
+    assert res.json() == {"ok": True, "imported": 1}
+
+    from services.db import get_cached_translation
+    cached = await get_cached_translation(100, 0, "zh")
+    assert cached == ["第一段。", "第二段。"]
+
+
+async def test_import_translations_skips_empty_paragraphs(admin_client, admin_db):
+    """Empty paragraph arrays are skipped — seeding shouldn't clobber an
+    existing translation with an empty placeholder if the export has a
+    chapter where translation failed."""
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    await save_translation(100, 0, "zh", ["existing"])
+    res = await admin_client.post(
+        "/api/admin/translations/import",
+        json={
+            "entries": [
+                {
+                    "book_id": 100,
+                    "chapter_index": 0,
+                    "target_language": "zh",
+                    "paragraphs": [],  # empty — skip
+                },
+            ],
+        },
+    )
+    assert res.status_code == 200
+    assert res.json()["imported"] == 0
+    from services.db import get_cached_translation
+    assert await get_cached_translation(100, 0, "zh") == ["existing"]
+
+
+async def test_import_translations_overwrites_existing(admin_client, admin_db):
+    """Non-empty imports DO overwrite — the whole point of seeding is
+    often to replace bad translations with fresh ones."""
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    await save_translation(100, 0, "zh", ["old translation"])
+    res = await admin_client.post(
+        "/api/admin/translations/import",
+        json={
+            "entries": [
+                {
+                    "book_id": 100,
+                    "chapter_index": 0,
+                    "target_language": "zh",
+                    "paragraphs": ["new translation"],
+                },
+            ],
+        },
+    )
+    assert res.status_code == 200
+    from services.db import get_cached_translation
+    assert await get_cached_translation(100, 0, "zh") == ["new translation"]
+
+
+async def test_import_translations_requires_admin(admin_db, admin_user):
+    user2 = await get_or_create_user(
+        google_id="user2", email="u2@test.com", name="U2", picture="",
+    )
+    await set_user_approved(user2["id"], True)
+
+    async def _override():
+        return await get_user_by_id(user2["id"])
+
+    app.dependency_overrides[get_current_user] = _override
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        res = await c.post(
+            "/api/admin/translations/import",
+            json={"entries": []},
+        )
+    app.dependency_overrides.clear()
+    assert res.status_code == 403
+
+
 async def test_move_translation_shifts_chapter_index(admin_client, admin_db):
     """POST /admin/translations/{id}/{idx}/{lang}/move reassigns an existing
     cached translation to a different chapter_index without retranslating.


### PR DESCRIPTION
## Summary

Tooling for "translate a book once, offline, then seed the prod DB" — so we pay for translation once on dev (or in-chat with a Max plan) and push the cache to prod without re-translating.

Three pieces:

- `backend/scripts/translate_book.py` — CLI that reuses the reader's splitter (`split_with_html_preference`) and the queue worker's translator (`translate_chapters_batch` with oversized-chunk splitting + BLOCK_NONE safety settings) to produce paragraph-aligned translations for one book. Writes to the local DB and/or exports JSON. Carries prior-chapter context for name/style consistency. Skips chapters whose translated paragraph count mismatches the source unless `--allow-misaligned`.
- `POST /admin/translations/import` — admin endpoint that bulk-writes pre-translated chapters into the cache. Overwrites existing entries (seeding usually replaces bad translations). Empty paragraphs arrays skipped.
- `backend/scripts/seed_translations.py` — uploads a `translate_book.py` JSON export to prod. Chunks large payloads so proxy body limits don't trip.

## Usage

```bash
# Translate locally (or generate translations in-chat and save via the
# import endpoint directly — the CLI isn't required, the import endpoint
# accepts any compatible JSON)
GEMINI_API_KEY=AIza... python scripts/translate_book.py \
    --book-id 1342 --lang zh \
    --output translations_1342_zh.json --write-local

# Push to prod
ADMIN_JWT=eyJ... python scripts/seed_translations.py \
    --file translations_1342_zh.json \
    --api-url https://api.book-reader.railway.app/api
```

## Test plan
- [x] 4 new admin tests: happy-path import, empty-paragraph skip, overwrite existing, non-admin forbidden.
- [x] Full backend suite: 385 passed.
- [ ] Manual: run `translate_book.py` on book 1342 for zh, verify paragraph counts match source after each chapter, export JSON, seed a local/prod DB via the endpoint, open the reader and confirm alignment.

Generated with [Claude Code](https://claude.com/claude-code)
