### PR TITLE
fix: reading companion refinements — accurate word extraction, deferred click, annotation sidebar

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -85,6 +85,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["X-TTS-Timings"],
 )
 
 # Chrome Private Network Access: allow localhost-to-localhost requests

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -236,13 +236,19 @@ async def translate(req: TranslateRequest, user: dict = Depends(get_current_user
 @router.post("/tts")
 async def tts(req: TTSRequest):
     """Synthesize text with Edge TTS (free, no login required)."""
+    import json as _json
     try:
-        audio, content_type = await synthesize(
+        audio, content_type, boundaries = await synthesize(
             req.text, req.language, req.rate, gender=req.gender
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
-    return Response(content=audio, media_type=content_type)
+    headers: dict = {}
+    if boundaries:
+        timings_json = _json.dumps(boundaries, separators=(",", ":"))
+        if len(timings_json) <= 8000:
+            headers["X-TTS-Timings"] = timings_json
+    return Response(content=audio, media_type=content_type, headers=headers)
 
 
 @router.post("/tts/chunks")

--- a/backend/services/tts.py
+++ b/backend/services/tts.py
@@ -90,17 +90,26 @@ async def synthesize(
     rate: float = 1.0,
     *,
     gender: Gender = "female",
-) -> tuple[bytes, str]:
-    """Synthesize text with Edge TTS. Returns (mp3_bytes, "audio/mpeg")."""
+) -> tuple[bytes, str, list[dict]]:
+    """Synthesize text with Edge TTS.
+    Returns (mp3_bytes, "audio/mpeg", word_boundaries).
+    Each boundary: {"offset_ms": float, "text": str}
+    """
     voice = _pick_edge_voice(language, gender)
     communicate = edge_tts.Communicate(text.replace("\n", " "), voice, rate=_rate_str(rate))
 
     buf = io.BytesIO()
+    boundaries: list[dict] = []
     async for chunk in communicate.stream():
         if chunk["type"] == "audio":
             buf.write(chunk["data"])
+        elif chunk["type"] == "WordBoundary":
+            boundaries.append({
+                "offset_ms": round(chunk["offset"] / 10_000, 1),
+                "text": chunk["text"],
+            })
 
-    return buf.getvalue(), "audio/mpeg"
+    return buf.getvalue(), "audio/mpeg", boundaries
 
 
 # ── Text chunking ─────────────────────────────────────────────────────────────

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -178,7 +178,7 @@ async def test_tts_returns_audio(client):
     with patch(
         "routers.ai.synthesize",
         new_callable=AsyncMock,
-        return_value=(fake_audio, "audio/mpeg"),
+        return_value=(fake_audio, "audio/mpeg", []),
     ):
         resp = await client.post("/api/ai/tts", json={
             "text": "Hello world",
@@ -195,7 +195,7 @@ async def test_tts_no_auth_required(client):
     with patch(
         "routers.ai.synthesize",
         new_callable=AsyncMock,
-        return_value=(b"mp3", "audio/mpeg"),
+        return_value=(b"mp3", "audio/mpeg", []),
     ):
         resp = await client.post("/api/ai/tts", json={"text": "x", "language": "en", "rate": 1.0})
     assert resp.status_code == 200
@@ -205,7 +205,7 @@ async def test_tts_defaults_to_female_gender(client):
     with patch(
         "routers.ai.synthesize",
         new_callable=AsyncMock,
-        return_value=(b"mp3", "audio/mpeg"),
+        return_value=(b"mp3", "audio/mpeg", []),
     ) as mock_synth:
         await client.post("/api/ai/tts", json={"text": "x", "language": "en", "rate": 1.0})
     assert mock_synth.call_args.kwargs["gender"] == "female"
@@ -215,7 +215,7 @@ async def test_tts_accepts_male_gender(client):
     with patch(
         "routers.ai.synthesize",
         new_callable=AsyncMock,
-        return_value=(b"mp3", "audio/mpeg"),
+        return_value=(b"mp3", "audio/mpeg", []),
     ) as mock_synth:
         await client.post("/api/ai/tts", json={"text": "x", "language": "en", "rate": 1.0, "gender": "male"})
     assert mock_synth.call_args.kwargs["gender"] == "male"

--- a/backend/tests/test_tts.py
+++ b/backend/tests/test_tts.py
@@ -85,7 +85,7 @@ async def test_edge_synthesize_returns_mp3_bytes():
     mock_comm.stream = fake_stream
 
     with patch("services.tts.edge_tts.Communicate", return_value=mock_comm):
-        audio, ct = await synthesize("Hello world", "en", 1.0)
+        audio, ct, _ = await synthesize("Hello world", "en", 1.0)
 
     assert audio == b"chunk1chunk2"
     assert ct == "audio/mpeg"
@@ -100,9 +100,28 @@ async def test_edge_synthesize_ignores_non_audio_chunks():
     mock_comm.stream = fake_stream
 
     with patch("services.tts.edge_tts.Communicate", return_value=mock_comm):
-        audio, _ = await synthesize("Hello", "en", 1.0)
+        audio, _, _ = await synthesize("Hello", "en", 1.0)
 
     assert audio == b"audio_only"
+
+
+
+async def test_edge_synthesize_collects_word_boundaries():
+    async def fake_stream():
+        yield {"type": "audio", "data": b"audio"}
+        yield {"type": "WordBoundary", "offset": 1_000_000, "duration": 500_000, "text": "Hello"}
+        yield {"type": "WordBoundary", "offset": 5_000_000, "duration": 400_000, "text": "world"}
+
+    mock_comm = MagicMock()
+    mock_comm.stream = fake_stream
+
+    with patch("services.tts.edge_tts.Communicate", return_value=mock_comm):
+        _, _, boundaries = await synthesize("Hello world", "en", 1.0)
+
+    assert len(boundaries) == 2
+    assert boundaries[0] == {"offset_ms": 100.0, "text": "Hello"}
+    assert boundaries[1] == {"offset_ms": 500.0, "text": "world"}
+
 
 
 async def test_edge_synthesize_uses_female_voice_by_default():

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -190,22 +190,22 @@ test("askQuestion sends POST to /ai/qa", async () => {
 
 // ── TTS ───────────────────────────────────────────────────────────────────────
 
+const mockTtsResponse = (extra?: Record<string, string>) => ({
+  ok: true,
+  headers: { get: jest.fn().mockImplementation((h: string) => extra?.[h] ?? null) },
+  blob: jest.fn().mockResolvedValue(new Blob(["mp3"])),
+});
+
 test("synthesizeSpeech returns a blob URL", async () => {
   global.URL.createObjectURL = jest.fn().mockReturnValue("blob:fake-url");
-  global.fetch = jest.fn().mockResolvedValue({
-    ok: true,
-    blob: jest.fn().mockResolvedValue(new Blob(["mp3"])),
-  });
-  const url = await synthesizeSpeech("Hello", "en", 1.0);
+  global.fetch = jest.fn().mockResolvedValue(mockTtsResponse());
+  const { url } = await synthesizeSpeech("Hello", "en", 1.0);
   expect(url).toBe("blob:fake-url");
 });
 
 test("synthesizeSpeech defaults gender to 'female'", async () => {
   global.URL.createObjectURL = jest.fn().mockReturnValue("blob:fake");
-  global.fetch = jest.fn().mockResolvedValue({
-    ok: true,
-    blob: jest.fn().mockResolvedValue(new Blob(["x"])),
-  });
+  global.fetch = jest.fn().mockResolvedValue(mockTtsResponse());
   await synthesizeSpeech("Hello", "en");
   const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
   expect(body.gender).toBe("female");
@@ -213,10 +213,7 @@ test("synthesizeSpeech defaults gender to 'female'", async () => {
 
 test("synthesizeSpeech sends explicit gender value", async () => {
   global.URL.createObjectURL = jest.fn().mockReturnValue("blob:fake");
-  global.fetch = jest.fn().mockResolvedValue({
-    ok: true,
-    blob: jest.fn().mockResolvedValue(new Blob(["x"])),
-  });
+  global.fetch = jest.fn().mockResolvedValue(mockTtsResponse());
   await synthesizeSpeech("Hello", "en", 1.0, "male");
   const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
   expect(body.gender).toBe("male");
@@ -224,14 +221,21 @@ test("synthesizeSpeech sends explicit gender value", async () => {
 
 test("synthesizeSpeech forwards an AbortSignal to fetch", async () => {
   global.URL.createObjectURL = jest.fn().mockReturnValue("blob:fake");
-  global.fetch = jest.fn().mockResolvedValue({
-    ok: true,
-    blob: jest.fn().mockResolvedValue(new Blob(["x"])),
-  });
+  global.fetch = jest.fn().mockResolvedValue(mockTtsResponse());
   const abort = new AbortController();
   await synthesizeSpeech("Hello", "en", 1.0, "female", abort.signal);
   const opts = (global.fetch as jest.Mock).mock.calls[0][1];
   expect(opts.signal).toBe(abort.signal);
+});
+
+test("synthesizeSpeech parses X-TTS-Timings header into wordBoundaries", async () => {
+  global.URL.createObjectURL = jest.fn().mockReturnValue("blob:fake");
+  const timings = [{ offset_ms: 100, text: "Hello" }, { offset_ms: 400, text: "world" }];
+  global.fetch = jest.fn().mockResolvedValue(
+    mockTtsResponse({ "X-TTS-Timings": JSON.stringify(timings) })
+  );
+  const { wordBoundaries } = await synthesizeSpeech("Hello world", "en", 1.0);
+  expect(wordBoundaries).toEqual(timings);
 });
 
 test("getTtsChunks calls /ai/tts/chunks and returns the chunk list", async () => {

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useRef, useState, useCallback } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { getBookChapters, deleteTranslationCache, getAudiobook, deleteAudiobook, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, retryChapterTranslation, enqueueBookTranslation, saveReadingProgress, getAnnotations, saveVocabularyWord, exportVocabularyToObsidian, TranslationStatus, BookMeta, BookChapter, Audiobook, ApiError, Annotation } from "@/lib/api";
 import { recordRecentBook, saveLastChapter, getLastChapter } from "@/lib/recentBooks";
@@ -13,6 +13,7 @@ import AudiobookSearch from "@/components/AudiobookSearch";
 import SentenceReader from "@/components/SentenceReader";
 import WordLookup from "@/components/WordLookup";
 import AnnotationToolbar from "@/components/AnnotationToolbar";
+import AnnotationsSidebar from "@/components/AnnotationsSidebar";
 import VocabularyToast from "@/components/VocabularyToast";
 
 // In-memory cache: bookId → chapters (survives client-side navigation)
@@ -22,11 +23,20 @@ const metaCache = new Map<string, BookMeta>();
 export default function ReaderPage() {
   const { bookId } = useParams<{ bookId: string }>();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { data: session } = useSession();
 
   const [meta, setMeta] = useState<BookMeta | null>(metaCache.get(bookId) ?? null);
   const [chapters, setChapters] = useState<BookChapter[]>(chaptersCache.get(bookId) ?? []);
-  const [chapterIndex, setChapterIndex] = useState(() => getLastChapter(Number(bookId)));
+  const [chapterIndex, setChapterIndex] = useState(() => {
+    // ?chapter=N from vocabulary deep links takes priority over last-read
+    const qch = searchParams?.get("chapter");
+    if (qch !== null && qch !== undefined) {
+      const n = parseInt(qch, 10);
+      if (!isNaN(n) && n >= 0) return n;
+    }
+    return getLastChapter(Number(bookId));
+  });
   const [loading, setLoading] = useState(!chaptersCache.has(bookId));
   const [error, setError] = useState("");
 
@@ -680,6 +690,22 @@ export default function ReaderPage() {
             </svg>
             Insight
           </button>
+
+          {/* Annotations sidebar */}
+          {session?.backendToken && (
+            <AnnotationsSidebar
+              annotations={annotations}
+              totalCount={annotations.length}
+              onJump={(ann) => {
+                if (ann.chapter_index !== chapterIndex) setChapterIndex(ann.chapter_index);
+              }}
+              onEdit={(ann) => setAnnotationPanel({
+                sentenceText: ann.sentence_text,
+                chapterIndex: ann.chapter_index,
+                position: { x: window.innerWidth / 2, y: window.innerHeight / 2 },
+              })}
+            />
+          )}
 
           {/* Vocabulary link */}
           {session?.backendToken && (

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1029,7 +1029,7 @@ export default function ReaderPage() {
                       return;
                     }
                     synthesizeSpeech(segText, bookLanguage, 1.0, getSettings().ttsGender)
-                      .then((url) => {
+                      .then(({ url }) => {
                         const audio = new Audio(url);
                         audio.onended = () => URL.revokeObjectURL(url);
                         audio.play().catch(() => URL.revokeObjectURL(url));

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { getVocabulary, deleteVocabularyWord, exportVocabularyToObsidian, VocabularyWord } from "@/lib/api";
@@ -11,7 +11,9 @@ export default function VocabularyPage() {
   const [words, setWords] = useState<VocabularyWord[]>([]);
   const [loading, setLoading] = useState(true);
   const [exportMsg, setExportMsg] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
   const [deleting, setDeleting] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
 
   useEffect(() => {
     getVocabulary()
@@ -20,12 +22,20 @@ export default function VocabularyPage() {
       .finally(() => setLoading(false));
   }, [session?.backendToken]);
 
-  // Group words alphabetically
-  const grouped = words.reduce<Record<string, VocabularyWord[]>>((acc, w) => {
-    const letter = w.word[0]?.toUpperCase() ?? "#";
-    (acc[letter] ??= []).push(w);
-    return acc;
-  }, {});
+  // Filter + group alphabetically
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return q ? words.filter((w) => w.word.toLowerCase().includes(q)) : words;
+  }, [words, search]);
+
+  const grouped = useMemo(() =>
+    filtered.reduce<Record<string, VocabularyWord[]>>((acc, w) => {
+      const letter = w.word[0]?.toUpperCase() ?? "#";
+      (acc[letter] ??= []).push(w);
+      return acc;
+    }, {}),
+    [filtered]
+  );
   const letters = Object.keys(grouped).sort();
 
   async function handleDelete(word: string) {
@@ -41,14 +51,22 @@ export default function VocabularyPage() {
   }
 
   async function handleExport(bookId?: number) {
+    setExporting(true);
     try {
-      const { url } = await exportVocabularyToObsidian(bookId);
-      setExportMsg(url);
+      const result = await exportVocabularyToObsidian(bookId);
+      const url = (result as { url?: string; urls?: string[] }).url
+        ?? (result as { urls?: string[] }).urls?.[0]
+        ?? "";
+      setExportMsg(url || "Exported successfully");
     } catch (e) {
       setExportMsg(e instanceof Error ? e.message : "Export failed");
+    } finally {
+      setExporting(false);
+      setTimeout(() => setExportMsg(null), 8000);
     }
-    setTimeout(() => setExportMsg(null), 6000);
   }
+
+  const totalOccurrences = words.reduce((sum, w) => sum + w.occurrences.length, 0);
 
   return (
     <div className="min-h-screen bg-parchment">
@@ -59,31 +77,29 @@ export default function VocabularyPage() {
         >
           ← Library
         </button>
-        <h1 className="font-serif font-bold text-ink flex-1">Vocabulary</h1>
+        <div className="flex-1">
+          <h1 className="font-serif font-bold text-ink">Vocabulary</h1>
+          {!loading && (
+            <p className="text-xs text-stone-400 mt-0.5">
+              {words.length} word{words.length !== 1 ? "s" : ""} · {totalOccurrences} occurrence{totalOccurrences !== 1 ? "s" : ""}
+            </p>
+          )}
+        </div>
         <button
           onClick={() => handleExport()}
-          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors"
+          disabled={exporting || words.length === 0}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors disabled:opacity-50"
           data-testid="export-all-btn"
         >
-          ↗ Export all to Obsidian
+          {exporting ? "Exporting…" : "↗ Export all to Obsidian"}
         </button>
       </header>
 
-      {/* Export result toast */}
+      {/* Export result */}
       {exportMsg && (
         <div className="mx-6 mt-4 border border-amber-300 bg-amber-50 rounded-xl px-4 py-3 text-sm text-ink">
           {exportMsg.startsWith("http") ? (
-            <>
-              Exported!{" "}
-              <a
-                href={exportMsg}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-amber-700 underline break-all"
-              >
-                {exportMsg}
-              </a>
-            </>
+            <>Exported! <a href={exportMsg} target="_blank" rel="noopener noreferrer" className="text-amber-700 underline break-all">{exportMsg}</a></>
           ) : (
             <span className="text-red-600">{exportMsg}</span>
           )}
@@ -91,6 +107,19 @@ export default function VocabularyPage() {
       )}
 
       <div className="max-w-2xl mx-auto px-6 py-8">
+        {/* Search */}
+        {words.length > 5 && (
+          <div className="mb-6">
+            <input
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search words…"
+              className="w-full rounded-xl border border-amber-200 bg-white px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+            />
+          </div>
+        )}
+
         {loading ? (
           <div className="space-y-3 animate-pulse">
             {Array.from({ length: 8 }).map((_, i) => (
@@ -101,10 +130,10 @@ export default function VocabularyPage() {
           <div className="text-center text-stone-400 mt-20">
             <p className="text-4xl mb-3">📖</p>
             <p className="font-serif text-lg">No saved words yet.</p>
-            <p className="text-sm mt-1">
-              Double-click any word while reading to save it here.
-            </p>
+            <p className="text-sm mt-1">Double-click any word while reading to save it here.</p>
           </div>
+        ) : filtered.length === 0 ? (
+          <p className="text-center text-stone-400 mt-12 text-sm">No words match &ldquo;{search}&rdquo;</p>
         ) : (
           <div className="space-y-8">
             {letters.map((letter) => (
@@ -116,7 +145,12 @@ export default function VocabularyPage() {
                   {grouped[letter].map((item) => (
                     <div key={item.word} className="bg-white rounded-xl border border-amber-100 p-4">
                       <div className="flex items-center justify-between mb-2">
-                        <h3 className="font-serif font-semibold text-ink text-base">{item.word}</h3>
+                        <div className="flex items-center gap-2">
+                          <h3 className="font-serif font-semibold text-ink text-base">{item.word}</h3>
+                          <span className="text-xs text-stone-400 bg-stone-100 rounded-full px-2 py-0.5">
+                            {item.occurrences.length}×
+                          </span>
+                        </div>
                         <button
                           onClick={() => handleDelete(item.word)}
                           disabled={deleting === item.word}
@@ -130,7 +164,7 @@ export default function VocabularyPage() {
                         {item.occurrences.map((occ, i) => (
                           <div key={i} className="text-sm text-stone-600">
                             <a
-                              href={`/reader/${occ.book_id}`}
+                              href={`/reader/${occ.book_id}?chapter=${occ.chapter_index}`}
                               className="text-amber-700 font-medium hover:underline"
                             >
                               {occ.book_title}

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -1,0 +1,128 @@
+"use client";
+import { useState } from "react";
+import type { Annotation } from "@/lib/api";
+
+const COLOR_BADGE: Record<string, string> = {
+  yellow: "bg-yellow-100 border-yellow-300 text-yellow-800",
+  blue:   "bg-blue-100 border-blue-300 text-blue-800",
+  green:  "bg-green-100 border-green-300 text-green-800",
+  pink:   "bg-pink-100 border-pink-300 text-pink-800",
+};
+
+const COLOR_DOT: Record<string, string> = {
+  yellow: "bg-yellow-400",
+  blue:   "bg-blue-400",
+  green:  "bg-green-400",
+  pink:   "bg-pink-400",
+};
+
+interface Props {
+  annotations: Annotation[];
+  /** Total annotation count across all chapters — shown in the badge */
+  totalCount: number;
+  /** Called when user clicks an annotation entry to jump to it */
+  onJump: (annotation: Annotation) => void;
+  onEdit: (annotation: Annotation) => void;
+}
+
+export default function AnnotationsSidebar({ annotations, totalCount, onJump, onEdit }: Props) {
+  const [open, setOpen] = useState(false);
+
+  // Group by chapter
+  const byChapter = annotations.reduce<Record<number, Annotation[]>>((acc, a) => {
+    (acc[a.chapter_index] ??= []).push(a);
+    return acc;
+  }, {});
+  const chapters = Object.keys(byChapter).map(Number).sort((a, b) => a - b);
+
+  return (
+    <>
+      {/* Toggle button — always visible */}
+      <button
+        onClick={() => setOpen((v) => !v)}
+        title="Annotations"
+        className="relative shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-xs font-medium transition-colors"
+        data-testid="annotations-toggle"
+      >
+        📝 Notes
+        {totalCount > 0 && (
+          <span className="absolute -top-1.5 -right-1.5 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-amber-600 text-white text-[10px] font-bold px-1">
+            {totalCount}
+          </span>
+        )}
+      </button>
+
+      {/* Drawer */}
+      {open && (
+        <div
+          className="fixed right-0 top-0 h-full w-80 bg-white border-l border-amber-200 shadow-2xl z-50 flex flex-col"
+          data-testid="annotations-sidebar"
+        >
+          <div className="flex items-center justify-between px-4 py-3 border-b border-amber-100">
+            <h2 className="font-serif font-semibold text-ink text-sm">Annotations</h2>
+            <button
+              onClick={() => setOpen(false)}
+              className="text-stone-400 hover:text-stone-600 text-lg leading-none"
+              aria-label="Close"
+            >
+              ✕
+            </button>
+          </div>
+
+          <div className="flex-1 overflow-y-auto p-4 space-y-6">
+            {annotations.length === 0 ? (
+              <div className="text-center text-stone-400 mt-10 text-sm">
+                <p className="text-3xl mb-2">📝</p>
+                <p>No annotations yet.</p>
+                <p className="mt-1 text-xs">Long-press a sentence to add one.</p>
+              </div>
+            ) : (
+              chapters.map((ch) => (
+                <div key={ch}>
+                  <h3 className="text-xs font-semibold text-stone-400 uppercase tracking-wide mb-2">
+                    Chapter {ch + 1}
+                  </h3>
+                  <div className="space-y-2">
+                    {byChapter[ch].map((ann) => (
+                      <div
+                        key={ann.id}
+                        className={`rounded-lg border px-3 py-2.5 cursor-pointer hover:opacity-80 transition-opacity ${COLOR_BADGE[ann.color] ?? COLOR_BADGE.yellow}`}
+                        onClick={() => { onJump(ann); setOpen(false); }}
+                      >
+                        <div className="flex items-start justify-between gap-2">
+                          <p className="text-xs italic leading-relaxed line-clamp-3 flex-1">
+                            &ldquo;{ann.sentence_text}&rdquo;
+                          </p>
+                          <button
+                            onClick={(e) => { e.stopPropagation(); onEdit(ann); setOpen(false); }}
+                            className="shrink-0 text-xs opacity-60 hover:opacity-100 mt-0.5"
+                            title="Edit annotation"
+                          >
+                            ✏️
+                          </button>
+                        </div>
+                        {ann.note_text && (
+                          <p className="mt-1.5 text-xs font-medium border-t border-current/20 pt-1.5">
+                            {ann.note_text}
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Backdrop */}
+      {open && (
+        <div
+          className="fixed inset-0 z-40 bg-black/10"
+          onClick={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { Annotation } from "@/lib/api";
+import type { Annotation, WordBoundary } from "@/lib/api";
 
 // ── Text parsing ────────────────────────────────────────────────────────────
 
@@ -20,6 +20,7 @@ interface Paragraph {
 export interface ChunkInfo {
   text: string;
   duration: number;  // 0 if not yet loaded; positive once the chunk's audio loads
+  wordBoundaries?: WordBoundary[];
 }
 
 // Common abbreviations that should not trigger a sentence split
@@ -124,41 +125,61 @@ function parseIntoSegments(
   }
 
   // Step 2b: build time map.
-  // Two paths:
-  //   a) chunks given → distribute segments within each chunk by word count,
-  //      using the chunk's MEASURED duration. This is much more accurate
-  //      than linear interpolation across the whole chapter because it
-  //      accounts for varying speech rate per chunk.
-  //   b) no chunks → fall back to linear word-proportion across `duration`.
-  // Character count is a better proxy for TTS speaking time than word count
-  // because words vary widely in length (e.g. "I" vs "extraordinarily").
-  const wordCounts = allTexts.map((s) => Math.max(1, s.trim().length));
+  // Three paths (in order of accuracy):
+  //   a) chunks with word boundaries → exact timing from TTS engine (offset_ms per word)
+  //   b) chunks without word boundaries → character-count proportional per chunk
+  //   c) no chunks → character-count linear fallback (LibriVox audiobook path)
+  const charCounts = allTexts.map((s) => Math.max(1, s.trim().length));
   const startTimes: number[] = new Array(allTexts.length).fill(0);
 
   if (chunks && chunks.length > 0) {
     let chunkStartTime = 0;
     for (let ci = 0; ci < chunks.length; ci++) {
       const chunk = chunks[ci];
-      // Indices of segments in this chunk
       const segIndices: number[] = [];
       for (let s = 0; s < allTexts.length; s++) {
         if (segmentChunkIdx[s] === ci) segIndices.push(s);
       }
-      const chunkWords = segIndices.reduce((sum, idx) => sum + wordCounts[idx], 0) || 1;
-      let elapsed = 0;
-      for (const idx of segIndices) {
-        startTimes[idx] = chunkStartTime + (elapsed / chunkWords) * chunk.duration;
-        elapsed += wordCounts[idx];
+
+      const wbs = chunk.wordBoundaries;
+      if (wbs && wbs.length > 0) {
+        // Path a: locate each segment's start position in the (newline-normalised)
+        // chunk text, count preceding words, and map to the corresponding word
+        // boundary's offset_ms for exact TTS timing.
+        const normalised = chunk.text.replace(/\n/g, " ");
+        let cursor = 0;
+        for (const idx of segIndices) {
+          const seg = allTexts[idx];
+          const pos = normalised.indexOf(seg, cursor);
+          if (pos >= 0) {
+            const wordsBefore =
+              pos === 0 ? 0 : normalised.slice(0, pos).trim().split(/\s+/).length;
+            const wb = wbs[Math.min(wordsBefore, wbs.length - 1)];
+            startTimes[idx] = chunkStartTime + wb.offset_ms / 1000;
+            cursor = pos + seg.length;
+          } else {
+            startTimes[idx] = chunkStartTime;
+          }
+        }
+      } else {
+        // Path b: character-count proportional distribution within chunk
+        const chunkChars = segIndices.reduce((sum, idx) => sum + charCounts[idx], 0) || 1;
+        let elapsed = 0;
+        for (const idx of segIndices) {
+          startTimes[idx] = chunkStartTime + (elapsed / chunkChars) * chunk.duration;
+          elapsed += charCounts[idx];
+        }
       }
+
       chunkStartTime += chunk.duration;
     }
   } else {
-    // Linear fallback (used by the LibriVox audiobook path)
-    const totalWords = wordCounts.reduce((a, b) => a + b, 0) || 1;
+    // Path c: linear fallback (LibriVox audiobook path)
+    const totalChars = charCounts.reduce((a, b) => a + b, 0) || 1;
     let elapsed = 0;
     for (let i = 0; i < allTexts.length; i++) {
-      startTimes[i] = (elapsed / totalWords) * duration;
-      elapsed += wordCounts[i];
+      startTimes[i] = (elapsed / totalChars) * duration;
+      elapsed += charCounts[i];
     }
   }
 
@@ -254,6 +275,8 @@ export default function SentenceReader({
   // Long-press tracking
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressStartPos = useRef<{ x: number; y: number } | null>(null);
+  // Deferred single-click: we delay onClick by 200ms so a dblclick can cancel it
+  const clickTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Track which internal paragraph index each rendered paragraph corresponds
   // to, so we can pair it with the right translation entry. We count only
   // non-illustration paragraphs because TranslationView's paragraphs array
@@ -308,6 +331,11 @@ export default function SentenceReader({
     return () => clearTimeout(t);
   }, [wordToast]);
 
+  // Cancel pending single-click on unmount
+  useEffect(() => () => {
+    if (clickTimer.current) clearTimeout(clickTimer.current);
+  }, []);
+
   const hasTranslations = translations && translations.length > 0;
   const isParallel = hasTranslations && translationDisplayMode === "parallel";
 
@@ -347,14 +375,33 @@ export default function SentenceReader({
   }
 
   function handleDoubleClick(e: React.MouseEvent, seg: Segment) {
+    // Cancel the deferred single-click so TTS doesn't seek on double-click
+    if (clickTimer.current) {
+      clearTimeout(clickTimer.current);
+      clickTimer.current = null;
+    }
     if (!onWordSave) return;
     e.preventDefault();
-    const sel = window.getSelection()?.toString().trim();
+
+    // 1. Browser usually selects the double-clicked word — use that first
+    const sel = window.getSelection()?.toString().trim() ?? "";
     let word = sel && !sel.includes(" ") ? sel : "";
-    if (!word) {
-      // Fallback: extract word at click position via nearest word boundary
-      word = seg.text.split(/\s+/).find((w) => w.length > 1) ?? seg.text;
+
+    // 2. Try caretRangeFromPoint for accurate word-at-cursor detection
+    if (!word && "caretRangeFromPoint" in document) {
+      const range = (document as Document & { caretRangeFromPoint(x: number, y: number): Range | null })
+        .caretRangeFromPoint(e.clientX, e.clientY);
+      if (range) {
+        range.expand("word");
+        word = range.toString().trim();
+      }
     }
+
+    // 3. Last resort: find the longest word in the segment near the click
+    if (!word) {
+      word = seg.text.split(/\s+/).reduce((a, b) => (b.length > a.length ? b : a), "");
+    }
+
     word = word.replace(/[^a-zA-Z\u00C0-\u024F\u0400-\u04FF'-]/g, "");
     if (!word) return;
     setWordToast(word);
@@ -392,10 +439,25 @@ export default function SentenceReader({
             : "text-stone-400 cursor-default";
         };
 
-        const handleSegClick = (seg: { startTime: number; text: string; chunkIdx: number }) => {
+        const handleSegClick = (
+          e: React.MouseEvent,
+          seg: { startTime: number; text: string; chunkIdx: number },
+        ) => {
           if (disabled) return;
           if (!isSegmentLoaded(seg)) return;
-          onSegmentClick(seg.startTime, seg.text);
+          // If this segment has an annotation, open the toolbar for editing
+          // instead of seeking TTS — but only on a deliberate single-click
+          // (defer 200ms so a double-click can cancel first)
+          if (clickTimer.current) clearTimeout(clickTimer.current);
+          clickTimer.current = setTimeout(() => {
+            clickTimer.current = null;
+            const annotation = annotationMap.get(seg.text);
+            if (annotation && onAnnotate) {
+              onAnnotate(seg.text, chapterIndex, { x: e.clientX, y: e.clientY });
+            } else {
+              onSegmentClick(seg.startTime, seg.text);
+            }
+          }, 200);
         };
 
         // Render a segment span with annotation underline + note icon
@@ -410,7 +472,7 @@ export default function SentenceReader({
               key={seg.flatIdx}
               ref={active ? (el) => { activeRef.current = el; } : undefined}
               data-seg={seg.flatIdx}
-              onClick={() => handleSegClick(seg)}
+              onClick={(e) => handleSegClick(e, seg)}
               onDoubleClick={(e) => handleDoubleClick(e, seg)}
               onPointerDown={(e) => handlePointerDown(e, seg)}
               onPointerUp={cancelLongPress}

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -392,7 +392,7 @@ export default function SentenceReader({
       const range = (document as Document & { caretRangeFromPoint(x: number, y: number): Range | null })
         .caretRangeFromPoint(e.clientX, e.clientY);
       if (range) {
-        range.expand("word");
+        (range as Range & { expand(unit: string): void }).expand("word");
         word = range.toString().trim();
       }
     }

--- a/frontend/src/components/TTSControls.tsx
+++ b/frontend/src/components/TTSControls.tsx
@@ -1,12 +1,13 @@
 "use client";
 import { useEffect, useRef, useState, useCallback } from "react";
-import { synthesizeSpeech, getTtsChunks } from "@/lib/api";
+import { synthesizeSpeech, getTtsChunks, WordBoundary } from "@/lib/api";
 import { getSettings, saveSettings } from "@/lib/settings";
 import { getAudioPosition, saveAudioPosition, clearAudioPosition } from "@/lib/audio";
 
 export interface ChunkSnapshot {
   text: string;
   duration: number;  // 0 until the chunk's audio loads
+  wordBoundaries?: WordBoundary[];
 }
 
 interface Props {
@@ -174,7 +175,7 @@ export default function TTSControls({
         return;
       }
 
-      setAllChunks(chunkTexts.map((t) => ({ text: t, duration: 0 })));
+      setAllChunks(chunkTexts.map((t) => ({ text: t, duration: 0, wordBoundaries: [] })));
 
       const savedPos = getAudioPosition(bookId, chapterIndex);
       let cumulative = 0;
@@ -191,9 +192,10 @@ export default function TTSControls({
         });
 
         let url = "";
+        let wordBoundaries: WordBoundary[] = [];
         for (let attempt = 0; attempt < 3; attempt++) {
           try {
-            url = await synthesizeSpeech(chunkText, language, 1.0, currentGender, abort.signal);
+            ({ url, wordBoundaries } = await synthesizeSpeech(chunkText, language, 1.0, currentGender, abort.signal));
             break;
           } catch (e) {
             if (abort.signal.aborted || attempt === 2) throw e;
@@ -226,7 +228,7 @@ export default function TTSControls({
         setGlobalDuration(computeGlobalDuration());
         setAllChunks((prev) => {
           const next = [...prev];
-          next[i] = { text: chunkText, duration };
+          next[i] = { text: chunkText, duration, wordBoundaries };
           return next;
         });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -377,13 +377,18 @@ export function askQuestion(
  * Microsoft Edge TTS). Authorization is required, so the call goes
  * through `request`-style headers.
  */
+export interface WordBoundary {
+  offset_ms: number;
+  text: string;
+}
+
 export async function synthesizeSpeech(
   text: string,
   language: string,
   rate = 1.0,
   gender: "female" | "male" = "female",
   signal?: AbortSignal,
-): Promise<string> {
+): Promise<{ url: string; wordBoundaries: WordBoundary[] }> {
   const res = await fetch(`${BASE}/ai/tts`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -394,8 +399,12 @@ export async function synthesizeSpeech(
     const err = await res.json().catch(() => ({ detail: res.statusText }));
     throw new Error(err.detail || "TTS failed");
   }
+  const timingsHeader = res.headers.get("X-TTS-Timings");
+  const wordBoundaries: WordBoundary[] = timingsHeader
+    ? (JSON.parse(timingsHeader) as WordBoundary[])
+    : [];
   const blob = await res.blob();
-  return URL.createObjectURL(blob);
+  return { url: URL.createObjectURL(blob), wordBoundaries };
 }
 
 export async function getTtsChunks(text: string): Promise<string[]> {


### PR DESCRIPTION
## Summary

- **Accurate word extraction on double-click**: use `caretRangeFromPoint` to detect the exact word under cursor position rather than guessing from selection
- **Deferred single-click (200ms)**: double-clicking no longer fires TTS seek twice; the single-click timer is cancelled before it runs
- **Annotated-sentence click opens toolbar**: clicking a sentence that already has an annotation opens the edit toolbar instead of seeking TTS
- **AnnotationsSidebar**: collapsible right-side drawer grouped by chapter, total badge count, click-to-jump + edit button, backdrop overlay
- **Vocabulary page improvements**: search/filter input (shown when >5 words), occurrence count badge, deep chapter links, export progress state
- **Reader deep links**: `?chapter=N` URL param restores the correct chapter on load; AnnotationsSidebar fully wired with jump/edit handlers
- **WordBoundary plumbing**: `synthesizeSpeech` now surfaces `X-TTS-Timings` header as `wordBoundaries[]` for future word-level highlight support

## Test plan

- [x] All 183 frontend unit tests pass
- [x] `synthesizeSpeech` mock updated for new `{ url, wordBoundaries }` return shape, plus new test for header parsing
- [ ] Manual: double-click a word → word saved without TTS seek double-fire
- [ ] Manual: single-click annotated sentence → toolbar opens pre-filled
- [ ] Manual: Annotations sidebar opens, chapters grouped, click jumps to correct chapter
- [ ] Manual: `/vocabulary` search, occurrence count, deep link to chapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
