### PR TITLE
fix: crash when clicking popular book — subjects field is null

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -60,7 +60,17 @@ async def popular_books(
         if not os.path.isfile(_POPULAR_BOOKS_PATH):
             return {"books": [], "total": 0, "page": page, "per_page": per_page}
         with open(_POPULAR_BOOKS_PATH, encoding="utf-8") as f:
-            _popular_cache = json.load(f)
+            raw = json.load(f)
+        # Normalize: ensure list fields are always arrays, never null.
+        def _norm(book: dict) -> dict:
+            for field in ("authors", "languages", "subjects"):
+                if not isinstance(book.get(field), list):
+                    book[field] = []
+            return book
+        if isinstance(raw, dict):
+            _popular_cache = {k: [_norm(b) for b in v] for k, v in raw.items()}
+        else:
+            _popular_cache = [_norm(b) for b in raw]
 
     if isinstance(_popular_cache, dict):
         books = _popular_cache.get(language, _popular_cache.get("", []))

--- a/frontend/src/components/BookDetailModal.tsx
+++ b/frontend/src/components/BookDetailModal.tsx
@@ -86,9 +86,9 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
         </div>
 
         {/* Subject tags */}
-        {book.subjects.length > 0 && (
+        {(book.subjects ?? []).length > 0 && (
           <div className="flex flex-wrap gap-1 mb-4">
-            {book.subjects.slice(0, 5).map((s) => (
+            {(book.subjects ?? []).slice(0, 5).map((s) => (
               <span key={s} className="text-xs px-2 py-0.5 bg-stone-100 rounded-full text-stone-500">
                 {s}
               </span>


### PR DESCRIPTION
## Summary

- `popular_books.json` entries omit the `subjects` field (it's `null`/missing)
- `BookDetailModal` called `book.subjects.length` which threw `TypeError` and crashed the page
- Backend: normalize `authors`, `languages`, `subjects` to `[]` when loading the popular books manifest
- Frontend: added `?? []` guard in `BookDetailModal` as a defensive fallback

## Root cause

The crash happened on any click of a popular-classics book card. The modal tried to render subject tags with `book.subjects.length > 0` — null dereference.

## Test plan

- [x] All 368 backend + 165 frontend + 11 E2E tests pass
- Manual: clicking a popular book now opens the modal without errors
