### PR TITLE
fix(sidebar): eliminate double tab bar — merge References into outer sidebar

### DIFF
--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -82,7 +82,7 @@ export default function ReaderPage() {
 
   // Sidebar — hidden by default, resizable, tabbed
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [sidebarTab, setSidebarTab] = useState<"chat" | "vocab" | "translate">("chat");
+  const [sidebarTab, setSidebarTab] = useState<"chat" | "references" | "vocab" | "translate">("chat");
   const [vocabWords, setVocabWords] = useState<VocabularyWord[]>([]);
   const [sidebarWidth, setSidebarWidth] = useState(320);
   const isResizing = useRef(false);
@@ -1260,8 +1260,8 @@ export default function ReaderPage() {
             <>
               {/* Tab bar */}
               <div className="flex shrink-0 border-b border-amber-200 bg-white/70">
-                {(["chat", "vocab", "translate"] as const).map((tab) => {
-                  const labels: Record<string, string> = { chat: "💬 Chat", vocab: "📚 Vocab", translate: "🌐 Translate" };
+                {(["chat", "references", "vocab", "translate"] as const).map((tab) => {
+                  const labels: Record<string, string> = { chat: "💬 Chat", references: "🔗 Refs", vocab: "📚 Vocab", translate: "🌐 Translate" };
                   return (
                     <button
                       key={tab}
@@ -1283,13 +1283,14 @@ export default function ReaderPage() {
                 })}
               </div>
 
-              {/* Chat tab — keep mounted so history persists */}
-              <div className={`flex flex-col flex-1 overflow-hidden ${sidebarTab === "chat" ? "" : "hidden"}`}>
+              {/* Chat/References tab — keep mounted so history persists */}
+              <div className={`flex flex-col flex-1 overflow-hidden ${sidebarTab === "chat" || sidebarTab === "references" ? "" : "hidden"}`}>
                 <InsightChat
                   bookId={bookId}
                   userId={session?.backendUser?.id ?? null}
                   hasGeminiKey={hasGeminiKey ?? false}
-                  isVisible={sidebarOpen && sidebarTab === "chat"}
+                  isVisible={sidebarOpen && (sidebarTab === "chat" || sidebarTab === "references")}
+                  view={sidebarTab === "references" ? "references" : "chat"}
                   chapterText={current?.text ?? ""}
                   chapterTitle={current?.title || `Chapter ${chapterIndex + 1}`}
                   selectedText={selectedText}

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -51,6 +51,8 @@ interface Props {
   onAIUsed?: () => void;    // called whenever an AI (non-cached) call is made
   onSaveInsight?: (question: string, answer: string) => void;
   chapterIndex?: number;
+  /** When provided by the parent sidebar, hides the internal tab bar and uses this value instead */
+  view?: "chat" | "references";
 }
 
 export default function InsightChat({
@@ -67,8 +69,10 @@ export default function InsightChat({
   onAIUsed,
   onSaveInsight,
   chapterIndex,
+  view,
 }: Props) {
-  const [tab, setTab] = useState<Tab>("chat");
+  const [internalTab, setInternalTab] = useState<Tab>("chat");
+  const tab = view ?? internalTab;
   // Keyed by absolute message index (loadedFrom + i) so "Load earlier" doesn't reset saved state
   const [savedInsights, setSavedInsights] = useState<Set<number>>(new Set());
 
@@ -294,22 +298,24 @@ export default function InsightChat({
 
   return (
     <div className="flex flex-col h-full overflow-hidden bg-white">
-      {/* Tab bar */}
-      <div className="flex border-b border-amber-200 shrink-0">
-        {tabs.map((t) => (
-          <button
-            key={t.id}
-            onClick={() => setTab(t.id)}
-            className={`flex-1 py-2 text-xs font-medium transition-colors ${
-              tab === t.id
-                ? "bg-amber-100 text-amber-900 border-b-2 border-amber-600"
-                : "text-amber-700 hover:bg-amber-50"
-            }`}
-          >
-            {t.icon} {t.label}
-          </button>
-        ))}
-      </div>
+      {/* Tab bar — hidden when parent sidebar controls the view */}
+      {!view && (
+        <div className="flex border-b border-amber-200 shrink-0">
+          {tabs.map((t) => (
+            <button
+              key={t.id}
+              onClick={() => setInternalTab(t.id)}
+              className={`flex-1 py-2 text-xs font-medium transition-colors ${
+                tab === t.id
+                  ? "bg-amber-100 text-amber-900 border-b-2 border-amber-600"
+                  : "text-amber-700 hover:bg-amber-50"
+              }`}
+            >
+              {t.icon} {t.label}
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* ── CHAT TAB ─────────────────────────────────────────────────── */}
       {tab === "chat" && (


### PR DESCRIPTION
## Summary
- The sidebar showed two tab bars: the outer "Chat | Vocab | Translate" row and InsightChat's own internal "Chat | References" row stacked on top of each other
- Fix: add a `view` prop to `InsightChat` — when provided by the parent, the internal tab bar is hidden and the component renders whichever view the prop specifies
- Add "References" (🔗 Refs) as a first-class tab in the outer sidebar alongside Chat, Vocab, and Translate
- InsightChat stays mounted for both `chat` and `references` tabs so chat history persists when switching

## Test plan
- [ ] Open sidebar → tabs show "💬 Chat | 🔗 Refs | 📚 Vocab | 🌐 Translate" — no second tab bar inside
- [ ] Switch between Chat and Refs — content changes, no double bar
- [ ] Switch to Vocab/Translate and back to Chat — chat history preserved
