### PR TITLE
fix(tts): prevent premature last-sentence highlight for unloaded chunks

### DIFF
--- a/frontend/src/__tests__/SentenceReader.extended.test.tsx
+++ b/frontend/src/__tests__/SentenceReader.extended.test.tsx
@@ -163,6 +163,45 @@ describe("SentenceReader highlighting based on currentTime", () => {
     expect(active?.textContent).toContain("First sentence");
   });
 
+  it("unloaded chunks (duration=0) do not cause premature last-sentence highlight", () => {
+    const chunk1 = "First loaded chunk.";
+    const chunk2 = "Second unloaded chunk that is longer.";
+    const chunks: ChunkInfo[] = [
+      { text: chunk1, duration: 3 },
+      { text: chunk2, duration: 0 }, // not yet loaded
+    ];
+
+    const { container, rerender } = render(
+      <SentenceReader
+        text={`${chunk1}\n\n${chunk2}`}
+        duration={10}
+        currentTime={0}
+        isPlaying={false}
+        onSegmentClick={noop}
+        chunks={chunks}
+      />
+    );
+
+    // At t=3.5 we've just passed chunk 1 — chunk 2 is still loading.
+    // Should NOT jump to the last sentence of chunk 2.
+    rerender(
+      <SentenceReader
+        text={`${chunk1}\n\n${chunk2}`}
+        duration={10}
+        currentTime={3.5}
+        isPlaying={true}
+        onSegmentClick={noop}
+        chunks={chunks}
+      />
+    );
+    const active = container.querySelector(".bg-amber-300");
+    // Either the last loaded sentence (chunk 1) is highlighted, or nothing is —
+    // but it must NOT be a sentence from chunk 2 (the unloaded chunk).
+    if (active) {
+      expect(active.textContent).toContain("First loaded chunk");
+    }
+  });
+
   it("uses chunk durations for timing when chunks are provided", () => {
     const chunk1 = "First chunk text here.";
     const chunk2 = "Second chunk is here and it is longer.";

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -141,6 +141,13 @@ function parseIntoSegments(
         if (segmentChunkIdx[s] === ci) segIndices.push(s);
       }
 
+      if (chunk.duration === 0) {
+        // Not yet loaded — Infinity prevents these segments from ever matching
+        // currentTime prematurely. Recalculated once the chunk loads.
+        for (const idx of segIndices) startTimes[idx] = Infinity;
+        continue; // chunkStartTime stays unchanged until we know the real duration
+      }
+
       const wbs = chunk.wordBoundaries;
       if (wbs && wbs.length > 0) {
         // Path a: locate each segment's start position in the (newline-normalised)


### PR DESCRIPTION
## Summary

When TTS chunks load sequentially, `SentenceReader` received partially-loaded `allChunks` where later chunks still had `duration=0`. The timing calculation assigned every segment in those unloaded chunks the same `startTime` (the cumulative end-time of all loaded chunks so far). As soon as playback reached that time, `currentIdx` advanced all the way to the **last sentence** of the chapter — freezing auto-scroll there for the rest of playback, even though only ~7 sentences had actually been read.

## Root cause

In `buildParagraphData` (SentenceReader.tsx), the path-b timing loop iterated over all chunks including unloaded ones:
```
chunkStartTime += chunk.duration  // += 0 → never advances
startTimes[idx] = chunkStartTime  // same value for ALL unloaded segments
```
Then in `currentIdx`:
```
if (allSegments[i].startTime <= currentTime) best = i  // all unloaded match → jumps to last
```

## Fix

Assign `Infinity` as the `startTime` for segments in any chunk whose `duration === 0`. Since `Infinity > any currentTime`, the `currentIdx` loop's `else break` fires before reaching unloaded segments. Timing is recalculated correctly once each chunk loads.

## Test plan
- [ ] Open a long chapter (e.g. Frankenstein ch.27) and click **Read**
- [ ] Watch sentence highlighting — it should track along progressively, not jump to the last sentence after ~7 sentences
- [ ] Auto-scroll should follow the currently-reading sentence throughout
- [ ] Regression test added: `SentenceReader.extended.test.tsx` — "unloaded chunks (duration=0) do not cause premature last-sentence highlight"
