### PR TITLE
feat: tabbed sidebar panel + translation safe-apply gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,8 +79,7 @@ Branch naming: `feat/`, `fix/`, `chore/`, `test/`
        git -C /Users/alfmunny/Projects/AI/book-reader-ai rebase origin/main
        git -C /Users/alfmunny/Projects/AI/book-reader-ai push origin "$BRANCH" --force-with-lease
      fi
-     FAILED=$(gh pr checks <N> --json name,conclusion 2>/dev/null \
-       | python3 -c "import json,sys; d=json.load(sys.stdin); print(sum(1 for c in d if c['conclusion'] in ('FAILURE','ERROR','CANCELLED')))" 2>/dev/null)
+     FAILED=$(gh pr view <N> --json statusCheckRollup -q '[.statusCheckRollup[]? | select(.conclusion=="FAILURE" or .conclusion=="ERROR" or .conclusion=="CANCELLED")] | length' 2>/dev/null)
      [ "$FAILED" != "" ] && [ "$FAILED" -gt 0 ] && echo "$FAILED check(s) failed" && gh pr checks <N> && break
      sleep 20
    done

--- a/frontend/e2e/annotations.spec.ts
+++ b/frontend/e2e/annotations.spec.ts
@@ -1,0 +1,189 @@
+/**
+ * E2E: Annotation sidebar — Notes tab in the unified reader sidebar.
+ *
+ * The reader uses a tab-based sidebar (Chat / Notes / Translation / Export).
+ * The "📝 Notes" tab button in the header only shows when the session has a
+ * backendToken. These tests mock the session accordingly.
+ */
+import { test, expect, Page } from "@playwright/test";
+import { MOCK_BOOK, MOCK_FAUST, MOCK_CHAPTERS } from "./fixtures";
+
+const MOCK_ANNOTATIONS = [
+  {
+    id: 1,
+    book_id: 1342,
+    chapter_index: 0,
+    sentence_text: "It is a truth universally acknowledged",
+    color: "yellow",
+    note_text: "Famous opening line",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    user_id: 1,
+  },
+  {
+    id: 2,
+    book_id: 1342,
+    chapter_index: 0,
+    sentence_text: "that a single man in possession of a good fortune",
+    color: "blue",
+    note_text: "",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    user_id: 1,
+  },
+];
+
+async function setupAnnotations(page: Page, annotations: typeof MOCK_ANNOTATIONS | [] = []) {
+  await page.setViewportSize({ width: 1280, height: 800 });
+
+  await page.route("**/api/auth/session", (r) =>
+    r.fulfill({
+      json: {
+        user: { name: "Test User", email: "test@example.com", image: "" },
+        expires: "2030-01-01T00:00:00.000Z",
+        backendToken: "mock-backend-token",
+      },
+    })
+  );
+  await page.route("**/api/user/me", (r) =>
+    r.fulfill({
+      json: { id: 1, email: "test@example.com", name: "Test", picture: "", hasGeminiKey: false, role: "user", approved: true },
+    })
+  );
+  await page.route("**/api/books/cached", (r) => r.fulfill({ json: [MOCK_BOOK] }));
+  await page.route(/\/api\/books\/\d+\/chapters$/, (r) => {
+    const match = r.request().url().match(/\/books\/(\d+)\/chapters/);
+    const bookId = Number(match?.[1] ?? 0);
+    r.fulfill({
+      json: { book_id: bookId, meta: bookId === 2229 ? MOCK_FAUST : MOCK_BOOK, chapters: MOCK_CHAPTERS, images: [] },
+    });
+  });
+  await page.route(/\/api\/books\/\d+$/, (r) => r.fulfill({ json: MOCK_BOOK }));
+  await page.route(/\/api\/books\/\d+\/translation-status/, (r) =>
+    r.fulfill({ json: { book_id: 1342, target_language: "en", total_chapters: 3, translated_chapters: 3, bulk_active: false } })
+  );
+  await page.route(/\/api\/audiobooks\/\d+$/, (r) => r.fulfill({ status: 404, json: { detail: "Not linked" } }));
+  await page.route("**/api/ai/translate", (r) => r.fulfill({ json: { paragraphs: ["[translated]"], cached: true } }));
+  await page.route("**/api/ai/insight", (r) => r.fulfill({ json: { insight: "A mock insight." } }));
+  await page.route("**/api/ai/tts", (r) => r.fulfill({ status: 200, contentType: "audio/mpeg", body: Buffer.from([0xff, 0xfb]) }));
+  await page.route(/\/api\/annotations/, (r) => r.fulfill({ json: annotations }));
+  await page.route("**/api/user/reading-progress", (r) => r.fulfill({ json: [] }));
+  await page.route("**/api/books/*/chapters/*/translation", (r) =>
+    r.fulfill({ json: { status: "ready", paragraphs: ["Translated."], provider: "gemini" } })
+  );
+}
+
+/** The "📝 Notes" header button that opens the sidebar to the notes tab. */
+const notesHeaderBtn = (page: Page) =>
+  page.getByRole("button", { name: /Notes/ }).first();
+
+test.describe("Notes tab — empty state", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupAnnotations(page, []);
+    await page.goto("/reader/1342");
+    await expect(page.getByText(MOCK_CHAPTERS[0].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 10000 });
+  });
+
+  test("📝 Notes button is visible in header when authenticated", async ({ page }) => {
+    await expect(notesHeaderBtn(page)).toBeVisible();
+  });
+
+  test("clicking Notes button opens the sidebar", async ({ page }) => {
+    await notesHeaderBtn(page).click();
+    // The notes tab content is shown — empty state message
+    await expect(page.getByText("No annotations yet.")).toBeVisible({ timeout: 3000 });
+  });
+
+  test("empty notes sidebar shows friendly empty-state message", async ({ page }) => {
+    await notesHeaderBtn(page).click();
+    await expect(page.getByText("No annotations yet.")).toBeVisible({ timeout: 3000 });
+  });
+
+  test("empty notes sidebar shows usage hint", async ({ page }) => {
+    await notesHeaderBtn(page).click();
+    await expect(page.getByText("Long-press a sentence to add one.", { exact: false })).toBeVisible({ timeout: 3000 });
+  });
+
+  test("sidebar has tab bar with all four tabs when open", async ({ page }) => {
+    await notesHeaderBtn(page).click();
+    await expect(page.getByText("No annotations yet.")).toBeVisible({ timeout: 3000 });
+    // Sidebar's own internal tab bar appears with all four tabs (labels rendered as text)
+    // Use locator scoped to the second row (sidebar area, not just the header buttons)
+    await expect(page.getByText("No annotations yet.")).toBeVisible();
+    // The sidebar tab bar text is distinct from the header tab buttons
+    // Verify by checking for a second "📝 Notes" tab (header + sidebar tab bar = 2)
+    await expect(page.getByRole("button", { name: /📝 Notes/ })).toHaveCount(2);
+  });
+
+  test("clicking Notes button again closes the sidebar", async ({ page }) => {
+    // Open
+    await notesHeaderBtn(page).click();
+    await expect(page.getByText("No annotations yet.")).toBeVisible({ timeout: 3000 });
+
+    // Close (toggle — same button click when tab is "notes")
+    await notesHeaderBtn(page).click();
+    await expect(page.getByText("No annotations yet.")).not.toBeVisible({ timeout: 3000 });
+  });
+
+  test("Notes button is NOT visible without backendToken", async ({ page }) => {
+    // Navigate fresh without auth
+    await page.route("**/api/auth/session", (r) =>
+      r.fulfill({ json: { user: { name: "T", email: "t@t.com", image: "" }, expires: "2030-01-01" } })
+    );
+    await page.reload();
+    await expect(page.getByText(MOCK_CHAPTERS[0].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 10000 });
+    // The Notes tab button in the header should be hidden when no backendToken
+    const notesBtn = page.getByRole("button", { name: /^📝 Notes$/ });
+    await expect(notesBtn).not.toBeVisible({ timeout: 3000 });
+  });
+});
+
+test.describe("Notes tab — with annotations", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupAnnotations(page, MOCK_ANNOTATIONS);
+    await page.goto("/reader/1342");
+    await expect(page.getByText(MOCK_CHAPTERS[0].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 10000 });
+  });
+
+  test("header Notes button shows annotation count badge", async ({ page }) => {
+    // The badge appears on the Notes header button when annotations exist
+    const btn = notesHeaderBtn(page);
+    await expect(btn).toBeVisible();
+    // The badge shows the count (2 annotations)
+    await expect(btn.locator("span")).toContainText("2");
+  });
+
+  test("opening notes tab lists annotation text", async ({ page }) => {
+    await notesHeaderBtn(page).click();
+    // "Famous opening line" is the note_text — unique to the sidebar, not in chapter body
+    await expect(page.getByText("Famous opening line")).toBeVisible({ timeout: 8000 });
+  });
+
+  test("opening notes tab shows annotation note text", async ({ page }) => {
+    await notesHeaderBtn(page).click();
+    await expect(page.getByText("Famous opening line")).toBeVisible({ timeout: 8000 });
+  });
+
+  test("notes tab groups annotations under chapter heading", async ({ page }) => {
+    await notesHeaderBtn(page).click();
+    await expect(page.getByText("Chapter 1", { exact: false })).toBeVisible({ timeout: 8000 });
+  });
+
+  test("notes tab shows both annotation entries", async ({ page }) => {
+    await notesHeaderBtn(page).click();
+    // Note texts are unique to the sidebar (not in chapter body)
+    await expect(page.getByText("Famous opening line")).toBeVisible({ timeout: 8000 });
+    // Second annotation has no note_text — verify via count badge (2 annotations)
+    await expect(notesHeaderBtn(page).locator("span")).toContainText("2");
+  });
+
+  test("clicking an annotation in the sidebar closes the panel", async ({ page }) => {
+    await notesHeaderBtn(page).click();
+    // "Famous opening line" is unique to the sidebar annotations list
+    await expect(page.getByText("Famous opening line")).toBeVisible({ timeout: 8000 });
+
+    // Click the annotation entry — should close sidebar and jump to sentence
+    await page.getByText("Famous opening line").click();
+    await expect(page.getByText("Famous opening line")).not.toBeVisible({ timeout: 3000 });
+  });
+});

--- a/frontend/e2e/mobile-reader.spec.ts
+++ b/frontend/e2e/mobile-reader.spec.ts
@@ -57,8 +57,8 @@ test.describe("Desktop reader unchanged", () => {
     await page.goto("/reader/1342");
     await expect(page.getByText(MOCK_CHAPTERS[0].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 10000 });
 
-    // Header has chapter select and Translate
+    // Header has chapter select and Translation tab button
     await expect(page.locator("header select").first()).toBeVisible();
-    await expect(page.locator("header").getByText("Translate")).toBeVisible();
+    await expect(page.locator("header").getByText("Translation")).toBeVisible();
   });
 });

--- a/frontend/e2e/reader.spec.ts
+++ b/frontend/e2e/reader.spec.ts
@@ -72,7 +72,9 @@ test("translation does not show Gemini reminder (queue returns ready)", async ({
   await page.goto("/reader/1342");
   await expect(page.getByText(/truth universally acknowledged/)).toBeVisible();
 
-  await page.getByRole("button", { name: /Translate/ }).first().click();
+  // Open Translation panel then enable translation
+  await page.getByRole("button", { name: /Translation/ }).first().click();
+  await page.getByRole("switch", { name: /Enable translation/i }).click();
 
   // Translation should appear
   await expect(page.getByText("Translated text.")).toBeVisible();
@@ -93,7 +95,9 @@ test("translation shows queued state when worker is processing", async ({ page }
   await page.goto("/reader/1342");
   await expect(page.getByText(/truth universally acknowledged/)).toBeVisible();
 
-  await page.getByRole("button", { name: /Translate/ }).first().click();
+  // Open Translation panel then enable translation
+  await page.getByRole("button", { name: /Translation/ }).first().click();
+  await page.getByRole("switch", { name: /Enable translation/i }).click();
 
   // Should show a queued/waiting indicator — not translated text
   await expect(page.getByText("Translated text.")).not.toBeVisible({ timeout: 3000 });
@@ -111,7 +115,8 @@ test("translation shows worker offline message when worker not running", async (
   );
 
   await page.goto("/reader/1342");
-  await page.getByRole("button", { name: /Translate/ }).first().click();
+  await page.getByRole("button", { name: /Translation/ }).first().click();
+  await page.getByRole("switch", { name: /Enable translation/i }).click();
 
   await expect(page.getByText("queue · worker is offline", { exact: true })).toBeVisible({ timeout: 5000 });
 });

--- a/frontend/e2e/tts-highlight.spec.ts
+++ b/frontend/e2e/tts-highlight.spec.ts
@@ -1,0 +1,435 @@
+/**
+ * E2E: TTS voice + sentence highlight synchronization.
+ *
+ * Tests that the sentence highlighted during TTS playback tracks the
+ * audio's currentTime accurately. Uses a controlled mock Audio element
+ * (injected before page load) so we can advance playback time without
+ * waiting for real audio to play.
+ *
+ * ## Why this matters
+ * The reader splits chapter text into sentences and assigns a `startTime`
+ * to each. When the audio's `currentTime` advances past a sentence's
+ * `startTime`, SentenceReader applies `bg-amber-300` to that `[data-seg]`
+ * span. Two timing estimation paths exist:
+ *   - Path a (accurate): TTS returns word boundaries via X-TTS-Timings header
+ *   - Path b (estimate): character-count proportional distribution per chunk
+ *
+ * If the backend does not return word boundaries, path b's estimates can
+ * drift enough for the highlight to noticeably lag or lead the voice.
+ *
+ * ## Running against the real TTS API
+ * These tests mock the TTS endpoint. To run against the real backend
+ * (slower, requires valid credentials in .env.local):
+ *   PLAYWRIGHT_REAL_TTS=1 npm run test:e2e -- e2e/tts-highlight.spec.ts
+ * In real-TTS mode the tests in "real TTS API" describe block are
+ * enabled; all others still run with mocks.
+ */
+import { test, expect, Page } from "@playwright/test";
+import { MOCK_BOOK, MOCK_FAUST, MOCK_CHAPTERS } from "./fixtures";
+
+// ── Chapter text with three distinct sentences for highlight testing ──────────
+// splitSentences() splits on .!? + whitespace + uppercase, so these three
+// sentences will each become a separate data-seg span.
+const TTS_CHAPTER_TEXT =
+  "The sky was pale. The birds were still. The world held its breath.";
+
+// Character counts for each sentence (for path-b timing estimates):
+//   "The sky was pale."     = 18 chars → startTime ≈ 0s
+//   "The birds were still." = 21 chars → startTime ≈ 18/57 * 3 ≈ 0.95s
+//   "The world held its breath." = 26 chars → startTime ≈ 39/57 * 3 ≈ 2.05s
+//   Total = 57 chars, mock chunk duration = 3s
+const CHUNK_DURATION_S = 3;
+
+// ── Mock Audio constructor injected before page load ──────────────────────────
+// Overrides window.Audio so TTSControls creates controllable mock instances
+// instead of real HTMLAudioElement objects. Exposes window.__tts_advance(t) to
+// fire a timeupdate event with a given currentTime on the most-recent instance.
+const MOCK_AUDIO_SCRIPT = `
+  const __ttsInstances = [];
+  window.__ttsInstances = __ttsInstances;
+
+  function MockAudio(src) {
+    this.src = src || '';
+    this.preload = 'auto';
+    this.playbackRate = 1;
+    this._currentTime = 0;
+    this._duration = window.__ttsMockDuration || ${CHUNK_DURATION_S};
+    this._listeners = {};
+    __ttsInstances.push(this);
+  }
+
+  Object.defineProperty(MockAudio.prototype, 'currentTime', {
+    get() { return this._currentTime; },
+    set(v) { this._currentTime = v; },
+    configurable: true,
+  });
+  Object.defineProperty(MockAudio.prototype, 'duration', {
+    get() { return this._duration; },
+    configurable: true,
+  });
+
+  MockAudio.prototype.addEventListener = function(type, fn, opts) {
+    if (!this._listeners[type]) this._listeners[type] = [];
+    this._listeners[type].push({ fn, once: !!(opts && opts.once) });
+    // Auto-fire loadedmetadata so TTSControls' Promise resolves
+    if (type === 'loadedmetadata') {
+      const self = this;
+      setTimeout(function() { self._fire('loadedmetadata'); }, 10);
+    }
+  };
+
+  MockAudio.prototype.removeEventListener = function(type, fn) {
+    if (!this._listeners[type]) return;
+    this._listeners[type] = this._listeners[type].filter(function(e) { return e.fn !== fn; });
+  };
+
+  MockAudio.prototype.play = function() { return Promise.resolve(); };
+  MockAudio.prototype.pause = function() {};
+
+  MockAudio.prototype._fire = function(type) {
+    var entries = (this._listeners[type] || []).slice();
+    var self = this;
+    self._listeners[type] = (self._listeners[type] || []).filter(function(e) { return !e.once; });
+    entries.forEach(function(e) {
+      try { e.fn(new Event(type)); } catch(err) {}
+    });
+  };
+
+  MockAudio.prototype._advance = function(time) {
+    this._currentTime = time;
+    this._fire('timeupdate');
+  };
+
+  window.Audio = MockAudio;
+
+  window.__tts_advance = function(time) {
+    var last = __ttsInstances[__ttsInstances.length - 1];
+    if (last) last._advance(time);
+  };
+  window.__tts_count = function() { return __ttsInstances.length; };
+`;
+
+// ── Shared route setup ────────────────────────────────────────────────────────
+
+async function setupTtsReader(page: Page, chapterText = TTS_CHAPTER_TEXT) {
+  await page.setViewportSize({ width: 1280, height: 800 });
+
+  // Inject mock Audio before any page scripts run
+  await page.addInitScript(MOCK_AUDIO_SCRIPT);
+
+  // Session with backendToken (required for API calls via backend proxy)
+  await page.route("**/api/auth/session", (r) =>
+    r.fulfill({
+      json: {
+        user: { name: "Test User", email: "test@example.com", image: "" },
+        expires: "2030-01-01T00:00:00.000Z",
+        backendToken: "mock-backend-token",
+      },
+    })
+  );
+  await page.route("**/api/user/me", (r) =>
+    r.fulfill({
+      json: { id: 1, email: "test@example.com", name: "Test", picture: "", hasGeminiKey: false, role: "user", approved: true },
+    })
+  );
+  await page.route("**/api/books/cached", (r) => r.fulfill({ json: [MOCK_BOOK] }));
+  await page.route(/\/api\/books\/\d+\/chapters$/, (r) => {
+    const match = r.request().url().match(/\/books\/(\d+)\/chapters/);
+    const bookId = Number(match?.[1] ?? 0);
+    r.fulfill({
+      json: {
+        book_id: bookId,
+        meta: bookId === 2229 ? MOCK_FAUST : MOCK_BOOK,
+        chapters: [
+          { title: "Chapter I", text: chapterText },
+          ...MOCK_CHAPTERS.slice(1),
+        ],
+        images: [],
+      },
+    });
+  });
+  await page.route(/\/api\/books\/\d+$/, (r) => r.fulfill({ json: MOCK_BOOK }));
+  await page.route(/\/api\/books\/\d+\/translation-status/, (r) =>
+    r.fulfill({ json: { book_id: 1342, target_language: "en", total_chapters: 3, translated_chapters: 3, bulk_active: false } })
+  );
+  await page.route(/\/api\/audiobooks\/\d+$/, (r) => r.fulfill({ status: 404, json: { detail: "Not linked" } }));
+  await page.route("**/api/ai/translate", (r) => r.fulfill({ json: { paragraphs: ["[translated]"], cached: true } }));
+  await page.route("**/api/ai/insight", (r) => r.fulfill({ json: { insight: "A mock insight." } }));
+  await page.route(/\/api\/annotations/, (r) => r.fulfill({ json: [] }));
+  await page.route("**/api/user/reading-progress", (r) => r.fulfill({ json: [] }));
+  await page.route("**/api/books/*/chapters/*/translation", (r) =>
+    r.fulfill({ json: { status: "ready", paragraphs: ["Translated."], provider: "gemini" } })
+  );
+
+  // TTS chunk split: return chapter text as a single chunk so TTSControls
+  // makes exactly one synthesizeSpeech call for the whole chapter.
+  await page.route("**/api/ai/tts/chunks", (r) =>
+    r.fulfill({ json: { chunks: [chapterText] } })
+  );
+
+  // TTS audio: return an empty audio blob (mock Audio ignores the URL content).
+  // No X-TTS-Timings header → path b (character-proportional) timing is used.
+  await page.route("**/api/ai/tts", (r) =>
+    r.fulfill({
+      status: 200,
+      contentType: "audio/wav",
+      body: Buffer.from([]),
+    })
+  );
+}
+
+/** Return the index of the currently highlighted segment (the one with bg-amber-300). */
+async function getHighlightedSegIdx(page: Page): Promise<number | null> {
+  return page.evaluate(() => {
+    const el = document.querySelector(".bg-amber-300[data-seg]") as HTMLElement | null;
+    if (!el) return null;
+    return parseInt(el.getAttribute("data-seg") ?? "-1", 10);
+  });
+}
+
+/** Wait until the TTS Read button shows "Pause" (playing state). */
+async function waitForPlaying(page: Page) {
+  await expect(page.getByText("⏸ Pause")).toBeVisible({ timeout: 10000 });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe("TTS button states", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupTtsReader(page);
+    await page.goto("/reader/1342");
+    await expect(page.getByText(TTS_CHAPTER_TEXT.slice(0, 20), { exact: false })).toBeVisible({ timeout: 10000 });
+  });
+
+  test("Read button is visible and in paused state initially", async ({ page }) => {
+    await expect(page.getByText("▶ Read")).toBeVisible();
+  });
+
+  test("clicking Read enters loading state", async ({ page }) => {
+    await page.getByText("▶ Read").click();
+    // Loading spinner appears briefly while chunks are fetched + audio synthesised
+    await expect(page.getByText(/Preparing/)).toBeVisible({ timeout: 5000 });
+  });
+
+  test("clicking Read transitions to playing state", async ({ page }) => {
+    await page.getByText("▶ Read").click();
+    // After mock loadedmetadata fires, TTSControls sets status="playing"
+    await waitForPlaying(page);
+  });
+
+  test("Pause button pauses playback", async ({ page }) => {
+    await page.getByText("▶ Read").click();
+    await waitForPlaying(page);
+    await page.getByText("⏸ Pause").click();
+    await expect(page.getByText("▶ Read")).toBeVisible({ timeout: 3000 });
+  });
+
+  test("seek bar appears once audio is loaded", async ({ page }) => {
+    await page.getByText("▶ Read").click();
+    await waitForPlaying(page);
+    // Seek slider is rendered when chunks.length > 0 and globalDuration > 0
+    await expect(page.locator('input[aria-label="Playback position"]')).toBeVisible({ timeout: 3000 });
+  });
+
+  test("loading progress indicator appears during synthesis", async ({ page }) => {
+    // Slow the TTS route so loading state stays visible long enough to assert.
+    // (Without delay the mock resolves so fast the indicator flashes by in <16ms.)
+    await page.route("**/api/ai/tts", async (r) => {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      await r.fulfill({ status: 200, contentType: "audio/wav", body: Buffer.from([]) });
+    });
+
+    await page.getByText("▶ Read").click();
+    await expect(page.getByText(/Generating chunk/)).toBeVisible({ timeout: 5000 });
+  });
+});
+
+test.describe("TTS sentence highlight synchronization", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupTtsReader(page);
+    await page.goto("/reader/1342");
+    await expect(page.getByText(TTS_CHAPTER_TEXT.slice(0, 20), { exact: false })).toBeVisible({ timeout: 10000 });
+    // Start playback and wait for audio to "load" (mock fires loadedmetadata)
+    await page.getByText("▶ Read").click();
+    await waitForPlaying(page);
+  });
+
+  test("no sentence is highlighted before playback starts", async ({ page }) => {
+    // After page loads but BEFORE clicking Read, currentTime=0 so no highlight
+    // This is implicitly checked by the beforeEach of other describe blocks
+    // (we navigated but haven't clicked Read yet in a fresh test)
+  });
+
+  test("first sentence is highlighted at start of playback", async ({ page }) => {
+    // Advance to t=0.1s — first sentence startTime is 0s, so it should highlight
+    await page.evaluate(() => { (window as any).__tts_advance(0.1); });
+    await page.waitForTimeout(200); // let React re-render
+
+    const idx = await getHighlightedSegIdx(page);
+    expect(idx).toBe(0);
+  });
+
+  test("second sentence highlights when time passes its start", async ({ page }) => {
+    // path-b estimate: sentence 1 starts at 18/57 * 3 ≈ 0.95s
+    // Advance to 1.1s — safely past 0.95s but before sentence 2 (2.05s)
+    await page.evaluate(() => { (window as any).__tts_advance(1.1); });
+    await page.waitForTimeout(200);
+
+    const idx = await getHighlightedSegIdx(page);
+    expect(idx).toBe(1);
+  });
+
+  test("third sentence highlights when time passes its start", async ({ page }) => {
+    // path-b estimate: sentence 2 starts at 39/57 * 3 ≈ 2.05s
+    // Advance to 2.2s — safely past 2.05s
+    await page.evaluate(() => { (window as any).__tts_advance(2.2); });
+    await page.waitForTimeout(200);
+
+    const idx = await getHighlightedSegIdx(page);
+    expect(idx).toBe(2);
+  });
+
+  test("highlight follows time forward through all three sentences", async ({ page }) => {
+    // Advance through first sentence
+    await page.evaluate(() => { (window as any).__tts_advance(0.1); });
+    await page.waitForTimeout(150);
+    expect(await getHighlightedSegIdx(page)).toBe(0);
+
+    // Advance through second sentence
+    await page.evaluate(() => { (window as any).__tts_advance(1.1); });
+    await page.waitForTimeout(150);
+    expect(await getHighlightedSegIdx(page)).toBe(1);
+
+    // Advance through third sentence
+    await page.evaluate(() => { (window as any).__tts_advance(2.2); });
+    await page.waitForTimeout(150);
+    expect(await getHighlightedSegIdx(page)).toBe(2);
+  });
+
+  test("only one sentence is highlighted at a time", async ({ page }) => {
+    await page.evaluate(() => { (window as any).__tts_advance(1.1); });
+    await page.waitForTimeout(200);
+
+    const count = await page.evaluate(() =>
+      document.querySelectorAll(".bg-amber-300[data-seg]").length
+    );
+    expect(count).toBe(1);
+  });
+
+  test("highlighted sentence has accessible data-seg attribute", async ({ page }) => {
+    await page.evaluate(() => { (window as any).__tts_advance(0.5); });
+    await page.waitForTimeout(200);
+
+    const segAttr = await page.evaluate(() => {
+      const el = document.querySelector(".bg-amber-300[data-seg]");
+      return el?.getAttribute("data-seg") ?? null;
+    });
+    expect(segAttr).not.toBeNull();
+    expect(Number(segAttr)).toBeGreaterThanOrEqual(0);
+  });
+});
+
+test.describe("TTS highlight with word boundaries (path a)", () => {
+  // Word boundaries enable exact per-word timing instead of character estimates.
+  // The X-TTS-Timings header carries: [{ word: "The", offset_ms: 0 }, ...]
+  // Segment start times are then derived from actual word offsets.
+
+  test("exact word-boundary timing highlights correct sentence", async ({ page }) => {
+    // Override the TTS route to include word boundaries.
+    // sentence 0 "The sky was pale."     starts at word 0 → offset_ms 0
+    // sentence 1 "The birds were still." starts at word 4 → offset_ms 1200
+    // sentence 2 "The world held its breath." starts at word 8 → offset_ms 2100
+    const wordBoundaries = [
+      { word: "The", offset_ms: 0 },
+      { word: "sky", offset_ms: 300 },
+      { word: "was", offset_ms: 550 },
+      { word: "pale.", offset_ms: 800 },
+      { word: "The", offset_ms: 1200 },
+      { word: "birds", offset_ms: 1450 },
+      { word: "were", offset_ms: 1650 },
+      { word: "still.", offset_ms: 1850 },
+      { word: "The", offset_ms: 2100 },
+      { word: "world", offset_ms: 2300 },
+      { word: "held", offset_ms: 2500 },
+      { word: "its", offset_ms: 2700 },
+      { word: "breath.", offset_ms: 2900 },
+    ];
+
+    await page.route("**/api/ai/tts", (r) =>
+      r.fulfill({
+        status: 200,
+        contentType: "audio/wav",
+        body: Buffer.from([]),
+        headers: { "X-TTS-Timings": JSON.stringify(wordBoundaries) },
+      })
+    );
+
+    await setupTtsReader(page);
+    await page.goto("/reader/1342");
+    await expect(page.getByText(TTS_CHAPTER_TEXT.slice(0, 20), { exact: false })).toBeVisible({ timeout: 10000 });
+
+    await page.getByText("▶ Read").click();
+    await waitForPlaying(page);
+
+    // At t=1.3s, word boundary says sentence 1 started at 1.2s
+    await page.evaluate(() => { (window as any).__tts_advance(1.3); });
+    await page.waitForTimeout(200);
+
+    const idx = await getHighlightedSegIdx(page);
+    expect(idx).toBe(1); // second sentence (0-indexed)
+  });
+});
+
+test.describe("TTS highlight — real API (skipped unless PLAYWRIGHT_REAL_TTS=1)", () => {
+  /**
+   * These tests exercise the FULL TTS pipeline: real Gemini TTS API call,
+   * real audio synthesis, real X-TTS-Timings header, real audio playback.
+   *
+   * Purpose: catch bugs that only manifest with actual TTS audio timing,
+   * e.g. the voice speaking faster than the character-proportional estimate.
+   *
+   * How to run:
+   *   PLAYWRIGHT_REAL_TTS=1 npm run test:e2e -- e2e/tts-highlight.spec.ts
+   *
+   * Requires:
+   *   - Backend running locally (or NEXT_PUBLIC_API_URL pointing to staging)
+   *   - Valid GEMINI_API_KEY / GOOGLE_TTS_KEY in backend environment
+   *   - A real auth session (not the mocked one)
+   *
+   * What to look for when the sync is broken:
+   *   - "highlighted sentence text" logged below won't match the voice
+   *   - Check whether X-TTS-Timings is present in the TTS response headers
+   *   - If empty, path b (char-proportional) is being used — fix the backend
+   *     to always return word boundaries for the highlight to be accurate
+   */
+  test.skip(!process.env.PLAYWRIGHT_REAL_TTS, "set PLAYWRIGHT_REAL_TTS=1 to enable");
+
+  test("voice matches highlighted sentence with real audio (manual verification)", async ({ page }) => {
+    // With real TTS, we can't assert exact timing automatically.
+    // Instead, we log what's highlighted at regular intervals so a human
+    // can compare against what the voice is saying.
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto("/reader/1342");
+    await expect(page.getByText(MOCK_CHAPTERS[0].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 10000 });
+
+    await page.getByText("▶ Read").click();
+    await expect(page.getByText("⏸ Pause")).toBeVisible({ timeout: 30000 });
+
+    // Sample highlighted sentence every 500ms for 5 seconds
+    const samples: { t: number; text: string | null }[] = [];
+    for (let i = 0; i < 10; i++) {
+      await page.waitForTimeout(500);
+      const text = await page.evaluate(() => {
+        const el = document.querySelector(".bg-amber-300[data-seg]");
+        return el?.textContent ?? null;
+      });
+      samples.push({ t: (i + 1) * 0.5, text });
+    }
+
+    console.log("TTS highlight samples (compare against voice):", JSON.stringify(samples, null, 2));
+    console.log("If highlighted text lags the voice, X-TTS-Timings header may be missing from backend TTS responses.");
+
+    // Basic assertion: at least one sentence was highlighted during playback
+    expect(samples.some((s) => s.text !== null)).toBe(true);
+  });
+});

--- a/frontend/e2e/ux-reading.spec.ts
+++ b/frontend/e2e/ux-reading.spec.ts
@@ -1,0 +1,215 @@
+/**
+ * E2E: Reading UX — progress, navigation, font size, theme, keyboard shortcuts.
+ *
+ * These tests verify the core reader UX patterns expected by users of book reader
+ * apps (Kindle, Apple Books, etc.): persistent progress indicators, smooth chapter
+ * navigation, readable customisation, and keyboard accessibility.
+ */
+import { test, expect, Page } from "@playwright/test";
+import { mockBackend, MOCK_CHAPTERS } from "./fixtures";
+
+async function setupReader(page: Page) {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await mockBackend(page);
+  await page.route("**/api/annotations/*", (r) => r.fulfill({ json: [] }));
+  await page.route("**/api/user/reading-progress", (r) => r.fulfill({ json: [] }));
+  await page.route("**/api/books/*/chapters/*/translation", (r) =>
+    r.fulfill({ json: { status: "ready", paragraphs: ["Translated."], provider: "gemini" } })
+  );
+}
+
+test.describe("Reading progress indicator", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupReader(page);
+    await page.goto("/reader/1342");
+    await expect(page.getByText(MOCK_CHAPTERS[0].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 10000 });
+  });
+
+  test("progress bar is always visible", async ({ page }) => {
+    const bar = page.locator('[title*="% through book"]');
+    await expect(bar).toBeVisible();
+  });
+
+  test("chapter counter shows 1 / 3 on first chapter", async ({ page }) => {
+    // Full text is "1 / 3 · 33%" — match the chapter fraction part
+    await expect(page.getByText("1 / 3", { exact: false })).toBeVisible();
+  });
+
+  test("chapter counter updates to 2 / 3 after navigating forward", async ({ page }) => {
+    await page.keyboard.press("ArrowRight");
+    await expect(page.getByText(MOCK_CHAPTERS[1].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("2 / 3", { exact: false })).toBeVisible();
+  });
+
+  test("chapter counter updates to 3 / 3 at last chapter", async ({ page }) => {
+    await page.keyboard.press("ArrowRight");
+    await page.keyboard.press("ArrowRight");
+    await expect(page.getByText(MOCK_CHAPTERS[2].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("3 / 3", { exact: false })).toBeVisible();
+  });
+
+  test("progress bar width increases when navigating to later chapters", async ({ page }) => {
+    const innerBar = page.locator('[title*="% through book"] > div');
+    const widthBefore = await innerBar.evaluate((el) =>
+      parseFloat((el as HTMLElement).style.width)
+    );
+
+    await page.keyboard.press("ArrowRight");
+    await expect(page.getByText(MOCK_CHAPTERS[1].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 5000 });
+
+    const widthAfter = await innerBar.evaluate((el) =>
+      parseFloat((el as HTMLElement).style.width)
+    );
+    expect(widthAfter).toBeGreaterThan(widthBefore);
+  });
+});
+
+test.describe("Keyboard navigation", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupReader(page);
+    await page.goto("/reader/1342");
+    await expect(page.getByText(MOCK_CHAPTERS[0].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 10000 });
+  });
+
+  test("ArrowRight navigates to next chapter", async ({ page }) => {
+    await page.keyboard.press("ArrowRight");
+    await expect(page.getByText(MOCK_CHAPTERS[1].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 5000 });
+  });
+
+  test("ArrowLeft navigates to previous chapter from chapter 2", async ({ page }) => {
+    await page.keyboard.press("ArrowRight");
+    await expect(page.getByText(MOCK_CHAPTERS[1].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 5000 });
+
+    await page.keyboard.press("ArrowLeft");
+    await expect(page.getByText(MOCK_CHAPTERS[0].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 5000 });
+  });
+
+  test("ArrowLeft does nothing on first chapter", async ({ page }) => {
+    await page.keyboard.press("ArrowLeft");
+    // Still on chapter 1
+    await expect(page.getByText(MOCK_CHAPTERS[0].text.slice(0, 20), { exact: false })).toBeVisible();
+    await expect(page.getByText("1 / 3", { exact: false })).toBeVisible();
+  });
+
+  test("ArrowRight does nothing on last chapter", async ({ page }) => {
+    await page.keyboard.press("ArrowRight");
+    await page.keyboard.press("ArrowRight");
+    await expect(page.getByText(MOCK_CHAPTERS[2].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 5000 });
+
+    await page.keyboard.press("ArrowRight");
+    // Still on chapter 3
+    await expect(page.getByText("3 / 3", { exact: false })).toBeVisible();
+  });
+});
+
+test.describe("Bottom-of-chapter navigation", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupReader(page);
+    await page.goto("/reader/1342");
+    await expect(page.getByText(MOCK_CHAPTERS[0].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 10000 });
+  });
+
+  test("bottom prev chapter link is present", async ({ page }) => {
+    await expect(page.getByText("← Previous chapter")).toBeVisible();
+  });
+
+  test("bottom next chapter link is present", async ({ page }) => {
+    await expect(page.getByText("Next chapter →")).toBeVisible();
+  });
+
+  test("bottom prev chapter is disabled on first chapter", async ({ page }) => {
+    const prevBtn = page.getByText("← Previous chapter");
+    await expect(prevBtn).toHaveAttribute("disabled", "");
+  });
+
+  test("bottom next chapter navigates forward", async ({ page }) => {
+    await page.getByText("Next chapter →").click();
+    await expect(page.getByText(MOCK_CHAPTERS[1].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 5000 });
+  });
+
+  test("bottom next chapter is disabled on last chapter", async ({ page }) => {
+    await page.keyboard.press("ArrowRight");
+    await page.keyboard.press("ArrowRight");
+    await expect(page.getByText(MOCK_CHAPTERS[2].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 5000 });
+    const nextBtn = page.getByText("Next chapter →");
+    await expect(nextBtn).toHaveAttribute("disabled", "");
+  });
+});
+
+test.describe("Display customisation (desktop)", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupReader(page);
+    await page.goto("/reader/1342");
+    await expect(page.getByText(MOCK_CHAPTERS[0].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 10000 });
+  });
+
+  test("font size button is visible in header", async ({ page }) => {
+    const fontBtn = page.locator('button[title^="Font size:"]');
+    await expect(fontBtn).toBeVisible();
+  });
+
+  test("font size button cycles through sizes on click", async ({ page }) => {
+    const fontBtn = page.locator('button[title^="Font size:"]');
+    // Default is "base" — clicking advances to "lg"
+    await fontBtn.click();
+    await expect(fontBtn).toHaveAttribute("title", "Font size: lg");
+    await fontBtn.click();
+    await expect(fontBtn).toHaveAttribute("title", "Font size: xl");
+    await fontBtn.click();
+    await expect(fontBtn).toHaveAttribute("title", "Font size: sm");
+    await fontBtn.click();
+    await expect(fontBtn).toHaveAttribute("title", "Font size: base");
+  });
+
+  test("theme button is visible in header", async ({ page }) => {
+    const themeBtn = page.locator('button[title^="Theme:"]');
+    await expect(themeBtn).toBeVisible();
+  });
+
+  test("theme button cycles through light → sepia → dark", async ({ page }) => {
+    const themeBtn = page.locator('button[title^="Theme:"]');
+    // Default is "light" → click to get "sepia"
+    await themeBtn.click();
+    await expect(themeBtn).toHaveAttribute("title", "Theme: sepia");
+    const htmlTheme = await page.evaluate(() => document.documentElement.getAttribute("data-theme"));
+    expect(htmlTheme).toBe("sepia");
+
+    await themeBtn.click();
+    await expect(themeBtn).toHaveAttribute("title", "Theme: dark");
+
+    await themeBtn.click();
+    await expect(themeBtn).toHaveAttribute("title", "Theme: light");
+  });
+
+  test("font size change persists across chapter navigation", async ({ page }) => {
+    const fontBtn = page.locator('button[title^="Font size:"]');
+    await fontBtn.click(); // base → lg
+    await expect(fontBtn).toHaveAttribute("title", "Font size: lg");
+
+    await page.keyboard.press("ArrowRight");
+    await expect(page.getByText(MOCK_CHAPTERS[1].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 5000 });
+    // Font size should still be "lg" after navigation
+    await expect(fontBtn).toHaveAttribute("title", "Font size: lg");
+  });
+
+  test("desktop header shows chapter selector dropdown", async ({ page }) => {
+    await expect(page.locator("header select").first()).toBeVisible();
+  });
+
+  test("chapter selector dropdown lets user jump directly to a chapter", async ({ page }) => {
+    const select = page.locator("header select").first();
+    await select.selectOption({ index: 2 }); // chapter III
+    await expect(page.getByText(MOCK_CHAPTERS[2].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 5000 });
+  });
+});
+
+test.describe("Back to library navigation", () => {
+  test("← Library link navigates to home", async ({ page }) => {
+    await setupReader(page);
+    await page.goto("/reader/1342");
+    await expect(page.getByText(MOCK_CHAPTERS[0].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 10000 });
+
+    await page.locator("header").getByText("Library").click();
+    await expect(page).toHaveURL("/");
+  });
+});

--- a/frontend/e2e/word-lookup.spec.ts
+++ b/frontend/e2e/word-lookup.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * E2E: Word lookup — double-click to look up a word's dictionary definition.
+ *
+ * The reader supports a desktop "double-click a word" flow that opens a popup
+ * with dictionary definitions from dictionaryapi.dev. These tests mock that
+ * external API to keep tests hermetic.
+ */
+import { test, expect, Page } from "@playwright/test";
+import { mockBackend, MOCK_CHAPTERS } from "./fixtures";
+
+const MOCK_DEFINITION = [
+  {
+    word: "truth",
+    phonetic: "/truːθ/",
+    meanings: [
+      {
+        partOfSpeech: "noun",
+        definitions: [
+          { definition: "the quality or state of being true" },
+          { definition: "that which is true or in accordance with fact or reality" },
+        ],
+      },
+    ],
+  },
+];
+
+async function setupLookup(page: Page) {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await mockBackend(page);
+  await page.route("**/api/annotations/*", (r) => r.fulfill({ json: [] }));
+  await page.route("**/api/user/reading-progress", (r) => r.fulfill({ json: [] }));
+
+  // Mock the dictionary API (used by both WordLookup and WordActionDrawer)
+  await page.route("**dictionaryapi.dev**", (r) =>
+    r.fulfill({ json: MOCK_DEFINITION })
+  );
+}
+
+/**
+ * Programmatically select a word and fire a synthetic dblclick on the reader
+ * scroll container. Using a synthetic event avoids the browser's native
+ * double-click behaviour (which clears the programmatic selection before the
+ * React handler can read it).
+ */
+async function triggerWordLookup(page: Page, word: string) {
+  await page.evaluate((w) => {
+    const scroll = document.getElementById("reader-scroll");
+    if (!scroll) return;
+
+    // 1. Walk text nodes to find and select the word
+    const walker = document.createTreeWalker(scroll, NodeFilter.SHOW_TEXT);
+    let node = walker.nextNode() as Text | null;
+    let found = false;
+    while (node) {
+      const idx = node.textContent?.indexOf(w) ?? -1;
+      if (idx !== -1) {
+        const range = document.createRange();
+        range.setStart(node, idx);
+        range.setEnd(node, idx + w.length);
+        window.getSelection()!.removeAllRanges();
+        window.getSelection()!.addRange(range);
+        found = true;
+        break;
+      }
+      node = walker.nextNode() as Text | null;
+    }
+    if (!found) return;
+
+    // 2. Fire a synthetic dblclick on the scroll container — does NOT move the
+    //    mouse pointer, so the programmatic selection stays intact when the
+    //    React onDoubleClick handler reads window.getSelection().
+    const rect = scroll.getBoundingClientRect();
+    scroll.dispatchEvent(
+      new MouseEvent("dblclick", {
+        bubbles: true,
+        cancelable: true,
+        clientX: rect.left + rect.width / 2,
+        clientY: rect.top + rect.height / 3,
+      })
+    );
+  }, word);
+}
+
+test.describe("Word lookup popup", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupLookup(page);
+    await page.goto("/reader/1342");
+    await expect(
+      page.getByText(MOCK_CHAPTERS[0].text.slice(0, 20), { exact: false })
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("double-clicking a word opens the lookup popup", async ({ page }) => {
+    await triggerWordLookup(page, "truth");
+    // The phonetic from the mock confirms the popup opened (not just chapter text)
+    await expect(page.getByText("/truːθ/")).toBeVisible({ timeout: 5000 });
+  });
+
+  test("word lookup displays phonetic transcription", async ({ page }) => {
+    await triggerWordLookup(page, "truth");
+    await expect(page.getByText("/truːθ/")).toBeVisible({ timeout: 5000 });
+  });
+
+  test("word lookup displays dictionary definition", async ({ page }) => {
+    await triggerWordLookup(page, "truth");
+    await expect(
+      page.getByText("the quality or state of being true", { exact: false })
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test("word lookup shows part of speech", async ({ page }) => {
+    await triggerWordLookup(page, "truth");
+    await expect(page.getByText("noun", { exact: false })).toBeVisible({ timeout: 5000 });
+  });
+
+  test("word lookup shows error message for unknown word", async ({ page }) => {
+    // Override dictionary mock to return 404 for this test
+    await page.route("**dictionaryapi.dev**", (r) =>
+      r.fulfill({ status: 404, json: { message: "No Definitions Found" } })
+    );
+
+    await triggerWordLookup(page, "truth");
+    await expect(page.getByText("No definition found")).toBeVisible({ timeout: 5000 });
+  });
+
+  test("word lookup closes on Escape key", async ({ page }) => {
+    await triggerWordLookup(page, "truth");
+    await expect(page.getByText("/truːθ/")).toBeVisible({ timeout: 5000 });
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByText("/truːθ/")).not.toBeVisible({ timeout: 3000 });
+  });
+
+  test("word lookup closes when clicking outside", async ({ page }) => {
+    await triggerWordLookup(page, "truth");
+    await expect(page.getByText("/truːθ/")).toBeVisible({ timeout: 5000 });
+
+    // Click in the empty reading area far from the popup
+    await page.mouse.click(50, 500);
+    await expect(page.getByText("/truːθ/")).not.toBeVisible({ timeout: 3000 });
+  });
+});
+
+test.describe("Word lookup — single-word constraint", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupLookup(page);
+    await page.goto("/reader/1342");
+    await expect(
+      page.getByText(MOCK_CHAPTERS[0].text.slice(0, 20), { exact: false })
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("selecting a multi-word phrase does not open lookup", async ({ page }) => {
+    // Select "a truth" (contains space — the handler rejects /\s/ selections)
+    await page.evaluate(() => {
+      const scroll = document.getElementById("reader-scroll");
+      if (!scroll) return;
+      const walker = document.createTreeWalker(scroll, NodeFilter.SHOW_TEXT);
+      let node = walker.nextNode() as Text | null;
+      while (node) {
+        const idx = node.textContent?.indexOf("a truth") ?? -1;
+        if (idx !== -1) {
+          const range = document.createRange();
+          range.setStart(node, idx);
+          range.setEnd(node, idx + 7); // "a truth" — 7 chars with a space
+          window.getSelection()!.removeAllRanges();
+          window.getSelection()!.addRange(range);
+
+          const rect = scroll.getBoundingClientRect();
+          scroll.dispatchEvent(
+            new MouseEvent("dblclick", {
+              bubbles: true,
+              cancelable: true,
+              clientX: rect.left + rect.width / 2,
+              clientY: rect.top + rect.height / 3,
+            })
+          );
+          return;
+        }
+        node = walker.nextNode() as Text | null;
+      }
+    });
+
+    // Popup should NOT appear (space in selection triggers the guard)
+    await expect(page.getByText("/truːθ/")).not.toBeVisible({ timeout: 2000 });
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -14,7 +14,6 @@ import SentenceReader from "@/components/SentenceReader";
 import WordLookup from "@/components/WordLookup";
 import WordActionDrawer, { type WordAction } from "@/components/WordActionDrawer";
 import AnnotationToolbar from "@/components/AnnotationToolbar";
-import AnnotationsSidebar from "@/components/AnnotationsSidebar";
 import VocabularyToast from "@/components/VocabularyToast";
 
 // In-memory cache: bookId → chapters (survives client-side navigation)
@@ -80,8 +79,9 @@ export default function ReaderPage() {
   const [ttsChunks, setTtsChunks] = useState<{ text: string; duration: number }[]>([]);
   const ttsSeekRef = useRef<(t: number) => void>(() => {});
 
-  // Sidebar (insight chat) — hidden by default, resizable
+  // Sidebar panel — hidden by default, resizable; tab controls which panel is shown
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [sidebarTab, setSidebarTab] = useState<"chat" | "notes" | "translate" | "export">("chat");
   const [sidebarWidth, setSidebarWidth] = useState(320);
   const isResizing = useRef(false);
   const resizeStartX = useRef(0);
@@ -89,7 +89,6 @@ export default function ReaderPage() {
 
   // Immersive mode — on mobile, hide header/toolbar; tap to toggle
   const [toolbarVisible, setToolbarVisible] = useState(true);
-  const [translateExpanded, setTranslateExpanded] = useState(false);
   const hideTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const isMobileRef = useRef(false);
@@ -211,6 +210,9 @@ export default function ReaderPage() {
   const currentChapterKey = useRef<string>(""); // tracks which chapter is currently displayed
   const [translationEnabled, setTranslationEnabled] = useState(false);
   const [translationLang, setTranslationLang] = useState("en");
+  // Staged language — changing the dropdown doesn't fire translation;
+  // user must click Apply to copy pendingTranslationLang → translationLang.
+  const [pendingTranslationLang, setPendingTranslationLang] = useState("en");
   // Translation provider removed — queue handles all translation via the admin's chain.
   const [displayMode, setDisplayMode] = useState<"parallel" | "inline">("parallel");
   const [translatedParagraphs, setTranslatedParagraphs] = useState<string[]>([]);
@@ -228,6 +230,7 @@ export default function ReaderPage() {
   useEffect(() => {
     const s = getSettings();
     setTranslationLang(s.translationLang);
+    setPendingTranslationLang(s.translationLang);
     // translationProvider setting is retained for back-compat but no longer read here.
     setAudiobookEnabled(s.audiobookEnabled);
     setFontSize(s.fontSize);
@@ -327,6 +330,7 @@ export default function ReaderPage() {
     const available = LANGUAGES.filter((l) => l.code !== bookLanguage);
     if (translationLang === bookLanguage && available.length > 0) {
       setTranslationLang(available[0].code);
+      setPendingTranslationLang(available[0].code);
     }
   }, [bookLanguage, translationLang]);
 
@@ -767,184 +771,80 @@ export default function ReaderPage() {
             )}
           </button>
 
-          {/* Insight chat toggle — desktop only (mobile uses bottom bar) */}
-          <button
-            onClick={() => setSidebarOpen((v) => !v)}
-            title="Toggle insight chat"
-            className={`hidden md:flex shrink-0 items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-medium transition-colors ${
-              sidebarOpen
-                ? "bg-amber-700 text-white border-amber-700"
-                : "border-amber-300 text-amber-700 hover:bg-amber-50"
-            }`}
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="1.8" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round"
-                d="M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.418-4.03 8-9 8a9.77 9.77 0 01-4-.836L3 20l1.09-3.27A7.96 7.96 0 013 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-            </svg>
-            Insight
-          </button>
-
-          {/* Annotations sidebar — desktop only */}
-          {session?.backendToken && (
-            <div className="hidden md:block">
-            <AnnotationsSidebar
-              annotations={annotations}
-              totalCount={annotations.length}
-              loading={annotationsLoading}
-              onJump={(ann) => {
-                if (ann.chapter_index !== chapterIndex) {
-                  setChapterIndex(ann.chapter_index);
-                  setTimeout(() => setScrollTargetSentence(ann.sentence_text), 400);
-                } else {
-                  setScrollTargetSentence(undefined);
-                  setTimeout(() => setScrollTargetSentence(ann.sentence_text), 10);
-                }
-              }}
-              onEdit={(ann) => setAnnotationPanel({
-                sentenceText: ann.sentence_text,
-                chapterIndex: ann.chapter_index,
-                position: { x: window.innerWidth / 2, y: window.innerHeight / 2 },
-              })}
-            />
-            </div>
-          )}
-
-          {/* Vocabulary link — desktop only */}
-          {session?.backendToken && (
+          {/* Panel tab buttons — desktop only; each opens the sidebar to a specific tab */}
+          <div className="hidden md:flex items-center gap-1 shrink-0">
+            {/* Chat tab */}
             <button
-              onClick={() => router.push("/vocabulary")}
-              title="Vocabulary"
-              className="hidden md:flex shrink-0 items-center gap-1.5 px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-xs font-medium transition-colors"
-            >
-              📚 Vocab
-            </button>
-          )}
-
-          {/* Export vocabulary to Obsidian — desktop only */}
-          {session?.backendToken && (
-            <button
-              onClick={handleObsidianExport}
-              title="Export vocabulary to Obsidian"
-              className="hidden lg:flex shrink-0 items-center gap-1.5 px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-xs font-medium transition-colors"
-            >
-              ↗ Obsidian
-            </button>
-          )}
-
-          {/* Audiobook toggle — desktop only */}
-          {audiobookEnabled && (
-            <button
-              onClick={() => audiobook ? undefined : setShowAudioSearch(true)}
-              title={audiobook ? "Audiobook linked" : "Find audiobook"}
-              className={`hidden md:flex shrink-0 items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-medium transition-colors ${
-                audiobook
-                  ? "bg-amber-100 text-amber-900 border-amber-400"
+              onClick={() => { setSidebarTab("chat"); setSidebarOpen((v) => sidebarTab === "chat" ? !v : true); }}
+              title="Insight chat"
+              className={`flex items-center gap-1 px-2.5 py-1.5 rounded-lg border text-xs font-medium transition-colors ${
+                sidebarOpen && sidebarTab === "chat"
+                  ? "bg-amber-700 text-white border-amber-700"
                   : "border-amber-300 text-amber-700 hover:bg-amber-50"
               }`}
-            >
-              🎧 {audiobook ? "Audio" : "Find Audio"}
-            </button>
-          )}
-        </div>
+            >💬 Chat</button>
 
-        {/* Row 2: Translation toolbar — desktop only (mobile uses bottom bar expand) */}
-        <div className="hidden md:flex items-center gap-3 px-4 pb-2 flex-wrap">
-          <button
-            onClick={() => setTranslationEnabled((v) => !v)}
-            className={`text-xs px-3 py-2 md:py-1 rounded-full border font-medium transition-colors min-h-[44px] md:min-h-0 ${
-              translationEnabled
-                ? "bg-amber-700 text-white border-amber-700"
-                : "border-amber-300 text-amber-700 hover:bg-amber-50"
-            }`}
-          >
-            🌐 Translate
-          </button>
-
-          {translationEnabled && (
-            <>
-              <select
-                className="text-xs rounded border border-amber-300 px-2 py-2 md:py-1 text-ink bg-white min-h-[44px] md:min-h-0"
-                value={translationLang}
-                onChange={(e) => setTranslationLang(e.target.value)}
+            {/* Notes tab */}
+            {session?.backendToken && (
+              <button
+                onClick={() => { setSidebarTab("notes"); setSidebarOpen((v) => sidebarTab === "notes" ? !v : true); }}
+                title="Annotations"
+                className={`relative flex items-center gap-1 px-2.5 py-1.5 rounded-lg border text-xs font-medium transition-colors ${
+                  sidebarOpen && sidebarTab === "notes"
+                    ? "bg-amber-700 text-white border-amber-700"
+                    : "border-amber-300 text-amber-700 hover:bg-amber-50"
+                }`}
               >
-                {LANGUAGES.filter((l) => l.code !== bookLanguage).map((l) => (
-                  <option key={l.code} value={l.code}>{l.label}</option>
-                ))}
-              </select>
-
-              <div className="flex rounded border border-amber-300 overflow-hidden text-xs">
-                <button
-                  onClick={() => setDisplayMode("inline")}
-                  className={`px-3 py-2 md:py-1 transition-colors min-h-[44px] md:min-h-0 ${
-                    displayMode === "inline"
-                      ? "bg-amber-700 text-white"
-                      : "text-amber-700 hover:bg-amber-50"
-                  }`}
-                >
-                  <span className="md:hidden">⊞</span>
-                  <span className="hidden md:inline">Inline</span>
-                </button>
-                <button
-                  onClick={() => setDisplayMode("parallel")}
-                  className={`px-3 py-2 md:py-1 border-l border-amber-300 transition-colors min-h-[44px] md:min-h-0 ${
-                    displayMode === "parallel"
-                      ? "bg-amber-700 text-white"
-                      : "text-amber-700 hover:bg-amber-50"
-                  }`}
-                >
-                  <span className="md:hidden">⫼</span>
-                  <span className="hidden md:inline">Side by side</span>
-                </button>
-              </div>
-
-              {/* Provider dropdown removed — all translations now flow
-                  through the queue worker which uses the admin's
-                  configured model chain. Users no longer choose their
-                  own Gemini vs. Google provider. */}
-
-              {/* Show the translation status text whether we're loading or
-                  done. While queued this surfaces "queue · position N" /
-                  "queue · translating now" so the user sees progress
-                  instead of an opaque "Translating…". When complete it
-                  shows the provider/model that produced the result. */}
-              {translationLoading ? (
-                <span className="text-xs text-amber-600 animate-pulse">
-                  {translationUsedProvider || "Translating…"}
-                </span>
-              ) : translationUsedProvider &&
-                translationUsedProvider !== "login required" &&
-                translationUsedProvider !== "gemini key required" ? (
-                <span className="hidden md:inline text-xs text-amber-400">
-                  via {translationUsedProvider}
-                </span>
-              ) : null}
-
-              {isAdmin && !translationLoading && translatedParagraphs.length > 0 && (
-                <button
-                  onClick={handleRetranslate}
-                  className="hidden md:inline-block text-xs px-2 py-1 rounded border border-amber-300 text-amber-600 hover:bg-amber-50 ml-auto"
-                >
-                  Retranslate
-                </button>
-              )}
-
-              {/* Any user can retry their own failed chapter — the queue row
-                  is in 'failed' state, a fresh request is idempotent, and
-                  priority=10 means the worker picks it up ahead of background
-                  auto-enqueued items. */}
-              {!translationLoading &&
-                translationUsedProvider.startsWith("queue failed") && (
-                  <button
-                    onClick={handleRetryFailed}
-                    className="text-xs px-2 py-1 rounded border border-red-300 text-red-600 hover:bg-red-50 ml-auto"
-                    title="Re-queue this chapter for the background worker"
-                  >
-                    Retry
-                  </button>
+                📝 Notes
+                {annotations.length > 0 && (
+                  <span className="absolute -top-1.5 -right-1.5 min-w-[16px] h-4 flex items-center justify-center rounded-full bg-amber-600 text-white text-[9px] font-bold px-1">
+                    {annotations.length}
+                  </span>
                 )}
-            </>
-          )}
+              </button>
+            )}
+
+            {/* Translation tab */}
+            <button
+              onClick={() => { setSidebarTab("translate"); setSidebarOpen((v) => sidebarTab === "translate" ? !v : true); }}
+              title="Translation"
+              className={`flex items-center gap-1 px-2.5 py-1.5 rounded-lg border text-xs font-medium transition-colors ${
+                sidebarOpen && sidebarTab === "translate"
+                  ? "bg-amber-700 text-white border-amber-700"
+                  : translationEnabled
+                  ? "bg-amber-100 text-amber-800 border-amber-400"
+                  : "border-amber-300 text-amber-700 hover:bg-amber-50"
+              }`}
+            >🌐 Translation</button>
+
+            {/* Export tab */}
+            {session?.backendToken && (
+              <button
+                onClick={() => { setSidebarTab("export"); setSidebarOpen((v) => sidebarTab === "export" ? !v : true); }}
+                title="Export tools"
+                className={`flex items-center gap-1 px-2.5 py-1.5 rounded-lg border text-xs font-medium transition-colors ${
+                  sidebarOpen && sidebarTab === "export"
+                    ? "bg-amber-700 text-white border-amber-700"
+                    : "border-amber-300 text-amber-700 hover:bg-amber-50"
+                }`}
+              >↗ Export</button>
+            )}
+
+            {/* Audiobook */}
+            {audiobookEnabled && (
+              <button
+                onClick={() => audiobook ? undefined : setShowAudioSearch(true)}
+                title={audiobook ? "Audiobook linked" : "Find audiobook"}
+                className={`flex items-center gap-1 px-2.5 py-1.5 rounded-lg border text-xs font-medium transition-colors ${
+                  audiobook
+                    ? "bg-amber-100 text-amber-900 border-amber-400"
+                    : "border-amber-300 text-amber-700 hover:bg-amber-50"
+                }`}
+              >🎧</button>
+            )}
+          </div>
         </div>
+
       </header>
 
       {/* ── Banners (hidden in immersive mode on mobile) ──────────────── */}
@@ -1343,7 +1243,7 @@ export default function ReaderPage() {
           </div>
         )}
 
-        {/* Insight Chat sidebar — fullscreen overlay on mobile, inline on desktop */}
+        {/* Side panel — fullscreen overlay on mobile, inline on desktop */}
         <div
           style={sidebarOpen ? { width: sidebarWidth } : { width: 0 }}
           className={`flex flex-col overflow-hidden shrink-0 ${
@@ -1352,40 +1252,249 @@ export default function ReaderPage() {
               : "border-l border-amber-200"
           }`}
         >
-          {/* Mobile close button for fullscreen sidebar */}
           {sidebarOpen && (
-            <div className="flex md:hidden items-center justify-between px-4 py-3 border-b border-amber-200 shrink-0 bg-white/70">
-              <span className="font-serif font-semibold text-ink text-sm">Insight Chat</span>
-              <button
-                onClick={() => setSidebarOpen(false)}
-                className="min-w-[44px] min-h-[44px] flex items-center justify-center text-amber-700 hover:text-amber-900 text-lg"
-                aria-label="Close sidebar"
-              >
-                ✕
-              </button>
-            </div>
+            <>
+              {/* Tab bar */}
+              <div className="flex shrink-0 border-b border-amber-200 bg-white/70">
+                {(["chat", "notes", "translate", "export"] as const).map((tab) => {
+                  const labels: Record<string, string> = { chat: "💬 Chat", notes: "📝 Notes", translate: "🌐 Translation", export: "↗ Export" };
+                  return (
+                    <button
+                      key={tab}
+                      onClick={() => setSidebarTab(tab)}
+                      className={`relative flex-1 py-2.5 text-xs font-medium transition-colors border-b-2 ${
+                        sidebarTab === tab
+                          ? "text-amber-700 border-amber-700"
+                          : "text-stone-500 border-transparent hover:text-amber-600"
+                      }`}
+                    >
+                      {labels[tab]}
+                      {tab === "notes" && annotations.length > 0 && (
+                        <span className="absolute top-1 right-1 min-w-[14px] h-3.5 flex items-center justify-center rounded-full bg-amber-600 text-white text-[8px] font-bold px-0.5">
+                          {annotations.length}
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+                {/* Mobile close button */}
+                <button
+                  onClick={() => setSidebarOpen(false)}
+                  className="md:hidden shrink-0 px-3 text-amber-700 hover:text-amber-900 text-lg min-h-[44px]"
+                  aria-label="Close panel"
+                >✕</button>
+              </div>
+
+              {/* ── Chat tab ── keep mounted so history persists */}
+              <div className={`flex flex-col flex-1 overflow-hidden ${sidebarTab === "chat" ? "" : "hidden"}`}>
+                <InsightChat
+                  bookId={bookId}
+                  userId={session?.backendUser?.id ?? null}
+                  hasGeminiKey={hasGeminiKey ?? false}
+                  isVisible={sidebarOpen && sidebarTab === "chat"}
+                  chapterText={current?.text ?? ""}
+                  chapterTitle={current?.title || `Chapter ${chapterIndex + 1}`}
+                  selectedText={selectedText}
+                  bookTitle={meta?.title ?? ""}
+                  author={meta?.authors[0] ?? ""}
+                  bookLanguage={bookLanguage}
+                  onAIUsed={notifyAIUsed}
+                  chapterIndex={chapterIndex}
+                  onSaveInsight={session?.backendToken ? (question, answer) => {
+                    saveInsight({ book_id: Number(bookId), chapter_index: chapterIndex, question, answer })
+                      .then(() => setObsidianToast("Insight saved to book notes"))
+                      .catch(() => setObsidianToast("Failed to save insight"))
+                      .finally(() => setTimeout(() => setObsidianToast(null), 3000));
+                  } : undefined}
+                />
+              </div>
+
+              {/* ── Notes tab ── */}
+              {sidebarTab === "notes" && (
+                <div className="flex-1 overflow-y-auto p-4 space-y-6">
+                  {annotationsLoading && annotations.length === 0 ? (
+                    <div className="flex justify-center mt-10">
+                      <span className="w-5 h-5 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+                    </div>
+                  ) : annotations.length === 0 ? (
+                    <div className="text-center text-stone-400 mt-10 text-sm">
+                      <p className="text-3xl mb-2">📝</p>
+                      <p>No annotations yet.</p>
+                      <p className="mt-1 text-xs">Long-press a sentence to add one.</p>
+                    </div>
+                  ) : (
+                    <>
+                      {annotationsLoading && (
+                        <div className="flex justify-center py-1">
+                          <span className="w-4 h-4 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+                        </div>
+                      )}
+                      {Object.keys(
+                        annotations.reduce<Record<number, true>>((acc, a) => { acc[a.chapter_index] = true; return acc; }, {})
+                      ).map(Number).sort((a, b) => a - b).map((ch) => (
+                        <div key={ch}>
+                          <h3 className="text-xs font-semibold text-stone-400 uppercase tracking-wide mb-2">Chapter {ch + 1}</h3>
+                          <div className="space-y-2">
+                            {annotations.filter((a) => a.chapter_index === ch).map((ann) => (
+                              <div
+                                key={ann.id}
+                                className={`rounded-lg border px-3 py-2.5 cursor-pointer hover:opacity-80 transition-opacity ${
+                                  { yellow: "bg-yellow-100 border-yellow-300 text-yellow-800", blue: "bg-blue-100 border-blue-300 text-blue-800", green: "bg-green-100 border-green-300 text-green-800", pink: "bg-pink-100 border-pink-300 text-pink-800" }[ann.color] ?? "bg-yellow-100 border-yellow-300 text-yellow-800"
+                                }`}
+                                onClick={() => {
+                                  if (ann.chapter_index !== chapterIndex) {
+                                    setChapterIndex(ann.chapter_index);
+                                    setTimeout(() => setScrollTargetSentence(ann.sentence_text), 400);
+                                  } else {
+                                    setScrollTargetSentence(undefined);
+                                    setTimeout(() => setScrollTargetSentence(ann.sentence_text), 10);
+                                  }
+                                  setSidebarOpen(false);
+                                }}
+                              >
+                                <div className="flex items-start justify-between gap-2">
+                                  <p className="text-xs italic leading-relaxed line-clamp-3 flex-1">&ldquo;{ann.sentence_text}&rdquo;</p>
+                                  <button
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      setAnnotationPanel({ sentenceText: ann.sentence_text, chapterIndex: ann.chapter_index, position: { x: window.innerWidth / 2, y: window.innerHeight / 2 } });
+                                      setSidebarOpen(false);
+                                    }}
+                                    className="shrink-0 text-xs opacity-60 hover:opacity-100 mt-0.5"
+                                    title="Edit annotation"
+                                  >✏️</button>
+                                </div>
+                                {ann.note_text && (
+                                  <p className="mt-1.5 text-xs font-medium border-t border-current/20 pt-1.5">{ann.note_text}</p>
+                                )}
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      ))}
+                    </>
+                  )}
+                </div>
+              )}
+
+              {/* ── Translation tab ── */}
+              {sidebarTab === "translate" && (
+                <div className="flex-1 overflow-y-auto p-4 space-y-5">
+                  {/* Enable/disable toggle */}
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-medium text-ink">Translation</span>
+                    <button
+                      onClick={() => setTranslationEnabled((v) => !v)}
+                      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                        translationEnabled ? "bg-amber-600" : "bg-stone-300"
+                      }`}
+                      role="switch"
+                      aria-checked={translationEnabled}
+                    >
+                      <span className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                        translationEnabled ? "translate-x-6" : "translate-x-1"
+                      }`} />
+                    </button>
+                  </div>
+
+                  {translationEnabled && (
+                    <>
+                      {/* Language selector + Apply */}
+                      <div className="space-y-2">
+                        <label className="text-xs text-stone-500 font-medium uppercase tracking-wide">Language</label>
+                        <div className="flex gap-2">
+                          <select
+                            className="flex-1 text-xs rounded border border-amber-300 px-2 py-2 text-ink bg-white"
+                            value={pendingTranslationLang}
+                            onChange={(e) => setPendingTranslationLang(e.target.value)}
+                          >
+                            {LANGUAGES.filter((l) => l.code !== bookLanguage).map((l) => (
+                              <option key={l.code} value={l.code}>{l.label}</option>
+                            ))}
+                          </select>
+                          <button
+                            onClick={() => setTranslationLang(pendingTranslationLang)}
+                            disabled={pendingTranslationLang === translationLang}
+                            className="px-3 py-2 text-xs rounded border border-amber-500 bg-amber-600 text-white hover:bg-amber-700 disabled:opacity-40 disabled:cursor-not-allowed font-medium"
+                          >
+                            Apply
+                          </button>
+                        </div>
+                        {pendingTranslationLang !== translationLang && (
+                          <p className="text-xs text-amber-600">Click Apply to translate into {LANGUAGES.find((l) => l.code === pendingTranslationLang)?.label ?? pendingTranslationLang}.</p>
+                        )}
+                      </div>
+
+                      {/* Display mode */}
+                      <div className="space-y-2">
+                        <label className="text-xs text-stone-500 font-medium uppercase tracking-wide">Display</label>
+                        <div className="flex rounded border border-amber-300 overflow-hidden text-xs">
+                          <button
+                            onClick={() => setDisplayMode("inline")}
+                            className={`flex-1 px-3 py-2 transition-colors ${displayMode === "inline" ? "bg-amber-700 text-white" : "text-amber-700 hover:bg-amber-50"}`}
+                          >Inline</button>
+                          <button
+                            onClick={() => setDisplayMode("parallel")}
+                            className={`flex-1 px-3 py-2 border-l border-amber-300 transition-colors ${displayMode === "parallel" ? "bg-amber-700 text-white" : "text-amber-700 hover:bg-amber-50"}`}
+                          >Side by side</button>
+                        </div>
+                      </div>
+
+                      {/* Status */}
+                      {translationLoading ? (
+                        <p className="text-xs text-amber-600 animate-pulse">{translationUsedProvider || "Translating…"}</p>
+                      ) : translationUsedProvider && translationUsedProvider !== "login required" && translationUsedProvider !== "gemini key required" ? (
+                        <p className="text-xs text-stone-400">via {translationUsedProvider}</p>
+                      ) : null}
+
+                      {/* Admin: retranslate */}
+                      {isAdmin && !translationLoading && translatedParagraphs.length > 0 && (
+                        <button
+                          onClick={handleRetranslate}
+                          className="w-full text-xs px-3 py-2 rounded border border-amber-300 text-amber-600 hover:bg-amber-50"
+                        >Retranslate this chapter</button>
+                      )}
+
+                      {/* Retry failed */}
+                      {!translationLoading && translationUsedProvider.startsWith("queue failed") && (
+                        <button
+                          onClick={handleRetryFailed}
+                          className="w-full text-xs px-3 py-2 rounded border border-red-300 text-red-600 hover:bg-red-50"
+                        >Retry</button>
+                      )}
+                    </>
+                  )}
+                </div>
+              )}
+
+              {/* ── Export tab ── */}
+              {sidebarTab === "export" && (
+                <div className="flex-1 overflow-y-auto p-4 space-y-3">
+                  <p className="text-xs text-stone-400 uppercase tracking-wide font-medium">Vocabulary</p>
+                  <button
+                    onClick={() => router.push("/vocabulary")}
+                    className="w-full flex items-center gap-2 px-4 py-3 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors"
+                  >
+                    <span className="text-lg">📚</span>
+                    <div className="text-left">
+                      <p className="font-medium">Vocabulary list</p>
+                      <p className="text-xs text-stone-400 font-normal">View all saved words</p>
+                    </div>
+                  </button>
+                  <button
+                    onClick={handleObsidianExport}
+                    className="w-full flex items-center gap-2 px-4 py-3 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors"
+                  >
+                    <span className="text-lg">↗</span>
+                    <div className="text-left">
+                      <p className="font-medium">Export to Obsidian</p>
+                      <p className="text-xs text-stone-400 font-normal">Open vocab in Obsidian vault</p>
+                    </div>
+                  </button>
+                </div>
+              )}
+            </>
           )}
-          {/* Keep mounted so chat history persists across open/close */}
-          <InsightChat
-            bookId={bookId}
-            userId={session?.backendUser?.id ?? null}
-            hasGeminiKey={hasGeminiKey ?? false}
-            isVisible={sidebarOpen}
-            chapterText={current?.text ?? ""}
-            chapterTitle={current?.title || `Chapter ${chapterIndex + 1}`}
-            selectedText={selectedText}
-            bookTitle={meta?.title ?? ""}
-            author={meta?.authors[0] ?? ""}
-            bookLanguage={bookLanguage}
-            onAIUsed={notifyAIUsed}
-            chapterIndex={chapterIndex}
-            onSaveInsight={session?.backendToken ? (question, answer) => {
-              saveInsight({ book_id: Number(bookId), chapter_index: chapterIndex, question, answer })
-                .then(() => setObsidianToast("Insight saved to book notes"))
-                .catch(() => setObsidianToast("Failed to save insight"))
-                .finally(() => setTimeout(() => setObsidianToast(null), 3000));
-            } : undefined}
-          />
         </div>
       </div>
 
@@ -1406,36 +1515,6 @@ export default function ReaderPage() {
       {/* ── Mobile floating bottom toolbar ─────────────────────────────── */}
       {!loading && chapters.length > 0 && (
         <div className="md:hidden fixed bottom-0 left-0 right-0 z-30 safe-bottom">
-          {/* Translation options expand panel */}
-          {translateExpanded && translationEnabled && (
-            <div className="bg-white/95 backdrop-blur border-t border-amber-200 px-3 py-2 flex items-center gap-2 animate-slide-up">
-              <select
-                className="text-xs rounded border border-amber-300 px-2 py-2 text-ink bg-white flex-1 min-h-[44px]"
-                value={translationLang}
-                onChange={(e) => setTranslationLang(e.target.value)}
-              >
-                {LANGUAGES.map((l) => (
-                  <option key={l.code} value={l.code}>{l.label}</option>
-                ))}
-              </select>
-              <div className="flex rounded border border-amber-300 overflow-hidden text-xs">
-                <button
-                  onClick={() => setDisplayMode("inline")}
-                  className={`px-3 py-2 min-h-[44px] transition-colors ${
-                    displayMode === "inline" ? "bg-amber-700 text-white" : "text-amber-700 hover:bg-amber-50"
-                  }`}
-                >Inline</button>
-                <button
-                  onClick={() => setDisplayMode("parallel")}
-                  className={`px-3 py-2 min-h-[44px] border-l border-amber-300 transition-colors ${
-                    displayMode === "parallel" ? "bg-amber-700 text-white" : "text-amber-700 hover:bg-amber-50"
-                  }`}
-                >Side by side</button>
-              </div>
-            </div>
-          )}
-
-          {/* Main bottom bar */}
           <div className="bg-white/95 backdrop-blur border-t border-amber-200 px-1 py-1 flex items-center justify-around gap-0.5">
             <button
               onClick={() => goToChapter(Math.max(0, chapterIndex - 1))}
@@ -1444,20 +1523,10 @@ export default function ReaderPage() {
               aria-label="Previous chapter"
             >‹</button>
 
+            {/* Translation shortcut — opens panel on Translation tab */}
             <button
-              onClick={() => {
-                if (!translationEnabled) {
-                  setTranslationEnabled(true);
-                  setTranslateExpanded(true);
-                } else {
-                  setTranslateExpanded((v) => !v);
-                }
-              }}
-              onDoubleClick={() => {
-                setTranslationEnabled(false);
-                setTranslateExpanded(false);
-              }}
-              title="Tap: toggle options · Double-tap: turn off"
+              onClick={() => { setSidebarTab("translate"); setSidebarOpen(true); }}
+              title="Translation settings"
               className={`min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg text-sm transition-colors ${
                 translationEnabled
                   ? "bg-amber-700 text-white"
@@ -1490,10 +1559,11 @@ export default function ReaderPage() {
               ))}
             </select>
 
+            {/* Chat shortcut — opens panel on Chat tab */}
             <button
-              onClick={() => setSidebarOpen((v) => !v)}
+              onClick={() => { setSidebarTab("chat"); setSidebarOpen(true); }}
               className={`min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg text-sm transition-colors ${
-                sidebarOpen
+                sidebarOpen && sidebarTab === "chat"
                   ? "bg-amber-700 text-white"
                   : "text-amber-700 bg-amber-50 border border-amber-200"
               }`}

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1390,6 +1390,7 @@ export default function ReaderPage() {
                       }`}
                       role="switch"
                       aria-checked={translationEnabled}
+                      aria-label="Enable translation"
                     >
                       <span className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
                         translationEnabled ? "translate-x-6" : "translate-x-1"


### PR DESCRIPTION
## Summary

- **Unified tabbed sidebar panel**: replaces scattered header buttons (Insight, Notes, Vocab, Obsidian, Translation row) with a single resizable panel containing 4 tabs — Chat, Notes, Translation, Export
- **Translation safe-apply gate**: language dropdown stages into `pendingTranslationLang`; explicit **Apply** button required to trigger translation — prevents accidental token spend
- **Mobile**: 🌐 opens Translation tab; 💬 opens Chat tab; removes old expand/collapse translation row

## What changed

**Desktop header** — 4 compact tab buttons replace the old per-feature buttons. Clicking a tab opens the panel to that tab; clicking the active tab closes it.

**Sidebar panel tabs:**
- *Chat* — InsightChat (stays mounted so history persists across tab switches)
- *Notes* — annotations list inline; clicking an entry jumps to the sentence
- *Translation* — enable toggle, language selector + Apply button, display mode, status, admin controls
- *Export* — Vocabulary list link + Obsidian export with descriptions

**Translation UX** — `pendingTranslationLang` holds staged selection; `translationLang` (drives the translation effect) only updates on Apply. Hint text appears when pending ≠ active.

## Test plan

- [x] 306 frontend tests pass
- [x] 659 backend tests pass
- [ ] Desktop: 4 tab buttons in header, each opens panel to correct tab; active tab click closes panel
- [ ] Translation tab: change language → no translation fires; click Apply → translation fires
- [ ] Notes tab: list renders; clicking jumps to sentence and closes panel
- [ ] Export tab: Vocabulary and Obsidian buttons work
- [ ] Mobile: 🌐 opens Translation tab, 💬 opens Chat tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)
