### PR TITLE
fix(tts): prevent spurious highlight when no segment has started yet

### DIFF
--- a/frontend/src/__tests__/SentenceReader.extended.test.tsx
+++ b/frontend/src/__tests__/SentenceReader.extended.test.tsx
@@ -163,6 +163,46 @@ describe("SentenceReader highlighting based on currentTime", () => {
     expect(active?.textContent).toContain("First sentence");
   });
 
+  it("all-zero chunks (none loaded) produce no highlight at all", () => {
+    // Exact bug scenario: setAllChunks fires with ALL duration=0 before any chunk
+    // loads, then audio starts. ALL segments have Infinity startTime → currentIdx = -1
+    // → no sentence should be highlighted.
+    const sentences = [
+      "First sentence here.",
+      "Second sentence here.",
+      "Third sentence here.",
+      "Fourth sentence is the last one.",
+    ];
+    const allChunksZero: ChunkInfo[] = sentences.map((t) => ({ text: t, duration: 0 }));
+    const fullText = sentences.join("\n\n");
+
+    const { container, rerender } = render(
+      <SentenceReader
+        text={fullText}
+        duration={0}
+        currentTime={0}
+        isPlaying={false}
+        onSegmentClick={noop}
+        chunks={allChunksZero}
+      />
+    );
+
+    // Simulate: audio starts (duration and currentTime become non-zero)
+    // before any chunk has loaded its real duration.
+    rerender(
+      <SentenceReader
+        text={fullText}
+        duration={20}
+        currentTime={0.5}
+        isPlaying={true}
+        onSegmentClick={noop}
+        chunks={allChunksZero}
+      />
+    );
+    // No sentence should be highlighted — all chunks still loading.
+    expect(container.querySelector(".bg-amber-300")).toBeNull();
+  });
+
   it("unloaded chunks (duration=0) do not cause premature last-sentence highlight", () => {
     const chunk1 = "First loaded chunk.";
     const chunk2 = "Second unloaded chunk that is longer.";

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -180,6 +180,12 @@ function parseIntoSegments(
 
       chunkStartTime += chunk.duration;
     }
+    // Segments that couldn't be matched to any chunk (segmentChunkIdx === -1) keep
+    // startTime = 0, which would make them spuriously match currentTime > 0. Assign
+    // Infinity so they behave like unloaded chunks.
+    for (let s = 0; s < allTexts.length; s++) {
+      if (segmentChunkIdx[s] === -1) startTimes[s] = Infinity;
+    }
   } else {
     // Path c: linear fallback (LibriVox audiobook path)
     const totalChars = charCounts.reduce((a, b) => a + b, 0) || 1;
@@ -326,7 +332,7 @@ export default function SentenceReader({
   // Current segment: last one whose startTime ≤ currentTime
   const currentIdx = useMemo(() => {
     if (duration === 0 || currentTime === 0) return -1;
-    let best = 0;
+    let best = -1;
     for (let i = 0; i < allSegments.length; i++) {
       if (allSegments[i].startTime <= currentTime) best = i;
       else break;


### PR DESCRIPTION
## Summary
- `let best = 0` in `currentIdx` caused the first sentence to highlight spuriously when all startTimes were `Infinity` (none loaded yet). Changed to `best = -1` so no sentence is highlighted until one actually starts.
- Segments with `segmentChunkIdx === -1` (couldn't be matched to any chunk) kept `startTime = 0`, making them satisfy `startTime <= currentTime` for any non-zero time. They now receive `Infinity` like all other unloaded segments.

Together these two bugs could cause incorrect sentences to be highlighted during TTS loading, including possibly the last sentence of the chapter.

## Test plan
- New simulation test: renders with all-zero chunks, then rerender with `currentTime=0.5` → asserts `container.querySelector(".bg-amber-300") === null`
- All 309 frontend tests pass
