### PR TITLE
fix: reading companion round-3 — stale ref, rate limiting, save dedup, loading state

### DIFF
--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 from datetime import datetime, timezone
 
@@ -238,17 +239,24 @@ async def export_obsidian(
         connected = _find_connected_books(bid, all_vocab)
         title = book.get("title", f"Book {bid}") if book else f"Book {bid}"
 
-        # Translate annotation quotes with Google Translate (free, best-effort)
+        # Translate annotation quotes (capped at 10, parallelized with semaphore)
         ann_translations: dict[int, str] = {}
-        for ann in annotations:
-            try:
+        sem = asyncio.Semaphore(3)
+        async def _translate_one(ann: dict) -> tuple[int, str]:
+            async with sem:
                 translated = await translate_text(
                     ann["sentence_text"], "en", req.target_language or "zh"
                 )
-                if translated:
-                    ann_translations[ann["id"]] = translated[0]
-            except Exception:
-                pass
+                return ann["id"], translated[0] if translated else ""
+        results = await asyncio.gather(
+            *[_translate_one(a) for a in annotations[:10]],
+            return_exceptions=True,
+        )
+        for res in results:
+            if isinstance(res, tuple):
+                ann_id, text = res
+                if text:
+                    ann_translations[ann_id] = text
 
         content = _build_book_markdown(
             book, words_for_book, annotations, connected, book_insights,

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -45,6 +45,7 @@ export default function ReaderPage() {
 
   // Annotations
   const [annotations, setAnnotations] = useState<Annotation[]>([]);
+  const [annotationsLoading, setAnnotationsLoading] = useState(false);
   const [annotationPanel, setAnnotationPanel] = useState<{
     sentenceText: string;
     chapterIndex: number;
@@ -223,7 +224,11 @@ export default function ReaderPage() {
   // Load annotations for this book (requires auth)
   useEffect(() => {
     if (!bookId || !session?.backendToken) return;
-    getAnnotations(Number(bookId)).then(setAnnotations).catch(() => {});
+    setAnnotationsLoading(true);
+    getAnnotations(Number(bookId))
+      .then(setAnnotations)
+      .catch(() => {})
+      .finally(() => setAnnotationsLoading(false));
   }, [bookId, session?.backendToken]);
 
   const bookLanguage = meta?.languages[0] || "en";
@@ -697,6 +702,7 @@ export default function ReaderPage() {
             <AnnotationsSidebar
               annotations={annotations}
               totalCount={annotations.length}
+              loading={annotationsLoading}
               onJump={(ann) => {
                 if (ann.chapter_index !== chapterIndex) {
                   setChapterIndex(ann.chapter_index);

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -23,9 +23,10 @@ interface Props {
   /** Called when user clicks an annotation entry to jump to it */
   onJump: (annotation: Annotation) => void;
   onEdit: (annotation: Annotation) => void;
+  loading?: boolean;
 }
 
-export default function AnnotationsSidebar({ annotations, totalCount, onJump, onEdit }: Props) {
+export default function AnnotationsSidebar({ annotations, totalCount, onJump, onEdit, loading }: Props) {
   const [open, setOpen] = useState(false);
 
   // Group by chapter
@@ -70,7 +71,11 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
           </div>
 
           <div className="flex-1 overflow-y-auto p-4 space-y-6">
-            {annotations.length === 0 ? (
+            {loading ? (
+              <div className="flex justify-center mt-10">
+                <span className="w-5 h-5 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+              </div>
+            ) : annotations.length === 0 ? (
               <div className="text-center text-stone-400 mt-10 text-sm">
                 <p className="text-3xl mb-2">📝</p>
                 <p>No annotations yet.</p>

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -69,6 +69,7 @@ export default function InsightChat({
   chapterIndex,
 }: Props) {
   const [tab, setTab] = useState<Tab>("chat");
+  const [savedInsights, setSavedInsights] = useState<Set<number>>(new Set());
 
   // ── Chat ─────────────────────────────────────────────────────────────
   // Read language from settings at first render (lazy init avoids the
@@ -421,11 +422,15 @@ export default function InsightChat({
                   </div>
                   {onSaveInsight && prevUserMsg && (
                     <button
-                      onClick={() => onSaveInsight(prevUserMsg.content, msg.content)}
-                      title="Save this insight to book notes"
-                      className="mt-2 flex items-center gap-1 text-[10px] text-amber-500 hover:text-amber-800 transition-colors"
+                      onClick={() => {
+                        if (savedInsights.has(i)) return;
+                        setSavedInsights((prev) => new Set(prev).add(i));
+                        onSaveInsight(prevUserMsg.content, msg.content);
+                      }}
+                      title={savedInsights.has(i) ? "Already saved to notes" : "Save this insight to book notes"}
+                      className={`mt-2 flex items-center gap-1 text-[10px] transition-colors ${savedInsights.has(i) ? "text-amber-300 cursor-default" : "text-amber-500 hover:text-amber-800"}`}
                     >
-                      🔖 Save to notes
+                      🔖 {savedInsights.has(i) ? "Saved" : "Save to notes"}
                     </button>
                   )}
                 </div>

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -278,7 +278,7 @@ export default function SentenceReader({
 }: Props) {
   const [wordToast, setWordToast] = useState<string | null>(null);
   const [flashTarget, setFlashTarget] = useState<string | null>(null);
-  const jumpTargetRef = useRef<HTMLElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressStartPos = useRef<{ x: number; y: number } | null>(null);
   // Deferred single-click: we delay onClick by 200ms so a dblclick can cancel it
@@ -337,11 +337,16 @@ export default function SentenceReader({
     return () => clearTimeout(t);
   }, [wordToast]);
 
-  // Scroll to and flash the target sentence when scrollTargetSentence changes
+  // Scroll to and flash the target sentence when scrollTargetSentence changes.
+  // We query the DOM by data attribute after the render that sets flashTarget,
+  // avoiding stale-ref issues between renders.
   useEffect(() => {
     if (!scrollTargetSentence) return;
     setFlashTarget(scrollTargetSentence);
-    const scroll = setTimeout(() => jumpTargetRef.current?.scrollIntoView({ behavior: "smooth", block: "center" }), 80);
+    const scroll = setTimeout(() => {
+      const el = containerRef.current?.querySelector("[data-jump-target]") as HTMLElement | null;
+      el?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, 80);
     const clear = setTimeout(() => setFlashTarget(null), 2500);
     return () => { clearTimeout(scroll); clearTimeout(clear); };
   }, [scrollTargetSentence]);
@@ -435,7 +440,7 @@ export default function SentenceReader({
           <strong>{wordToast}</strong> saved to vocabulary
         </div>
       )}
-      <div className={isParallel ? "max-w-7xl mx-auto divide-y divide-amber-100" : "prose-reader mx-auto space-y-4"}>
+      <div ref={containerRef} className={isParallel ? "max-w-7xl mx-auto divide-y divide-amber-100" : "prose-reader mx-auto space-y-4"}>
       {paragraphs.map((para, pIdx) => {
         // Track the text paragraph index so we
         // can pair with the right entry in translations[].
@@ -490,11 +495,9 @@ export default function SentenceReader({
           return (
             <span
               key={seg.flatIdx}
-              ref={(el) => {
-                if (active) activeRef.current = el;
-                if (isJumpTarget) jumpTargetRef.current = el;
-              }}
+              ref={active ? (el) => { activeRef.current = el; } : undefined}
               data-seg={seg.flatIdx}
+              data-jump-target={isJumpTarget ? "true" : undefined}
               onClick={(e) => handleSegClick(e, seg)}
               onDoubleClick={(e) => handleDoubleClick(e, seg)}
               onPointerDown={(e) => handlePointerDown(e, seg)}


### PR DESCRIPTION
## Summary

- **SentenceReader stale ref**: replaced `jumpTargetRef` with `containerRef + querySelector("[data-jump-target]")` to eliminate race between `setFlashTarget` state update and the 80ms scroll timeout — DOM attribute is always fresh at query time
- **Translation rate limiting**: `translate_text` now runs via `asyncio.gather` with `Semaphore(3)`, capped at 10 annotations, so exports don't block on serial HTTP calls or risk hitting Google Translate rate limits
- **InsightChat duplicate saves**: track saved message indices in state; button shows "Saved" and is disabled after first click to prevent duplicate DB entries
- **Annotation loading state**: `AnnotationsSidebar` now accepts a `loading` prop and shows a spinner while the initial fetch is in flight, replacing the misleading "No annotations yet" flash

## Test plan

- [ ] All 183 Jest tests pass
- [ ] All 104 backend pytest tests pass
- [ ] TypeScript build clean
