### PR TITLE
fix: correct TTS highlight sync and line-break prosody

### DIFF
--- a/backend/services/tts.py
+++ b/backend/services/tts.py
@@ -93,7 +93,7 @@ async def synthesize(
 ) -> tuple[bytes, str]:
     """Synthesize text with Edge TTS. Returns (mp3_bytes, "audio/mpeg")."""
     voice = _pick_edge_voice(language, gender)
-    communicate = edge_tts.Communicate(text, voice, rate=_rate_str(rate))
+    communicate = edge_tts.Communicate(text.replace("\n", " "), voice, rate=_rate_str(rate))
 
     buf = io.BytesIO()
     async for chunk in communicate.stream():

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -107,7 +107,7 @@ function parseIntoSegments(
       const seg = allTexts[s];
       // Find this segment within the remaining chunk text
       while (chunkIdx < chunks.length) {
-        const chunkText = chunks[chunkIdx].text;
+        const chunkText = chunks[chunkIdx].text.replace(/\n/g, " ");
         const pos = chunkText.indexOf(seg, cursor);
         if (pos >= 0) {
           segmentChunkIdx[s] = chunkIdx;


### PR DESCRIPTION
## Summary

- **Fix highlight jumping to last line on playback start**: `SentenceReader` normalises `\n → " "` in chunk text before `indexOf`, so line-wrapped prose segments are correctly matched to their chunk and receive proper `startTime` values. Previously they all got `startTime = 0`, causing `currentIdx` to resolve to the last segment the moment playback began.
- **Fix unnatural pause/tone at visual line ends**: `tts.py` now strips newlines before passing text to Edge TTS. Edge TTS treats `\n` as a sentence/paragraph boundary (adding prosodic pauses and pitch changes), which made the voice sound like it was ending a sentence at every soft line-wrap in Gutenberg text.

## Test plan

- [x] Frontend unit tests pass (165 tests)
- [x] Backend tests pass (368 tests)
- [x] E2E tests pass (11 tests)
- Manual: start TTS on any chapter — first highlighted segment should match the first spoken sentence; no unnatural pauses mid-sentence at line breaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
