### PR TITLE
test(tts): strengthen unloaded-chunk regression assertion

### DIFF
--- a/frontend/src/__tests__/SentenceReader.extended.test.tsx
+++ b/frontend/src/__tests__/SentenceReader.extended.test.tsx
@@ -195,11 +195,10 @@ describe("SentenceReader highlighting based on currentTime", () => {
       />
     );
     const active = container.querySelector(".bg-amber-300");
-    // Either the last loaded sentence (chunk 1) is highlighted, or nothing is —
-    // but it must NOT be a sentence from chunk 2 (the unloaded chunk).
-    if (active) {
-      expect(active.textContent).toContain("First loaded chunk");
-    }
+    // The loaded chunk must be highlighted — not null, and not from the unloaded chunk.
+    expect(active).not.toBeNull();
+    expect(active!.textContent).toContain("First loaded chunk");
+    expect(active!.textContent).not.toContain("Second unloaded chunk");
   });
 
   it("uses chunk durations for timing when chunks are provided", () => {


### PR DESCRIPTION
## Summary
Tightens the regression test added in #173. The previous assertion used an `if (active)` guard — if nothing was highlighted, the test would pass silently without checking anything.

Replaced with three hard assertions:
1. `expect(active).not.toBeNull()` — something must be highlighted
2. `expect(active.textContent).toContain("First loaded chunk")` — must be the loaded chunk
3. `expect(active.textContent).not.toContain("Second unloaded chunk")` — must not be the unloaded chunk

## Test plan
- [ ] All 28 SentenceReader tests pass
