### PR TITLE
fix(tts): prevent English pronunciation fallback in non-English TTS

### DIFF
--- a/backend/services/tts.py
+++ b/backend/services/tts.py
@@ -6,6 +6,32 @@ import io
 from typing import Literal
 
 import edge_tts
+import edge_tts.communicate as _edge_communicate
+
+# ── Fix: edge_tts hardcodes xml:lang='en-US' in SSML, which causes
+# MultilingualNeural voices to auto-switch to English pronunciation
+# for words that "look English" (names, places, Latin terms).
+# Patch mkssml to derive xml:lang from the voice name instead. ──────────
+
+_original_mkssml = _edge_communicate.mkssml
+
+
+def _lang_aware_mkssml(tc, escaped_text):
+    import re
+    m = re.search(r"\(([a-z]{2}-[A-Z]{2})", tc.voice)
+    lang = m.group(1) if m else "en-US"
+    return (
+        f"<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='{lang}'>"
+        f"<voice name='{tc.voice}'>"
+        f"<prosody pitch='{tc.pitch}' rate='{tc.rate}' volume='{tc.volume}'>"
+        f"{escaped_text}"
+        "</prosody>"
+        "</voice>"
+        "</speak>"
+    )
+
+
+_edge_communicate.mkssml = _lang_aware_mkssml
 
 Gender = Literal["female", "male"]
 

--- a/backend/tests/test_tts.py
+++ b/backend/tests/test_tts.py
@@ -211,3 +211,45 @@ Und manche liebe Schatten steigen auf;
 def test_chunk_empty_input():
     assert chunk_text("") == []
     assert chunk_text("\n\n  \n\n") == []
+
+
+# ── SSML language lock (xml:lang derived from voice) ─────────────────────────
+
+def _make_tc(voice, rate="+0%", volume="+0%", pitch="+0Hz"):
+    from edge_tts.data_classes import TTSConfig
+    return TTSConfig(voice=voice, rate=rate, volume=volume, pitch=pitch, boundary="WordBoundary")
+
+
+def test_mkssml_uses_voice_language_not_en_us():
+    """The patched mkssml should set xml:lang to match the voice locale,
+    preventing MultilingualNeural voices from auto-switching to English."""
+    from services.tts import _lang_aware_mkssml
+    ssml = _lang_aware_mkssml(_make_tc("de-DE-FlorianMultilingualNeural"), "Hallo Welt")
+    assert "xml:lang='de-DE'" in ssml
+    assert "xml:lang='en-US'" not in ssml
+
+
+def test_mkssml_english_voice_uses_en_us():
+    from services.tts import _lang_aware_mkssml
+    ssml = _lang_aware_mkssml(_make_tc("en-US-EmmaMultilingualNeural"), "Hello world")
+    assert "xml:lang='en-US'" in ssml
+
+
+def test_mkssml_french_voice_uses_fr_fr():
+    from services.tts import _lang_aware_mkssml
+    ssml = _lang_aware_mkssml(_make_tc("fr-FR-VivienneMultilingualNeural"), "Bonjour le monde")
+    assert "xml:lang='fr-FR'" in ssml
+
+
+def test_mkssml_preserves_prosody():
+    from services.tts import _lang_aware_mkssml
+    ssml = _lang_aware_mkssml(_make_tc("de-DE-FlorianMultilingualNeural", rate="+20%", pitch="+5Hz"), "Text")
+    assert "rate='+20%'" in ssml
+    assert "pitch='+5Hz'" in ssml
+
+
+def test_edge_tts_mkssml_is_patched():
+    """Verify the module-level monkey-patch is in effect."""
+    import edge_tts.communicate as etc
+    from services.tts import _lang_aware_mkssml
+    assert etc.mkssml is _lang_aware_mkssml


### PR DESCRIPTION
## Summary

Fixes German (and other non-English) TTS randomly switching to English pronunciation for names, places, and ALL-CAPS headings.

### Root cause

`edge_tts` hardcodes `xml:lang='en-US'` in its SSML template. When using MultilingualNeural voices, the TTS engine auto-detects language per word. Words like `Mephistopheles`, `Jerusalem`, `DIREKTOR` get flagged as "English-looking" and pronounced with English phonetics — even in a fully German text.

### Fix

Monkey-patch `edge_tts.communicate.mkssml` to derive `xml:lang` from the voice locale:
- `de-DE-FlorianMultilingualNeural` → `xml:lang='de-DE'`
- `fr-FR-VivienneMultilingualNeural` → `xml:lang='fr-FR'`
- `en-US-EmmaMultilingualNeural` → `xml:lang='en-US'` (unchanged)

This locks the engine to the correct language while keeping the high-quality Multilingual voice.

### Tests added

5 new tests in `test_tts.py`:
- German voice → `xml:lang='de-DE'`
- English voice → `xml:lang='en-US'`
- French voice → `xml:lang='fr-FR'`
- Prosody attributes preserved
- Monkey-patch is in effect

## Test plan

- [x] Backend: 29 TTS tests passed, 100% coverage on tts.py

https://claude.ai/code/session_01EaGzJ8nKeRiADoBc3hRaqj