### PR TITLE
fix(freemium): check plan before cache to prevent cache bypass

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -208,7 +208,17 @@ async def request_chapter_translation(
         enqueue, queue_status_for_chapter, worker,
     )
 
-    # 1. Already cached? Cached translations are always served regardless of plan.
+    # 1. Freemium gate: free-plan users can only translate free classics.
+    # Checked before the cache so the cache (shared per-book) cannot be used
+    # to bypass the plan restriction.
+    free_ids = get_free_ids()
+    if free_ids and book_id not in free_ids and user.get("plan", "free") != "paid":
+        raise HTTPException(
+            status_code=402,
+            detail="Translation for this book requires a paid plan.",
+        )
+
+    # 2. Already cached?
     cached = await get_cached_translation_with_meta(
         book_id, chapter_index, req.target_language,
     )
@@ -220,14 +230,6 @@ async def request_chapter_translation(
             "model": cached.get("model"),
             "title_translation": cached.get("title_translation"),
         }
-
-    # 2. Freemium gate: free-plan users can only translate free classics.
-    free_ids = get_free_ids()
-    if free_ids and book_id not in free_ids and user.get("plan", "free") != "paid":
-        raise HTTPException(
-            status_code=402,
-            detail="Translation for this book requires a paid plan.",
-        )
 
     # 3. Already queued / running?
     qstatus = await queue_status_for_chapter(

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -423,8 +423,17 @@ async def test_import_stream_always_allowed_for_free_user(client, classics_cache
 
 async def test_chapter_translation_blocked_for_free_user_non_classic(client, classics_cache):
     """AI translation on non-classic book → 402 for free-plan user."""
+    resp = await client.post(
+        "/api/books/9999/chapters/0/translation",
+        json={"target_language": "de"},
+    )
+    assert resp.status_code == 402
+
+
+async def test_chapter_translation_blocked_even_when_cached(client, classics_cache):
+    """Gate fires before cache check — shared cache cannot bypass the plan gate."""
     from services.db import save_translation
-    # book 9999 is not in CLASSICS_FIXTURE → gate fires
+    await save_translation(9999, 0, "de", ["Übersetzung"])
     resp = await client.post(
         "/api/books/9999/chapters/0/translation",
         json={"target_language": "de"},


### PR DESCRIPTION
## Summary

The freemium gate was checked *after* the translation cache lookup. Since the cache is shared per-book (not per-user), a free-plan user could receive a cached translation for a non-free book if a paid user or the admin had already translated it — effectively bypassing the plan restriction.

Gate now runs first, before any cache check.

## Test plan

- Added `test_chapter_translation_blocked_even_when_cached`: saves a translation for a non-free book, then verifies a free-plan user still gets 402
- Full suite: 171 frontend unit tests, 11 E2E tests, 398 backend tests — all pass
