### PR TITLE
feat: annotations, vocabulary tracking, and Obsidian export

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -11,6 +11,8 @@ from routers.audiobooks import router as audiobooks_router
 from routers.auth import router as auth_router
 from routers.user import router as user_router
 from routers.admin import router as admin_router
+from routers.annotations import router as annotations_router
+from routers.vocabulary import router as vocabulary_router
 from services.db import init_db
 
 
@@ -105,6 +107,8 @@ app.include_router(books_router, prefix="/api")
 app.include_router(ai_router, prefix="/api")
 app.include_router(audiobooks_router, prefix="/api")
 app.include_router(admin_router, prefix="/api")
+app.include_router(annotations_router, prefix="/api")
+app.include_router(vocabulary_router, prefix="/api")
 
 
 @app.get("/api/health")

--- a/backend/migrations/014_annotations_vocabulary.sql
+++ b/backend/migrations/014_annotations_vocabulary.sql
@@ -1,0 +1,32 @@
+CREATE TABLE IF NOT EXISTS annotations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    book_id INTEGER NOT NULL,
+    chapter_index INTEGER NOT NULL,
+    sentence_text TEXT NOT NULL,
+    note_text TEXT NOT NULL DEFAULT '',
+    color TEXT NOT NULL DEFAULT 'yellow',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS vocabulary (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    word TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, word)
+);
+
+CREATE TABLE IF NOT EXISTS word_occurrences (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    vocabulary_id INTEGER NOT NULL,
+    book_id INTEGER NOT NULL,
+    chapter_index INTEGER NOT NULL,
+    sentence_text TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (vocabulary_id) REFERENCES vocabulary(id) ON DELETE CASCADE
+);
+
+ALTER TABLE users ADD COLUMN github_token TEXT;
+ALTER TABLE users ADD COLUMN obsidian_repo TEXT;
+ALTER TABLE users ADD COLUMN obsidian_path TEXT DEFAULT 'All Notes/002 Literature Notes/000 Books';

--- a/backend/routers/annotations.py
+++ b/backend/routers/annotations.py
@@ -1,0 +1,56 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from services.auth import get_current_user
+from services.db import create_annotation, get_annotations, update_annotation, delete_annotation
+
+router = APIRouter(prefix="/annotations", tags=["annotations"])
+
+
+class AnnotationCreate(BaseModel):
+    book_id: int
+    chapter_index: int
+    sentence_text: str
+    note_text: str = ""
+    color: str = "yellow"
+
+
+class AnnotationUpdate(BaseModel):
+    note_text: str
+    color: str
+
+
+@router.post("")
+async def create(req: AnnotationCreate, user: dict = Depends(get_current_user)):
+    return await create_annotation(
+        user["id"],
+        req.book_id,
+        req.chapter_index,
+        req.sentence_text,
+        req.note_text,
+        req.color,
+    )
+
+
+@router.get("")
+async def list_annotations(book_id: int, user: dict = Depends(get_current_user)):
+    return await get_annotations(user["id"], book_id)
+
+
+@router.patch("/{annotation_id}")
+async def update(
+    annotation_id: int,
+    req: AnnotationUpdate,
+    user: dict = Depends(get_current_user),
+):
+    result = await update_annotation(annotation_id, user["id"], req.note_text, req.color)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Annotation not found")
+    return result
+
+
+@router.delete("/{annotation_id}")
+async def delete(annotation_id: int, user: dict = Depends(get_current_user)):
+    deleted = await delete_annotation(annotation_id, user["id"])
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Annotation not found")
+    return {"ok": True}

--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -1,0 +1,278 @@
+import base64
+from datetime import datetime, timezone
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from services.auth import get_current_user, encrypt_api_key, decrypt_api_key
+from services.db import (
+    save_word,
+    get_vocabulary,
+    delete_word,
+    get_obsidian_settings,
+    get_cached_book,
+)
+
+router = APIRouter(prefix="/vocabulary", tags=["vocabulary"])
+
+
+class WordSave(BaseModel):
+    word: str
+    book_id: int
+    chapter_index: int
+    sentence_text: str
+
+
+class ExportRequest(BaseModel):
+    book_id: int | None = None
+
+
+@router.post("")
+async def save(req: WordSave, user: dict = Depends(get_current_user)):
+    return await save_word(
+        user["id"],
+        req.word,
+        req.book_id,
+        req.chapter_index,
+        req.sentence_text,
+    )
+
+
+@router.get("")
+async def list_vocabulary(user: dict = Depends(get_current_user)):
+    return await get_vocabulary(user["id"])
+
+
+@router.delete("/{word}")
+async def remove_word(word: str, user: dict = Depends(get_current_user)):
+    deleted = await delete_word(user["id"], word)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Word not found")
+    return {"ok": True}
+
+
+# ── Obsidian export ───────────────────────────────────────────────────────────
+
+async def _github_put(
+    token: str,
+    repo: str,
+    path: str,
+    filename: str,
+    content_md: str,
+    message: str,
+) -> str:
+    """PUT a file to GitHub, fetching existing sha first if needed. Returns the file URL."""
+    api_url = f"https://api.github.com/repos/{repo}/contents/{path}/{filename}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    async with httpx.AsyncClient(timeout=30) as client:
+        # Try to get current sha (for updates)
+        get_resp = await client.get(api_url, headers=headers)
+        sha = get_resp.json().get("sha") if get_resp.status_code == 200 else None
+
+        body: dict = {
+            "message": message,
+            "content": base64.b64encode(content_md.encode()).decode(),
+        }
+        if sha:
+            body["sha"] = sha
+
+        put_resp = await client.put(api_url, headers=headers, json=body)
+
+    if put_resp.status_code not in (200, 201):
+        raise HTTPException(
+            status_code=502,
+            detail=f"GitHub API error {put_resp.status_code}: {put_resp.text[:200]}",
+        )
+    return put_resp.json()["content"]["html_url"]
+
+
+def _build_book_markdown(
+    book: dict,
+    words_for_book: list[dict],
+    annotations: list[dict],
+    connected: list[dict],
+    book_id: int,
+    export_date: str,
+) -> str:
+    authors = ", ".join(book.get("authors", [])) if book else "Unknown"
+    title = book.get("title", f"Book {book_id}") if book else f"Book {book_id}"
+
+    lines = [
+        "---",
+        f"Author: {authors}",
+        "Language: English",
+        f"Source: gutenberg.org/ebooks/{book_id}",
+        f"Export-Date: {export_date}",
+        "---",
+        "#reading #books",
+        "",
+        "## Vocabulary",
+    ]
+
+    for entry in words_for_book:
+        word = entry["word"]
+        for occ in entry["occurrences"]:
+            if occ["book_id"] == book_id:
+                lines.append(
+                    f"- [[{word}]] — Ch.{occ['chapter_index']}: \"{occ['sentence_text']}\""
+                )
+
+    lines += ["", "## Connected Books (shared vocabulary)"]
+    for conn in connected:
+        shared_words = ", ".join(f"[[{w}]]" for w in conn["shared_words"])
+        lines.append(f"- [[{conn['title']}]] — shared: {shared_words}")
+
+    lines += ["", "## Annotations"]
+    # Group by chapter
+    chapters: dict[int, list] = {}
+    for ann in annotations:
+        chapters.setdefault(ann["chapter_index"], []).append(ann)
+    for ch_idx in sorted(chapters):
+        lines.append(f"### Chapter {ch_idx}")
+        for ann in chapters[ch_idx]:
+            lines.append(f"> \"{ann['sentence_text']}\"")
+            if ann.get("note_text"):
+                lines.append(ann["note_text"])
+
+    return "\n".join(lines) + "\n"
+
+
+def _build_word_markdown(word: str, occurrences: list[dict]) -> str:
+    lines = [f"# {word}", "", "## In your books"]
+    for occ in occurrences:
+        book_title = occ.get("book_title") or f"Book {occ['book_id']}"
+        lines.append(f"- [[{book_title}]] Ch.{occ['chapter_index']} — \"{occ['sentence_text']}\"")
+
+    unique_titles = list(dict.fromkeys(
+        occ.get("book_title") or f"Book {occ['book_id']}" for occ in occurrences
+    ))
+    lines += ["", "## Books"]
+    for t in unique_titles:
+        lines.append(f"- [[{t}]]")
+
+    return "\n".join(lines) + "\n"
+
+
+def _find_connected_books(
+    book_id: int,
+    all_vocab: list[dict],
+    min_shared: int = 2,
+) -> list[dict]:
+    """Return books sharing ≥ min_shared vocabulary words with book_id."""
+    # words used in target book
+    words_in_book: dict[str, str] = {}
+    for entry in all_vocab:
+        for occ in entry["occurrences"]:
+            if occ["book_id"] == book_id:
+                words_in_book[entry["word"]] = entry["word"]
+
+    # count shared words per other book
+    book_words: dict[int, dict] = {}
+    for entry in all_vocab:
+        word = entry["word"]
+        if word not in words_in_book:
+            continue
+        for occ in entry["occurrences"]:
+            if occ["book_id"] != book_id:
+                bid = occ["book_id"]
+                btitle = occ.get("book_title") or f"Book {bid}"
+                if bid not in book_words:
+                    book_words[bid] = {"title": btitle, "shared_words": []}
+                if word not in book_words[bid]["shared_words"]:
+                    book_words[bid]["shared_words"].append(word)
+
+    return [
+        {"title": v["title"], "shared_words": v["shared_words"]}
+        for v in book_words.values()
+        if len(v["shared_words"]) >= min_shared
+    ]
+
+
+@router.post("/export/obsidian")
+async def export_obsidian(
+    req: ExportRequest,
+    user: dict = Depends(get_current_user),
+):
+    settings = await get_obsidian_settings(user["id"])
+    github_token_enc = settings.get("github_token")
+    repo = settings.get("obsidian_repo")
+    obs_path = settings.get("obsidian_path") or "All Notes/002 Literature Notes/000 Books"
+
+    if not github_token_enc or not repo:
+        raise HTTPException(
+            status_code=400,
+            detail="Obsidian settings (GitHub token and repo) not configured",
+        )
+
+    github_token = decrypt_api_key(github_token_enc)
+    export_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    all_vocab = await get_vocabulary(user["id"])
+
+    from services.db import get_annotations as db_get_annotations
+
+    try:
+        if req.book_id is not None:
+            # Export single book
+            book = await get_cached_book(req.book_id)
+            annotations = await db_get_annotations(user["id"], req.book_id)
+            words_for_book = [
+                v for v in all_vocab
+                if any(occ["book_id"] == req.book_id for occ in v["occurrences"])
+            ]
+            connected = _find_connected_books(req.book_id, all_vocab)
+            title = book.get("title", f"Book {req.book_id}") if book else f"Book {req.book_id}"
+            filename = f"{title}.md"
+            content = _build_book_markdown(
+                book, words_for_book, annotations, connected, req.book_id, export_date
+            )
+            url = await _github_put(
+                github_token, repo, obs_path, filename, content, f"Update {filename}"
+            )
+            return {"url": url}
+        else:
+            # Export all — one file per book + one per word
+            book_ids = list({
+                occ["book_id"]
+                for entry in all_vocab
+                for occ in entry["occurrences"]
+            })
+
+            urls = []
+            for bid in book_ids:
+                book = await get_cached_book(bid)
+                annotations = await db_get_annotations(user["id"], bid)
+                words_for_book = [
+                    v for v in all_vocab
+                    if any(occ["book_id"] == bid for occ in v["occurrences"])
+                ]
+                connected = _find_connected_books(bid, all_vocab)
+                title = book.get("title", f"Book {bid}") if book else f"Book {bid}"
+                filename = f"{title}.md"
+                content = _build_book_markdown(
+                    book, words_for_book, annotations, connected, bid, export_date
+                )
+                url = await _github_put(
+                    github_token, repo, obs_path, filename, content, f"Update {filename}"
+                )
+                urls.append(url)
+
+            # Export individual word notes
+            vocab_path = f"{obs_path}/vocabulary"
+            for entry in all_vocab:
+                word = entry["word"]
+                word_md = _build_word_markdown(word, entry["occurrences"])
+                filename = f"{word}.md"
+                url = await _github_put(
+                    github_token, repo, vocab_path, filename, word_md, f"Update {filename}"
+                )
+                urls.append(url)
+
+            return {"urls": urls}
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -537,3 +537,176 @@ async def list_cached_books() -> list[dict]:
                 d[field] = json.loads(d[field])
         result.append(d)
     return result
+
+
+# ── Annotations ───────────────────────────────────────────────────────────────
+
+async def create_annotation(
+    user_id: int,
+    book_id: int,
+    chapter_index: int,
+    sentence_text: str,
+    note_text: str,
+    color: str,
+) -> dict:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            """INSERT INTO annotations (user_id, book_id, chapter_index, sentence_text, note_text, color)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (user_id, book_id, chapter_index, sentence_text, note_text, color),
+        )
+        await db.commit()
+        row_id = cursor.lastrowid
+        async with db.execute("SELECT * FROM annotations WHERE id = ?", (row_id,)) as c:
+            row = await c.fetchone()
+    return dict(row)
+
+
+async def get_annotations(user_id: int, book_id: int) -> list[dict]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT * FROM annotations WHERE user_id = ? AND book_id = ? ORDER BY chapter_index, created_at",
+            (user_id, book_id),
+        ) as cursor:
+            rows = await cursor.fetchall()
+    return [dict(r) for r in rows]
+
+
+async def update_annotation(
+    annotation_id: int,
+    user_id: int,
+    note_text: str,
+    color: str,
+) -> dict | None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        await db.execute(
+            "UPDATE annotations SET note_text = ?, color = ? WHERE id = ? AND user_id = ?",
+            (note_text, color, annotation_id, user_id),
+        )
+        await db.commit()
+        async with db.execute(
+            "SELECT * FROM annotations WHERE id = ? AND user_id = ?",
+            (annotation_id, user_id),
+        ) as cursor:
+            row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
+async def delete_annotation(annotation_id: int, user_id: int) -> bool:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "DELETE FROM annotations WHERE id = ? AND user_id = ?",
+            (annotation_id, user_id),
+        )
+        await db.commit()
+    return cursor.rowcount > 0
+
+
+# ── Vocabulary ────────────────────────────────────────────────────────────────
+
+async def save_word(
+    user_id: int,
+    word: str,
+    book_id: int,
+    chapter_index: int,
+    sentence_text: str,
+) -> dict:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        await db.execute(
+            "INSERT OR IGNORE INTO vocabulary (user_id, word) VALUES (?, ?)",
+            (user_id, word),
+        )
+        await db.commit()
+        async with db.execute(
+            "SELECT id FROM vocabulary WHERE user_id = ? AND word = ?",
+            (user_id, word),
+        ) as cursor:
+            vocab_row = await cursor.fetchone()
+        vocab_id = vocab_row["id"]
+
+        # Avoid duplicate occurrences for same word+book+sentence
+        await db.execute(
+            """INSERT OR IGNORE INTO word_occurrences (vocabulary_id, book_id, chapter_index, sentence_text)
+               SELECT ?, ?, ?, ?
+               WHERE NOT EXISTS (
+                   SELECT 1 FROM word_occurrences
+                   WHERE vocabulary_id = ? AND book_id = ? AND sentence_text = ?
+               )""",
+            (vocab_id, book_id, chapter_index, sentence_text,
+             vocab_id, book_id, sentence_text),
+        )
+        await db.commit()
+
+        async with db.execute("SELECT * FROM vocabulary WHERE id = ?", (vocab_id,)) as cursor:
+            row = await cursor.fetchone()
+    return dict(row)
+
+
+async def get_vocabulary(user_id: int) -> list[dict]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT id, word, created_at FROM vocabulary WHERE user_id = ? ORDER BY word",
+            (user_id,),
+        ) as cursor:
+            vocab_rows = await cursor.fetchall()
+
+        result = []
+        for v in vocab_rows:
+            async with db.execute(
+                """SELECT wo.book_id, b.title AS book_title, wo.chapter_index, wo.sentence_text
+                   FROM word_occurrences wo
+                   LEFT JOIN books b ON b.id = wo.book_id
+                   WHERE wo.vocabulary_id = ?
+                   ORDER BY wo.created_at""",
+                (v["id"],),
+            ) as cursor:
+                occurrences = [dict(r) for r in await cursor.fetchall()]
+            result.append({
+                "id": v["id"],
+                "word": v["word"],
+                "created_at": v["created_at"],
+                "occurrences": occurrences,
+            })
+    return result
+
+
+async def delete_word(user_id: int, word: str) -> bool:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "DELETE FROM vocabulary WHERE user_id = ? AND word = ?",
+            (user_id, word),
+        )
+        await db.commit()
+    return cursor.rowcount > 0
+
+
+# ── Obsidian / GitHub settings ────────────────────────────────────────────────
+
+async def update_obsidian_settings(
+    user_id: int,
+    github_token_encrypted: str | None,
+    repo: str | None,
+    path: str | None,
+) -> None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "UPDATE users SET github_token = ?, obsidian_repo = ?, obsidian_path = ? WHERE id = ?",
+            (github_token_encrypted, repo, path, user_id),
+        )
+        await db.commit()
+
+
+async def get_obsidian_settings(user_id: int) -> dict:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT github_token, obsidian_repo, obsidian_path FROM users WHERE id = ?",
+            (user_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+    return dict(row) if row else {}

--- a/backend/services/migrations.py
+++ b/backend/services/migrations.py
@@ -83,6 +83,8 @@ async def run(db_path: str) -> list[str]:
              "SELECT 1 FROM pragma_table_info('rate_limiter_usage') WHERE name='model'"),
             ("012_user_plan",
              "SELECT 1 FROM pragma_table_info('users') WHERE name='plan'"),
+            ("014_annotations_vocabulary",
+             "SELECT name FROM sqlite_master WHERE type='table' AND name='annotations'"),
         ]
         bootstrapped: list[str] = []
         for version, check_sql in bootstrap_checks:

--- a/backend/tests/test_router_annotations.py
+++ b/backend/tests/test_router_annotations.py
@@ -1,0 +1,159 @@
+"""
+Tests for routers/annotations.py — CRUD for book annotations.
+"""
+
+import pytest
+from services.db import save_book, create_annotation
+
+_BOOK_META = {
+    "title": "Test Book",
+    "authors": ["Author"],
+    "languages": ["en"],
+    "subjects": [],
+    "download_count": 0,
+    "cover": "",
+}
+BOOK_ID = 8001
+
+
+async def test_create_annotation(client, test_user):
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    resp = await client.post("/api/annotations", json={
+        "book_id": BOOK_ID,
+        "chapter_index": 2,
+        "sentence_text": "It was the best of times.",
+        "note_text": "Famous opener",
+        "color": "yellow",
+    })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["book_id"] == BOOK_ID
+    assert data["chapter_index"] == 2
+    assert data["sentence_text"] == "It was the best of times."
+    assert data["note_text"] == "Famous opener"
+    assert data["color"] == "yellow"
+    assert data["id"] is not None
+
+
+async def test_create_annotation_defaults(client, test_user):
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    resp = await client.post("/api/annotations", json={
+        "book_id": BOOK_ID,
+        "chapter_index": 0,
+        "sentence_text": "A sentence.",
+    })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["note_text"] == ""
+    assert data["color"] == "yellow"
+
+
+async def test_get_annotations_for_book(client, test_user):
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    await create_annotation(test_user["id"], BOOK_ID, 0, "Sentence 1", "note1", "blue")
+    await create_annotation(test_user["id"], BOOK_ID, 1, "Sentence 2", "note2", "red")
+
+    resp = await client.get(f"/api/annotations?book_id={BOOK_ID}")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) == 2
+    texts = {a["sentence_text"] for a in items}
+    assert "Sentence 1" in texts
+    assert "Sentence 2" in texts
+
+
+async def test_get_annotations_returns_own_only(client, test_user):
+    """Annotations from other users should not appear."""
+    from services.db import get_or_create_user
+    other = await get_or_create_user(
+        google_id="other-g", email="other@example.com", name="Other", picture=""
+    )
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    await create_annotation(test_user["id"], BOOK_ID, 0, "My sentence", "mine", "yellow")
+    await create_annotation(other["id"], BOOK_ID, 0, "Other sentence", "theirs", "green")
+
+    resp = await client.get(f"/api/annotations?book_id={BOOK_ID}")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) == 1
+    assert items[0]["sentence_text"] == "My sentence"
+
+
+async def test_update_annotation(client, test_user):
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    ann = await create_annotation(test_user["id"], BOOK_ID, 0, "Text", "old note", "yellow")
+
+    resp = await client.patch(f"/api/annotations/{ann['id']}", json={
+        "note_text": "updated note",
+        "color": "red",
+    })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["note_text"] == "updated note"
+    assert data["color"] == "red"
+
+
+async def test_update_annotation_not_found_returns_404(client, test_user):
+    resp = await client.patch("/api/annotations/99999", json={
+        "note_text": "x",
+        "color": "blue",
+    })
+    assert resp.status_code == 404
+
+
+async def test_update_annotation_own_only(client, test_user):
+    """Cannot update another user's annotation — 404 rather than 403 (ownership hidden)."""
+    from services.db import get_or_create_user
+    other = await get_or_create_user(
+        google_id="other-g2", email="other2@example.com", name="Other2", picture=""
+    )
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    ann = await create_annotation(other["id"], BOOK_ID, 0, "Their text", "", "yellow")
+
+    resp = await client.patch(f"/api/annotations/{ann['id']}", json={
+        "note_text": "hijack",
+        "color": "red",
+    })
+    assert resp.status_code == 404
+
+
+async def test_delete_annotation(client, test_user):
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    ann = await create_annotation(test_user["id"], BOOK_ID, 0, "To delete", "", "yellow")
+
+    resp = await client.delete(f"/api/annotations/{ann['id']}")
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+    # Confirm gone
+    resp = await client.get(f"/api/annotations?book_id={BOOK_ID}")
+    assert resp.json() == []
+
+
+async def test_delete_annotation_not_found_returns_404(client, test_user):
+    resp = await client.delete("/api/annotations/99999")
+    assert resp.status_code == 404
+
+
+async def test_delete_annotation_own_only(client, test_user):
+    from services.db import get_or_create_user
+    other = await get_or_create_user(
+        google_id="other-g3", email="other3@example.com", name="Other3", picture=""
+    )
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    ann = await create_annotation(other["id"], BOOK_ID, 0, "Theirs", "", "yellow")
+
+    resp = await client.delete(f"/api/annotations/{ann['id']}")
+    assert resp.status_code == 404
+
+
+async def test_annotations_require_auth(anon_client):
+    resp = await anon_client.get(f"/api/annotations?book_id={BOOK_ID}")
+    assert resp.status_code == 401
+
+    resp = await anon_client.post("/api/annotations", json={
+        "book_id": BOOK_ID,
+        "chapter_index": 0,
+        "sentence_text": "x",
+    })
+    assert resp.status_code == 401

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -1,0 +1,204 @@
+"""
+Tests for routers/vocabulary.py — save/get/delete words and Obsidian export.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from services.db import save_book, save_word, update_obsidian_settings
+from services.auth import encrypt_api_key
+
+_BOOK_META = {
+    "title": "Moby Dick",
+    "authors": ["Herman Melville"],
+    "languages": ["en"],
+    "subjects": [],
+    "download_count": 0,
+    "cover": "",
+}
+BOOK_ID = 9001
+
+
+async def test_save_word(client, test_user):
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    resp = await client.post("/api/vocabulary", json={
+        "word": "leviathan",
+        "book_id": BOOK_ID,
+        "chapter_index": 3,
+        "sentence_text": "The great leviathan swam past.",
+    })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["word"] == "leviathan"
+    assert data["user_id"] == test_user["id"]
+
+
+async def test_save_word_deduplicates_occurrence(client, test_user):
+    """Saving the same word+book+sentence twice should not create duplicate occurrences."""
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    payload = {
+        "word": "whale",
+        "book_id": BOOK_ID,
+        "chapter_index": 1,
+        "sentence_text": "Call me Ishmael.",
+    }
+    await client.post("/api/vocabulary", json=payload)
+    await client.post("/api/vocabulary", json=payload)
+
+    resp = await client.get("/api/vocabulary")
+    vocab = resp.json()
+    whale = next(v for v in vocab if v["word"] == "whale")
+    assert len(whale["occurrences"]) == 1
+
+
+async def test_get_vocabulary_empty(client, test_user):
+    resp = await client.get("/api/vocabulary")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_get_vocabulary_with_occurrences(client, test_user):
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_word(test_user["id"], "ahab", BOOK_ID, 5, "Captain Ahab spoke.")
+
+    resp = await client.get("/api/vocabulary")
+    assert resp.status_code == 200
+    vocab = resp.json()
+    assert len(vocab) == 1
+    entry = vocab[0]
+    assert entry["word"] == "ahab"
+    assert len(entry["occurrences"]) == 1
+    occ = entry["occurrences"][0]
+    assert occ["book_id"] == BOOK_ID
+    assert occ["chapter_index"] == 5
+    assert occ["sentence_text"] == "Captain Ahab spoke."
+    assert occ["book_title"] == "Moby Dick"
+
+
+async def test_get_vocabulary_own_only(client, test_user):
+    from services.db import get_or_create_user
+    other = await get_or_create_user(
+        google_id="voc-other", email="vocother@example.com", name="Other", picture=""
+    )
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_word(other["id"], "secret", BOOK_ID, 0, "A secret word.")
+
+    resp = await client.get("/api/vocabulary")
+    assert resp.json() == []
+
+
+async def test_delete_word(client, test_user):
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_word(test_user["id"], "cetacean", BOOK_ID, 0, "A cetacean species.")
+
+    resp = await client.delete("/api/vocabulary/cetacean")
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+    # Confirm gone
+    vocab = (await client.get("/api/vocabulary")).json()
+    assert not any(v["word"] == "cetacean" for v in vocab)
+
+
+async def test_delete_word_not_found(client, test_user):
+    resp = await client.delete("/api/vocabulary/nonexistentword")
+    assert resp.status_code == 404
+
+
+async def test_delete_word_own_only(client, test_user):
+    from services.db import get_or_create_user
+    other = await get_or_create_user(
+        google_id="voc-other2", email="vocother2@example.com", name="Other2", picture=""
+    )
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_word(other["id"], "pirate", BOOK_ID, 0, "A pirate's life.")
+
+    resp = await client.delete("/api/vocabulary/pirate")
+    assert resp.status_code == 404
+
+
+async def test_vocabulary_requires_auth(anon_client):
+    resp = await anon_client.get("/api/vocabulary")
+    assert resp.status_code == 401
+
+    resp = await anon_client.post("/api/vocabulary", json={
+        "word": "x", "book_id": 1, "chapter_index": 0, "sentence_text": "x"
+    })
+    assert resp.status_code == 401
+
+
+# ── Export endpoint ───────────────────────────────────────────────────────────
+
+async def _setup_export(test_user, book_id=BOOK_ID):
+    await save_book(book_id, _BOOK_META, "text")
+    await save_word(test_user["id"], "leviathan", book_id, 3, "The great leviathan.")
+    enc_token = encrypt_api_key("ghp_test_token")
+    await update_obsidian_settings(
+        test_user["id"],
+        enc_token,
+        "user/obsidian-notes",
+        "All Notes/002 Literature Notes/000 Books",
+    )
+
+
+async def test_export_single_book(client, test_user):
+    await _setup_export(test_user)
+
+    fake_put_response = {
+        "content": {"html_url": "https://github.com/user/obsidian-notes/blob/main/Moby Dick.md"}
+    }
+    with patch("routers.vocabulary._github_put", new_callable=AsyncMock, return_value="https://github.com/user/obsidian-notes/blob/main/Moby Dick.md"):
+        resp = await client.post("/api/vocabulary/export/obsidian", json={"book_id": BOOK_ID})
+
+    assert resp.status_code == 200
+    assert "url" in resp.json()
+
+
+async def test_export_all_books(client, test_user):
+    await _setup_export(test_user)
+
+    with patch("routers.vocabulary._github_put", new_callable=AsyncMock, return_value="https://github.com/user/repo/blob/main/file.md"):
+        resp = await client.post("/api/vocabulary/export/obsidian", json={})
+
+    assert resp.status_code == 200
+    assert "urls" in resp.json()
+
+
+async def test_export_without_settings_returns_400(client, test_user):
+    resp = await client.post("/api/vocabulary/export/obsidian", json={"book_id": BOOK_ID})
+    assert resp.status_code == 400
+    assert "not configured" in resp.json()["detail"]
+
+
+async def test_export_github_api_error_returns_502(client, test_user):
+    await _setup_export(test_user)
+
+    with patch(
+        "routers.vocabulary._github_put",
+        new_callable=AsyncMock,
+        side_effect=Exception("network error"),
+    ):
+        resp = await client.post("/api/vocabulary/export/obsidian", json={"book_id": BOOK_ID})
+
+    assert resp.status_code == 500
+
+
+async def test_export_calls_github_with_correct_content(client, test_user):
+    """Verify the markdown content passed to GitHub contains expected sections."""
+    await _setup_export(test_user)
+
+    captured_content = {}
+
+    async def fake_put(token, repo, path, filename, content_md, message):
+        captured_content["content"] = content_md
+        captured_content["filename"] = filename
+        return "https://github.com/example/url"
+
+    with patch("routers.vocabulary._github_put", side_effect=fake_put):
+        resp = await client.post("/api/vocabulary/export/obsidian", json={"book_id": BOOK_ID})
+
+    assert resp.status_code == 200
+    content = captured_content["content"]
+    assert "## Vocabulary" in content
+    assert "leviathan" in content
+    assert "## Annotations" in content
+    assert "gutenberg.org/ebooks/" in content

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,13 @@
       "name": "book-reader-ai-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@capacitor/app": "^8.1.0",
+        "@capacitor/cli": "^8.3.1",
+        "@capacitor/core": "^8.3.1",
+        "@capacitor/haptics": "^8.0.2",
+        "@capacitor/ios": "^8.3.1",
+        "@capacitor/keyboard": "^8.0.3",
+        "@capacitor/status-bar": "^8.0.2",
         "next": "14.2.3",
         "next-auth": "^5.0.0-beta.30",
         "react": "^18",
@@ -629,6 +636,101 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@capacitor/app": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.0.tgz",
+      "integrity": "sha512-MlmttTOWHDedr/G4SrhNRxsXMqY+R75S4MM4eIgzsgCzOYhb/MpCkA5Q3nuOCfL1oHm26xjUzqZ5aupbOwdfYg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/cli": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.3.1.tgz",
+      "integrity": "sha512-1sPGW4THTDfR6YjXwZ0jM7oAfAtciPOHN00qs/3sNAQx1kKrrEYSfDPwCm1/xlAgi0OeL69SiRfw314Ans+1sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/cli-framework-output": "^2.2.8",
+        "@ionic/utils-subprocess": "^3.0.1",
+        "@ionic/utils-terminal": "^2.3.5",
+        "commander": "^12.1.0",
+        "debug": "^4.4.0",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^11.2.0",
+        "kleur": "^4.1.5",
+        "native-run": "^2.0.3",
+        "open": "^8.4.0",
+        "plist": "^3.1.0",
+        "prompts": "^2.4.2",
+        "rimraf": "^6.0.1",
+        "semver": "^7.6.3",
+        "tar": "^7.5.3",
+        "tslib": "^2.8.1",
+        "xml2js": "^0.6.2"
+      },
+      "bin": {
+        "cap": "bin/capacitor",
+        "capacitor": "bin/capacitor"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@capacitor/cli/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@capacitor/core": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.3.1.tgz",
+      "integrity": "sha512-UF8ItlHguU1Z6GXfPTeT2gakf+ctNI8pAS1kwSBQlsJMlfD4OPoto/SmKnOxKCQvnF4WRcdWeg6C0zREUNaAQg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/haptics": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/haptics/-/haptics-8.0.2.tgz",
+      "integrity": "sha512-c2hZzRR5Fk1tbTvhG1jhh2XBAf3EhnIerMIb2sl7Mt41Gxx1fhBJFDa0/BI1IbY4loVepyyuqNC9820/GZuoWQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/ios": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.3.1.tgz",
+      "integrity": "sha512-BEhLyYYHWJLib4mpaPMaaylbC8meqgxbNYwQJH2svsSLW7yo/hFie+Zoo66a44XnqcMd2tvmAuzimWunXZi/xA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^8.3.0"
+      }
+    },
+    "node_modules/@capacitor/keyboard": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/keyboard/-/keyboard-8.0.3.tgz",
+      "integrity": "sha512-27Bv5/2w1Ss2njguBgTS98O0Bb8DRJhAARyzXYib0JlT/n6BrJw/EZ0CokM4C8GFUjFDjJnEKF1Ie01buTMEXQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/status-bar": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-8.0.2.tgz",
+      "integrity": "sha512-WXs8YB8B9eEaPZz+bcdY6t2nForF1FLoj/JU0Dl9RRgQnddnS98FEEyDooQhaY7wivr000j4+SC1FyeJkrFO7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -778,6 +880,206 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@ionic/cli-framework-output": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ionic/cli-framework-output/-/cli-framework-output-2.2.8.tgz",
+      "integrity": "sha512-TshtaFQsovB4NWRBydbNFawql6yul7d5bMiW1WYYf17hd99V6xdDdk3vtF51bw6sLkxON3bDQpWsnUc9/hVo3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-terminal": "2.3.5",
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-array": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-array/-/utils-array-2.1.6.tgz",
+      "integrity": "sha512-0JZ1Zkp3wURnv8oq6Qt7fMPo5MpjbLoUoa9Bu2Q4PJuSDWM8H8gwF3dQO7VTeUj3/0o1IB1wGkFWZZYgUXZMUg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-fs": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-3.1.7.tgz",
+      "integrity": "sha512-2EknRvMVfhnyhL1VhFkSLa5gOcycK91VnjfrTB0kbqkTFCOXyXgVLI5whzq7SLrgD9t1aqos3lMMQyVzaQ5gVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^8.0.0",
+        "debug": "^4.0.0",
+        "fs-extra": "^9.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-fs/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@ionic/utils-object": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-object/-/utils-object-2.1.6.tgz",
+      "integrity": "sha512-vCl7sl6JjBHFw99CuAqHljYJpcE88YaH2ZW4ELiC/Zwxl5tiwn4kbdP/gxi2OT3MQb1vOtgAmSNRtusvgxI8ww==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-process": {
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-process/-/utils-process-2.1.12.tgz",
+      "integrity": "sha512-Jqkgyq7zBs/v/J3YvKtQQiIcxfJyplPgECMWgdO0E1fKrrH8EF0QGHNJ9mJCn6PYe2UtHNS8JJf5G21e09DfYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-object": "2.1.6",
+        "@ionic/utils-terminal": "2.3.5",
+        "debug": "^4.0.0",
+        "signal-exit": "^3.0.3",
+        "tree-kill": "^1.2.2",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-process/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@ionic/utils-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-stream/-/utils-stream-3.1.7.tgz",
+      "integrity": "sha512-eSELBE7NWNFIHTbTC2jiMvh1ABKGIpGdUIvARsNPMNQhxJB3wpwdiVnoBoTYp+5a6UUIww4Kpg7v6S7iTctH1w==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-subprocess": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-subprocess/-/utils-subprocess-3.0.1.tgz",
+      "integrity": "sha512-cT4te3AQQPeIM9WCwIg8ohroJ8TjsYaMb2G4ZEgv9YzeDqHZ4JpeIKqG2SoaA3GmVQ3sOfhPM6Ox9sxphV/d1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-array": "2.1.6",
+        "@ionic/utils-fs": "3.1.7",
+        "@ionic/utils-process": "2.1.12",
+        "@ionic/utils-stream": "3.1.7",
+        "@ionic/utils-terminal": "2.3.5",
+        "cross-spawn": "^7.0.3",
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-terminal": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.5.tgz",
+      "integrity": "sha512-3cKScz9Jx2/Pr9ijj1OzGlBDfcmx7OMVBt4+P1uRR0SSW4cm1/y3Mo4OY3lfkuaYifMNBW8Wz6lQHbs1bihr7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/slice-ansi": "^4.0.0",
+        "debug": "^4.0.0",
+        "signal-exit": "^3.0.3",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "tslib": "^2.0.1",
+        "untildify": "^4.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-terminal/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/@ionic/utils-terminal/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@ionic/utils-terminal/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@ionic/utils-terminal/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@ionic/utils-terminal/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -794,6 +1096,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -2000,6 +2314,15 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/fs-extra": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.5.tgz",
+      "integrity": "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -2067,7 +2390,6 @@
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2098,6 +2420,12 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==",
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -2411,6 +2739,15 @@
         "win32"
       ]
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2441,7 +2778,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2451,7 +2787,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2509,6 +2844,24 @@
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/autoprefixer": {
@@ -2664,6 +3017,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.17",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
@@ -2677,6 +3050,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2688,6 +3070,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bplist-parser": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.2.tgz",
+      "integrity": "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "1.6.x"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -2755,6 +3149,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -2940,6 +3343,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/ci-info": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -3059,7 +3471,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3072,7 +3483,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
@@ -3113,7 +3523,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3240,6 +3649,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3308,6 +3726,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/elementtree": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
+      "integrity": "sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "sax": "1.1.4"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/emittery": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
@@ -3339,6 +3769,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/error-ex": {
@@ -3519,6 +3958,15 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3575,6 +4023,20 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/fs.realpath": {
@@ -3893,8 +4355,16 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -3972,6 +4442,21 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3986,7 +4471,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4067,11 +4551,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -5258,6 +5753,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -6284,10 +6800,21 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mkdirp": {
@@ -6353,6 +6880,31 @@
       },
       "funding": {
         "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/native-run": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/native-run/-/native-run-2.0.3.tgz",
+      "integrity": "sha512-U1PllBuzW5d1gfan+88L+Hky2eZx+9gv3Pf6rNBxKbORxi7boHzqiA6QFGSnqMem4j0A9tZ08NMIs5+0m/VS1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-fs": "^3.1.7",
+        "@ionic/utils-terminal": "^2.3.4",
+        "bplist-parser": "^0.3.2",
+        "debug": "^4.3.4",
+        "elementtree": "^0.1.7",
+        "ini": "^4.1.1",
+        "plist": "^3.1.0",
+        "split2": "^4.2.0",
+        "through2": "^4.0.2",
+        "tslib": "^2.6.2",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "native-run": "bin/native-run"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/natural-compare": {
@@ -6567,6 +7119,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -6626,7 +7195,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parse-entities": {
@@ -6710,7 +7278,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6746,6 +7313,12 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6844,6 +7417,20 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/plist": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
       }
     },
     "node_modules/postcss": {
@@ -7058,6 +7645,28 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prompts/node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -7184,6 +7793,20 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -7344,6 +7967,103 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -7375,12 +8095,38 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
+      "integrity": "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==",
+      "license": "ISC"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -7408,7 +8154,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7421,7 +8166,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7434,7 +8178,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7453,6 +8196,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -7461,6 +8210,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
     "node_modules/source-map": {
@@ -7503,6 +8269,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -7539,6 +8314,15 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -7876,6 +8660,31 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -7958,6 +8767,15 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
       }
     },
     "node_modules/tinyglobby": {
@@ -8074,6 +8892,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -8148,7 +8975,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -8238,6 +9064,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -8271,6 +9106,15 @@
         "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -8308,7 +9152,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {
@@ -8439,7 +9282,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8596,6 +9438,37 @@
         "node": ">=18"
       }
     },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -8682,6 +9555,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,9 +10,18 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "ios": "cap sync ios && cap open ios",
+    "cap:sync": "cap sync"
   },
   "dependencies": {
+    "@capacitor/app": "^8.1.0",
+    "@capacitor/cli": "^8.3.1",
+    "@capacitor/core": "^8.3.1",
+    "@capacitor/haptics": "^8.0.2",
+    "@capacitor/ios": "^8.3.1",
+    "@capacitor/keyboard": "^8.0.3",
+    "@capacitor/status-bar": "^8.0.2",
     "next": "14.2.3",
     "next-auth": "^5.0.0-beta.30",
     "react": "^18",

--- a/frontend/src/__tests__/AnnotationToolbar.test.tsx
+++ b/frontend/src/__tests__/AnnotationToolbar.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Tests for AnnotationToolbar component.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("@/lib/api", () => ({
+  createAnnotation: jest.fn(),
+  updateAnnotation: jest.fn(),
+  deleteAnnotation: jest.fn(),
+}));
+
+import * as api from "@/lib/api";
+import AnnotationToolbar from "@/components/AnnotationToolbar";
+
+const mockCreateAnnotation = api.createAnnotation as jest.MockedFunction<typeof api.createAnnotation>;
+const mockUpdateAnnotation = api.updateAnnotation as jest.MockedFunction<typeof api.updateAnnotation>;
+const mockDeleteAnnotation = api.deleteAnnotation as jest.MockedFunction<typeof api.deleteAnnotation>;
+
+const BASE_PROPS = {
+  sentenceText: "It is a truth universally acknowledged.",
+  chapterIndex: 0,
+  bookId: 1,
+  position: { x: 100, y: 200 },
+  onClose: jest.fn(),
+  onSaved: jest.fn(),
+  onDeleted: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test("renders color picker and save button", () => {
+  render(<AnnotationToolbar {...BASE_PROPS} />);
+  expect(screen.getByTestId("annotation-toolbar")).toBeInTheDocument();
+  expect(screen.getByLabelText("Yellow")).toBeInTheDocument();
+  expect(screen.getByLabelText("Blue")).toBeInTheDocument();
+  expect(screen.getByLabelText("Green")).toBeInTheDocument();
+  expect(screen.getByLabelText("Pink")).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /save/i })).toBeInTheDocument();
+});
+
+test("does not show Delete button when no existing annotation", () => {
+  render(<AnnotationToolbar {...BASE_PROPS} />);
+  expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+});
+
+test("shows Delete button when existingAnnotation is provided", () => {
+  render(
+    <AnnotationToolbar
+      {...BASE_PROPS}
+      existingAnnotation={{ id: 42, note_text: "My note", color: "blue" }}
+    />,
+  );
+  expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
+});
+
+test("pre-fills color and note from existingAnnotation", () => {
+  render(
+    <AnnotationToolbar
+      {...BASE_PROPS}
+      existingAnnotation={{ id: 42, note_text: "Interesting passage", color: "green" }}
+    />,
+  );
+  const textarea = screen.getByPlaceholderText(/Add a note/i) as HTMLTextAreaElement;
+  expect(textarea.value).toBe("Interesting passage");
+  // Green button should appear selected (scale-110 class)
+  const greenBtn = screen.getByLabelText("Green");
+  expect(greenBtn.className).toMatch(/scale-110/);
+});
+
+test("calls createAnnotation and onSaved when saving new annotation", async () => {
+  const annotation = {
+    id: 1,
+    chapter_index: 0,
+    sentence_text: BASE_PROPS.sentenceText,
+    note_text: "My note",
+    color: "yellow",
+  };
+  mockCreateAnnotation.mockResolvedValue(annotation);
+
+  render(<AnnotationToolbar {...BASE_PROPS} />);
+
+  const textarea = screen.getByPlaceholderText(/Add a note/i);
+  await userEvent.type(textarea, "My note");
+
+  await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+  await waitFor(() => {
+    expect(mockCreateAnnotation).toHaveBeenCalledWith({
+      book_id: 1,
+      chapter_index: 0,
+      sentence_text: BASE_PROPS.sentenceText,
+      note_text: "My note",
+      color: "yellow",
+    });
+    expect(BASE_PROPS.onSaved).toHaveBeenCalledWith(annotation);
+    expect(BASE_PROPS.onClose).toHaveBeenCalled();
+  });
+});
+
+test("calls updateAnnotation when saving existing annotation", async () => {
+  const updated = {
+    id: 42,
+    chapter_index: 0,
+    sentence_text: BASE_PROPS.sentenceText,
+    note_text: "Updated",
+    color: "blue",
+  };
+  mockUpdateAnnotation.mockResolvedValue(updated);
+
+  render(
+    <AnnotationToolbar
+      {...BASE_PROPS}
+      existingAnnotation={{ id: 42, note_text: "Old note", color: "yellow" }}
+    />,
+  );
+
+  // Change color to blue
+  await userEvent.click(screen.getByLabelText("Blue"));
+
+  await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+  await waitFor(() => {
+    expect(mockUpdateAnnotation).toHaveBeenCalledWith(42, expect.objectContaining({ color: "blue" }));
+    expect(BASE_PROPS.onSaved).toHaveBeenCalledWith(updated);
+  });
+});
+
+test("calls deleteAnnotation and onDeleted when deleting", async () => {
+  mockDeleteAnnotation.mockResolvedValue({ ok: true });
+
+  render(
+    <AnnotationToolbar
+      {...BASE_PROPS}
+      existingAnnotation={{ id: 42, note_text: "", color: "pink" }}
+    />,
+  );
+
+  await userEvent.click(screen.getByRole("button", { name: /delete/i }));
+
+  await waitFor(() => {
+    expect(mockDeleteAnnotation).toHaveBeenCalledWith(42);
+    expect(BASE_PROPS.onDeleted).toHaveBeenCalledWith(42);
+    expect(BASE_PROPS.onClose).toHaveBeenCalled();
+  });
+});
+
+test("calls onClose when X button is clicked", async () => {
+  render(<AnnotationToolbar {...BASE_PROPS} />);
+  await userEvent.click(screen.getByRole("button", { name: /✕/i }));
+  expect(BASE_PROPS.onClose).toHaveBeenCalled();
+});

--- a/frontend/src/__tests__/VocabularyPage.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Tests for vocabulary page.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mock next-auth
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { backendToken: "token123" } }),
+}));
+
+// Mock next/navigation
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getVocabulary: jest.fn(),
+  deleteVocabularyWord: jest.fn(),
+  exportVocabularyToObsidian: jest.fn(),
+}));
+
+import * as api from "@/lib/api";
+import VocabularyPage from "@/app/vocabulary/page";
+
+const mockGetVocabulary = api.getVocabulary as jest.MockedFunction<typeof api.getVocabulary>;
+const mockDeleteVocabularyWord = api.deleteVocabularyWord as jest.MockedFunction<typeof api.deleteVocabularyWord>;
+const mockExportVocabularyToObsidian = api.exportVocabularyToObsidian as jest.MockedFunction<typeof api.exportVocabularyToObsidian>;
+
+const SAMPLE_WORDS = [
+  {
+    id: 1,
+    word: "ephemeral",
+    occurrences: [
+      {
+        book_id: 10,
+        book_title: "Moby Dick",
+        chapter_index: 2,
+        sentence_text: "The ephemeral whale loomed.",
+      },
+    ],
+  },
+  {
+    id: 2,
+    word: "ardent",
+    occurrences: [
+      {
+        book_id: 10,
+        book_title: "Moby Dick",
+        chapter_index: 5,
+        sentence_text: "His ardent gaze swept the sea.",
+      },
+    ],
+  },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetVocabulary.mockResolvedValue(SAMPLE_WORDS);
+});
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+test("renders word list after load", async () => {
+  render(<VocabularyPage />);
+  await flushPromises();
+  expect(await screen.findByText("ephemeral")).toBeInTheDocument();
+  expect(screen.getByText("ardent")).toBeInTheDocument();
+});
+
+test("shows book title and chapter for each occurrence", async () => {
+  render(<VocabularyPage />);
+  // Wait for words to load
+  const titles = await screen.findAllByText("Moby Dick");
+  expect(titles.length).toBeGreaterThanOrEqual(1);
+  // chapter_index 2 → displayed as "Ch.3" (1-based)
+  expect(screen.getByText("Ch.3")).toBeInTheDocument();
+});
+
+test("groups words alphabetically under correct letter heading", async () => {
+  render(<VocabularyPage />);
+  await flushPromises();
+  // 'a' for ardent, 'e' for ephemeral
+  expect(await screen.findByText("A")).toBeInTheDocument();
+  expect(screen.getByText("E")).toBeInTheDocument();
+});
+
+test("delete button calls deleteVocabularyWord and removes word", async () => {
+  mockDeleteVocabularyWord.mockResolvedValue({ ok: true });
+
+  render(<VocabularyPage />);
+  await flushPromises();
+  await screen.findByText("ephemeral");
+
+  const deleteBtn = screen.getByTestId("delete-ephemeral");
+  await userEvent.click(deleteBtn);
+
+  await waitFor(() => {
+    expect(mockDeleteVocabularyWord).toHaveBeenCalledWith("ephemeral");
+    expect(screen.queryByText("ephemeral")).not.toBeInTheDocument();
+  });
+});
+
+test("export button calls exportVocabularyToObsidian with no book_id", async () => {
+  mockExportVocabularyToObsidian.mockResolvedValue({ url: "https://github.com/example/pr/1" });
+
+  render(<VocabularyPage />);
+  await flushPromises();
+  await screen.findByText("ephemeral");
+
+  const exportBtn = screen.getByTestId("export-all-btn");
+  await userEvent.click(exportBtn);
+
+  await waitFor(() => {
+    expect(mockExportVocabularyToObsidian).toHaveBeenCalledWith(undefined);
+  });
+});
+
+test("shows empty state when no words", async () => {
+  mockGetVocabulary.mockResolvedValue([]);
+  render(<VocabularyPage />);
+  await flushPromises();
+  expect(await screen.findByText(/No saved words yet/i)).toBeInTheDocument();
+});

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -2,7 +2,7 @@
 import { useSession, signOut } from "next-auth/react";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { saveGeminiKey, deleteGeminiKey, getMe } from "@/lib/api";
+import { saveGeminiKey, deleteGeminiKey, getMe, getObsidianSettings, saveObsidianSettings } from "@/lib/api";
 import { getSettings, saveSettings, AppSettings } from "@/lib/settings";
 
 const LANGUAGES = [
@@ -28,6 +28,13 @@ export default function ProfilePage() {
   const [removingKey, setRemovingKey] = useState(false);
   const [keyMessage, setKeyMessage] = useState<{ text: string; ok: boolean } | null>(null);
 
+  // ── Obsidian settings state ────────────────────────────────────────────────
+  const [obsidianToken, setObsidianToken] = useState("");
+  const [obsidianRepo, setObsidianRepo] = useState("");
+  const [obsidianPath, setObsidianPath] = useState("All Notes/002 Literature Notes/000 Books");
+  const [obsidianSaving, setObsidianSaving] = useState(false);
+  const [obsidianMsg, setObsidianMsg] = useState<{ text: string; ok: boolean } | null>(null);
+
   // ── Preferences state ──────────────────────────────────────────────────────
   const [settings, setSettings] = useState<AppSettings>({
     insightLang: "en",
@@ -46,6 +53,15 @@ export default function ProfilePage() {
     getMe().then((me) => {
       setHasKey(me.hasGeminiKey);
       setIsAdmin(me.role === "admin");
+    }).catch(() => {});
+  }, [session?.backendToken]);
+
+  // Load Obsidian settings
+  useEffect(() => {
+    if (!session?.backendToken) return;
+    getObsidianSettings().then((s) => {
+      setObsidianRepo(s.obsidian_repo ?? "");
+      setObsidianPath(s.obsidian_path ?? "All Notes/002 Literature Notes/000 Books");
     }).catch(() => {});
   }, [session?.backendToken]);
 
@@ -77,6 +93,24 @@ export default function ProfilePage() {
       setKeyMessage({ text: e instanceof Error ? e.message : "Failed to save key", ok: false });
     } finally {
       setSavingKey(false);
+    }
+  }
+
+  async function handleSaveObsidian() {
+    setObsidianSaving(true);
+    setObsidianMsg(null);
+    try {
+      await saveObsidianSettings({
+        ...(obsidianToken.trim() ? { github_token: obsidianToken.trim() } : {}),
+        obsidian_repo: obsidianRepo.trim(),
+        obsidian_path: obsidianPath.trim(),
+      });
+      setObsidianToken("");
+      setObsidianMsg({ text: "Obsidian settings saved.", ok: true });
+    } catch (e: unknown) {
+      setObsidianMsg({ text: e instanceof Error ? e.message : "Failed to save", ok: false });
+    } finally {
+      setObsidianSaving(false);
     }
   }
 
@@ -198,6 +232,72 @@ export default function ProfilePage() {
           {keyMessage && (
             <p className={`mt-3 text-sm ${keyMessage.ok ? "text-emerald-700" : "text-red-600"}`}>
               {keyMessage.text}
+            </p>
+          )}
+        </section>
+
+        {/* ── Obsidian Export Settings ────────────────────────────────────── */}
+        <section className="bg-white rounded-2xl border border-amber-100 p-6 space-y-4">
+          <div>
+            <h2 className="font-serif text-lg font-semibold text-ink mb-1">Obsidian Export</h2>
+            <p className="text-sm text-stone-500">
+              Configure GitHub integration so vocabulary can be pushed to your Obsidian vault.
+            </p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-ink mb-1">
+              GitHub Token
+            </label>
+            <input
+              type="password"
+              placeholder="ghp_… (never shown back)"
+              value={obsidianToken}
+              onChange={(e) => setObsidianToken(e.target.value)}
+              className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-amber-400"
+            />
+            <p className="text-xs text-stone-400 mt-1">
+              Requires <code>contents:write</code> permission on your vault repo.
+            </p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-ink mb-1">
+              Obsidian Repo
+            </label>
+            <input
+              type="text"
+              placeholder="username/obsidian-notes"
+              value={obsidianRepo}
+              onChange={(e) => setObsidianRepo(e.target.value)}
+              className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-ink mb-1">
+              Vault Path
+            </label>
+            <input
+              type="text"
+              placeholder="All Notes/002 Literature Notes/000 Books"
+              value={obsidianPath}
+              onChange={(e) => setObsidianPath(e.target.value)}
+              className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+            />
+          </div>
+
+          <button
+            onClick={handleSaveObsidian}
+            disabled={obsidianSaving}
+            className="rounded-lg bg-amber-700 text-white px-5 py-2 text-sm hover:bg-amber-800 disabled:opacity-50 transition-colors"
+          >
+            {obsidianSaving ? "Saving…" : "Save Obsidian settings"}
+          </button>
+
+          {obsidianMsg && (
+            <p className={`text-sm ${obsidianMsg.ok ? "text-emerald-700" : "text-red-600"}`}>
+              {obsidianMsg.text}
             </p>
           )}
         </section>

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { getBookChapters, deleteTranslationCache, getAudiobook, deleteAudiobook, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, retryChapterTranslation, enqueueBookTranslation, saveReadingProgress, TranslationStatus, BookMeta, BookChapter, Audiobook, ApiError } from "@/lib/api";
+import { getBookChapters, deleteTranslationCache, getAudiobook, deleteAudiobook, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, retryChapterTranslation, enqueueBookTranslation, saveReadingProgress, getAnnotations, saveVocabularyWord, exportVocabularyToObsidian, TranslationStatus, BookMeta, BookChapter, Audiobook, ApiError, Annotation } from "@/lib/api";
 import { recordRecentBook, saveLastChapter, getLastChapter } from "@/lib/recentBooks";
 import { getSettings, saveSettings, FontSize, Theme } from "@/lib/settings";
 import InsightChat, { LANGUAGES } from "@/components/InsightChat";
@@ -12,6 +12,8 @@ import AudiobookPlayer from "@/components/AudiobookPlayer";
 import AudiobookSearch from "@/components/AudiobookSearch";
 import SentenceReader from "@/components/SentenceReader";
 import WordLookup from "@/components/WordLookup";
+import AnnotationToolbar from "@/components/AnnotationToolbar";
+import VocabularyToast from "@/components/VocabularyToast";
 
 // In-memory cache: bookId → chapters (survives client-side navigation)
 const chaptersCache = new Map<string, BookChapter[]>();
@@ -30,6 +32,20 @@ export default function ReaderPage() {
 
   const [selectedText, setSelectedText] = useState("");
   const [lookupWord, setLookupWord] = useState<{ word: string; x: number; y: number } | null>(null);
+
+  // Annotations
+  const [annotations, setAnnotations] = useState<Annotation[]>([]);
+  const [annotationPanel, setAnnotationPanel] = useState<{
+    sentenceText: string;
+    chapterIndex: number;
+    position: { x: number; y: number };
+  } | null>(null);
+
+  // Vocabulary toast
+  const [vocabToastWord, setVocabToastWord] = useState<string | null>(null);
+
+  // Obsidian export toast
+  const [obsidianToast, setObsidianToast] = useState<string | null>(null);
 
   // Audiobook
   const [audiobookEnabled, setAudiobookEnabled] = useState(true);
@@ -192,6 +208,12 @@ export default function ReaderPage() {
     setAudiobook(null);
     getAudiobook(Number(bookId)).then(setAudiobook).catch(() => {});
   }, [bookId]);
+
+  // Load annotations for this book (requires auth)
+  useEffect(() => {
+    if (!bookId || !session?.backendToken) return;
+    getAnnotations(Number(bookId)).then(setAnnotations).catch(() => {});
+  }, [bookId, session?.backendToken]);
 
   const bookLanguage = meta?.languages[0] || "en";
 
@@ -485,6 +507,33 @@ export default function ReaderPage() {
     document.getElementById("reader-scroll")?.scrollTo(0, 0);
   }
 
+  // Vocabulary save handler
+  async function handleWordSave(word: string, sentenceText: string) {
+    try {
+      await saveVocabularyWord({
+        word,
+        book_id: Number(bookId),
+        chapter_index: chapterIndex,
+        sentence_text: sentenceText,
+      });
+      setVocabToastWord(word);
+    } catch {
+      // silently ignore (user may not be logged in)
+    }
+  }
+
+  // Obsidian export handler
+  async function handleObsidianExport() {
+    try {
+      const { url } = await exportVocabularyToObsidian(Number(bookId));
+      setObsidianToast(url);
+      setTimeout(() => setObsidianToast(null), 6000);
+    } catch (e) {
+      setObsidianToast(e instanceof Error ? e.message : "Export failed");
+      setTimeout(() => setObsidianToast(null), 4000);
+    }
+  }
+
   const current = chapters[chapterIndex];
   const chapterParagraphs = current?.text
     ? current.text.split(/\n\n+/).filter((p) => p.trim())
@@ -631,6 +680,28 @@ export default function ReaderPage() {
             </svg>
             Insight
           </button>
+
+          {/* Vocabulary link */}
+          {session?.backendToken && (
+            <button
+              onClick={() => router.push("/vocabulary")}
+              title="Vocabulary"
+              className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-xs font-medium transition-colors"
+            >
+              📚 Vocab
+            </button>
+          )}
+
+          {/* Export vocabulary to Obsidian */}
+          {session?.backendToken && (
+            <button
+              onClick={handleObsidianExport}
+              title="Export vocabulary to Obsidian"
+              className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-xs font-medium transition-colors"
+            >
+              ↗ Obsidian
+            </button>
+          )}
 
           {/* Audiobook toggle — only shown when feature is enabled in settings */}
           {audiobookEnabled && (
@@ -913,12 +984,15 @@ export default function ReaderPage() {
                   isPlaying={audiobook ? audioIsPlaying : ttsIsPlaying}
                   chunks={!audiobook && ttsChunks.length > 0 ? ttsChunks : undefined}
                   disabled={!audiobook && ttsIsLoading}
-                  // Translation props: SentenceReader renders both original
-                  // (highlighted) and translation (when enabled). This ensures
-                  // highlighting works regardless of translation state.
                   translations={translationEnabled ? translatedParagraphs : undefined}
                   translationDisplayMode={displayMode}
                   translationLoading={translationLoading}
+                  annotations={session?.backendToken ? annotations.filter((a) => a.chapter_index === chapterIndex) : undefined}
+                  chapterIndex={chapterIndex}
+                  onWordSave={session?.backendToken ? handleWordSave : undefined}
+                  onAnnotate={session?.backendToken ? (sentenceText, ci, position) => {
+                    setAnnotationPanel({ sentenceText, chapterIndex: ci, position });
+                  } : undefined}
                   onSegmentClick={(startTime, segText) => {
                     if (audiobook) {
                       seekAudioRef.current(startTime);
@@ -968,6 +1042,65 @@ export default function ReaderPage() {
               position={{ x: lookupWord.x, y: lookupWord.y }}
               onClose={() => setLookupWord(null)}
             />
+          )}
+
+          {/* Annotation toolbar */}
+          {annotationPanel && (
+            <AnnotationToolbar
+              sentenceText={annotationPanel.sentenceText}
+              chapterIndex={annotationPanel.chapterIndex}
+              bookId={Number(bookId)}
+              position={annotationPanel.position}
+              existingAnnotation={annotations.find(
+                (a) =>
+                  a.sentence_text === annotationPanel.sentenceText &&
+                  a.chapter_index === annotationPanel.chapterIndex,
+              )}
+              onClose={() => setAnnotationPanel(null)}
+              onSaved={(annotation) => {
+                setAnnotations((prev) => {
+                  const idx = prev.findIndex((a) => a.id === annotation.id);
+                  if (idx >= 0) {
+                    const next = [...prev];
+                    next[idx] = annotation;
+                    return next;
+                  }
+                  return [...prev, annotation];
+                });
+              }}
+              onDeleted={(id) => {
+                setAnnotations((prev) => prev.filter((a) => a.id !== id));
+              }}
+            />
+          )}
+
+          {/* Vocabulary save toast */}
+          {vocabToastWord && (
+            <VocabularyToast
+              word={vocabToastWord}
+              onDone={() => setVocabToastWord(null)}
+            />
+          )}
+
+          {/* Obsidian export toast */}
+          {obsidianToast && (
+            <div className="fixed bottom-6 right-6 z-50 bg-white border border-amber-300 shadow-lg rounded-xl px-5 py-3 text-sm text-ink max-w-xs">
+              {obsidianToast.startsWith("http") ? (
+                <>
+                  Exported!{" "}
+                  <a
+                    href={obsidianToast}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-amber-700 underline break-all"
+                  >
+                    {obsidianToast}
+                  </a>
+                </>
+              ) : (
+                <span className="text-red-600">{obsidianToast}</span>
+              )}
+            </div>
           )}
 
           {/* Audiobook player */}

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -1,0 +1,154 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { getVocabulary, deleteVocabularyWord, exportVocabularyToObsidian, VocabularyWord } from "@/lib/api";
+
+export default function VocabularyPage() {
+  const { data: session } = useSession();
+  const router = useRouter();
+
+  const [words, setWords] = useState<VocabularyWord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [exportMsg, setExportMsg] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  useEffect(() => {
+    getVocabulary()
+      .then(setWords)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [session?.backendToken]);
+
+  // Group words alphabetically
+  const grouped = words.reduce<Record<string, VocabularyWord[]>>((acc, w) => {
+    const letter = w.word[0]?.toUpperCase() ?? "#";
+    (acc[letter] ??= []).push(w);
+    return acc;
+  }, {});
+  const letters = Object.keys(grouped).sort();
+
+  async function handleDelete(word: string) {
+    setDeleting(word);
+    try {
+      await deleteVocabularyWord(word);
+      setWords((prev) => prev.filter((w) => w.word !== word));
+    } catch {
+      // ignore
+    } finally {
+      setDeleting(null);
+    }
+  }
+
+  async function handleExport(bookId?: number) {
+    try {
+      const { url } = await exportVocabularyToObsidian(bookId);
+      setExportMsg(url);
+    } catch (e) {
+      setExportMsg(e instanceof Error ? e.message : "Export failed");
+    }
+    setTimeout(() => setExportMsg(null), 6000);
+  }
+
+  return (
+    <div className="min-h-screen bg-parchment">
+      <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-6 py-4 flex items-center gap-4">
+        <button
+          onClick={() => router.push("/")}
+          className="text-amber-700 hover:text-amber-900 text-sm"
+        >
+          ← Library
+        </button>
+        <h1 className="font-serif font-bold text-ink flex-1">Vocabulary</h1>
+        <button
+          onClick={() => handleExport()}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors"
+          data-testid="export-all-btn"
+        >
+          ↗ Export all to Obsidian
+        </button>
+      </header>
+
+      {/* Export result toast */}
+      {exportMsg && (
+        <div className="mx-6 mt-4 border border-amber-300 bg-amber-50 rounded-xl px-4 py-3 text-sm text-ink">
+          {exportMsg.startsWith("http") ? (
+            <>
+              Exported!{" "}
+              <a
+                href={exportMsg}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-amber-700 underline break-all"
+              >
+                {exportMsg}
+              </a>
+            </>
+          ) : (
+            <span className="text-red-600">{exportMsg}</span>
+          )}
+        </div>
+      )}
+
+      <div className="max-w-2xl mx-auto px-6 py-8">
+        {loading ? (
+          <div className="space-y-3 animate-pulse">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} className="h-5 bg-amber-100 rounded w-full" />
+            ))}
+          </div>
+        ) : words.length === 0 ? (
+          <div className="text-center text-stone-400 mt-20">
+            <p className="text-4xl mb-3">📖</p>
+            <p className="font-serif text-lg">No saved words yet.</p>
+            <p className="text-sm mt-1">
+              Double-click any word while reading to save it here.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-8">
+            {letters.map((letter) => (
+              <div key={letter}>
+                <h2 className="font-serif font-bold text-xl text-amber-700 mb-3 border-b border-amber-100 pb-1">
+                  {letter}
+                </h2>
+                <div className="space-y-4">
+                  {grouped[letter].map((item) => (
+                    <div key={item.word} className="bg-white rounded-xl border border-amber-100 p-4">
+                      <div className="flex items-center justify-between mb-2">
+                        <h3 className="font-serif font-semibold text-ink text-base">{item.word}</h3>
+                        <button
+                          onClick={() => handleDelete(item.word)}
+                          disabled={deleting === item.word}
+                          className="text-xs text-red-400 hover:text-red-600 disabled:opacity-50 transition-colors"
+                          data-testid={`delete-${item.word}`}
+                        >
+                          {deleting === item.word ? "Deleting…" : "Delete"}
+                        </button>
+                      </div>
+                      <div className="space-y-1.5">
+                        {item.occurrences.map((occ, i) => (
+                          <div key={i} className="text-sm text-stone-600">
+                            <a
+                              href={`/reader/${occ.book_id}`}
+                              className="text-amber-700 font-medium hover:underline"
+                            >
+                              {occ.book_title}
+                            </a>{" "}
+                            <span className="text-stone-400">{`Ch.${occ.chapter_index + 1}`}</span>
+                            {" — "}
+                            <span className="italic">&ldquo;{occ.sentence_text}&rdquo;</span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -1,0 +1,170 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import { createAnnotation, updateAnnotation, deleteAnnotation, Annotation } from "@/lib/api";
+
+const COLORS = [
+  { key: "yellow", label: "Yellow", bg: "bg-yellow-400", border: "border-yellow-500" },
+  { key: "blue", label: "Blue", bg: "bg-blue-400", border: "border-blue-500" },
+  { key: "green", label: "Green", bg: "bg-green-400", border: "border-green-500" },
+  { key: "pink", label: "Pink", bg: "bg-pink-400", border: "border-pink-500" },
+] as const;
+
+type ColorKey = (typeof COLORS)[number]["key"];
+
+interface Props {
+  sentenceText: string;
+  chapterIndex: number;
+  bookId: number;
+  position: { x: number; y: number };
+  existingAnnotation?: { id: number; note_text: string; color: string };
+  onClose: () => void;
+  onSaved: (annotation: Annotation) => void;
+  onDeleted: (id: number) => void;
+}
+
+export default function AnnotationToolbar({
+  sentenceText,
+  chapterIndex,
+  bookId,
+  position,
+  existingAnnotation,
+  onClose,
+  onSaved,
+  onDeleted,
+}: Props) {
+  const [color, setColor] = useState<ColorKey>(
+    (existingAnnotation?.color as ColorKey) ?? "yellow",
+  );
+  const [note, setNote] = useState(existingAnnotation?.note_text ?? "");
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [onClose]);
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  // Position the panel so it doesn't overflow viewport
+  const panelStyle: React.CSSProperties = {
+    position: "fixed",
+    top: Math.min(position.y, window.innerHeight - 240),
+    left: Math.min(position.x, window.innerWidth - 280),
+    zIndex: 1000,
+  };
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      let saved: Annotation;
+      if (existingAnnotation) {
+        saved = await updateAnnotation(existingAnnotation.id, {
+          note_text: note,
+          color,
+        });
+      } else {
+        saved = await createAnnotation({
+          book_id: bookId,
+          chapter_index: chapterIndex,
+          sentence_text: sentenceText,
+          note_text: note,
+          color,
+        });
+      }
+      onSaved(saved);
+      onClose();
+    } catch {
+      // ignore errors silently
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!existingAnnotation) return;
+    setDeleting(true);
+    try {
+      await deleteAnnotation(existingAnnotation.id);
+      onDeleted(existingAnnotation.id);
+      onClose();
+    } catch {
+      // ignore errors silently
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <div
+      ref={panelRef}
+      style={panelStyle}
+      className="w-64 bg-white border border-amber-200 rounded-xl shadow-xl p-4 space-y-3"
+      data-testid="annotation-toolbar"
+    >
+      {/* Color picker */}
+      <div className="flex items-center gap-2">
+        {COLORS.map((c) => (
+          <button
+            key={c.key}
+            title={c.label}
+            onClick={() => setColor(c.key)}
+            className={`w-7 h-7 rounded-full ${c.bg} border-2 transition-all ${
+              color === c.key ? `${c.border} scale-110` : "border-transparent"
+            }`}
+            aria-label={c.label}
+          />
+        ))}
+      </div>
+
+      {/* Note textarea */}
+      <textarea
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+        placeholder="Add a note… (optional)"
+        rows={3}
+        className="w-full text-sm border border-stone-300 rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-amber-400"
+      />
+
+      {/* Actions */}
+      <div className="flex items-center gap-2">
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          className="flex-1 rounded-lg bg-amber-700 text-white text-sm py-1.5 hover:bg-amber-800 disabled:opacity-50 transition-colors"
+        >
+          {saving ? "Saving…" : "Save"}
+        </button>
+        {existingAnnotation && (
+          <button
+            onClick={handleDelete}
+            disabled={deleting}
+            className="rounded-lg border border-red-300 text-red-600 text-sm px-3 py-1.5 hover:bg-red-50 disabled:opacity-50 transition-colors"
+          >
+            {deleting ? "…" : "Delete"}
+          </button>
+        )}
+        <button
+          onClick={onClose}
+          className="rounded-lg border border-stone-300 text-stone-500 text-sm px-3 py-1.5 hover:bg-stone-50 transition-colors"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -1,5 +1,6 @@
 "use client";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Annotation } from "@/lib/api";
 
 // ── Text parsing ────────────────────────────────────────────────────────────
 
@@ -208,7 +209,29 @@ interface Props {
   translationDisplayMode?: "parallel" | "inline";
   /** Show a loading skeleton for translations that haven't arrived yet. */
   translationLoading?: boolean;
+  /** Called when the user double-clicks a word to save it to vocabulary. */
+  onWordSave?: (word: string, sentenceText: string) => void;
+  /**
+   * Called when the user long-presses a sentence (400ms hold).
+   * Provides the sentence text, chapter index, and pointer position.
+   */
+  onAnnotate?: (
+    sentenceText: string,
+    chapterIndex: number,
+    position: { x: number; y: number },
+  ) => void;
+  /** Chapter index — used with onAnnotate. */
+  chapterIndex?: number;
+  /** Existing annotations to highlight matching segments. */
+  annotations?: Annotation[];
 }
+
+const ANNOTATION_COLOR_CLASS: Record<string, string> = {
+  yellow: "border-b-2 border-yellow-400",
+  blue: "border-b-2 border-blue-400",
+  green: "border-b-2 border-green-400",
+  pink: "border-b-2 border-pink-400",
+};
 
 export default function SentenceReader({
   text,
@@ -221,7 +244,16 @@ export default function SentenceReader({
   translations,
   translationDisplayMode = "parallel",
   translationLoading = false,
+  onWordSave,
+  onAnnotate,
+  chapterIndex = 0,
+  annotations,
 }: Props) {
+  // Toast state for vocabulary save
+  const [wordToast, setWordToast] = useState<string | null>(null);
+  // Long-press tracking
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressStartPos = useRef<{ x: number; y: number } | null>(null);
   // Track which internal paragraph index each rendered paragraph corresponds
   // to, so we can pair it with the right translation entry. We count only
   // non-illustration paragraphs because TranslationView's paragraphs array
@@ -269,11 +301,76 @@ export default function SentenceReader({
     }
   }, [currentIdx, isPlaying]);
 
+  // Auto-clear vocabulary toast after 2s
+  useEffect(() => {
+    if (!wordToast) return;
+    const t = setTimeout(() => setWordToast(null), 2000);
+    return () => clearTimeout(t);
+  }, [wordToast]);
+
   const hasTranslations = translations && translations.length > 0;
   const isParallel = hasTranslations && translationDisplayMode === "parallel";
 
+  // Build a lookup map: sentence_text → annotation
+  const annotationMap = useMemo(() => {
+    const map = new Map<string, Annotation>();
+    annotations?.forEach((a) => map.set(a.sentence_text, a));
+    return map;
+  }, [annotations]);
+
+  // Long-press handlers (shared across segments)
+  function handlePointerDown(e: React.PointerEvent, seg: Segment) {
+    if (!onAnnotate) return;
+    const startX = e.clientX;
+    const startY = e.clientY;
+    longPressStartPos.current = { x: startX, y: startY };
+    longPressTimer.current = setTimeout(() => {
+      longPressTimer.current = null;
+      longPressStartPos.current = null;
+      onAnnotate(seg.text, chapterIndex, { x: startX, y: startY });
+    }, 400);
+  }
+
+  function cancelLongPress() {
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+    longPressStartPos.current = null;
+  }
+
+  function handlePointerMove(e: React.PointerEvent) {
+    if (!longPressStartPos.current) return;
+    const dx = e.clientX - longPressStartPos.current.x;
+    const dy = e.clientY - longPressStartPos.current.y;
+    if (Math.sqrt(dx * dx + dy * dy) > 10) cancelLongPress();
+  }
+
+  function handleDoubleClick(e: React.MouseEvent, seg: Segment) {
+    if (!onWordSave) return;
+    e.preventDefault();
+    const sel = window.getSelection()?.toString().trim();
+    let word = sel && !sel.includes(" ") ? sel : "";
+    if (!word) {
+      // Fallback: extract word at click position via nearest word boundary
+      word = seg.text.split(/\s+/).find((w) => w.length > 1) ?? seg.text;
+    }
+    word = word.replace(/[^a-zA-Z\u00C0-\u024F\u0400-\u04FF'-]/g, "");
+    if (!word) return;
+    setWordToast(word);
+    onWordSave(word, seg.text);
+  }
+
   return (
-    <div className={isParallel ? "max-w-7xl mx-auto divide-y divide-amber-100" : "prose-reader mx-auto space-y-4"}>
+    <>
+      {/* Vocabulary toast */}
+      {wordToast && (
+        <div className="fixed bottom-6 right-6 z-50 bg-white border border-amber-300 shadow-lg rounded-xl px-5 py-3 text-sm font-medium text-ink">
+          <span role="img" aria-label="save">💾</span>{" "}
+          <strong>{wordToast}</strong> saved to vocabulary
+        </div>
+      )}
+      <div className={isParallel ? "max-w-7xl mx-auto divide-y divide-amber-100" : "prose-reader mx-auto space-y-4"}>
       {paragraphs.map((para, pIdx) => {
         // Track the text paragraph index so we
         // can pair with the right entry in translations[].
@@ -301,46 +398,51 @@ export default function SentenceReader({
           onSegmentClick(seg.startTime, seg.text);
         };
 
+        // Render a segment span with annotation underline + note icon
+        const renderSeg = (seg: Segment, extraClass = "", trailingSpace = false) => {
+          const active = seg.flatIdx === currentIdx;
+          const annotation = annotationMap.get(seg.text);
+          const annotationClass = annotation
+            ? (ANNOTATION_COLOR_CLASS[annotation.color] ?? ANNOTATION_COLOR_CLASS.yellow)
+            : "";
+          return (
+            <span
+              key={seg.flatIdx}
+              ref={active ? (el) => { activeRef.current = el; } : undefined}
+              data-seg={seg.flatIdx}
+              onClick={() => handleSegClick(seg)}
+              onDoubleClick={(e) => handleDoubleClick(e, seg)}
+              onPointerDown={(e) => handlePointerDown(e, seg)}
+              onPointerUp={cancelLongPress}
+              onPointerCancel={cancelLongPress}
+              onPointerMove={handlePointerMove}
+              className={`rounded px-0.5 -mx-0.5 transition-colors duration-200 ${segClass(seg)} ${annotationClass} ${extraClass}`}
+            >
+              {seg.text}
+              {annotation?.note_text ? <span className="ml-0.5 text-xs select-none">📝</span> : null}
+              {trailingSpace ? " " : ""}
+            </span>
+          );
+        };
+
         // Render the original text (highlighted, clickable)
         let originalContent: React.ReactNode;
         if (para.isVerse) {
           originalContent = (
             <div className="font-serif text-base text-ink leading-relaxed">
-              {para.segments.map((seg) => {
-                const active = seg.flatIdx === currentIdx;
-                return (
-                  <span key={seg.flatIdx} className="block">
-                    <span
-                      ref={active ? (el) => { activeRef.current = el; } : undefined}
-                      data-seg={seg.flatIdx}
-                      onClick={() => handleSegClick(seg)}
-                      className={`rounded px-0.5 -mx-0.5 transition-colors duration-200 ${segClass(seg)}`}
-                    >
-                      {seg.text}
-                    </span>
-                  </span>
-                );
-              })}
+              {para.segments.map((seg) => (
+                <span key={seg.flatIdx} className="block">
+                  {renderSeg(seg)}
+                </span>
+              ))}
             </div>
           );
         } else {
           originalContent = (
             <p className="font-serif text-base text-ink leading-relaxed">
-              {para.segments.map((seg, sIdx) => {
-                const active = seg.flatIdx === currentIdx;
-                return (
-                  <span
-                    key={seg.flatIdx}
-                    ref={active ? (el) => { activeRef.current = el; } : undefined}
-                    data-seg={seg.flatIdx}
-                    onClick={() => handleSegClick(seg)}
-                    className={`rounded px-0.5 -mx-0.5 transition-colors duration-200 ${segClass(seg)}`}
-                  >
-                    {seg.text}
-                    {sIdx < para.segments.length - 1 ? " " : ""}
-                  </span>
-                );
-              })}
+              {para.segments.map((seg, sIdx) =>
+                renderSeg(seg, "", sIdx < para.segments.length - 1)
+              )}
             </p>
           );
         }
@@ -391,5 +493,6 @@ export default function SentenceReader({
         );
       })}
     </div>
+    </>
   );
 }

--- a/frontend/src/components/VocabularyToast.tsx
+++ b/frontend/src/components/VocabularyToast.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { useEffect, useState } from "react";
+
+interface Props {
+  word: string;
+  onDone: () => void;
+}
+
+export default function VocabularyToast({ word, onDone }: Props) {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setVisible(false);
+      setTimeout(onDone, 300);
+    }, 2000);
+    return () => clearTimeout(timer);
+  }, [onDone]);
+
+  return (
+    <div
+      className={`fixed bottom-6 right-6 z-50 bg-white border border-amber-300 shadow-lg rounded-xl px-5 py-3 text-sm font-medium text-ink transition-all duration-300 ${
+        visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+      }`}
+    >
+      <span role="img" aria-label="save">💾</span>{" "}
+      <strong>{word}</strong> saved to vocabulary
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -515,3 +515,112 @@ export function saveReadingProgress(bookId: number, chapterIndex: number) {
     body: JSON.stringify({ chapter_index: chapterIndex }),
   });
 }
+
+// ── Annotations ───────────────────────────────────────────────────────────────
+
+export interface Annotation {
+  id: number;
+  chapter_index: number;
+  sentence_text: string;
+  note_text: string;
+  color: string;
+}
+
+export function getAnnotations(bookId: number) {
+  return request<Annotation[]>(`/annotations?book_id=${bookId}`);
+}
+
+export function createAnnotation(data: {
+  book_id: number;
+  chapter_index: number;
+  sentence_text: string;
+  note_text: string;
+  color: string;
+}) {
+  return request<Annotation>("/annotations", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export function updateAnnotation(id: number, data: { note_text?: string; color?: string }) {
+  return request<Annotation>(`/annotations/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export function deleteAnnotation(id: number) {
+  return request<{ ok: boolean }>(`/annotations/${id}`, { method: "DELETE" });
+}
+
+// ── Vocabulary ────────────────────────────────────────────────────────────────
+
+export interface VocabularyOccurrence {
+  book_id: number;
+  book_title: string;
+  chapter_index: number;
+  sentence_text: string;
+}
+
+export interface VocabularyWord {
+  id: number;
+  word: string;
+  occurrences: VocabularyOccurrence[];
+}
+
+export function getVocabulary() {
+  return request<VocabularyWord[]>("/vocabulary");
+}
+
+export function saveVocabularyWord(data: {
+  word: string;
+  book_id: number;
+  chapter_index: number;
+  sentence_text: string;
+}) {
+  return request<{ ok: boolean }>("/vocabulary", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export function deleteVocabularyWord(word: string) {
+  return request<{ ok: boolean }>(`/vocabulary/${encodeURIComponent(word)}`, {
+    method: "DELETE",
+  });
+}
+
+export function exportVocabularyToObsidian(bookId?: number) {
+  return request<{ url: string }>("/vocabulary/export/obsidian", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(bookId !== undefined ? { book_id: bookId } : {}),
+  });
+}
+
+// ── Obsidian settings ─────────────────────────────────────────────────────────
+
+export interface ObsidianSettings {
+  obsidian_repo: string;
+  obsidian_path: string;
+}
+
+export function getObsidianSettings() {
+  return request<ObsidianSettings>("/user/obsidian-settings");
+}
+
+export function saveObsidianSettings(data: {
+  github_token?: string;
+  obsidian_repo: string;
+  obsidian_path: string;
+}) {
+  return request<{ ok: boolean }>("/user/obsidian-settings", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}


### PR DESCRIPTION
## Summary

Adds a personal reading companion layer — sentence annotations, vocabulary tracking with cross-book context, and one-click Obsidian export.

**Backend**
- DB migration: `annotations`, `vocabulary`, `word_occurrences` tables + `github_token`/`obsidian_repo`/`obsidian_path` on users
- `POST/GET/PATCH/DELETE /api/annotations` — per-sentence highlights and notes (auth, own-only)
- `POST/GET/DELETE /api/vocabulary` + `POST /api/vocabulary/export/obsidian` — word saving with cross-book occurrence tracking; Obsidian Markdown export pushed to GitHub via REST API
- `GET/PATCH /api/user/obsidian-settings` — store encrypted GitHub token + vault config

**Frontend**
- **SentenceReader**: double-click word → save to vocabulary (toast); long-press sentence 400ms → floating `AnnotationToolbar`; colored underlines + 📝 icon on annotated segments; TTS single-click unchanged
- **AnnotationToolbar**: color picker (yellow/blue/green/pink), optional note, save/delete, closes on outside click or Escape
- **VocabularyToast**: 2s bottom-right confirmation
- **`/vocabulary` page**: alphabetical word list, each word shows all cross-book occurrences with links back to the reader chapter
- **Reader header**: "📚 Vocab" link + "↗ Obsidian" export button per book
- **Profile page**: Obsidian settings section (GitHub token, repo URL, vault path)

**Obsidian export format** matches the user's existing vault structure (`002 Literature Notes/000 Books/`) with `[[wikilinks]]` for words and connected books — Obsidian's graph view shows book clusters connected via shared vocabulary.

## Test plan

- [x] Backend: 25 new tests (annotations CRUD, vocabulary CRUD, export with mocked GitHub API)
- [x] Frontend: 13 new tests (AnnotationToolbar, VocabularyPage)
- [x] Full suite: 182 frontend + 104 backend tests passing
- Manual: double-click word while reading → toast appears; long-press sentence → toolbar; Profile → save GitHub token → Export button pushes to vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)
