### PR TITLE
test(frontend): add unit tests for InsightChat, BulkTranslateTab, ProfilePage, api errors, ImportPage

### DIFF
--- a/frontend/src/__tests__/BulkTranslateTab.test.tsx
+++ b/frontend/src/__tests__/BulkTranslateTab.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * BulkTranslateTab — status polling, plan generation, job start/stop,
+ * confirmation guards, error display, and progress calculation.
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import BulkTranslateTab from "@/components/BulkTranslateTab";
+
+const IDLE_STATUS = { running: false, state: null, preview: null };
+const RUNNING_STATUS = {
+  running: true,
+  state: {
+    id: 1,
+    status: "running",
+    target_language: "zh",
+    provider: "gemini",
+    model: "gemini-2.5-flash",
+    dry_run: false,
+    total_chapters: 100,
+    completed_chapters: 50,
+    failed_chapters: 0,
+    skipped_chapters: 0,
+    requests_made: 50,
+    current_book_id: 1342,
+    current_book_title: "Pride and Prejudice",
+    current_chapter_index: 5,
+    last_error: "",
+    started_at: "2026-01-01T00:00:00Z",
+    ended_at: null,
+  },
+  preview: null,
+};
+const EMPTY_HISTORY: never[] = [];
+
+function makeAdminFetch(statusResp = IDLE_STATUS, historyResp = EMPTY_HISTORY) {
+  return jest.fn().mockImplementation((path: string) => {
+    if (path.includes("/status")) return Promise.resolve(statusResp);
+    if (path.includes("/history")) return Promise.resolve(historyResp);
+    if (path.includes("/plan")) return Promise.resolve({
+      total_books: 2,
+      total_chapters: 40,
+      total_batches: 4,
+      total_words: 80000,
+      estimated_minutes_at_rpm: 200,
+      estimated_days_at_rpd: 0.28,
+      books: [],
+    });
+    if (path.includes("/start") || path.includes("/stop")) return Promise.resolve({});
+    return Promise.resolve({});
+  });
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.spyOn(window, "confirm").mockReturnValue(true);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+describe("BulkTranslateTab — status polling", () => {
+  it("calls status and history endpoints on mount", async () => {
+    const adminFetch = makeAdminFetch();
+    render(<BulkTranslateTab adminFetch={adminFetch} />);
+    await waitFor(() => {
+      expect(adminFetch).toHaveBeenCalledWith("/admin/bulk-translate/status");
+      expect(adminFetch).toHaveBeenCalledWith("/admin/bulk-translate/history");
+    });
+  });
+
+  it("polls every 3 seconds", async () => {
+    const adminFetch = makeAdminFetch();
+    render(<BulkTranslateTab adminFetch={adminFetch} />);
+    await waitFor(() => expect(adminFetch).toHaveBeenCalled());
+    const callsBefore = adminFetch.mock.calls.length;
+
+    act(() => { jest.advanceTimersByTime(3000); });
+    await waitFor(() => expect(adminFetch.mock.calls.length).toBeGreaterThan(callsBefore));
+  });
+});
+
+describe("BulkTranslateTab — plan generation", () => {
+  it("shows plan estimates after clicking Plan button", async () => {
+    const adminFetch = makeAdminFetch();
+    render(<BulkTranslateTab adminFetch={adminFetch} />);
+    await waitFor(() => screen.getByRole("button", { name: /plan/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /plan/i }));
+
+    await waitFor(() => {
+      expect(adminFetch).toHaveBeenCalledWith(
+        "/admin/bulk-translate/plan",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+    await waitFor(() => {
+      // Plan results are displayed — chapter count
+      expect(screen.getByText(/40/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows error message when plan request fails", async () => {
+    const adminFetch = jest.fn().mockImplementation((path: string) => {
+      if (path.includes("/status")) return Promise.resolve(IDLE_STATUS);
+      if (path.includes("/history")) return Promise.resolve(EMPTY_HISTORY);
+      if (path.includes("/plan")) return Promise.reject(new Error("Network error"));
+      return Promise.resolve({});
+    });
+    render(<BulkTranslateTab adminFetch={adminFetch} />);
+    await waitFor(() => screen.getByRole("button", { name: /plan/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /plan/i }));
+    await waitFor(() => expect(screen.getByText(/Network error/)).toBeInTheDocument());
+  });
+});
+
+describe("BulkTranslateTab — start/stop job", () => {
+  it("calls start endpoint and refreshes status after confirmation", async () => {
+    const adminFetch = makeAdminFetch();
+    render(<BulkTranslateTab adminFetch={adminFetch} />);
+    await waitFor(() => screen.getByRole("button", { name: /start/i }));
+
+    // Click the "Start real job" button (not dry run)
+    fireEvent.click(screen.getByRole("button", { name: /start real/i }));
+
+    await waitFor(() =>
+      expect(adminFetch).toHaveBeenCalledWith(
+        "/admin/bulk-translate/start",
+        expect.objectContaining({ method: "POST" })
+      )
+    );
+  });
+
+  it("does NOT call start endpoint when user cancels confirmation", async () => {
+    (window.confirm as jest.Mock).mockReturnValue(false);
+    const adminFetch = makeAdminFetch();
+    render(<BulkTranslateTab adminFetch={adminFetch} />);
+    await waitFor(() => screen.getByRole("button", { name: /start real/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /start real/i }));
+
+    await act(async () => {});
+    expect(adminFetch).not.toHaveBeenCalledWith(
+      "/admin/bulk-translate/start",
+      expect.anything()
+    );
+  });
+
+  it("shows Stop button and calls stop endpoint when job is running", async () => {
+    const adminFetch = makeAdminFetch(RUNNING_STATUS);
+    render(<BulkTranslateTab adminFetch={adminFetch} />);
+    await waitFor(() => screen.getByRole("button", { name: /stop/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /stop/i }));
+
+    await waitFor(() =>
+      expect(adminFetch).toHaveBeenCalledWith(
+        "/admin/bulk-translate/stop",
+        expect.objectContaining({ method: "POST" })
+      )
+    );
+  });
+});
+
+describe("BulkTranslateTab — progress display", () => {
+  it("shows correct progress percentage when job is running", async () => {
+    const adminFetch = makeAdminFetch(RUNNING_STATUS);
+    render(<BulkTranslateTab adminFetch={adminFetch} />);
+    // 50/100 = 50%
+    await waitFor(() => expect(screen.getByText(/50%/)).toBeInTheDocument());
+  });
+
+  it("shows current book title while running", async () => {
+    const adminFetch = makeAdminFetch(RUNNING_STATUS);
+    render(<BulkTranslateTab adminFetch={adminFetch} />);
+    await waitFor(() =>
+      expect(screen.getByText(/Pride and Prejudice/)).toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/src/__tests__/ImportPage.test.tsx
+++ b/frontend/src/__tests__/ImportPage.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Import page — stage transitions, error handling, 401 gate, and
+ * auto-redirect after completion.
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import BookImportPage from "@/app/import/[bookId]/page";
+import { ApiError } from "@/lib/api";
+
+jest.mock("next/navigation", () => ({
+  useParams: jest.fn().mockReturnValue({ bookId: "1342" }),
+  useRouter: jest.fn().mockReturnValue({ push: jest.fn() }),
+  useSearchParams: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue(null) }),
+}));
+
+jest.mock("@/lib/api", () => {
+  const actual = jest.requireActual("@/lib/api");
+  return {
+    ...actual,
+    importBookStream: jest.fn(),
+    ApiError: actual.ApiError,
+  };
+});
+
+jest.mock("@/lib/settings", () => ({
+  getSettings: jest.fn().mockReturnValue({ translationLang: "de" }),
+}));
+
+const { importBookStream } = require("@/lib/api");
+
+async function* makeStream(events: object[]) {
+  for (const ev of events) yield ev;
+}
+
+async function* failingStream(error: Error) {
+  throw error;
+  yield {}; // never reached; satisfies generator type
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("ImportPage — stage transitions", () => {
+  it("shows stage list after starting import", async () => {
+    importBookStream.mockReturnValue(makeStream([]));
+    render(<BookImportPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: /start import/i }));
+    await waitFor(() => {
+      expect(screen.getByText("Download text")).toBeInTheDocument();
+      expect(screen.getByText("Split chapters")).toBeInTheDocument();
+    });
+  });
+
+  it("shows book title after meta event", async () => {
+    importBookStream.mockReturnValue(
+      makeStream([{ event: "meta", title: "Pride and Prejudice" }])
+    );
+    render(<BookImportPage />);
+    fireEvent.click(screen.getByRole("button", { name: /start import/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Pride and Prejudice/i)).toBeInTheDocument()
+    );
+  });
+
+  it("marks Split chapters as done after chapters event", async () => {
+    importBookStream.mockReturnValue(
+      makeStream([{ event: "chapters", total: 61 }])
+    );
+    render(<BookImportPage />);
+    fireEvent.click(screen.getByRole("button", { name: /start import/i }));
+
+    // "Start reading now" button appears only after splitting is done and chapterCount > 0
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /start reading now/i })).toBeInTheDocument()
+    );
+  });
+
+  it("redirects to reader after done event (after 1.5s delay)", async () => {
+    const { useRouter } = require("next/navigation");
+    const push = jest.fn();
+    useRouter.mockReturnValue({ push });
+
+    importBookStream.mockReturnValue(makeStream([{ event: "done" }]));
+    render(<BookImportPage />);
+    fireEvent.click(screen.getByRole("button", { name: /start import/i }));
+
+    await waitFor(() => screen.getByText(/Done — opening your book/i));
+    act(() => jest.advanceTimersByTime(1500));
+    expect(push).toHaveBeenCalledWith("/reader/1342");
+  });
+});
+
+describe("ImportPage — error handling", () => {
+  it("shows error message when stream emits error event", async () => {
+    importBookStream.mockReturnValue(
+      makeStream([{ event: "error", message: "Gutenberg timeout", stage: "fetching" }])
+    );
+    render(<BookImportPage />);
+    fireEvent.click(screen.getByRole("button", { name: /start import/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Gutenberg timeout/i)).toBeInTheDocument()
+    );
+  });
+
+  it("shows generic error message on stream throw", async () => {
+    importBookStream.mockReturnValue(failingStream(new Error("Network error")));
+    render(<BookImportPage />);
+    fireEvent.click(screen.getByRole("button", { name: /start import/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Network error/i)).toBeInTheDocument()
+    );
+  });
+
+  it("shows login-required message on 401 ApiError", async () => {
+    importBookStream.mockReturnValue(
+      failingStream(new ApiError(401, "Login required"))
+    );
+    render(<BookImportPage />);
+    fireEvent.click(screen.getByRole("button", { name: /start import/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Login required/i)).toBeInTheDocument()
+    );
+  });
+});
+
+describe("ImportPage — abort / cancel", () => {
+  it("shows Cancel button during import", async () => {
+    importBookStream.mockReturnValue(makeStream([]));
+    render(<BookImportPage />);
+    fireEvent.click(screen.getByRole("button", { name: /start import/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /^Cancel$/i })).toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/src/__tests__/InsightChat.history.test.tsx
+++ b/frontend/src/__tests__/InsightChat.history.test.tsx
@@ -40,11 +40,12 @@ beforeEach(() => {
 describe("InsightChat — history persistence", () => {
   it("saves messages to localStorage after receiving an insight", async () => {
     render(<InsightChat {...BASE} />);
-    await waitFor(() =>
-      expect(localStorage.getItem(HISTORY_KEY(1, "1342"))).not.toBeNull()
-    );
-    const stored = JSON.parse(localStorage.getItem(HISTORY_KEY(1, "1342"))!);
-    expect(stored.some((m: any) => m.content === "Chapter insight.")).toBe(true);
+    await waitFor(() => {
+      const raw = localStorage.getItem(HISTORY_KEY(1, "1342"));
+      expect(raw).not.toBeNull();
+      const stored = JSON.parse(raw!);
+      expect(stored.some((m: any) => m.content === "Chapter insight.")).toBe(true);
+    });
   });
 
   it("restores previous messages from localStorage on mount", async () => {

--- a/frontend/src/__tests__/InsightChat.history.test.tsx
+++ b/frontend/src/__tests__/InsightChat.history.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * InsightChat — localStorage history persistence, chapter deduplication,
+ * message pagination, and max-message cap.
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import InsightChat from "@/components/InsightChat";
+
+jest.mock("@/lib/api", () => ({
+  getInsight: jest.fn().mockResolvedValue({ insight: "Chapter insight." }),
+  askQuestion: jest.fn().mockResolvedValue({ answer: "A fine answer." }),
+}));
+
+jest.mock("@/lib/settings", () => ({
+  getSettings: jest.fn().mockReturnValue({ insightLang: "en", chatFontSize: "xs" }),
+  saveSettings: jest.fn(),
+}));
+
+const BASE = {
+  bookId: "1342",
+  userId: 1,
+  hasGeminiKey: true,
+  isVisible: true,
+  chapterText: "It is a truth universally acknowledged.",
+  chapterTitle: "Chapter I",
+  selectedText: "",
+  bookTitle: "Pride and Prejudice",
+  author: "Jane Austen",
+  bookLanguage: "en",
+};
+
+const HISTORY_KEY = (userId: number | string, bookId: string) =>
+  `chat-history:${userId}:${bookId}`;
+
+beforeEach(() => {
+  localStorage.clear();
+  jest.clearAllMocks();
+});
+
+describe("InsightChat — history persistence", () => {
+  it("saves messages to localStorage after receiving an insight", async () => {
+    render(<InsightChat {...BASE} />);
+    await waitFor(() =>
+      expect(localStorage.getItem(HISTORY_KEY(1, "1342"))).not.toBeNull()
+    );
+    const stored = JSON.parse(localStorage.getItem(HISTORY_KEY(1, "1342"))!);
+    expect(stored.some((m: any) => m.content === "Chapter insight.")).toBe(true);
+  });
+
+  it("restores previous messages from localStorage on mount", async () => {
+    const existing = [
+      { role: "assistant", content: "Old insight.", isChapterHeader: false },
+    ];
+    localStorage.setItem(HISTORY_KEY(1, "1342"), JSON.stringify(existing));
+
+    render(<InsightChat {...BASE} isVisible={false} />);
+    await screen.findByText("Old insight.");
+  });
+
+  it("scopes history by userId so different users don't share chat", async () => {
+    const user1History = [{ role: "assistant", content: "User 1 insight." }];
+    localStorage.setItem(HISTORY_KEY(1, "1342"), JSON.stringify(user1History));
+
+    render(<InsightChat {...BASE} userId={2} isVisible={false} />);
+    // User 2 should NOT see user 1's messages
+    expect(screen.queryByText("User 1 insight.")).not.toBeInTheDocument();
+  });
+
+  it("caps stored messages at 200 (MAX_STORED)", async () => {
+    // Seed 210 messages
+    const manyMessages = Array.from({ length: 210 }, (_, i) => ({
+      role: "assistant",
+      content: `msg-${i}`,
+    }));
+    localStorage.setItem(HISTORY_KEY(1, "1342"), JSON.stringify(manyMessages));
+
+    render(<InsightChat {...BASE} isVisible={false} />);
+
+    // Trigger a new message to force a save
+    await act(async () => {
+      const input = screen.getByRole("textbox");
+      fireEvent.change(input, { target: { value: "hello" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+    });
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem(HISTORY_KEY(1, "1342"))!);
+      expect(stored.length).toBeLessThanOrEqual(200);
+    });
+  });
+});
+
+describe("InsightChat — chapter deduplication", () => {
+  it("does not fetch insight twice for the same chapter", async () => {
+    const { getInsight } = require("@/lib/api");
+    const { rerender } = render(<InsightChat {...BASE} />);
+    await waitFor(() => expect(getInsight).toHaveBeenCalledTimes(1));
+
+    // Re-render with same chapter (simulate sidebar close/reopen)
+    rerender(<InsightChat {...BASE} isVisible={false} />);
+    rerender(<InsightChat {...BASE} isVisible={true} />);
+
+    await act(async () => {});
+    // Still only one call
+    expect(getInsight).toHaveBeenCalledTimes(1);
+  });
+
+  it("fetches insight again for a new chapter", async () => {
+    const { getInsight } = require("@/lib/api");
+    const { rerender } = render(<InsightChat {...BASE} />);
+    await waitFor(() => expect(getInsight).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <InsightChat
+        {...BASE}
+        chapterText="Mr. Bennet was among the earliest."
+        chapterTitle="Chapter II"
+      />
+    );
+    await waitFor(() => expect(getInsight).toHaveBeenCalledTimes(2));
+  });
+
+  it("restores visitedKeys from history so insight is not re-fetched after reload", async () => {
+    const { getInsight } = require("@/lib/api");
+    const chapterKey = BASE.chapterText.slice(0, 100);
+    const history = [
+      { role: "assistant", content: "Chapter I", isChapterHeader: true, chapterKey },
+      { role: "assistant", content: "Saved insight." },
+    ];
+    localStorage.setItem(HISTORY_KEY(1, "1342"), JSON.stringify(history));
+
+    render(<InsightChat {...BASE} />);
+    await act(async () => {});
+    // visitedKeys was populated from history → no new API call
+    expect(getInsight).not.toHaveBeenCalled();
+  });
+});
+
+describe("InsightChat — pagination", () => {
+  it("shows 'Load earlier' button when history has more than 30 messages", () => {
+    const manyMessages = Array.from({ length: 35 }, (_, i) => ({
+      role: "assistant" as const,
+      content: `msg-${i}`,
+    }));
+    localStorage.setItem(HISTORY_KEY(1, "1342"), JSON.stringify(manyMessages));
+
+    render(<InsightChat {...BASE} isVisible={false} />);
+    expect(screen.getByText(/Load earlier/)).toBeInTheDocument();
+  });
+
+  it("does not show 'Load earlier' when fewer than 30 messages", () => {
+    const fewMessages = Array.from({ length: 5 }, (_, i) => ({
+      role: "assistant" as const,
+      content: `msg-${i}`,
+    }));
+    localStorage.setItem(HISTORY_KEY(1, "1342"), JSON.stringify(fewMessages));
+
+    render(<InsightChat {...BASE} isVisible={false} />);
+    expect(screen.queryByText(/Load earlier/)).not.toBeInTheDocument();
+  });
+});
+
+describe("InsightChat — hasGeminiKey=false", () => {
+  it("does not fetch insight and does not call onAIUsed", async () => {
+    const { getInsight } = require("@/lib/api");
+    const onAIUsed = jest.fn();
+    render(<InsightChat {...BASE} hasGeminiKey={false} onAIUsed={onAIUsed} />);
+    await act(async () => {});
+    expect(getInsight).not.toHaveBeenCalled();
+    expect(onAIUsed).not.toHaveBeenCalled();
+  });
+
+  it("disables the textarea when hasGeminiKey is false", () => {
+    render(<InsightChat {...BASE} hasGeminiKey={false} />);
+    expect(screen.getByRole("textbox")).toBeDisabled();
+  });
+});

--- a/frontend/src/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/__tests__/ProfilePage.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * ProfilePage — Gemini key save/delete, Obsidian settings, preferences,
+ * success/error messages, and admin visibility.
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import ProfilePage from "@/app/profile/page";
+
+jest.mock("next-auth/react", () => ({
+  useSession: jest.fn().mockReturnValue({
+    data: { backendToken: "test-token", backendUser: { name: "Test" } },
+  }),
+  signOut: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn().mockReturnValue({ push: jest.fn() }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  saveGeminiKey: jest.fn().mockResolvedValue({}),
+  deleteGeminiKey: jest.fn().mockResolvedValue({}),
+  getMe: jest.fn().mockResolvedValue({ hasGeminiKey: false, role: "user" }),
+  getObsidianSettings: jest.fn().mockResolvedValue({
+    obsidian_repo: "user/vault",
+    obsidian_path: "Notes/Books",
+  }),
+  saveObsidianSettings: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock("@/lib/settings", () => ({
+  getSettings: jest.fn().mockReturnValue({
+    insightLang: "en",
+    translationLang: "de",
+    translationEnabled: false,
+    ttsGender: "female",
+    chatFontSize: "xs",
+    translationProvider: "auto",
+    fontSize: "base",
+    theme: "light",
+  }),
+  saveSettings: jest.fn(),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("ProfilePage — Gemini key management", () => {
+  it("does not call saveGeminiKey when input is empty", async () => {
+    const { saveGeminiKey } = require("@/lib/api");
+    render(<ProfilePage />);
+    fireEvent.click(screen.getByRole("button", { name: /save key/i }));
+    await act(async () => {});
+    expect(saveGeminiKey).not.toHaveBeenCalled();
+  });
+
+  it("calls saveGeminiKey with trimmed key and shows success message", async () => {
+    const { saveGeminiKey } = require("@/lib/api");
+    render(<ProfilePage />);
+
+    const input = screen.getByPlaceholderText(/AIza/i);
+    fireEvent.change(input, { target: { value: "  my-key  " } });
+    fireEvent.click(screen.getByRole("button", { name: /save key/i }));
+
+    await waitFor(() => {
+      expect(saveGeminiKey).toHaveBeenCalledWith("my-key");
+      expect(screen.getByText(/Gemini API key saved/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows error message when saveGeminiKey fails", async () => {
+    const { saveGeminiKey } = require("@/lib/api");
+    saveGeminiKey.mockRejectedValueOnce(new Error("Invalid key format"));
+
+    render(<ProfilePage />);
+    const input = screen.getByPlaceholderText(/AIza/i);
+    fireEvent.change(input, { target: { value: "bad-key" } });
+    fireEvent.click(screen.getByRole("button", { name: /save key/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Invalid key format/i)).toBeInTheDocument()
+    );
+  });
+
+  it("calls deleteGeminiKey and shows success message when key exists", async () => {
+    const { getMe, deleteGeminiKey } = require("@/lib/api");
+    getMe.mockResolvedValueOnce({ hasGeminiKey: true, role: "user" });
+
+    render(<ProfilePage />);
+    await waitFor(() => screen.getByRole("button", { name: /remove key/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /remove key/i }));
+
+    await waitFor(() => {
+      expect(deleteGeminiKey).toHaveBeenCalled();
+      expect(screen.getByText(/Gemini key removed/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows error message when deleteGeminiKey fails", async () => {
+    const { getMe, deleteGeminiKey } = require("@/lib/api");
+    getMe.mockResolvedValueOnce({ hasGeminiKey: true, role: "user" });
+    deleteGeminiKey.mockRejectedValueOnce(new Error("Server error"));
+
+    render(<ProfilePage />);
+    await waitFor(() => screen.getByRole("button", { name: /remove key/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /remove key/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/Server error/i)).toBeInTheDocument()
+    );
+  });
+});
+
+describe("ProfilePage — Obsidian settings", () => {
+  it("loads existing Obsidian repo from API on mount", async () => {
+    render(<ProfilePage />);
+    await waitFor(() => {
+      const repoInput = screen.getByPlaceholderText(/username\/obsidian-notes/i);
+      expect((repoInput as HTMLInputElement).value).toBe("user/vault");
+    });
+  });
+
+  it("calls saveObsidianSettings and clears token input on success", async () => {
+    const { saveObsidianSettings } = require("@/lib/api");
+    render(<ProfilePage />);
+    await waitFor(() => screen.getByPlaceholderText(/username\/obsidian-notes/i));
+
+    const tokenInput = screen.getByPlaceholderText(/ghp_/i);
+    fireEvent.change(tokenInput, { target: { value: "ghp_abc123" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /save obsidian settings/i }));
+
+    await waitFor(() => {
+      expect(saveObsidianSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ github_token: "ghp_abc123" })
+      );
+      expect(screen.getByText(/Obsidian settings saved/i)).toBeInTheDocument();
+    });
+    expect((tokenInput as HTMLInputElement).value).toBe("");
+  });
+
+  it("does not include github_token when token input is empty", async () => {
+    const { saveObsidianSettings } = require("@/lib/api");
+    render(<ProfilePage />);
+    await waitFor(() => screen.getByPlaceholderText(/username\/obsidian-notes/i));
+
+    fireEvent.click(screen.getByRole("button", { name: /save obsidian settings/i }));
+
+    await waitFor(() => expect(saveObsidianSettings).toHaveBeenCalled());
+    const call = saveObsidianSettings.mock.calls[0][0];
+    expect(call).not.toHaveProperty("github_token");
+  });
+
+  it("shows error when saveObsidianSettings fails", async () => {
+    const { saveObsidianSettings } = require("@/lib/api");
+    saveObsidianSettings.mockRejectedValueOnce(new Error("Auth failed"));
+
+    render(<ProfilePage />);
+    await waitFor(() => screen.getByRole("button", { name: /save obsidian settings/i }));
+    fireEvent.click(screen.getByRole("button", { name: /save obsidian settings/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Auth failed/i)).toBeInTheDocument()
+    );
+  });
+});
+
+describe("ProfilePage — preferences", () => {
+  it("loads settings from localStorage on mount and shows translation language", async () => {
+    render(<ProfilePage />);
+    await act(async () => {});
+    // Two selects on page: insight lang and translation lang
+    const selects = screen.getAllByRole("combobox");
+    const translationSelect = selects.find(
+      (s) => (s as HTMLSelectElement).value === "de"
+    );
+    expect(translationSelect).toBeDefined();
+  });
+
+  it("calls saveSettings when Save preferences button is clicked", async () => {
+    const { saveSettings } = require("@/lib/settings");
+    render(<ProfilePage />);
+
+    fireEvent.click(screen.getByRole("button", { name: /save preferences/i }));
+    expect(saveSettings).toHaveBeenCalled();
+  });
+
+  it("shows 'Saved!' confirmation after saving preferences", async () => {
+    render(<ProfilePage />);
+    fireEvent.click(screen.getByRole("button", { name: /save preferences/i }));
+    expect(screen.getByRole("button", { name: /saved!/i })).toBeInTheDocument();
+  });
+});
+
+describe("ProfilePage — admin visibility", () => {
+  it("does not show Admin Panel button for regular users", async () => {
+    render(<ProfilePage />);
+    await waitFor(() => screen.getByText(/Profile/i));
+    expect(screen.queryByRole("button", { name: /admin panel/i })).not.toBeInTheDocument();
+  });
+
+  it("shows Admin Panel button when user is admin", async () => {
+    const { getMe } = require("@/lib/api");
+    getMe.mockResolvedValueOnce({ hasGeminiKey: false, role: "admin" });
+
+    render(<ProfilePage />);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /admin panel/i })).toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/src/__tests__/api.errors.test.ts
+++ b/frontend/src/__tests__/api.errors.test.ts
@@ -1,0 +1,128 @@
+/**
+ * api.ts — ApiError status codes, markSessionSettled/awaitSession gate,
+ * and status-specific error propagation.
+ */
+import {
+  setAuthToken,
+  markSessionSettled,
+  awaitSession,
+  ApiError,
+  getBookMeta,
+  getMe,
+  saveGeminiKey,
+  requestChapterTranslation,
+  getChapterTranslation,
+} from "@/lib/api";
+
+function mockResponse(body: unknown, status: number) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: String(status),
+    json: jest.fn().mockResolvedValue(body),
+  });
+}
+
+beforeEach(() => {
+  setAuthToken("test-token");
+  // Ensure session is settled so requests don't block
+  markSessionSettled();
+  jest.clearAllMocks();
+});
+
+describe("ApiError — status code propagation", () => {
+  it("throws ApiError with status 401 on unauthorized response", async () => {
+    mockResponse({ detail: "Not authenticated" }, 401);
+    await expect(getMe()).rejects.toMatchObject({
+      name: "ApiError",
+      status: 401,
+      message: "Not authenticated",
+    });
+  });
+
+  it("throws ApiError with status 403 on forbidden response", async () => {
+    mockResponse({ detail: "Gemini API key required" }, 403);
+    await expect(
+      requestChapterTranslation(1342, 0, "de")
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it("throws ApiError with status 404 on not found response", async () => {
+    mockResponse({ detail: "Translation not cached" }, 404);
+    await expect(
+      getChapterTranslation(1342, 0, "de")
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("throws ApiError with status 400 on bad request", async () => {
+    mockResponse({ detail: "Cannot translate to same language" }, 400);
+    await expect(
+      requestChapterTranslation(1342, 0, "en")
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("uses statusText as fallback when response body has no detail field", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: jest.fn().mockRejectedValue(new Error("no json")),
+    });
+    await expect(getBookMeta(1)).rejects.toThrow("Internal Server Error");
+  });
+
+  it("ApiError instance is instanceof Error", async () => {
+    mockResponse({ detail: "Oops" }, 500);
+    try {
+      await getBookMeta(1);
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error);
+      expect(e).toBeInstanceOf(ApiError);
+    }
+  });
+});
+
+describe("awaitSession — session-settled gate", () => {
+  it("resolves immediately when session is already settled", async () => {
+    // markSessionSettled() was called in beforeEach
+    const resolved = jest.fn();
+    await awaitSession().then(resolved);
+    expect(resolved).toHaveBeenCalled();
+  });
+});
+
+describe("getChapterTranslation — read-only cache check", () => {
+  it("sends GET request to the correct endpoint", async () => {
+    mockResponse({ status: "ready", paragraphs: ["Übersetzung"], provider: "gemini" }, 200);
+    const result = await getChapterTranslation(1342, 0, "de");
+    const url: string = (global.fetch as jest.Mock).mock.calls[0][0];
+    expect(url).toContain("/books/1342/chapters/0/translation");
+    expect(url).toContain("target_language=de");
+    expect((global.fetch as jest.Mock).mock.calls[0][1]?.method).toBeUndefined(); // GET (default)
+    expect(result.status).toBe("ready");
+    expect(result.paragraphs).toEqual(["Übersetzung"]);
+  });
+
+  it("throws ApiError(404) when translation is not cached", async () => {
+    mockResponse({ detail: "Translation not cached" }, 404);
+    await expect(getChapterTranslation(1342, 0, "fr")).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});
+
+describe("saveGeminiKey — key management", () => {
+  it("sends PUT request with key in body", async () => {
+    mockResponse({}, 200);
+    await saveGeminiKey("AIza-my-key");
+    const [url, opts] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toContain("/user/gemini-key");
+    expect(opts.method).toBe("POST");
+    expect(JSON.parse(opts.body)).toMatchObject({ api_key: "AIza-my-key" });
+  });
+
+  it("throws on 403 (e.g. key validation failure)", async () => {
+    mockResponse({ detail: "Invalid key" }, 403);
+    await expect(saveGeminiKey("bad")).rejects.toMatchObject({ status: 403 });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 53 new Jest unit tests (305 → 368 total), covering: InsightChat history persistence and chapter deduplication, BulkTranslateTab polling/plan/start/stop/progress, ProfilePage Gemini key management/Obsidian settings/preferences/admin visibility, api.ts ApiError status codes and session gate, and ImportPage stage transitions/error handling/abort
- Fixes a flawed test in InsightChat.history that resolved `waitFor` too early (after chapter header stored) before the insight response settled — the `waitFor` now checks the full localStorage condition in one assertion

## Test plan
- [ ] All 368 Jest tests pass: `npm --prefix frontend test -- --no-coverage --ci`
- [ ] InsightChat: history saves/restores, userId scoping, 200-message cap, chapter deduplication, `visitedKeys` restored from history, pagination, Gemini key gate
- [ ] BulkTranslateTab: polls on mount, polls every 3s, plan generation + error, start/stop with confirm guard, progress display
- [ ] ProfilePage: Gemini key save/delete with success+error, Obsidian settings load/save/error, preferences, admin panel button
- [ ] api.ts: 401/403/404/400 ApiError with status codes, `statusText` fallback, `instanceof Error`, `getChapterTranslation` GET URL, `saveGeminiKey` POST body
- [ ] ImportPage: stage list, meta title, chapters done → "Start reading now", done event redirect, error event, stream throw, 401 ApiError, Cancel button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
