### PR TITLE
feat(reader): explicit Translate this chapter button; no auto-translate on nav

### DIFF
--- a/frontend/e2e/annotation-translation.spec.ts
+++ b/frontend/e2e/annotation-translation.spec.ts
@@ -46,7 +46,9 @@ test("enabling the translation toggle loads translation and persists to settings
 
   await openAndEnableTranslation(page);
 
-  // Translation appears after enabling the toggle
+  // Enabling the toggle alone does not fire — user must click the button
+  await page.getByRole("button", { name: "Translate this chapter" }).click();
+
   await expect(page.getByText("Auto-loaded translation.")).toBeVisible({ timeout: 5000 });
 
   // translationEnabled saved to settings
@@ -73,7 +75,10 @@ test("translationEnabled persists: reopening the reader resumes translation", as
   });
   await page.goto("/reader/1342");
 
-  // Translation auto-fires because settings say it was enabled
+  // Toggle is restored — user opens sidebar and clicks the button
+  await page.getByRole("button", { name: /Translate/i }).first().click();
+  await page.getByRole("button", { name: "Translate this chapter" }).click();
+
   await expect(page.getByText("Persisted translation.")).toBeVisible({ timeout: 5000 });
 });
 

--- a/frontend/e2e/reader.spec.ts
+++ b/frontend/e2e/reader.spec.ts
@@ -74,6 +74,8 @@ test("translation does not show Gemini reminder (queue returns ready)", async ({
 
   await seedTranslationEnabled(page);
   await expect(page.getByText(/truth universally acknowledged/)).toBeVisible();
+  await page.getByRole("button", { name: /Translate/i }).first().click();
+  await page.getByRole("button", { name: "Translate this chapter" }).click();
   await expect(page.getByText("Translated text.")).toBeVisible();
   await expect(page.getByText(/AI features require your own Gemini API key/)).not.toBeVisible();
 });
@@ -88,8 +90,10 @@ test("translation shows queued state when worker is processing", async ({ page }
 
   await seedTranslationEnabled(page);
   await expect(page.getByText(/truth universally acknowledged/)).toBeVisible();
+  await page.getByRole("button", { name: /Translate/i }).first().click();
+  await page.getByRole("button", { name: "Translate this chapter" }).click();
   await expect(page.getByText("Translated text.")).not.toBeVisible({ timeout: 3000 });
-  await expect(page.getByText(/queue · position 2/)).toBeVisible({ timeout: 5000 });
+  await expect(page.getByText(/queue · position 2/).first()).toBeVisible({ timeout: 5000 });
 });
 
 test("translation shows worker offline message when worker not running", async ({ page }) => {
@@ -102,7 +106,9 @@ test("translation shows worker offline message when worker not running", async (
 
   await seedTranslationEnabled(page);
   await expect(page.getByText(/truth universally acknowledged/)).toBeVisible({ timeout: 10000 });
-  await expect(page.getByText(/queue · worker is offline/)).toBeVisible({ timeout: 5000 });
+  await page.getByRole("button", { name: /Translate/i }).first().click();
+  await page.getByRole("button", { name: "Translate this chapter" }).click();
+  await expect(page.getByText(/queue · worker is offline/).first()).toBeVisible({ timeout: 5000 });
 });
 
 test("Your Library shows chapter badge from recent-read data", async ({ page }) => {

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -327,11 +327,15 @@ export default function ReaderPage() {
     }
   }, [bookLanguage, translationLang]);
 
+  // Load from in-memory cache when translation is enabled and chapter/lang changes.
+  // API calls only happen via handleTranslateThisChapter (explicit user action).
   useEffect(() => {
     const current = chapters[chapterIndex];
     if (!translationEnabled || !current?.text) {
       setTranslatedParagraphs([]);
       setTranslatedTitle(null);
+      setTranslationLoading(false);
+      setTranslationUsedProvider("");
       return;
     }
     const cacheKey = `${bookId}-${chapterIndex}-${translationLang}`;
@@ -343,126 +347,90 @@ export default function ReaderPage() {
       return;
     }
 
-    // If logged in but key status not yet loaded, wait for getMe() to resolve.
-    if (session && hasGeminiKey === null) return;
+    // No cached translation — clear stale state; user must click "Translate this chapter"
+    setTranslatedParagraphs([]);
+    setTranslatedTitle(null);
+    setTranslationLoading(false);
+    setTranslationUsedProvider("");
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [translationEnabled, translationLang, chapterIndex, bookId, chapters]);
 
-    let cancelled = false;
+  async function handleTranslateThisChapter() {
+    const current = chapters[chapterIndex];
+    if (!current?.text) return;
+    const cacheKey = `${bookId}-${chapterIndex}-${translationLang}`;
+    currentChapterKey.current = cacheKey;
+
     setTranslationLoading(true);
     setTranslatedParagraphs([]);
     setTranslationUsedProvider("");
 
     const bid = Number(bookId);
 
-    function showCached(res: {
-      paragraphs?: string[];
-      provider?: string;
-      model?: string;
-      title_translation?: string | null;
-    }) {
+    function showResult(res: { paragraphs?: string[]; provider?: string; model?: string; title_translation?: string | null }) {
       if (!res.paragraphs) return;
       translationCache.current.set(cacheKey, res.paragraphs);
       setTranslatedParagraphs(res.paragraphs);
       setTranslatedTitle(res.title_translation ?? null);
-      const providerLabel = res.provider
-        ? (res.model ? `${res.provider} (${res.model})` : res.provider)
-        : "cached";
-      setTranslationUsedProvider(providerLabel);
+      setTranslationUsedProvider(res.provider ? (res.model ? `${res.provider} (${res.model})` : res.provider) : "cached");
       setTranslationLoading(false);
     }
 
+    function describeStatus(r: { status: string; position?: number | null; worker_running?: boolean }): string {
+      if (r.status === "running") return "queue · translating now";
+      if (r.worker_running === false) return "queue · worker is offline";
+      return `queue · position ${r.position ?? "?"}`;
+    }
+
+    let res;
+    try {
+      res = await requestChapterTranslation(bid, chapterIndex, translationLang);
+    } catch (e) {
+      if (currentChapterKey.current === cacheKey) {
+        if (e instanceof ApiError && e.status === 401) setTranslationUsedProvider("login required");
+        else if (e instanceof ApiError && e.status === 403) setTranslationUsedProvider("gemini key required");
+        else setTranslationUsedProvider("error · check admin queue");
+        setTranslationLoading(false);
+      }
+      return;
+    }
+    if (currentChapterKey.current !== cacheKey) return;
+
+    if (res.status === "ready") { showResult(res); return; }
+
+    if (hasGeminiKey === false && !isAdmin) {
+      setTranslationUsedProvider("gemini key required");
+      setTranslationLoading(false);
+      return;
+    }
+
+    setTranslationUsedProvider(describeStatus(res));
+
     (async () => {
-      // 1. Request the translation — returns cached OR queue status.
-      let res;
       try {
-        res = await requestChapterTranslation(bid, chapterIndex, translationLang);
-      } catch (e) {
-        console.error("Failed to request chapter translation:", e);
-        if (!cancelled && currentChapterKey.current === cacheKey) {
-          if (e instanceof ApiError && e.status === 401) {
-            setTranslationUsedProvider("login required");
-          } else if (e instanceof ApiError && e.status === 403) {
-            setTranslationUsedProvider("gemini key required");
-          } else {
-            setTranslationUsedProvider("error · check admin queue");
-          }
-          setTranslationLoading(false);
-        }
-        return;
-      }
-      if (cancelled || currentChapterKey.current !== cacheKey) return;
-
-      if (res.status === "ready") {
-        showCached(res);
-        return;
-      }
-
-      // Logged in but no Gemini key — translation was queued but won't run
-      // without a key. Show a notice instead of the misleading queue banner.
-      if (hasGeminiKey === false) {
-        if (!cancelled && currentChapterKey.current === cacheKey) {
-          setTranslationUsedProvider("gemini key required");
-          setTranslationLoading(false);
-        }
-        return;
-      }
-
-      // 2. Queued / running — show status banner and poll every 3s.
-      //    No hard timeout: as long as the chapter is actually being
-      //    processed, we keep waiting. The user can toggle translate off
-      //    if they want to stop.
-      function describeStatus(r: { status: string; position?: number | null; worker_running?: boolean }): string {
-        if (r.status === "running") return "queue · translating now";
-        // Pending: distinguish "worker is processing, wait your turn"
-        // from "worker is offline — this will never complete without admin action".
-        if (r.worker_running === false) return "queue · worker is offline";
-        return `queue · position ${r.position ?? "?"}`;
-      }
-
-      setTranslationUsedProvider(describeStatus(res));
-
-      // Kick the whole-book banner immediately so "N not started" doesn't
-      // misreport the chapter we just enqueued — users clicking "Translate
-      // all N remaining" next would otherwise see a stale count and a
-      // confusing no-op ("enqueued=0" because we already enqueued this).
-      (async () => {
-        try {
-          const status = await getBookTranslationStatus(bid, translationLang);
-          if (!cancelled && currentChapterKey.current === cacheKey) {
-            setBookTranslationStatus(status);
-          }
-        } catch { /* ignore */ }
-      })();
-
-      const POLL_MS = 3000;
-      while (!cancelled && currentChapterKey.current === cacheKey) {
-        await new Promise((r) => setTimeout(r, POLL_MS));
-        if (cancelled || currentChapterKey.current !== cacheKey) return;
-        let tick;
-        try {
-          tick = await requestChapterTranslation(bid, chapterIndex, translationLang);
-        } catch {
-          continue; // transient error — try again next tick
-        }
-        if (cancelled || currentChapterKey.current !== cacheKey) return;
-
-        if (tick.status === "ready") {
-          showCached(tick);
-          return;
-        }
-        if (tick.status === "failed") {
-          setTranslationUsedProvider(
-            `queue failed${tick.attempts ? ` · ${tick.attempts} attempts` : ""}`,
-          );
-          setTranslationLoading(false);
-          return;
-        }
-        setTranslationUsedProvider(describeStatus(tick));
-      }
+        const status = await getBookTranslationStatus(bid, translationLang);
+        if (currentChapterKey.current === cacheKey) setBookTranslationStatus(status);
+      } catch { /* ignore */ }
     })();
 
-    return () => { cancelled = true; };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [translationEnabled, translationLang, chapterIndex, bookId, hasGeminiKey, chapters]);
+    const POLL_MS = 3000;
+    let cancelled = false;
+    while (!cancelled && currentChapterKey.current === cacheKey) {
+      await new Promise((r) => setTimeout(r, POLL_MS));
+      if (cancelled || currentChapterKey.current !== cacheKey) return;
+      let tick;
+      try { tick = await requestChapterTranslation(bid, chapterIndex, translationLang); }
+      catch { continue; }
+      if (cancelled || currentChapterKey.current !== cacheKey) return;
+      if (tick.status === "ready") { showResult(tick); return; }
+      if (tick.status === "failed") {
+        setTranslationUsedProvider(`queue failed${tick.attempts ? ` · ${tick.attempts} attempts` : ""}`);
+        setTranslationLoading(false);
+        return;
+      }
+      setTranslationUsedProvider(describeStatus(tick));
+    }
+  }
 
   // Poll book-level translation status when translation is enabled — shows
   // the admin-level bulk-translate progress for this book ("42/60 chapters ready").
@@ -1369,6 +1337,24 @@ export default function ReaderPage() {
                         >Side by side</button>
                       </div>
                     </div>
+
+                    {/* Translate this chapter button — explicit user action required */}
+                    {translationEnabled && !translationLoading && translatedParagraphs.length === 0 && translationUsedProvider === "" && (
+                      <div className="mb-4">
+                        {session?.backendToken ? (
+                          <button
+                            onClick={handleTranslateThisChapter}
+                            className="w-full px-3 py-2 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-sm font-medium transition-colors"
+                          >
+                            Translate this chapter
+                          </button>
+                        ) : (
+                          <p className="text-xs text-amber-700">
+                            <a href="/api/auth/signin" className="underline font-medium">Sign in</a> to translate this chapter.
+                          </p>
+                        )}
+                      </div>
+                    )}
 
                     {/* Status */}
                     {translationEnabled && (


### PR DESCRIPTION
## Summary

- Translation no longer fires automatically when enabling the toggle, changing the language, or navigating chapters
- A "Translate this chapter" button appears in the sidebar translate panel whenever translation is enabled but no translation exists yet for the current chapter
- If the user is not signed in, the button is replaced by a "Sign in to translate" link
- Cached translations (already fetched chapters) still display instantly without requiring a click

## Test plan

- [x] Jest: 305 tests pass
- [x] E2E: 72 tests pass (updated 5 tests to click the button before expecting translation results)
