### PR TITLE
fix(reader): match annotations by substring for text-selection annotations

### DIFF
--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -416,6 +416,16 @@ export default function SentenceReader({
     return map;
   }, [annotations]);
 
+  // Lookup that handles selections made within a sentence (substring match fallback)
+  const getAnnotation = useMemo(() => {
+    const anns = annotations ?? [];
+    return (segText: string): Annotation | undefined => {
+      const exact = annotationMap.get(segText);
+      if (exact) return exact;
+      return anns.find((a) => a.sentence_text.length >= 10 && segText.includes(a.sentence_text));
+    };
+  }, [annotations, annotationMap]);
+
   // Long-press handlers (shared across segments)
   function handlePointerDown(e: React.PointerEvent, seg: Segment) {
     if (!onAnnotate) return;
@@ -513,7 +523,7 @@ export default function SentenceReader({
         const renderSeg = (seg: Segment, extraClass = "", trailingSpace = false) => {
           const active = seg.flatIdx === currentIdx;
           const isJumpTarget = flashTarget !== null && seg.text === flashTarget;
-          const annotation = annotationMap.get(seg.text);
+          const annotation = getAnnotation(seg.text);
           const annotationClass = annotation
             ? (ANNOTATION_COLOR_CLASS[annotation.color] ?? ANNOTATION_COLOR_CLASS.yellow)
             : "";
@@ -572,7 +582,7 @@ export default function SentenceReader({
 
         // Annotation side mark helpers for this paragraph
         const paraAnnotations = para.segments
-          .map((s) => annotationMap.get(s.text))
+          .map((s) => getAnnotation(s.text))
           .filter(Boolean) as Annotation[];
         const paraHasAnnotation = paraAnnotations.length > 0;
         const dominantColor = paraAnnotations[0]?.color ?? "yellow";


### PR DESCRIPTION
## Summary

- Annotations created via text selection (SelectionToolbar) store the selected text as `sentence_text`, which is a substring of the full segment text
- The `annotationMap` only did exact-key lookups, so these annotations never appeared as highlights/borders in the reader text
- Added a `getAnnotation` helper that falls back to substring matching when no exact match is found (≥10 chars to avoid false positives)

## Test plan
- [ ] Annotate a sentence via full click (SentenceActionPopup → Note) → underline appears in text ✓
- [ ] Annotate via text selection (SelectionToolbar → Note) → segment containing the selection gets the underline/border
- [ ] All 301 frontend Jest tests pass
