### PR TITLE
fix(reader): toolbar Translate opens sidebar only; translationEnabled persists

### DIFF
--- a/frontend/e2e/annotation-translation.spec.ts
+++ b/frontend/e2e/annotation-translation.spec.ts
@@ -64,14 +64,13 @@ test("translationEnabled persists: reopening the reader resumes translation", as
     })
   );
 
-  await page.goto("/reader/1342");
-  await page.evaluate(() => {
+  await page.addInitScript(() => {
     localStorage.setItem(
       "book-reader-settings",
       JSON.stringify({ translationEnabled: true, translationLang: "de", insightLang: "en", ttsGender: "female", fontSize: "base", theme: "light" })
     );
   });
-  await page.reload();
+  await page.goto("/reader/1342");
 
   // Translation auto-fires because settings say it was enabled
   await expect(page.getByText("Persisted translation.")).toBeVisible({ timeout: 5000 });
@@ -104,14 +103,13 @@ test("translation language is persisted to settings on change", async ({ page })
 });
 
 test("translation language is loaded from settings on page open", async ({ page }) => {
-  await page.goto("/reader/1342");
-  await page.evaluate(() => {
+  await page.addInitScript(() => {
     localStorage.setItem(
       "book-reader-settings",
       JSON.stringify({ translationLang: "fr", insightLang: "en", ttsGender: "female", fontSize: "base", theme: "light" })
     );
   });
-  await page.reload();
+  await page.goto("/reader/1342");
 
   await page.getByRole("button", { name: /Translate/i }).first().click();
   await expect(page.getByText("Target language")).toBeVisible({ timeout: 3000 });

--- a/frontend/e2e/annotation-translation.spec.ts
+++ b/frontend/e2e/annotation-translation.spec.ts
@@ -2,7 +2,8 @@
  * E2E: Annotation and Translation features
  *
  * Covers:
- * - Translation auto-loads when sidebar is opened (no "Translate this chapter" button)
+ * - Toolbar Translate button opens sidebar without auto-enabling translation
+ * - User enables translation via the toggle; state persists to settings
  * - Translation language persists to settings
  * - Notes sidebar shows annotations grouped by chapter
  * - InsightChat has no References tab or internal tab bar
@@ -14,9 +15,26 @@ test.beforeEach(async ({ page }) => {
   await mockBackend(page);
 });
 
+/** Open the translate sidebar and flip the toggle from Disabled → Enabled. */
+async function openAndEnableTranslation(page: import("@playwright/test").Page) {
+  await page.getByRole("button", { name: /Translate/i }).first().click();
+  await page.locator("label").filter({ hasText: /Disabled/ }).click();
+}
+
 // ── Translation ───────────────────────────────────────────────────────────────
 
-test("translation auto-loads when Translate button is clicked", async ({ page }) => {
+test("toolbar Translate button opens sidebar without enabling translation", async ({ page }) => {
+  await page.goto("/reader/1342");
+  await expect(page.getByText(/truth universally acknowledged/)).toBeVisible();
+
+  await page.getByRole("button", { name: /Translate/i }).first().click();
+
+  // Sidebar translate panel is visible, but translation is still disabled
+  await expect(page.getByText("Target language")).toBeVisible({ timeout: 3000 });
+  await expect(page.getByText("Disabled")).toBeVisible();
+});
+
+test("enabling the translation toggle loads translation and persists to settings", async ({ page }) => {
   await page.route("**/api/books/*/chapters/*/translation", (route) =>
     route.fulfill({
       json: { status: "ready", paragraphs: ["Auto-loaded translation."], cached: true },
@@ -26,18 +44,40 @@ test("translation auto-loads when Translate button is clicked", async ({ page })
   await page.goto("/reader/1342");
   await expect(page.getByText(/truth universally acknowledged/)).toBeVisible();
 
-  // Single click on Translate — no secondary "Translate this chapter" needed
-  await page.getByRole("button", { name: /Translate/i }).first().click();
+  await openAndEnableTranslation(page);
 
-  // Translation should appear automatically
+  // Translation appears after enabling the toggle
   await expect(page.getByText("Auto-loaded translation.")).toBeVisible({ timeout: 5000 });
+
+  // translationEnabled saved to settings
+  const saved = await page.evaluate(() => {
+    const raw = localStorage.getItem("book-reader-settings");
+    return raw ? JSON.parse(raw) : null;
+  });
+  expect(saved?.translationEnabled).toBe(true);
+});
+
+test("translationEnabled persists: reopening the reader resumes translation", async ({ page }) => {
+  await page.route("**/api/books/*/chapters/*/translation", (route) =>
+    route.fulfill({
+      json: { status: "ready", paragraphs: ["Persisted translation."], cached: true },
+    })
+  );
+
+  await page.goto("/reader/1342");
+  await page.evaluate(() => {
+    localStorage.setItem(
+      "book-reader-settings",
+      JSON.stringify({ translationEnabled: true, translationLang: "de", insightLang: "en", ttsGender: "female", fontSize: "base", theme: "light" })
+    );
+  });
+  await page.reload();
+
+  // Translation auto-fires because settings say it was enabled
+  await expect(page.getByText("Persisted translation.")).toBeVisible({ timeout: 5000 });
 });
 
 test("translation sidebar has no standalone title heading", async ({ page }) => {
-  await page.route("**/api/books/*/chapters/*/translation", (route) =>
-    route.fulfill({ json: { status: "ready", paragraphs: ["Text."], cached: true } })
-  );
-
   await page.goto("/reader/1342");
   await page.getByRole("button", { name: /Translate/i }).first().click();
 
@@ -51,14 +91,11 @@ test("translation language is persisted to settings on change", async ({ page })
   );
 
   await page.goto("/reader/1342");
-  await page.getByRole("button", { name: /Translate/i }).first().click();
+  await openAndEnableTranslation(page);
 
-  // "Target language" label is next to the language select in the translate panel
   await expect(page.getByText("Target language")).toBeVisible({ timeout: 3000 });
-  // Select German from the dropdown labeled "Target language"
   await page.locator("label", { hasText: "Target language" }).locator("..").locator("select").selectOption({ value: "de" });
 
-  // Verify settings are persisted to localStorage
   const saved = await page.evaluate(() => {
     const raw = localStorage.getItem("book-reader-settings");
     return raw ? JSON.parse(raw) : null;
@@ -67,7 +104,6 @@ test("translation language is persisted to settings on change", async ({ page })
 });
 
 test("translation language is loaded from settings on page open", async ({ page }) => {
-  // Seed settings with French as preferred translation language
   await page.goto("/reader/1342");
   await page.evaluate(() => {
     localStorage.setItem(
@@ -80,7 +116,6 @@ test("translation language is loaded from settings on page open", async ({ page 
   await page.getByRole("button", { name: /Translate/i }).first().click();
   await expect(page.getByText("Target language")).toBeVisible({ timeout: 3000 });
 
-  // The language dropdown should show French as the selected value
   const selectValue = await page.locator("label", { hasText: "Target language" })
     .locator("..").locator("select").inputValue();
   expect(selectValue).toBe("fr");

--- a/frontend/e2e/reader.spec.ts
+++ b/frontend/e2e/reader.spec.ts
@@ -49,35 +49,33 @@ test("continue-reading: reopening a book restores the last-read chapter", async 
   await expect(page.getByText(MOCK_CHAPTERS[2].text.slice(0, 30), { exact: false })).toBeVisible({ timeout: 5000 });
 });
 
+/** Seed localStorage with translationEnabled=true so translation auto-fires on page load. */
+async function seedTranslationEnabled(page: import("@playwright/test").Page, lang = "de") {
+  await page.goto("/reader/1342");
+  await page.evaluate((l) => {
+    localStorage.setItem(
+      "book-reader-settings",
+      JSON.stringify({ translationEnabled: true, translationLang: l, insightLang: "en", ttsGender: "female", fontSize: "base", theme: "light" })
+    );
+  }, lang);
+  await page.reload();
+}
+
 test("translation does not show Gemini reminder (queue returns ready)", async ({ page }) => {
-  // User has no Gemini key — translation still works via the queue
-  // (admin's key). No Gemini reminder should show.
   await page.route("**/api/user/me", (route) =>
     route.fulfill({
       json: { id: 1, email: "test@example.com", name: "Test", picture: "", hasGeminiKey: false, role: "user", approved: true },
     })
   );
-  // Unified queue-aware translate endpoint returns ready+paragraphs.
   await page.route("**/api/books/*/chapters/*/translation", (route) =>
     route.fulfill({
-      json: {
-        status: "ready",
-        paragraphs: ["Translated text."],
-        provider: "gemini",
-        model: "gemini-2.5-flash",
-      },
+      json: { status: "ready", paragraphs: ["Translated text."], provider: "gemini", model: "gemini-2.5-flash" },
     })
   );
 
-  await page.goto("/reader/1342");
+  await seedTranslationEnabled(page);
   await expect(page.getByText(/truth universally acknowledged/)).toBeVisible();
-
-  // Clicking the Translate header button enables translation automatically
-  await page.getByRole("button", { name: /Translate/ }).first().click();
-
-  // Translation should appear
   await expect(page.getByText("Translated text.")).toBeVisible();
-  // Gemini reminder should NOT appear
   await expect(page.getByText(/AI features require your own Gemini API key/)).not.toBeVisible();
 });
 
@@ -86,17 +84,11 @@ test("translation shows queued state when worker is processing", async ({ page }
     route.fulfill({ json: { id: 1, email: "t@t.com", name: "T", picture: "", hasGeminiKey: true, role: "user", approved: true } })
   );
   await page.route("**/api/books/*/chapters/*/translation", (route) =>
-    route.fulfill({
-      json: { status: "pending", position: 2, worker_running: true },
-    })
+    route.fulfill({ json: { status: "pending", position: 2, worker_running: true } })
   );
 
-  await page.goto("/reader/1342");
+  await seedTranslationEnabled(page);
   await expect(page.getByText(/truth universally acknowledged/)).toBeVisible();
-
-  await page.getByRole("button", { name: /Translate/ }).first().click();
-
-  // Should show a queued/waiting indicator — not translated text
   await expect(page.getByText("Translated text.")).not.toBeVisible({ timeout: 3000 });
   await expect(page.getByText("queue · position 2", { exact: true })).toBeVisible({ timeout: 5000 });
 });
@@ -106,16 +98,11 @@ test("translation shows worker offline message when worker not running", async (
     route.fulfill({ json: { id: 1, email: "t@t.com", name: "T", picture: "", hasGeminiKey: true, role: "user", approved: true } })
   );
   await page.route("**/api/books/*/chapters/*/translation", (route) =>
-    route.fulfill({
-      json: { status: "pending", position: 1, worker_running: false },
-    })
+    route.fulfill({ json: { status: "pending", position: 1, worker_running: false } })
   );
 
-  await page.goto("/reader/1342");
+  await seedTranslationEnabled(page);
   await expect(page.getByText(/truth universally acknowledged/)).toBeVisible({ timeout: 10000 });
-
-  await page.getByRole("button", { name: /Translate/ }).first().click();
-
   await expect(page.getByText("queue · worker is offline", { exact: true })).toBeVisible({ timeout: 5000 });
 });
 

--- a/frontend/e2e/reader.spec.ts
+++ b/frontend/e2e/reader.spec.ts
@@ -51,14 +51,13 @@ test("continue-reading: reopening a book restores the last-read chapter", async 
 
 /** Seed localStorage with translationEnabled=true so translation auto-fires on page load. */
 async function seedTranslationEnabled(page: import("@playwright/test").Page, lang = "de") {
-  await page.goto("/reader/1342");
-  await page.evaluate((l) => {
+  await page.addInitScript((l: string) => {
     localStorage.setItem(
       "book-reader-settings",
       JSON.stringify({ translationEnabled: true, translationLang: l, insightLang: "en", ttsGender: "female", fontSize: "base", theme: "light" })
     );
   }, lang);
-  await page.reload();
+  await page.goto("/reader/1342");
 }
 
 test("translation does not show Gemini reminder (queue returns ready)", async ({ page }) => {

--- a/frontend/e2e/reader.spec.ts
+++ b/frontend/e2e/reader.spec.ts
@@ -89,7 +89,7 @@ test("translation shows queued state when worker is processing", async ({ page }
   await seedTranslationEnabled(page);
   await expect(page.getByText(/truth universally acknowledged/)).toBeVisible();
   await expect(page.getByText("Translated text.")).not.toBeVisible({ timeout: 3000 });
-  await expect(page.getByText("queue · position 2", { exact: true })).toBeVisible({ timeout: 5000 });
+  await expect(page.getByText(/queue · position 2/)).toBeVisible({ timeout: 5000 });
 });
 
 test("translation shows worker offline message when worker not running", async ({ page }) => {
@@ -102,7 +102,7 @@ test("translation shows worker offline message when worker not running", async (
 
   await seedTranslationEnabled(page);
   await expect(page.getByText(/truth universally acknowledged/)).toBeVisible({ timeout: 10000 });
-  await expect(page.getByText("queue · worker is offline", { exact: true })).toBeVisible({ timeout: 5000 });
+  await expect(page.getByText(/queue · worker is offline/)).toBeVisible({ timeout: 5000 });
 });
 
 test("Your Library shows chapter badge from recent-read data", async ({ page }) => {

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -39,6 +39,7 @@ export default function ProfilePage() {
   const [settings, setSettings] = useState<AppSettings>({
     insightLang: "en",
     translationLang: "en",
+    translationEnabled: false,
     ttsGender: "female",
     chatFontSize: "xs",
     translationProvider: "auto",

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -197,7 +197,9 @@ export default function ReaderPage() {
   // Translation state
   const translationCache = useRef(new Map<string, string[]>());
   const currentChapterKey = useRef<string>(""); // tracks which chapter is currently displayed
-  const [translationEnabled, setTranslationEnabled] = useState(false);
+  const [translationEnabled, setTranslationEnabled] = useState<boolean>(() =>
+    typeof window !== "undefined" ? getSettings().translationEnabled : false
+  );
   const [translationLang, setTranslationLang] = useState<string>(() =>
     typeof window !== "undefined" ? getSettings().translationLang : "en"
   );
@@ -755,7 +757,7 @@ export default function ReaderPage() {
 
           {/* Translate toggle — opens sidebar with translation controls */}
           <button
-            onClick={() => { setSidebarTab("translate"); setTranslationEnabled(true); setSidebarOpen((v) => sidebarTab === "translate" ? !v : true); }}
+            onClick={() => { setSidebarTab("translate"); setSidebarOpen((v) => sidebarTab === "translate" ? !v : true); }}
             title="Translation"
             className={`hidden md:flex shrink-0 items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-medium transition-colors ${
               sidebarOpen && sidebarTab === "translate"
@@ -888,45 +890,6 @@ export default function ReaderPage() {
           </span>
         </div>
       )}
-
-      {/* Book-level translation progress — shown whenever the queue is
-          holding at least one chapter of THIS book in THIS language,
-          even if a legacy bulk job isn't running. Gives the user a
-          whole-book view (e.g. "18/21 chapters ready · 3 processing")
-          in addition to the per-chapter banner above. */}
-      {translationEnabled && bookTranslationStatus && (() => {
-        const s = bookTranslationStatus;
-        const queued = (s.queue_pending ?? 0) + (s.queue_running ?? 0);
-        const ready = s.translated_chapters;
-        const total = s.total_chapters;
-        // Chapters that are neither done nor queued — the "nothing is
-        // happening for these" bucket the user can act on via the
-        // Translate-whole-book button.
-        const notStarted = Math.max(
-          0,
-          total - ready - queued - (s.queue_failed ?? 0),
-        );
-        return (
-          <div className="bg-amber-50 border-b border-amber-200 px-3 md:px-4 py-1.5 text-xs text-amber-800 flex items-center gap-2 flex-wrap">
-            {queued > 0 && <span className="inline-block w-1.5 h-1.5 bg-amber-500 rounded-full animate-pulse shrink-0" />}
-            <span className="flex-1 min-w-0">
-              <strong>{ready} / {total}</strong> chapters translated
-              {queued > 0 && (<> · <strong>{queued}</strong> processing</>)}
-              {s.queue_failed ? (<> · <span className="text-red-600">{s.queue_failed} failed</span></>) : null}
-            </span>
-            {notStarted > 0 && (
-              <button
-                onClick={handleTranslateWholeBook}
-                disabled={enqueueingBook}
-                className="shrink-0 text-xs px-3 py-1 rounded-full border border-amber-400 bg-white text-amber-800 hover:bg-amber-100 disabled:opacity-50"
-                title={`Queue the remaining ${notStarted} chapters into ${translationLang}`}
-              >
-                {enqueueingBook ? "Queueing…" : `Translate all ${notStarted} remaining`}
-              </button>
-            )}
-          </div>
-        );
-      })()}
 
       </div>{/* end banners wrapper */}
 
@@ -1334,7 +1297,7 @@ export default function ReaderPage() {
                         type="checkbox"
                         className="sr-only"
                         checked={translationEnabled}
-                        onChange={(e) => setTranslationEnabled(e.target.checked)}
+                        onChange={(e) => { setTranslationEnabled(e.target.checked); saveSettings({ translationEnabled: e.target.checked }); }}
                       />
                       <span className="text-sm text-ink">{translationEnabled ? "Enabled" : "Disabled"}</span>
                     </label>

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -456,7 +456,7 @@ export default function ReaderPage() {
 
     return () => { cancelled = true; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [translationEnabled, translationLang, chapterIndex, bookId, hasGeminiKey]);
+  }, [translationEnabled, translationLang, chapterIndex, bookId, hasGeminiKey, chapters]);
 
   // Poll book-level translation status when translation is enabled — shows
   // the admin-level bulk-translate progress for this book ("42/60 chapters ready").

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -416,7 +416,8 @@ export default function SentenceReader({
     return map;
   }, [annotations]);
 
-  // Lookup that handles selections made within a sentence (substring match fallback)
+  // Lookup with substring fallback: annotations from text-selection may store a
+  // substring of the segment text rather than the full sentence.
   const getAnnotation = useMemo(() => {
     const anns = annotations ?? [];
     return (segText: string): Annotation | undefined => {

--- a/frontend/src/lib/settings.ts
+++ b/frontend/src/lib/settings.ts
@@ -7,6 +7,7 @@ export type TTSGender = "female" | "male";
 export interface AppSettings {
   insightLang: string;
   translationLang: string;
+  translationEnabled: boolean;
   ttsGender: TTSGender;
   translationProvider: TranslationProvider;
   fontSize: FontSize;
@@ -17,6 +18,7 @@ export interface AppSettings {
 const DEFAULTS: AppSettings = {
   insightLang: "en",
   translationLang: "en",
+  translationEnabled: false,
   ttsGender: "female",
   translationProvider: "auto",
   fontSize: "base",


### PR DESCRIPTION
## Summary

- **Toolbar Translate button** no longer auto-enables translation — it just opens the sidebar. The user controls translation via the toggle inside the panel.
- **`translationEnabled` persists** to `localStorage` settings (new field added to `AppSettings`). Toggle saves on change; page initializes from saved state so translation state survives reloads and navigation.
- **Book-level progress banner** removed from the top of the reading area — it now lives only in the translate sidebar panel (added in the prior PR).
- **E2E tests** updated: translation queue/queued/offline tests seed `translationEnabled: true` in `localStorage` instead of relying on the toolbar button auto-enabling. New tests cover: toolbar opens sidebar without enabling, toggle enables + saves, persisted setting resumes translation on reload.

## Test plan

- [x] 305/305 Jest tests pass
- [ ] Manual: click 🌐 Translate in toolbar → sidebar opens, translation toggle is OFF
- [ ] Manual: enable toggle → translation fires, setting saved; reload → translation auto-fires again
- [ ] Manual: disable toggle → setting saved; reload → translation is off
