### PR TITLE
feat(reader): show book-level translation progress in sidebar

### DIFF
--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1386,6 +1386,36 @@ export default function ReaderPage() {
                       </div>
                     )}
 
+                    {/* Book-level translation progress */}
+                    {translationEnabled && bookTranslationStatus && (() => {
+                      const s = bookTranslationStatus;
+                      const queued = (s.queue_pending ?? 0) + (s.queue_running ?? 0);
+                      const ready = s.translated_chapters;
+                      const total = s.total_chapters;
+                      const notStarted = Math.max(0, total - ready - queued - (s.queue_failed ?? 0));
+                      return (
+                        <div className="mt-3 pt-3 border-t border-amber-200">
+                          <div className="flex items-center gap-1.5 text-xs text-amber-700">
+                            {queued > 0 && <span className="inline-block w-1.5 h-1.5 bg-amber-500 rounded-full animate-pulse shrink-0" />}
+                            <span>
+                              <strong>{ready} / {total}</strong> chapters translated
+                              {queued > 0 && (<> · <strong>{queued}</strong> processing</>)}
+                              {s.queue_failed ? (<> · <span className="text-red-600">{s.queue_failed} failed</span></>) : null}
+                            </span>
+                          </div>
+                          {notStarted > 0 && (
+                            <button
+                              onClick={handleTranslateWholeBook}
+                              disabled={enqueueingBook}
+                              className="mt-2 w-full text-xs px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-50"
+                            >
+                              {enqueueingBook ? "Queueing…" : `Translate remaining ${notStarted}`}
+                            </button>
+                          )}
+                        </div>
+                      );
+                    })()}
+
                     {/* Admin: retranslate */}
                     {isAdmin && !translationLoading && translatedParagraphs.length > 0 && (
                       <button


### PR DESCRIPTION
## Summary

- The top-of-page banner already shows book-level translation progress ("18/21 chapters translated · 3 processing"). The translate sidebar panel now mirrors the same information so the user can see overall progress without scrolling up, and trigger "Translate remaining N" directly from the panel when chapters are still pending.
- Shown below the per-chapter status line, behind a `border-t` divider, only when `translationEnabled && bookTranslationStatus` are both truthy.

## Test plan

- [x] 301/301 Jest tests pass
- [ ] Manual: open translate sidebar → see "X / Y chapters translated" when book has translated chapters
- [ ] Manual: when all chapters are translated → see "120 / 120 chapters translated" with no extra button
- [ ] Manual: when some chapters still pending → "Translate remaining N" button appears and works
