### PR TITLE
feat(discover): language filter tabs + dict-format popular books manifest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # Book Reader AI — Claude Code Rules
 
+## Session startup
+
+At the start of every session, read all files listed in
+`/Users/alfmunny/.claude/projects/-Users-alfmunny-Projects-AI/memory/MEMORY.md`
+before doing any work.
+
 ## Testing policy
 
 **Every feature and bug fix must include tests.**
@@ -9,13 +15,13 @@
 - Never mark a task done until the relevant tests pass
 - After completing a feature or bug fix, run the **full** test suite and confirm it passes before committing:
   ```
-  cd frontend && npm test -- --no-coverage --ci
-  cd backend && pytest --tb=short -q
+  npm --prefix frontend test -- --no-coverage --ci
+  /Users/alfmunny/Projects/AI/book-reader-ai/backend/venv/bin/pytest --tb=short -q
   ```
 
 ### Frontend (Jest + React Testing Library)
 - Test files live in `frontend/src/__tests__/`
-- Run with: `cd frontend && npm test -- --no-coverage`
+- Run with: `npm --prefix frontend test -- --no-coverage`
 - Mock external API calls (`@/lib/api`) with `jest.mock`
 - Mock ESM-only packages (e.g. `react-markdown`) in `frontend/src/__mocks__/`
 - Use `@testing-library/user-event` for user interactions, not `fireEvent` for complex flows
@@ -23,13 +29,13 @@
 
 ### Backend (pytest)
 - Test files live in `backend/tests/`
-- Run with: `cd backend && pytest`
+- Run with: `/Users/alfmunny/Projects/AI/book-reader-ai/backend/venv/bin/pytest`
 - Use `pytest-asyncio` for async route/service tests
 - Mock external HTTP calls (Anthropic, Gemini, Google) — never hit real APIs in tests
 
 ### E2E (Playwright)
 - Test files live in `frontend/e2e/`
-- Run with: `cd frontend && npm run test:e2e` (or `:ui` for interactive mode)
+- Run with: `npm --prefix frontend run test:e2e` (or `:ui` for interactive mode)
 - Dev server is started automatically by Playwright with `PLAYWRIGHT_TEST=1` to bypass auth middleware
 - Backend is mocked via `page.route()` — see `frontend/e2e/fixtures.ts` for shared API stubs
 - Use E2E for full user flows (navigation, persistence across reloads) where unit tests fall short
@@ -48,17 +54,20 @@
 
 **Never commit directly to `main`.** All changes must go through a PR.
 
-1. Create a feature branch: `git checkout -b feat/description` (or `fix/`, `chore/`)
-2. Make commits on the branch
-3. Run the full test suite before pushing
-4. Push the branch and open a PR: `gh pr create`
-5. CI must pass before merging
+Branch naming: `feat/`, `fix/`, `chore/`, `test/`
 
-Branch naming convention:
-- `feat/` — new feature
-- `fix/` — bug fix
-- `chore/` — tooling, CI, deps
-- `test/` — tests only
+**Exact sequence every time:**
+1. `git -C <repo> fetch origin main && git -C <repo> rebase origin/main`
+2. `git -C <repo> checkout -b feat/description`
+3. Make commits; run full test suite before pushing
+4. Before push: verify the branch's PR is still OPEN — `gh pr list --head <branch> --json state`
+5. `git -C <repo> push -u origin <branch>`
+6. Write PR body to `/tmp/pr-body.md`, then `gh pr create --body-file /tmp/pr-body.md`
+7. `gh pr merge <N> --auto --squash`
+8. Launch background watcher: poll `gh pr view <N> --json state` every 20s until MERGED; report result
+
+**Never use `cd && git`** — use `git -C <path>` instead (bare-repo security check cannot be bypassed).
+**Never use `git` binaries directly** — always `git -C /Users/alfmunny/Projects/AI/book-reader-ai`.
 
 ## Code style
 

--- a/backend/popular_books.json
+++ b/backend/popular_books.json
@@ -1,2402 +1,7487 @@
-[
-  {
-    "id": 84,
-    "title": "Frankenstein; or, the modern prometheus",
-    "authors": [
-      "Shelley, Mary Wollstonecraft"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 178271,
-    "cover": "https://www.gutenberg.org/cache/epub/84/pg84.cover.medium.jpg"
-  },
-  {
-    "id": 45304,
-    "title": "The City of God, Volume I",
-    "authors": [
-      "Augustine, of Hippo, Saint"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 146974,
-    "cover": "https://www.gutenberg.org/cache/epub/45304/pg45304.cover.medium.jpg"
-  },
-  {
-    "id": 2701,
-    "title": "Moby Dick; Or, The Whale",
-    "authors": [
-      "Melville, Herman"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 112302,
-    "cover": "https://www.gutenberg.org/cache/epub/2701/pg2701.cover.medium.jpg"
-  },
-  {
-    "id": 1342,
-    "title": "Pride and Prejudice",
-    "authors": [
-      "Austen, Jane"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 107502,
-    "cover": "https://www.gutenberg.org/cache/epub/1342/pg1342.cover.medium.jpg"
-  },
-  {
-    "id": 768,
-    "title": "Wuthering Heights",
-    "authors": [
-      "Brontë, Emily"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 72775,
-    "cover": "https://www.gutenberg.org/cache/epub/768/pg768.cover.medium.jpg"
-  },
-  {
-    "id": 1513,
-    "title": "Romeo and Juliet",
-    "authors": [
-      "Shakespeare, William"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 70272,
-    "cover": "https://www.gutenberg.org/cache/epub/1513/pg1513.cover.medium.jpg"
-  },
-  {
-    "id": 11,
-    "title": "Alice's Adventures in Wonderland",
-    "authors": [
-      "Carroll, Lewis"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 65243,
-    "cover": "https://www.gutenberg.org/cache/epub/11/pg11.cover.medium.jpg"
-  },
-  {
-    "id": 64317,
-    "title": "The Great Gatsby",
-    "authors": [
-      "Fitzgerald, F. Scott (Francis Scott)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 60632,
-    "cover": "https://www.gutenberg.org/cache/epub/64317/pg64317.cover.medium.jpg"
-  },
-  {
-    "id": 100,
-    "title": "The Complete Works of William Shakespeare",
-    "authors": [
-      "Shakespeare, William"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 60527,
-    "cover": "https://www.gutenberg.org/cache/epub/100/pg100.cover.medium.jpg"
-  },
-  {
-    "id": 1260,
-    "title": "Jane Eyre: An Autobiography",
-    "authors": [
-      "Brontë, Charlotte"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 57602,
-    "cover": "https://www.gutenberg.org/cache/epub/1260/pg1260.cover.medium.jpg"
-  },
-  {
-    "id": 2641,
-    "title": "A Room with a View",
-    "authors": [
-      "Forster, E. M. (Edward Morgan)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 57366,
-    "cover": "https://www.gutenberg.org/cache/epub/2641/pg2641.cover.medium.jpg"
-  },
-  {
-    "id": 43,
-    "title": "The strange case of Dr. Jekyll and Mr. Hyde",
-    "authors": [
-      "Stevenson, Robert Louis"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 56894,
-    "cover": "https://www.gutenberg.org/cache/epub/43/pg43.cover.medium.jpg"
-  },
-  {
-    "id": 145,
-    "title": "Middlemarch",
-    "authors": [
-      "Eliot, George"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 53885,
-    "cover": "https://www.gutenberg.org/cache/epub/145/pg145.cover.medium.jpg"
-  },
-  {
-    "id": 174,
-    "title": "The Picture of Dorian Gray",
-    "authors": [
-      "Wilde, Oscar"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 52794,
-    "cover": "https://www.gutenberg.org/cache/epub/174/pg174.cover.medium.jpg"
-  },
-  {
-    "id": 844,
-    "title": "The Importance of Being Earnest: A Trivial Comedy for Serious People",
-    "authors": [
-      "Wilde, Oscar"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 51790,
-    "cover": "https://www.gutenberg.org/cache/epub/844/pg844.cover.medium.jpg"
-  },
-  {
-    "id": 2554,
-    "title": "Crime and Punishment",
-    "authors": [
-      "Dostoyevsky, Fyodor"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 49665,
-    "cover": "https://www.gutenberg.org/cache/epub/2554/pg2554.cover.medium.jpg"
-  },
-  {
-    "id": 37106,
-    "title": "Little Women; Or, Meg, Jo, Beth, and Amy",
-    "authors": [
-      "Alcott, Louisa May"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 49414,
-    "cover": "https://www.gutenberg.org/cache/epub/37106/pg37106.cover.medium.jpg"
-  },
-  {
-    "id": 67979,
-    "title": "The Blue Castle: a novel",
-    "authors": [
-      "Montgomery, L. M. (Lucy Maud)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 47023,
-    "cover": "https://www.gutenberg.org/cache/epub/67979/pg67979.cover.medium.jpg"
-  },
-  {
-    "id": 1184,
-    "title": "The Count of Monte Cristo",
-    "authors": [
-      "Dumas, Alexandre",
-      "Maquet, Auguste"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 44760,
-    "cover": "https://www.gutenberg.org/cache/epub/1184/pg1184.cover.medium.jpg"
-  },
-  {
-    "id": 3207,
-    "title": "Leviathan",
-    "authors": [
-      "Hobbes, Thomas"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 42900,
-    "cover": "https://www.gutenberg.org/cache/epub/3207/pg3207.cover.medium.jpg"
-  },
-  {
-    "id": 5197,
-    "title": "My Life — Volume 1",
-    "authors": [
-      "Wagner, Richard"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 42691,
-    "cover": "https://www.gutenberg.org/cache/epub/5197/pg5197.cover.medium.jpg"
-  },
-  {
-    "id": 345,
-    "title": "Dracula",
-    "authors": [
-      "Stoker, Bram"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 42360,
-    "cover": "https://www.gutenberg.org/cache/epub/345/pg345.cover.medium.jpg"
-  },
-  {
-    "id": 2542,
-    "title": "A Doll's House : a play",
-    "authors": [
-      "Ibsen, Henrik"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 41568,
-    "cover": "https://www.gutenberg.org/cache/epub/2542/pg2542.cover.medium.jpg"
-  },
-  {
-    "id": 8492,
-    "title": "The King in Yellow",
-    "authors": [
-      "Chambers, Robert W. (Robert William)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 40983,
-    "cover": "https://www.gutenberg.org/cache/epub/8492/pg8492.cover.medium.jpg"
-  },
-  {
-    "id": 16389,
-    "title": "The Enchanted April",
-    "authors": [
-      "Von Arnim, Elizabeth"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 40805,
-    "cover": "https://www.gutenberg.org/cache/epub/16389/pg16389.cover.medium.jpg"
-  },
-  {
-    "id": 1259,
-    "title": "Twenty years after",
-    "authors": [
-      "Dumas, Alexandre",
-      "Maquet, Auguste"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 40022,
-    "cover": "https://www.gutenberg.org/cache/epub/1259/pg1259.cover.medium.jpg"
-  },
-  {
-    "id": 28054,
-    "title": "The Brothers Karamazov",
-    "authors": [
-      "Dostoyevsky, Fyodor"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 39032,
-    "cover": "https://www.gutenberg.org/cache/epub/28054/pg28054.cover.medium.jpg"
-  },
-  {
-    "id": 76,
-    "title": "Adventures of Huckleberry Finn",
-    "authors": [
-      "Twain, Mark"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 38960,
-    "cover": "https://www.gutenberg.org/cache/epub/76/pg76.cover.medium.jpg"
-  },
-  {
-    "id": 1661,
-    "title": "The Adventures of Sherlock Holmes",
-    "authors": [
-      "Doyle, Arthur Conan"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 38703,
-    "cover": "https://www.gutenberg.org/cache/epub/1661/pg1661.cover.medium.jpg"
-  },
-  {
-    "id": 6761,
-    "title": "The Adventures of Ferdinand Count Fathom — Complete",
-    "authors": [
-      "Smollett, T. (Tobias)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 38235,
-    "cover": "https://www.gutenberg.org/cache/epub/6761/pg6761.cover.medium.jpg"
-  },
-  {
-    "id": 98,
-    "title": "A Tale of Two Cities",
-    "authors": [
-      "Dickens, Charles"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 38103,
-    "cover": "https://www.gutenberg.org/cache/epub/98/pg98.cover.medium.jpg"
-  },
-  {
-    "id": 394,
-    "title": "Cranford",
-    "authors": [
-      "Gaskell, Elizabeth Cleghorn"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 38083,
-    "cover": "https://www.gutenberg.org/cache/epub/394/pg394.cover.medium.jpg"
-  },
-  {
-    "id": 2160,
-    "title": "The Expedition of Humphry Clinker",
-    "authors": [
-      "Smollett, T. (Tobias)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 37810,
-    "cover": "https://www.gutenberg.org/cache/epub/2160/pg2160.cover.medium.jpg"
-  },
-  {
-    "id": 6593,
-    "title": "History of Tom Jones, a Foundling",
-    "authors": [
-      "Fielding, Henry"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 37687,
-    "cover": "https://www.gutenberg.org/cache/epub/6593/pg6593.cover.medium.jpg"
-  },
-  {
-    "id": 4085,
-    "title": "The Adventures of Roderick Random",
-    "authors": [
-      "Smollett, T. (Tobias)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 36803,
-    "cover": "https://www.gutenberg.org/cache/epub/4085/pg4085.cover.medium.jpg"
-  },
-  {
-    "id": 1080,
-    "title": "A Modest Proposal: For preventing the children of poor people in Ireland, from being a burden on their parents or country, and for making them beneficial to the publick",
-    "authors": [
-      "Swift, Jonathan"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 35578,
-    "cover": "https://www.gutenberg.org/cache/epub/1080/pg1080.cover.medium.jpg"
-  },
-  {
-    "id": 1400,
-    "title": "Great Expectations",
-    "authors": [
-      "Dickens, Charles"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 33787,
-    "cover": "https://www.gutenberg.org/cache/epub/1400/pg1400.cover.medium.jpg"
-  },
-  {
-    "id": 16328,
-    "title": "Beowulf: An Anglo-Saxon Epic Poem",
-    "authors": [],
-    "languages": [
-      "en"
-    ],
-    "download_count": 30984,
-    "cover": "https://www.gutenberg.org/cache/epub/16328/pg16328.cover.medium.jpg"
-  },
-  {
-    "id": 37683,
-    "title": "Chambers's Twentieth Century Dictionary (part 1 of 4: A-D)",
-    "authors": [],
-    "languages": [
-      "en"
-    ],
-    "download_count": 30765,
-    "cover": "https://www.gutenberg.org/cache/epub/37683/pg37683.cover.medium.jpg"
-  },
-  {
-    "id": 26471,
-    "title": "Spoon River Anthology",
-    "authors": [
-      "Masters, Edgar Lee"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 30062,
-    "cover": "https://www.gutenberg.org/cache/epub/26471/pg26471.cover.medium.jpg"
-  },
-  {
-    "id": 1232,
-    "title": "The Prince",
-    "authors": [
-      "Machiavelli, Niccolò"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 29532,
-    "cover": "https://www.gutenberg.org/cache/epub/1232/pg1232.cover.medium.jpg"
-  },
-  {
-    "id": 1998,
-    "title": "Thus Spake Zarathustra: A Book for All and None",
-    "authors": [
-      "Nietzsche, Friedrich Wilhelm"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 29327,
-    "cover": "https://www.gutenberg.org/cache/epub/1998/pg1998.cover.medium.jpg"
-  },
-  {
-    "id": 28942,
-    "title": "The Junior Classics, Volume 1: Fairy and wonder tales",
-    "authors": [
-      "Neilson, William Allan"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 28853,
-    "cover": "https://www.gutenberg.org/cache/epub/28942/pg28942.cover.medium.jpg"
-  },
-  {
-    "id": 1952,
-    "title": "The Yellow Wallpaper",
-    "authors": [
-      "Gilman, Charlotte Perkins"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 28479,
-    "cover": "https://www.gutenberg.org/cache/epub/1952/pg1952.cover.medium.jpg"
-  },
-  {
-    "id": 2680,
-    "title": "Meditations",
-    "authors": [
-      "Marcus Aurelius, Emperor of Rome"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 28425,
-    "cover": "https://www.gutenberg.org/cache/epub/2680/pg2680.cover.medium.jpg"
-  },
-  {
-    "id": 25344,
-    "title": "The Scarlet Letter",
-    "authors": [
-      "Hawthorne, Nathaniel"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 28370,
-    "cover": "https://www.gutenberg.org/cache/epub/25344/pg25344.cover.medium.jpg"
-  },
-  {
-    "id": 5200,
-    "title": "Metamorphosis",
-    "authors": [
-      "Kafka, Franz"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 28364,
-    "cover": "https://www.gutenberg.org/cache/epub/5200/pg5200.cover.medium.jpg"
-  },
-  {
-    "id": 2591,
-    "title": "Grimms' Fairy Tales",
-    "authors": [
-      "Grimm, Jacob",
-      "Grimm, Wilhelm"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 27642,
-    "cover": "https://www.gutenberg.org/cache/epub/2591/pg2591.cover.medium.jpg"
-  },
-  {
-    "id": 4300,
-    "title": "Ulysses",
-    "authors": [
-      "Joyce, James"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 27259,
-    "cover": "https://www.gutenberg.org/cache/epub/4300/pg4300.cover.medium.jpg"
-  },
-  {
-    "id": 2600,
-    "title": "War and Peace",
-    "authors": [
-      "Tolstoy, Leo, graf"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 27051,
-    "cover": "https://www.gutenberg.org/cache/epub/2600/pg2600.cover.medium.jpg"
-  },
-  {
-    "id": 205,
-    "title": "Walden, and On The Duty Of Civil Disobedience",
-    "authors": [
-      "Thoreau, Henry David"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 26622,
-    "cover": "https://www.gutenberg.org/cache/epub/205/pg205.cover.medium.jpg"
-  },
-  {
-    "id": 45,
-    "title": "Anne of Green Gables",
-    "authors": [
-      "Montgomery, L. M. (Lucy Maud)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 26339,
-    "cover": "https://www.gutenberg.org/cache/epub/45/pg45.cover.medium.jpg"
-  },
-  {
-    "id": 74,
-    "title": "The Adventures of Tom Sawyer, Complete",
-    "authors": [
-      "Twain, Mark"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 25830,
-    "cover": "https://www.gutenberg.org/cache/epub/74/pg74.cover.medium.jpg"
-  },
-  {
-    "id": 3296,
-    "title": "The Confessions of St. Augustine",
-    "authors": [
-      "Augustine, of Hippo, Saint"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 25581,
-    "cover": "https://www.gutenberg.org/cache/epub/3296/pg3296.cover.medium.jpg"
-  },
-  {
-    "id": 829,
-    "title": "Gulliver's Travels into Several Remote Nations of the World",
-    "authors": [
-      "Swift, Jonathan"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 25457,
-    "cover": "https://www.gutenberg.org/cache/epub/829/pg829.cover.medium.jpg"
-  },
-  {
-    "id": 26184,
-    "title": "Simple Sabotage Field Manual",
-    "authors": [
-      "United States. Office of Strategic Services"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 24602,
-    "cover": "https://www.gutenberg.org/cache/epub/26184/pg26184.cover.medium.jpg"
-  },
-  {
-    "id": 120,
-    "title": "Treasure Island",
-    "authors": [
-      "Stevenson, Robert Louis"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 24601,
-    "cover": "https://www.gutenberg.org/cache/epub/120/pg120.cover.medium.jpg"
-  },
-  {
-    "id": 36034,
-    "title": "White nights, and other stories",
-    "authors": [
-      "Dostoyevsky, Fyodor"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 23874,
-    "cover": "https://www.gutenberg.org/cache/epub/36034/pg36034.cover.medium.jpg"
-  },
-  {
-    "id": 8800,
-    "title": "The divine comedy",
-    "authors": [
-      "Dante Alighieri"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 22965,
-    "cover": "https://www.gutenberg.org/cache/epub/8800/pg8800.cover.medium.jpg"
-  },
-  {
-    "id": 1727,
-    "title": "The Odyssey: Rendered into English prose for the use of those who cannot read the original",
-    "authors": [
-      "Homer"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 22827,
-    "cover": "https://www.gutenberg.org/cache/epub/1727/pg1727.cover.medium.jpg"
-  },
-  {
-    "id": 1399,
-    "title": "Anna Karenina",
-    "authors": [
-      "Tolstoy, Leo, graf"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 22617,
-    "cover": "https://www.gutenberg.org/cache/epub/1399/pg1399.cover.medium.jpg"
-  },
-  {
-    "id": 28189,
-    "title": "My Friends the Savages: Notes and Observations of a Perak settler (Malay Peninsula)",
-    "authors": [
-      "Cerruti, Giovanni Battista"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 21898,
-    "cover": "https://www.gutenberg.org/cache/epub/28189/pg28189.cover.medium.jpg"
-  },
-  {
-    "id": 2852,
-    "title": "The Hound of the Baskervilles",
-    "authors": [
-      "Doyle, Arthur Conan"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 21608,
-    "cover": "https://www.gutenberg.org/cache/epub/2852/pg2852.cover.medium.jpg"
-  },
-  {
-    "id": 26225,
-    "title": "Fifteen Thousand Useful Phrases",
-    "authors": [
-      "Kleiser, Grenville"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 21496,
-    "cover": "https://www.gutenberg.org/cache/epub/26225/pg26225.cover.medium.jpg"
-  },
-  {
-    "id": 408,
-    "title": "The Souls of Black Folk",
-    "authors": [
-      "Du Bois, W. E. B. (William Edward Burghardt)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 21414,
-    "cover": "https://www.gutenberg.org/cache/epub/408/pg408.cover.medium.jpg"
-  },
-  {
-    "id": 244,
-    "title": "A Study in Scarlet",
-    "authors": [
-      "Doyle, Arthur Conan"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 21389,
-    "cover": "https://www.gutenberg.org/cache/epub/244/pg244.cover.medium.jpg"
-  },
-  {
-    "id": 22788,
-    "title": "The Federalist Papers",
-    "authors": [
-      "Hamilton, Alexander",
-      "Jay, John",
-      "Madison, James"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 20967,
-    "cover": "https://www.gutenberg.org/cache/epub/22788/pg22788.cover.medium.jpg"
-  },
-  {
-    "id": 34901,
-    "title": "On Liberty",
-    "authors": [
-      "Mill, John Stuart"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 20878,
-    "cover": "https://www.gutenberg.org/cache/epub/34901/pg34901.cover.medium.jpg"
-  },
-  {
-    "id": 27673,
-    "title": "Oedipus King of Thebes: Translated into English Rhyming Verse with Explanatory Notes",
-    "authors": [
-      "Sophocles"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 20775,
-    "cover": "https://www.gutenberg.org/cache/epub/27673/pg27673.cover.medium.jpg"
-  },
-  {
-    "id": 55,
-    "title": "The Wonderful Wizard of Oz",
-    "authors": [
-      "Baum, L. Frank (Lyman Frank)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 20616,
-    "cover": "https://www.gutenberg.org/cache/epub/55/pg55.cover.medium.jpg"
-  },
-  {
-    "id": 4363,
-    "title": "Beyond Good and Evil",
-    "authors": [
-      "Nietzsche, Friedrich Wilhelm"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 20616,
-    "cover": "https://www.gutenberg.org/cache/epub/4363/pg4363.cover.medium.jpg"
-  },
-  {
-    "id": 23,
-    "title": "Narrative of the Life of Frederick Douglass, an American Slave",
-    "authors": [
-      "Douglass, Frederick"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 20603,
-    "cover": "https://www.gutenberg.org/cache/epub/23/pg23.cover.medium.jpg"
-  },
-  {
-    "id": 72679,
-    "title": "The lesser Key of Solomon, Goetia, the book of evil spirits : $b contains two hundred diagrams and seals for invocation and convocation of spirits, necromancy, witchcraft and black art",
-    "authors": [],
-    "languages": [
-      "en"
-    ],
-    "download_count": 20464,
-    "cover": "https://www.gutenberg.org/cache/epub/72679/pg72679.cover.medium.jpg"
-  },
-  {
-    "id": 7370,
-    "title": "Second Treatise of Government",
-    "authors": [
-      "Locke, John"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 20172,
-    "cover": "https://www.gutenberg.org/cache/epub/7370/pg7370.cover.medium.jpg"
-  },
-  {
-    "id": 78248,
-    "title": "Prolegomena to the study of Greek religion",
-    "authors": [
-      "Harrison, Jane Ellen"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 19776,
-    "cover": "https://www.gutenberg.org/cache/epub/78248/pg78248.cover.medium.jpg"
-  },
-  {
-    "id": 219,
-    "title": "Heart of Darkness",
-    "authors": [
-      "Conrad, Joseph"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 19150,
-    "cover": "https://www.gutenberg.org/cache/epub/219/pg219.cover.medium.jpg"
-  },
-  {
-    "id": 161,
-    "title": "Sense and Sensibility",
-    "authors": [
-      "Austen, Jane"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 18666,
-    "cover": "https://www.gutenberg.org/cache/epub/161/pg161.cover.medium.jpg"
-  },
-  {
-    "id": 16,
-    "title": "Peter Pan : $b [Peter and Wendy]",
-    "authors": [
-      "Barrie, J. M. (James Matthew)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 18458,
-    "cover": "https://www.gutenberg.org/cache/epub/16/pg16.cover.medium.jpg"
-  },
-  {
-    "id": 22789,
-    "title": "On the Duties of the Clergy",
-    "authors": [
-      "Ambrose, Saint, Bishop of Milan"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 18332,
-    "cover": "https://www.gutenberg.org/cache/epub/22789/pg22789.cover.medium.jpg"
-  },
-  {
-    "id": 135,
-    "title": "Les Misérables",
-    "authors": [
-      "Hugo, Victor"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 18171,
-    "cover": "https://www.gutenberg.org/cache/epub/135/pg135.cover.medium.jpg"
-  },
-  {
-    "id": 24869,
-    "title": "The Rámáyan of Válmíki, translated into English verse",
-    "authors": [
-      "Valmiki"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 18135,
-    "cover": "https://www.gutenberg.org/cache/epub/24869/pg24869.cover.medium.jpg"
-  },
-  {
-    "id": 730,
-    "title": "Oliver Twist",
-    "authors": [
-      "Dickens, Charles"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 17382,
-    "cover": "https://www.gutenberg.org/cache/epub/730/pg730.cover.medium.jpg"
-  },
-  {
-    "id": 2148,
-    "title": "The Works of Edgar Allan Poe — Volume 2",
-    "authors": [
-      "Poe, Edgar Allan"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 17308,
-    "cover": "https://www.gutenberg.org/cache/epub/2148/pg2148.cover.medium.jpg"
-  },
-  {
-    "id": 1497,
-    "title": "The Republic",
-    "authors": [
-      "Plato"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 17277,
-    "cover": "https://www.gutenberg.org/cache/epub/1497/pg1497.cover.medium.jpg"
-  },
-  {
-    "id": 215,
-    "title": "The call of the wild",
-    "authors": [
-      "London, Jack"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 17250,
-    "cover": "https://www.gutenberg.org/cache/epub/215/pg215.cover.medium.jpg"
-  },
-  {
-    "id": 31885,
-    "title": "Bible Myths and their Parallels in other Religions: Being a Comparison of the Old and New Testament Myths and Miracles with those of the Heathen Nations of Antiquity Considering also their Origin and Meaning",
-    "authors": [
-      "Doane, T. W. (Thomas William)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 17141,
-    "cover": "https://www.gutenberg.org/cache/epub/31885/pg31885.cover.medium.jpg"
-  },
-  {
-    "id": 45368,
-    "title": "The Outline of History: Being a Plain History of Life and Mankind",
-    "authors": [
-      "Wells, H. G. (Herbert George)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 17130,
-    "cover": "https://www.gutenberg.org/cache/epub/45368/pg45368.cover.medium.jpg"
-  },
-  {
-    "id": 164,
-    "title": "Twenty Thousand Leagues under the Sea",
-    "authors": [
-      "Verne, Jules"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 17061,
-    "cover": "https://www.gutenberg.org/cache/epub/164/pg164.cover.medium.jpg"
-  },
-  {
-    "id": 521,
-    "title": "The Life and Adventures of Robinson Crusoe",
-    "authors": [
-      "Defoe, Daniel"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 17011,
-    "cover": "https://www.gutenberg.org/cache/epub/521/pg521.cover.medium.jpg"
-  },
-  {
-    "id": 3206,
-    "title": "Moby Multiple Language Lists of Common Words",
-    "authors": [
-      "Ward, Grady"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 16993,
-    "cover": "https://www.gutenberg.org/cache/epub/3206/pg3206.cover.medium.jpg"
-  },
-  {
-    "id": 20203,
-    "title": "Autobiography of Benjamin Franklin",
-    "authors": [
-      "Franklin, Benjamin"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 16978,
-    "cover": "https://www.gutenberg.org/cache/epub/20203/pg20203.cover.medium.jpg"
-  },
-  {
-    "id": 30254,
-    "title": "The Romance of Lust: A classic Victorian erotic novel",
-    "authors": [
-      "Anonymous"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 16790,
-    "cover": "https://www.gutenberg.org/cache/epub/30254/pg30254.cover.medium.jpg"
-  },
-  {
-    "id": 21765,
-    "title": "The Metamorphoses of Ovid, Books I-VII",
-    "authors": [
-      "Ovid"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 16655,
-    "cover": "https://www.gutenberg.org/cache/epub/21765/pg21765.cover.medium.jpg"
-  },
-  {
-    "id": 1023,
-    "title": "Bleak House",
-    "authors": [
-      "Dickens, Charles"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 16318,
-    "cover": "https://www.gutenberg.org/cache/epub/1023/pg1023.cover.medium.jpg"
-  },
-  {
-    "id": 36,
-    "title": "The war of the worlds",
-    "authors": [
-      "Wells, H. G. (Herbert George)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 16182,
-    "cover": "https://www.gutenberg.org/cache/epub/36/pg36.cover.medium.jpg"
-  },
-  {
-    "id": 132,
-    "title": "The Art of War",
-    "authors": [
-      "Sunzi, active 6th century B.C."
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 16140,
-    "cover": "https://www.gutenberg.org/cache/epub/132/pg132.cover.medium.jpg"
-  },
-  {
-    "id": 996,
-    "title": "Don Quixote",
-    "authors": [
-      "Cervantes Saavedra, Miguel de"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 16106,
-    "cover": "https://www.gutenberg.org/cache/epub/996/pg996.cover.medium.jpg"
-  },
-  {
-    "id": 46,
-    "title": "A Christmas Carol in Prose; Being a Ghost Story of Christmas",
-    "authors": [
-      "Dickens, Charles"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 15993,
-    "cover": "https://www.gutenberg.org/cache/epub/46/pg46.cover.medium.jpg"
-  },
-  {
-    "id": 13188,
-    "title": "Putnam's Word Book: A Practical Aid in Expressing Ideas Through the Use of an Exact and Varied Vocabulary",
-    "authors": [
-      "Flemming, Louis A. (Louis Andrew)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 15913,
-    "cover": "https://www.gutenberg.org/cache/epub/13188/pg13188.cover.medium.jpg"
-  },
-  {
-    "id": 19488,
-    "title": "The Life of Joan of Arc, Vol. 1 and 2",
-    "authors": [
-      "France, Anatole"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 15477,
-    "cover": "https://www.gutenberg.org/cache/epub/19488/pg19488.cover.medium.jpg"
-  },
-  {
-    "id": 209,
-    "title": "The Turn of the Screw",
-    "authors": [
-      "James, Henry"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 15425,
-    "cover": "https://www.gutenberg.org/cache/epub/209/pg209.cover.medium.jpg"
-  },
-  {
-    "id": 57724,
-    "title": "A Cyclopaedia of Canadian Biography: Being Chiefly Men of the Time: A Collection of Persons Distinguished in Professional and Political Life, Leaders in the Commerce and Industry of Canada, and Successful Pioneers",
-    "authors": [],
-    "languages": [
-      "en"
-    ],
-    "download_count": 15400,
-    "cover": "https://www.gutenberg.org/cache/epub/57724/pg57724.cover.medium.jpg"
-  },
-  {
-    "id": 35,
-    "title": "The Time Machine",
-    "authors": [
-      "Wells, H. G. (Herbert George)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 15303,
-    "cover": "https://www.gutenberg.org/cache/epub/35/pg35.cover.medium.jpg"
-  },
-  {
-    "id": 20000,
-    "title": "Twenty Thousand Leagues Under the Sea",
-    "authors": [
-      "Verne, Jules"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 15300,
-    "cover": "https://www.gutenberg.org/cache/epub/20000/pg20000.cover.medium.jpg"
-  },
-  {
-    "id": 15399,
-    "title": "The Interesting Narrative of the Life of Olaudah Equiano, Or Gustavus Vassa, The African: Written By Himself",
-    "authors": [
-      "Equiano, Olaudah"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 15284,
-    "cover": "https://www.gutenberg.org/cache/epub/15399/pg15399.cover.medium.jpg"
-  },
-  {
-    "id": 3300,
-    "title": "An Inquiry into the Nature and Causes of the Wealth of Nations",
-    "authors": [
-      "Smith, Adam"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 15170,
-    "cover": "https://www.gutenberg.org/cache/epub/3300/pg3300.cover.medium.jpg"
-  },
-  {
-    "id": 25851,
-    "title": "The Life of Charles Dickens, Vol. I-III, Complete",
-    "authors": [
-      "Forster, John"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 15049,
-    "cover": "https://www.gutenberg.org/cache/epub/25851/pg25851.cover.medium.jpg"
-  },
-  {
-    "id": 41,
-    "title": "The Legend of Sleepy Hollow",
-    "authors": [
-      "Irving, Washington"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 14944,
-    "cover": "https://www.gutenberg.org/cache/epub/41/pg41.cover.medium.jpg"
-  },
-  {
-    "id": 2814,
-    "title": "Dubliners",
-    "authors": [
-      "Joyce, James"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 14935,
-    "cover": "https://www.gutenberg.org/cache/epub/2814/pg2814.cover.medium.jpg"
-  },
-  {
-    "id": 44608,
-    "title": "The Bābur-nāma in English (Memoirs of Bābur)",
-    "authors": [
-      "Babur, Emperor of Hindustan"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 14798,
-    "cover": "https://www.gutenberg.org/cache/epub/44608/pg44608.cover.medium.jpg"
-  },
-  {
-    "id": 21436,
-    "title": "Poems Every Child Should Know",
-    "authors": [],
-    "languages": [
-      "en"
-    ],
-    "download_count": 14785,
-    "cover": "https://www.gutenberg.org/cache/epub/21436/pg21436.cover.medium.jpg"
-  },
-  {
-    "id": 41445,
-    "title": "Frankenstein; Or, The Modern Prometheus",
-    "authors": [
-      "Shelley, Mary Wollstonecraft"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 14673,
-    "cover": "https://www.gutenberg.org/cache/epub/41445/pg41445.cover.medium.jpg"
-  },
-  {
-    "id": 158,
-    "title": "Emma",
-    "authors": [
-      "Austen, Jane"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 14548,
-    "cover": "https://www.gutenberg.org/cache/epub/158/pg158.cover.medium.jpg"
-  },
-  {
-    "id": 10,
-    "title": "The King James Version of the Bible",
-    "authors": [],
-    "languages": [
-      "en"
-    ],
-    "download_count": 14420,
-    "cover": "https://www.gutenberg.org/cache/epub/10/pg10.cover.medium.jpg"
-  },
-  {
-    "id": 1257,
-    "title": "The three musketeers",
-    "authors": [
-      "Dumas, Alexandre",
-      "Maquet, Auguste"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 14084,
-    "cover": "https://www.gutenberg.org/cache/epub/1257/pg1257.cover.medium.jpg"
-  },
-  {
-    "id": 600,
-    "title": "Notes from the Underground",
-    "authors": [
-      "Dostoyevsky, Fyodor"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 14064,
-    "cover": "https://www.gutenberg.org/cache/epub/600/pg600.cover.medium.jpg"
-  },
-  {
-    "id": 6133,
-    "title": "The Extraordinary Adventures of Arsène Lupin, Gentleman-Burglar",
-    "authors": [
-      "Leblanc, Maurice"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 14000,
-    "cover": "https://www.gutenberg.org/cache/epub/6133/pg6133.cover.medium.jpg"
-  },
-  {
-    "id": 45001,
-    "title": "Institutes of the Christian Religion (Vol. 1 of 2)",
-    "authors": [
-      "Calvin, Jean"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 13764,
-    "cover": "https://www.gutenberg.org/cache/epub/45001/pg45001.cover.medium.jpg"
-  },
-  {
-    "id": 4280,
-    "title": "The Critique of Pure Reason",
-    "authors": [
-      "Kant, Immanuel"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 13762,
-    "cover": "https://www.gutenberg.org/cache/epub/4280/pg4280.cover.medium.jpg"
-  },
-  {
-    "id": 3268,
-    "title": "The Mysteries of Udolpho",
-    "authors": [
-      "Radcliffe, Ann Ward"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 13617,
-    "cover": "https://www.gutenberg.org/cache/epub/3268/pg3268.cover.medium.jpg"
-  },
-  {
-    "id": 27827,
-    "title": "The Kama Sutra of Vatsyayana: Translated From the Sanscrit in Seven Parts With Preface, Introduction and Concluding Remarks",
-    "authors": [
-      "Vatsyayana"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 13597,
-    "cover": "https://www.gutenberg.org/cache/epub/27827/pg27827.cover.medium.jpg"
-  },
-  {
-    "id": 69087,
-    "title": "The murder of Roger Ackroyd",
-    "authors": [
-      "Christie, Agatha"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 13583,
-    "cover": "https://www.gutenberg.org/cache/epub/69087/pg69087.cover.medium.jpg"
-  },
-  {
-    "id": 6400,
-    "title": "The Lives of the Twelve Caesars, Complete",
-    "authors": [
-      "Suetonius"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 13473,
-    "cover": "https://www.gutenberg.org/cache/epub/6400/pg6400.cover.medium.jpg"
-  },
-  {
-    "id": 43578,
-    "title": "An Introduction to Entomology: Vol. 3: or Elements of the Natural History of the Insects",
-    "authors": [
-      "Kirby, William",
-      "Spence, William"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 13460,
-    "cover": "https://www.gutenberg.org/cache/epub/43578/pg43578.cover.medium.jpg"
-  },
-  {
-    "id": 245,
-    "title": "Life on the Mississippi",
-    "authors": [
-      "Twain, Mark"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 13400,
-    "cover": "https://www.gutenberg.org/cache/epub/245/pg245.cover.medium.jpg"
-  },
-  {
-    "id": 1946,
-    "title": "On War",
-    "authors": [
-      "Clausewitz, Carl von"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 13399,
-    "cover": "https://www.gutenberg.org/cache/epub/1946/pg1946.cover.medium.jpg"
-  },
-  {
-    "id": 1322,
-    "title": "Leaves of Grass",
-    "authors": [
-      "Whitman, Walt"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 13334,
-    "cover": "https://www.gutenberg.org/cache/epub/1322/pg1322.cover.medium.jpg"
-  },
-  {
-    "id": 110,
-    "title": "Tess of the d'Urbervilles: A Pure Woman",
-    "authors": [
-      "Hardy, Thomas"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 13232,
-    "cover": "https://www.gutenberg.org/cache/epub/110/pg110.cover.medium.jpg"
-  },
-  {
-    "id": 779,
-    "title": "The Tragical History of Doctor Faustus: From the Quarto of 1604",
-    "authors": [
-      "Marlowe, Christopher"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 13205,
-    "cover": "https://www.gutenberg.org/cache/epub/779/pg779.cover.medium.jpg"
-  },
-  {
-    "id": 20027,
-    "title": "Grimms' Fairy Tales",
-    "authors": [
-      "Grimm, Jacob",
-      "Grimm, Wilhelm"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 13185,
-    "cover": "https://www.gutenberg.org/cache/epub/20027/pg20027.cover.medium.jpg"
-  },
-  {
-    "id": 34413,
-    "title": "The Love Letters of Mary Wollstonecraft to Gilbert Imlay",
-    "authors": [
-      "Wollstonecraft, Mary"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 13170,
-    "cover": "https://www.gutenberg.org/cache/epub/34413/pg34413.cover.medium.jpg"
-  },
-  {
-    "id": 26,
-    "title": "Paradise Lost",
-    "authors": [
-      "Milton, John"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 13147,
-    "cover": "https://www.gutenberg.org/cache/epub/26/pg26.cover.medium.jpg"
-  },
-  {
-    "id": 1695,
-    "title": "The Man Who Was Thursday: A Nightmare",
-    "authors": [
-      "Chesterton, G. K. (Gilbert Keith)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 13140,
-    "cover": "https://www.gutenberg.org/cache/epub/1695/pg1695.cover.medium.jpg"
-  },
-  {
-    "id": 10007,
-    "title": "Carmilla",
-    "authors": [
-      "Le Fanu, Joseph Sheridan"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 13081,
-    "cover": "https://www.gutenberg.org/cache/epub/10007/pg10007.cover.medium.jpg"
-  },
-  {
-    "id": 514,
-    "title": "Little Women",
-    "authors": [
-      "Alcott, Louisa May"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 13056,
-    "cover": "https://www.gutenberg.org/cache/epub/514/pg514.cover.medium.jpg"
-  },
-  {
-    "id": 3011,
-    "title": "The Lady of the Lake",
-    "authors": [
-      "Scott, Walter"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 12958,
-    "cover": "https://www.gutenberg.org/cache/epub/3011/pg3011.cover.medium.jpg"
-  },
-  {
-    "id": 19942,
-    "title": "Candide",
-    "authors": [
-      "Voltaire"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 12894,
-    "cover": "https://www.gutenberg.org/cache/epub/19942/pg19942.cover.medium.jpg"
-  },
-  {
-    "id": 40533,
-    "title": "The Life of John Marshall, Volume 4: The building of the nation, 1815-1835",
-    "authors": [
-      "Beveridge, Albert J. (Albert Jeremiah)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 12834,
-    "cover": "https://www.gutenberg.org/cache/epub/40533/pg40533.cover.medium.jpg"
-  },
-  {
-    "id": 2097,
-    "title": "The Sign of the Four",
-    "authors": [
-      "Doyle, Arthur Conan"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 12678,
-    "cover": "https://www.gutenberg.org/cache/epub/2097/pg2097.cover.medium.jpg"
-  },
-  {
-    "id": 25833,
-    "title": "The Great Controversy Between Christ and Satan",
-    "authors": [
-      "White, Ellen Gould Harmon"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 12600,
-    "cover": "https://www.gutenberg.org/cache/epub/25833/pg25833.cover.medium.jpg"
-  },
-  {
-    "id": 3825,
-    "title": "Pygmalion",
-    "authors": [
-      "Shaw, Bernard"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 12543,
-    "cover": "https://www.gutenberg.org/cache/epub/3825/pg3825.cover.medium.jpg"
-  },
-  {
-    "id": 1524,
-    "title": "Hamlet",
-    "authors": [
-      "Shakespeare, William"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 12507,
-    "cover": "https://www.gutenberg.org/cache/epub/1524/pg1524.cover.medium.jpg"
-  },
-  {
-    "id": 43671,
-    "title": "A History of Epidemics in Britain, Volume 2 (of 2): From the Extinction of Plague to the Present Time",
-    "authors": [
-      "Creighton, Charles"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 12503,
-    "cover": "https://www.gutenberg.org/cache/epub/43671/pg43671.cover.medium.jpg"
-  },
-  {
-    "id": 43255,
-    "title": "Domesday Book and Beyond: Three Essays in the Early History of England",
-    "authors": [
-      "Maitland, Frederic William"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 12471,
-    "cover": "https://www.gutenberg.org/cache/epub/43255/pg43255.cover.medium.jpg"
-  },
-  {
-    "id": 6130,
-    "title": "The Iliad",
-    "authors": [
-      "Homer"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 12447,
-    "cover": "https://www.gutenberg.org/cache/epub/6130/pg6130.cover.medium.jpg"
-  },
-  {
-    "id": 65238,
-    "title": "The Secret of Chimneys",
-    "authors": [
-      "Christie, Agatha"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 12388,
-    "cover": "https://www.gutenberg.org/cache/epub/65238/pg65238.cover.medium.jpg"
-  },
-  {
-    "id": 67098,
-    "title": "Winnie-the-Pooh",
-    "authors": [
-      "Milne, A. A. (Alan Alexander)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 12269,
-    "cover": "https://www.gutenberg.org/cache/epub/67098/pg67098.cover.medium.jpg"
-  },
-  {
-    "id": 2527,
-    "title": "The Sorrows of Young Werther",
-    "authors": [
-      "Goethe, Johann Wolfgang von"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 12240,
-    "cover": "https://www.gutenberg.org/cache/epub/2527/pg2527.cover.medium.jpg"
-  },
-  {
-    "id": 2638,
-    "title": "The Idiot",
-    "authors": [
-      "Dostoyevsky, Fyodor"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 12235,
-    "cover": "https://www.gutenberg.org/cache/epub/2638/pg2638.cover.medium.jpg"
-  },
-  {
-    "id": 24253,
-    "title": "Folkways: A Study of the Sociological Importance of Usages, Manners, Customs, Mores, and Morals",
-    "authors": [
-      "Sumner, William Graham"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 12205,
-    "cover": "https://www.gutenberg.org/cache/epub/24253/pg24253.cover.medium.jpg"
-  },
-  {
-    "id": 165,
-    "title": "McTeague: A Story of San Francisco",
-    "authors": [
-      "Norris, Frank"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 12196,
-    "cover": "https://www.gutenberg.org/cache/epub/165/pg165.cover.medium.jpg"
-  },
-  {
-    "id": 45249,
-    "title": "The History of Signboards, from the Earliest times to the Present Day",
-    "authors": [
-      "Hotten, John Camden",
-      "Larwood, Jacob"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 12180,
-    "cover": "https://www.gutenberg.org/cache/epub/45249/pg45249.cover.medium.jpg"
-  },
-  {
-    "id": 24739,
-    "title": "Bidwell's Travels, from Wall Street to London Prison: Fifteen Years in Solitude",
-    "authors": [
-      "Bidwell, Austin"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 12094,
-    "cover": "https://www.gutenberg.org/cache/epub/24739/pg24739.cover.medium.jpg"
-  },
-  {
-    "id": 11030,
-    "title": "Incidents in the Life of a Slave Girl, Written by Herself",
-    "authors": [
-      "Jacobs, Harriet A. (Harriet Ann)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 12053,
-    "cover": "https://www.gutenberg.org/cache/epub/11030/pg11030.cover.medium.jpg"
-  },
-  {
-    "id": 1251,
-    "title": "Le Morte d'Arthur: Volume 1",
-    "authors": [
-      "Malory, Thomas, Sir"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11998,
-    "cover": "https://www.gutenberg.org/cache/epub/1251/pg1251.cover.medium.jpg"
-  },
-  {
-    "id": 43453,
-    "title": "A Pickle for the Knowing Ones",
-    "authors": [
-      "Dexter, Timothy"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11969,
-    "cover": "https://www.gutenberg.org/cache/epub/43453/pg43453.cover.medium.jpg"
-  },
-  {
-    "id": 42671,
-    "title": "Pride and Prejudice",
-    "authors": [
-      "Austen, Jane"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11938,
-    "cover": "https://www.gutenberg.org/cache/epub/42671/pg42671.cover.medium.jpg"
-  },
-  {
-    "id": 22542,
-    "title": "Jesus the Christ: A Study of the Messiah and His Mission According to Holy; Scriptures Both Ancient and Modern",
-    "authors": [
-      "Talmage, James E. (James Edward)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11930,
-    "cover": "https://www.gutenberg.org/cache/epub/22542/pg22542.cover.medium.jpg"
-  },
-  {
-    "id": 39647,
-    "title": "The Spanish American Reader",
-    "authors": [
-      "Nelson, Ernesto"
-    ],
-    "languages": [
-      "en",
-      "es"
-    ],
-    "download_count": 11889,
-    "cover": "https://www.gutenberg.org/cache/epub/39647/pg39647.cover.medium.jpg"
-  },
-  {
-    "id": 236,
-    "title": "The Jungle Book",
-    "authors": [
-      "Kipling, Rudyard"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11874,
-    "cover": "https://www.gutenberg.org/cache/epub/236/pg236.cover.medium.jpg"
-  },
-  {
-    "id": 29090,
-    "title": "The Complete Poetical Works of Samuel Taylor Coleridge. Vol 1 and 2",
-    "authors": [
-      "Coleridge, Samuel Taylor"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11789,
-    "cover": "https://www.gutenberg.org/cache/epub/29090/pg29090.cover.medium.jpg"
-  },
-  {
-    "id": 10681,
-    "title": "Roget's Thesaurus of English Words and Phrases",
-    "authors": [
-      "Roget, Peter Mark"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11688,
-    "cover": "https://www.gutenberg.org/cache/epub/10681/pg10681.cover.medium.jpg"
-  },
-  {
-    "id": 4217,
-    "title": "A Portrait of the Artist as a Young Man",
-    "authors": [
-      "Joyce, James"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11674,
-    "cover": "https://www.gutenberg.org/cache/epub/4217/pg4217.cover.medium.jpg"
-  },
-  {
-    "id": 71046,
-    "title": "Modern English biography, volume 2 (of 4), I-Q",
-    "authors": [
-      "Boase, Frederic"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11668,
-    "cover": "https://www.gutenberg.org/cache/epub/71046/pg71046.cover.medium.jpg"
-  },
-  {
-    "id": 815,
-    "title": "Democracy in America — Volume 1",
-    "authors": [
-      "Tocqueville, Alexis de"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11623,
-    "cover": "https://www.gutenberg.org/cache/epub/815/pg815.cover.medium.jpg"
-  },
-  {
-    "id": 12082,
-    "title": "Color Images from Mars Rovers: Spirit and Opportunity",
-    "authors": [
-      "Webster, Bob"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11619,
-    "cover": "https://www.gutenberg.org/cache/epub/12082/pg12082.cover.medium.jpg"
-  },
-  {
-    "id": 21700,
-    "title": "Don Juan",
-    "authors": [
-      "Byron, George Gordon Byron, Baron"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11531,
-    "cover": "https://www.gutenberg.org/cache/epub/21700/pg21700.cover.medium.jpg"
-  },
-  {
-    "id": 22981,
-    "title": "Letters of Two Brides",
-    "authors": [
-      "Balzac, Honoré de"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11526,
-    "cover": "https://www.gutenberg.org/cache/epub/22981/pg22981.cover.medium.jpg"
-  },
-  {
-    "id": 8438,
-    "title": "The Ethics of Aristotle",
-    "authors": [
-      "Aristotle"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11506,
-    "cover": "https://www.gutenberg.org/cache/epub/8438/pg8438.cover.medium.jpg"
-  },
-  {
-    "id": 12,
-    "title": "Through the Looking-Glass",
-    "authors": [
-      "Carroll, Lewis"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11498,
-    "cover": "https://www.gutenberg.org/cache/epub/12/pg12.cover.medium.jpg"
-  },
-  {
-    "id": 2465,
-    "title": "Carmen",
-    "authors": [
-      "Mérimée, Prosper"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11498,
-    "cover": "https://www.gutenberg.org/cache/epub/2465/pg2465.cover.medium.jpg"
-  },
-  {
-    "id": 37499,
-    "title": "Napoleon's Letters to Josephine, 1796-1812: For the First Time Collected and Translated, with Notes Social, Historical, and Chronological, from Contemporary Sources",
-    "authors": [
-      "Napoleon I, Emperor of the French"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11450,
-    "cover": "https://www.gutenberg.org/cache/epub/37499/pg37499.cover.medium.jpg"
-  },
-  {
-    "id": 42324,
-    "title": "Frankenstein; Or, The Modern Prometheus",
-    "authors": [
-      "Shelley, Mary Wollstonecraft"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11392,
-    "cover": "https://www.gutenberg.org/cache/epub/42324/pg42324.cover.medium.jpg"
-  },
-  {
-    "id": 52319,
-    "title": "The Genealogy of Morals: The Complete Works, Volume Thirteen, edited by Dr. Oscar Levy.",
-    "authors": [
-      "Nietzsche, Friedrich Wilhelm"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11383,
-    "cover": "https://www.gutenberg.org/cache/epub/52319/pg52319.cover.medium.jpg"
-  },
-  {
-    "id": 43579,
-    "title": "An Introduction to Entomology: Vol. 4: or Elements of the Natural History of the Insects",
-    "authors": [
-      "Kirby, William",
-      "Spence, William"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11356,
-    "cover": "https://www.gutenberg.org/cache/epub/43579/pg43579.cover.medium.jpg"
-  },
-  {
-    "id": 105,
-    "title": "Persuasion",
-    "authors": [
-      "Austen, Jane"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11355,
-    "cover": "https://www.gutenberg.org/cache/epub/105/pg105.cover.medium.jpg"
-  },
-  {
-    "id": 20265,
-    "title": "Anne of the Island",
-    "authors": [
-      "Montgomery, L. M. (Lucy Maud)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11257,
-    "cover": "https://www.gutenberg.org/cache/epub/20265/pg20265.cover.medium.jpg"
-  },
-  {
-    "id": 2147,
-    "title": "The Works of Edgar Allan Poe — Volume 1",
-    "authors": [
-      "Poe, Edgar Allan"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11249,
-    "cover": "https://www.gutenberg.org/cache/epub/2147/pg2147.cover.medium.jpg"
-  },
-  {
-    "id": 43945,
-    "title": "A Treatise Upon the Law of Copyright in the United Kingdom and the Dominions of the Crown,: and in the United States of America Containing a Full Appendix of All Acts of Parliament International Conventions, Orders in Council, Treasury Minute and Acts of Congress Now in Force.",
-    "authors": [
-      "MacGillivray, Evan James"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11235,
-    "cover": "https://www.gutenberg.org/cache/epub/43945/pg43945.cover.medium.jpg"
-  },
-  {
-    "id": 45109,
-    "title": "The Enchiridion",
-    "authors": [
-      "Epictetus"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11202,
-    "cover": "https://www.gutenberg.org/cache/epub/45109/pg45109.cover.medium.jpg"
-  },
-  {
-    "id": 103,
-    "title": "Around the World in Eighty Days",
-    "authors": [
-      "Verne, Jules"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11197,
-    "cover": "https://www.gutenberg.org/cache/epub/103/pg103.cover.medium.jpg"
-  },
-  {
-    "id": 108,
-    "title": "The Return of Sherlock Holmes",
-    "authors": [
-      "Doyle, Arthur Conan"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11165,
-    "cover": "https://www.gutenberg.org/cache/epub/108/pg108.cover.medium.jpg"
-  },
-  {
-    "id": 1001,
-    "title": "Divine Comedy, Longfellow's Translation, Hell",
-    "authors": [
-      "Dante Alighieri"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11148,
-    "cover": "https://www.gutenberg.org/cache/epub/1001/pg1001.cover.medium.jpg"
-  },
-  {
-    "id": 175,
-    "title": "The Phantom of the Opera",
-    "authors": [
-      "Leroux, Gaston"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11112,
-    "cover": "https://www.gutenberg.org/cache/epub/175/pg175.cover.medium.jpg"
-  },
-  {
-    "id": 1228,
-    "title": "On the Origin of Species By Means of Natural Selection: Or, the Preservation of Favoured Races in the Struggle for Life",
-    "authors": [
-      "Darwin, Charles"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11105,
-    "cover": "https://www.gutenberg.org/cache/epub/1228/pg1228.cover.medium.jpg"
-  },
-  {
-    "id": 44653,
-    "title": "A Latin Grammar for Schools and Colleges",
-    "authors": [
-      "Lane, George Martin"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11080,
-    "cover": "https://www.gutenberg.org/cache/epub/44653/pg44653.cover.medium.jpg"
-  },
-  {
-    "id": 10636,
-    "title": "The Travels of Marco Polo — Volume 1",
-    "authors": [
-      "Polo, Marco",
-      "Rusticiano, da Pisa"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11059,
-    "cover": "https://www.gutenberg.org/cache/epub/10636/pg10636.cover.medium.jpg"
-  },
-  {
-    "id": 3600,
-    "title": "Essays of Michel de Montaigne — Complete",
-    "authors": [
-      "Montaigne, Michel de"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 11049,
-    "cover": "https://www.gutenberg.org/cache/epub/3600/pg3600.cover.medium.jpg"
-  },
-  {
-    "id": 43840,
-    "title": "Poison Romance and Poison Mysteries",
-    "authors": [
-      "Thompson, C. J. S. (Charles John Samuel)"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 10963,
-    "cover": "https://www.gutenberg.org/cache/epub/43840/pg43840.cover.medium.jpg"
-  },
-  {
-    "id": 15272,
-    "title": "Spenser's The Faerie Queene, Book I",
-    "authors": [
-      "Spenser, Edmund"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 10941,
-    "cover": "https://www.gutenberg.org/cache/epub/15272/pg15272.cover.medium.jpg"
-  },
-  {
-    "id": 19839,
-    "title": "Emma",
-    "authors": [
-      "Austen, Jane"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 10869,
-    "cover": "https://www.gutenberg.org/cache/epub/19839/pg19839.cover.medium.jpg"
-  },
-  {
-    "id": 7142,
-    "title": "The History of the Peloponnesian War",
-    "authors": [
-      "Thucydides"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 10859,
-    "cover": "https://www.gutenberg.org/cache/epub/7142/pg7142.cover.medium.jpg"
-  },
-  {
-    "id": 41537,
-    "title": "The Divine Comedy of Dante Alighieri: The Inferno",
-    "authors": [
-      "Dante Alighieri"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 10859,
-    "cover": "https://www.gutenberg.org/cache/epub/41537/pg41537.cover.medium.jpg"
-  },
-  {
-    "id": 1514,
-    "title": "A Midsummer Night's Dream",
-    "authors": [
-      "Shakespeare, William"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 10824,
-    "cover": "https://www.gutenberg.org/cache/epub/1514/pg1514.cover.medium.jpg"
-  },
-  {
-    "id": 23784,
-    "title": "The History of Sir Richard Calmady: A Romance",
-    "authors": [
-      "Malet, Lucas"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 10819,
-    "cover": "https://www.gutenberg.org/cache/epub/23784/pg23784.cover.medium.jpg"
-  },
-  {
-    "id": 921,
-    "title": "De Profundis",
-    "authors": [
-      "Wilde, Oscar"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 10815,
-    "cover": "https://www.gutenberg.org/cache/epub/921/pg921.cover.medium.jpg"
-  },
-  {
-    "id": 11339,
-    "title": "Aesop's Fables; a new translation",
-    "authors": [
-      "Aesop"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 10755,
-    "cover": "https://www.gutenberg.org/cache/epub/11339/pg11339.cover.medium.jpg"
-  },
-  {
-    "id": 18269,
-    "title": "Pascal's Pensées",
-    "authors": [
-      "Pascal, Blaise"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 10750,
-    "cover": "https://www.gutenberg.org/cache/epub/18269/pg18269.cover.medium.jpg"
-  },
-  {
-    "id": 834,
-    "title": "The Memoirs of Sherlock Holmes",
-    "authors": [
-      "Doyle, Arthur Conan"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 10724,
-    "cover": "https://www.gutenberg.org/cache/epub/834/pg834.cover.medium.jpg"
-  },
-  {
-    "id": 50498,
-    "title": "The Raft",
-    "authors": [
-      "Dawson, Coningsby"
-    ],
-    "languages": [
-      "en"
-    ],
-    "download_count": 10674,
-    "cover": "https://www.gutenberg.org/cache/epub/50498/pg50498.cover.medium.jpg"
-  }
-]
+{
+  "": [
+    {
+      "id": 84,
+      "title": "Frankenstein; or, the modern prometheus",
+      "authors": [
+        "Shelley, Mary Wollstonecraft"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 178271,
+      "cover": "https://www.gutenberg.org/cache/epub/84/pg84.cover.medium.jpg"
+    },
+    {
+      "id": 45304,
+      "title": "The City of God, Volume I",
+      "authors": [
+        "Augustine, of Hippo, Saint"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 146974,
+      "cover": "https://www.gutenberg.org/cache/epub/45304/pg45304.cover.medium.jpg"
+    },
+    {
+      "id": 2701,
+      "title": "Moby Dick; Or, The Whale",
+      "authors": [
+        "Melville, Herman"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 112302,
+      "cover": "https://www.gutenberg.org/cache/epub/2701/pg2701.cover.medium.jpg"
+    },
+    {
+      "id": 1342,
+      "title": "Pride and Prejudice",
+      "authors": [
+        "Austen, Jane"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 107502,
+      "cover": "https://www.gutenberg.org/cache/epub/1342/pg1342.cover.medium.jpg"
+    },
+    {
+      "id": 768,
+      "title": "Wuthering Heights",
+      "authors": [
+        "Brontë, Emily"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 72775,
+      "cover": "https://www.gutenberg.org/cache/epub/768/pg768.cover.medium.jpg"
+    },
+    {
+      "id": 1513,
+      "title": "Romeo and Juliet",
+      "authors": [
+        "Shakespeare, William"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 70272,
+      "cover": "https://www.gutenberg.org/cache/epub/1513/pg1513.cover.medium.jpg"
+    },
+    {
+      "id": 11,
+      "title": "Alice's Adventures in Wonderland",
+      "authors": [
+        "Carroll, Lewis"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 65243,
+      "cover": "https://www.gutenberg.org/cache/epub/11/pg11.cover.medium.jpg"
+    },
+    {
+      "id": 64317,
+      "title": "The Great Gatsby",
+      "authors": [
+        "Fitzgerald, F. Scott (Francis Scott)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 60632,
+      "cover": "https://www.gutenberg.org/cache/epub/64317/pg64317.cover.medium.jpg"
+    },
+    {
+      "id": 100,
+      "title": "The Complete Works of William Shakespeare",
+      "authors": [
+        "Shakespeare, William"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 60527,
+      "cover": "https://www.gutenberg.org/cache/epub/100/pg100.cover.medium.jpg"
+    },
+    {
+      "id": 1260,
+      "title": "Jane Eyre: An Autobiography",
+      "authors": [
+        "Brontë, Charlotte"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 57602,
+      "cover": "https://www.gutenberg.org/cache/epub/1260/pg1260.cover.medium.jpg"
+    },
+    {
+      "id": 2641,
+      "title": "A Room with a View",
+      "authors": [
+        "Forster, E. M. (Edward Morgan)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 57366,
+      "cover": "https://www.gutenberg.org/cache/epub/2641/pg2641.cover.medium.jpg"
+    },
+    {
+      "id": 43,
+      "title": "The strange case of Dr. Jekyll and Mr. Hyde",
+      "authors": [
+        "Stevenson, Robert Louis"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 56894,
+      "cover": "https://www.gutenberg.org/cache/epub/43/pg43.cover.medium.jpg"
+    },
+    {
+      "id": 145,
+      "title": "Middlemarch",
+      "authors": [
+        "Eliot, George"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 53885,
+      "cover": "https://www.gutenberg.org/cache/epub/145/pg145.cover.medium.jpg"
+    },
+    {
+      "id": 174,
+      "title": "The Picture of Dorian Gray",
+      "authors": [
+        "Wilde, Oscar"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 52794,
+      "cover": "https://www.gutenberg.org/cache/epub/174/pg174.cover.medium.jpg"
+    },
+    {
+      "id": 844,
+      "title": "The Importance of Being Earnest: A Trivial Comedy for Serious People",
+      "authors": [
+        "Wilde, Oscar"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 51790,
+      "cover": "https://www.gutenberg.org/cache/epub/844/pg844.cover.medium.jpg"
+    },
+    {
+      "id": 2554,
+      "title": "Crime and Punishment",
+      "authors": [
+        "Dostoyevsky, Fyodor"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 49665,
+      "cover": "https://www.gutenberg.org/cache/epub/2554/pg2554.cover.medium.jpg"
+    },
+    {
+      "id": 37106,
+      "title": "Little Women; Or, Meg, Jo, Beth, and Amy",
+      "authors": [
+        "Alcott, Louisa May"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 49414,
+      "cover": "https://www.gutenberg.org/cache/epub/37106/pg37106.cover.medium.jpg"
+    },
+    {
+      "id": 67979,
+      "title": "The Blue Castle: a novel",
+      "authors": [
+        "Montgomery, L. M. (Lucy Maud)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 47023,
+      "cover": "https://www.gutenberg.org/cache/epub/67979/pg67979.cover.medium.jpg"
+    },
+    {
+      "id": 1184,
+      "title": "The Count of Monte Cristo",
+      "authors": [
+        "Dumas, Alexandre",
+        "Maquet, Auguste"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 44760,
+      "cover": "https://www.gutenberg.org/cache/epub/1184/pg1184.cover.medium.jpg"
+    },
+    {
+      "id": 3207,
+      "title": "Leviathan",
+      "authors": [
+        "Hobbes, Thomas"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 42900,
+      "cover": "https://www.gutenberg.org/cache/epub/3207/pg3207.cover.medium.jpg"
+    },
+    {
+      "id": 5197,
+      "title": "My Life — Volume 1",
+      "authors": [
+        "Wagner, Richard"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 42691,
+      "cover": "https://www.gutenberg.org/cache/epub/5197/pg5197.cover.medium.jpg"
+    },
+    {
+      "id": 345,
+      "title": "Dracula",
+      "authors": [
+        "Stoker, Bram"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 42360,
+      "cover": "https://www.gutenberg.org/cache/epub/345/pg345.cover.medium.jpg"
+    },
+    {
+      "id": 2542,
+      "title": "A Doll's House : a play",
+      "authors": [
+        "Ibsen, Henrik"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 41568,
+      "cover": "https://www.gutenberg.org/cache/epub/2542/pg2542.cover.medium.jpg"
+    },
+    {
+      "id": 8492,
+      "title": "The King in Yellow",
+      "authors": [
+        "Chambers, Robert W. (Robert William)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 40983,
+      "cover": "https://www.gutenberg.org/cache/epub/8492/pg8492.cover.medium.jpg"
+    },
+    {
+      "id": 16389,
+      "title": "The Enchanted April",
+      "authors": [
+        "Von Arnim, Elizabeth"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 40805,
+      "cover": "https://www.gutenberg.org/cache/epub/16389/pg16389.cover.medium.jpg"
+    },
+    {
+      "id": 1259,
+      "title": "Twenty years after",
+      "authors": [
+        "Dumas, Alexandre",
+        "Maquet, Auguste"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 40022,
+      "cover": "https://www.gutenberg.org/cache/epub/1259/pg1259.cover.medium.jpg"
+    },
+    {
+      "id": 28054,
+      "title": "The Brothers Karamazov",
+      "authors": [
+        "Dostoyevsky, Fyodor"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 39032,
+      "cover": "https://www.gutenberg.org/cache/epub/28054/pg28054.cover.medium.jpg"
+    },
+    {
+      "id": 76,
+      "title": "Adventures of Huckleberry Finn",
+      "authors": [
+        "Twain, Mark"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 38960,
+      "cover": "https://www.gutenberg.org/cache/epub/76/pg76.cover.medium.jpg"
+    },
+    {
+      "id": 1661,
+      "title": "The Adventures of Sherlock Holmes",
+      "authors": [
+        "Doyle, Arthur Conan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 38703,
+      "cover": "https://www.gutenberg.org/cache/epub/1661/pg1661.cover.medium.jpg"
+    },
+    {
+      "id": 6761,
+      "title": "The Adventures of Ferdinand Count Fathom — Complete",
+      "authors": [
+        "Smollett, T. (Tobias)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 38235,
+      "cover": "https://www.gutenberg.org/cache/epub/6761/pg6761.cover.medium.jpg"
+    },
+    {
+      "id": 98,
+      "title": "A Tale of Two Cities",
+      "authors": [
+        "Dickens, Charles"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 38103,
+      "cover": "https://www.gutenberg.org/cache/epub/98/pg98.cover.medium.jpg"
+    },
+    {
+      "id": 394,
+      "title": "Cranford",
+      "authors": [
+        "Gaskell, Elizabeth Cleghorn"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 38083,
+      "cover": "https://www.gutenberg.org/cache/epub/394/pg394.cover.medium.jpg"
+    },
+    {
+      "id": 2160,
+      "title": "The Expedition of Humphry Clinker",
+      "authors": [
+        "Smollett, T. (Tobias)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 37810,
+      "cover": "https://www.gutenberg.org/cache/epub/2160/pg2160.cover.medium.jpg"
+    },
+    {
+      "id": 6593,
+      "title": "History of Tom Jones, a Foundling",
+      "authors": [
+        "Fielding, Henry"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 37687,
+      "cover": "https://www.gutenberg.org/cache/epub/6593/pg6593.cover.medium.jpg"
+    },
+    {
+      "id": 4085,
+      "title": "The Adventures of Roderick Random",
+      "authors": [
+        "Smollett, T. (Tobias)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 36803,
+      "cover": "https://www.gutenberg.org/cache/epub/4085/pg4085.cover.medium.jpg"
+    },
+    {
+      "id": 1080,
+      "title": "A Modest Proposal: For preventing the children of poor people in Ireland, from being a burden on their parents or country, and for making them beneficial to the publick",
+      "authors": [
+        "Swift, Jonathan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 35578,
+      "cover": "https://www.gutenberg.org/cache/epub/1080/pg1080.cover.medium.jpg"
+    },
+    {
+      "id": 1400,
+      "title": "Great Expectations",
+      "authors": [
+        "Dickens, Charles"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 33787,
+      "cover": "https://www.gutenberg.org/cache/epub/1400/pg1400.cover.medium.jpg"
+    },
+    {
+      "id": 16328,
+      "title": "Beowulf: An Anglo-Saxon Epic Poem",
+      "authors": [],
+      "languages": [
+        "en"
+      ],
+      "download_count": 30984,
+      "cover": "https://www.gutenberg.org/cache/epub/16328/pg16328.cover.medium.jpg"
+    },
+    {
+      "id": 37683,
+      "title": "Chambers's Twentieth Century Dictionary (part 1 of 4: A-D)",
+      "authors": [],
+      "languages": [
+        "en"
+      ],
+      "download_count": 30765,
+      "cover": "https://www.gutenberg.org/cache/epub/37683/pg37683.cover.medium.jpg"
+    },
+    {
+      "id": 24141,
+      "title": "警世通言",
+      "authors": [
+        "Feng, Menglong"
+      ],
+      "languages": [
+        "zh"
+      ],
+      "download_count": 30430,
+      "cover": "https://www.gutenberg.org/cache/epub/24141/pg24141.cover.medium.jpg"
+    },
+    {
+      "id": 26471,
+      "title": "Spoon River Anthology",
+      "authors": [
+        "Masters, Edgar Lee"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 30062,
+      "cover": "https://www.gutenberg.org/cache/epub/26471/pg26471.cover.medium.jpg"
+    },
+    {
+      "id": 1232,
+      "title": "The Prince",
+      "authors": [
+        "Machiavelli, Niccolò"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 29532,
+      "cover": "https://www.gutenberg.org/cache/epub/1232/pg1232.cover.medium.jpg"
+    },
+    {
+      "id": 1998,
+      "title": "Thus Spake Zarathustra: A Book for All and None",
+      "authors": [
+        "Nietzsche, Friedrich Wilhelm"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 29327,
+      "cover": "https://www.gutenberg.org/cache/epub/1998/pg1998.cover.medium.jpg"
+    },
+    {
+      "id": 28942,
+      "title": "The Junior Classics, Volume 1: Fairy and wonder tales",
+      "authors": [
+        "Neilson, William Allan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 28853,
+      "cover": "https://www.gutenberg.org/cache/epub/28942/pg28942.cover.medium.jpg"
+    },
+    {
+      "id": 1952,
+      "title": "The Yellow Wallpaper",
+      "authors": [
+        "Gilman, Charlotte Perkins"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 28479,
+      "cover": "https://www.gutenberg.org/cache/epub/1952/pg1952.cover.medium.jpg"
+    },
+    {
+      "id": 2680,
+      "title": "Meditations",
+      "authors": [
+        "Marcus Aurelius, Emperor of Rome"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 28425,
+      "cover": "https://www.gutenberg.org/cache/epub/2680/pg2680.cover.medium.jpg"
+    },
+    {
+      "id": 25344,
+      "title": "The Scarlet Letter",
+      "authors": [
+        "Hawthorne, Nathaniel"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 28370,
+      "cover": "https://www.gutenberg.org/cache/epub/25344/pg25344.cover.medium.jpg"
+    },
+    {
+      "id": 5200,
+      "title": "Metamorphosis",
+      "authors": [
+        "Kafka, Franz"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 28364,
+      "cover": "https://www.gutenberg.org/cache/epub/5200/pg5200.cover.medium.jpg"
+    },
+    {
+      "id": 2591,
+      "title": "Grimms' Fairy Tales",
+      "authors": [
+        "Grimm, Jacob",
+        "Grimm, Wilhelm"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 27642,
+      "cover": "https://www.gutenberg.org/cache/epub/2591/pg2591.cover.medium.jpg"
+    },
+    {
+      "id": 4300,
+      "title": "Ulysses",
+      "authors": [
+        "Joyce, James"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 27259,
+      "cover": "https://www.gutenberg.org/cache/epub/4300/pg4300.cover.medium.jpg"
+    },
+    {
+      "id": 2600,
+      "title": "War and Peace",
+      "authors": [
+        "Tolstoy, Leo, graf"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 27051,
+      "cover": "https://www.gutenberg.org/cache/epub/2600/pg2600.cover.medium.jpg"
+    },
+    {
+      "id": 205,
+      "title": "Walden, and On The Duty Of Civil Disobedience",
+      "authors": [
+        "Thoreau, Henry David"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 26622,
+      "cover": "https://www.gutenberg.org/cache/epub/205/pg205.cover.medium.jpg"
+    },
+    {
+      "id": 45,
+      "title": "Anne of Green Gables",
+      "authors": [
+        "Montgomery, L. M. (Lucy Maud)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 26339,
+      "cover": "https://www.gutenberg.org/cache/epub/45/pg45.cover.medium.jpg"
+    },
+    {
+      "id": 74,
+      "title": "The Adventures of Tom Sawyer, Complete",
+      "authors": [
+        "Twain, Mark"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 25830,
+      "cover": "https://www.gutenberg.org/cache/epub/74/pg74.cover.medium.jpg"
+    },
+    {
+      "id": 3296,
+      "title": "The Confessions of St. Augustine",
+      "authors": [
+        "Augustine, of Hippo, Saint"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 25581,
+      "cover": "https://www.gutenberg.org/cache/epub/3296/pg3296.cover.medium.jpg"
+    },
+    {
+      "id": 829,
+      "title": "Gulliver's Travels into Several Remote Nations of the World",
+      "authors": [
+        "Swift, Jonathan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 25457,
+      "cover": "https://www.gutenberg.org/cache/epub/829/pg829.cover.medium.jpg"
+    },
+    {
+      "id": 26184,
+      "title": "Simple Sabotage Field Manual",
+      "authors": [
+        "United States. Office of Strategic Services"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 24602,
+      "cover": "https://www.gutenberg.org/cache/epub/26184/pg26184.cover.medium.jpg"
+    },
+    {
+      "id": 120,
+      "title": "Treasure Island",
+      "authors": [
+        "Stevenson, Robert Louis"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 24601,
+      "cover": "https://www.gutenberg.org/cache/epub/120/pg120.cover.medium.jpg"
+    },
+    {
+      "id": 36034,
+      "title": "White nights, and other stories",
+      "authors": [
+        "Dostoyevsky, Fyodor"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 23874,
+      "cover": "https://www.gutenberg.org/cache/epub/36034/pg36034.cover.medium.jpg"
+    },
+    {
+      "id": 8800,
+      "title": "The divine comedy",
+      "authors": [
+        "Dante Alighieri"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 22965,
+      "cover": "https://www.gutenberg.org/cache/epub/8800/pg8800.cover.medium.jpg"
+    },
+    {
+      "id": 1727,
+      "title": "The Odyssey: Rendered into English prose for the use of those who cannot read the original",
+      "authors": [
+        "Homer"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 22827,
+      "cover": "https://www.gutenberg.org/cache/epub/1727/pg1727.cover.medium.jpg"
+    },
+    {
+      "id": 1399,
+      "title": "Anna Karenina",
+      "authors": [
+        "Tolstoy, Leo, graf"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 22617,
+      "cover": "https://www.gutenberg.org/cache/epub/1399/pg1399.cover.medium.jpg"
+    },
+    {
+      "id": 28189,
+      "title": "My Friends the Savages: Notes and Observations of a Perak settler (Malay Peninsula)",
+      "authors": [
+        "Cerruti, Giovanni Battista"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 21898,
+      "cover": "https://www.gutenberg.org/cache/epub/28189/pg28189.cover.medium.jpg"
+    },
+    {
+      "id": 2852,
+      "title": "The Hound of the Baskervilles",
+      "authors": [
+        "Doyle, Arthur Conan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 21608,
+      "cover": "https://www.gutenberg.org/cache/epub/2852/pg2852.cover.medium.jpg"
+    },
+    {
+      "id": 26225,
+      "title": "Fifteen Thousand Useful Phrases",
+      "authors": [
+        "Kleiser, Grenville"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 21496,
+      "cover": "https://www.gutenberg.org/cache/epub/26225/pg26225.cover.medium.jpg"
+    },
+    {
+      "id": 408,
+      "title": "The Souls of Black Folk",
+      "authors": [
+        "Du Bois, W. E. B. (William Edward Burghardt)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 21414,
+      "cover": "https://www.gutenberg.org/cache/epub/408/pg408.cover.medium.jpg"
+    },
+    {
+      "id": 20968,
+      "title": "Three Hundred Tang Poems, Volume 1",
+      "authors": [
+        "Various"
+      ],
+      "languages": [
+        "zh"
+      ],
+      "download_count": 21390,
+      "cover": "https://www.gutenberg.org/cache/epub/20968/pg20968.cover.medium.jpg"
+    },
+    {
+      "id": 244,
+      "title": "A Study in Scarlet",
+      "authors": [
+        "Doyle, Arthur Conan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 21389,
+      "cover": "https://www.gutenberg.org/cache/epub/244/pg244.cover.medium.jpg"
+    },
+    {
+      "id": 22788,
+      "title": "The Federalist Papers",
+      "authors": [
+        "Hamilton, Alexander",
+        "Jay, John",
+        "Madison, James"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 20967,
+      "cover": "https://www.gutenberg.org/cache/epub/22788/pg22788.cover.medium.jpg"
+    },
+    {
+      "id": 34901,
+      "title": "On Liberty",
+      "authors": [
+        "Mill, John Stuart"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 20878,
+      "cover": "https://www.gutenberg.org/cache/epub/34901/pg34901.cover.medium.jpg"
+    },
+    {
+      "id": 27673,
+      "title": "Oedipus King of Thebes: Translated into English Rhyming Verse with Explanatory Notes",
+      "authors": [
+        "Sophocles"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 20775,
+      "cover": "https://www.gutenberg.org/cache/epub/27673/pg27673.cover.medium.jpg"
+    },
+    {
+      "id": 55,
+      "title": "The Wonderful Wizard of Oz",
+      "authors": [
+        "Baum, L. Frank (Lyman Frank)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 20616,
+      "cover": "https://www.gutenberg.org/cache/epub/55/pg55.cover.medium.jpg"
+    },
+    {
+      "id": 4363,
+      "title": "Beyond Good and Evil",
+      "authors": [
+        "Nietzsche, Friedrich Wilhelm"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 20616,
+      "cover": "https://www.gutenberg.org/cache/epub/4363/pg4363.cover.medium.jpg"
+    },
+    {
+      "id": 23,
+      "title": "Narrative of the Life of Frederick Douglass, an American Slave",
+      "authors": [
+        "Douglass, Frederick"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 20603,
+      "cover": "https://www.gutenberg.org/cache/epub/23/pg23.cover.medium.jpg"
+    },
+    {
+      "id": 72679,
+      "title": "The lesser Key of Solomon, Goetia, the book of evil spirits : $b contains two hundred diagrams and seals for invocation and convocation of spirits, necromancy, witchcraft and black art",
+      "authors": [],
+      "languages": [
+        "en"
+      ],
+      "download_count": 20464,
+      "cover": "https://www.gutenberg.org/cache/epub/72679/pg72679.cover.medium.jpg"
+    },
+    {
+      "id": 7370,
+      "title": "Second Treatise of Government",
+      "authors": [
+        "Locke, John"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 20172,
+      "cover": "https://www.gutenberg.org/cache/epub/7370/pg7370.cover.medium.jpg"
+    },
+    {
+      "id": 78248,
+      "title": "Prolegomena to the study of Greek religion",
+      "authors": [
+        "Harrison, Jane Ellen"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 19776,
+      "cover": "https://www.gutenberg.org/cache/epub/78248/pg78248.cover.medium.jpg"
+    },
+    {
+      "id": 77700,
+      "title": "Entstehung und Ausbreitung der Alchemie, mit einem Anhange : $b zur älteren Geschichte der Metalle; ein Beitrag zur Kulturgeschichte",
+      "authors": [
+        "Lippmann, Edmund O. von (Edmund Oskar)"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 19637,
+      "cover": "https://www.gutenberg.org/cache/epub/77700/pg77700.cover.medium.jpg"
+    },
+    {
+      "id": 26296,
+      "title": "Les mille et une nuits, tome premier",
+      "authors": [],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 19180,
+      "cover": "https://www.gutenberg.org/cache/epub/26296/pg26296.cover.medium.jpg"
+    },
+    {
+      "id": 219,
+      "title": "Heart of Darkness",
+      "authors": [
+        "Conrad, Joseph"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 19150,
+      "cover": "https://www.gutenberg.org/cache/epub/219/pg219.cover.medium.jpg"
+    },
+    {
+      "id": 161,
+      "title": "Sense and Sensibility",
+      "authors": [
+        "Austen, Jane"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 18666,
+      "cover": "https://www.gutenberg.org/cache/epub/161/pg161.cover.medium.jpg"
+    },
+    {
+      "id": 27166,
+      "title": "吶喊",
+      "authors": [
+        "Lu, Xun"
+      ],
+      "languages": [
+        "zh"
+      ],
+      "download_count": 18556,
+      "cover": "https://www.gutenberg.org/cache/epub/27166/pg27166.cover.medium.jpg"
+    },
+    {
+      "id": 16,
+      "title": "Peter Pan : $b [Peter and Wendy]",
+      "authors": [
+        "Barrie, J. M. (James Matthew)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 18458,
+      "cover": "https://www.gutenberg.org/cache/epub/16/pg16.cover.medium.jpg"
+    },
+    {
+      "id": 22789,
+      "title": "On the Duties of the Clergy",
+      "authors": [
+        "Ambrose, Saint, Bishop of Milan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 18332,
+      "cover": "https://www.gutenberg.org/cache/epub/22789/pg22789.cover.medium.jpg"
+    },
+    {
+      "id": 135,
+      "title": "Les Misérables",
+      "authors": [
+        "Hugo, Victor"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 18171,
+      "cover": "https://www.gutenberg.org/cache/epub/135/pg135.cover.medium.jpg"
+    },
+    {
+      "id": 24869,
+      "title": "The Rámáyan of Válmíki, translated into English verse",
+      "authors": [
+        "Valmiki"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 18135,
+      "cover": "https://www.gutenberg.org/cache/epub/24869/pg24869.cover.medium.jpg"
+    },
+    {
+      "id": 20228,
+      "title": "Noli Me Tangere",
+      "authors": [
+        "Rizal, José"
+      ],
+      "languages": [
+        "tl"
+      ],
+      "download_count": 17441,
+      "cover": "https://www.gutenberg.org/cache/epub/20228/pg20228.cover.medium.jpg"
+    },
+    {
+      "id": 730,
+      "title": "Oliver Twist",
+      "authors": [
+        "Dickens, Charles"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 17382,
+      "cover": "https://www.gutenberg.org/cache/epub/730/pg730.cover.medium.jpg"
+    },
+    {
+      "id": 2148,
+      "title": "The Works of Edgar Allan Poe — Volume 2",
+      "authors": [
+        "Poe, Edgar Allan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 17308,
+      "cover": "https://www.gutenberg.org/cache/epub/2148/pg2148.cover.medium.jpg"
+    },
+    {
+      "id": 1497,
+      "title": "The Republic",
+      "authors": [
+        "Plato"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 17277,
+      "cover": "https://www.gutenberg.org/cache/epub/1497/pg1497.cover.medium.jpg"
+    },
+    {
+      "id": 215,
+      "title": "The call of the wild",
+      "authors": [
+        "London, Jack"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 17250,
+      "cover": "https://www.gutenberg.org/cache/epub/215/pg215.cover.medium.jpg"
+    },
+    {
+      "id": 31885,
+      "title": "Bible Myths and their Parallels in other Religions: Being a Comparison of the Old and New Testament Myths and Miracles with those of the Heathen Nations of Antiquity Considering also their Origin and Meaning",
+      "authors": [
+        "Doane, T. W. (Thomas William)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 17141,
+      "cover": "https://www.gutenberg.org/cache/epub/31885/pg31885.cover.medium.jpg"
+    },
+    {
+      "id": 45368,
+      "title": "The Outline of History: Being a Plain History of Life and Mankind",
+      "authors": [
+        "Wells, H. G. (Herbert George)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 17130,
+      "cover": "https://www.gutenberg.org/cache/epub/45368/pg45368.cover.medium.jpg"
+    },
+    {
+      "id": 164,
+      "title": "Twenty Thousand Leagues under the Sea",
+      "authors": [
+        "Verne, Jules"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 17061,
+      "cover": "https://www.gutenberg.org/cache/epub/164/pg164.cover.medium.jpg"
+    },
+    {
+      "id": 521,
+      "title": "The Life and Adventures of Robinson Crusoe",
+      "authors": [
+        "Defoe, Daniel"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 17011,
+      "cover": "https://www.gutenberg.org/cache/epub/521/pg521.cover.medium.jpg"
+    },
+    {
+      "id": 3206,
+      "title": "Moby Multiple Language Lists of Common Words",
+      "authors": [
+        "Ward, Grady"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 16993,
+      "cover": "https://www.gutenberg.org/cache/epub/3206/pg3206.cover.medium.jpg"
+    },
+    {
+      "id": 20203,
+      "title": "Autobiography of Benjamin Franklin",
+      "authors": [
+        "Franklin, Benjamin"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 16978,
+      "cover": "https://www.gutenberg.org/cache/epub/20203/pg20203.cover.medium.jpg"
+    },
+    {
+      "id": 30254,
+      "title": "The Romance of Lust: A classic Victorian erotic novel",
+      "authors": [
+        "Anonymous"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 16790,
+      "cover": "https://www.gutenberg.org/cache/epub/30254/pg30254.cover.medium.jpg"
+    },
+    {
+      "id": 21765,
+      "title": "The Metamorphoses of Ovid, Books I-VII",
+      "authors": [
+        "Ovid"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 16655,
+      "cover": "https://www.gutenberg.org/cache/epub/21765/pg21765.cover.medium.jpg"
+    },
+    {
+      "id": 1023,
+      "title": "Bleak House",
+      "authors": [
+        "Dickens, Charles"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 16318,
+      "cover": "https://www.gutenberg.org/cache/epub/1023/pg1023.cover.medium.jpg"
+    },
+    {
+      "id": 36,
+      "title": "The war of the worlds",
+      "authors": [
+        "Wells, H. G. (Herbert George)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 16182,
+      "cover": "https://www.gutenberg.org/cache/epub/36/pg36.cover.medium.jpg"
+    },
+    {
+      "id": 132,
+      "title": "The Art of War",
+      "authors": [
+        "Sunzi, active 6th century B.C."
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 16140,
+      "cover": "https://www.gutenberg.org/cache/epub/132/pg132.cover.medium.jpg"
+    },
+    {
+      "id": 996,
+      "title": "Don Quixote",
+      "authors": [
+        "Cervantes Saavedra, Miguel de"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 16106,
+      "cover": "https://www.gutenberg.org/cache/epub/996/pg996.cover.medium.jpg"
+    },
+    {
+      "id": 46,
+      "title": "A Christmas Carol in Prose; Being a Ghost Story of Christmas",
+      "authors": [
+        "Dickens, Charles"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15993,
+      "cover": "https://www.gutenberg.org/cache/epub/46/pg46.cover.medium.jpg"
+    },
+    {
+      "id": 13188,
+      "title": "Putnam's Word Book: A Practical Aid in Expressing Ideas Through the Use of an Exact and Varied Vocabulary",
+      "authors": [
+        "Flemming, Louis A. (Louis Andrew)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15913,
+      "cover": "https://www.gutenberg.org/cache/epub/13188/pg13188.cover.medium.jpg"
+    },
+    {
+      "id": 19488,
+      "title": "The Life of Joan of Arc, Vol. 1 and 2",
+      "authors": [
+        "France, Anatole"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15477,
+      "cover": "https://www.gutenberg.org/cache/epub/19488/pg19488.cover.medium.jpg"
+    },
+    {
+      "id": 209,
+      "title": "The Turn of the Screw",
+      "authors": [
+        "James, Henry"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15425,
+      "cover": "https://www.gutenberg.org/cache/epub/209/pg209.cover.medium.jpg"
+    },
+    {
+      "id": 57724,
+      "title": "A Cyclopaedia of Canadian Biography: Being Chiefly Men of the Time: A Collection of Persons Distinguished in Professional and Political Life, Leaders in the Commerce and Industry of Canada, and Successful Pioneers",
+      "authors": [],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15400,
+      "cover": "https://www.gutenberg.org/cache/epub/57724/pg57724.cover.medium.jpg"
+    },
+    {
+      "id": 35,
+      "title": "The Time Machine",
+      "authors": [
+        "Wells, H. G. (Herbert George)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15303,
+      "cover": "https://www.gutenberg.org/cache/epub/35/pg35.cover.medium.jpg"
+    },
+    {
+      "id": 20000,
+      "title": "Twenty Thousand Leagues Under the Sea",
+      "authors": [
+        "Verne, Jules"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15300,
+      "cover": "https://www.gutenberg.org/cache/epub/20000/pg20000.cover.medium.jpg"
+    },
+    {
+      "id": 15399,
+      "title": "The Interesting Narrative of the Life of Olaudah Equiano, Or Gustavus Vassa, The African: Written By Himself",
+      "authors": [
+        "Equiano, Olaudah"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15284,
+      "cover": "https://www.gutenberg.org/cache/epub/15399/pg15399.cover.medium.jpg"
+    },
+    {
+      "id": 3300,
+      "title": "An Inquiry into the Nature and Causes of the Wealth of Nations",
+      "authors": [
+        "Smith, Adam"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15170,
+      "cover": "https://www.gutenberg.org/cache/epub/3300/pg3300.cover.medium.jpg"
+    },
+    {
+      "id": 25851,
+      "title": "The Life of Charles Dickens, Vol. I-III, Complete",
+      "authors": [
+        "Forster, John"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15049,
+      "cover": "https://www.gutenberg.org/cache/epub/25851/pg25851.cover.medium.jpg"
+    },
+    {
+      "id": 41,
+      "title": "The Legend of Sleepy Hollow",
+      "authors": [
+        "Irving, Washington"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14944,
+      "cover": "https://www.gutenberg.org/cache/epub/41/pg41.cover.medium.jpg"
+    },
+    {
+      "id": 2814,
+      "title": "Dubliners",
+      "authors": [
+        "Joyce, James"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14935,
+      "cover": "https://www.gutenberg.org/cache/epub/2814/pg2814.cover.medium.jpg"
+    },
+    {
+      "id": 44608,
+      "title": "The Bābur-nāma in English (Memoirs of Bābur)",
+      "authors": [
+        "Babur, Emperor of Hindustan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14798,
+      "cover": "https://www.gutenberg.org/cache/epub/44608/pg44608.cover.medium.jpg"
+    },
+    {
+      "id": 21436,
+      "title": "Poems Every Child Should Know",
+      "authors": [],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14785,
+      "cover": "https://www.gutenberg.org/cache/epub/21436/pg21436.cover.medium.jpg"
+    },
+    {
+      "id": 41445,
+      "title": "Frankenstein; Or, The Modern Prometheus",
+      "authors": [
+        "Shelley, Mary Wollstonecraft"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14673,
+      "cover": "https://www.gutenberg.org/cache/epub/41445/pg41445.cover.medium.jpg"
+    },
+    {
+      "id": 158,
+      "title": "Emma",
+      "authors": [
+        "Austen, Jane"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14548,
+      "cover": "https://www.gutenberg.org/cache/epub/158/pg158.cover.medium.jpg"
+    },
+    {
+      "id": 10,
+      "title": "The King James Version of the Bible",
+      "authors": [],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14420,
+      "cover": "https://www.gutenberg.org/cache/epub/10/pg10.cover.medium.jpg"
+    },
+    {
+      "id": 40739,
+      "title": "Die Traumdeutung",
+      "authors": [
+        "Freud, Sigmund"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 14241,
+      "cover": "https://www.gutenberg.org/cache/epub/40739/pg40739.cover.medium.jpg"
+    },
+    {
+      "id": 1257,
+      "title": "The three musketeers",
+      "authors": [
+        "Dumas, Alexandre",
+        "Maquet, Auguste"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14084,
+      "cover": "https://www.gutenberg.org/cache/epub/1257/pg1257.cover.medium.jpg"
+    },
+    {
+      "id": 600,
+      "title": "Notes from the Underground",
+      "authors": [
+        "Dostoyevsky, Fyodor"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14064,
+      "cover": "https://www.gutenberg.org/cache/epub/600/pg600.cover.medium.jpg"
+    },
+    {
+      "id": 6133,
+      "title": "The Extraordinary Adventures of Arsène Lupin, Gentleman-Burglar",
+      "authors": [
+        "Leblanc, Maurice"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14000,
+      "cover": "https://www.gutenberg.org/cache/epub/6133/pg6133.cover.medium.jpg"
+    },
+    {
+      "id": 45001,
+      "title": "Institutes of the Christian Religion (Vol. 1 of 2)",
+      "authors": [
+        "Calvin, Jean"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13764,
+      "cover": "https://www.gutenberg.org/cache/epub/45001/pg45001.cover.medium.jpg"
+    },
+    {
+      "id": 4280,
+      "title": "The Critique of Pure Reason",
+      "authors": [
+        "Kant, Immanuel"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13762,
+      "cover": "https://www.gutenberg.org/cache/epub/4280/pg4280.cover.medium.jpg"
+    },
+    {
+      "id": 2000,
+      "title": "Don Quijote",
+      "authors": [
+        "Cervantes Saavedra, Miguel de"
+      ],
+      "languages": [
+        "es"
+      ],
+      "download_count": 13676,
+      "cover": "https://www.gutenberg.org/cache/epub/2000/pg2000.cover.medium.jpg"
+    },
+    {
+      "id": 3268,
+      "title": "The Mysteries of Udolpho",
+      "authors": [
+        "Radcliffe, Ann Ward"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13617,
+      "cover": "https://www.gutenberg.org/cache/epub/3268/pg3268.cover.medium.jpg"
+    },
+    {
+      "id": 27827,
+      "title": "The Kama Sutra of Vatsyayana: Translated From the Sanscrit in Seven Parts With Preface, Introduction and Concluding Remarks",
+      "authors": [
+        "Vatsyayana"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13597,
+      "cover": "https://www.gutenberg.org/cache/epub/27827/pg27827.cover.medium.jpg"
+    },
+    {
+      "id": 69087,
+      "title": "The murder of Roger Ackroyd",
+      "authors": [
+        "Christie, Agatha"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13583,
+      "cover": "https://www.gutenberg.org/cache/epub/69087/pg69087.cover.medium.jpg"
+    },
+    {
+      "id": 6400,
+      "title": "The Lives of the Twelve Caesars, Complete",
+      "authors": [
+        "Suetonius"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13473,
+      "cover": "https://www.gutenberg.org/cache/epub/6400/pg6400.cover.medium.jpg"
+    },
+    {
+      "id": 43578,
+      "title": "An Introduction to Entomology: Vol. 3: or Elements of the Natural History of the Insects",
+      "authors": [
+        "Kirby, William",
+        "Spence, William"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13460,
+      "cover": "https://www.gutenberg.org/cache/epub/43578/pg43578.cover.medium.jpg"
+    },
+    {
+      "id": 24746,
+      "title": "Reise in die Aequinoctial-Gegenden des neuen Continents. Band 2.",
+      "authors": [
+        "Humboldt, Alexander von"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 13451,
+      "cover": "https://www.gutenberg.org/cache/epub/24746/pg24746.cover.medium.jpg"
+    },
+    {
+      "id": 245,
+      "title": "Life on the Mississippi",
+      "authors": [
+        "Twain, Mark"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13400,
+      "cover": "https://www.gutenberg.org/cache/epub/245/pg245.cover.medium.jpg"
+    },
+    {
+      "id": 1946,
+      "title": "On War",
+      "authors": [
+        "Clausewitz, Carl von"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13399,
+      "cover": "https://www.gutenberg.org/cache/epub/1946/pg1946.cover.medium.jpg"
+    },
+    {
+      "id": 1322,
+      "title": "Leaves of Grass",
+      "authors": [
+        "Whitman, Walt"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13334,
+      "cover": "https://www.gutenberg.org/cache/epub/1322/pg1322.cover.medium.jpg"
+    },
+    {
+      "id": 110,
+      "title": "Tess of the d'Urbervilles: A Pure Woman",
+      "authors": [
+        "Hardy, Thomas"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13232,
+      "cover": "https://www.gutenberg.org/cache/epub/110/pg110.cover.medium.jpg"
+    },
+    {
+      "id": 779,
+      "title": "The Tragical History of Doctor Faustus: From the Quarto of 1604",
+      "authors": [
+        "Marlowe, Christopher"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13205,
+      "cover": "https://www.gutenberg.org/cache/epub/779/pg779.cover.medium.jpg"
+    },
+    {
+      "id": 20027,
+      "title": "Grimms' Fairy Tales",
+      "authors": [
+        "Grimm, Jacob",
+        "Grimm, Wilhelm"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13185,
+      "cover": "https://www.gutenberg.org/cache/epub/20027/pg20027.cover.medium.jpg"
+    },
+    {
+      "id": 34413,
+      "title": "The Love Letters of Mary Wollstonecraft to Gilbert Imlay",
+      "authors": [
+        "Wollstonecraft, Mary"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13170,
+      "cover": "https://www.gutenberg.org/cache/epub/34413/pg34413.cover.medium.jpg"
+    },
+    {
+      "id": 26,
+      "title": "Paradise Lost",
+      "authors": [
+        "Milton, John"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13147,
+      "cover": "https://www.gutenberg.org/cache/epub/26/pg26.cover.medium.jpg"
+    },
+    {
+      "id": 1695,
+      "title": "The Man Who Was Thursday: A Nightmare",
+      "authors": [
+        "Chesterton, G. K. (Gilbert Keith)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13140,
+      "cover": "https://www.gutenberg.org/cache/epub/1695/pg1695.cover.medium.jpg"
+    },
+    {
+      "id": 10007,
+      "title": "Carmilla",
+      "authors": [
+        "Le Fanu, Joseph Sheridan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13081,
+      "cover": "https://www.gutenberg.org/cache/epub/10007/pg10007.cover.medium.jpg"
+    },
+    {
+      "id": 514,
+      "title": "Little Women",
+      "authors": [
+        "Alcott, Louisa May"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13056,
+      "cover": "https://www.gutenberg.org/cache/epub/514/pg514.cover.medium.jpg"
+    },
+    {
+      "id": 3011,
+      "title": "The Lady of the Lake",
+      "authors": [
+        "Scott, Walter"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12958,
+      "cover": "https://www.gutenberg.org/cache/epub/3011/pg3011.cover.medium.jpg"
+    },
+    {
+      "id": 19942,
+      "title": "Candide",
+      "authors": [
+        "Voltaire"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12894,
+      "cover": "https://www.gutenberg.org/cache/epub/19942/pg19942.cover.medium.jpg"
+    },
+    {
+      "id": 47629,
+      "title": "Ang \"Filibusterismo\" (Karugtóng ng Noli Me Tangere)",
+      "authors": [
+        "Rizal, José"
+      ],
+      "languages": [
+        "tl"
+      ],
+      "download_count": 12849,
+      "cover": "https://www.gutenberg.org/cache/epub/47629/pg47629.cover.medium.jpg"
+    },
+    {
+      "id": 40533,
+      "title": "The Life of John Marshall, Volume 4: The building of the nation, 1815-1835",
+      "authors": [
+        "Beveridge, Albert J. (Albert Jeremiah)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12834,
+      "cover": "https://www.gutenberg.org/cache/epub/40533/pg40533.cover.medium.jpg"
+    },
+    {
+      "id": 2097,
+      "title": "The Sign of the Four",
+      "authors": [
+        "Doyle, Arthur Conan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12678,
+      "cover": "https://www.gutenberg.org/cache/epub/2097/pg2097.cover.medium.jpg"
+    },
+    {
+      "id": 25833,
+      "title": "The Great Controversy Between Christ and Satan",
+      "authors": [
+        "White, Ellen Gould Harmon"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12600,
+      "cover": "https://www.gutenberg.org/cache/epub/25833/pg25833.cover.medium.jpg"
+    },
+    {
+      "id": 3825,
+      "title": "Pygmalion",
+      "authors": [
+        "Shaw, Bernard"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12543,
+      "cover": "https://www.gutenberg.org/cache/epub/3825/pg3825.cover.medium.jpg"
+    },
+    {
+      "id": 1524,
+      "title": "Hamlet",
+      "authors": [
+        "Shakespeare, William"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12507,
+      "cover": "https://www.gutenberg.org/cache/epub/1524/pg1524.cover.medium.jpg"
+    },
+    {
+      "id": 43671,
+      "title": "A History of Epidemics in Britain, Volume 2 (of 2): From the Extinction of Plague to the Present Time",
+      "authors": [
+        "Creighton, Charles"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12503,
+      "cover": "https://www.gutenberg.org/cache/epub/43671/pg43671.cover.medium.jpg"
+    },
+    {
+      "id": 20051,
+      "title": "Märchen der Gebrüder Grimm 2",
+      "authors": [
+        "Grimm, Jacob",
+        "Grimm, Wilhelm"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 12471,
+      "cover": "https://www.gutenberg.org/cache/epub/20051/pg20051.cover.medium.jpg"
+    },
+    {
+      "id": 43255,
+      "title": "Domesday Book and Beyond: Three Essays in the Early History of England",
+      "authors": [
+        "Maitland, Frederic William"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12471,
+      "cover": "https://www.gutenberg.org/cache/epub/43255/pg43255.cover.medium.jpg"
+    },
+    {
+      "id": 6130,
+      "title": "The Iliad",
+      "authors": [
+        "Homer"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12447,
+      "cover": "https://www.gutenberg.org/cache/epub/6130/pg6130.cover.medium.jpg"
+    },
+    {
+      "id": 65238,
+      "title": "The Secret of Chimneys",
+      "authors": [
+        "Christie, Agatha"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12388,
+      "cover": "https://www.gutenberg.org/cache/epub/65238/pg65238.cover.medium.jpg"
+    },
+    {
+      "id": 67098,
+      "title": "Winnie-the-Pooh",
+      "authors": [
+        "Milne, A. A. (Alan Alexander)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12269,
+      "cover": "https://www.gutenberg.org/cache/epub/67098/pg67098.cover.medium.jpg"
+    },
+    {
+      "id": 2527,
+      "title": "The Sorrows of Young Werther",
+      "authors": [
+        "Goethe, Johann Wolfgang von"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12240,
+      "cover": "https://www.gutenberg.org/cache/epub/2527/pg2527.cover.medium.jpg"
+    },
+    {
+      "id": 2638,
+      "title": "The Idiot",
+      "authors": [
+        "Dostoyevsky, Fyodor"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12235,
+      "cover": "https://www.gutenberg.org/cache/epub/2638/pg2638.cover.medium.jpg"
+    },
+    {
+      "id": 24253,
+      "title": "Folkways: A Study of the Sociological Importance of Usages, Manners, Customs, Mores, and Morals",
+      "authors": [
+        "Sumner, William Graham"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12205,
+      "cover": "https://www.gutenberg.org/cache/epub/24253/pg24253.cover.medium.jpg"
+    },
+    {
+      "id": 165,
+      "title": "McTeague: A Story of San Francisco",
+      "authors": [
+        "Norris, Frank"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12196,
+      "cover": "https://www.gutenberg.org/cache/epub/165/pg165.cover.medium.jpg"
+    },
+    {
+      "id": 45249,
+      "title": "The History of Signboards, from the Earliest times to the Present Day",
+      "authors": [
+        "Hotten, John Camden",
+        "Larwood, Jacob"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12180,
+      "cover": "https://www.gutenberg.org/cache/epub/45249/pg45249.cover.medium.jpg"
+    },
+    {
+      "id": 23962,
+      "title": "西遊記",
+      "authors": [
+        "Wu, Cheng'en"
+      ],
+      "languages": [
+        "zh"
+      ],
+      "download_count": 12133,
+      "cover": "https://www.gutenberg.org/cache/epub/23962/pg23962.cover.medium.jpg"
+    },
+    {
+      "id": 24739,
+      "title": "Bidwell's Travels, from Wall Street to London Prison: Fifteen Years in Solitude",
+      "authors": [
+        "Bidwell, Austin"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12094,
+      "cover": "https://www.gutenberg.org/cache/epub/24739/pg24739.cover.medium.jpg"
+    },
+    {
+      "id": 11030,
+      "title": "Incidents in the Life of a Slave Girl, Written by Herself",
+      "authors": [
+        "Jacobs, Harriet A. (Harriet Ann)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12053,
+      "cover": "https://www.gutenberg.org/cache/epub/11030/pg11030.cover.medium.jpg"
+    },
+    {
+      "id": 1251,
+      "title": "Le Morte d'Arthur: Volume 1",
+      "authors": [
+        "Malory, Thomas, Sir"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11998,
+      "cover": "https://www.gutenberg.org/cache/epub/1251/pg1251.cover.medium.jpg"
+    },
+    {
+      "id": 43453,
+      "title": "A Pickle for the Knowing Ones",
+      "authors": [
+        "Dexter, Timothy"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11969,
+      "cover": "https://www.gutenberg.org/cache/epub/43453/pg43453.cover.medium.jpg"
+    },
+    {
+      "id": 42671,
+      "title": "Pride and Prejudice",
+      "authors": [
+        "Austen, Jane"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11938,
+      "cover": "https://www.gutenberg.org/cache/epub/42671/pg42671.cover.medium.jpg"
+    },
+    {
+      "id": 22542,
+      "title": "Jesus the Christ: A Study of the Messiah and His Mission According to Holy; Scriptures Both Ancient and Modern",
+      "authors": [
+        "Talmage, James E. (James Edward)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11930,
+      "cover": "https://www.gutenberg.org/cache/epub/22542/pg22542.cover.medium.jpg"
+    },
+    {
+      "id": 39647,
+      "title": "The Spanish American Reader",
+      "authors": [
+        "Nelson, Ernesto"
+      ],
+      "languages": [
+        "en",
+        "es"
+      ],
+      "download_count": 11889,
+      "cover": "https://www.gutenberg.org/cache/epub/39647/pg39647.cover.medium.jpg"
+    },
+    {
+      "id": 236,
+      "title": "The Jungle Book",
+      "authors": [
+        "Kipling, Rudyard"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11874,
+      "cover": "https://www.gutenberg.org/cache/epub/236/pg236.cover.medium.jpg"
+    },
+    {
+      "id": 29090,
+      "title": "The Complete Poetical Works of Samuel Taylor Coleridge. Vol 1 and 2",
+      "authors": [
+        "Coleridge, Samuel Taylor"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11789,
+      "cover": "https://www.gutenberg.org/cache/epub/29090/pg29090.cover.medium.jpg"
+    },
+    {
+      "id": 10681,
+      "title": "Roget's Thesaurus of English Words and Phrases",
+      "authors": [
+        "Roget, Peter Mark"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11688,
+      "cover": "https://www.gutenberg.org/cache/epub/10681/pg10681.cover.medium.jpg"
+    },
+    {
+      "id": 4217,
+      "title": "A Portrait of the Artist as a Young Man",
+      "authors": [
+        "Joyce, James"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11674,
+      "cover": "https://www.gutenberg.org/cache/epub/4217/pg4217.cover.medium.jpg"
+    },
+    {
+      "id": 71046,
+      "title": "Modern English biography, volume 2 (of 4), I-Q",
+      "authors": [
+        "Boase, Frederic"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11668,
+      "cover": "https://www.gutenberg.org/cache/epub/71046/pg71046.cover.medium.jpg"
+    },
+    {
+      "id": 815,
+      "title": "Democracy in America — Volume 1",
+      "authors": [
+        "Tocqueville, Alexis de"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11623,
+      "cover": "https://www.gutenberg.org/cache/epub/815/pg815.cover.medium.jpg"
+    },
+    {
+      "id": 12082,
+      "title": "Color Images from Mars Rovers: Spirit and Opportunity",
+      "authors": [
+        "Webster, Bob"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11619,
+      "cover": "https://www.gutenberg.org/cache/epub/12082/pg12082.cover.medium.jpg"
+    },
+    {
+      "id": 21700,
+      "title": "Don Juan",
+      "authors": [
+        "Byron, George Gordon Byron, Baron"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11531,
+      "cover": "https://www.gutenberg.org/cache/epub/21700/pg21700.cover.medium.jpg"
+    },
+    {
+      "id": 22981,
+      "title": "Letters of Two Brides",
+      "authors": [
+        "Balzac, Honoré de"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11526,
+      "cover": "https://www.gutenberg.org/cache/epub/22981/pg22981.cover.medium.jpg"
+    },
+    {
+      "id": 8438,
+      "title": "The Ethics of Aristotle",
+      "authors": [
+        "Aristotle"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11506,
+      "cover": "https://www.gutenberg.org/cache/epub/8438/pg8438.cover.medium.jpg"
+    },
+    {
+      "id": 12,
+      "title": "Through the Looking-Glass",
+      "authors": [
+        "Carroll, Lewis"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11498,
+      "cover": "https://www.gutenberg.org/cache/epub/12/pg12.cover.medium.jpg"
+    },
+    {
+      "id": 2465,
+      "title": "Carmen",
+      "authors": [
+        "Mérimée, Prosper"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11498,
+      "cover": "https://www.gutenberg.org/cache/epub/2465/pg2465.cover.medium.jpg"
+    },
+    {
+      "id": 37499,
+      "title": "Napoleon's Letters to Josephine, 1796-1812: For the First Time Collected and Translated, with Notes Social, Historical, and Chronological, from Contemporary Sources",
+      "authors": [
+        "Napoleon I, Emperor of the French"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11450,
+      "cover": "https://www.gutenberg.org/cache/epub/37499/pg37499.cover.medium.jpg"
+    },
+    {
+      "id": 42324,
+      "title": "Frankenstein; Or, The Modern Prometheus",
+      "authors": [
+        "Shelley, Mary Wollstonecraft"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11392,
+      "cover": "https://www.gutenberg.org/cache/epub/42324/pg42324.cover.medium.jpg"
+    },
+    {
+      "id": 52319,
+      "title": "The Genealogy of Morals: The Complete Works, Volume Thirteen, edited by Dr. Oscar Levy.",
+      "authors": [
+        "Nietzsche, Friedrich Wilhelm"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11383,
+      "cover": "https://www.gutenberg.org/cache/epub/52319/pg52319.cover.medium.jpg"
+    },
+    {
+      "id": 43579,
+      "title": "An Introduction to Entomology: Vol. 4: or Elements of the Natural History of the Insects",
+      "authors": [
+        "Kirby, William",
+        "Spence, William"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11356,
+      "cover": "https://www.gutenberg.org/cache/epub/43579/pg43579.cover.medium.jpg"
+    },
+    {
+      "id": 105,
+      "title": "Persuasion",
+      "authors": [
+        "Austen, Jane"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11355,
+      "cover": "https://www.gutenberg.org/cache/epub/105/pg105.cover.medium.jpg"
+    },
+    {
+      "id": 20265,
+      "title": "Anne of the Island",
+      "authors": [
+        "Montgomery, L. M. (Lucy Maud)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11257,
+      "cover": "https://www.gutenberg.org/cache/epub/20265/pg20265.cover.medium.jpg"
+    },
+    {
+      "id": 2147,
+      "title": "The Works of Edgar Allan Poe — Volume 1",
+      "authors": [
+        "Poe, Edgar Allan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11249,
+      "cover": "https://www.gutenberg.org/cache/epub/2147/pg2147.cover.medium.jpg"
+    },
+    {
+      "id": 43945,
+      "title": "A Treatise Upon the Law of Copyright in the United Kingdom and the Dominions of the Crown,: and in the United States of America Containing a Full Appendix of All Acts of Parliament International Conventions, Orders in Council, Treasury Minute and Acts of Congress Now in Force.",
+      "authors": [
+        "MacGillivray, Evan James"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11235,
+      "cover": "https://www.gutenberg.org/cache/epub/43945/pg43945.cover.medium.jpg"
+    },
+    {
+      "id": 45109,
+      "title": "The Enchiridion",
+      "authors": [
+        "Epictetus"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11202,
+      "cover": "https://www.gutenberg.org/cache/epub/45109/pg45109.cover.medium.jpg"
+    },
+    {
+      "id": 103,
+      "title": "Around the World in Eighty Days",
+      "authors": [
+        "Verne, Jules"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11197,
+      "cover": "https://www.gutenberg.org/cache/epub/103/pg103.cover.medium.jpg"
+    },
+    {
+      "id": 108,
+      "title": "The Return of Sherlock Holmes",
+      "authors": [
+        "Doyle, Arthur Conan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11165,
+      "cover": "https://www.gutenberg.org/cache/epub/108/pg108.cover.medium.jpg"
+    },
+    {
+      "id": 24571,
+      "title": "Der Struwwelpeter: oder lustige Geschichten und drollige Bilder",
+      "authors": [
+        "Hoffmann, Heinrich"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 11158,
+      "cover": "https://www.gutenberg.org/cache/epub/24571/pg24571.cover.medium.jpg"
+    },
+    {
+      "id": 1001,
+      "title": "Divine Comedy, Longfellow's Translation, Hell",
+      "authors": [
+        "Dante Alighieri"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11148,
+      "cover": "https://www.gutenberg.org/cache/epub/1001/pg1001.cover.medium.jpg"
+    },
+    {
+      "id": 175,
+      "title": "The Phantom of the Opera",
+      "authors": [
+        "Leroux, Gaston"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11112,
+      "cover": "https://www.gutenberg.org/cache/epub/175/pg175.cover.medium.jpg"
+    },
+    {
+      "id": 1228,
+      "title": "On the Origin of Species By Means of Natural Selection: Or, the Preservation of Favoured Races in the Struggle for Life",
+      "authors": [
+        "Darwin, Charles"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11105,
+      "cover": "https://www.gutenberg.org/cache/epub/1228/pg1228.cover.medium.jpg"
+    },
+    {
+      "id": 44653,
+      "title": "A Latin Grammar for Schools and Colleges",
+      "authors": [
+        "Lane, George Martin"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11080,
+      "cover": "https://www.gutenberg.org/cache/epub/44653/pg44653.cover.medium.jpg"
+    },
+    {
+      "id": 10636,
+      "title": "The Travels of Marco Polo — Volume 1",
+      "authors": [
+        "Polo, Marco",
+        "Rusticiano, da Pisa"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11059,
+      "cover": "https://www.gutenberg.org/cache/epub/10636/pg10636.cover.medium.jpg"
+    }
+  ],
+  "en": [
+    {
+      "id": 84,
+      "title": "Frankenstein; or, the modern prometheus",
+      "authors": [
+        "Shelley, Mary Wollstonecraft"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 178271,
+      "cover": "https://www.gutenberg.org/cache/epub/84/pg84.cover.medium.jpg"
+    },
+    {
+      "id": 45304,
+      "title": "The City of God, Volume I",
+      "authors": [
+        "Augustine, of Hippo, Saint"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 146974,
+      "cover": "https://www.gutenberg.org/cache/epub/45304/pg45304.cover.medium.jpg"
+    },
+    {
+      "id": 2701,
+      "title": "Moby Dick; Or, The Whale",
+      "authors": [
+        "Melville, Herman"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 112302,
+      "cover": "https://www.gutenberg.org/cache/epub/2701/pg2701.cover.medium.jpg"
+    },
+    {
+      "id": 1342,
+      "title": "Pride and Prejudice",
+      "authors": [
+        "Austen, Jane"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 107502,
+      "cover": "https://www.gutenberg.org/cache/epub/1342/pg1342.cover.medium.jpg"
+    },
+    {
+      "id": 768,
+      "title": "Wuthering Heights",
+      "authors": [
+        "Brontë, Emily"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 72775,
+      "cover": "https://www.gutenberg.org/cache/epub/768/pg768.cover.medium.jpg"
+    },
+    {
+      "id": 1513,
+      "title": "Romeo and Juliet",
+      "authors": [
+        "Shakespeare, William"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 70272,
+      "cover": "https://www.gutenberg.org/cache/epub/1513/pg1513.cover.medium.jpg"
+    },
+    {
+      "id": 11,
+      "title": "Alice's Adventures in Wonderland",
+      "authors": [
+        "Carroll, Lewis"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 65243,
+      "cover": "https://www.gutenberg.org/cache/epub/11/pg11.cover.medium.jpg"
+    },
+    {
+      "id": 64317,
+      "title": "The Great Gatsby",
+      "authors": [
+        "Fitzgerald, F. Scott (Francis Scott)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 60632,
+      "cover": "https://www.gutenberg.org/cache/epub/64317/pg64317.cover.medium.jpg"
+    },
+    {
+      "id": 100,
+      "title": "The Complete Works of William Shakespeare",
+      "authors": [
+        "Shakespeare, William"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 60527,
+      "cover": "https://www.gutenberg.org/cache/epub/100/pg100.cover.medium.jpg"
+    },
+    {
+      "id": 1260,
+      "title": "Jane Eyre: An Autobiography",
+      "authors": [
+        "Brontë, Charlotte"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 57602,
+      "cover": "https://www.gutenberg.org/cache/epub/1260/pg1260.cover.medium.jpg"
+    },
+    {
+      "id": 2641,
+      "title": "A Room with a View",
+      "authors": [
+        "Forster, E. M. (Edward Morgan)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 57366,
+      "cover": "https://www.gutenberg.org/cache/epub/2641/pg2641.cover.medium.jpg"
+    },
+    {
+      "id": 43,
+      "title": "The strange case of Dr. Jekyll and Mr. Hyde",
+      "authors": [
+        "Stevenson, Robert Louis"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 56894,
+      "cover": "https://www.gutenberg.org/cache/epub/43/pg43.cover.medium.jpg"
+    },
+    {
+      "id": 145,
+      "title": "Middlemarch",
+      "authors": [
+        "Eliot, George"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 53885,
+      "cover": "https://www.gutenberg.org/cache/epub/145/pg145.cover.medium.jpg"
+    },
+    {
+      "id": 174,
+      "title": "The Picture of Dorian Gray",
+      "authors": [
+        "Wilde, Oscar"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 52794,
+      "cover": "https://www.gutenberg.org/cache/epub/174/pg174.cover.medium.jpg"
+    },
+    {
+      "id": 844,
+      "title": "The Importance of Being Earnest: A Trivial Comedy for Serious People",
+      "authors": [
+        "Wilde, Oscar"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 51790,
+      "cover": "https://www.gutenberg.org/cache/epub/844/pg844.cover.medium.jpg"
+    },
+    {
+      "id": 2554,
+      "title": "Crime and Punishment",
+      "authors": [
+        "Dostoyevsky, Fyodor"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 49665,
+      "cover": "https://www.gutenberg.org/cache/epub/2554/pg2554.cover.medium.jpg"
+    },
+    {
+      "id": 37106,
+      "title": "Little Women; Or, Meg, Jo, Beth, and Amy",
+      "authors": [
+        "Alcott, Louisa May"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 49414,
+      "cover": "https://www.gutenberg.org/cache/epub/37106/pg37106.cover.medium.jpg"
+    },
+    {
+      "id": 67979,
+      "title": "The Blue Castle: a novel",
+      "authors": [
+        "Montgomery, L. M. (Lucy Maud)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 47023,
+      "cover": "https://www.gutenberg.org/cache/epub/67979/pg67979.cover.medium.jpg"
+    },
+    {
+      "id": 1184,
+      "title": "The Count of Monte Cristo",
+      "authors": [
+        "Dumas, Alexandre",
+        "Maquet, Auguste"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 44760,
+      "cover": "https://www.gutenberg.org/cache/epub/1184/pg1184.cover.medium.jpg"
+    },
+    {
+      "id": 3207,
+      "title": "Leviathan",
+      "authors": [
+        "Hobbes, Thomas"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 42900,
+      "cover": "https://www.gutenberg.org/cache/epub/3207/pg3207.cover.medium.jpg"
+    },
+    {
+      "id": 5197,
+      "title": "My Life — Volume 1",
+      "authors": [
+        "Wagner, Richard"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 42691,
+      "cover": "https://www.gutenberg.org/cache/epub/5197/pg5197.cover.medium.jpg"
+    },
+    {
+      "id": 345,
+      "title": "Dracula",
+      "authors": [
+        "Stoker, Bram"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 42360,
+      "cover": "https://www.gutenberg.org/cache/epub/345/pg345.cover.medium.jpg"
+    },
+    {
+      "id": 2542,
+      "title": "A Doll's House : a play",
+      "authors": [
+        "Ibsen, Henrik"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 41568,
+      "cover": "https://www.gutenberg.org/cache/epub/2542/pg2542.cover.medium.jpg"
+    },
+    {
+      "id": 8492,
+      "title": "The King in Yellow",
+      "authors": [
+        "Chambers, Robert W. (Robert William)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 40983,
+      "cover": "https://www.gutenberg.org/cache/epub/8492/pg8492.cover.medium.jpg"
+    },
+    {
+      "id": 16389,
+      "title": "The Enchanted April",
+      "authors": [
+        "Von Arnim, Elizabeth"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 40805,
+      "cover": "https://www.gutenberg.org/cache/epub/16389/pg16389.cover.medium.jpg"
+    },
+    {
+      "id": 1259,
+      "title": "Twenty years after",
+      "authors": [
+        "Dumas, Alexandre",
+        "Maquet, Auguste"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 40022,
+      "cover": "https://www.gutenberg.org/cache/epub/1259/pg1259.cover.medium.jpg"
+    },
+    {
+      "id": 28054,
+      "title": "The Brothers Karamazov",
+      "authors": [
+        "Dostoyevsky, Fyodor"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 39032,
+      "cover": "https://www.gutenberg.org/cache/epub/28054/pg28054.cover.medium.jpg"
+    },
+    {
+      "id": 76,
+      "title": "Adventures of Huckleberry Finn",
+      "authors": [
+        "Twain, Mark"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 38960,
+      "cover": "https://www.gutenberg.org/cache/epub/76/pg76.cover.medium.jpg"
+    },
+    {
+      "id": 1661,
+      "title": "The Adventures of Sherlock Holmes",
+      "authors": [
+        "Doyle, Arthur Conan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 38703,
+      "cover": "https://www.gutenberg.org/cache/epub/1661/pg1661.cover.medium.jpg"
+    },
+    {
+      "id": 6761,
+      "title": "The Adventures of Ferdinand Count Fathom — Complete",
+      "authors": [
+        "Smollett, T. (Tobias)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 38235,
+      "cover": "https://www.gutenberg.org/cache/epub/6761/pg6761.cover.medium.jpg"
+    },
+    {
+      "id": 98,
+      "title": "A Tale of Two Cities",
+      "authors": [
+        "Dickens, Charles"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 38103,
+      "cover": "https://www.gutenberg.org/cache/epub/98/pg98.cover.medium.jpg"
+    },
+    {
+      "id": 394,
+      "title": "Cranford",
+      "authors": [
+        "Gaskell, Elizabeth Cleghorn"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 38083,
+      "cover": "https://www.gutenberg.org/cache/epub/394/pg394.cover.medium.jpg"
+    },
+    {
+      "id": 2160,
+      "title": "The Expedition of Humphry Clinker",
+      "authors": [
+        "Smollett, T. (Tobias)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 37810,
+      "cover": "https://www.gutenberg.org/cache/epub/2160/pg2160.cover.medium.jpg"
+    },
+    {
+      "id": 6593,
+      "title": "History of Tom Jones, a Foundling",
+      "authors": [
+        "Fielding, Henry"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 37687,
+      "cover": "https://www.gutenberg.org/cache/epub/6593/pg6593.cover.medium.jpg"
+    },
+    {
+      "id": 4085,
+      "title": "The Adventures of Roderick Random",
+      "authors": [
+        "Smollett, T. (Tobias)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 36803,
+      "cover": "https://www.gutenberg.org/cache/epub/4085/pg4085.cover.medium.jpg"
+    },
+    {
+      "id": 1080,
+      "title": "A Modest Proposal: For preventing the children of poor people in Ireland, from being a burden on their parents or country, and for making them beneficial to the publick",
+      "authors": [
+        "Swift, Jonathan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 35578,
+      "cover": "https://www.gutenberg.org/cache/epub/1080/pg1080.cover.medium.jpg"
+    },
+    {
+      "id": 1400,
+      "title": "Great Expectations",
+      "authors": [
+        "Dickens, Charles"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 33787,
+      "cover": "https://www.gutenberg.org/cache/epub/1400/pg1400.cover.medium.jpg"
+    },
+    {
+      "id": 16328,
+      "title": "Beowulf: An Anglo-Saxon Epic Poem",
+      "authors": [],
+      "languages": [
+        "en"
+      ],
+      "download_count": 30984,
+      "cover": "https://www.gutenberg.org/cache/epub/16328/pg16328.cover.medium.jpg"
+    },
+    {
+      "id": 37683,
+      "title": "Chambers's Twentieth Century Dictionary (part 1 of 4: A-D)",
+      "authors": [],
+      "languages": [
+        "en"
+      ],
+      "download_count": 30765,
+      "cover": "https://www.gutenberg.org/cache/epub/37683/pg37683.cover.medium.jpg"
+    },
+    {
+      "id": 26471,
+      "title": "Spoon River Anthology",
+      "authors": [
+        "Masters, Edgar Lee"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 30062,
+      "cover": "https://www.gutenberg.org/cache/epub/26471/pg26471.cover.medium.jpg"
+    },
+    {
+      "id": 1232,
+      "title": "The Prince",
+      "authors": [
+        "Machiavelli, Niccolò"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 29532,
+      "cover": "https://www.gutenberg.org/cache/epub/1232/pg1232.cover.medium.jpg"
+    },
+    {
+      "id": 1998,
+      "title": "Thus Spake Zarathustra: A Book for All and None",
+      "authors": [
+        "Nietzsche, Friedrich Wilhelm"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 29327,
+      "cover": "https://www.gutenberg.org/cache/epub/1998/pg1998.cover.medium.jpg"
+    },
+    {
+      "id": 28942,
+      "title": "The Junior Classics, Volume 1: Fairy and wonder tales",
+      "authors": [
+        "Neilson, William Allan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 28853,
+      "cover": "https://www.gutenberg.org/cache/epub/28942/pg28942.cover.medium.jpg"
+    },
+    {
+      "id": 1952,
+      "title": "The Yellow Wallpaper",
+      "authors": [
+        "Gilman, Charlotte Perkins"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 28479,
+      "cover": "https://www.gutenberg.org/cache/epub/1952/pg1952.cover.medium.jpg"
+    },
+    {
+      "id": 2680,
+      "title": "Meditations",
+      "authors": [
+        "Marcus Aurelius, Emperor of Rome"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 28425,
+      "cover": "https://www.gutenberg.org/cache/epub/2680/pg2680.cover.medium.jpg"
+    },
+    {
+      "id": 25344,
+      "title": "The Scarlet Letter",
+      "authors": [
+        "Hawthorne, Nathaniel"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 28370,
+      "cover": "https://www.gutenberg.org/cache/epub/25344/pg25344.cover.medium.jpg"
+    },
+    {
+      "id": 5200,
+      "title": "Metamorphosis",
+      "authors": [
+        "Kafka, Franz"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 28364,
+      "cover": "https://www.gutenberg.org/cache/epub/5200/pg5200.cover.medium.jpg"
+    },
+    {
+      "id": 2591,
+      "title": "Grimms' Fairy Tales",
+      "authors": [
+        "Grimm, Jacob",
+        "Grimm, Wilhelm"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 27642,
+      "cover": "https://www.gutenberg.org/cache/epub/2591/pg2591.cover.medium.jpg"
+    },
+    {
+      "id": 4300,
+      "title": "Ulysses",
+      "authors": [
+        "Joyce, James"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 27259,
+      "cover": "https://www.gutenberg.org/cache/epub/4300/pg4300.cover.medium.jpg"
+    },
+    {
+      "id": 2600,
+      "title": "War and Peace",
+      "authors": [
+        "Tolstoy, Leo, graf"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 27051,
+      "cover": "https://www.gutenberg.org/cache/epub/2600/pg2600.cover.medium.jpg"
+    },
+    {
+      "id": 205,
+      "title": "Walden, and On The Duty Of Civil Disobedience",
+      "authors": [
+        "Thoreau, Henry David"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 26622,
+      "cover": "https://www.gutenberg.org/cache/epub/205/pg205.cover.medium.jpg"
+    },
+    {
+      "id": 45,
+      "title": "Anne of Green Gables",
+      "authors": [
+        "Montgomery, L. M. (Lucy Maud)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 26339,
+      "cover": "https://www.gutenberg.org/cache/epub/45/pg45.cover.medium.jpg"
+    },
+    {
+      "id": 74,
+      "title": "The Adventures of Tom Sawyer, Complete",
+      "authors": [
+        "Twain, Mark"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 25830,
+      "cover": "https://www.gutenberg.org/cache/epub/74/pg74.cover.medium.jpg"
+    },
+    {
+      "id": 3296,
+      "title": "The Confessions of St. Augustine",
+      "authors": [
+        "Augustine, of Hippo, Saint"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 25581,
+      "cover": "https://www.gutenberg.org/cache/epub/3296/pg3296.cover.medium.jpg"
+    },
+    {
+      "id": 829,
+      "title": "Gulliver's Travels into Several Remote Nations of the World",
+      "authors": [
+        "Swift, Jonathan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 25457,
+      "cover": "https://www.gutenberg.org/cache/epub/829/pg829.cover.medium.jpg"
+    },
+    {
+      "id": 26184,
+      "title": "Simple Sabotage Field Manual",
+      "authors": [
+        "United States. Office of Strategic Services"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 24602,
+      "cover": "https://www.gutenberg.org/cache/epub/26184/pg26184.cover.medium.jpg"
+    },
+    {
+      "id": 120,
+      "title": "Treasure Island",
+      "authors": [
+        "Stevenson, Robert Louis"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 24601,
+      "cover": "https://www.gutenberg.org/cache/epub/120/pg120.cover.medium.jpg"
+    },
+    {
+      "id": 36034,
+      "title": "White nights, and other stories",
+      "authors": [
+        "Dostoyevsky, Fyodor"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 23874,
+      "cover": "https://www.gutenberg.org/cache/epub/36034/pg36034.cover.medium.jpg"
+    },
+    {
+      "id": 8800,
+      "title": "The divine comedy",
+      "authors": [
+        "Dante Alighieri"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 22965,
+      "cover": "https://www.gutenberg.org/cache/epub/8800/pg8800.cover.medium.jpg"
+    },
+    {
+      "id": 1727,
+      "title": "The Odyssey: Rendered into English prose for the use of those who cannot read the original",
+      "authors": [
+        "Homer"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 22827,
+      "cover": "https://www.gutenberg.org/cache/epub/1727/pg1727.cover.medium.jpg"
+    },
+    {
+      "id": 1399,
+      "title": "Anna Karenina",
+      "authors": [
+        "Tolstoy, Leo, graf"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 22617,
+      "cover": "https://www.gutenberg.org/cache/epub/1399/pg1399.cover.medium.jpg"
+    },
+    {
+      "id": 28189,
+      "title": "My Friends the Savages: Notes and Observations of a Perak settler (Malay Peninsula)",
+      "authors": [
+        "Cerruti, Giovanni Battista"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 21898,
+      "cover": "https://www.gutenberg.org/cache/epub/28189/pg28189.cover.medium.jpg"
+    },
+    {
+      "id": 2852,
+      "title": "The Hound of the Baskervilles",
+      "authors": [
+        "Doyle, Arthur Conan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 21608,
+      "cover": "https://www.gutenberg.org/cache/epub/2852/pg2852.cover.medium.jpg"
+    },
+    {
+      "id": 26225,
+      "title": "Fifteen Thousand Useful Phrases",
+      "authors": [
+        "Kleiser, Grenville"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 21496,
+      "cover": "https://www.gutenberg.org/cache/epub/26225/pg26225.cover.medium.jpg"
+    },
+    {
+      "id": 408,
+      "title": "The Souls of Black Folk",
+      "authors": [
+        "Du Bois, W. E. B. (William Edward Burghardt)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 21414,
+      "cover": "https://www.gutenberg.org/cache/epub/408/pg408.cover.medium.jpg"
+    },
+    {
+      "id": 244,
+      "title": "A Study in Scarlet",
+      "authors": [
+        "Doyle, Arthur Conan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 21389,
+      "cover": "https://www.gutenberg.org/cache/epub/244/pg244.cover.medium.jpg"
+    },
+    {
+      "id": 22788,
+      "title": "The Federalist Papers",
+      "authors": [
+        "Hamilton, Alexander",
+        "Jay, John",
+        "Madison, James"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 20967,
+      "cover": "https://www.gutenberg.org/cache/epub/22788/pg22788.cover.medium.jpg"
+    },
+    {
+      "id": 34901,
+      "title": "On Liberty",
+      "authors": [
+        "Mill, John Stuart"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 20878,
+      "cover": "https://www.gutenberg.org/cache/epub/34901/pg34901.cover.medium.jpg"
+    },
+    {
+      "id": 27673,
+      "title": "Oedipus King of Thebes: Translated into English Rhyming Verse with Explanatory Notes",
+      "authors": [
+        "Sophocles"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 20775,
+      "cover": "https://www.gutenberg.org/cache/epub/27673/pg27673.cover.medium.jpg"
+    },
+    {
+      "id": 55,
+      "title": "The Wonderful Wizard of Oz",
+      "authors": [
+        "Baum, L. Frank (Lyman Frank)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 20616,
+      "cover": "https://www.gutenberg.org/cache/epub/55/pg55.cover.medium.jpg"
+    },
+    {
+      "id": 4363,
+      "title": "Beyond Good and Evil",
+      "authors": [
+        "Nietzsche, Friedrich Wilhelm"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 20616,
+      "cover": "https://www.gutenberg.org/cache/epub/4363/pg4363.cover.medium.jpg"
+    },
+    {
+      "id": 23,
+      "title": "Narrative of the Life of Frederick Douglass, an American Slave",
+      "authors": [
+        "Douglass, Frederick"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 20603,
+      "cover": "https://www.gutenberg.org/cache/epub/23/pg23.cover.medium.jpg"
+    },
+    {
+      "id": 72679,
+      "title": "The lesser Key of Solomon, Goetia, the book of evil spirits : $b contains two hundred diagrams and seals for invocation and convocation of spirits, necromancy, witchcraft and black art",
+      "authors": [],
+      "languages": [
+        "en"
+      ],
+      "download_count": 20464,
+      "cover": "https://www.gutenberg.org/cache/epub/72679/pg72679.cover.medium.jpg"
+    },
+    {
+      "id": 7370,
+      "title": "Second Treatise of Government",
+      "authors": [
+        "Locke, John"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 20172,
+      "cover": "https://www.gutenberg.org/cache/epub/7370/pg7370.cover.medium.jpg"
+    },
+    {
+      "id": 78248,
+      "title": "Prolegomena to the study of Greek religion",
+      "authors": [
+        "Harrison, Jane Ellen"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 19776,
+      "cover": "https://www.gutenberg.org/cache/epub/78248/pg78248.cover.medium.jpg"
+    },
+    {
+      "id": 219,
+      "title": "Heart of Darkness",
+      "authors": [
+        "Conrad, Joseph"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 19150,
+      "cover": "https://www.gutenberg.org/cache/epub/219/pg219.cover.medium.jpg"
+    },
+    {
+      "id": 161,
+      "title": "Sense and Sensibility",
+      "authors": [
+        "Austen, Jane"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 18666,
+      "cover": "https://www.gutenberg.org/cache/epub/161/pg161.cover.medium.jpg"
+    },
+    {
+      "id": 16,
+      "title": "Peter Pan : $b [Peter and Wendy]",
+      "authors": [
+        "Barrie, J. M. (James Matthew)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 18458,
+      "cover": "https://www.gutenberg.org/cache/epub/16/pg16.cover.medium.jpg"
+    },
+    {
+      "id": 22789,
+      "title": "On the Duties of the Clergy",
+      "authors": [
+        "Ambrose, Saint, Bishop of Milan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 18332,
+      "cover": "https://www.gutenberg.org/cache/epub/22789/pg22789.cover.medium.jpg"
+    },
+    {
+      "id": 135,
+      "title": "Les Misérables",
+      "authors": [
+        "Hugo, Victor"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 18171,
+      "cover": "https://www.gutenberg.org/cache/epub/135/pg135.cover.medium.jpg"
+    },
+    {
+      "id": 24869,
+      "title": "The Rámáyan of Válmíki, translated into English verse",
+      "authors": [
+        "Valmiki"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 18135,
+      "cover": "https://www.gutenberg.org/cache/epub/24869/pg24869.cover.medium.jpg"
+    },
+    {
+      "id": 730,
+      "title": "Oliver Twist",
+      "authors": [
+        "Dickens, Charles"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 17382,
+      "cover": "https://www.gutenberg.org/cache/epub/730/pg730.cover.medium.jpg"
+    },
+    {
+      "id": 2148,
+      "title": "The Works of Edgar Allan Poe — Volume 2",
+      "authors": [
+        "Poe, Edgar Allan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 17308,
+      "cover": "https://www.gutenberg.org/cache/epub/2148/pg2148.cover.medium.jpg"
+    },
+    {
+      "id": 1497,
+      "title": "The Republic",
+      "authors": [
+        "Plato"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 17277,
+      "cover": "https://www.gutenberg.org/cache/epub/1497/pg1497.cover.medium.jpg"
+    },
+    {
+      "id": 215,
+      "title": "The call of the wild",
+      "authors": [
+        "London, Jack"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 17250,
+      "cover": "https://www.gutenberg.org/cache/epub/215/pg215.cover.medium.jpg"
+    },
+    {
+      "id": 31885,
+      "title": "Bible Myths and their Parallels in other Religions: Being a Comparison of the Old and New Testament Myths and Miracles with those of the Heathen Nations of Antiquity Considering also their Origin and Meaning",
+      "authors": [
+        "Doane, T. W. (Thomas William)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 17141,
+      "cover": "https://www.gutenberg.org/cache/epub/31885/pg31885.cover.medium.jpg"
+    },
+    {
+      "id": 45368,
+      "title": "The Outline of History: Being a Plain History of Life and Mankind",
+      "authors": [
+        "Wells, H. G. (Herbert George)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 17130,
+      "cover": "https://www.gutenberg.org/cache/epub/45368/pg45368.cover.medium.jpg"
+    },
+    {
+      "id": 164,
+      "title": "Twenty Thousand Leagues under the Sea",
+      "authors": [
+        "Verne, Jules"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 17061,
+      "cover": "https://www.gutenberg.org/cache/epub/164/pg164.cover.medium.jpg"
+    },
+    {
+      "id": 521,
+      "title": "The Life and Adventures of Robinson Crusoe",
+      "authors": [
+        "Defoe, Daniel"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 17011,
+      "cover": "https://www.gutenberg.org/cache/epub/521/pg521.cover.medium.jpg"
+    },
+    {
+      "id": 3206,
+      "title": "Moby Multiple Language Lists of Common Words",
+      "authors": [
+        "Ward, Grady"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 16993,
+      "cover": "https://www.gutenberg.org/cache/epub/3206/pg3206.cover.medium.jpg"
+    },
+    {
+      "id": 20203,
+      "title": "Autobiography of Benjamin Franklin",
+      "authors": [
+        "Franklin, Benjamin"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 16978,
+      "cover": "https://www.gutenberg.org/cache/epub/20203/pg20203.cover.medium.jpg"
+    },
+    {
+      "id": 30254,
+      "title": "The Romance of Lust: A classic Victorian erotic novel",
+      "authors": [
+        "Anonymous"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 16790,
+      "cover": "https://www.gutenberg.org/cache/epub/30254/pg30254.cover.medium.jpg"
+    },
+    {
+      "id": 21765,
+      "title": "The Metamorphoses of Ovid, Books I-VII",
+      "authors": [
+        "Ovid"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 16655,
+      "cover": "https://www.gutenberg.org/cache/epub/21765/pg21765.cover.medium.jpg"
+    },
+    {
+      "id": 1023,
+      "title": "Bleak House",
+      "authors": [
+        "Dickens, Charles"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 16318,
+      "cover": "https://www.gutenberg.org/cache/epub/1023/pg1023.cover.medium.jpg"
+    },
+    {
+      "id": 36,
+      "title": "The war of the worlds",
+      "authors": [
+        "Wells, H. G. (Herbert George)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 16182,
+      "cover": "https://www.gutenberg.org/cache/epub/36/pg36.cover.medium.jpg"
+    },
+    {
+      "id": 132,
+      "title": "The Art of War",
+      "authors": [
+        "Sunzi, active 6th century B.C."
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 16140,
+      "cover": "https://www.gutenberg.org/cache/epub/132/pg132.cover.medium.jpg"
+    },
+    {
+      "id": 996,
+      "title": "Don Quixote",
+      "authors": [
+        "Cervantes Saavedra, Miguel de"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 16106,
+      "cover": "https://www.gutenberg.org/cache/epub/996/pg996.cover.medium.jpg"
+    },
+    {
+      "id": 46,
+      "title": "A Christmas Carol in Prose; Being a Ghost Story of Christmas",
+      "authors": [
+        "Dickens, Charles"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15993,
+      "cover": "https://www.gutenberg.org/cache/epub/46/pg46.cover.medium.jpg"
+    },
+    {
+      "id": 13188,
+      "title": "Putnam's Word Book: A Practical Aid in Expressing Ideas Through the Use of an Exact and Varied Vocabulary",
+      "authors": [
+        "Flemming, Louis A. (Louis Andrew)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15913,
+      "cover": "https://www.gutenberg.org/cache/epub/13188/pg13188.cover.medium.jpg"
+    },
+    {
+      "id": 19488,
+      "title": "The Life of Joan of Arc, Vol. 1 and 2",
+      "authors": [
+        "France, Anatole"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15477,
+      "cover": "https://www.gutenberg.org/cache/epub/19488/pg19488.cover.medium.jpg"
+    },
+    {
+      "id": 209,
+      "title": "The Turn of the Screw",
+      "authors": [
+        "James, Henry"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15425,
+      "cover": "https://www.gutenberg.org/cache/epub/209/pg209.cover.medium.jpg"
+    },
+    {
+      "id": 57724,
+      "title": "A Cyclopaedia of Canadian Biography: Being Chiefly Men of the Time: A Collection of Persons Distinguished in Professional and Political Life, Leaders in the Commerce and Industry of Canada, and Successful Pioneers",
+      "authors": [],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15400,
+      "cover": "https://www.gutenberg.org/cache/epub/57724/pg57724.cover.medium.jpg"
+    },
+    {
+      "id": 35,
+      "title": "The Time Machine",
+      "authors": [
+        "Wells, H. G. (Herbert George)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15303,
+      "cover": "https://www.gutenberg.org/cache/epub/35/pg35.cover.medium.jpg"
+    },
+    {
+      "id": 20000,
+      "title": "Twenty Thousand Leagues Under the Sea",
+      "authors": [
+        "Verne, Jules"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15300,
+      "cover": "https://www.gutenberg.org/cache/epub/20000/pg20000.cover.medium.jpg"
+    },
+    {
+      "id": 15399,
+      "title": "The Interesting Narrative of the Life of Olaudah Equiano, Or Gustavus Vassa, The African: Written By Himself",
+      "authors": [
+        "Equiano, Olaudah"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15284,
+      "cover": "https://www.gutenberg.org/cache/epub/15399/pg15399.cover.medium.jpg"
+    },
+    {
+      "id": 3300,
+      "title": "An Inquiry into the Nature and Causes of the Wealth of Nations",
+      "authors": [
+        "Smith, Adam"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15170,
+      "cover": "https://www.gutenberg.org/cache/epub/3300/pg3300.cover.medium.jpg"
+    },
+    {
+      "id": 25851,
+      "title": "The Life of Charles Dickens, Vol. I-III, Complete",
+      "authors": [
+        "Forster, John"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 15049,
+      "cover": "https://www.gutenberg.org/cache/epub/25851/pg25851.cover.medium.jpg"
+    },
+    {
+      "id": 41,
+      "title": "The Legend of Sleepy Hollow",
+      "authors": [
+        "Irving, Washington"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14944,
+      "cover": "https://www.gutenberg.org/cache/epub/41/pg41.cover.medium.jpg"
+    },
+    {
+      "id": 2814,
+      "title": "Dubliners",
+      "authors": [
+        "Joyce, James"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14935,
+      "cover": "https://www.gutenberg.org/cache/epub/2814/pg2814.cover.medium.jpg"
+    },
+    {
+      "id": 44608,
+      "title": "The Bābur-nāma in English (Memoirs of Bābur)",
+      "authors": [
+        "Babur, Emperor of Hindustan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14798,
+      "cover": "https://www.gutenberg.org/cache/epub/44608/pg44608.cover.medium.jpg"
+    },
+    {
+      "id": 21436,
+      "title": "Poems Every Child Should Know",
+      "authors": [],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14785,
+      "cover": "https://www.gutenberg.org/cache/epub/21436/pg21436.cover.medium.jpg"
+    },
+    {
+      "id": 41445,
+      "title": "Frankenstein; Or, The Modern Prometheus",
+      "authors": [
+        "Shelley, Mary Wollstonecraft"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14673,
+      "cover": "https://www.gutenberg.org/cache/epub/41445/pg41445.cover.medium.jpg"
+    },
+    {
+      "id": 158,
+      "title": "Emma",
+      "authors": [
+        "Austen, Jane"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14548,
+      "cover": "https://www.gutenberg.org/cache/epub/158/pg158.cover.medium.jpg"
+    },
+    {
+      "id": 10,
+      "title": "The King James Version of the Bible",
+      "authors": [],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14420,
+      "cover": "https://www.gutenberg.org/cache/epub/10/pg10.cover.medium.jpg"
+    },
+    {
+      "id": 1257,
+      "title": "The three musketeers",
+      "authors": [
+        "Dumas, Alexandre",
+        "Maquet, Auguste"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14084,
+      "cover": "https://www.gutenberg.org/cache/epub/1257/pg1257.cover.medium.jpg"
+    },
+    {
+      "id": 600,
+      "title": "Notes from the Underground",
+      "authors": [
+        "Dostoyevsky, Fyodor"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14064,
+      "cover": "https://www.gutenberg.org/cache/epub/600/pg600.cover.medium.jpg"
+    },
+    {
+      "id": 6133,
+      "title": "The Extraordinary Adventures of Arsène Lupin, Gentleman-Burglar",
+      "authors": [
+        "Leblanc, Maurice"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 14000,
+      "cover": "https://www.gutenberg.org/cache/epub/6133/pg6133.cover.medium.jpg"
+    },
+    {
+      "id": 45001,
+      "title": "Institutes of the Christian Religion (Vol. 1 of 2)",
+      "authors": [
+        "Calvin, Jean"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13764,
+      "cover": "https://www.gutenberg.org/cache/epub/45001/pg45001.cover.medium.jpg"
+    },
+    {
+      "id": 4280,
+      "title": "The Critique of Pure Reason",
+      "authors": [
+        "Kant, Immanuel"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13762,
+      "cover": "https://www.gutenberg.org/cache/epub/4280/pg4280.cover.medium.jpg"
+    },
+    {
+      "id": 3268,
+      "title": "The Mysteries of Udolpho",
+      "authors": [
+        "Radcliffe, Ann Ward"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13617,
+      "cover": "https://www.gutenberg.org/cache/epub/3268/pg3268.cover.medium.jpg"
+    },
+    {
+      "id": 27827,
+      "title": "The Kama Sutra of Vatsyayana: Translated From the Sanscrit in Seven Parts With Preface, Introduction and Concluding Remarks",
+      "authors": [
+        "Vatsyayana"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13597,
+      "cover": "https://www.gutenberg.org/cache/epub/27827/pg27827.cover.medium.jpg"
+    },
+    {
+      "id": 69087,
+      "title": "The murder of Roger Ackroyd",
+      "authors": [
+        "Christie, Agatha"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13583,
+      "cover": "https://www.gutenberg.org/cache/epub/69087/pg69087.cover.medium.jpg"
+    },
+    {
+      "id": 6400,
+      "title": "The Lives of the Twelve Caesars, Complete",
+      "authors": [
+        "Suetonius"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13473,
+      "cover": "https://www.gutenberg.org/cache/epub/6400/pg6400.cover.medium.jpg"
+    },
+    {
+      "id": 43578,
+      "title": "An Introduction to Entomology: Vol. 3: or Elements of the Natural History of the Insects",
+      "authors": [
+        "Kirby, William",
+        "Spence, William"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13460,
+      "cover": "https://www.gutenberg.org/cache/epub/43578/pg43578.cover.medium.jpg"
+    },
+    {
+      "id": 245,
+      "title": "Life on the Mississippi",
+      "authors": [
+        "Twain, Mark"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13400,
+      "cover": "https://www.gutenberg.org/cache/epub/245/pg245.cover.medium.jpg"
+    },
+    {
+      "id": 1946,
+      "title": "On War",
+      "authors": [
+        "Clausewitz, Carl von"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13399,
+      "cover": "https://www.gutenberg.org/cache/epub/1946/pg1946.cover.medium.jpg"
+    },
+    {
+      "id": 1322,
+      "title": "Leaves of Grass",
+      "authors": [
+        "Whitman, Walt"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13334,
+      "cover": "https://www.gutenberg.org/cache/epub/1322/pg1322.cover.medium.jpg"
+    },
+    {
+      "id": 110,
+      "title": "Tess of the d'Urbervilles: A Pure Woman",
+      "authors": [
+        "Hardy, Thomas"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13232,
+      "cover": "https://www.gutenberg.org/cache/epub/110/pg110.cover.medium.jpg"
+    },
+    {
+      "id": 779,
+      "title": "The Tragical History of Doctor Faustus: From the Quarto of 1604",
+      "authors": [
+        "Marlowe, Christopher"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13205,
+      "cover": "https://www.gutenberg.org/cache/epub/779/pg779.cover.medium.jpg"
+    },
+    {
+      "id": 20027,
+      "title": "Grimms' Fairy Tales",
+      "authors": [
+        "Grimm, Jacob",
+        "Grimm, Wilhelm"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13185,
+      "cover": "https://www.gutenberg.org/cache/epub/20027/pg20027.cover.medium.jpg"
+    },
+    {
+      "id": 34413,
+      "title": "The Love Letters of Mary Wollstonecraft to Gilbert Imlay",
+      "authors": [
+        "Wollstonecraft, Mary"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13170,
+      "cover": "https://www.gutenberg.org/cache/epub/34413/pg34413.cover.medium.jpg"
+    },
+    {
+      "id": 26,
+      "title": "Paradise Lost",
+      "authors": [
+        "Milton, John"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13147,
+      "cover": "https://www.gutenberg.org/cache/epub/26/pg26.cover.medium.jpg"
+    },
+    {
+      "id": 1695,
+      "title": "The Man Who Was Thursday: A Nightmare",
+      "authors": [
+        "Chesterton, G. K. (Gilbert Keith)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13140,
+      "cover": "https://www.gutenberg.org/cache/epub/1695/pg1695.cover.medium.jpg"
+    },
+    {
+      "id": 10007,
+      "title": "Carmilla",
+      "authors": [
+        "Le Fanu, Joseph Sheridan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13081,
+      "cover": "https://www.gutenberg.org/cache/epub/10007/pg10007.cover.medium.jpg"
+    },
+    {
+      "id": 514,
+      "title": "Little Women",
+      "authors": [
+        "Alcott, Louisa May"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 13056,
+      "cover": "https://www.gutenberg.org/cache/epub/514/pg514.cover.medium.jpg"
+    },
+    {
+      "id": 3011,
+      "title": "The Lady of the Lake",
+      "authors": [
+        "Scott, Walter"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12958,
+      "cover": "https://www.gutenberg.org/cache/epub/3011/pg3011.cover.medium.jpg"
+    },
+    {
+      "id": 19942,
+      "title": "Candide",
+      "authors": [
+        "Voltaire"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12894,
+      "cover": "https://www.gutenberg.org/cache/epub/19942/pg19942.cover.medium.jpg"
+    },
+    {
+      "id": 40533,
+      "title": "The Life of John Marshall, Volume 4: The building of the nation, 1815-1835",
+      "authors": [
+        "Beveridge, Albert J. (Albert Jeremiah)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12834,
+      "cover": "https://www.gutenberg.org/cache/epub/40533/pg40533.cover.medium.jpg"
+    },
+    {
+      "id": 2097,
+      "title": "The Sign of the Four",
+      "authors": [
+        "Doyle, Arthur Conan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12678,
+      "cover": "https://www.gutenberg.org/cache/epub/2097/pg2097.cover.medium.jpg"
+    },
+    {
+      "id": 25833,
+      "title": "The Great Controversy Between Christ and Satan",
+      "authors": [
+        "White, Ellen Gould Harmon"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12600,
+      "cover": "https://www.gutenberg.org/cache/epub/25833/pg25833.cover.medium.jpg"
+    },
+    {
+      "id": 3825,
+      "title": "Pygmalion",
+      "authors": [
+        "Shaw, Bernard"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12543,
+      "cover": "https://www.gutenberg.org/cache/epub/3825/pg3825.cover.medium.jpg"
+    },
+    {
+      "id": 1524,
+      "title": "Hamlet",
+      "authors": [
+        "Shakespeare, William"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12507,
+      "cover": "https://www.gutenberg.org/cache/epub/1524/pg1524.cover.medium.jpg"
+    },
+    {
+      "id": 43671,
+      "title": "A History of Epidemics in Britain, Volume 2 (of 2): From the Extinction of Plague to the Present Time",
+      "authors": [
+        "Creighton, Charles"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12503,
+      "cover": "https://www.gutenberg.org/cache/epub/43671/pg43671.cover.medium.jpg"
+    },
+    {
+      "id": 43255,
+      "title": "Domesday Book and Beyond: Three Essays in the Early History of England",
+      "authors": [
+        "Maitland, Frederic William"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12471,
+      "cover": "https://www.gutenberg.org/cache/epub/43255/pg43255.cover.medium.jpg"
+    },
+    {
+      "id": 6130,
+      "title": "The Iliad",
+      "authors": [
+        "Homer"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12447,
+      "cover": "https://www.gutenberg.org/cache/epub/6130/pg6130.cover.medium.jpg"
+    },
+    {
+      "id": 65238,
+      "title": "The Secret of Chimneys",
+      "authors": [
+        "Christie, Agatha"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12388,
+      "cover": "https://www.gutenberg.org/cache/epub/65238/pg65238.cover.medium.jpg"
+    },
+    {
+      "id": 67098,
+      "title": "Winnie-the-Pooh",
+      "authors": [
+        "Milne, A. A. (Alan Alexander)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12269,
+      "cover": "https://www.gutenberg.org/cache/epub/67098/pg67098.cover.medium.jpg"
+    },
+    {
+      "id": 2527,
+      "title": "The Sorrows of Young Werther",
+      "authors": [
+        "Goethe, Johann Wolfgang von"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12240,
+      "cover": "https://www.gutenberg.org/cache/epub/2527/pg2527.cover.medium.jpg"
+    },
+    {
+      "id": 2638,
+      "title": "The Idiot",
+      "authors": [
+        "Dostoyevsky, Fyodor"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12235,
+      "cover": "https://www.gutenberg.org/cache/epub/2638/pg2638.cover.medium.jpg"
+    },
+    {
+      "id": 24253,
+      "title": "Folkways: A Study of the Sociological Importance of Usages, Manners, Customs, Mores, and Morals",
+      "authors": [
+        "Sumner, William Graham"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12205,
+      "cover": "https://www.gutenberg.org/cache/epub/24253/pg24253.cover.medium.jpg"
+    },
+    {
+      "id": 165,
+      "title": "McTeague: A Story of San Francisco",
+      "authors": [
+        "Norris, Frank"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12196,
+      "cover": "https://www.gutenberg.org/cache/epub/165/pg165.cover.medium.jpg"
+    },
+    {
+      "id": 45249,
+      "title": "The History of Signboards, from the Earliest times to the Present Day",
+      "authors": [
+        "Hotten, John Camden",
+        "Larwood, Jacob"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12180,
+      "cover": "https://www.gutenberg.org/cache/epub/45249/pg45249.cover.medium.jpg"
+    },
+    {
+      "id": 24739,
+      "title": "Bidwell's Travels, from Wall Street to London Prison: Fifteen Years in Solitude",
+      "authors": [
+        "Bidwell, Austin"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12094,
+      "cover": "https://www.gutenberg.org/cache/epub/24739/pg24739.cover.medium.jpg"
+    },
+    {
+      "id": 11030,
+      "title": "Incidents in the Life of a Slave Girl, Written by Herself",
+      "authors": [
+        "Jacobs, Harriet A. (Harriet Ann)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 12053,
+      "cover": "https://www.gutenberg.org/cache/epub/11030/pg11030.cover.medium.jpg"
+    },
+    {
+      "id": 1251,
+      "title": "Le Morte d'Arthur: Volume 1",
+      "authors": [
+        "Malory, Thomas, Sir"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11998,
+      "cover": "https://www.gutenberg.org/cache/epub/1251/pg1251.cover.medium.jpg"
+    },
+    {
+      "id": 43453,
+      "title": "A Pickle for the Knowing Ones",
+      "authors": [
+        "Dexter, Timothy"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11969,
+      "cover": "https://www.gutenberg.org/cache/epub/43453/pg43453.cover.medium.jpg"
+    },
+    {
+      "id": 42671,
+      "title": "Pride and Prejudice",
+      "authors": [
+        "Austen, Jane"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11938,
+      "cover": "https://www.gutenberg.org/cache/epub/42671/pg42671.cover.medium.jpg"
+    },
+    {
+      "id": 22542,
+      "title": "Jesus the Christ: A Study of the Messiah and His Mission According to Holy; Scriptures Both Ancient and Modern",
+      "authors": [
+        "Talmage, James E. (James Edward)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11930,
+      "cover": "https://www.gutenberg.org/cache/epub/22542/pg22542.cover.medium.jpg"
+    },
+    {
+      "id": 39647,
+      "title": "The Spanish American Reader",
+      "authors": [
+        "Nelson, Ernesto"
+      ],
+      "languages": [
+        "en",
+        "es"
+      ],
+      "download_count": 11889,
+      "cover": "https://www.gutenberg.org/cache/epub/39647/pg39647.cover.medium.jpg"
+    },
+    {
+      "id": 236,
+      "title": "The Jungle Book",
+      "authors": [
+        "Kipling, Rudyard"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11874,
+      "cover": "https://www.gutenberg.org/cache/epub/236/pg236.cover.medium.jpg"
+    },
+    {
+      "id": 29090,
+      "title": "The Complete Poetical Works of Samuel Taylor Coleridge. Vol 1 and 2",
+      "authors": [
+        "Coleridge, Samuel Taylor"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11789,
+      "cover": "https://www.gutenberg.org/cache/epub/29090/pg29090.cover.medium.jpg"
+    },
+    {
+      "id": 10681,
+      "title": "Roget's Thesaurus of English Words and Phrases",
+      "authors": [
+        "Roget, Peter Mark"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11688,
+      "cover": "https://www.gutenberg.org/cache/epub/10681/pg10681.cover.medium.jpg"
+    },
+    {
+      "id": 4217,
+      "title": "A Portrait of the Artist as a Young Man",
+      "authors": [
+        "Joyce, James"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11674,
+      "cover": "https://www.gutenberg.org/cache/epub/4217/pg4217.cover.medium.jpg"
+    },
+    {
+      "id": 71046,
+      "title": "Modern English biography, volume 2 (of 4), I-Q",
+      "authors": [
+        "Boase, Frederic"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11668,
+      "cover": "https://www.gutenberg.org/cache/epub/71046/pg71046.cover.medium.jpg"
+    },
+    {
+      "id": 815,
+      "title": "Democracy in America — Volume 1",
+      "authors": [
+        "Tocqueville, Alexis de"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11623,
+      "cover": "https://www.gutenberg.org/cache/epub/815/pg815.cover.medium.jpg"
+    },
+    {
+      "id": 12082,
+      "title": "Color Images from Mars Rovers: Spirit and Opportunity",
+      "authors": [
+        "Webster, Bob"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11619,
+      "cover": "https://www.gutenberg.org/cache/epub/12082/pg12082.cover.medium.jpg"
+    },
+    {
+      "id": 21700,
+      "title": "Don Juan",
+      "authors": [
+        "Byron, George Gordon Byron, Baron"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11531,
+      "cover": "https://www.gutenberg.org/cache/epub/21700/pg21700.cover.medium.jpg"
+    },
+    {
+      "id": 22981,
+      "title": "Letters of Two Brides",
+      "authors": [
+        "Balzac, Honoré de"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11526,
+      "cover": "https://www.gutenberg.org/cache/epub/22981/pg22981.cover.medium.jpg"
+    },
+    {
+      "id": 8438,
+      "title": "The Ethics of Aristotle",
+      "authors": [
+        "Aristotle"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11506,
+      "cover": "https://www.gutenberg.org/cache/epub/8438/pg8438.cover.medium.jpg"
+    },
+    {
+      "id": 12,
+      "title": "Through the Looking-Glass",
+      "authors": [
+        "Carroll, Lewis"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11498,
+      "cover": "https://www.gutenberg.org/cache/epub/12/pg12.cover.medium.jpg"
+    },
+    {
+      "id": 2465,
+      "title": "Carmen",
+      "authors": [
+        "Mérimée, Prosper"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11498,
+      "cover": "https://www.gutenberg.org/cache/epub/2465/pg2465.cover.medium.jpg"
+    },
+    {
+      "id": 37499,
+      "title": "Napoleon's Letters to Josephine, 1796-1812: For the First Time Collected and Translated, with Notes Social, Historical, and Chronological, from Contemporary Sources",
+      "authors": [
+        "Napoleon I, Emperor of the French"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11450,
+      "cover": "https://www.gutenberg.org/cache/epub/37499/pg37499.cover.medium.jpg"
+    },
+    {
+      "id": 42324,
+      "title": "Frankenstein; Or, The Modern Prometheus",
+      "authors": [
+        "Shelley, Mary Wollstonecraft"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11392,
+      "cover": "https://www.gutenberg.org/cache/epub/42324/pg42324.cover.medium.jpg"
+    },
+    {
+      "id": 52319,
+      "title": "The Genealogy of Morals: The Complete Works, Volume Thirteen, edited by Dr. Oscar Levy.",
+      "authors": [
+        "Nietzsche, Friedrich Wilhelm"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11383,
+      "cover": "https://www.gutenberg.org/cache/epub/52319/pg52319.cover.medium.jpg"
+    },
+    {
+      "id": 43579,
+      "title": "An Introduction to Entomology: Vol. 4: or Elements of the Natural History of the Insects",
+      "authors": [
+        "Kirby, William",
+        "Spence, William"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11356,
+      "cover": "https://www.gutenberg.org/cache/epub/43579/pg43579.cover.medium.jpg"
+    },
+    {
+      "id": 105,
+      "title": "Persuasion",
+      "authors": [
+        "Austen, Jane"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11355,
+      "cover": "https://www.gutenberg.org/cache/epub/105/pg105.cover.medium.jpg"
+    },
+    {
+      "id": 20265,
+      "title": "Anne of the Island",
+      "authors": [
+        "Montgomery, L. M. (Lucy Maud)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11257,
+      "cover": "https://www.gutenberg.org/cache/epub/20265/pg20265.cover.medium.jpg"
+    },
+    {
+      "id": 2147,
+      "title": "The Works of Edgar Allan Poe — Volume 1",
+      "authors": [
+        "Poe, Edgar Allan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11249,
+      "cover": "https://www.gutenberg.org/cache/epub/2147/pg2147.cover.medium.jpg"
+    },
+    {
+      "id": 43945,
+      "title": "A Treatise Upon the Law of Copyright in the United Kingdom and the Dominions of the Crown,: and in the United States of America Containing a Full Appendix of All Acts of Parliament International Conventions, Orders in Council, Treasury Minute and Acts of Congress Now in Force.",
+      "authors": [
+        "MacGillivray, Evan James"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11235,
+      "cover": "https://www.gutenberg.org/cache/epub/43945/pg43945.cover.medium.jpg"
+    },
+    {
+      "id": 45109,
+      "title": "The Enchiridion",
+      "authors": [
+        "Epictetus"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11202,
+      "cover": "https://www.gutenberg.org/cache/epub/45109/pg45109.cover.medium.jpg"
+    },
+    {
+      "id": 103,
+      "title": "Around the World in Eighty Days",
+      "authors": [
+        "Verne, Jules"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11197,
+      "cover": "https://www.gutenberg.org/cache/epub/103/pg103.cover.medium.jpg"
+    },
+    {
+      "id": 108,
+      "title": "The Return of Sherlock Holmes",
+      "authors": [
+        "Doyle, Arthur Conan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11165,
+      "cover": "https://www.gutenberg.org/cache/epub/108/pg108.cover.medium.jpg"
+    },
+    {
+      "id": 1001,
+      "title": "Divine Comedy, Longfellow's Translation, Hell",
+      "authors": [
+        "Dante Alighieri"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11148,
+      "cover": "https://www.gutenberg.org/cache/epub/1001/pg1001.cover.medium.jpg"
+    },
+    {
+      "id": 175,
+      "title": "The Phantom of the Opera",
+      "authors": [
+        "Leroux, Gaston"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11112,
+      "cover": "https://www.gutenberg.org/cache/epub/175/pg175.cover.medium.jpg"
+    },
+    {
+      "id": 1228,
+      "title": "On the Origin of Species By Means of Natural Selection: Or, the Preservation of Favoured Races in the Struggle for Life",
+      "authors": [
+        "Darwin, Charles"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11105,
+      "cover": "https://www.gutenberg.org/cache/epub/1228/pg1228.cover.medium.jpg"
+    },
+    {
+      "id": 44653,
+      "title": "A Latin Grammar for Schools and Colleges",
+      "authors": [
+        "Lane, George Martin"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11080,
+      "cover": "https://www.gutenberg.org/cache/epub/44653/pg44653.cover.medium.jpg"
+    },
+    {
+      "id": 10636,
+      "title": "The Travels of Marco Polo — Volume 1",
+      "authors": [
+        "Polo, Marco",
+        "Rusticiano, da Pisa"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11059,
+      "cover": "https://www.gutenberg.org/cache/epub/10636/pg10636.cover.medium.jpg"
+    },
+    {
+      "id": 3600,
+      "title": "Essays of Michel de Montaigne — Complete",
+      "authors": [
+        "Montaigne, Michel de"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 11049,
+      "cover": "https://www.gutenberg.org/cache/epub/3600/pg3600.cover.medium.jpg"
+    },
+    {
+      "id": 43840,
+      "title": "Poison Romance and Poison Mysteries",
+      "authors": [
+        "Thompson, C. J. S. (Charles John Samuel)"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 10963,
+      "cover": "https://www.gutenberg.org/cache/epub/43840/pg43840.cover.medium.jpg"
+    },
+    {
+      "id": 15272,
+      "title": "Spenser's The Faerie Queene, Book I",
+      "authors": [
+        "Spenser, Edmund"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 10941,
+      "cover": "https://www.gutenberg.org/cache/epub/15272/pg15272.cover.medium.jpg"
+    },
+    {
+      "id": 19839,
+      "title": "Emma",
+      "authors": [
+        "Austen, Jane"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 10869,
+      "cover": "https://www.gutenberg.org/cache/epub/19839/pg19839.cover.medium.jpg"
+    },
+    {
+      "id": 7142,
+      "title": "The History of the Peloponnesian War",
+      "authors": [
+        "Thucydides"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 10859,
+      "cover": "https://www.gutenberg.org/cache/epub/7142/pg7142.cover.medium.jpg"
+    },
+    {
+      "id": 41537,
+      "title": "The Divine Comedy of Dante Alighieri: The Inferno",
+      "authors": [
+        "Dante Alighieri"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 10859,
+      "cover": "https://www.gutenberg.org/cache/epub/41537/pg41537.cover.medium.jpg"
+    },
+    {
+      "id": 1514,
+      "title": "A Midsummer Night's Dream",
+      "authors": [
+        "Shakespeare, William"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 10824,
+      "cover": "https://www.gutenberg.org/cache/epub/1514/pg1514.cover.medium.jpg"
+    },
+    {
+      "id": 23784,
+      "title": "The History of Sir Richard Calmady: A Romance",
+      "authors": [
+        "Malet, Lucas"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 10819,
+      "cover": "https://www.gutenberg.org/cache/epub/23784/pg23784.cover.medium.jpg"
+    },
+    {
+      "id": 921,
+      "title": "De Profundis",
+      "authors": [
+        "Wilde, Oscar"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 10815,
+      "cover": "https://www.gutenberg.org/cache/epub/921/pg921.cover.medium.jpg"
+    },
+    {
+      "id": 11339,
+      "title": "Aesop's Fables; a new translation",
+      "authors": [
+        "Aesop"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 10755,
+      "cover": "https://www.gutenberg.org/cache/epub/11339/pg11339.cover.medium.jpg"
+    },
+    {
+      "id": 18269,
+      "title": "Pascal's Pensées",
+      "authors": [
+        "Pascal, Blaise"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 10750,
+      "cover": "https://www.gutenberg.org/cache/epub/18269/pg18269.cover.medium.jpg"
+    },
+    {
+      "id": 834,
+      "title": "The Memoirs of Sherlock Holmes",
+      "authors": [
+        "Doyle, Arthur Conan"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 10724,
+      "cover": "https://www.gutenberg.org/cache/epub/834/pg834.cover.medium.jpg"
+    },
+    {
+      "id": 50498,
+      "title": "The Raft",
+      "authors": [
+        "Dawson, Coningsby"
+      ],
+      "languages": [
+        "en"
+      ],
+      "download_count": 10674,
+      "cover": "https://www.gutenberg.org/cache/epub/50498/pg50498.cover.medium.jpg"
+    }
+  ],
+  "de": [
+    {
+      "id": 77700,
+      "title": "Entstehung und Ausbreitung der Alchemie, mit einem Anhange : $b zur älteren Geschichte der Metalle; ein Beitrag zur Kulturgeschichte",
+      "authors": [
+        "Lippmann, Edmund O. von (Edmund Oskar)"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 19637,
+      "cover": "https://www.gutenberg.org/cache/epub/77700/pg77700.cover.medium.jpg"
+    },
+    {
+      "id": 40739,
+      "title": "Die Traumdeutung",
+      "authors": [
+        "Freud, Sigmund"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 14241,
+      "cover": "https://www.gutenberg.org/cache/epub/40739/pg40739.cover.medium.jpg"
+    },
+    {
+      "id": 24746,
+      "title": "Reise in die Aequinoctial-Gegenden des neuen Continents. Band 2.",
+      "authors": [
+        "Humboldt, Alexander von"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 13451,
+      "cover": "https://www.gutenberg.org/cache/epub/24746/pg24746.cover.medium.jpg"
+    },
+    {
+      "id": 20051,
+      "title": "Märchen der Gebrüder Grimm 2",
+      "authors": [
+        "Grimm, Jacob",
+        "Grimm, Wilhelm"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 12471,
+      "cover": "https://www.gutenberg.org/cache/epub/20051/pg20051.cover.medium.jpg"
+    },
+    {
+      "id": 24571,
+      "title": "Der Struwwelpeter: oder lustige Geschichten und drollige Bilder",
+      "authors": [
+        "Hoffmann, Heinrich"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 11158,
+      "cover": "https://www.gutenberg.org/cache/epub/24571/pg24571.cover.medium.jpg"
+    },
+    {
+      "id": 31284,
+      "title": "Josefine Mutzenbacher: oder Die Geschichte einer Wienerischen Dirne von ihr selbst erzählt",
+      "authors": [
+        "Salten, Felix"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 9672,
+      "cover": "https://www.gutenberg.org/cache/epub/31284/pg31284.cover.medium.jpg"
+    },
+    {
+      "id": 35312,
+      "title": "Aus dem Leben eines Taugenichts: Novelle",
+      "authors": [
+        "Eichendorff, Joseph, Freiherr von"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 9305,
+      "cover": "https://www.gutenberg.org/cache/epub/35312/pg35312.cover.medium.jpg"
+    },
+    {
+      "id": 20050,
+      "title": "Märchen der Gebrüder Grimm 1",
+      "authors": [
+        "Grimm, Jacob",
+        "Grimm, Wilhelm"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 8014,
+      "cover": "https://www.gutenberg.org/cache/epub/20050/pg20050.cover.medium.jpg"
+    },
+    {
+      "id": 19636,
+      "title": "Bildergeschichten",
+      "authors": [
+        "Busch, Wilhelm"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 7567,
+      "cover": "https://www.gutenberg.org/cache/epub/19636/pg19636.cover.medium.jpg"
+    },
+    {
+      "id": 34811,
+      "title": "Buddenbrooks: Verfall einer Familie",
+      "authors": [
+        "Mann, Thomas"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 6513,
+      "cover": "https://www.gutenberg.org/cache/epub/34811/pg34811.cover.medium.jpg"
+    },
+    {
+      "id": 3221,
+      "title": "Mr. Honey's Large Business Dictionary (English-German)",
+      "authors": [
+        "Honig, Winfried"
+      ],
+      "languages": [
+        "de",
+        "en"
+      ],
+      "download_count": 6382,
+      "cover": "https://www.gutenberg.org/cache/epub/3221/pg3221.cover.medium.jpg"
+    },
+    {
+      "id": 22367,
+      "title": "Die Verwandlung",
+      "authors": [
+        "Kafka, Franz"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 6019,
+      "cover": "https://www.gutenberg.org/cache/epub/22367/pg22367.cover.medium.jpg"
+    },
+    {
+      "id": 50285,
+      "title": "Dr. Mabuse, der Spieler : $b Roman",
+      "authors": [
+        "Jacques, Norbert"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 5918,
+      "cover": "https://www.gutenberg.org/cache/epub/50285/pg50285.cover.medium.jpg"
+    },
+    {
+      "id": 21798,
+      "title": "Winnetou I",
+      "authors": [
+        "May, Karl"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 5764,
+      "cover": "https://www.gutenberg.org/cache/epub/21798/pg21798.cover.medium.jpg"
+    },
+    {
+      "id": 56156,
+      "title": "Venus im Pelz",
+      "authors": [
+        "Sacher-Masoch, Leopold, Ritter von"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 4967,
+      "cover": "https://www.gutenberg.org/cache/epub/56156/pg56156.cover.medium.jpg"
+    },
+    {
+      "id": 38126,
+      "title": "Der Untertan",
+      "authors": [
+        "Mann, Heinrich"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 4751,
+      "cover": "https://www.gutenberg.org/cache/epub/38126/pg38126.cover.medium.jpg"
+    },
+    {
+      "id": 49501,
+      "title": "Anzeiger für Kunde der deutschen Vorzeit (Jg. 26, 1879): Neue Folge",
+      "authors": [
+        "Various"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 4464,
+      "cover": "https://www.gutenberg.org/cache/epub/49501/pg49501.cover.medium.jpg"
+    },
+    {
+      "id": 2229,
+      "title": "Faust: Der Tragödie erster Teil",
+      "authors": [
+        "Goethe, Johann Wolfgang von"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 4430,
+      "cover": "https://www.gutenberg.org/cache/epub/2229/pg2229.cover.medium.jpg"
+    },
+    {
+      "id": 7205,
+      "title": "Also sprach Zarathustra: Ein Buch für Alle und Keinen",
+      "authors": [
+        "Nietzsche, Friedrich Wilhelm"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 4243,
+      "cover": "https://www.gutenberg.org/cache/epub/7205/pg7205.cover.medium.jpg"
+    },
+    {
+      "id": 21185,
+      "title": "Woyzeck",
+      "authors": [
+        "Büchner, Georg"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 4128,
+      "cover": "https://www.gutenberg.org/cache/epub/21185/pg21185.cover.medium.jpg"
+    },
+    {
+      "id": 75007,
+      "title": "Vollständiges Orthographisches Wörterbuch der deutschen Sprache : $b mit etymologischen Angaben, kurzen Sacherklärungen und Verdeutschungen der Fremdwörter",
+      "authors": [
+        "Duden, Konrad"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 4072,
+      "cover": "https://www.gutenberg.org/cache/epub/75007/pg75007.cover.medium.jpg"
+    },
+    {
+      "id": 21158,
+      "title": "Sammlung deutscher Gedichte 001",
+      "authors": [
+        "Various"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 3706,
+      "cover": "https://www.gutenberg.org/cache/epub/21158/pg21158.cover.medium.jpg"
+    },
+    {
+      "id": 58804,
+      "title": "Die Deutschen Familiennamen, geschichtlich, geographisch, sprachlich",
+      "authors": [
+        "Heintze, Albert"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 3643,
+      "cover": "https://www.gutenberg.org/cache/epub/58804/pg58804.cover.medium.jpg"
+    },
+    {
+      "id": 22160,
+      "title": "Studien und Plaudereien. First Series",
+      "authors": [
+        "Stern, Sigmon M. (Sigmon Martin)"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 3610,
+      "cover": "https://www.gutenberg.org/cache/epub/22160/pg22160.cover.medium.jpg"
+    },
+    {
+      "id": 23756,
+      "title": "Geschichte Alexanders des Grossen",
+      "authors": [
+        "Droysen, Johann Gustav"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 3539,
+      "cover": "https://www.gutenberg.org/cache/epub/23756/pg23756.cover.medium.jpg"
+    },
+    {
+      "id": 68400,
+      "title": "Der Marquis de Sade und seine Zeit.",
+      "authors": [
+        "Bloch, Iwan"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 3491,
+      "cover": "https://www.gutenberg.org/cache/epub/68400/pg68400.cover.medium.jpg"
+    },
+    {
+      "id": 21000,
+      "title": "Faust: Eine Tragödie [erster Teil]",
+      "authors": [
+        "Goethe, Johann Wolfgang von"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 3414,
+      "cover": "https://www.gutenberg.org/cache/epub/21000/pg21000.cover.medium.jpg"
+    },
+    {
+      "id": 21801,
+      "title": "Briefe an eine Freundin",
+      "authors": [
+        "Humboldt, Wilhelm von"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 3364,
+      "cover": "https://www.gutenberg.org/cache/epub/21801/pg21801.cover.medium.jpg"
+    },
+    {
+      "id": 37128,
+      "title": "Kleine Dichtungen",
+      "authors": [
+        "Walser, Robert"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 3274,
+      "cover": "https://www.gutenberg.org/cache/epub/37128/pg37128.cover.medium.jpg"
+    },
+    {
+      "id": 66452,
+      "title": "Die Liebe: Novelle",
+      "authors": [
+        "Kaltneker, Hans"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 3110,
+      "cover": "https://www.gutenberg.org/cache/epub/66452/pg66452.cover.medium.jpg"
+    },
+    {
+      "id": 17161,
+      "title": "Max und Moritz: Eine Bubengeschichte in sieben Streichen",
+      "authors": [
+        "Busch, Wilhelm"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2892,
+      "cover": "https://www.gutenberg.org/cache/epub/17161/pg17161.cover.medium.jpg"
+    },
+    {
+      "id": 25721,
+      "title": "Caspar Hauser; oder, Die Trägheit des Herzens, Roman",
+      "authors": [
+        "Wassermann, Jakob"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2892,
+      "cover": "https://www.gutenberg.org/cache/epub/25721/pg25721.cover.medium.jpg"
+    },
+    {
+      "id": 65661,
+      "title": "Der Zauberberg. Erster Band",
+      "authors": [
+        "Mann, Thomas"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2887,
+      "cover": "https://www.gutenberg.org/cache/epub/65661/pg65661.cover.medium.jpg"
+    },
+    {
+      "id": 47804,
+      "title": "Die Räuber: Ein Schauspiel",
+      "authors": [
+        "Schiller, Friedrich"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2871,
+      "cover": "https://www.gutenberg.org/cache/epub/47804/pg47804.cover.medium.jpg"
+    },
+    {
+      "id": 23393,
+      "title": "Japanische Märchen",
+      "authors": [],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2809,
+      "cover": "https://www.gutenberg.org/files/23393/c001.jpg"
+    },
+    {
+      "id": 21053,
+      "title": "An anthology of German literature",
+      "authors": [
+        "Thomas, Calvin"
+      ],
+      "languages": [
+        "de",
+        "en"
+      ],
+      "download_count": 2725,
+      "cover": "https://www.gutenberg.org/cache/epub/21053/pg21053.cover.medium.jpg"
+    },
+    {
+      "id": 43438,
+      "title": "Erotika Biblion",
+      "authors": [
+        "Mirabeau, Honoré-Gabriel de Riqueti, comte de"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2685,
+      "cover": "https://www.gutenberg.org/cache/epub/43438/pg43438.cover.medium.jpg"
+    },
+    {
+      "id": 51260,
+      "title": "Anzeiger des Germanischen Nationalmuseums, Jahrgang 1901",
+      "authors": [
+        "Various"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2667,
+      "cover": "https://www.gutenberg.org/cache/epub/51260/pg51260.cover.medium.jpg"
+    },
+    {
+      "id": 37266,
+      "title": "Reigen: Zehn Dialoge",
+      "authors": [
+        "Schnitzler, Arthur"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2628,
+      "cover": "https://www.gutenberg.org/cache/epub/37266/pg37266.cover.medium.jpg"
+    },
+    {
+      "id": 78079,
+      "title": "Allgemeine Physiologie",
+      "authors": [
+        "Verworn, Max"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2623,
+      "cover": "https://www.gutenberg.org/cache/epub/78079/pg78079.cover.medium.jpg"
+    },
+    {
+      "id": 43759,
+      "title": "Geflügelte Worte: Der Citatenschatz des deutschen Volkes",
+      "authors": [
+        "Büchmann, Georg",
+        "Robert-tornow, Walter"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2615,
+      "cover": "https://www.gutenberg.org/cache/epub/43759/pg43759.cover.medium.jpg"
+    },
+    {
+      "id": 23333,
+      "title": "Ein Mann: Des Seefahrers und aufrechten Bürgers Joachim Nettelbeck wundersame Lebensgeschichte von ihm selbst erzählt",
+      "authors": [
+        "Nettelbeck, Joachim"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2587,
+      "cover": "https://www.gutenberg.org/cache/epub/23333/pg23333.cover.medium.jpg"
+    },
+    {
+      "id": 41818,
+      "title": "Hermann Lauscher",
+      "authors": [
+        "Hesse, Hermann"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2529,
+      "cover": "https://www.gutenberg.org/cache/epub/41818/pg41818.cover.medium.jpg"
+    },
+    {
+      "id": 78125,
+      "title": "Liebe ist ewig : $b Roman",
+      "authors": [
+        "Polenz, Wilhelm von"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2524,
+      "cover": "https://www.gutenberg.org/cache/epub/78125/pg78125.cover.medium.jpg"
+    },
+    {
+      "id": 47406,
+      "title": "Aphorismen zur Lebensweisheit",
+      "authors": [
+        "Schopenhauer, Arthur"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2511,
+      "cover": "https://www.gutenberg.org/cache/epub/47406/pg47406.cover.medium.jpg"
+    },
+    {
+      "id": 37065,
+      "title": "Totem und Tabu: Einige Übereinstimmungen im Seelenleben der Wilden und der Neurotiker",
+      "authors": [
+        "Freud, Sigmund"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2460,
+      "cover": "https://www.gutenberg.org/cache/epub/37065/pg37065.cover.medium.jpg"
+    },
+    {
+      "id": 78056,
+      "title": "Urwald",
+      "authors": [
+        "Francé, R. H. (Raoul Heinrich)"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2454,
+      "cover": "https://www.gutenberg.org/cache/epub/78056/pg78056.cover.medium.jpg"
+    },
+    {
+      "id": 34717,
+      "title": "Die Verwirrungen des Zöglings Törleß",
+      "authors": [
+        "Musil, Robert"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2430,
+      "cover": "https://www.gutenberg.org/cache/epub/34717/pg34717.cover.medium.jpg"
+    },
+    {
+      "id": 35999,
+      "title": "Seelenverkäufer: Das Schicksal einer Deutsch-Amerikanerin",
+      "authors": [
+        "Gontard-Schuck, M."
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2426,
+      "cover": "https://www.gutenberg.org/cache/epub/35999/pg35999.cover.medium.jpg"
+    },
+    {
+      "id": 5322,
+      "title": "Woyzeck",
+      "authors": [
+        "Büchner, Georg"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2377,
+      "cover": "https://www.gutenberg.org/cache/epub/5322/pg5322.cover.medium.jpg"
+    },
+    {
+      "id": 23134,
+      "title": "Frau Pauline Brater: Lebensbild einer deutschen Frau",
+      "authors": [
+        "Sapper, Agnes"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2373,
+      "cover": "https://www.gutenberg.org/cache/epub/23134/pg23134.cover.medium.jpg"
+    },
+    {
+      "id": 22627,
+      "title": "German Science Reader: An Introduction to Scientific German, for Students of Physics, Chemistry and Engineering",
+      "authors": [
+        "Kroeh, Charles Frederick"
+      ],
+      "languages": [
+        "de",
+        "en"
+      ],
+      "download_count": 2351,
+      "cover": "https://www.gutenberg.org/cache/epub/22627/pg22627.cover.medium.jpg"
+    },
+    {
+      "id": 39762,
+      "title": "Etymologisches Wörterbuch der deutschen Seemannssprache",
+      "authors": [
+        "Goedel, Gustav"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2338,
+      "cover": "https://www.gutenberg.org/cache/epub/39762/pg39762.cover.medium.jpg"
+    },
+    {
+      "id": 20684,
+      "title": "Peterchens Mondfahrt",
+      "authors": [
+        "Bassewitz, Gerdt von"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2322,
+      "cover": "https://www.gutenberg.org/cache/epub/20684/pg20684.cover.medium.jpg"
+    },
+    {
+      "id": 19794,
+      "title": "Die Leiden des jungen Werther",
+      "authors": [
+        "Goethe, Johann Wolfgang von"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2295,
+      "cover": "https://www.gutenberg.org/cache/epub/19794/pg19794.cover.medium.jpg"
+    },
+    {
+      "id": 39619,
+      "title": "Trotzkopf als Grossmutter",
+      "authors": [
+        "La Chapelle-Roobol, Suze"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2271,
+      "cover": "https://www.gutenberg.org/cache/epub/39619/pg39619.cover.medium.jpg"
+    },
+    {
+      "id": 78026,
+      "title": "Skizzen einer Fußreise durch Oesterreich, Steiermark, Kärnthen, Salzburg, Berchtesgaden, Tirol und Baiern nach Wien, : $b nebst einer romantisch pittoresken Darstellung mehrerer Ritterburgen und ihrer Volkssagen, Gebirgsgegenden und Eisglätscher auf dieser Wanderung, unternommen im Jahre 1825 von Joseph Kyselak. (2/2)",
+      "authors": [
+        "Kyselak, Josef"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2243,
+      "cover": "https://www.gutenberg.org/cache/epub/78026/pg78026.cover.medium.jpg"
+    },
+    {
+      "id": 40920,
+      "title": "Nationalismus",
+      "authors": [
+        "Tagore, Rabindranath"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2239,
+      "cover": "https://www.gutenberg.org/cache/epub/40920/pg40920.cover.medium.jpg"
+    },
+    {
+      "id": 29376,
+      "title": "Bahnwärter Thiel",
+      "authors": [
+        "Hauptmann, Gerhart"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2212,
+      "cover": "https://www.gutenberg.org/cache/epub/29376/pg29376.cover.medium.jpg"
+    },
+    {
+      "id": 41907,
+      "title": "Demian: Die Geschichte von Emil Sinclairs Jugend",
+      "authors": [
+        "Hesse, Hermann"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2210,
+      "cover": "https://www.gutenberg.org/cache/epub/41907/pg41907.cover.medium.jpg"
+    },
+    {
+      "id": 43332,
+      "title": "Das Lämmchen",
+      "authors": [
+        "Schmid, Christoph von"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2129,
+      "cover": "https://www.gutenberg.org/cache/epub/43332/pg43332.cover.medium.jpg"
+    },
+    {
+      "id": 24782,
+      "title": "Der Dunkelgraf",
+      "authors": [
+        "Bechstein, Ludwig"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2119,
+      "cover": "https://www.gutenberg.org/cache/epub/24782/pg24782.cover.medium.jpg"
+    },
+    {
+      "id": 60360,
+      "title": "Der Wille zur Macht: Eine Auslegung alles Geschehens",
+      "authors": [
+        "Nietzsche, Friedrich Wilhelm"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2103,
+      "cover": "https://www.gutenberg.org/cache/epub/60360/pg60360.cover.medium.jpg"
+    },
+    {
+      "id": 35264,
+      "title": "Professor Unrat, oder, Das Ende eines Tyrannen",
+      "authors": [
+        "Mann, Heinrich"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2091,
+      "cover": "https://www.gutenberg.org/cache/epub/35264/pg35264.cover.medium.jpg"
+    },
+    {
+      "id": 35328,
+      "title": "Königliche Hoheit: Roman",
+      "authors": [
+        "Mann, Thomas"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2082,
+      "cover": "https://www.gutenberg.org/cache/epub/35328/pg35328.cover.medium.jpg"
+    },
+    {
+      "id": 29553,
+      "title": "Bunte Steine: Ein Festgeschenk",
+      "authors": [
+        "Stifter, Adalbert"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2074,
+      "cover": "https://www.gutenberg.org/cache/epub/29553/pg29553.cover.medium.jpg"
+    },
+    {
+      "id": 39938,
+      "title": "Drei Abhandlungen zur Sexualtheorie",
+      "authors": [
+        "Freud, Sigmund"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 2034,
+      "cover": "https://www.gutenberg.org/cache/epub/39938/pg39938.cover.medium.jpg"
+    },
+    {
+      "id": 78030,
+      "title": "Kloster Himmelpforte : $b Geschichtliches Drama in 4 Akten",
+      "authors": [
+        "Falke, Robert"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1991,
+      "cover": "https://www.gutenberg.org/cache/epub/78030/pg78030.cover.medium.jpg"
+    },
+    {
+      "id": 55925,
+      "title": "Kant's gesammelte Schriften. Band V. Kritik der Urtheilskraft.",
+      "authors": [
+        "Kant, Immanuel"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1953,
+      "cover": "https://www.gutenberg.org/cache/epub/55925/pg55925.cover.medium.jpg"
+    },
+    {
+      "id": 22630,
+      "title": "Der Roman eines geborenen Verbrechers: Selbstbiographie des Strafgefangenen Antonino M...",
+      "authors": [
+        "M., Antonino"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1946,
+      "cover": "https://www.gutenberg.org/cache/epub/22630/pg22630.cover.medium.jpg"
+    },
+    {
+      "id": 29006,
+      "title": "Die Dichtungen von Georg Trakl: Erste Gesamtausgabe",
+      "authors": [
+        "Trakl, Georg"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1939,
+      "cover": "https://www.gutenberg.org/cache/epub/29006/pg29006.cover.medium.jpg"
+    },
+    {
+      "id": 39816,
+      "title": "Macchiavellis Buch vom Fürsten",
+      "authors": [
+        "Machiavelli, Niccolò"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1939,
+      "cover": "https://www.gutenberg.org/cache/epub/39816/pg39816.cover.medium.jpg"
+    },
+    {
+      "id": 61543,
+      "title": "Psychologische Typen",
+      "authors": [
+        "Jung, C. G. (Carl Gustav)"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1922,
+      "cover": "https://www.gutenberg.org/cache/epub/61543/pg61543.cover.medium.jpg"
+    },
+    {
+      "id": 22824,
+      "title": "Der Wehrwolf: Eine Bauernchronik",
+      "authors": [
+        "Löns, Hermann"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1907,
+      "cover": "https://www.gutenberg.org/cache/epub/22824/pg22824.cover.medium.jpg"
+    },
+    {
+      "id": 20944,
+      "title": "Nach Amerika! Ein Volksbuch. Zweiter Band.",
+      "authors": [
+        "Gerstäcker, Friedrich"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1904,
+      "cover": "https://www.gutenberg.org/cache/epub/20944/pg20944.cover.medium.jpg"
+    },
+    {
+      "id": 39441,
+      "title": "Leibnitz' Monadologie: Deutsch mit einer Abhandlung über Leibnitz' und Herbart's Theorieen des wirklichen Geschehens",
+      "authors": [
+        "Leibniz, Gottfried Wilhelm, Freiherr von"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1902,
+      "cover": "https://www.gutenberg.org/cache/epub/39441/pg39441.cover.medium.jpg"
+    },
+    {
+      "id": 34099,
+      "title": "In Stahlgewittern, aus dem Tagebuch eines Stoßtruppführers",
+      "authors": [
+        "Jünger, Ernst"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1886,
+      "cover": "https://www.gutenberg.org/cache/epub/34099/pg34099.cover.medium.jpg"
+    },
+    {
+      "id": 25048,
+      "title": "Soldan's Geschichte der Hexenprozesse. Zweiter Band",
+      "authors": [
+        "Soldan, Wilhelm Gottlieb"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1868,
+      "cover": "https://www.gutenberg.org/cache/epub/25048/pg25048.cover.medium.jpg"
+    },
+    {
+      "id": 3220,
+      "title": "Mr. Honey's Large Business Dictionary (German-English)",
+      "authors": [
+        "Honig, Winfried"
+      ],
+      "languages": [
+        "de",
+        "en"
+      ],
+      "download_count": 1862,
+      "cover": "https://www.gutenberg.org/cache/epub/3220/pg3220.cover.medium.jpg"
+    },
+    {
+      "id": 3213,
+      "title": "Mr. Honey's Beginner's Dictionary (English-German)",
+      "authors": [
+        "Honig, Winfried"
+      ],
+      "languages": [
+        "de",
+        "en"
+      ],
+      "download_count": 1838,
+      "cover": "https://www.gutenberg.org/cache/epub/3213/pg3213.cover.medium.jpg"
+    },
+    {
+      "id": 61948,
+      "title": "Mittelniederdeutsches Handwörterbuch",
+      "authors": [
+        "Lübben, August"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1820,
+      "cover": "https://www.gutenberg.org/cache/epub/61948/pg61948.cover.medium.jpg"
+    },
+    {
+      "id": 36901,
+      "title": "Zwischen neun und neun",
+      "authors": [
+        "Perutz, Leo"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1765,
+      "cover": "https://www.gutenberg.org/cache/epub/36901/pg36901.cover.medium.jpg"
+    },
+    {
+      "id": 77678,
+      "title": "Die Zelle und die Gewebe (Vol. 1/2) : $b Grundzüge der allgemeinen Anatomie und Physiologie",
+      "authors": [
+        "Hertwig, Oscar"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1722,
+      "cover": "https://www.gutenberg.org/cache/epub/77678/pg77678.cover.medium.jpg"
+    },
+    {
+      "id": 34265,
+      "title": "Das Anjekind: Eine Erzählung",
+      "authors": [
+        "Bonsels, Waldemar"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1719,
+      "cover": "https://www.gutenberg.org/cache/epub/34265/pg34265.cover.medium.jpg"
+    },
+    {
+      "id": 21021,
+      "title": "Die Biene Maja und ihre Abenteuer",
+      "authors": [
+        "Bonsels, Waldemar"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1713,
+      "cover": "https://www.gutenberg.org/cache/epub/21021/pg21021.cover.medium.jpg"
+    },
+    {
+      "id": 21593,
+      "title": "Das Urteil: Eine Geschichte",
+      "authors": [
+        "Kafka, Franz"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1709,
+      "cover": "https://www.gutenberg.org/cache/epub/21593/pg21593.cover.medium.jpg"
+    },
+    {
+      "id": 37579,
+      "title": "Aufsätze",
+      "authors": [
+        "Walser, Robert"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1701,
+      "cover": "https://www.gutenberg.org/cache/epub/37579/pg37579.cover.medium.jpg"
+    },
+    {
+      "id": 21989,
+      "title": "Ein Landarzt: Kleine Erzählungen",
+      "authors": [
+        "Kafka, Franz"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1672,
+      "cover": "https://www.gutenberg.org/cache/epub/21989/pg21989.cover.medium.jpg"
+    },
+    {
+      "id": 30843,
+      "title": "Massenpsychologie und Ich-Analyse",
+      "authors": [
+        "Freud, Sigmund"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1669,
+      "cover": "https://www.gutenberg.org/cache/epub/30843/pg30843.cover.medium.jpg"
+    },
+    {
+      "id": 24176,
+      "title": "Jakob von Gunten: Ein Tagebuch",
+      "authors": [
+        "Walser, Robert"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1654,
+      "cover": "https://www.gutenberg.org/cache/epub/24176/pg24176.cover.medium.jpg"
+    },
+    {
+      "id": 69327,
+      "title": "Der Prozess: Roman",
+      "authors": [
+        "Kafka, Franz"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1651,
+      "cover": "https://www.gutenberg.org/cache/epub/69327/pg69327.cover.medium.jpg"
+    },
+    {
+      "id": 75802,
+      "title": "Der Steppenwolf",
+      "authors": [
+        "Hesse, Hermann"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1641,
+      "cover": "https://www.gutenberg.org/cache/epub/75802/pg75802.cover.medium.jpg"
+    },
+    {
+      "id": 22570,
+      "title": "Wo Gritlis Kinder hingekommen sind: Geschichten für Kinder und auch für solche, welche die; Kinder lieb haben, 8. Band",
+      "authors": [
+        "Spyri, Johanna"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1634,
+      "cover": "https://www.gutenberg.org/cache/epub/22570/pg22570.cover.medium.jpg"
+    },
+    {
+      "id": 2403,
+      "title": "Die Wahlverwandtschaften",
+      "authors": [
+        "Goethe, Johann Wolfgang von"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1584,
+      "cover": "https://www.gutenberg.org/cache/epub/2403/pg2403.cover.medium.jpg"
+    },
+    {
+      "id": 32763,
+      "title": "Die Nacht der Erfüllung: Erzählungen",
+      "authors": [
+        "Tagore, Rabindranath"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1569,
+      "cover": "https://www.gutenberg.org/cache/epub/32763/pg32763.cover.medium.jpg"
+    },
+    {
+      "id": 3208,
+      "title": "Mr. Honey's Medium Business Dictionary (German-English)",
+      "authors": [
+        "Honig, Winfried"
+      ],
+      "languages": [
+        "de",
+        "en"
+      ],
+      "download_count": 1566,
+      "cover": "https://www.gutenberg.org/cache/epub/3208/pg3208.cover.medium.jpg"
+    },
+    {
+      "id": 65662,
+      "title": "Der Zauberberg. Zweiter Band",
+      "authors": [
+        "Mann, Thomas"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1560,
+      "cover": "https://www.gutenberg.org/cache/epub/65662/pg65662.cover.medium.jpg"
+    },
+    {
+      "id": 23243,
+      "title": "Mister Galgenstrick: und andere Humoresken",
+      "authors": [
+        "Ettlinger, Karl"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1556,
+      "cover": "https://www.gutenberg.org/cache/epub/23243/pg23243.cover.medium.jpg"
+    },
+    {
+      "id": 24817,
+      "title": "Über die Geometrie der alten Aegypter.: Vortrag, gehalten in der feierlichen Sitzung der Kaiserlichen Akademie der Wissenschaften am 29. Mai 1884.",
+      "authors": [
+        "Weyr, Emil"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1548,
+      "cover": "https://www.gutenberg.org/cache/epub/24817/pg24817.cover.medium.jpg"
+    },
+    {
+      "id": 36172,
+      "title": "Geschwister Tanner",
+      "authors": [
+        "Walser, Robert"
+      ],
+      "languages": [
+        "de"
+      ],
+      "download_count": 1546,
+      "cover": "https://www.gutenberg.org/cache/epub/36172/pg36172.cover.medium.jpg"
+    }
+  ],
+  "fr": [
+    {
+      "id": 26296,
+      "title": "Les mille et une nuits, tome premier",
+      "authors": [],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 19180,
+      "cover": "https://www.gutenberg.org/cache/epub/26296/pg26296.cover.medium.jpg"
+    },
+    {
+      "id": 2650,
+      "title": "Du côté de chez Swann",
+      "authors": [
+        "Proust, Marcel"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 9067,
+      "cover": "https://www.gutenberg.org/cache/epub/2650/pg2650.cover.medium.jpg"
+    },
+    {
+      "id": 62215,
+      "title": "Le Fantôme de l'Opéra",
+      "authors": [
+        "Leroux, Gaston"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 9043,
+      "cover": "https://www.gutenberg.org/cache/epub/62215/pg62215.cover.medium.jpg"
+    },
+    {
+      "id": 32854,
+      "title": "Arsène Lupin, gentleman-cambrioleur",
+      "authors": [
+        "Leblanc, Maurice"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 8344,
+      "cover": "https://www.gutenberg.org/cache/epub/32854/pg32854.cover.medium.jpg"
+    },
+    {
+      "id": 28718,
+      "title": "Les crimes de l'amour: Précédé d'un avant-propos, suivi des idées sur les romans, de l'auteur des crimes de l'amour à Villeterque, d'une notice bio-bibliographique du marquis de Sade: l'homme et ses écrits et du discours prononcé par le marquis de Sade à la section des piques.",
+      "authors": [
+        "Sade, marquis de"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 7614,
+      "cover": "https://www.gutenberg.org/cache/epub/28718/pg28718.cover.medium.jpg"
+    },
+    {
+      "id": 20973,
+      "title": "Le tour du monde en quatre-vingts jours",
+      "authors": [
+        "Verne, Jules"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 7257,
+      "cover": "https://www.gutenberg.org/cache/epub/20973/pg20973.cover.medium.jpg"
+    },
+    {
+      "id": 17989,
+      "title": "Le comte de Monte-Cristo, Tome I",
+      "authors": [
+        "Dumas, Alexandre",
+        "Maquet, Auguste"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 7186,
+      "cover": "https://www.gutenberg.org/cache/epub/17989/pg17989.cover.medium.jpg"
+    },
+    {
+      "id": 19919,
+      "title": "Maman Léo: Les Habits Noirs Tome V",
+      "authors": [
+        "Féval, Paul"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 6613,
+      "cover": "https://www.gutenberg.org/cache/epub/19919/pg19919.cover.medium.jpg"
+    },
+    {
+      "id": 17489,
+      "title": "Les misérables Tome I: Fantine",
+      "authors": [
+        "Hugo, Victor"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 6308,
+      "cover": "https://www.gutenberg.org/cache/epub/17489/pg17489.cover.medium.jpg"
+    },
+    {
+      "id": 13951,
+      "title": "Les trois mousquetaires",
+      "authors": [
+        "Dumas, Alexandre",
+        "Maquet, Auguste"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 6079,
+      "cover": "https://www.gutenberg.org/cache/epub/13951/pg13951.cover.medium.jpg"
+    },
+    {
+      "id": 18143,
+      "title": "Roméo et Juliette: Tragédie",
+      "authors": [
+        "Shakespeare, William"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 6038,
+      "cover": "https://www.gutenberg.org/cache/epub/18143/pg18143.cover.medium.jpg"
+    },
+    {
+      "id": 4791,
+      "title": "Voyage au Centre de la Terre",
+      "authors": [
+        "Verne, Jules"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 4669,
+      "cover": "https://www.gutenberg.org/cache/epub/4791/pg4791.cover.medium.jpg"
+    },
+    {
+      "id": 38674,
+      "title": "De la terre à la lune, trajet direct en 97 heures 20 minutes",
+      "authors": [
+        "Verne, Jules"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 4579,
+      "cover": "https://www.gutenberg.org/cache/epub/38674/pg38674.cover.medium.jpg"
+    },
+    {
+      "id": 14287,
+      "title": "L'île mystérieuse",
+      "authors": [
+        "Verne, Jules"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 4549,
+      "cover": "https://www.gutenberg.org/cache/epub/14287/pg14287.cover.medium.jpg"
+    },
+    {
+      "id": 5097,
+      "title": "Vingt mille Lieues Sous Les Mers — Complete",
+      "authors": [
+        "Verne, Jules"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 4461,
+      "cover": "https://www.gutenberg.org/cache/epub/5097/pg5097.cover.medium.jpg"
+    },
+    {
+      "id": 29049,
+      "title": "Histoire amoureuse des Gaules; suivie des Romans historico-satiriques du XVIIe siècle, Tome I",
+      "authors": [
+        "Bussy, Roger de Rabutin, comte de"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 4148,
+      "cover": "https://www.gutenberg.org/cache/epub/29049/pg29049.cover.medium.jpg"
+    },
+    {
+      "id": 23520,
+      "title": "Mon oncle et mon curé; Le voeu de Nadia",
+      "authors": [
+        "La Brète, Jean de"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 3861,
+      "cover": "https://www.gutenberg.org/cache/epub/23520/pg23520.cover.medium.jpg"
+    },
+    {
+      "id": 25575,
+      "title": "Mémoires d'Outre-Tombe, Tome 4",
+      "authors": [
+        "Chateaubriand, François-René, vicomte de"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 3812,
+      "cover": "https://www.gutenberg.org/cache/epub/25575/pg25575.cover.medium.jpg"
+    },
+    {
+      "id": 25335,
+      "title": "Robert Burns. Vol. 1, La Vie",
+      "authors": [
+        "Angellier, Auguste"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 3804,
+      "cover": "https://www.gutenberg.org/cache/epub/25335/pg25335.cover.medium.jpg"
+    },
+    {
+      "id": 20971,
+      "title": "Fables de La Fontaine, livre premier",
+      "authors": [
+        "La Fontaine, Jean de"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 3758,
+      "cover": "https://www.gutenberg.org/cache/epub/20971/pg20971.cover.medium.jpg"
+    },
+    {
+      "id": 78027,
+      "title": "Les enchantements de la forêt",
+      "authors": [
+        "Theuriet, André"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 3755,
+      "cover": "https://www.gutenberg.org/cache/epub/78027/pg78027.cover.medium.jpg"
+    },
+    {
+      "id": 36635,
+      "title": "Amitié amoureuse",
+      "authors": [
+        "Lecomte du Noüy, Hermine Oudinot"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 3685,
+      "cover": "https://www.gutenberg.org/cache/epub/36635/pg36635.cover.medium.jpg"
+    },
+    {
+      "id": 24850,
+      "title": "Lourdes",
+      "authors": [
+        "Zola, Émile"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 3614,
+      "cover": "https://www.gutenberg.org/cache/epub/24850/pg24850.cover.medium.jpg"
+    },
+    {
+      "id": 24766,
+      "title": "Étude Médico-Légale: Psychopathia Sexualis: avec recherches spéciales sur l'inversion sexuelle",
+      "authors": [
+        "Krafft-Ebing, R. von (Richard)"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 3490,
+      "cover": "https://www.gutenberg.org/cache/epub/24766/pg24766.cover.medium.jpg"
+    },
+    {
+      "id": 17518,
+      "title": "Les misérables Tome IV: L'idylle rue Plumet et l'épopée rue Saint-Denis",
+      "authors": [
+        "Hugo, Victor"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 3480,
+      "cover": "https://www.gutenberg.org/cache/epub/17518/pg17518.cover.medium.jpg"
+    },
+    {
+      "id": 15113,
+      "title": "Vie de Jésus",
+      "authors": [
+        "Renan, Ernest"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 3298,
+      "cover": "https://www.gutenberg.org/cache/epub/15113/pg15113.cover.medium.jpg"
+    },
+    {
+      "id": 27573,
+      "title": "Esprit des lois: livres I à V, précédés d'une introduction de l'éditeur",
+      "authors": [
+        "Montesquieu, Charles de Secondat, baron de"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 3244,
+      "cover": "https://www.gutenberg.org/cache/epub/27573/pg27573.cover.medium.jpg"
+    },
+    {
+      "id": 78064,
+      "title": "Lucifer : $b roman moderne",
+      "authors": [
+        "Magre, Maurice"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 3224,
+      "cover": "https://www.gutenberg.org/cache/epub/78064/pg78064.cover.medium.jpg"
+    },
+    {
+      "id": 2419,
+      "title": "La dame aux camélias",
+      "authors": [
+        "Dumas, Alexandre"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 3142,
+      "cover": "https://www.gutenberg.org/cache/epub/2419/pg2419.cover.medium.jpg"
+    },
+    {
+      "id": 33250,
+      "title": "L'art roman dans le Sud-Manche: Album",
+      "authors": [
+        "Lebert, Marie"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 2856,
+      "cover": "https://www.gutenberg.org/cache/epub/33250/pg33250.cover.medium.jpg"
+    },
+    {
+      "id": 14155,
+      "title": "Madame Bovary",
+      "authors": [
+        "Flaubert, Gustave"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 2737,
+      "cover": "https://www.gutenberg.org/cache/epub/14155/pg14155.cover.medium.jpg"
+    },
+    {
+      "id": 25097,
+      "title": "Cités et ruines américaines: Mitla, Palenqué, Izamal, Chichen-Itza, Uxmal",
+      "authors": [
+        "Viollet-le-Duc, Eugène-Emmanuel"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 2697,
+      "cover": "https://www.gutenberg.org/cache/epub/25097/pg25097.cover.medium.jpg"
+    },
+    {
+      "id": 6099,
+      "title": "Les Fleurs du Mal",
+      "authors": [
+        "Baudelaire, Charles"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 2674,
+      "cover": "https://www.gutenberg.org/cache/epub/6099/pg6099.cover.medium.jpg"
+    },
+    {
+      "id": 70891,
+      "title": "Notre-Dame de Paris - Tome 1",
+      "authors": [
+        "Hugo, Victor"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 2667,
+      "cover": "https://www.gutenberg.org/cache/epub/70891/pg70891.cover.medium.jpg"
+    },
+    {
+      "id": 78101,
+      "title": "L'homme à l'Hispano : $b roman",
+      "authors": [
+        "Frondaie, Pierre"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 2649,
+      "cover": "https://www.gutenberg.org/cache/epub/78101/pg78101.cover.medium.jpg"
+    },
+    {
+      "id": 20972,
+      "title": "Histoires ou Contes du temps passé avec des moralités",
+      "authors": [
+        "Perrault, Charles"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 2555,
+      "cover": "https://www.gutenberg.org/cache/epub/20972/pg20972.cover.medium.jpg"
+    },
+    {
+      "id": 78098,
+      "title": "L'art d'aimer: ou conseils à un jeune homme qui se destine à l'amour",
+      "authors": [
+        "Mendès, Catulle"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 2544,
+      "cover": "https://www.gutenberg.org/cache/epub/78098/pg78098.cover.medium.jpg"
+    },
+    {
+      "id": 66897,
+      "title": "Amours d'Extrême-Orient: Illustrations d'après nature par Amédée Vignola",
+      "authors": [
+        "Diraison-Seylor, Olivier"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 2528,
+      "cover": "https://www.gutenberg.org/cache/epub/66897/pg66897.cover.medium.jpg"
+    },
+    {
+      "id": 78059,
+      "title": "L'homme tout nu",
+      "authors": [
+        "Mendès, Catulle"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 2476,
+      "cover": "https://www.gutenberg.org/cache/epub/78059/pg78059.cover.medium.jpg"
+    },
+    {
+      "id": 78080,
+      "title": "Journal de la société de 1789 - Nº II",
+      "authors": [
+        "Condorcet, Jean-Antoine-Nicolas de Caritat, marquis de",
+        "Grouvelle, Philippe-Antoine",
+        "Hassenfratz, J. H. (Jean-Henri)",
+        "Pressac de la Chagnaye, Louis-François-Dominique-Norbert"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 2428,
+      "cover": "https://www.gutenberg.org/cache/epub/78080/pg78080.cover.medium.jpg"
+    },
+    {
+      "id": 78074,
+      "title": "Chroniques de J. Froissart, tome 09/13 : $b 1377-1380 (Depuis la prise de Bergerac jusqu'à la mort de Charles V)",
+      "authors": [
+        "Froissart, Jean"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 2395,
+      "cover": "https://www.gutenberg.org/cache/epub/78074/pg78074.cover.medium.jpg"
+    },
+    {
+      "id": 78069,
+      "title": "Deux générations",
+      "authors": [
+        "Tolstoy, Leo, graf"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 2389,
+      "cover": "https://www.gutenberg.org/cache/epub/78069/pg78069.cover.medium.jpg"
+    },
+    {
+      "id": 19657,
+      "title": "Notre-Dame de Paris",
+      "authors": [
+        "Hugo, Victor"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 2283,
+      "cover": "https://www.gutenberg.org/cache/epub/19657/pg19657.cover.medium.jpg"
+    },
+    {
+      "id": 78063,
+      "title": "Le jeune Européen",
+      "authors": [
+        "Drieu La Rochelle, Pierre"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 2231,
+      "cover": "https://www.gutenberg.org/cache/epub/78063/pg78063.cover.medium.jpg"
+    },
+    {
+      "id": 21804,
+      "title": "Aventures d'un Gentilhomme Breton aux îles Philippines",
+      "authors": [
+        "La Gironière, Paul P. de"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 2212,
+      "cover": "https://www.gutenberg.org/cache/epub/21804/pg21804.cover.medium.jpg"
+    },
+    {
+      "id": 78041,
+      "title": "En pays lointain",
+      "authors": [
+        "London, Jack"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 2197,
+      "cover": "https://www.gutenberg.org/cache/epub/78041/pg78041.cover.medium.jpg"
+    },
+    {
+      "id": 78021,
+      "title": "L'imposture",
+      "authors": [
+        "Bernanos, Georges"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 2171,
+      "cover": "https://www.gutenberg.org/cache/epub/78021/pg78021.cover.medium.jpg"
+    },
+    {
+      "id": 78036,
+      "title": "Quand le rideau s'est baissé",
+      "authors": [
+        "Mille, Pierre"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 2150,
+      "cover": "https://www.gutenberg.org/cache/epub/78036/pg78036.cover.medium.jpg"
+    },
+    {
+      "id": 22751,
+      "title": "Littérature Française (Première Année) : $b Moyen-Âge, Renaissance, Dix-Septième Siècle",
+      "authors": [
+        "Aubert, Eugène"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1958,
+      "cover": "https://www.gutenberg.org/cache/epub/22751/pg22751.cover.medium.jpg"
+    },
+    {
+      "id": 27035,
+      "title": "Entretiens / Interviews / Entrevistas",
+      "authors": [
+        "Lebert, Marie"
+      ],
+      "languages": [
+        "en",
+        "es",
+        "fr"
+      ],
+      "download_count": 1949,
+      "cover": "https://www.gutenberg.org/cache/epub/27035/pg27035.cover.medium.jpg"
+    },
+    {
+      "id": 57656,
+      "title": "Dictionnaire d'argot fin-de-siècle",
+      "authors": [
+        "Virmaître, Charles"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1923,
+      "cover": "https://www.gutenberg.org/cache/epub/57656/pg57656.cover.medium.jpg"
+    },
+    {
+      "id": 13846,
+      "title": "Discours de la méthode",
+      "authors": [
+        "Descartes, René"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1914,
+      "cover": "https://www.gutenberg.org/cache/epub/13846/pg13846.cover.medium.jpg"
+    },
+    {
+      "id": 36708,
+      "title": "Soeur Thérèse de l'Enfant-Jésus et de la Sainte Face: Histoire d'une âme écrite par elle-même",
+      "authors": [
+        "Thérèse, de Lisieux, Saint"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1913,
+      "cover": "https://www.gutenberg.org/cache/epub/36708/pg36708.cover.medium.jpg"
+    },
+    {
+      "id": 52006,
+      "title": "Les liaisons dangereuses: Lettres recueillies dans une Société et publiées pour l'instruction de quelques autres",
+      "authors": [
+        "Laclos, Choderlos de"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1902,
+      "cover": "https://www.gutenberg.org/cache/epub/52006/pg52006.cover.medium.jpg"
+    },
+    {
+      "id": 78226,
+      "title": "La région du Tchad et du Ouadaï; études ethnographiques, dialecte Toubou, Tome 1 (de 2)",
+      "authors": [
+        "Carbou, Henri"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1893,
+      "cover": "https://www.gutenberg.org/cache/epub/78226/pg78226.cover.medium.jpg"
+    },
+    {
+      "id": 48852,
+      "title": "Le parler populaire des Canadiens français: ou, Lexique des canadianismes, acadianismes, anglicismes, américanismes, mots anglais les plus en usage au sein des familles canadiennes et acadiennes françaises",
+      "authors": [
+        "Dionne, N.-E. (Narcisse-Eutrope)"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1808,
+      "cover": "https://www.gutenberg.org/cache/epub/48852/pg48852.cover.medium.jpg"
+    },
+    {
+      "id": 22039,
+      "title": "Madame Thérèse: Introduction and notes by Edward Manley",
+      "authors": [
+        "Erckmann-Chatrian"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1805,
+      "cover": "https://www.gutenberg.org/cache/epub/22039/pg22039.cover.medium.jpg"
+    },
+    {
+      "id": 24768,
+      "title": "Abrégé de l'Histoire Générale des Voyages (Tome 2)",
+      "authors": [
+        "La Harpe, Jean-François de"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1781,
+      "cover": "https://www.gutenberg.org/cache/epub/24768/pg24768.cover.medium.jpg"
+    },
+    {
+      "id": 4650,
+      "title": "Candide, ou l'optimisme",
+      "authors": [
+        "Voltaire"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1762,
+      "cover": "https://www.gutenberg.org/cache/epub/4650/pg4650.cover.medium.jpg"
+    },
+    {
+      "id": 32298,
+      "title": "Anciennes loix des François conservées dans les coutumes angloises recueillies par Littleton, Vol. II",
+      "authors": [
+        "Littleton, Thomas, Sir",
+        "Hoüard, David"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1751,
+      "cover": "https://www.gutenberg.org/cache/epub/32298/pg32298.cover.medium.jpg"
+    },
+    {
+      "id": 64830,
+      "title": "Mémoires de Miss Coote: Exploits d'une fouetteuse britannique racontés par elle-même",
+      "authors": [
+        "Coote, Rosa Belinda"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1734,
+      "cover": "https://www.gutenberg.org/cache/epub/64830/pg64830.cover.medium.jpg"
+    },
+    {
+      "id": 61565,
+      "title": "L'Oeuvre Poètique de Charles Baudelaire: Les Fleurs du Mal",
+      "authors": [
+        "Baudelaire, Charles"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1702,
+      "cover": "https://www.gutenberg.org/cache/epub/61565/pg61565.cover.medium.jpg"
+    },
+    {
+      "id": 33931,
+      "title": "Popular Tales",
+      "authors": [
+        "Perrault, Charles"
+      ],
+      "languages": [
+        "en",
+        "fr"
+      ],
+      "download_count": 1690,
+      "cover": "https://www.gutenberg.org/cache/epub/33931/pg33931.cover.medium.jpg"
+    },
+    {
+      "id": 28788,
+      "title": "Jeux et exercices des jeunes filles",
+      "authors": [
+        "Du Parquet, Marguerite, active 19th century"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1687,
+      "cover": "https://www.gutenberg.org/cache/epub/28788/pg28788.cover.medium.jpg"
+    },
+    {
+      "id": 17494,
+      "title": "Les misérables Tome III: Marius",
+      "authors": [
+        "Hugo, Victor"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1681,
+      "cover": "https://www.gutenberg.org/cache/epub/17494/pg17494.cover.medium.jpg"
+    },
+    {
+      "id": 48529,
+      "title": "Essais de Montaigne (self-édition) - Volume I",
+      "authors": [
+        "Montaigne, Michel de"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1681,
+      "cover": "https://www.gutenberg.org/cache/epub/48529/pg48529.cover.medium.jpg"
+    },
+    {
+      "id": 16816,
+      "title": "Le roman de la rose - Tome I",
+      "authors": [
+        "Guillaume, de Lorris",
+        "Jean, de Meun"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1671,
+      "cover": "https://www.gutenberg.org/cache/epub/16816/pg16816.cover.medium.jpg"
+    },
+    {
+      "id": 22813,
+      "title": "La Mère de la Marquise",
+      "authors": [
+        "About, Edmond"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1660,
+      "cover": "https://www.gutenberg.org/cache/epub/22813/pg22813.cover.medium.jpg"
+    },
+    {
+      "id": 12949,
+      "title": "Contes Français",
+      "authors": [],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1599,
+      "cover": "https://www.gutenberg.org/cache/epub/12949/pg12949.cover.medium.jpg"
+    },
+    {
+      "id": 54482,
+      "title": "Dictionnaire de la langue verte",
+      "authors": [
+        "Delvau, Alfred"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1580,
+      "cover": "https://www.gutenberg.org/cache/epub/54482/pg54482.cover.medium.jpg"
+    },
+    {
+      "id": 798,
+      "title": "Le rouge et le noir: chronique du XIXe siècle",
+      "authors": [
+        "Stendhal"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1578,
+      "cover": "https://www.gutenberg.org/cache/epub/798/pg798.cover.medium.jpg"
+    },
+    {
+      "id": 43901,
+      "title": "Lettres de Madame de Sévigné: Précédées d'une notice sur sa vie et du traité sur le style épistolaire de Madame de Sévigné",
+      "authors": [
+        "Sévigné, Marie de Rabutin-Chantal, marquise de"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1575,
+      "cover": "https://www.gutenberg.org/cache/epub/43901/pg43901.cover.medium.jpg"
+    },
+    {
+      "id": 17519,
+      "title": "Les misérables Tome V: Jean Valjean",
+      "authors": [
+        "Hugo, Victor"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1559,
+      "cover": "https://www.gutenberg.org/cache/epub/17519/pg17519.cover.medium.jpg"
+    },
+    {
+      "id": 17899,
+      "title": "Poésies choisies de André Chénier",
+      "authors": [
+        "Chénier, André"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1551,
+      "cover": "https://www.gutenberg.org/cache/epub/17899/pg17899.cover.medium.jpg"
+    },
+    {
+      "id": 71062,
+      "title": "Charmes",
+      "authors": [
+        "Valéry, Paul"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1547,
+      "cover": "https://www.gutenberg.org/cache/epub/71062/pg71062.cover.medium.jpg"
+    },
+    {
+      "id": 56327,
+      "title": "Fables de La Fontaine",
+      "authors": [
+        "La Fontaine, Jean de"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1527,
+      "cover": "https://www.gutenberg.org/cache/epub/56327/pg56327.cover.medium.jpg"
+    },
+    {
+      "id": 53082,
+      "title": "Les apôtres",
+      "authors": [
+        "Renan, Ernest"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1499,
+      "cover": "https://www.gutenberg.org/cache/epub/53082/pg53082.cover.medium.jpg"
+    },
+    {
+      "id": 19631,
+      "title": "Épigramme",
+      "authors": [
+        "Maynard, François de"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1494,
+      "cover": "https://www.gutenberg.org/cache/epub/19631/pg19631.cover.medium.jpg"
+    },
+    {
+      "id": 55569,
+      "title": "Calligrammes: Poèmes de la paix et de la guerre (1913-1916)",
+      "authors": [
+        "Apollinaire, Guillaume"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1462,
+      "cover": "https://www.gutenberg.org/cache/epub/55569/pg55569.cover.medium.jpg"
+    },
+    {
+      "id": 70954,
+      "title": "Trois femmes",
+      "authors": [
+        "Mille, Pierre"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1442,
+      "cover": "https://www.gutenberg.org/cache/epub/70954/pg70954.cover.medium.jpg"
+    },
+    {
+      "id": 39429,
+      "title": "Histoire du moyen âge 395-1270",
+      "authors": [
+        "Langlois, Charles Victor"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1431,
+      "cover": "https://www.gutenberg.org/cache/epub/39429/pg39429.cover.medium.jpg"
+    },
+    {
+      "id": 8591,
+      "title": "French Lyrics",
+      "authors": [],
+      "languages": [
+        "en",
+        "fr"
+      ],
+      "download_count": 1392,
+      "cover": "https://www.gutenberg.org/cache/epub/8591/pg8591.cover.medium.jpg"
+    },
+    {
+      "id": 25378,
+      "title": "Les Contemporains, 3ème Série: Études et Portraits Littéraires",
+      "authors": [
+        "Lemaître, Jules"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1380,
+      "cover": "https://www.gutenberg.org/cache/epub/25378/pg25378.cover.medium.jpg"
+    },
+    {
+      "id": 45150,
+      "title": "Dictionnaire érotique moderne",
+      "authors": [
+        "Delvau, Alfred"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1371,
+      "cover": "https://www.gutenberg.org/cache/epub/45150/pg45150.cover.medium.jpg"
+    },
+    {
+      "id": 71280,
+      "title": "Lexicon Latinum : $b Universae phraseologiae corpus congestum etc.",
+      "authors": [
+        "Wagner, Franz"
+      ],
+      "languages": [
+        "fr",
+        "la"
+      ],
+      "download_count": 1367,
+      "cover": "https://www.gutenberg.org/cache/epub/71280/pg71280.cover.medium.jpg"
+    },
+    {
+      "id": 30781,
+      "title": "Dictionnaire raisonné de l'architecture française du XIe au XVIe siècle - Tome 1 - (A)",
+      "authors": [
+        "Viollet-le-Duc, Eugène-Emmanuel"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1343,
+      "cover": "https://www.gutenberg.org/cache/epub/30781/pg30781.cover.medium.jpg"
+    },
+    {
+      "id": 44354,
+      "title": "Dictionnaire de nos fautes contre la langue française",
+      "authors": [
+        "Rinfret, Raoul"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1343,
+      "cover": "https://www.gutenberg.org/cache/epub/44354/pg44354.cover.medium.jpg"
+    },
+    {
+      "id": 11748,
+      "title": "French Conversation and Composition",
+      "authors": [
+        "Wann, Harry Vincent"
+      ],
+      "languages": [
+        "en",
+        "fr"
+      ],
+      "download_count": 1337,
+      "cover": "https://www.gutenberg.org/cache/epub/11748/pg11748.cover.medium.jpg"
+    },
+    {
+      "id": 21825,
+      "title": "L'automne d'une femme",
+      "authors": [
+        "Prévost, Marcel"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1333,
+      "cover": "https://www.gutenberg.org/cache/epub/21825/pg21825.cover.medium.jpg"
+    },
+    {
+      "id": 43851,
+      "title": "La Comédie humaine - Volume 02",
+      "authors": [
+        "Balzac, Honoré de"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1330,
+      "cover": "https://www.gutenberg.org/cache/epub/43851/pg43851.cover.medium.jpg"
+    },
+    {
+      "id": 54182,
+      "title": "Journal d'un bourgeois de Paris, 1405-1449",
+      "authors": [],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1301,
+      "cover": "https://www.gutenberg.org/cache/epub/54182/pg54182.cover.medium.jpg"
+    },
+    {
+      "id": 23654,
+      "title": "Mémoires d'Outre-Tombe, Tome 2",
+      "authors": [
+        "Chateaubriand, François-René, vicomte de"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1294,
+      "cover": "https://www.gutenberg.org/cache/epub/23654/pg23654.cover.medium.jpg"
+    },
+    {
+      "id": 14192,
+      "title": "Le portrait de Dorian Gray",
+      "authors": [
+        "Wilde, Oscar"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1290,
+      "cover": "https://www.gutenberg.org/cache/epub/14192/pg14192.cover.medium.jpg"
+    },
+    {
+      "id": 22741,
+      "title": "Physiologie du goût",
+      "authors": [
+        "Brillat-Savarin"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1290,
+      "cover": "https://www.gutenberg.org/cache/epub/22741/pg22741.cover.medium.jpg"
+    },
+    {
+      "id": 10775,
+      "title": "Le Horla",
+      "authors": [
+        "Maupassant, Guy de"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1288,
+      "cover": "https://www.gutenberg.org/cache/epub/10775/pg10775.cover.medium.jpg"
+    },
+    {
+      "id": 1256,
+      "title": "Cyrano de Bergerac",
+      "authors": [
+        "Rostand, Edmond"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1277,
+      "cover": "https://www.gutenberg.org/cache/epub/1256/pg1256.cover.medium.jpg"
+    },
+    {
+      "id": 46183,
+      "title": "La maison d'un artiste, Tome 1",
+      "authors": [
+        "Goncourt, Edmond de"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1235,
+      "cover": "https://www.gutenberg.org/cache/epub/46183/pg46183.cover.medium.jpg"
+    },
+    {
+      "id": 25382,
+      "title": "Facecies et motz subtilz, d'aucuns excellens esprits et tresnobles seigneurs",
+      "authors": [
+        "Domenichi, Lodovico"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1216,
+      "cover": "https://www.gutenberg.org/cache/epub/25382/pg25382.cover.medium.jpg"
+    },
+    {
+      "id": 23098,
+      "title": "La Femme Abbé",
+      "authors": [
+        "Maréchal, Sylvain"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1205,
+      "cover": "https://www.gutenberg.org/cache/epub/23098/pg23098.cover.medium.jpg"
+    },
+    {
+      "id": 5423,
+      "title": "L'homme Qui Rit",
+      "authors": [
+        "Hugo, Victor"
+      ],
+      "languages": [
+        "fr"
+      ],
+      "download_count": 1203,
+      "cover": "https://www.gutenberg.org/cache/epub/5423/pg5423.cover.medium.jpg"
+    }
+  ],
+  "ja": [
+    {
+      "id": 35018,
+      "title": "雲形紋章",
+      "authors": [
+        "Falkner, John Meade"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 4470,
+      "cover": "https://www.gutenberg.org/cache/epub/35018/pg35018.cover.medium.jpg"
+    },
+    {
+      "id": 41325,
+      "title": "幽霊書店",
+      "authors": [
+        "Morley, Christopher"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 1363,
+      "cover": "https://www.gutenberg.org/cache/epub/41325/pg41325.cover.medium.jpg"
+    },
+    {
+      "id": 20683,
+      "title": "奥の細道",
+      "authors": [
+        "Matsuo, Bashō"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 1138,
+      "cover": "https://www.gutenberg.org/cache/epub/20683/pg20683.cover.medium.jpg"
+    },
+    {
+      "id": 34158,
+      "title": "入れかわった男",
+      "authors": [
+        "Oppenheim, E. Phillips (Edward Phillips)"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 1066,
+      "cover": "https://www.gutenberg.org/cache/epub/34158/pg34158.cover.medium.jpg"
+    },
+    {
+      "id": 36459,
+      "title": "羹",
+      "authors": [
+        "Tanizaki, Jun'ichiro"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 961,
+      "cover": "https://www.gutenberg.org/cache/epub/36459/pg36459.cover.medium.jpg"
+    },
+    {
+      "id": 35327,
+      "title": "あめりか物語",
+      "authors": [
+        "Nagai, Kafu"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 881,
+      "cover": "https://www.gutenberg.org/cache/epub/35327/pg35327.cover.medium.jpg"
+    },
+    {
+      "id": 32978,
+      "title": "下宿人",
+      "authors": [
+        "Lowndes, Marie Belloc"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 862,
+      "cover": "https://www.gutenberg.org/cache/epub/32978/pg32978.cover.medium.jpg"
+    },
+    {
+      "id": 31617,
+      "title": "刺靑",
+      "authors": [
+        "Tanizaki, Jun'ichiro"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 761,
+      "cover": "https://www.gutenberg.org/cache/epub/31617/pg31617.cover.medium.jpg"
+    },
+    {
+      "id": 1982,
+      "title": "羅生門",
+      "authors": [
+        "Akutagawa, Ryūnosuke"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 750,
+      "cover": "https://www.gutenberg.org/cache/epub/1982/pg1982.cover.medium.jpg"
+    },
+    {
+      "id": 31757,
+      "title": "お目出たき人",
+      "authors": [
+        "Mushanokoji, Saneatsu"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 681,
+      "cover": "https://www.gutenberg.org/cache/epub/31757/pg31757.cover.medium.jpg"
+    },
+    {
+      "id": 32941,
+      "title": "何處へ",
+      "authors": [
+        "Masamune, Hakuchō"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 656,
+      "cover": "https://www.gutenberg.org/cache/epub/32941/pg32941.cover.medium.jpg"
+    },
+    {
+      "id": 33307,
+      "title": "友情",
+      "authors": [
+        "Mushanokoji, Saneatsu"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 653,
+      "cover": "https://www.gutenberg.org/cache/epub/33307/pg33307.cover.medium.jpg"
+    },
+    {
+      "id": 34636,
+      "title": "腕くらべ",
+      "authors": [
+        "Nagai, Kafu"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 646,
+      "cover": "https://www.gutenberg.org/cache/epub/34636/pg34636.cover.medium.jpg"
+    },
+    {
+      "id": 36358,
+      "title": "火星の記憶",
+      "authors": [
+        "Jones, Raymond F."
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 567,
+      "cover": "https://www.gutenberg.org/cache/epub/36358/pg36358.cover.medium.jpg"
+    },
+    {
+      "id": 34084,
+      "title": "法螺男爵旅土産",
+      "authors": [
+        "Sasaki, Kuni"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 515,
+      "cover": "https://www.gutenberg.org/cache/epub/34084/pg34084.cover.medium.jpg"
+    },
+    {
+      "id": 39287,
+      "title": "苦悶の欄",
+      "authors": [
+        "Biggers, Earl Derr"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 505,
+      "cover": "https://www.gutenberg.org/cache/epub/39287/pg39287.cover.medium.jpg"
+    },
+    {
+      "id": 38697,
+      "title": "殉情詩集",
+      "authors": [
+        "Sato, Haruo"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 484,
+      "cover": "https://www.gutenberg.org/cache/epub/38697/pg38697.cover.medium.jpg"
+    },
+    {
+      "id": 36976,
+      "title": "裁判",
+      "authors": [
+        "Rice, Elmer"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 453,
+      "cover": "https://www.gutenberg.org/cache/epub/36976/pg36976.cover.medium.jpg"
+    },
+    {
+      "id": 34013,
+      "title": "血笑記",
+      "authors": [
+        "Andreyev, Leonid"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 445,
+      "cover": "https://www.gutenberg.org/cache/epub/34013/pg34013.cover.medium.jpg"
+    },
+    {
+      "id": 2592,
+      "title": "マルチン・ルターの小信仰問答書",
+      "authors": [
+        "Luther, Martin"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 418,
+      "cover": "https://www.gutenberg.org/cache/epub/2592/pg2592.cover.medium.jpg"
+    },
+    {
+      "id": 37605,
+      "title": "惡魔",
+      "authors": [
+        "Tanizaki, Jun'ichiro"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 414,
+      "cover": "https://www.gutenberg.org/cache/epub/37605/pg37605.cover.medium.jpg"
+    },
+    {
+      "id": 37626,
+      "title": "續惡魔",
+      "authors": [
+        "Tanizaki, Jun'ichiro"
+      ],
+      "languages": [
+        "ja"
+      ],
+      "download_count": 396,
+      "cover": "https://www.gutenberg.org/cache/epub/37626/pg37626.cover.medium.jpg"
+    }
+  ]
+}

--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -53,7 +53,11 @@ async def popular_books(
     page: int = Query(1, ge=1),
     per_page: int = Query(50, ge=1, le=200),
 ):
-    """Return a paginated slice of the curated popular Gutenberg books manifest."""
+    """Return a paginated slice of the curated popular Gutenberg books manifest.
+
+    The manifest is either the new dict format {language: [books]} produced by
+    seed_books.py --collections, or the legacy flat list.
+    """
     global _popular_cache
     if _popular_cache is None:
         if not os.path.isfile(_POPULAR_BOOKS_PATH):
@@ -61,15 +65,19 @@ async def popular_books(
         with open(_POPULAR_BOOKS_PATH, encoding="utf-8") as f:
             _popular_cache = json.load(f)
 
-    filtered = (
-        [b for b in _popular_cache if language in b.get("languages", [])]
-        if language
-        else _popular_cache
-    )
-    total = len(filtered)
+    if isinstance(_popular_cache, dict):
+        books = _popular_cache.get(language, _popular_cache.get("", []))
+    else:
+        books = (
+            [b for b in _popular_cache if language in b.get("languages", [])]
+            if language
+            else _popular_cache
+        )
+
+    total = len(books)
     start = (page - 1) * per_page
     return {
-        "books": filtered[start : start + per_page],
+        "books": books[start : start + per_page],
         "total": total,
         "page": page,
         "per_page": per_page,

--- a/backend/scripts/seed_books.py
+++ b/backend/scripts/seed_books.py
@@ -32,6 +32,16 @@ GUTENDEX_API = "https://gutendex.com/books"
 DEFAULT_LANGUAGES = ["en", "de", "fr"]
 DEFAULT_COUNT = 100  # total across all languages
 
+# Collections for the Discover page: language code → number of books to fetch.
+# Empty string "" means all-language (no language filter, global popularity).
+COLLECTIONS: dict[str, int] = {
+    "": 200,
+    "en": 200,
+    "de": 100,
+    "fr": 100,
+    "ja": 100,
+}
+
 
 def _get_text_url(formats: dict) -> str:
     """Extract the plain-text download URL from Gutendex formats."""
@@ -42,16 +52,17 @@ def _get_text_url(formats: dict) -> str:
 
 
 async def fetch_popular(language: str, count: int) -> list[dict]:
-    """Fetch the top `count` most-downloaded books for a language from Gutendex."""
+    """Fetch the top `count` most-downloaded books for a language from Gutendex.
+
+    Pass language="" to fetch across all languages (global popularity ranking).
+    """
     books = []
     page = 1
     async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
         while len(books) < count:
-            params = {
-                "languages": language,
-                "sort": "popular",
-                "page": page,
-            }
+            params: dict = {"sort": "popular", "page": page}
+            if language:
+                params["languages"] = language
             try:
                 resp = await client.get(GUTENDEX_API, params=params)
                 resp.raise_for_status()
@@ -167,6 +178,35 @@ async def seed(languages: list[str], total_count: int, dry_run: bool = False, ma
     return all_books
 
 
+def _to_entry(b: dict) -> dict:
+    return {
+        "id": b["id"],
+        "title": b["title"],
+        "authors": b["authors"],
+        "languages": b["languages"],
+        "download_count": b["download_count"],
+        "cover": b.get("cover", ""),
+    }
+
+
+async def build_collections_manifest() -> dict[str, list[dict]]:
+    """Fetch each language collection from Gutendex and return a manifest dict.
+
+    Keys are language codes ("" = all-language global ranking).
+    Values are lists of book metadata sorted by download_count descending.
+    Focuses on classic literature via Gutendex's popularity ranking, which
+    naturally surfaces canonical public-domain works (Austen, Dickens, Goethe…).
+    """
+    manifest: dict[str, list[dict]] = {}
+    for lang, count in COLLECTIONS.items():
+        label = lang.upper() if lang else "ALL"
+        print(f"── {label} ({count} books) ──")
+        books = await fetch_popular(lang, count)
+        print(f"  Fetched {len(books)} books")
+        manifest[lang] = [_to_entry(b) for b in books]
+    return manifest
+
+
 def main():
     parser = argparse.ArgumentParser(description="Seed the database with popular Gutenberg books")
     parser.add_argument("--count", type=int, default=DEFAULT_COUNT,
@@ -181,7 +221,21 @@ def main():
     parser.add_argument("--manifest-only", action="store_true",
                         help="Fetch metadata from Gutendex and write popular_books.json only; "
                              "skip downloading full text to the database.")
+    parser.add_argument("--collections", action="store_true",
+                        help="Build the multi-language collections manifest used by the Discover "
+                             "page (all/en/de/fr/ja). Implies --manifest-only.")
     args = parser.parse_args()
+
+    manifest_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "popular_books.json")
+
+    if args.collections:
+        print("Building multi-language collections manifest…\n")
+        manifest = asyncio.run(build_collections_manifest())
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(manifest, f, ensure_ascii=False, indent=2)
+        total = sum(len(v) for v in manifest.values())
+        print(f"\nManifest written to {manifest_path} ({len(manifest)} collections, {total} entries)")
+        return
 
     languages = [l.strip() for l in args.languages.split(",")]
     books = asyncio.run(seed(languages, args.count, args.dry_run, args.manifest_only))
@@ -190,35 +244,26 @@ def main():
     if args.dry_run:
         return
 
-    # Write a JSON manifest for the frontend "Popular Books" page
-    manifest_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "popular_books.json")
-    new_entries = [
-        {
-            "id": b["id"],
-            "title": b["title"],
-            "authors": b["authors"],
-            "languages": b["languages"],
-            "download_count": b["download_count"],
-            "cover": b.get("cover", ""),
-        }
-        for b in books
-    ]
+    # Write a flat JSON manifest (legacy format used for DB seeding)
+    new_entries = [_to_entry(b) for b in books]
 
     if args.append and os.path.isfile(manifest_path):
         with open(manifest_path, encoding="utf-8") as f:
             existing = json.load(f)
-        by_id: dict[int, dict] = {b["id"]: b for b in existing}
-        for entry in new_entries:
-            by_id[entry["id"]] = entry   # overwrite if duplicate ID
-        manifest = list(by_id.values())
-        # Keep popularity ordering across the merged set
-        manifest.sort(key=lambda x: x.get("download_count", 0), reverse=True)
+        if isinstance(existing, list):
+            by_id: dict[int, dict] = {b["id"]: b for b in existing}
+            for entry in new_entries:
+                by_id[entry["id"]] = entry
+            manifest_list = list(by_id.values())
+            manifest_list.sort(key=lambda x: x.get("download_count", 0), reverse=True)
+        else:
+            manifest_list = new_entries
     else:
-        manifest = new_entries
+        manifest_list = new_entries
 
     with open(manifest_path, "w", encoding="utf-8") as f:
-        json.dump(manifest, f, ensure_ascii=False, indent=2)
-    print(f"Manifest written to {manifest_path} ({len(manifest)} books)")
+        json.dump(manifest_list, f, ensure_ascii=False, indent=2)
+    print(f"Manifest written to {manifest_path} ({len(manifest_list)} books)")
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -97,25 +97,26 @@ async def test_search_delegates_to_gutenberg(client):
 
 # ── /books/popular pagination ────────────────────────────────────────────────
 
-POPULAR_BOOKS = [
-    {
-        "id": i,
-        "title": f"Book {i}",
-        "authors": [f"Author {i}"],
-        "languages": ["en"],
-        "download_count": i * 100,
-        "cover": "",
-    }
-    for i in range(1, 121)
-]
+def _make_books(start: int, count: int, lang: str = "en") -> list[dict]:
+    return [
+        {"id": start + i, "title": f"Book {start + i}", "authors": [f"Author {start + i}"],
+         "languages": [lang], "download_count": (start + i) * 100, "cover": ""}
+        for i in range(count)
+    ]
 
+
+POPULAR_CACHE_DICT = {
+    "": _make_books(1, 120),        # 120 all-language books
+    "en": _make_books(1, 120),      # same for English in this fixture
+    "de": _make_books(200, 30),     # 30 German books
+}
 
 import routers.books as _books_router
 
 
 @pytest.fixture(autouse=False)
 def popular_cache(monkeypatch):
-    monkeypatch.setattr(_books_router, "_popular_cache", list(POPULAR_BOOKS))
+    monkeypatch.setattr(_books_router, "_popular_cache", POPULAR_CACHE_DICT)
     yield
     monkeypatch.setattr(_books_router, "_popular_cache", None)
 
@@ -146,6 +147,21 @@ async def test_popular_books_last_page(client, popular_cache):
     data = resp.json()
     assert data["page"] == 3
     assert len(data["books"]) == 20
+
+
+async def test_popular_books_language_filter(client, popular_cache):
+    resp = await client.get("/api/books/popular?language=de")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 30
+    assert data["books"][0]["id"] == 200
+
+
+async def test_popular_books_unknown_language_falls_back_to_all(client, popular_cache):
+    resp = await client.get("/api/books/popular?language=xx")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 120  # falls back to "" collection
 
 
 async def test_popular_books_empty_when_no_manifest(client):

--- a/frontend/src/__tests__/discoverPopular.test.tsx
+++ b/frontend/src/__tests__/discoverPopular.test.tsx
@@ -44,7 +44,7 @@ function makeBook(id: number) {
   };
 }
 
-function makePopularResponse(page: number, total = 120, perPage = 50) {
+function makePopularResponse(page: number, total = 200, perPage = 50) {
   const start = (page - 1) * perPage;
   const books = Array.from({ length: Math.min(perPage, total - start) }, (_, i) =>
     makeBook(start + i + 1)
@@ -60,7 +60,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   mockGetMe.mockResolvedValue({ role: "user" });
-  mockGetPopularBooks.mockResolvedValue(makePopularResponse(1));
+  mockGetPopularBooks.mockResolvedValue(makePopularResponse(1)); // default: 200 total, 4 pages
 });
 
 afterEach(() => {
@@ -72,7 +72,47 @@ const flushPromises = () => new Promise((r) => setTimeout(r, 0));
 async function renderDiscover() {
   render(<Home />);
   await act(flushPromises);
+  await act(flushPromises); // second flush: tab→"discover" triggers popular books effect
 }
+
+describe("Popular Classics – language filter", () => {
+  it("shows All/English/Deutsch/Français/日本語 tabs", async () => {
+    await renderDiscover();
+    expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "English" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Deutsch" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Français" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "日本語" })).toBeInTheDocument();
+  });
+
+  it("clicking a language tab fetches with that language and resets to page 1", async () => {
+    const user = userEvent.setup();
+    mockGetPopularBooks
+      .mockResolvedValueOnce(makePopularResponse(1, 120))  // initial load (All)
+      .mockResolvedValueOnce(makePopularResponse(1, 200)); // English tab
+    await renderDiscover();
+    await user.click(screen.getByRole("button", { name: "English" }));
+    await act(flushPromises);
+    expect(mockGetPopularBooks).toHaveBeenCalledWith("en", 1);
+  });
+
+  it("language change resets pagination to page 1", async () => {
+    const user = userEvent.setup();
+    mockGetPopularBooks
+      .mockResolvedValueOnce(makePopularResponse(1))       // initial All
+      .mockResolvedValueOnce(makePopularResponse(2))       // page 2
+      .mockResolvedValueOnce(makePopularResponse(1, 100)); // German page 1
+    await renderDiscover();
+    // Go to page 2
+    await user.click(screen.getByRole("button", { name: /Next/i }));
+    await act(flushPromises);
+    expect(screen.getByText("Page 2 of 4")).toBeInTheDocument();
+    // Switch language → should reset to page 1
+    await user.click(screen.getByRole("button", { name: "Deutsch" }));
+    await act(flushPromises);
+    expect(mockGetPopularBooks).toHaveBeenLastCalledWith("de", 1);
+  });
+});
 
 describe("Popular Classics – view toggle", () => {
   it("renders grid view by default", async () => {
@@ -114,7 +154,7 @@ describe("Popular Classics – view toggle", () => {
 describe("Popular Classics – pagination", () => {
   it("shows pagination when total > per_page", async () => {
     await renderDiscover();
-    expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
+    expect(screen.getByText("Page 1 of 4")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Next/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Prev/i })).toBeDisabled();
   });
@@ -133,8 +173,8 @@ describe("Popular Classics – pagination", () => {
     await renderDiscover();
     await user.click(screen.getByRole("button", { name: /Next/i }));
     await act(flushPromises);
-    expect(mockGetPopularBooks).toHaveBeenCalledWith(2);
-    expect(screen.getByText("Page 2 of 3")).toBeInTheDocument();
+    expect(mockGetPopularBooks).toHaveBeenCalledWith("", 2);
+    expect(screen.getByText("Page 2 of 4")).toBeInTheDocument();
   });
 
   it("Prev is enabled on page 2 and navigates back to page 1", async () => {
@@ -150,23 +190,22 @@ describe("Popular Classics – pagination", () => {
     expect(prev).not.toBeDisabled();
     await user.click(prev);
     await act(flushPromises);
-    expect(mockGetPopularBooks).toHaveBeenCalledWith(1);
-    expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
+    expect(mockGetPopularBooks).toHaveBeenCalledWith("", 1);
+    expect(screen.getByText("Page 1 of 4")).toBeInTheDocument();
   });
 
   it("Next is disabled on the last page", async () => {
-    mockGetPopularBooks.mockResolvedValue(makePopularResponse(3, 120));
-    // Simulate starting on page 3 by rendering and navigating
     const user = userEvent.setup();
     mockGetPopularBooks
       .mockResolvedValueOnce(makePopularResponse(1))
       .mockResolvedValueOnce(makePopularResponse(2))
-      .mockResolvedValueOnce(makePopularResponse(3));
+      .mockResolvedValueOnce(makePopularResponse(3))
+      .mockResolvedValueOnce(makePopularResponse(4));
     await renderDiscover();
-    await user.click(screen.getByRole("button", { name: /Next/i }));
-    await act(flushPromises);
-    await user.click(screen.getByRole("button", { name: /Next/i }));
-    await act(flushPromises);
+    for (let i = 0; i < 3; i++) {
+      await user.click(screen.getByRole("button", { name: /Next/i }));
+      await act(flushPromises);
+    }
     expect(screen.getByRole("button", { name: /Next/i })).toBeDisabled();
   });
 });

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -15,6 +15,14 @@ const FEATURED = [
   { query: "Pride and Prejudice", lang: "en" },
 ];
 
+const POPULAR_LANGS = [
+  { code: "", label: "All" },
+  { code: "en", label: "English" },
+  { code: "de", label: "Deutsch" },
+  { code: "fr", label: "Français" },
+  { code: "ja", label: "日本語" },
+];
+
 
 function timeAgo(ms: number): string {
   const diff = Date.now() - ms;
@@ -60,6 +68,7 @@ export default function Home() {
 
   const [popularBooks, setPopularBooks] = useState<BookMeta[]>([]);
   const [popularLoading, setPopularLoading] = useState(false);
+  const [popularLang, setPopularLang] = useState("");
   const [popularPage, setPopularPage] = useState(1);
   const [popularTotal, setPopularTotal] = useState(0);
   const [popularView, setPopularView] = useState<"grid" | "list">("grid");
@@ -71,14 +80,19 @@ export default function Home() {
   useEffect(() => {
     if (tab !== "discover") return;
     setPopularLoading(true);
-    getPopularBooks(popularPage)
+    getPopularBooks(popularLang, popularPage)
       .then((data) => {
         setPopularBooks(data.books);
         setPopularTotal(data.total);
       })
       .catch(() => { setPopularBooks([]); setPopularTotal(0); })
       .finally(() => setPopularLoading(false));
-  }, [tab, popularPage]);
+  }, [tab, popularLang, popularPage]);
+
+  function handlePopularLangChange(lang: string) {
+    setPopularLang(lang);
+    setPopularPage(1);
+  }
 
   async function handleSearch(q = query, l = lang) {
     if (!q.trim()) return;
@@ -306,8 +320,25 @@ export default function Home() {
 
             {/* Popular Classics section */}
             <section>
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="font-serif font-semibold text-ink text-lg">Popular Classics</h2>
+              <div className="flex flex-wrap items-center justify-between gap-y-3 mb-4">
+                <div className="flex items-center gap-2">
+                  <h2 className="font-serif font-semibold text-ink text-lg">Popular Classics</h2>
+                  <div className="flex gap-1.5">
+                    {POPULAR_LANGS.map((l) => (
+                      <button
+                        key={l.code}
+                        onClick={() => handlePopularLangChange(l.code)}
+                        className={`text-xs rounded-full px-3 py-1 border transition-colors ${
+                          popularLang === l.code
+                            ? "bg-amber-700 text-white border-amber-700"
+                            : "border-amber-300 text-amber-700 hover:bg-amber-50"
+                        }`}
+                      >
+                        {l.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
                 <div className="flex items-center gap-1 border border-amber-200 rounded-lg p-0.5 bg-white">
                   <button
                     onClick={() => setPopularView("grid")}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -81,8 +81,10 @@ export interface PopularBooksResponse {
   per_page: number;
 }
 
-export function getPopularBooks(page = 1) {
-  return request<PopularBooksResponse>(`/books/popular?page=${page}`);
+export function getPopularBooks(language = "", page = 1) {
+  const params = new URLSearchParams({ page: String(page) });
+  if (language) params.set("language", language);
+  return request<PopularBooksResponse>(`/books/popular?${params}`);
 }
 
 export function getBookMeta(id: number) {


### PR DESCRIPTION
## Summary

- **Language filter tabs** (All / English / Deutsch / Français / 日本語) added to the Popular Classics section on the Discover page; switching tab resets to page 1
- **popular_books.json** converted from a flat list to a dict keyed by language code (`""`, `"en"`, `"de"`, `"fr"`, `"ja"`) — 200 EN, 100 DE/FR, 22 JA
- **`seed_books.py --collections`** new flag builds the dict-format manifest in one shot; backend `/books/popular` endpoint handles both legacy flat-list and new dict formats
- **`getPopularBooks(language, page)`** updated to pass `language` query param; `PopularBooksResponse` type added

## Test plan

- [x] 166 frontend unit tests pass (incl. 12 new `discoverPopular` tests: language filter, view toggle, pagination)
- [x] 391 backend pytest tests pass (incl. 6 new popular-books dict-format tests)
- [x] 11 E2E Playwright tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
