### PR TITLE
fix: reader and import pages are public, only profile/admin/pending require login

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -122,10 +122,6 @@ export default function Home() {
   }
 
   function openBook(id: number) {
-    if (status === "unauthenticated") {
-      router.push(`/login?callbackUrl=/reader/${id}`);
-      return;
-    }
     const inLibrary = recentBooks.some((b) => b.id === id);
     if (inLibrary) {
       router.push(`/reader/${id}`);

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -15,10 +15,10 @@ export default auth((req) => {
 });
 
 export const config = {
-  // Protect everything except the home page, login page, NextAuth API routes,
-  // and static assets. The home page (/) is public; auth is required only when
-  // a user actually tries to open a book.
+  // Only protect pages that are meaningless or dangerous without an identity:
+  // profile settings, admin panel, and the pending-approval holding page.
+  // Reading and importing public-domain books requires no login.
   matcher: [
-    "/((?!login|api/auth|_next/static|_next/image|favicon.ico).+)",
+    "/(profile|admin|pending)(.*)",
   ],
 };


### PR DESCRIPTION
## Summary
- Middleware matcher narrowed from `(.+)` to `(profile|admin|pending)(.*)` — only those three path prefixes require a session
- `/reader/[bookId]` and `/import/[bookId]` are now fully public; clicking any book from Popular Classics or search results proceeds without a login wall
- Removed the premature `status === "unauthenticated"` redirect from `openBook()` — middleware handles auth when actually needed

## Test plan
- [ ] Visit `/` unauthenticated → home loads, shows Discover tab
- [ ] Click a Popular Classics book → goes to `/import/` without login prompt
- [ ] Navigate to `/profile` unauthenticated → redirected to `/login`
- [ ] All 11 E2E tests pass
