### PR TITLE
fix: reading companion round-1 — bugs + book notes with insights

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,7 @@ from routers.user import router as user_router
 from routers.admin import router as admin_router
 from routers.annotations import router as annotations_router
 from routers.vocabulary import router as vocabulary_router
+from routers.insights import router as insights_router
 from services.db import init_db
 
 
@@ -110,6 +111,7 @@ app.include_router(audiobooks_router, prefix="/api")
 app.include_router(admin_router, prefix="/api")
 app.include_router(annotations_router, prefix="/api")
 app.include_router(vocabulary_router, prefix="/api")
+app.include_router(insights_router, prefix="/api")
 
 
 @app.get("/api/health")

--- a/backend/migrations/015_reading_companion_fixes.sql
+++ b/backend/migrations/015_reading_companion_fixes.sql
@@ -1,0 +1,18 @@
+-- Prevent duplicate annotations for same sentence
+CREATE UNIQUE INDEX IF NOT EXISTS uq_annotations_sentence
+    ON annotations (user_id, book_id, chapter_index, sentence_text);
+
+-- Prevent duplicate word occurrences for same sentence in same chapter
+CREATE UNIQUE INDEX IF NOT EXISTS uq_word_occurrences
+    ON word_occurrences (vocabulary_id, book_id, chapter_index, sentence_text);
+
+-- Book insights: saved Q&A from the AI reading companion
+CREATE TABLE IF NOT EXISTS book_insights (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    book_id INTEGER NOT NULL,
+    chapter_index INTEGER,
+    question TEXT NOT NULL,
+    answer TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/routers/annotations.py
+++ b/backend/routers/annotations.py
@@ -1,3 +1,4 @@
+from typing import Literal
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from services.auth import get_current_user
@@ -6,17 +7,20 @@ from services.db import create_annotation, get_annotations, update_annotation, d
 router = APIRouter(prefix="/annotations", tags=["annotations"])
 
 
+AnnotationColor = Literal["yellow", "blue", "green", "pink"]
+
+
 class AnnotationCreate(BaseModel):
     book_id: int
     chapter_index: int
     sentence_text: str
     note_text: str = ""
-    color: str = "yellow"
+    color: AnnotationColor = "yellow"
 
 
 class AnnotationUpdate(BaseModel):
     note_text: str
-    color: str
+    color: AnnotationColor
 
 
 @router.post("")

--- a/backend/routers/insights.py
+++ b/backend/routers/insights.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from services.auth import get_current_user
+from services.db import save_insight, get_insights, delete_insight
+
+router = APIRouter(prefix="/insights", tags=["insights"])
+
+
+class InsightCreate(BaseModel):
+    book_id: int
+    chapter_index: int | None = None
+    question: str
+    answer: str
+
+
+@router.post("")
+async def create(req: InsightCreate, user: dict = Depends(get_current_user)):
+    return await save_insight(
+        user["id"],
+        req.book_id,
+        req.chapter_index,
+        req.question,
+        req.answer,
+    )
+
+
+@router.get("")
+async def list_insights(book_id: int, user: dict = Depends(get_current_user)):
+    return await get_insights(user["id"], book_id)
+
+
+@router.delete("/{insight_id}")
+async def delete(insight_id: int, user: dict = Depends(get_current_user)):
+    deleted = await delete_insight(insight_id, user["id"])
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Insight not found")
+    return {"ok": True}

--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -12,7 +12,9 @@ from services.db import (
     delete_word,
     get_obsidian_settings,
     get_cached_book,
+    get_insights,
 )
+from services.translate import translate_text
 
 router = APIRouter(prefix="/vocabulary", tags=["vocabulary"])
 
@@ -26,6 +28,7 @@ class WordSave(BaseModel):
 
 class ExportRequest(BaseModel):
     book_id: int | None = None
+    target_language: str = "zh"
 
 
 @router.post("")
@@ -95,8 +98,10 @@ def _build_book_markdown(
     words_for_book: list[dict],
     annotations: list[dict],
     connected: list[dict],
+    insights: list[dict],
     book_id: int,
     export_date: str,
+    ann_translations: dict[int, str] | None = None,
 ) -> str:
     authors = ", ".join(book.get("authors", [])) if book else "Unknown"
     title = book.get("title", f"Book {book_id}") if book else f"Book {book_id}"
@@ -127,16 +132,24 @@ def _build_book_markdown(
         lines.append(f"- [[{conn['title']}]] — shared: {shared_words}")
 
     lines += ["", "## Annotations"]
-    # Group by chapter
     chapters: dict[int, list] = {}
     for ann in annotations:
         chapters.setdefault(ann["chapter_index"], []).append(ann)
     for ch_idx in sorted(chapters):
-        lines.append(f"### Chapter {ch_idx}")
+        lines.append(f"\n### Chapter {ch_idx + 1}")
         for ann in chapters[ch_idx]:
-            lines.append(f"> \"{ann['sentence_text']}\"")
+            lines.append(f"\n> \"{ann['sentence_text']}\"")
+            if ann_translations and ann["id"] in ann_translations:
+                lines.append(f"> *{ann_translations[ann['id']]}*")
             if ann.get("note_text"):
-                lines.append(ann["note_text"])
+                lines.append(f"\n{ann['note_text']}")
+
+    if insights:
+        lines += ["", "## Reading Insights"]
+        for ins in insights:
+            ch_label = f" (Ch.{ins['chapter_index'] + 1})" if ins.get("chapter_index") is not None else ""
+            lines.append(f"\n**Q{ch_label}:** {ins['question']}")
+            lines.append(f"\n{ins['answer']}")
 
     return "\n".join(lines) + "\n"
 
@@ -214,25 +227,42 @@ async def export_obsidian(
 
     from services.db import get_annotations as db_get_annotations
 
+    async def _build_and_push_book(bid: int) -> str:
+        book = await get_cached_book(bid)
+        annotations = await db_get_annotations(user["id"], bid)
+        book_insights = await get_insights(user["id"], bid)
+        words_for_book = [
+            v for v in all_vocab
+            if any(occ["book_id"] == bid for occ in v["occurrences"])
+        ]
+        connected = _find_connected_books(bid, all_vocab)
+        title = book.get("title", f"Book {bid}") if book else f"Book {bid}"
+
+        # Translate annotation quotes with Google Translate (free, best-effort)
+        ann_translations: dict[int, str] = {}
+        for ann in annotations:
+            try:
+                translated = await translate_text(
+                    ann["sentence_text"], "en", req.target_language or "zh"
+                )
+                if translated:
+                    ann_translations[ann["id"]] = translated[0]
+            except Exception:
+                pass
+
+        content = _build_book_markdown(
+            book, words_for_book, annotations, connected, book_insights,
+            bid, export_date, ann_translations,
+        )
+        filename = f"{title}.md"
+        return await _github_put(
+            github_token, repo, obs_path, filename, content, f"Update {filename}"
+        )
+
     try:
         if req.book_id is not None:
-            # Export single book
-            book = await get_cached_book(req.book_id)
-            annotations = await db_get_annotations(user["id"], req.book_id)
-            words_for_book = [
-                v for v in all_vocab
-                if any(occ["book_id"] == req.book_id for occ in v["occurrences"])
-            ]
-            connected = _find_connected_books(req.book_id, all_vocab)
-            title = book.get("title", f"Book {req.book_id}") if book else f"Book {req.book_id}"
-            filename = f"{title}.md"
-            content = _build_book_markdown(
-                book, words_for_book, annotations, connected, req.book_id, export_date
-            )
-            url = await _github_put(
-                github_token, repo, obs_path, filename, content, f"Update {filename}"
-            )
-            return {"url": url}
+            url = await _build_and_push_book(req.book_id)
+            return {"urls": [url]}
         else:
             # Export all — one file per book + one per word
             book_ids = list({
@@ -243,21 +273,7 @@ async def export_obsidian(
 
             urls = []
             for bid in book_ids:
-                book = await get_cached_book(bid)
-                annotations = await db_get_annotations(user["id"], bid)
-                words_for_book = [
-                    v for v in all_vocab
-                    if any(occ["book_id"] == bid for occ in v["occurrences"])
-                ]
-                connected = _find_connected_books(bid, all_vocab)
-                title = book.get("title", f"Book {bid}") if book else f"Book {bid}"
-                filename = f"{title}.md"
-                content = _build_book_markdown(
-                    book, words_for_book, annotations, connected, bid, export_date
-                )
-                url = await _github_put(
-                    github_token, repo, obs_path, filename, content, f"Update {filename}"
-                )
+                url = await _build_and_push_book(bid)
                 urls.append(url)
 
             # Export individual word notes

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -553,7 +553,9 @@ async def create_annotation(
         db.row_factory = aiosqlite.Row
         cursor = await db.execute(
             """INSERT INTO annotations (user_id, book_id, chapter_index, sentence_text, note_text, color)
-               VALUES (?, ?, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?)
+               ON CONFLICT (user_id, book_id, chapter_index, sentence_text)
+               DO UPDATE SET note_text = excluded.note_text, color = excluded.color""",
             (user_id, book_id, chapter_index, sentence_text, note_text, color),
         )
         await db.commit()
@@ -628,16 +630,11 @@ async def save_word(
             vocab_row = await cursor.fetchone()
         vocab_id = vocab_row["id"]
 
-        # Avoid duplicate occurrences for same word+book+sentence
+        # UNIQUE INDEX on (vocabulary_id, book_id, chapter_index, sentence_text) prevents duplicates
         await db.execute(
             """INSERT OR IGNORE INTO word_occurrences (vocabulary_id, book_id, chapter_index, sentence_text)
-               SELECT ?, ?, ?, ?
-               WHERE NOT EXISTS (
-                   SELECT 1 FROM word_occurrences
-                   WHERE vocabulary_id = ? AND book_id = ? AND sentence_text = ?
-               )""",
-            (vocab_id, book_id, chapter_index, sentence_text,
-             vocab_id, book_id, sentence_text),
+               VALUES (?, ?, ?, ?)""",
+            (vocab_id, book_id, chapter_index, sentence_text),
         )
         await db.commit()
 
@@ -710,3 +707,47 @@ async def get_obsidian_settings(user_id: int) -> dict:
         ) as cursor:
             row = await cursor.fetchone()
     return dict(row) if row else {}
+
+
+# ── Book Insights (saved AI Q&A) ──────────────────────────────────────────────
+
+async def save_insight(
+    user_id: int,
+    book_id: int,
+    chapter_index: int | None,
+    question: str,
+    answer: str,
+) -> dict:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            """INSERT INTO book_insights (user_id, book_id, chapter_index, question, answer)
+               VALUES (?, ?, ?, ?, ?)""",
+            (user_id, book_id, chapter_index, question, answer),
+        )
+        await db.commit()
+        row_id = cursor.lastrowid
+        async with db.execute("SELECT * FROM book_insights WHERE id = ?", (row_id,)) as c:
+            row = await c.fetchone()
+    return dict(row)
+
+
+async def get_insights(user_id: int, book_id: int) -> list[dict]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT * FROM book_insights WHERE user_id = ? AND book_id = ? ORDER BY created_at",
+            (user_id, book_id),
+        ) as cursor:
+            rows = await cursor.fetchall()
+    return [dict(r) for r in rows]
+
+
+async def delete_insight(insight_id: int, user_id: int) -> bool:
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "DELETE FROM book_insights WHERE id = ? AND user_id = ?",
+            (insight_id, user_id),
+        )
+        await db.commit()
+    return cursor.rowcount > 0

--- a/backend/tests/test_router_annotations.py
+++ b/backend/tests/test_router_annotations.py
@@ -85,12 +85,12 @@ async def test_update_annotation(client, test_user):
 
     resp = await client.patch(f"/api/annotations/{ann['id']}", json={
         "note_text": "updated note",
-        "color": "red",
+        "color": "blue",
     })
     assert resp.status_code == 200
     data = resp.json()
     assert data["note_text"] == "updated note"
-    assert data["color"] == "red"
+    assert data["color"] == "blue"
 
 
 async def test_update_annotation_not_found_returns_404(client, test_user):
@@ -112,7 +112,7 @@ async def test_update_annotation_own_only(client, test_user):
 
     resp = await client.patch(f"/api/annotations/{ann['id']}", json={
         "note_text": "hijack",
-        "color": "red",
+        "color": "blue",
     })
     assert resp.status_code == 404
 

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -150,7 +150,8 @@ async def test_export_single_book(client, test_user):
         resp = await client.post("/api/vocabulary/export/obsidian", json={"book_id": BOOK_ID})
 
     assert resp.status_code == 200
-    assert "url" in resp.json()
+    assert "urls" in resp.json()
+    assert len(resp.json()["urls"]) == 1
 
 
 async def test_export_all_books(client, test_user):

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -146,7 +146,8 @@ async def test_export_single_book(client, test_user):
     fake_put_response = {
         "content": {"html_url": "https://github.com/user/obsidian-notes/blob/main/Moby Dick.md"}
     }
-    with patch("routers.vocabulary._github_put", new_callable=AsyncMock, return_value="https://github.com/user/obsidian-notes/blob/main/Moby Dick.md"):
+    with patch("routers.vocabulary._github_put", new_callable=AsyncMock, return_value="https://github.com/user/obsidian-notes/blob/main/Moby Dick.md"), \
+         patch("routers.vocabulary.translate_text", new_callable=AsyncMock, return_value=[]):
         resp = await client.post("/api/vocabulary/export/obsidian", json={"book_id": BOOK_ID})
 
     assert resp.status_code == 200
@@ -157,7 +158,8 @@ async def test_export_single_book(client, test_user):
 async def test_export_all_books(client, test_user):
     await _setup_export(test_user)
 
-    with patch("routers.vocabulary._github_put", new_callable=AsyncMock, return_value="https://github.com/user/repo/blob/main/file.md"):
+    with patch("routers.vocabulary._github_put", new_callable=AsyncMock, return_value="https://github.com/user/repo/blob/main/file.md"), \
+         patch("routers.vocabulary.translate_text", new_callable=AsyncMock, return_value=[]):
         resp = await client.post("/api/vocabulary/export/obsidian", json={})
 
     assert resp.status_code == 200
@@ -173,11 +175,8 @@ async def test_export_without_settings_returns_400(client, test_user):
 async def test_export_github_api_error_returns_502(client, test_user):
     await _setup_export(test_user)
 
-    with patch(
-        "routers.vocabulary._github_put",
-        new_callable=AsyncMock,
-        side_effect=Exception("network error"),
-    ):
+    with patch("routers.vocabulary._github_put", new_callable=AsyncMock, side_effect=Exception("network error")), \
+         patch("routers.vocabulary.translate_text", new_callable=AsyncMock, return_value=[]):
         resp = await client.post("/api/vocabulary/export/obsidian", json={"book_id": BOOK_ID})
 
     assert resp.status_code == 500
@@ -194,7 +193,8 @@ async def test_export_calls_github_with_correct_content(client, test_user):
         captured_content["filename"] = filename
         return "https://github.com/example/url"
 
-    with patch("routers.vocabulary._github_put", side_effect=fake_put):
+    with patch("routers.vocabulary._github_put", side_effect=fake_put), \
+         patch("routers.vocabulary.translate_text", new_callable=AsyncMock, return_value=[]):
         resp = await client.post("/api/vocabulary/export/obsidian", json={"book_id": BOOK_ID})
 
     assert resp.status_code == 200

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { getBookChapters, deleteTranslationCache, getAudiobook, deleteAudiobook, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, retryChapterTranslation, enqueueBookTranslation, saveReadingProgress, getAnnotations, saveVocabularyWord, exportVocabularyToObsidian, TranslationStatus, BookMeta, BookChapter, Audiobook, ApiError, Annotation } from "@/lib/api";
+import { getBookChapters, deleteTranslationCache, getAudiobook, deleteAudiobook, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, retryChapterTranslation, enqueueBookTranslation, saveReadingProgress, getAnnotations, saveVocabularyWord, exportVocabularyToObsidian, saveInsight, TranslationStatus, BookMeta, BookChapter, Audiobook, ApiError, Annotation } from "@/lib/api";
 import { recordRecentBook, saveLastChapter, getLastChapter } from "@/lib/recentBooks";
 import { getSettings, saveSettings, FontSize, Theme } from "@/lib/settings";
 import InsightChat, { LANGUAGES } from "@/components/InsightChat";
@@ -50,6 +50,7 @@ export default function ReaderPage() {
     chapterIndex: number;
     position: { x: number; y: number };
   } | null>(null);
+  const [scrollTargetSentence, setScrollTargetSentence] = useState<string | undefined>();
 
   // Vocabulary toast
   const [vocabToastWord, setVocabToastWord] = useState<string | null>(null);
@@ -535,8 +536,8 @@ export default function ReaderPage() {
   // Obsidian export handler
   async function handleObsidianExport() {
     try {
-      const { url } = await exportVocabularyToObsidian(Number(bookId));
-      setObsidianToast(url);
+      const { urls } = await exportVocabularyToObsidian(Number(bookId));
+      setObsidianToast(urls[0] || "Exported successfully");
       setTimeout(() => setObsidianToast(null), 6000);
     } catch (e) {
       setObsidianToast(e instanceof Error ? e.message : "Export failed");
@@ -697,7 +698,14 @@ export default function ReaderPage() {
               annotations={annotations}
               totalCount={annotations.length}
               onJump={(ann) => {
-                if (ann.chapter_index !== chapterIndex) setChapterIndex(ann.chapter_index);
+                if (ann.chapter_index !== chapterIndex) {
+                  setChapterIndex(ann.chapter_index);
+                  // Scroll after chapter loads
+                  setTimeout(() => setScrollTargetSentence(ann.sentence_text), 400);
+                } else {
+                  setScrollTargetSentence(undefined);
+                  setTimeout(() => setScrollTargetSentence(ann.sentence_text), 10);
+                }
               }}
               onEdit={(ann) => setAnnotationPanel({
                 sentenceText: ann.sentence_text,
@@ -1016,9 +1024,11 @@ export default function ReaderPage() {
                   annotations={session?.backendToken ? annotations.filter((a) => a.chapter_index === chapterIndex) : undefined}
                   chapterIndex={chapterIndex}
                   onWordSave={session?.backendToken ? handleWordSave : undefined}
+                  onWordSaveBlocked={!session?.backendToken ? () => setVocabToastWord("Login to save words") : undefined}
                   onAnnotate={session?.backendToken ? (sentenceText, ci, position) => {
                     setAnnotationPanel({ sentenceText, chapterIndex: ci, position });
                   } : undefined}
+                  scrollTargetSentence={scrollTargetSentence}
                   onSegmentClick={(startTime, segText) => {
                     if (audiobook) {
                       seekAudioRef.current(startTime);
@@ -1204,6 +1214,13 @@ export default function ReaderPage() {
             author={meta?.authors[0] ?? ""}
             bookLanguage={bookLanguage}
             onAIUsed={notifyAIUsed}
+            chapterIndex={chapterIndex}
+            onSaveInsight={session?.backendToken ? (question, answer) => {
+              saveInsight({ book_id: Number(bookId), chapter_index: chapterIndex, question, answer })
+                .then(() => setObsidianToast("Insight saved to book notes"))
+                .catch(() => setObsidianToast("Failed to save insight"))
+                .finally(() => setTimeout(() => setObsidianToast(null), 3000));
+            } : undefined}
           />
         </div>
       </div>

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -53,11 +53,8 @@ export default function VocabularyPage() {
   async function handleExport(bookId?: number) {
     setExporting(true);
     try {
-      const result = await exportVocabularyToObsidian(bookId);
-      const url = (result as { url?: string; urls?: string[] }).url
-        ?? (result as { urls?: string[] }).urls?.[0]
-        ?? "";
-      setExportMsg(url || "Exported successfully");
+      const { urls } = await exportVocabularyToObsidian(bookId);
+      setExportMsg(urls[0] || "Exported successfully");
     } catch (e) {
       setExportMsg(e instanceof Error ? e.message : "Export failed");
     } finally {

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -38,6 +38,7 @@ export default function AnnotationToolbar({
   const [note, setNote] = useState(existingAnnotation?.note_text ?? "");
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
 
   // Close on outside click
@@ -70,13 +71,11 @@ export default function AnnotationToolbar({
 
   async function handleSave() {
     setSaving(true);
+    setError(null);
     try {
       let saved: Annotation;
       if (existingAnnotation) {
-        saved = await updateAnnotation(existingAnnotation.id, {
-          note_text: note,
-          color,
-        });
+        saved = await updateAnnotation(existingAnnotation.id, { note_text: note, color });
       } else {
         saved = await createAnnotation({
           book_id: bookId,
@@ -88,8 +87,8 @@ export default function AnnotationToolbar({
       }
       onSaved(saved);
       onClose();
-    } catch {
-      // ignore errors silently
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed. Please try again.");
     } finally {
       setSaving(false);
     }
@@ -98,12 +97,13 @@ export default function AnnotationToolbar({
   async function handleDelete() {
     if (!existingAnnotation) return;
     setDeleting(true);
+    setError(null);
     try {
       await deleteAnnotation(existingAnnotation.id);
       onDeleted(existingAnnotation.id);
       onClose();
-    } catch {
-      // ignore errors silently
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Delete failed. Please try again.");
     } finally {
       setDeleting(false);
     }
@@ -139,6 +139,11 @@ export default function AnnotationToolbar({
         rows={3}
         className="w-full text-sm border border-stone-300 rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-amber-400"
       />
+
+      {/* Error */}
+      {error && (
+        <p className="text-xs text-red-600 bg-red-50 rounded px-2 py-1">{error}</p>
+      )}
 
       {/* Actions */}
       <div className="flex items-center gap-2">

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -49,6 +49,8 @@ interface Props {
   author: string;
   bookLanguage: string;
   onAIUsed?: () => void;    // called whenever an AI (non-cached) call is made
+  onSaveInsight?: (question: string, answer: string) => void;
+  chapterIndex?: number;
 }
 
 export default function InsightChat({
@@ -63,6 +65,8 @@ export default function InsightChat({
   author,
   bookLanguage,
   onAIUsed,
+  onSaveInsight,
+  chapterIndex,
 }: Props) {
   const [tab, setTab] = useState<Tab>("chat");
 
@@ -409,11 +413,21 @@ export default function InsightChat({
               }
 
               // Assistant message — styled as a subtle card
+              const prevUserMsg = displayedMessages.slice(0, i).reverse().find((m) => m.role === "user");
               return (
                 <div key={i} className="bg-amber-50/60 border border-amber-100 rounded-2xl rounded-tl-sm px-4 py-3 max-w-[92%] shadow-sm">
                   <div className={`prose prose-sm prose-headings:font-serif prose-headings:text-ink prose-headings:font-semibold prose-headings:mt-3 prose-headings:mb-1.5 prose-p:text-ink prose-p:leading-relaxed prose-p:my-1.5 prose-strong:text-amber-900 prose-em:text-amber-800 prose-li:text-ink prose-li:leading-relaxed prose-li:my-0.5 prose-ul:my-1.5 prose-ol:my-1.5 max-w-none font-serif text-ink text-${chatFontSize}`}>
                     <ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.content}</ReactMarkdown>
                   </div>
+                  {onSaveInsight && prevUserMsg && (
+                    <button
+                      onClick={() => onSaveInsight(prevUserMsg.content, msg.content)}
+                      title="Save this insight to book notes"
+                      className="mt-2 flex items-center gap-1 text-[10px] text-amber-500 hover:text-amber-800 transition-colors"
+                    >
+                      🔖 Save to notes
+                    </button>
+                  )}
                 </div>
               );
             })}

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -232,6 +232,10 @@ interface Props {
   translationLoading?: boolean;
   /** Called when the user double-clicks a word to save it to vocabulary. */
   onWordSave?: (word: string, sentenceText: string) => void;
+  /** Called when user double-clicks but onWordSave is not available (e.g. unauthenticated). */
+  onWordSaveBlocked?: () => void;
+  /** Sentence text to scroll to and briefly highlight. */
+  scrollTargetSentence?: string;
   /**
    * Called when the user long-presses a sentence (400ms hold).
    * Provides the sentence text, chapter index, and pointer position.
@@ -266,13 +270,15 @@ export default function SentenceReader({
   translationDisplayMode = "parallel",
   translationLoading = false,
   onWordSave,
+  onWordSaveBlocked,
   onAnnotate,
   chapterIndex = 0,
   annotations,
+  scrollTargetSentence,
 }: Props) {
-  // Toast state for vocabulary save
   const [wordToast, setWordToast] = useState<string | null>(null);
-  // Long-press tracking
+  const [flashTarget, setFlashTarget] = useState<string | null>(null);
+  const jumpTargetRef = useRef<HTMLElement | null>(null);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressStartPos = useRef<{ x: number; y: number } | null>(null);
   // Deferred single-click: we delay onClick by 200ms so a dblclick can cancel it
@@ -331,6 +337,15 @@ export default function SentenceReader({
     return () => clearTimeout(t);
   }, [wordToast]);
 
+  // Scroll to and flash the target sentence when scrollTargetSentence changes
+  useEffect(() => {
+    if (!scrollTargetSentence) return;
+    setFlashTarget(scrollTargetSentence);
+    const scroll = setTimeout(() => jumpTargetRef.current?.scrollIntoView({ behavior: "smooth", block: "center" }), 80);
+    const clear = setTimeout(() => setFlashTarget(null), 2500);
+    return () => { clearTimeout(scroll); clearTimeout(clear); };
+  }, [scrollTargetSentence]);
+
   // Cancel pending single-click on unmount
   useEffect(() => () => {
     if (clickTimer.current) clearTimeout(clickTimer.current);
@@ -380,7 +395,7 @@ export default function SentenceReader({
       clearTimeout(clickTimer.current);
       clickTimer.current = null;
     }
-    if (!onWordSave) return;
+    if (!onWordSave) { onWordSaveBlocked?.(); return; }
     e.preventDefault();
 
     // 1. Browser usually selects the double-clicked word — use that first
@@ -402,8 +417,11 @@ export default function SentenceReader({
       word = seg.text.split(/\s+/).reduce((a, b) => (b.length > a.length ? b : a), "");
     }
 
-    word = word.replace(/[^a-zA-Z\u00C0-\u024F\u0400-\u04FF'-]/g, "");
-    if (!word) return;
+    word = word
+      .replace(/^[^a-zA-Z\u00C0-\u024F\u0400-\u04FF]+/, "")
+      .replace(/[^a-zA-Z\u00C0-\u024F\u0400-\u04FF]+$/, "")
+      .replace(/[-\u2013\u2014]+/g, "");
+    if (!word || word.length < 2) return;
     setWordToast(word);
     onWordSave(word, seg.text);
   }
@@ -463,14 +481,19 @@ export default function SentenceReader({
         // Render a segment span with annotation underline + note icon
         const renderSeg = (seg: Segment, extraClass = "", trailingSpace = false) => {
           const active = seg.flatIdx === currentIdx;
+          const isJumpTarget = flashTarget !== null && seg.text === flashTarget;
           const annotation = annotationMap.get(seg.text);
           const annotationClass = annotation
             ? (ANNOTATION_COLOR_CLASS[annotation.color] ?? ANNOTATION_COLOR_CLASS.yellow)
             : "";
+          const flashClass = isJumpTarget ? "ring-2 ring-amber-400 bg-amber-50" : "";
           return (
             <span
               key={seg.flatIdx}
-              ref={active ? (el) => { activeRef.current = el; } : undefined}
+              ref={(el) => {
+                if (active) activeRef.current = el;
+                if (isJumpTarget) jumpTargetRef.current = el;
+              }}
               data-seg={seg.flatIdx}
               onClick={(e) => handleSegClick(e, seg)}
               onDoubleClick={(e) => handleDoubleClick(e, seg)}
@@ -478,7 +501,7 @@ export default function SentenceReader({
               onPointerUp={cancelLongPress}
               onPointerCancel={cancelLongPress}
               onPointerMove={handlePointerMove}
-              className={`rounded px-0.5 -mx-0.5 transition-colors duration-200 ${segClass(seg)} ${annotationClass} ${extraClass}`}
+              className={`rounded px-0.5 -mx-0.5 transition-colors duration-200 ${segClass(seg)} ${annotationClass} ${flashClass} ${extraClass}`}
             >
               {seg.text}
               {annotation?.note_text ? <span className="ml-0.5 text-xs select-none">📝</span> : null}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -529,6 +529,7 @@ export function saveReadingProgress(bookId: number, chapterIndex: number) {
 
 export interface Annotation {
   id: number;
+  book_id: number;
   chapter_index: number;
   sentence_text: string;
   note_text: string;
@@ -603,12 +604,47 @@ export function deleteVocabularyWord(word: string) {
   });
 }
 
-export function exportVocabularyToObsidian(bookId?: number) {
-  return request<{ url: string }>("/vocabulary/export/obsidian", {
+export function exportVocabularyToObsidian(bookId?: number, targetLanguage = "zh") {
+  return request<{ urls: string[] }>("/vocabulary/export/obsidian", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(bookId !== undefined ? { book_id: bookId } : {}),
+    body: JSON.stringify({
+      ...(bookId !== undefined ? { book_id: bookId } : {}),
+      target_language: targetLanguage,
+    }),
   });
+}
+
+// ── Book Insights (saved AI Q&A) ──────────────────────────────────────────────
+
+export interface BookInsight {
+  id: number;
+  book_id: number;
+  chapter_index: number | null;
+  question: string;
+  answer: string;
+  created_at: string;
+}
+
+export function getInsights(bookId: number) {
+  return request<BookInsight[]>(`/insights?book_id=${bookId}`);
+}
+
+export function saveInsight(data: {
+  book_id: number;
+  chapter_index?: number;
+  question: string;
+  answer: string;
+}) {
+  return request<BookInsight>("/insights", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export function deleteInsight(id: number) {
+  return request<{ ok: boolean }>(`/insights/${id}`, { method: "DELETE" });
 }
 
 // ── Obsidian settings ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

**Bug fixes (Round 1):**
- Annotations UNIQUE constraint prevents duplicate sentence annotations; `create_annotation` uses `ON CONFLICT DO UPDATE`
- Word occurrence dedup now includes `chapter_index` via DB UNIQUE index (previously the same sentence in different chapters was silently ignored)
- Annotation color validated with `Literal["yellow","blue","green","pink"]` — invalid colors return 422
- `AnnotationToolbar` shows inline error message on save/delete failure instead of silently swallowing
- Vocabulary export response unified to `{"urls":[]}` for both single + all-book paths
- `Annotation` interface now includes `book_id` field
- Unauthenticated double-click calls `onWordSaveBlocked` callback (shows "Login to save words" toast) instead of doing nothing
- Word regex strips leading/trailing punctuation + dashes before saving to vocabulary

**New features:**
- `scrollTargetSentence` prop on SentenceReader — scrolls to and flash-highlights the matching sentence
- Annotation sidebar jump now scrolls to the exact sentence within the same chapter
- `book_insights` table + `/api/insights` CRUD for saving AI Q&A exchanges per book
- InsightChat "🔖 Save to notes" button on each assistant message
- Obsidian export includes **Reading Insights** section + Chinese translations of annotation quotes (using Google Translate)
- `exportVocabularyToObsidian` accepts `target_language` param

## Test plan

- [x] 183 frontend unit tests pass
- [x] 411 backend tests pass (including updated color + export response tests)
- [ ] Manual: annotation duplicate sentence — second save should update, not create new
- [ ] Manual: long-press annotated sentence → toolbar opens; click "Save" with server error → red error shown in toolbar
- [ ] Manual: double-click word when not logged in → "Login to save words" toast
- [ ] Manual: click annotation in sidebar → reader scrolls to and flashes the sentence
- [ ] Manual: InsightChat → send question → "🔖 Save to notes" button appears → click it → insight saved
- [ ] Manual: export to Obsidian → Obsidian note contains Annotations + Reading Insights sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)
