### PR TITLE
fix(reader): use GET translation endpoint to detect cached state without enqueuing

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -169,6 +169,27 @@ async def chapter_queue_status(
     return await queue_status_for_chapter(book_id, chapter_index, target_language)
 
 
+@router.get("/{book_id}/chapters/{chapter_index}/translation")
+async def get_chapter_translation(
+    book_id: int,
+    chapter_index: int,
+    target_language: str,
+    _user: dict = Depends(get_current_user),
+):
+    """Return the cached translation if available, 404 otherwise. Never enqueues."""
+    from services.db import get_cached_translation_with_meta
+    cached = await get_cached_translation_with_meta(book_id, chapter_index, target_language)
+    if not cached:
+        raise HTTPException(status_code=404, detail="Translation not cached")
+    return {
+        "status": "ready",
+        "paragraphs": cached["paragraphs"],
+        "provider": cached.get("provider"),
+        "model": cached.get("model"),
+        "title_translation": cached.get("title_translation"),
+    }
+
+
 class RequestTranslationBody(BaseModel):
     target_language: str
 

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -501,6 +501,31 @@ async def test_import_stream_public_without_login(anon_client):
     assert resp.status_code == 200
 
 
+# ── GET /chapters/{idx}/translation — read-only cache check ──────────────────
+
+async def test_get_chapter_translation_cached(client):
+    """GET returns cached translation when it exists."""
+    from services.db import save_translation
+    await save_translation(9999, 0, "de", ["Übersetzung"])
+    resp = await client.get("/api/books/9999/chapters/0/translation?target_language=de")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ready"
+    assert data["paragraphs"] == ["Übersetzung"]
+
+
+async def test_get_chapter_translation_not_cached(client):
+    """GET returns 404 when no cached translation exists."""
+    resp = await client.get("/api/books/9999/chapters/0/translation?target_language=fr")
+    assert resp.status_code == 404
+
+
+async def test_get_chapter_translation_requires_login(anon_client):
+    """GET requires authentication."""
+    resp = await anon_client.get("/api/books/9999/chapters/0/translation?target_language=de")
+    assert resp.status_code == 401
+
+
 async def test_chapter_translation_requires_gemini_key(client):
     """Logged-in user without a Gemini key cannot enqueue new translation."""
     resp = await client.post(

--- a/frontend/e2e/annotation-translation.spec.ts
+++ b/frontend/e2e/annotation-translation.spec.ts
@@ -35,11 +35,13 @@ test("toolbar Translate button opens sidebar without enabling translation", asyn
 });
 
 test("enabling the translation toggle loads translation and persists to settings", async ({ page }) => {
-  await page.route("**/api/books/*/chapters/*/translation", (route) =>
-    route.fulfill({
-      json: { status: "ready", paragraphs: ["Auto-loaded translation."], cached: true },
-    })
-  );
+  await page.route("**/api/books/*/chapters/*/translation", (route) => {
+    if (route.request().method() === "GET") {
+      route.fulfill({ status: 404, json: { detail: "Translation not cached" } });
+    } else {
+      route.fulfill({ json: { status: "ready", paragraphs: ["Auto-loaded translation."], cached: true } });
+    }
+  });
 
   await page.goto("/reader/1342");
   await expect(page.getByText(/truth universally acknowledged/)).toBeVisible();
@@ -60,11 +62,13 @@ test("enabling the translation toggle loads translation and persists to settings
 });
 
 test("translationEnabled persists: reopening the reader resumes translation", async ({ page }) => {
-  await page.route("**/api/books/*/chapters/*/translation", (route) =>
-    route.fulfill({
-      json: { status: "ready", paragraphs: ["Persisted translation."], cached: true },
-    })
-  );
+  await page.route("**/api/books/*/chapters/*/translation", (route) => {
+    if (route.request().method() === "GET") {
+      route.fulfill({ status: 404, json: { detail: "Translation not cached" } });
+    } else {
+      route.fulfill({ json: { status: "ready", paragraphs: ["Persisted translation."], cached: true } });
+    }
+  });
 
   // Seed settings with translationEnabled = true before first navigation
   await page.addInitScript(() => {
@@ -91,9 +95,13 @@ test("translation sidebar has no standalone title heading", async ({ page }) => 
 });
 
 test("translation language is persisted to settings on change", async ({ page }) => {
-  await page.route("**/api/books/*/chapters/*/translation", (route) =>
-    route.fulfill({ json: { status: "ready", paragraphs: ["Translated."], cached: true } })
-  );
+  await page.route("**/api/books/*/chapters/*/translation", (route) => {
+    if (route.request().method() === "GET") {
+      route.fulfill({ status: 404, json: { detail: "Translation not cached" } });
+    } else {
+      route.fulfill({ json: { status: "ready", paragraphs: ["Translated."], cached: true } });
+    }
+  });
 
   await page.goto("/reader/1342");
   await openAndEnableTranslation(page);

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -105,6 +105,15 @@ export async function mockBackend(page: Page) {
     route.fulfill({ status: 200, contentType: "audio/mpeg", body: Buffer.from([0xff, 0xfb]) })
   );
 
+  // GET translation check: 404 = not cached (shows "Translate this chapter" button)
+  await page.route(/\/api\/books\/\d+\/chapters\/\d+\/translation$/, (route) => {
+    if (route.request().method() === "GET") {
+      route.fulfill({ status: 404, json: { detail: "Translation not cached" } });
+    } else {
+      route.fallback();
+    }
+  });
+
   await page.route(/\/api\/books\/\d+\/chapters\/\d+\/queue-status/, (route) =>
     route.fulfill({ json: { queued: false, status: null, position: null, attempts: 0 } })
   );

--- a/frontend/e2e/reader.spec.ts
+++ b/frontend/e2e/reader.spec.ts
@@ -66,11 +66,13 @@ test("translation does not show Gemini reminder (queue returns ready)", async ({
       json: { id: 1, email: "test@example.com", name: "Test", picture: "", hasGeminiKey: false, role: "user", approved: true },
     })
   );
-  await page.route("**/api/books/*/chapters/*/translation", (route) =>
-    route.fulfill({
-      json: { status: "ready", paragraphs: ["Translated text."], provider: "gemini", model: "gemini-2.5-flash" },
-    })
-  );
+  await page.route("**/api/books/*/chapters/*/translation", (route) => {
+    if (route.request().method() === "GET") {
+      route.fulfill({ status: 404, json: { detail: "Translation not cached" } });
+    } else {
+      route.fulfill({ json: { status: "ready", paragraphs: ["Translated text."], provider: "gemini", model: "gemini-2.5-flash" } });
+    }
+  });
 
   await seedTranslationEnabled(page);
   await expect(page.getByText(/truth universally acknowledged/)).toBeVisible();

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { getBookChapters, deleteTranslationCache, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, getChapterQueueStatus, retryChapterTranslation, enqueueBookTranslation, saveReadingProgress, getAnnotations, getVocabulary, saveVocabularyWord, exportVocabularyToObsidian, saveInsight, TranslationStatus, BookMeta, BookChapter, ApiError, Annotation, VocabularyWord } from "@/lib/api";
+import { getBookChapters, deleteTranslationCache, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, getChapterTranslation, getChapterQueueStatus, retryChapterTranslation, enqueueBookTranslation, saveReadingProgress, getAnnotations, getVocabulary, saveVocabularyWord, exportVocabularyToObsidian, saveInsight, TranslationStatus, BookMeta, BookChapter, ApiError, Annotation, VocabularyWord } from "@/lib/api";
 import { recordRecentBook, saveLastChapter, getLastChapter } from "@/lib/recentBooks";
 import { getSettings, saveSettings, FontSize, Theme } from "@/lib/settings";
 import InsightChat, { LANGUAGES } from "@/components/InsightChat";
@@ -361,41 +361,40 @@ export default function ReaderPage() {
     const bid = Number(bookId);
 
     (async () => {
-      let queueStatus;
+      // First: check if server already has a cached translation (GET, never enqueues)
       try {
-        queueStatus = await getChapterQueueStatus(bid, chapterIndex, translationLang);
+        const res = await getChapterTranslation(bid, chapterIndex, translationLang);
+        if (cancelled || currentChapterKey.current !== cacheKey) return;
+        if (res.status === "ready" && res.paragraphs) {
+          translationCache.current.set(cacheKey, res.paragraphs);
+          setTranslatedParagraphs(res.paragraphs);
+          setTranslatedTitle(res.title_translation ?? null);
+          setTranslationUsedProvider(res.provider ? (res.model ? `${res.provider} (${res.model})` : res.provider) : "cached");
+          setTranslationLoading(false);
+          return;
+        }
       } catch {
-        if (!cancelled && currentChapterKey.current === cacheKey) setTranslationLoading(false);
-        return;
+        // 404 = not cached yet; other errors fall through to show button
       }
       if (cancelled || currentChapterKey.current !== cacheKey) return;
 
-      if (queueStatus.status === "done") {
-        // Server has a cached translation — fetch it via POST (returns instantly)
-        try {
-          const res = await requestChapterTranslation(bid, chapterIndex, translationLang);
-          if (cancelled || currentChapterKey.current !== cacheKey) return;
-          if (res.status === "ready" && res.paragraphs) {
-            translationCache.current.set(cacheKey, res.paragraphs);
-            setTranslatedParagraphs(res.paragraphs);
-            setTranslatedTitle(res.title_translation ?? null);
-            setTranslationUsedProvider(res.provider ? (res.model ? `${res.provider} (${res.model})` : res.provider) : "cached");
-          }
-        } catch { /* ignore */ }
-        if (!cancelled && currentChapterKey.current === cacheKey) setTranslationLoading(false);
-        return;
-      }
+      // Not cached — check if already queued so we can show the queue banner
+      try {
+        const queueStatus = await getChapterQueueStatus(bid, chapterIndex, translationLang);
+        if (cancelled || currentChapterKey.current !== cacheKey) return;
+        if (queueStatus.status === "pending" || queueStatus.status === "running") {
+          setTranslationLoading(false);
+          setTranslationUsedProvider(
+            queueStatus.status === "running"
+              ? "queue · translating now"
+              : `queue · position ${queueStatus.position ?? "?"}`
+          );
+          return;
+        }
+      } catch { /* ignore */ }
 
-      if (queueStatus.status === "pending" || queueStatus.status === "running") {
-        // Already queued — show queue banner and start polling via handleTranslateThisChapter
-        setTranslationLoading(false);
-        if (queueStatus.status === "running") setTranslationUsedProvider("queue · translating now");
-        else setTranslationUsedProvider(`queue · position ${queueStatus.position ?? "?"}`);
-        return;
-      }
-
-      // Not translated yet (null / failed / skipped) — show "Translate this chapter" button
-      setTranslationLoading(false);
+      // Not translated and not queued — show "Translate this chapter" button
+      if (!cancelled && currentChapterKey.current === cacheKey) setTranslationLoading(false);
     })();
 
     return () => { cancelled = true; };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -267,6 +267,18 @@ export function getChapterQueueStatus(
   );
 }
 
+/** Returns the cached translation if available, throws ApiError(404) if not.
+ * Never enqueues — safe to call on page load. */
+export function getChapterTranslation(
+  bookId: number,
+  chapterIndex: number,
+  targetLanguage: string,
+): Promise<ChapterTranslationResponse> {
+  return request<ChapterTranslationResponse>(
+    `/books/${bookId}/chapters/${chapterIndex}/translation?target_language=${encodeURIComponent(targetLanguage)}`,
+  );
+}
+
 /** Reader-side unified translate endpoint. Returns the cached translation
  * if available, otherwise enqueues the chapter (high priority) and
  * returns queue status. Reader polls until status === 'ready'. */


### PR DESCRIPTION
## Summary

The previous fix (#189) was wrong: `getChapterQueueStatus` **never returns "done"** because queue rows are deleted when a translation completes. A cached translation was indistinguishable from "not yet requested" — both return `status: null`.

**Root cause:** The only reliable way to know if a translation exists on the server is to query the `translations` table directly.

**Fix:**
- Added `GET /books/{id}/chapters/{idx}/translation?target_language=...` backend endpoint that returns the cached translation or 404 — never touches the queue table
- Added `getChapterTranslation()` frontend API function  
- On page load with `translationEnabled=true`, the useEffect now calls GET first:
  - 200 + paragraphs → auto-load the translation (button never shown)
  - 404 → check queue status: if pending/running show banner; if neither show "Translate this chapter" button
- Updated E2E mocks to return 404 for GET / "ready" for POST so explicit button-click tests still work

## Test plan

- [x] All 19 E2E tests pass (`reader.spec.ts` + `annotation-translation.spec.ts`)
- [x] All 305 Jest unit tests pass  
- [x] 654 backend pytest tests pass (3 new tests for GET endpoint)
