### PR TITLE
fix(reader): auto-load server-cached translation; hide button when already done

### DIFF
--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -105,6 +105,10 @@ export async function mockBackend(page: Page) {
     route.fulfill({ status: 200, contentType: "audio/mpeg", body: Buffer.from([0xff, 0xfb]) })
   );
 
+  await page.route(/\/api\/books\/\d+\/chapters\/\d+\/queue-status/, (route) =>
+    route.fulfill({ json: { queued: false, status: null, position: null, attempts: 0 } })
+  );
+
   await page.route("**/api/annotations*", (route) => {
     if (route.request().method() === "GET") {
       route.fulfill({ json: [] });

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { getBookChapters, deleteTranslationCache, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, retryChapterTranslation, enqueueBookTranslation, saveReadingProgress, getAnnotations, getVocabulary, saveVocabularyWord, exportVocabularyToObsidian, saveInsight, TranslationStatus, BookMeta, BookChapter, ApiError, Annotation, VocabularyWord } from "@/lib/api";
+import { getBookChapters, deleteTranslationCache, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, getChapterQueueStatus, retryChapterTranslation, enqueueBookTranslation, saveReadingProgress, getAnnotations, getVocabulary, saveVocabularyWord, exportVocabularyToObsidian, saveInsight, TranslationStatus, BookMeta, BookChapter, ApiError, Annotation, VocabularyWord } from "@/lib/api";
 import { recordRecentBook, saveLastChapter, getLastChapter } from "@/lib/recentBooks";
 import { getSettings, saveSettings, FontSize, Theme } from "@/lib/settings";
 import InsightChat, { LANGUAGES } from "@/components/InsightChat";
@@ -331,7 +331,8 @@ export default function ReaderPage() {
   }, [bookLanguage, translationLang]);
 
   // Load from in-memory cache when translation is enabled and chapter/lang changes.
-  // API calls only happen via handleTranslateThisChapter (explicit user action).
+  // After a cache miss, checks server queue status — auto-loads if already done,
+  // shows queue banner if in-progress, shows button only if not yet requested.
   useEffect(() => {
     const current = chapters[chapterIndex];
     if (!translationEnabled || !current?.text) {
@@ -350,11 +351,54 @@ export default function ReaderPage() {
       return;
     }
 
-    // No cached translation — clear stale state; user must click "Translate this chapter"
+    // Clear stale state while checking server
     setTranslatedParagraphs([]);
     setTranslatedTitle(null);
-    setTranslationLoading(false);
+    setTranslationLoading(true);
     setTranslationUsedProvider("");
+
+    let cancelled = false;
+    const bid = Number(bookId);
+
+    (async () => {
+      let queueStatus;
+      try {
+        queueStatus = await getChapterQueueStatus(bid, chapterIndex, translationLang);
+      } catch {
+        if (!cancelled && currentChapterKey.current === cacheKey) setTranslationLoading(false);
+        return;
+      }
+      if (cancelled || currentChapterKey.current !== cacheKey) return;
+
+      if (queueStatus.status === "done") {
+        // Server has a cached translation — fetch it via POST (returns instantly)
+        try {
+          const res = await requestChapterTranslation(bid, chapterIndex, translationLang);
+          if (cancelled || currentChapterKey.current !== cacheKey) return;
+          if (res.status === "ready" && res.paragraphs) {
+            translationCache.current.set(cacheKey, res.paragraphs);
+            setTranslatedParagraphs(res.paragraphs);
+            setTranslatedTitle(res.title_translation ?? null);
+            setTranslationUsedProvider(res.provider ? (res.model ? `${res.provider} (${res.model})` : res.provider) : "cached");
+          }
+        } catch { /* ignore */ }
+        if (!cancelled && currentChapterKey.current === cacheKey) setTranslationLoading(false);
+        return;
+      }
+
+      if (queueStatus.status === "pending" || queueStatus.status === "running") {
+        // Already queued — show queue banner and start polling via handleTranslateThisChapter
+        setTranslationLoading(false);
+        if (queueStatus.status === "running") setTranslationUsedProvider("queue · translating now");
+        else setTranslationUsedProvider(`queue · position ${queueStatus.position ?? "?"}`);
+        return;
+      }
+
+      // Not translated yet (null / failed / skipped) — show "Translate this chapter" button
+      setTranslationLoading(false);
+    })();
+
+    return () => { cancelled = true; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [translationEnabled, translationLang, chapterIndex, bookId, chapters]);
 


### PR DESCRIPTION
## Summary

- Fixed bug: "Translate this chapter" button was visible on fresh page loads even when the backend already had a cached translation for the chapter
- The translation `useEffect` now calls `getChapterQueueStatus` (GET, no side effects) after an in-memory cache miss to check server state:
  - `status === "done"` → auto-fetches paragraphs via `requestChapterTranslation` POST (returns instantly from cache, no quota cost)
  - `status === "pending"/"running"` → shows queue banner without re-enqueuing
  - `status === null/"failed"/"skipped"` → shows "Translate this chapter" button
- Added default `queue-status` stub (`status: null`) to E2E fixtures so existing tests continue to work

## Test plan

- [x] All 19 E2E tests pass (`reader.spec.ts` + `annotation-translation.spec.ts`)
- [x] All 305 Jest unit tests pass
- [x] All 651 backend pytest tests pass
