### PR TITLE
fix(reader): ignore click when user drags to select text

### DIFF
--- a/frontend/src/__tests__/SentenceReader.extended.test.tsx
+++ b/frontend/src/__tests__/SentenceReader.extended.test.tsx
@@ -580,6 +580,34 @@ describe("SentenceReader click interactions", () => {
     expect(onSegmentClick).not.toHaveBeenCalled();
     expect(onSentenceClick).not.toHaveBeenCalled();
   });
+
+  it("click does not fire when user has made a text selection (drag-to-select)", () => {
+    const onSegmentClick = jest.fn();
+    const onSentenceClick = jest.fn();
+    const { container } = render(
+      <SentenceReader
+        text="Select this text."
+        duration={10}
+        currentTime={5}
+        isPlaying={true}
+        onSegmentClick={onSegmentClick}
+        onSentenceClick={onSentenceClick}
+      />
+    );
+
+    // Simulate browser behaviour: user dragged to select text, then mouseup fires click.
+    // Mock window.getSelection to return a non-empty selection string.
+    const origGetSelection = window.getSelection;
+    window.getSelection = () => ({ toString: () => "Select this" } as Selection);
+
+    const segs = getSegments(container);
+    fireEvent.click(segs[0]);
+
+    window.getSelection = origGetSelection;
+
+    expect(onSegmentClick).not.toHaveBeenCalled();
+    expect(onSentenceClick).not.toHaveBeenCalled();
+  });
 });
 
 describe("SentenceReader translations", () => {

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -526,6 +526,8 @@ export default function SentenceReader({
               data-jump-target={isJumpTarget ? "true" : undefined}
               onClick={(e) => {
                 if (disabled || !isSegmentLoaded(seg)) return;
+                // Ignore clicks that are the tail of a text-selection drag
+                if (window.getSelection()?.toString().length) return;
                 if (isPlaying || duration > 0) {
                   onSegmentClick(seg.startTime, seg.text);
                 } else if (onSentenceClick) {


### PR DESCRIPTION
## Summary

- **Bug**: Dragging to select text in the reader fired a click event on mouseup, triggering TTS seeks (when playing) or sentence popups (when idle).
- **Fix**: One-line guard in the `onClick` handler — `if (window.getSelection()?.toString().length) return;`. The browser preserves the selection at click time, so a non-empty selection means the user was dragging, not tapping.
- **Test**: New test mocks `window.getSelection` to return a non-empty string and verifies neither `onSegmentClick` nor `onSentenceClick` fires.

## Test plan

- [x] 301/301 Jest tests pass
- [ ] Manual: drag-select text in reader while TTS is playing — no seek should occur
- [ ] Manual: drag-select text while TTS is idle — no popup should appear
