### PR TITLE
fix(tts): use pure single-language voices to prevent English fallback

### DIFF
--- a/backend/services/tts.py
+++ b/backend/services/tts.py
@@ -1,50 +1,28 @@
 """
 TTS service using Microsoft Edge TTS (free, no API key, MP3 output).
+
+Uses pure single-language voices (not MultilingualNeural) to prevent
+the TTS engine from auto-switching to English pronunciation for words
+that "look English" — names, places, Latin terms, ALL-CAPS headings.
 """
 
 import io
 from typing import Literal
 
 import edge_tts
-import edge_tts.communicate as _edge_communicate
-
-# ── Fix: edge_tts hardcodes xml:lang='en-US' in SSML, which causes
-# MultilingualNeural voices to auto-switch to English pronunciation
-# for words that "look English" (names, places, Latin terms).
-# Patch mkssml to derive xml:lang from the voice name instead. ──────────
-
-_original_mkssml = _edge_communicate.mkssml
-
-
-def _lang_aware_mkssml(tc, escaped_text):
-    import re
-    m = re.search(r"\(([a-z]{2}-[A-Z]{2})", tc.voice)
-    lang = m.group(1) if m else "en-US"
-    return (
-        f"<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='{lang}'>"
-        f"<voice name='{tc.voice}'>"
-        f"<prosody pitch='{tc.pitch}' rate='{tc.rate}' volume='{tc.volume}'>"
-        f"{escaped_text}"
-        "</prosody>"
-        "</voice>"
-        "</speak>"
-    )
-
-
-_edge_communicate.mkssml = _lang_aware_mkssml
 
 Gender = Literal["female", "male"]
 
 EDGE_VOICE_FEMALE: dict[str, str] = {
-    "en": "en-US-EmmaMultilingualNeural",
-    "en-us": "en-US-EmmaMultilingualNeural",
-    "en-gb": "en-GB-AdaMultilingualNeural",
-    "de": "de-DE-SeraphinaMultilingualNeural",
-    "fr": "fr-FR-VivienneMultilingualNeural",
-    "es": "es-ES-XimenaMultilingualNeural",
+    "en": "en-US-JennyNeural",
+    "en-us": "en-US-JennyNeural",
+    "en-gb": "en-GB-SoniaNeural",
+    "de": "de-DE-KatjaNeural",
+    "fr": "fr-FR-DeniseNeural",
+    "es": "es-ES-ElviraNeural",
     "it": "it-IT-IsabellaNeural",
-    "pt": "pt-BR-ThalitaMultilingualNeural",
-    "zh": "zh-CN-XiaoxiaoMultilingualNeural",
+    "pt": "pt-BR-FranciscaNeural",
+    "zh": "zh-CN-XiaoxiaoNeural",
     "ja": "ja-JP-NanamiNeural",
     "ko": "ko-KR-SunHiNeural",
     "nl": "nl-NL-ColetteNeural",
@@ -64,17 +42,17 @@ EDGE_VOICE_FEMALE: dict[str, str] = {
 }
 
 EDGE_VOICE_MALE: dict[str, str] = {
-    "en": "en-US-AndrewMultilingualNeural",
-    "en-us": "en-US-AndrewMultilingualNeural",
+    "en": "en-US-GuyNeural",
+    "en-us": "en-US-GuyNeural",
     "en-gb": "en-GB-RyanNeural",
-    "de": "de-DE-FlorianMultilingualNeural",
-    "fr": "fr-FR-RemyMultilingualNeural",
+    "de": "de-DE-ConradNeural",
+    "fr": "fr-FR-HenriNeural",
     "es": "es-ES-AlvaroNeural",
-    "it": "it-IT-GiuseppeMultilingualNeural",
+    "it": "it-IT-DiegoNeural",
     "pt": "pt-BR-AntonioNeural",
     "zh": "zh-CN-YunyangNeural",
-    "ja": "ja-JP-MasaruMultilingualNeural",
-    "ko": "ko-KR-HyunsuMultilingualNeural",
+    "ja": "ja-JP-KeitaNeural",
+    "ko": "ko-KR-InJoonNeural",
     "nl": "nl-NL-MaartenNeural",
     "ru": "ru-RU-DmitryNeural",
     "ar": "ar-SA-HamedNeural",
@@ -91,8 +69,8 @@ EDGE_VOICE_MALE: dict[str, str] = {
     "he": "he-IL-AvriNeural",
 }
 
-_FALLBACK_FEMALE = "en-US-EmmaMultilingualNeural"
-_FALLBACK_MALE = "en-US-AndrewMultilingualNeural"
+_FALLBACK_FEMALE = "en-US-JennyNeural"
+_FALLBACK_MALE = "en-US-GuyNeural"
 
 
 def _pick_edge_voice(language: str, gender: Gender = "female") -> str:

--- a/backend/tests/test_tts.py
+++ b/backend/tests/test_tts.py
@@ -213,43 +213,27 @@ def test_chunk_empty_input():
     assert chunk_text("\n\n  \n\n") == []
 
 
-# ── SSML language lock (xml:lang derived from voice) ─────────────────────────
+# ── Pure single-language voices (no MultilingualNeural) ──────────────────────
 
-def _make_tc(voice, rate="+0%", volume="+0%", pitch="+0Hz"):
-    from edge_tts.data_classes import TTSConfig
-    return TTSConfig(voice=voice, rate=rate, volume=volume, pitch=pitch, boundary="WordBoundary")
-
-
-def test_mkssml_uses_voice_language_not_en_us():
-    """The patched mkssml should set xml:lang to match the voice locale,
-    preventing MultilingualNeural voices from auto-switching to English."""
-    from services.tts import _lang_aware_mkssml
-    ssml = _lang_aware_mkssml(_make_tc("de-DE-FlorianMultilingualNeural"), "Hallo Welt")
-    assert "xml:lang='de-DE'" in ssml
-    assert "xml:lang='en-US'" not in ssml
+def test_no_multilingual_voices():
+    """All voices should be pure single-language, not MultilingualNeural,
+    to prevent auto-switching to English pronunciation."""
+    for lang, voice in EDGE_VOICE_FEMALE.items():
+        assert "Multilingual" not in voice, f"Female {lang}: {voice} is Multilingual"
+    for lang, voice in EDGE_VOICE_MALE.items():
+        assert "Multilingual" not in voice, f"Male {lang}: {voice} is Multilingual"
 
 
-def test_mkssml_english_voice_uses_en_us():
-    from services.tts import _lang_aware_mkssml
-    ssml = _lang_aware_mkssml(_make_tc("en-US-EmmaMultilingualNeural"), "Hello world")
-    assert "xml:lang='en-US'" in ssml
+def test_german_voices_are_pure():
+    assert EDGE_VOICE_FEMALE["de"] == "de-DE-KatjaNeural"
+    assert EDGE_VOICE_MALE["de"] == "de-DE-ConradNeural"
 
 
-def test_mkssml_french_voice_uses_fr_fr():
-    from services.tts import _lang_aware_mkssml
-    ssml = _lang_aware_mkssml(_make_tc("fr-FR-VivienneMultilingualNeural"), "Bonjour le monde")
-    assert "xml:lang='fr-FR'" in ssml
+def test_french_voices_are_pure():
+    assert EDGE_VOICE_FEMALE["fr"] == "fr-FR-DeniseNeural"
+    assert EDGE_VOICE_MALE["fr"] == "fr-FR-HenriNeural"
 
 
-def test_mkssml_preserves_prosody():
-    from services.tts import _lang_aware_mkssml
-    ssml = _lang_aware_mkssml(_make_tc("de-DE-FlorianMultilingualNeural", rate="+20%", pitch="+5Hz"), "Text")
-    assert "rate='+20%'" in ssml
-    assert "pitch='+5Hz'" in ssml
-
-
-def test_edge_tts_mkssml_is_patched():
-    """Verify the module-level monkey-patch is in effect."""
-    import edge_tts.communicate as etc
-    from services.tts import _lang_aware_mkssml
-    assert etc.mkssml is _lang_aware_mkssml
+def test_english_voices_are_pure():
+    assert EDGE_VOICE_FEMALE["en"] == "en-US-JennyNeural"
+    assert EDGE_VOICE_MALE["en"] == "en-US-GuyNeural"


### PR DESCRIPTION
## Summary

Replaces all MultilingualNeural TTS voices with pure single-language voices to prevent auto-switching to English pronunciation.

### Problem

MultilingualNeural voices (e.g. `de-DE-FlorianMultilingualNeural`) auto-detect language per word. Words like `Mephistopheles`, `Jerusalem`, `DIREKTOR` get pronounced in English even in fully German text. The SSML `xml:lang` fix (#164) did not resolve this.

### Fix

Switch to pure single-language Neural voices that only know one language:

| Language | Before (Multilingual) | After (Pure) |
|----------|----------------------|-------------|
| 🇩🇪 German ♂ | FlorianMultilingualNeural | **ConradNeural** |
| 🇩🇪 German ♀ | SeraphinaMultilingualNeural | **KatjaNeural** |
| 🇫🇷 French ♂ | RemyMultilingualNeural | **HenriNeural** |
| 🇫🇷 French ♀ | VivienneMultilingualNeural | **DeniseNeural** |
| 🇺🇸 English ♂ | AndrewMultilingualNeural | **GuyNeural** |
| 🇺🇸 English ♀ | EmmaMultilingualNeural | **JennyNeural** |

Also removes the `mkssml` monkey-patch from #164 (no longer needed).

**Note:** existing cached TTS audio uses old voice names. Users will hear the new voice on cache miss or after clearing the audio cache.

## Test plan

- [x] Backend: 28 TTS tests passed, 100% coverage
- [x] Test verifies no Multilingual voices remain in either voice map

https://claude.ai/code/session_01EaGzJ8nKeRiADoBc3hRaqj