### PR TITLE
feat: selection toolbar + half-screen chat bottom sheet

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -84,3 +84,12 @@ body, [data-theme="light"] {
 .animate-slide-up {
   animation: slide-up 0.25s ease-out;
 }
+
+/* Toolbar fade-in */
+@keyframes fade-in {
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
+}
+.animate-fade-in {
+  animation: fade-in 0.15s ease-out;
+}

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -12,7 +12,7 @@ import AudiobookPlayer from "@/components/AudiobookPlayer";
 import AudiobookSearch from "@/components/AudiobookSearch";
 import SentenceReader from "@/components/SentenceReader";
 import WordLookup from "@/components/WordLookup";
-import WordActionDrawer, { type WordAction } from "@/components/WordActionDrawer";
+import SelectionToolbar from "@/components/SelectionToolbar";
 import AnnotationToolbar from "@/components/AnnotationToolbar";
 import AnnotationsSidebar from "@/components/AnnotationsSidebar";
 import VocabularyToast from "@/components/VocabularyToast";
@@ -43,7 +43,7 @@ export default function ReaderPage() {
 
   const [selectedText, setSelectedText] = useState("");
   const [lookupWord, setLookupWord] = useState<{ word: string; x: number; y: number } | null>(null);
-  const [wordAction, setWordAction] = useState<WordAction | null>(null);
+  const [chatSheetText, setChatSheetText] = useState<string | null>(null);
 
   // Annotations
   const [annotations, setAnnotations] = useState<Annotation[]>([]);
@@ -566,7 +566,7 @@ export default function ReaderPage() {
 
   const handleSelection = useCallback(() => {
     const sel = window.getSelection()?.toString().trim() || "";
-    if (sel.length > 10) setSelectedText(sel);
+    setSelectedText(sel.length > 2 ? sel : "");
   }, []);
 
   // Keyboard shortcuts
@@ -1133,15 +1133,6 @@ export default function ReaderPage() {
                     setAnnotationPanel({ sentenceText, chapterIndex: ci, position });
                   } : undefined}
                   scrollTargetSentence={scrollTargetSentence}
-                  onWordTap={(info) => {
-                    setWordAction({
-                      word: info.word,
-                      sentenceText: info.sentenceText,
-                      segmentStartTime: info.startTime,
-                      chapterIndex: info.chapterIndex,
-                      translationText: info.translationText,
-                    });
-                  }}
                   onSegmentClick={(startTime, segText) => {
                     if (audiobook) {
                       seekAudioRef.current(startTime);
@@ -1193,38 +1184,40 @@ export default function ReaderPage() {
             />
           )}
 
-          {/* Unified word action drawer (mobile + desktop) */}
-          <WordActionDrawer
-            action={wordAction}
-            onClose={() => setWordAction(null)}
-            onReadSentence={(text, startTime) => {
-              if (audiobook) {
-                seekAudioRef.current(startTime);
-              } else if (ttsDuration > 0) {
-                ttsSeekRef.current(startTime);
-              } else {
-                synthesizeSpeech(text, bookLanguage, 1.0, getSettings().ttsGender)
-                  .then(({ url }) => {
-                    const audio = new Audio(url);
-                    audio.onended = () => URL.revokeObjectURL(url);
-                    audio.play().catch(() => URL.revokeObjectURL(url));
-                  })
-                  .catch(() => {
-                    window.speechSynthesis.cancel();
-                    const utter = new SpeechSynthesisUtterance(text);
-                    utter.lang = bookLanguage;
-                    window.speechSynthesis.speak(utter);
-                  });
-              }
+          {/* Selection toolbar — appears when user selects text */}
+          <SelectionToolbar
+            onRead={(text) => {
+              synthesizeSpeech(text, bookLanguage, 1.0, getSettings().ttsGender)
+                .then(({ url }) => {
+                  const audio = new Audio(url);
+                  audio.onended = () => URL.revokeObjectURL(url);
+                  audio.play().catch(() => URL.revokeObjectURL(url));
+                })
+                .catch(() => {
+                  window.speechSynthesis.cancel();
+                  const utter = new SpeechSynthesisUtterance(text);
+                  utter.lang = bookLanguage;
+                  window.speechSynthesis.speak(utter);
+                });
             }}
-            onSaveWord={session?.backendToken ? handleWordSave : undefined}
-            onAnnotate={session?.backendToken ? (sentenceText, ci) => {
+            onHighlight={session?.backendToken ? (text) => {
               setAnnotationPanel({
-                sentenceText,
-                chapterIndex: ci,
+                sentenceText: text,
+                chapterIndex,
                 position: { x: window.innerWidth / 2, y: window.innerHeight / 2 },
               });
             } : undefined}
+            onNote={session?.backendToken ? (text) => {
+              setAnnotationPanel({
+                sentenceText: text,
+                chapterIndex,
+                position: { x: window.innerWidth / 2, y: window.innerHeight / 2 },
+              });
+            } : undefined}
+            onChat={(text) => {
+              setChatSheetText(text);
+              setSelectedText(text);
+            }}
           />
 
           {/* Annotation toolbar */}
@@ -1343,29 +1336,12 @@ export default function ReaderPage() {
           </div>
         )}
 
-        {/* Insight Chat sidebar — fullscreen overlay on mobile, inline on desktop */}
+        {/* Insight Chat — half-screen bottom sheet on mobile, inline sidebar on desktop */}
+        {/* Desktop: inline sidebar */}
         <div
           style={sidebarOpen ? { width: sidebarWidth } : { width: 0 }}
-          className={`flex flex-col overflow-hidden shrink-0 ${
-            sidebarOpen
-              ? "fixed inset-0 z-40 bg-parchment !w-full md:static md:z-auto md:!w-auto md:border-l md:border-amber-200"
-              : "border-l border-amber-200"
-          }`}
+          className="hidden md:flex flex-col overflow-hidden shrink-0 border-l border-amber-200"
         >
-          {/* Mobile close button for fullscreen sidebar */}
-          {sidebarOpen && (
-            <div className="flex md:hidden items-center justify-between px-4 py-3 border-b border-amber-200 shrink-0 bg-white/70">
-              <span className="font-serif font-semibold text-ink text-sm">Insight Chat</span>
-              <button
-                onClick={() => setSidebarOpen(false)}
-                className="min-w-[44px] min-h-[44px] flex items-center justify-center text-amber-700 hover:text-amber-900 text-lg"
-                aria-label="Close sidebar"
-              >
-                ✕
-              </button>
-            </div>
-          )}
-          {/* Keep mounted so chat history persists across open/close */}
           <InsightChat
             bookId={bookId}
             userId={session?.backendUser?.id ?? null}
@@ -1388,6 +1364,50 @@ export default function ReaderPage() {
           />
         </div>
       </div>
+
+      {/* Mobile: half-screen bottom sheet for chat */}
+      {(sidebarOpen || chatSheetText) && (
+        <div className="md:hidden fixed inset-0 z-40 flex flex-col">
+          {/* Tap-to-dismiss backdrop (top half — user can still see the text) */}
+          <div
+            className="flex-1 bg-black/10"
+            onClick={() => { setSidebarOpen(false); setChatSheetText(null); }}
+          />
+          {/* Chat sheet (bottom half) */}
+          <div className="h-[55vh] bg-parchment border-t border-amber-200 rounded-t-2xl shadow-2xl flex flex-col animate-slide-up safe-bottom">
+            {/* Drag handle + close */}
+            <div className="flex items-center justify-between px-4 py-2 border-b border-amber-200 shrink-0">
+              <div className="w-10 h-1 bg-amber-200 rounded-full" />
+              <span className="font-serif font-semibold text-ink text-sm">Chat</span>
+              <button
+                onClick={() => { setSidebarOpen(false); setChatSheetText(null); }}
+                className="min-w-[44px] min-h-[44px] flex items-center justify-center text-amber-700 text-lg"
+                aria-label="Close chat"
+              >✕</button>
+            </div>
+            <InsightChat
+              bookId={bookId}
+              userId={session?.backendUser?.id ?? null}
+              hasGeminiKey={hasGeminiKey ?? false}
+              isVisible={true}
+              chapterText={current?.text ?? ""}
+              chapterTitle={current?.title || `Chapter ${chapterIndex + 1}`}
+              selectedText={chatSheetText || selectedText}
+              bookTitle={meta?.title ?? ""}
+              author={meta?.authors[0] ?? ""}
+              bookLanguage={bookLanguage}
+              onAIUsed={notifyAIUsed}
+              chapterIndex={chapterIndex}
+              onSaveInsight={session?.backendToken ? (question, answer) => {
+                saveInsight({ book_id: Number(bookId), chapter_index: chapterIndex, question, answer })
+                  .then(() => setObsidianToast("Insight saved to book notes"))
+                  .catch(() => setObsidianToast("Failed to save insight"))
+                  .finally(() => setTimeout(() => setObsidianToast(null), 3000));
+              } : undefined}
+            />
+          </div>
+        </div>
+      )}
 
       {/* Audiobook search modal */}
       {audiobookEnabled && showAudioSearch && (

--- a/frontend/src/components/SelectionToolbar.tsx
+++ b/frontend/src/components/SelectionToolbar.tsx
@@ -1,0 +1,121 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+export interface SelectionAction {
+  text: string;
+  rect: DOMRect;
+}
+
+interface Props {
+  onRead?: (text: string) => void;
+  onHighlight?: (text: string) => void;
+  onNote?: (text: string) => void;
+  onChat?: (text: string) => void;
+}
+
+export default function SelectionToolbar({ onRead, onHighlight, onNote, onChat }: Props) {
+  const [selection, setSelection] = useState<SelectionAction | null>(null);
+  const toolbarRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleSelection() {
+      const sel = window.getSelection();
+      const text = sel?.toString().trim() ?? "";
+      if (text.length < 2) {
+        setSelection(null);
+        return;
+      }
+      const range = sel?.getRangeAt(0);
+      if (!range) return;
+      const rect = range.getBoundingClientRect();
+      // Only show for selections inside the reader area
+      const readerEl = document.getElementById("reader-scroll");
+      if (!readerEl?.contains(range.commonAncestorContainer)) return;
+      setSelection({ text, rect });
+    }
+
+    document.addEventListener("selectionchange", handleSelection);
+    return () => document.removeEventListener("selectionchange", handleSelection);
+  }, []);
+
+  // Close when clicking outside
+  useEffect(() => {
+    if (!selection) return;
+    function handleClick(e: MouseEvent) {
+      if (toolbarRef.current?.contains(e.target as Node)) return;
+      // Small delay to let the action handlers fire first
+      setTimeout(() => {
+        const sel = window.getSelection()?.toString().trim() ?? "";
+        if (sel.length < 2) setSelection(null);
+      }, 100);
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [selection]);
+
+  if (!selection) return null;
+
+  // Position toolbar above the selection, centered
+  const scrollEl = document.getElementById("reader-scroll");
+  const scrollRect = scrollEl?.getBoundingClientRect();
+  const toolbarWidth = 220;
+
+  let left = selection.rect.left + selection.rect.width / 2 - toolbarWidth / 2;
+  let top = selection.rect.top - 52;
+
+  // Keep within viewport
+  if (left < 8) left = 8;
+  if (left + toolbarWidth > window.innerWidth - 8) left = window.innerWidth - toolbarWidth - 8;
+  // If not enough space above, show below
+  if (top < (scrollRect?.top ?? 60)) {
+    top = selection.rect.bottom + 8;
+  }
+
+  function handleAction(fn?: (text: string) => void) {
+    if (!fn || !selection) return;
+    fn(selection.text);
+    window.getSelection()?.removeAllRanges();
+    setSelection(null);
+  }
+
+  return (
+    <div
+      ref={toolbarRef}
+      className="fixed z-50 flex items-center gap-0.5 bg-stone-800 rounded-xl shadow-xl px-1 py-1 animate-fade-in"
+      style={{ left, top }}
+    >
+      {onRead && (
+        <button
+          onClick={() => handleAction(onRead)}
+          className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[40px]"
+        >
+          🔊 Read
+        </button>
+      )}
+      {onHighlight && (
+        <button
+          onClick={() => handleAction(onHighlight)}
+          className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[40px]"
+        >
+          🎨 Highlight
+        </button>
+      )}
+      {onNote && (
+        <button
+          onClick={() => handleAction(onNote)}
+          className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[40px]"
+        >
+          📝 Note
+        </button>
+      )}
+      {onChat && (
+        <button
+          onClick={() => handleAction(onChat)}
+          className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[40px]"
+        >
+          💬 Chat
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the custom long-press → WordActionDrawer interaction with native text selection + floating toolbar, and changes mobile chat from fullscreen to half-screen bottom sheet.

### Selection Toolbar
```
Long press → browser selects text → toolbar appears above:
[🔊 Read] [🎨 Highlight] [📝 Note] [💬 Chat]
```
- Uses browser's native text selection (no custom gesture handling)
- Dark floating toolbar positioned near the selection
- Dismisses when selection is cleared or action is taken

### Half-Screen Chat (mobile)
```
┌─────────────────────┐
│ ...original text...  │  ← still visible (top 45%)
├─────────────────────┤
│ Chat                 │  ← bottom sheet (55vh)
│ AI: The meaning...   │
│ [input]       [send] │
└─────────────────────┘
```
- 💬 button (bottom bar or toolbar) opens 55vh sheet
- Tap the semi-transparent backdrop to dismiss
- Selected text passed as context to AI

### Removed
- `WordActionDrawer` component
- `onWordTap` prop from SentenceReader
- Fullscreen mobile sidebar overlay

## Test plan
- [x] Jest: 306 passed
- [x] TypeScript build: compiled successfully
- [ ] Manual: long-press text on mobile → selection + toolbar appears
- [ ] Manual: tap Read → speaks selected text
- [ ] Manual: tap Chat → half-screen sheet opens, can see text above
- [ ] Manual: desktop sidebar unchanged

https://claude.ai/code/session_01EaGzJ8nKeRiADoBc3hRaqj