### PR TITLE
test(e2e): add regression test — translate button hidden when server has cached translation

### DIFF
--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -105,8 +105,9 @@ export async function mockBackend(page: Page) {
     route.fulfill({ status: 200, contentType: "audio/mpeg", body: Buffer.from([0xff, 0xfb]) })
   );
 
-  // GET translation check: 404 = not cached (shows "Translate this chapter" button)
-  await page.route(/\/api\/books\/\d+\/chapters\/\d+\/translation$/, (route) => {
+  // GET translation check: 404 = not cached (shows "Translate this chapter" button).
+  // Regex matches ?target_language=... query string; excludes translation-status, /retry etc.
+  await page.route(/\/api\/books\/\d+\/chapters\/\d+\/translation(\?.*)?$/, (route) => {
     if (route.request().method() === "GET") {
       route.fulfill({ status: 404, json: { detail: "Translation not cached" } });
     } else {

--- a/frontend/e2e/reader.spec.ts
+++ b/frontend/e2e/reader.spec.ts
@@ -60,6 +60,23 @@ async function seedTranslationEnabled(page: import("@playwright/test").Page, lan
   await page.goto("/reader/1342");
 }
 
+test("translation auto-loads and hides button when server has cached translation", async ({ page }) => {
+  // Regression: button was shown even when server already had a cached translation
+  // because the old code only checked in-memory cache, not the server.
+  // Uses regex (not glob) to also match the ?target_language=... query string.
+  await page.route(/\/api\/books\/\d+\/chapters\/\d+\/translation(\?.*)?$/, (route) => {
+    if (route.request().method() === "GET") {
+      route.fulfill({ json: { status: "ready", paragraphs: ["Server-cached translation."], provider: "gemini" } });
+    } else {
+      route.fallback();
+    }
+  });
+
+  await seedTranslationEnabled(page);
+  await expect(page.getByText("Server-cached translation.")).toBeVisible({ timeout: 5000 });
+  await expect(page.getByRole("button", { name: "Translate this chapter" })).not.toBeVisible();
+});
+
 test("translation does not show Gemini reminder (queue returns ready)", async ({ page }) => {
   await page.route("**/api/user/me", (route) =>
     route.fulfill({


### PR DESCRIPTION
## Summary

- Adds the regression test that was missing from the bug fix: the "Translate this chapter" button must NOT appear when the server already has a cached translation for the chapter
- Fixes the fixture GET mock regex: the previous pattern ended with `$` which excluded URLs with `?target_language=...` query strings, so the mock never actually fired for GET requests
- The new test uses a regex pattern that matches query strings and would have failed against both wrong fixes (the queue-status approach and the first PR)

## Test plan

- [x] New test passes: `translation auto-loads and hides button when server has cached translation`
- [x] All 20 E2E tests pass
