### PR TITLE
feat(reader): sync ?chapter=N URL on chapter navigation

### DIFF
--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -609,6 +609,7 @@ export default function ReaderPage() {
 
   function goToChapter(index: number) {
     setChapterIndex(index);
+    router.replace(`/reader/${bookId}?chapter=${index}`, { scroll: false });
     saveLastChapter(Number(bookId), index);
     if (session?.backendToken) {
       saveReadingProgress(Number(bookId), index).catch(() => {});
@@ -809,7 +810,7 @@ export default function ReaderPage() {
               loading={annotationsLoading}
               onJump={(ann) => {
                 if (ann.chapter_index !== chapterIndex) {
-                  setChapterIndex(ann.chapter_index);
+                  goToChapter(ann.chapter_index);
                   setTimeout(() => setScrollTargetSentence(ann.sentence_text), 400);
                 } else {
                   setScrollTargetSentence(undefined);


### PR DESCRIPTION
## Summary
- `goToChapter` now calls `router.replace(/reader/{id}?chapter={N})` so the URL always reflects the active chapter
- Annotation sidebar `onJump` now routes through `goToChapter` instead of calling `setChapterIndex` directly, so jumping to an annotation also updates the URL
- Enables bookmarking, sharing, and browser back/forward for specific chapters
- Deep links from vocabulary/notes pages (`?chapter=N`) already worked on load; this makes in-app navigation consistent with those links

## Test plan
- [ ] Navigate chapters with prev/next — URL updates to `?chapter=N`
- [ ] Tap a chapter selector — URL updates
- [ ] Click an annotation in the sidebar — URL updates to matching chapter
- [ ] Copy URL mid-book, open in new tab — lands on the correct chapter
- [ ] Vocabulary page "Ch.X" link opens reader at that chapter
