### PR TITLE
feat: book detail modal on card click

### DIFF
--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -81,6 +81,12 @@ export async function mockBackend(page: Page) {
     route.fulfill({ json: MOCK_BOOK });
   });
 
+  await page.route(/\/api\/books\/\d+\/translation-status/, (route) =>
+    route.fulfill({
+      json: { book_id: 1342, target_language: "en", total_chapters: 3, translated_chapters: 3, bulk_active: false },
+    })
+  );
+
   await page.route(/\/api\/audiobooks\/\d+$/, (route) =>
     route.fulfill({ status: 404, json: { detail: "Not linked" } })
   );

--- a/frontend/e2e/home.spec.ts
+++ b/frontend/e2e/home.spec.ts
@@ -64,10 +64,12 @@ test("clicking a library book navigates to reader page", async ({ page }) => {
 
   // Explicitly open the Library tab in case the session effect flipped to Discover
   await page.getByRole("button", { name: "Your Library" }).click();
-  // Filter by author text — the "Pride and Prejudice" quick-search pill doesn't have it
+  // Click the book card — this opens the detail modal
   const bookCard = page.getByRole("button").filter({ hasText: "Jane Austen" });
   await expect(bookCard).toBeVisible();
   await bookCard.click();
+  // Click the CTA in the modal to navigate
+  await page.getByRole("button", { name: /Continue Reading|Start Reading/ }).click();
   await page.waitForURL(/\/reader\/1342/);
   expect(page.url()).toContain("/reader/1342");
 });

--- a/frontend/src/__tests__/discoverPopular.test.tsx
+++ b/frontend/src/__tests__/discoverPopular.test.tsx
@@ -30,6 +30,7 @@ jest.mock("@/lib/api", () => ({
   getPopularBooks: (...args: unknown[]) => mockGetPopularBooks(...args),
   getMe: (...args: unknown[]) => mockGetMe(...args),
   searchBooks: (...args: unknown[]) => mockSearchBooks(...args),
+  getBookTranslationStatus: () => Promise.resolve({ book_id: 0, target_language: "en", total_chapters: 0, translated_chapters: 0, bulk_active: false }),
 }));
 
 function makeBook(id: number) {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { searchBooks, getPopularBooks, getMe, BookMeta } from "@/lib/api";
 import { getRecentBooks, removeRecentBook, RecentBook } from "@/lib/recentBooks";
 import BookCard from "@/components/BookCard";
+import BookDetailModal from "@/components/BookDetailModal";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 
@@ -42,6 +43,7 @@ export default function Home() {
 
   const [tab, setTab] = useState<Tab>("library");
   const [isAdmin, setIsAdmin] = useState(false);
+  const [selectedBook, setSelectedBook] = useState<BookMeta | null>(null);
 
   // ── Library state ──
   const [recentBooks, setRecentBooks] = useState<RecentBook[]>([]);
@@ -130,6 +132,10 @@ export default function Home() {
     }
   }
 
+  function handleBookClick(book: BookMeta) {
+    setSelectedBook(book);
+  }
+
   return (
     <main className="min-h-screen bg-parchment">
       {/* Header */}
@@ -215,7 +221,7 @@ export default function Home() {
                   <BookCard
                     key={book.id}
                     book={book}
-                    onClick={() => openBook(book.id)}
+                    onClick={() => handleBookClick(book)}
                     badge={`Ch. ${book.lastChapter + 1} · ${timeAgo(book.lastRead)}`}
                     onRemove={() => {
                       if (!confirm(`Remove "${book.title}" from your library?`)) return;
@@ -318,7 +324,7 @@ export default function Home() {
               {!searching && searchResults.length > 0 && (
                 <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
                   {searchResults.map((book) => (
-                    <BookCard key={book.id} book={book} onClick={() => openBook(book.id)} />
+                    <BookCard key={book.id} book={book} onClick={() => handleBookClick(book)} />
                   ))}
                 </div>
               )}
@@ -407,7 +413,7 @@ export default function Home() {
                   {popularView === "grid" ? (
                     <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
                       {popularBooks.map((book) => (
-                        <BookCard key={book.id} book={book} onClick={() => openBook(book.id)} />
+                        <BookCard key={book.id} book={book} onClick={() => handleBookClick(book)} />
                       ))}
                     </div>
                   ) : (
@@ -415,7 +421,7 @@ export default function Home() {
                       {popularBooks.map((book, idx) => (
                         <button
                           key={book.id}
-                          onClick={() => openBook(book.id)}
+                          onClick={() => handleBookClick(book)}
                           className="flex items-center gap-3 w-full px-4 py-3 text-left hover:bg-amber-50 transition-colors"
                         >
                           <span className="text-xs text-amber-400 w-7 text-right shrink-0 tabular-nums">
@@ -475,6 +481,17 @@ export default function Home() {
         )}
       </div>
 
+      {selectedBook && (
+        <BookDetailModal
+          book={selectedBook}
+          recentBook={recentBooks.find((rb) => rb.id === selectedBook.id)}
+          onClose={() => setSelectedBook(null)}
+          onRead={() => {
+            setSelectedBook(null);
+            openBook(selectedBook.id);
+          }}
+        />
+      )}
     </main>
   );
 }

--- a/frontend/src/components/BookDetailModal.tsx
+++ b/frontend/src/components/BookDetailModal.tsx
@@ -1,0 +1,136 @@
+"use client";
+import { useEffect, useState } from "react";
+import { BookMeta, getBookTranslationStatus, TranslationStatus } from "@/lib/api";
+import { RecentBook } from "@/lib/recentBooks";
+import { getSettings } from "@/lib/settings";
+
+const LANG_NAMES: Record<string, string> = {
+  en: "English", de: "German", fr: "French", es: "Spanish",
+  it: "Italian", ja: "Japanese", zh: "Chinese", ru: "Russian",
+  pt: "Portuguese", nl: "Dutch", fi: "Finnish", sv: "Swedish",
+  no: "Norwegian", da: "Danish", pl: "Polish", cs: "Czech",
+};
+
+interface Props {
+  book: BookMeta;
+  recentBook?: RecentBook;
+  onClose: () => void;
+  onRead: () => void;
+}
+
+export default function BookDetailModal({ book, recentBook, onClose, onRead }: Props) {
+  const [translationStatus, setTranslationStatus] = useState<TranslationStatus | null>(null);
+  const translationLang = getSettings().translationLang;
+
+  useEffect(() => {
+    getBookTranslationStatus(book.id, translationLang)
+      .then(setTranslationStatus)
+      .catch(() => {});
+  }, [book.id, translationLang]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const hasTranslation =
+    translationStatus !== null && translationStatus.translated_chapters > 0;
+  const fullTranslation =
+    hasTranslation && translationStatus!.translated_chapters >= translationStatus!.total_chapters;
+  const showTranslation =
+    hasTranslation && translationLang !== (book.languages[0] ?? "en");
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="w-full sm:max-w-md bg-white rounded-t-2xl sm:rounded-2xl shadow-xl p-6 max-h-[85vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header: cover + metadata + close */}
+        <div className="flex items-start gap-4 mb-5">
+          <div className="w-16 h-24 shrink-0 rounded-lg border border-amber-100 bg-amber-50 overflow-hidden flex items-center justify-center text-3xl">
+            {book.cover
+              // eslint-disable-next-line @next/next/no-img-element
+              ? <img src={book.cover} alt={book.title} className="w-full h-full object-cover" />
+              : "📖"}
+          </div>
+          <div className="flex-1 min-w-0">
+            <h2 className="font-serif font-bold text-ink text-lg leading-tight mb-1">
+              {book.title}
+            </h2>
+            <p className="text-sm text-amber-700">{book.authors.join(", ")}</p>
+            <div className="flex flex-wrap gap-1 mt-2">
+              {book.languages.map((lang) => (
+                <span
+                  key={lang}
+                  className="text-xs px-2 py-0.5 bg-amber-50 border border-amber-200 rounded-full text-amber-700"
+                >
+                  {LANG_NAMES[lang] ?? lang.toUpperCase()}
+                </span>
+              ))}
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="shrink-0 w-8 h-8 flex items-center justify-center rounded-full text-stone-400 hover:bg-stone-100 hover:text-stone-600 transition-colors"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Subject tags */}
+        {book.subjects.length > 0 && (
+          <div className="flex flex-wrap gap-1 mb-4">
+            {book.subjects.slice(0, 5).map((s) => (
+              <span key={s} className="text-xs px-2 py-0.5 bg-stone-100 rounded-full text-stone-500">
+                {s}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Translation availability */}
+        {showTranslation && (
+          <div className="flex items-center gap-2 mb-4 text-sm text-emerald-700 bg-emerald-50 border border-emerald-200 rounded-lg px-3 py-2">
+            <span>✓</span>
+            <span>
+              {fullTranslation
+                ? `Full ${LANG_NAMES[translationLang] ?? translationLang} translation available`
+                : `${translationStatus!.translated_chapters}/${translationStatus!.total_chapters} chapters translated to ${LANG_NAMES[translationLang] ?? translationLang}`}
+            </span>
+          </div>
+        )}
+
+        {/* Continue-reading progress */}
+        {recentBook && (
+          <div className="mb-4 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2">
+            Last read: Chapter {recentBook.lastChapter + 1}
+          </div>
+        )}
+
+        {/* Primary CTA */}
+        <button
+          onClick={onRead}
+          className="w-full rounded-xl bg-amber-700 text-white py-3 text-sm font-medium hover:bg-amber-800 transition-colors"
+        >
+          {recentBook
+            ? `Continue Reading — Ch. ${recentBook.lastChapter + 1}`
+            : "Start Reading"}
+        </button>
+
+        {book.download_count > 0 && (
+          <p className="text-center text-xs text-stone-400 mt-3">
+            {book.download_count.toLocaleString()} downloads on Project Gutenberg
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Clicking any book card (library grid, search results, popular classics grid, popular classics list view) opens a slide-up `BookDetailModal` instead of navigating directly
- Modal shows: cover, title, author, language tags, subject tags, translation availability badge (from `/books/:id/translation-status`), last-read chapter for library books
- CTA: "Continue Reading — Ch. X" for library books, "Start Reading" otherwise
- Backdrop click or ESC closes the modal

## Test plan
- [ ] Click a popular classic → modal pops up with book details
- [ ] Click "Start Reading" → navigates to `/import/`
- [ ] Click a library book → modal shows "Continue Reading — Ch. X"
- [ ] Click backdrop → modal closes
- [ ] All 11 E2E tests pass; all 165 unit tests pass
