### PR TITLE
feat(auth): free classics public; other books require login

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -20,7 +20,7 @@ from services.db import (
 from services.splitter import build_chapters, build_chapters_from_html
 from services.translate import translate_text
 from services.tts import synthesize, chunk_text, EDGE_VOICE_MAP, _pick_edge_voice
-from services.auth import get_current_user, decrypt_api_key
+from services.auth import get_current_user, get_optional_user, decrypt_api_key
 from services.classics import get_classics, get_free_ids
 
 logger = logging.getLogger(__name__)
@@ -388,7 +388,7 @@ async def import_stream(
     book_id: int,
     target_language: str = Query("", description="Target language for pre-translation (empty = skip)"),
     generate_tts: bool = Query(False, description="Also pre-generate TTS audio for each chunk"),
-    user: dict = Depends(get_current_user),
+    user: dict | None = Depends(get_optional_user),
 ):
     """Stream import progress for a book via Server-Sent Events.
 
@@ -400,9 +400,18 @@ async def import_stream(
       done       — all steps complete
 
     Idempotent: skips already-cached work (same as preseed_translations.py).
+    Free classics are accessible without login; other books require a logged-in account.
     """
+    # Access gate: free classics are public; any other book requires login.
+    free_ids = get_free_ids()
+    if free_ids and book_id not in free_ids and user is None:
+        raise HTTPException(
+            status_code=401,
+            detail="Login required to read this book.",
+        )
+
     # Resolve Gemini key once up front
-    raw_key = user.get("gemini_key")
+    raw_key = user.get("gemini_key") if user else None
     decrypted_key: str | None = decrypt_api_key(raw_key) if raw_key else None
 
     async def generator() -> AsyncIterator[str]:
@@ -453,7 +462,7 @@ async def import_stream(
                 # completes them, so there's no double work in the happy path.
                 try:
                     from services.translation_queue import enqueue_for_book, worker
-                    queued_by = user.get("email") or user.get("name") or f"user#{user.get('id')}"
+                    queued_by = (user.get("email") or user.get("name") or f"user#{user.get('id')}") if user else "anon"
                     added = await enqueue_for_book(
                         book_id,
                         target_languages=[target_language],

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -166,3 +166,24 @@ async def get_current_user(request: Request) -> dict:
     if not user.get("approved") and not request.url.path.endswith("/user/me"):
         raise HTTPException(status_code=403, detail="Account pending approval")
     return user
+
+
+async def get_optional_user(request: Request) -> dict | None:
+    """Like get_current_user but returns None instead of raising 401 when no token is present.
+
+    Use on endpoints that are publicly accessible but behave differently for
+    authenticated users (e.g. free-classics import-stream).
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return None
+    try:
+        token = auth_header.removeprefix("Bearer ").strip()
+        payload = decode_jwt(token)
+        user_id = int(payload["sub"])
+        user = await get_user_by_id(user_id)
+        if not user or not user.get("approved"):
+            return None
+        return user
+    except Exception:
+        return None

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,7 +9,7 @@ Provides:
 import pytest
 import services.db as db_module
 from services.db import init_db, get_or_create_user, get_user_by_id
-from services.auth import create_jwt, get_current_user
+from services.auth import create_jwt, get_current_user, get_optional_user
 from main import app
 from httpx import AsyncClient, ASGITransport
 
@@ -37,15 +37,21 @@ async def test_user(tmp_db):
 
 @pytest.fixture
 async def client(test_user):
-    """
-    AsyncClient with auth dependency overridden to return test_user.
-    The real DB is already initialised by the test_user fixture.
-    """
+    """AsyncClient authenticated as test_user (overrides both auth dependencies)."""
     async def _override():
-        # Re-fetch on every request so tests that mutate the user (e.g. set gemini key) see fresh data
         return await get_user_by_id(test_user["id"])
 
     app.dependency_overrides[get_current_user] = _override
+    app.dependency_overrides[get_optional_user] = _override
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+async def anon_client(tmp_db):
+    """AsyncClient with no authentication (get_optional_user returns None)."""
+    app.dependency_overrides[get_optional_user] = lambda: None
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         yield c
     app.dependency_overrides.clear()

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -414,8 +414,22 @@ async def test_popular_russian_tab_returns_original_language_ru(client, classics
     assert books[0]["id"] == 2554
 
 
-async def test_import_stream_always_allowed_for_free_user(client, classics_cache):
-    """Reading is free for all — import stream has no plan gate."""
+async def test_import_stream_free_classic_no_login(anon_client, classics_cache):
+    """Free classic is accessible without login."""
+    await save_book(1342, MOCK_META, "text")
+    resp = await anon_client.get("/api/books/1342/import-stream")
+    assert resp.status_code == 200
+
+
+async def test_import_stream_non_classic_requires_login(anon_client, classics_cache):
+    """Non-free book requires login — unauthenticated request gets 401."""
+    await save_book(9999, {**MOCK_META, "id": 9999}, "text")
+    resp = await anon_client.get("/api/books/9999/import-stream")
+    assert resp.status_code == 401
+
+
+async def test_import_stream_non_classic_allowed_when_logged_in(client, classics_cache):
+    """Logged-in user can import any book."""
     await save_book(9999, {**MOCK_META, "id": 9999}, "text")
     resp = await client.get("/api/books/9999/import-stream")
     assert resp.status_code == 200

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -9,7 +9,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { importBookStream, ImportEvent } from "@/lib/api";
+import { importBookStream, ImportEvent, ApiError } from "@/lib/api";
 import { getSettings } from "@/lib/settings";
 
 type Stage = "fetching" | "splitting" | "translating" | "tts";
@@ -47,6 +47,7 @@ export default function BookImportPage() {
   const [bookTitle, setBookTitle] = useState("");
   const [chapterCount, setChapterCount] = useState(0);
   const [error, setError] = useState("");
+  const [loginRequired, setLoginRequired] = useState(false);
   const [isDone, setIsDone] = useState(false);
   const [generateTts, setGenerateTts] = useState(false);
   const [started, setStarted] = useState(false);
@@ -85,6 +86,10 @@ export default function BookImportPage() {
       }
     } catch (e: unknown) {
       if ((e as Error)?.name === "AbortError") return;
+      if (e instanceof ApiError && e.status === 401) {
+        setLoginRequired(true);
+        return;
+      }
       setError(e instanceof Error ? e.message : "Import failed");
     }
   }
@@ -294,6 +299,21 @@ export default function BookImportPage() {
                   </div>
                 );
               })}
+            </div>
+          )}
+
+          {loginRequired && (
+            <div className="bg-amber-50 border border-amber-200 rounded-xl p-6 text-center mb-4">
+              <p className="font-serif text-base font-semibold text-ink mb-1">Login required</p>
+              <p className="text-sm text-amber-800 mb-4">
+                Sign in to read this book. The 100 free classics are available without an account.
+              </p>
+              <a
+                href="/api/auth/signin"
+                className="inline-block rounded-lg bg-amber-700 text-white px-5 py-2 text-sm font-medium hover:bg-amber-800"
+              >
+                Sign in
+              </a>
             </div>
           )}
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -156,7 +156,7 @@ export async function* importBookStream(
   });
   if (!res.ok || !res.body) {
     const err = await res.json().catch(() => ({ detail: res.statusText }));
-    throw new Error(err.detail || "Import stream failed");
+    throw new ApiError(res.status, err.detail || "Import stream failed");
   }
 
   const reader = res.body.getReader();


### PR DESCRIPTION
## Summary

Implements the tiered access model:

| Action | Free classic | Other book |
|---|---|---|
| Read (import + chapters) | No login needed | Login required |
| AI features (translation, insight, QA) | Login required | Login + paid plan |

## Changes

- **`services/auth.py`**: added `get_optional_user` — returns `None` instead of 401 when no token present
- **`routers/books.py`**: `import_stream` now uses `get_optional_user`; non-free books get 401 when unauthenticated; guards `user.get()` calls for the `None` case
- **`frontend/src/lib/api.ts`**: `importBookStream` throws `ApiError` (with status) instead of generic `Error`
- **`frontend/src/app/import/[bookId]/page.tsx`**: shows an amber "Login required" panel with a sign-in link on 401
- **`tests/conftest.py`**: `client` fixture now overrides both `get_current_user` and `get_optional_user`; new `anon_client` fixture for unauthenticated tests
- **`test_router_books.py`**: replaced old "always allowed" test with three access-gate tests

## Test plan

- `test_import_stream_free_classic_no_login`: unauthenticated → 200 for free classic
- `test_import_stream_non_classic_requires_login`: unauthenticated → 401 for non-free book
- `test_import_stream_non_classic_allowed_when_logged_in`: authenticated → 200 for any book
- Full suite: 171 frontend unit tests, 11 E2E tests, 400 backend tests — all pass
