### PR TITLE
fix(theme): chapter title flips colour in dark/sepia modes

### DIFF
--- a/frontend/e2e/ux-reading.spec.ts
+++ b/frontend/e2e/ux-reading.spec.ts
@@ -181,6 +181,22 @@ test.describe("Display customisation (desktop)", () => {
     await expect(themeBtn).toHaveAttribute("title", "Theme: light");
   });
 
+  test("chapter title changes color in dark theme", async ({ page }) => {
+    const themeBtn = page.locator('button[title^="Theme:"]');
+    const heading = page.getByTestId("reader-chapter-heading").locator("h2");
+    await expect(heading).toBeVisible();
+
+    const lightColor = await heading.evaluate((el) => getComputedStyle(el).color);
+
+    // Cycle to dark theme (light → sepia → dark)
+    await themeBtn.click();
+    await themeBtn.click();
+    await expect(themeBtn).toHaveAttribute("title", "Theme: dark");
+
+    const darkColor = await heading.evaluate((el) => getComputedStyle(el).color);
+    expect(darkColor).not.toBe(lightColor);
+  });
+
   test("font size change persists across chapter navigation", async ({ page }) => {
     const fontBtn = page.locator('button[title^="Font size:"]');
     await fontBtn.click(); // base → lg

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -18,6 +18,7 @@ body, [data-theme="light"] {
 [data-theme="dark"] .bg-white\/60 { background-color: rgba(37, 37, 64, 0.6); }
 [data-theme="dark"] .bg-white\/40 { background-color: rgba(37, 37, 64, 0.4); }
 [data-theme="dark"] .text-ink { color: #e0dcd4; }
+[data-theme="dark"] .text-ink\/80 { color: rgba(224, 220, 212, 0.8); }
 [data-theme="dark"] .text-amber-700 { color: #d4a853; }
 [data-theme="dark"] .text-amber-800 { color: #c4983e; }
 [data-theme="dark"] .text-amber-600 { color: #ddb862; }
@@ -46,6 +47,7 @@ body, [data-theme="light"] {
 [data-theme="sepia"] .bg-white { background-color: #faf6ee; }
 [data-theme="sepia"] .bg-white\/60 { background-color: rgba(250, 246, 238, 0.6); }
 [data-theme="sepia"] .text-ink { color: #5b4636; }
+[data-theme="sepia"] .text-ink\/80 { color: rgba(91, 70, 54, 0.8); }
 
 /* ── Prose reader ── */
 .prose-reader {


### PR DESCRIPTION
## Summary

- `text-ink/80` (Tailwind opacity modifier) generates `.text-ink\/80` in CSS — a different selector than `.text-ink` — so the existing `[data-theme="dark"] .text-ink` and `[data-theme="sepia"] .text-ink` rules in `globals.css` never matched the chapter heading `<h2>`
- Added explicit overrides for `.text-ink\/80` in both dark and sepia themes so the chapter title now flips colour correctly

## Test plan

- [x] New E2E test: `chapter title changes color in dark theme` in `ux-reading.spec.ts` — verifies `getComputedStyle(h2).color` differs between light and dark modes
- [x] Full E2E suite passes (42/42)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
