### PR TITLE
fix: add page-ready guard to flaky worker-offline E2E test

### DIFF
--- a/frontend/e2e/reader.spec.ts
+++ b/frontend/e2e/reader.spec.ts
@@ -115,6 +115,8 @@ test("translation shows worker offline message when worker not running", async (
   );
 
   await page.goto("/reader/1342");
+  await expect(page.getByText(/truth universally acknowledged/)).toBeVisible({ timeout: 10000 });
+
   await page.getByRole("button", { name: /Translation/ }).first().click();
   await page.getByRole("switch", { name: /Enable translation/i }).click();
 


### PR DESCRIPTION
## Summary
- Adds a `await expect(page.getByText(/truth universally acknowledged/)).toBeVisible()` guard before clicking the Translation button in the "worker offline" test
- Without this guard the test clicks the button before the reader has finished rendering, causing a race condition (fails first run, passes on retry)
- Matches the pattern already used by the other two translation tests in the same file
- Same fix was applied directly to the `revert/pr-160` branch to unblock PR #162

## Test plan
- [x] `npm run test:e2e -- e2e/reader.spec.ts` — all 7 tests pass locally
