### PR TITLE
fix(sidebar): clean up translation/annotation UX

### DIFF
--- a/frontend/e2e/annotation-translation.spec.ts
+++ b/frontend/e2e/annotation-translation.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * E2E: Annotation and Translation features
+ *
+ * Covers:
+ * - Translation auto-loads when sidebar is opened (no "Translate this chapter" button)
+ * - Translation language persists to settings
+ * - Notes sidebar shows annotations grouped by chapter
+ * - InsightChat has no References tab or internal tab bar
+ */
+import { test, expect } from "./base";
+import { mockBackend } from "./fixtures";
+
+test.beforeEach(async ({ page }) => {
+  await mockBackend(page);
+});
+
+// ── Translation ───────────────────────────────────────────────────────────────
+
+test("translation auto-loads when Translate button is clicked", async ({ page }) => {
+  await page.route("**/api/books/*/chapters/*/translation", (route) =>
+    route.fulfill({
+      json: { status: "ready", paragraphs: ["Auto-loaded translation."], cached: true },
+    })
+  );
+
+  await page.goto("/reader/1342");
+  await expect(page.getByText(/truth universally acknowledged/)).toBeVisible();
+
+  // Single click on Translate — no secondary "Translate this chapter" needed
+  await page.getByRole("button", { name: /Translate/i }).first().click();
+
+  // Translation should appear automatically
+  await expect(page.getByText("Auto-loaded translation.")).toBeVisible({ timeout: 5000 });
+});
+
+test("translation sidebar has no standalone title heading", async ({ page }) => {
+  await page.route("**/api/books/*/chapters/*/translation", (route) =>
+    route.fulfill({ json: { status: "ready", paragraphs: ["Text."], cached: true } })
+  );
+
+  await page.goto("/reader/1342");
+  await page.getByRole("button", { name: /Translate/i }).first().click();
+
+  // The sidebar panel should NOT have a bare "Translation" <h3> heading
+  await expect(page.getByRole("heading", { name: /^Translation$/, level: 3 })).not.toBeVisible();
+});
+
+test("translation language is persisted to settings on change", async ({ page }) => {
+  await page.route("**/api/books/*/chapters/*/translation", (route) =>
+    route.fulfill({ json: { status: "ready", paragraphs: ["Translated."], cached: true } })
+  );
+
+  await page.goto("/reader/1342");
+  await page.getByRole("button", { name: /Translate/i }).first().click();
+
+  // "Target language" label is next to the language select in the translate panel
+  await expect(page.getByText("Target language")).toBeVisible({ timeout: 3000 });
+  // Select German from the dropdown labeled "Target language"
+  await page.locator("label", { hasText: "Target language" }).locator("..").locator("select").selectOption({ value: "de" });
+
+  // Verify settings are persisted to localStorage
+  const saved = await page.evaluate(() => {
+    const raw = localStorage.getItem("book-reader-settings");
+    return raw ? JSON.parse(raw) : null;
+  });
+  expect(saved?.translationLang).toBe("de");
+});
+
+test("translation language is loaded from settings on page open", async ({ page }) => {
+  // Seed settings with French as preferred translation language
+  await page.goto("/reader/1342");
+  await page.evaluate(() => {
+    localStorage.setItem(
+      "book-reader-settings",
+      JSON.stringify({ translationLang: "fr", insightLang: "en", ttsGender: "female", fontSize: "base", theme: "light" })
+    );
+  });
+  await page.reload();
+
+  await page.getByRole("button", { name: /Translate/i }).first().click();
+  await expect(page.getByText("Target language")).toBeVisible({ timeout: 3000 });
+
+  // The language dropdown should show French as the selected value
+  const selectValue = await page.locator("label", { hasText: "Target language" })
+    .locator("..").locator("select").inputValue();
+  expect(selectValue).toBe("fr");
+});
+
+// ── InsightChat cleanup ───────────────────────────────────────────────────────
+
+test("InsightChat has no References tab", async ({ page }) => {
+  await page.goto("/reader/1342");
+  await expect(page.getByText(/truth universally acknowledged/)).toBeVisible();
+
+  // Open Insight chat
+  await page.getByRole("button", { name: /Insight/i }).first().click();
+
+  // There should be no References tab in the chat panel
+  await expect(page.getByRole("tab", { name: /references/i })).not.toBeVisible();
+  await expect(page.getByText(/^References$/, { exact: true })).not.toBeVisible();
+});
+
+test("InsightChat has no internal tab bar", async ({ page }) => {
+  await page.goto("/reader/1342");
+  await page.getByRole("button", { name: /Insight/i }).first().click();
+
+  // The sidebar panel should NOT contain a secondary tab bar with Chat/References buttons
+  await expect(page.locator("[role=tablist]")).not.toBeVisible();
+});
+
+// ── Notes / Annotations ───────────────────────────────────────────────────────
+
+test("Notes button is visible when authenticated", async ({ page }) => {
+  await page.goto("/reader/1342");
+  await expect(page.getByText(/truth universally acknowledged/)).toBeVisible();
+
+  // Notes button should appear in the toolbar (backendToken in session mock enables it)
+  await expect(page.getByRole("button", { name: /notes/i })).toBeVisible({ timeout: 5000 });
+});
+
+test("Notes sidebar shows empty state when no annotations", async ({ page }) => {
+  await page.goto("/reader/1342");
+  await page.getByRole("button", { name: /notes/i }).click();
+
+  // Empty state text should appear
+  await expect(page.getByText("No annotations yet.")).toBeVisible({ timeout: 3000 });
+});
+
+test("Notes sidebar shows existing annotations from API", async ({ page }) => {
+  // Override the default empty-list stub with real annotations
+  await page.route("**/api/annotations*", (route) => {
+    if (route.request().method() === "GET") {
+      route.fulfill({
+        json: [
+          {
+            id: 10,
+            book_id: 1342,
+            chapter_index: 0,
+            sentence_text: "It is a truth universally acknowledged",
+            note_text: "Famous opening line",
+            color: "yellow",
+          },
+          {
+            id: 11,
+            book_id: 1342,
+            chapter_index: 1,
+            sentence_text: "Mr. Bennet was among the earliest",
+            note_text: "",
+            color: "blue",
+          },
+        ],
+      });
+    } else {
+      route.fulfill({ json: { ok: true } });
+    }
+  });
+
+  await page.goto("/reader/1342");
+  await page.getByRole("button", { name: /notes/i }).click();
+
+  // Note text and sentence snippet should both appear in the sidebar
+  await expect(page.getByText("Famous opening line")).toBeVisible({ timeout: 3000 });
+  // Sentence text is shown in the notes panel (quoted/excerpted form)
+  await expect(page.getByText(/truth universally acknowledged/).first()).toBeVisible({ timeout: 3000 });
+  await expect(page.getByText(/Mr\. Bennet was among/).first()).toBeVisible({ timeout: 3000 });
+});
+
+test("annotation count badge appears on Notes button when annotations exist", async ({ page }) => {
+  await page.route("**/api/annotations*", (route) => {
+    if (route.request().method() === "GET") {
+      route.fulfill({
+        json: [
+          { id: 1, book_id: 1342, chapter_index: 0, sentence_text: "Sentence.", note_text: "", color: "yellow" },
+          { id: 2, book_id: 1342, chapter_index: 0, sentence_text: "Another.", note_text: "", color: "blue" },
+        ],
+      });
+    } else {
+      route.fulfill({ json: { ok: true } });
+    }
+  });
+
+  await page.goto("/reader/1342");
+  await expect(page.getByText(/truth universally acknowledged/)).toBeVisible({ timeout: 5000 });
+
+  // The Notes button should display a count badge showing "2"
+  await expect(page.getByRole("button", { name: /notes/i }).getByText("2")).toBeVisible({ timeout: 5000 });
+});

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -36,11 +36,13 @@ export const MOCK_CHAPTERS = [
 export async function mockBackend(page: Page) {
   // Mock NextAuth session so useSession() returns status="authenticated" rather
   // than "unauthenticated". Without this the home page always flips to Discover.
+  // backendToken is included so annotation/notes features are enabled.
   await page.route("**/api/auth/session", (route) =>
     route.fulfill({
       json: {
         user: { name: "Test User", email: "test@example.com", image: "" },
         expires: "2030-01-01T00:00:00.000Z",
+        backendToken: "e2e-test-token",
       },
     })
   );
@@ -98,4 +100,16 @@ export async function mockBackend(page: Page) {
   await page.route("**/api/ai/tts", (route) =>
     route.fulfill({ status: 200, contentType: "audio/mpeg", body: Buffer.from([0xff, 0xfb]) })
   );
+
+  await page.route("**/api/annotations*", (route) => {
+    if (route.request().method() === "GET") {
+      route.fulfill({ json: [] });
+    } else if (route.request().method() === "POST") {
+      route.fulfill({
+        json: { id: 1, book_id: 1342, chapter_index: 0, sentence_text: "", note_text: "", color: "yellow" },
+      });
+    } else {
+      route.fulfill({ json: { ok: true } });
+    }
+  });
 }

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -48,7 +48,7 @@ export async function mockBackend(page: Page) {
   );
 
   await page.route("**/api/user/me", (route) =>
-    route.fulfill({ json: { id: 1, email: "test@example.com", name: "Test", picture: "", hasGeminiKey: false } })
+    route.fulfill({ json: { id: 1, email: "test@example.com", name: "Test", picture: "", hasGeminiKey: false, approved: true } })
   );
 
   await page.route("**/api/books/cached", (route) =>
@@ -87,6 +87,10 @@ export async function mockBackend(page: Page) {
     route.fulfill({
       json: { book_id: 1342, target_language: "en", total_chapters: 3, translated_chapters: 3, bulk_active: false },
     })
+  );
+
+  await page.route("**/api/user/reading-progress*", (route) =>
+    route.fulfill({ json: { entries: [] } })
   );
 
   await page.route("**/api/ai/translate", (route) =>

--- a/frontend/e2e/reader.spec.ts
+++ b/frontend/e2e/reader.spec.ts
@@ -72,8 +72,8 @@ test("translation does not show Gemini reminder (queue returns ready)", async ({
   await page.goto("/reader/1342");
   await expect(page.getByText(/truth universally acknowledged/)).toBeVisible();
 
+  // Clicking the Translate header button enables translation automatically
   await page.getByRole("button", { name: /Translate/ }).first().click();
-  await page.getByRole("button", { name: /Translate this chapter/i }).click();
 
   // Translation should appear
   await expect(page.getByText("Translated text.")).toBeVisible();
@@ -95,7 +95,6 @@ test("translation shows queued state when worker is processing", async ({ page }
   await expect(page.getByText(/truth universally acknowledged/)).toBeVisible();
 
   await page.getByRole("button", { name: /Translate/ }).first().click();
-  await page.getByRole("button", { name: /Translate this chapter/i }).click();
 
   // Should show a queued/waiting indicator — not translated text
   await expect(page.getByText("Translated text.")).not.toBeVisible({ timeout: 3000 });
@@ -116,7 +115,6 @@ test("translation shows worker offline message when worker not running", async (
   await expect(page.getByText(/truth universally acknowledged/)).toBeVisible({ timeout: 10000 });
 
   await page.getByRole("button", { name: /Translate/ }).first().click();
-  await page.getByRole("button", { name: /Translate this chapter/i }).click();
 
   await expect(page.getByText("queue · worker is offline", { exact: true })).toBeVisible({ timeout: 5000 });
 });

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -11,7 +11,6 @@ import TranslationView from "@/components/TranslationView";
 import SentenceReader from "@/components/SentenceReader";
 import SelectionToolbar from "@/components/SelectionToolbar";
 import AnnotationToolbar from "@/components/AnnotationToolbar";
-import AnnotationsSidebar from "@/components/AnnotationsSidebar";
 import VocabularyToast from "@/components/VocabularyToast";
 import SentenceActionPopup from "@/components/SentenceActionPopup";
 
@@ -69,7 +68,7 @@ export default function ReaderPage() {
 
   // Sidebar — hidden by default, resizable, tabbed
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [sidebarTab, setSidebarTab] = useState<"chat" | "references" | "vocab" | "translate">("chat");
+  const [sidebarTab, setSidebarTab] = useState<"chat" | "notes" | "vocab" | "translate">("chat");
   const [vocabWords, setVocabWords] = useState<VocabularyWord[]>([]);
   const [sidebarWidth, setSidebarWidth] = useState(320);
   const isResizing = useRef(false);
@@ -200,7 +199,6 @@ export default function ReaderPage() {
   const currentChapterKey = useRef<string>(""); // tracks which chapter is currently displayed
   const [translationEnabled, setTranslationEnabled] = useState(false);
   const [translationLang, setTranslationLang] = useState("en");
-  const [translationRequested, setTranslationRequested] = useState(false);
   // Translation provider removed — queue handles all translation via the admin's chain.
   const [displayMode, setDisplayMode] = useState<"parallel" | "inline">("parallel");
   const [translatedParagraphs, setTranslatedParagraphs] = useState<string[]>([]);
@@ -311,11 +309,6 @@ export default function ReaderPage() {
   // This replaces the previous per-paragraph translate loop — admins
   // stop double-spending tokens and all translation work flows through
   // the single queue (same model chain, same rate limits).
-  // Reset manual translation trigger when chapter or language changes
-  useEffect(() => {
-    setTranslationRequested(false);
-  }, [chapterIndex, translationLang]);
-
   // Reset translationLang when bookLanguage is known and they coincide.
   useEffect(() => {
     if (!bookLanguage) return;
@@ -340,9 +333,6 @@ export default function ReaderPage() {
       setTranslationUsedProvider("cached");
       return;
     }
-
-    // Don't auto-trigger — wait for user to click "Translate this chapter"
-    if (!translationRequested) return;
 
     // If logged in but key status not yet loaded, wait for getMe() to resolve.
     if (session && hasGeminiKey === null) return;
@@ -463,7 +453,7 @@ export default function ReaderPage() {
 
     return () => { cancelled = true; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [translationEnabled, translationLang, chapterIndex, bookId, hasGeminiKey, translationRequested]);
+  }, [translationEnabled, translationLang, chapterIndex, bookId, hasGeminiKey]);
 
   // Poll book-level translation status when translation is enabled — shows
   // the admin-level bulk-translate progress for this book ("42/60 chapters ready").
@@ -754,7 +744,7 @@ export default function ReaderPage() {
             onClick={() => { setSidebarTab("chat"); setSidebarOpen((v) => sidebarTab === "chat" ? !v : true); }}
             title="Toggle insight chat"
             className={`hidden md:flex shrink-0 items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-medium transition-colors ${
-              sidebarOpen && sidebarTab === "chat"
+              sidebarOpen && (sidebarTab === "chat")
                 ? "bg-amber-700 text-white border-amber-700"
                 : "border-amber-300 text-amber-700 hover:bg-amber-50"
             }`}
@@ -777,29 +767,24 @@ export default function ReaderPage() {
             🌐 Translate
           </button>
 
-          {/* Annotations sidebar — desktop only */}
+          {/* Notes sidebar toggle — desktop only */}
           {session?.backendToken && (
-            <div className="hidden md:block">
-            <AnnotationsSidebar
-              annotations={annotations}
-              totalCount={annotations.length}
-              loading={annotationsLoading}
-              onJump={(ann) => {
-                if (ann.chapter_index !== chapterIndex) {
-                  goToChapter(ann.chapter_index);
-                  setTimeout(() => setScrollTargetSentence(ann.sentence_text), 400);
-                } else {
-                  setScrollTargetSentence(undefined);
-                  setTimeout(() => setScrollTargetSentence(ann.sentence_text), 10);
-                }
-              }}
-              onEdit={(ann) => setAnnotationPanel({
-                sentenceText: ann.sentence_text,
-                chapterIndex: ann.chapter_index,
-                position: { x: window.innerWidth / 2, y: window.innerHeight / 2 },
-              })}
-            />
-            </div>
+            <button
+              onClick={() => { setSidebarTab("notes"); setSidebarOpen((v) => sidebarTab === "notes" ? !v : true); }}
+              title="Annotations & notes"
+              className={`relative hidden md:flex shrink-0 items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-medium transition-colors ${
+                sidebarOpen && sidebarTab === "notes"
+                  ? "bg-amber-700 text-white border-amber-700"
+                  : "border-amber-300 text-amber-700 hover:bg-amber-50"
+              }`}
+            >
+              📝 Notes
+              {annotations.length > 0 && (
+                <span className="absolute -top-1.5 -right-1.5 min-w-[16px] h-4 flex items-center justify-center rounded-full bg-amber-600 text-white text-[9px] font-bold px-1">
+                  {annotations.length}
+                </span>
+              )}
+            </button>
           )}
 
           {/* Vocabulary sidebar — desktop only */}
@@ -1199,39 +1184,13 @@ export default function ReaderPage() {
         >
           {sidebarOpen && (
             <>
-              {/* Tab bar */}
-              <div className="flex shrink-0 border-b border-amber-200 bg-white/70">
-                {(["chat", "references", "vocab", "translate"] as const).map((tab) => {
-                  const labels: Record<string, string> = { chat: "💬 Chat", references: "🔗 Refs", vocab: "📚 Vocab", translate: "🌐 Translate" };
-                  return (
-                    <button
-                      key={tab}
-                      onClick={() => setSidebarTab(tab)}
-                      className={`relative flex-1 py-2.5 text-xs font-medium transition-colors border-b-2 ${
-                        sidebarTab === tab
-                          ? "text-amber-700 border-amber-700"
-                          : "text-stone-500 border-transparent hover:text-amber-600"
-                      }`}
-                    >
-                      {labels[tab]}
-                      {tab === "vocab" && vocabWords.length > 0 && (
-                        <span className="absolute top-1 right-1 min-w-[14px] h-3.5 flex items-center justify-center rounded-full bg-amber-600 text-white text-[8px] font-bold px-0.5">
-                          {vocabWords.length}
-                        </span>
-                      )}
-                    </button>
-                  );
-                })}
-              </div>
-
-              {/* Chat/References tab — keep mounted so history persists */}
-              <div className={`flex flex-col flex-1 overflow-hidden ${sidebarTab === "chat" || sidebarTab === "references" ? "" : "hidden"}`}>
+              {/* Chat — keep mounted so history persists even when other tabs active */}
+              <div className={`flex flex-col flex-1 overflow-hidden ${sidebarTab === "chat" ? "" : "hidden"}`}>
                 <InsightChat
                   bookId={bookId}
                   userId={session?.backendUser?.id ?? null}
                   hasGeminiKey={hasGeminiKey ?? false}
-                  isVisible={sidebarOpen && (sidebarTab === "chat" || sidebarTab === "references")}
-                  view={sidebarTab === "references" ? "references" : "chat"}
+                  isVisible={sidebarOpen && sidebarTab === "chat"}
                   chapterText={current?.text ?? ""}
                   chapterTitle={current?.title || `Chapter ${chapterIndex + 1}`}
                   selectedText={selectedText}
@@ -1248,6 +1207,86 @@ export default function ReaderPage() {
                   } : undefined}
                 />
               </div>
+
+              {/* Notes tab */}
+              {sidebarTab === "notes" && (
+                <div className="flex-1 overflow-y-auto p-4 space-y-6">
+                  {annotationsLoading && annotations.length === 0 ? (
+                    <div className="flex justify-center mt-10">
+                      <span className="w-5 h-5 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+                    </div>
+                  ) : annotations.length === 0 ? (
+                    <div className="text-center text-stone-400 mt-10 text-sm">
+                      <p className="text-3xl mb-2">📝</p>
+                      <p>No annotations yet.</p>
+                      <p className="mt-1 text-xs">Long-press a sentence to add one.</p>
+                    </div>
+                  ) : (
+                    <>
+                      {Object.keys(
+                        annotations.reduce<Record<number, true>>((acc, a) => { acc[a.chapter_index] = true; return acc; }, {})
+                      ).map(Number).sort((a, b) => a - b).map((ch) => (
+                        <div key={ch}>
+                          <h3 className="text-xs font-semibold text-stone-400 uppercase tracking-wide mb-2">
+                            Chapter {ch + 1}
+                          </h3>
+                          <div className="space-y-2">
+                            {annotations.filter((a) => a.chapter_index === ch).map((ann) => {
+                              const colorBadge: Record<string, string> = {
+                                yellow: "bg-yellow-100 border-yellow-300 text-yellow-800",
+                                blue: "bg-blue-100 border-blue-300 text-blue-800",
+                                green: "bg-green-100 border-green-300 text-green-800",
+                                pink: "bg-pink-100 border-pink-300 text-pink-800",
+                              };
+                              return (
+                                <div
+                                  key={ann.id}
+                                  className={`rounded-lg border px-3 py-2.5 cursor-pointer hover:opacity-80 transition-opacity ${colorBadge[ann.color] ?? colorBadge.yellow}`}
+                                  onClick={() => {
+                                    if (ann.chapter_index !== chapterIndex) {
+                                      goToChapter(ann.chapter_index);
+                                      setTimeout(() => setScrollTargetSentence(ann.sentence_text), 400);
+                                    } else {
+                                      setScrollTargetSentence(undefined);
+                                      setTimeout(() => setScrollTargetSentence(ann.sentence_text), 10);
+                                    }
+                                    setSidebarOpen(false);
+                                  }}
+                                >
+                                  <div className="flex items-start justify-between gap-2">
+                                    <p className="text-xs italic leading-relaxed line-clamp-3 flex-1">
+                                      &ldquo;{ann.sentence_text}&rdquo;
+                                    </p>
+                                    <button
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        setAnnotationPanel({
+                                          sentenceText: ann.sentence_text,
+                                          chapterIndex: ann.chapter_index,
+                                          position: { x: window.innerWidth / 2, y: window.innerHeight / 2 },
+                                        });
+                                      }}
+                                      className="shrink-0 text-xs opacity-60 hover:opacity-100 mt-0.5"
+                                      title="Edit annotation"
+                                    >
+                                      ✏️
+                                    </button>
+                                  </div>
+                                  {ann.note_text && (
+                                    <p className="mt-1.5 text-xs font-medium border-t border-current/20 pt-1.5">
+                                      {ann.note_text}
+                                    </p>
+                                  )}
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      ))}
+                    </>
+                  )}
+                </div>
+              )}
 
               {/* Vocab tab */}
               {sidebarTab === "vocab" && (
@@ -1285,8 +1324,6 @@ export default function ReaderPage() {
               {sidebarTab === "translate" && (
                 <div className="flex-1 overflow-y-auto">
                   <div className="px-4 py-3 border-b border-amber-200 bg-amber-50/50">
-                    <h3 className="font-serif font-semibold text-ink text-sm mb-3">Translation</h3>
-
                     {/* Enable/disable toggle */}
                     <label className="flex items-center gap-3 mb-4 cursor-pointer">
                       <div className={`relative w-11 h-6 rounded-full transition-colors ${translationEnabled ? "bg-amber-600" : "bg-stone-300"}`}>
@@ -1307,7 +1344,10 @@ export default function ReaderPage() {
                       <select
                         className="w-full text-sm rounded-lg border border-amber-300 px-3 py-2 text-ink bg-white"
                         value={translationLang}
-                        onChange={(e) => setTranslationLang(e.target.value)}
+                        onChange={(e) => {
+                          setTranslationLang(e.target.value);
+                          saveSettings({ translationLang: e.target.value });
+                        }}
                       >
                         {LANGUAGES.filter((l) => l.code !== bookLanguage).map((l) => (
                           <option key={l.code} value={l.code}>{l.label}</option>
@@ -1333,16 +1373,6 @@ export default function ReaderPage() {
                         >Side by side</button>
                       </div>
                     </div>
-
-                    {/* Manual trigger — only shown when translation hasn't been requested yet */}
-                    {translationEnabled && !translationLoading && translatedParagraphs.length === 0 && !translationRequested && (
-                      <button
-                        onClick={() => setTranslationRequested(true)}
-                        className="mb-3 w-full text-sm px-3 py-2 rounded-lg border border-amber-500 bg-amber-600 text-white hover:bg-amber-700 font-medium transition-colors"
-                      >
-                        Translate this chapter
-                      </button>
-                    )}
 
                     {/* Status */}
                     {translationEnabled && (

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -198,7 +198,9 @@ export default function ReaderPage() {
   const translationCache = useRef(new Map<string, string[]>());
   const currentChapterKey = useRef<string>(""); // tracks which chapter is currently displayed
   const [translationEnabled, setTranslationEnabled] = useState(false);
-  const [translationLang, setTranslationLang] = useState("en");
+  const [translationLang, setTranslationLang] = useState<string>(() =>
+    typeof window !== "undefined" ? getSettings().translationLang : "en"
+  );
   // Translation provider removed — queue handles all translation via the admin's chain.
   const [displayMode, setDisplayMode] = useState<"parallel" | "inline">("parallel");
   const [translatedParagraphs, setTranslatedParagraphs] = useState<string[]>([]);
@@ -212,10 +214,9 @@ export default function ReaderPage() {
   const [theme, setTheme] = useState<Theme>("light");
   const [scrollProgress, setScrollProgress] = useState(0);
 
-  // Read settings on mount
+  // Read settings on mount (translationLang uses lazy useState above)
   useEffect(() => {
     const s = getSettings();
-    setTranslationLang(s.translationLang);
     // translationProvider setting is retained for back-compat but no longer read here.
     setFontSize(s.fontSize);
     setTheme(s.theme);

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -5,7 +5,6 @@ import remarkGfm from "remark-gfm";
 import {
   getInsight,
   askQuestion,
-  getReferences,
 } from "@/lib/api";
 import { getSettings, saveSettings } from "@/lib/settings";
 
@@ -26,8 +25,6 @@ const HISTORY_KEY = (userId: number | string, bookId: string) => `chat-history:$
 const INITIAL_DISPLAY = 30; // messages shown on first load
 const LOAD_BATCH = 20;      // messages revealed per "load earlier" click
 const MAX_STORED = 200;     // cap localStorage to last N messages
-
-type Tab = "chat" | "references";
 
 interface Message {
   role: "user" | "assistant";
@@ -51,8 +48,6 @@ interface Props {
   onAIUsed?: () => void;    // called whenever an AI (non-cached) call is made
   onSaveInsight?: (question: string, answer: string) => void;
   chapterIndex?: number;
-  /** When provided by the parent sidebar, hides the internal tab bar and uses this value instead */
-  view?: "chat" | "references";
 }
 
 export default function InsightChat({
@@ -69,10 +64,7 @@ export default function InsightChat({
   onAIUsed,
   onSaveInsight,
   chapterIndex,
-  view,
 }: Props) {
-  const [internalTab, setInternalTab] = useState<Tab>("chat");
-  const tab = view ?? internalTab;
   // Keyed by absolute message index (loadedFrom + i) so "Load earlier" doesn't reset saved state
   const [savedInsights, setSavedInsights] = useState<Set<number>>(new Set());
 
@@ -246,80 +238,13 @@ export default function InsightChat({
     }
   }
 
-  // ── Speak ─────────────────────────────────────────────────────────────
-  // ── References ──────────────────────────────────────────────────────
-  const [refsContent, setRefsContent] = useState("");
-  const [refsLoading, setRefsLoading] = useState(false);
-  const [refsError, setRefsError] = useState("");
-  const refsFetched = useRef(false);
-
-  async function fetchReferences() {
-    if (!hasGeminiKey || !bookTitle) return;
-    setRefsLoading(true);
-    setRefsError("");
-    onAIUsed?.();
-    try {
-      const r = await getReferences(
-        bookTitle, author,
-        chapterTitle, chapterText.slice(0, 800),
-        langRef.current
-      );
-      setRefsContent(r.references);
-    } catch (e: any) {
-      setRefsError(e.message);
-    } finally {
-      setRefsLoading(false);
-    }
-  }
-
-  // Auto-fetch references when the tab is first opened
-  useEffect(() => {
-    if (tab === "references" && !refsFetched.current && hasGeminiKey && bookTitle) {
-      refsFetched.current = true;
-      fetchReferences();
-    }
-  }, [tab, hasGeminiKey, bookTitle]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Reset when book changes
-  useEffect(() => {
-    setRefsContent("");
-    setRefsError("");
-    refsFetched.current = false;
-  }, [bookId]);
-
   // ── Render ────────────────────────────────────────────────────────────
   const displayedMessages = messages.slice(loadedFrom);
   const hasEarlier = loadedFrom > 0;
 
-  const tabs: { id: Tab; icon: string; label: string }[] = [
-    { id: "chat", icon: "💬", label: "Chat" },
-    { id: "references", icon: "📚", label: "References" },
-  ];
-
   return (
     <div className="flex flex-col h-full overflow-hidden bg-white">
-      {/* Tab bar — hidden when parent sidebar controls the view */}
-      {!view && (
-        <div className="flex border-b border-amber-200 shrink-0">
-          {tabs.map((t) => (
-            <button
-              key={t.id}
-              onClick={() => setInternalTab(t.id)}
-              className={`flex-1 py-2 text-xs font-medium transition-colors ${
-                tab === t.id
-                  ? "bg-amber-100 text-amber-900 border-b-2 border-amber-600"
-                  : "text-amber-700 hover:bg-amber-50"
-              }`}
-            >
-              {t.icon} {t.label}
-            </button>
-          ))}
-        </div>
-      )}
-
-      {/* ── CHAT TAB ─────────────────────────────────────────────────── */}
-      {tab === "chat" && (
-        <div className="flex flex-col flex-1 overflow-hidden">
+      <div className="flex flex-col flex-1 overflow-hidden">
           {/* Language bar */}
           <div className="flex items-center gap-2 px-3 py-2 border-b border-amber-100 shrink-0 bg-amber-50/50">
             <span className="text-xs text-amber-600 shrink-0">Language</span>
@@ -515,59 +440,7 @@ export default function InsightChat({
             </div>
             {hasGeminiKey && <p className="text-xs text-amber-400 mt-1.5">Enter · Shift+Enter for newline</p>}
           </div>
-        </div>
-      )}
-
-      {/* ── REFERENCES TAB ──────────────────────────────────────────── */}
-      {tab === "references" && (
-        <div className="flex-1 overflow-y-auto p-3 flex flex-col gap-3">
-          {!hasGeminiKey && (
-            <div className="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 text-xs text-amber-800">
-              References require a{" "}
-              <a href="/profile" target="_blank" className="underline font-medium">Gemini API key</a>{" "}
-              (free from Google AI Studio).
-            </div>
-          )}
-
-          {hasGeminiKey && !refsContent && !refsLoading && !refsError && (
-            <button
-              onClick={fetchReferences}
-              className="rounded-lg bg-amber-700 py-2 text-white text-sm font-medium hover:bg-amber-800"
-            >
-              Find references for this book
-            </button>
-          )}
-
-          {refsLoading && (
-            <div className="flex items-center gap-2 text-sm text-amber-700">
-              <span className="w-4 h-4 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
-              Finding references…
-            </div>
-          )}
-
-          {refsError && (
-            <div className="text-xs text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
-              {refsError}
-              <button onClick={fetchReferences} className="ml-2 underline">Retry</button>
-            </div>
-          )}
-
-          {refsContent && (
-            <div className={`prose prose-sm prose-p:leading-loose prose-li:leading-loose max-w-none font-serif text-${chatFontSize}`}>
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{refsContent}</ReactMarkdown>
-            </div>
-          )}
-
-          {refsContent && (
-            <button
-              onClick={() => { setRefsContent(""); fetchReferences(); }}
-              className="text-xs text-amber-600 hover:text-amber-900 self-start"
-            >
-              ↻ Refresh references
-            </button>
-          )}
-        </div>
-      )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Translation auto-loads** when enabled — no more "Translate this chapter" button; if already cached it shows instantly, otherwise queues in the background
- **Translation language persists** to localStorage settings so the user's preferred language is remembered across sessions
- **InsightChat**: removed References tab and `view` prop entirely — chat only
- **Sidebar tab bar removed**: inner tab buttons were redundant; only the header buttons (Chat / Notes / Vocab / Translate) control the active panel
- **Notes tab**: replaces the `AnnotationsSidebar` drawer with an inline panel inside the right sidebar, showing all annotations grouped by chapter with note text

## Test plan

- [ ] Enable translation → chapter translates automatically without clicking a button
- [ ] Change translation language in dropdown → reload page → language is remembered
- [ ] Open Insight Chat → no References tab, no internal tab bar
- [ ] Long-press a sentence → annotation is created → click Notes button → annotation appears in the Notes panel
- [ ] All 296 frontend Jest tests pass
- [ ] All 651 backend pytest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
