### PR TITLE
fix(reader): reset stale title/provider on chapter nav + show both titles

### DIFF
--- a/frontend/src/__tests__/ReaderBookTitle.test.tsx
+++ b/frontend/src/__tests__/ReaderBookTitle.test.tsx
@@ -1,20 +1,34 @@
 /**
  * Tests for the chapter heading shown at the top of each chapter's content area.
  *
- * The heading lives inside page.tsx's reader-scroll area and should:
- *   - render the chapter title when the current chapter has one
- *   - not render when the chapter title is empty/undefined (loading or missing)
+ * The heading should:
+ *   - always show the original chapter title
+ *   - show the translated title below when translation is enabled and available
+ *   - not render when the chapter title is empty/undefined
  */
 
 import React from "react";
 import { render, screen } from "@testing-library/react";
 
-// Minimal harness that mirrors the reader's chapter-heading rendering logic
-function ChapterHeadingHarness({ title }: { title: string | undefined }) {
+// Harness mirrors the updated reader chapter-heading rendering logic
+function ChapterHeadingHarness({
+  title,
+  translationEnabled = false,
+  translatedTitle = null,
+}: {
+  title: string | undefined;
+  translationEnabled?: boolean;
+  translatedTitle?: string | null;
+}) {
   return (
     <div>
       {title && (
-        <h2 data-testid="reader-chapter-heading">{title}</h2>
+        <div data-testid="reader-chapter-heading">
+          <h2>{title}</h2>
+          {translationEnabled && translatedTitle && (
+            <p>{translatedTitle}</p>
+          )}
+        </div>
       )}
     </div>
   );
@@ -40,5 +54,36 @@ describe("Reader chapter heading", () => {
   it("does not render while loading (title undefined)", () => {
     render(<ChapterHeadingHarness title={undefined} />);
     expect(screen.queryByTestId("reader-chapter-heading")).not.toBeInTheDocument();
+  });
+
+  it("shows original title even when translation is enabled but not yet loaded", () => {
+    render(<ChapterHeadingHarness title="Chapter I" translationEnabled={true} translatedTitle={null} />);
+    expect(screen.getByText("Chapter I")).toBeInTheDocument();
+    // no second title element
+    expect(screen.getAllByRole("heading").length).toBe(1);
+  });
+
+  it("shows both original and translated title when translation is available", () => {
+    render(
+      <ChapterHeadingHarness
+        title="Chapter I"
+        translationEnabled={true}
+        translatedTitle="第一章"
+      />
+    );
+    expect(screen.getByText("Chapter I")).toBeInTheDocument();
+    expect(screen.getByText("第一章")).toBeInTheDocument();
+  });
+
+  it("does not show translated title when translation is disabled", () => {
+    render(
+      <ChapterHeadingHarness
+        title="Chapter I"
+        translationEnabled={false}
+        translatedTitle="第一章"
+      />
+    );
+    expect(screen.getByText("Chapter I")).toBeInTheDocument();
+    expect(screen.queryByText("第一章")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -453,6 +453,8 @@ export default function ReaderPage() {
     saveLastChapter(Number(bookId), index);
     setSelectedText("");
     setTranslatedParagraphs([]);
+    setTranslatedTitle(null);
+    setTranslationUsedProvider("");
     setAudioCurrentTime(0);
     setAudioDuration(0);
     document.getElementById("reader-scroll")?.scrollTo(0, 0);
@@ -835,13 +837,18 @@ export default function ReaderPage() {
               </div>
             ) : (
               <>
-                {/* Chapter heading — shown at top of every chapter, scrolls with content */}
+                {/* Chapter heading — shows original title always; translated title below when available */}
                 {current?.title && (
-                  <h2 className="prose-reader mx-auto mb-8 text-center font-serif font-semibold text-lg text-ink/80" data-testid="reader-chapter-heading">
-                    {translationEnabled && translatedTitle
-                      ? translatedTitle
-                      : current.title}
-                  </h2>
+                  <div className="prose-reader mx-auto mb-8 text-center" data-testid="reader-chapter-heading">
+                    <h2 className="font-serif font-semibold text-lg text-ink/80">
+                      {current.title}
+                    </h2>
+                    {translationEnabled && translatedTitle && (
+                      <p className="font-serif text-base text-amber-700 mt-1">
+                        {translatedTitle}
+                      </p>
+                    )}
+                  </div>
                 )}
                 <SentenceReader
                   text={current?.text ?? ""}


### PR DESCRIPTION
## Summary

- `goToChapter()` now resets `translatedTitle` and `translationUsedProvider` on chapter navigation, so the previous chapter's stale translation label never bleeds into the next chapter
- Chapter heading always shows the original title; translated title appears below it (amber text) only when translation is enabled and a translation exists — both titles are visible simultaneously

## Test plan

- Updated `ReaderBookTitle.test.tsx` harness to match the new `<div>` + `<h2>` + `<p>` structure
- Added 3 new tests: original shown when translation not yet loaded, both titles shown when translation is available, translated title hidden when translation is disabled
- Full suite: 173 frontend unit tests, 11 E2E tests, 396 backend tests — all pass
