### PR TITLE
fix(reader): single click no longer triggers TTS when idle

### DIFF
--- a/frontend/src/__tests__/SentenceReader.extended.test.tsx
+++ b/frontend/src/__tests__/SentenceReader.extended.test.tsx
@@ -298,7 +298,7 @@ describe("SentenceReader segment click", () => {
     expect(onSegmentClick.mock.calls[0][0]).toBeGreaterThanOrEqual(0); // startTime
   });
 
-  it("single click calls onSegmentClick when no onSentenceClick provided", () => {
+  it("single click does not call onSegmentClick when TTS is idle", () => {
     const onSegmentClick = jest.fn();
     const { container } = render(
       <SentenceReader
@@ -313,7 +313,7 @@ describe("SentenceReader segment click", () => {
     const segs = getSegments(container);
     fireEvent.click(segs[0]);
 
-    expect(onSegmentClick).toHaveBeenCalledTimes(1);
+    expect(onSegmentClick).not.toHaveBeenCalled();
   });
 
   it("does not call onSegmentClick when disabled", () => {
@@ -498,9 +498,8 @@ describe("SentenceReader long-press annotation (onAnnotate)", () => {
 });
 
 describe("SentenceReader click interactions", () => {
-  it("single click calls onSentenceClick when TTS is idle and onSentenceClick provided", () => {
+  it("single click does nothing when TTS is idle", () => {
     const onSegmentClick = jest.fn();
-    const onSentenceClick = jest.fn();
     const { container } = render(
       <SentenceReader
         text="Click this sentence."
@@ -508,47 +507,23 @@ describe("SentenceReader click interactions", () => {
         currentTime={0}
         isPlaying={false}
         onSegmentClick={onSegmentClick}
-        onSentenceClick={onSentenceClick}
       />
     );
 
     const segs = getSegments(container);
     fireEvent.click(segs[0]);
 
-    expect(onSentenceClick).toHaveBeenCalledTimes(1);
-    expect(onSentenceClick.mock.calls[0][0].sentenceText).toContain("Click this sentence");
     expect(onSegmentClick).not.toHaveBeenCalled();
   });
 
   it("single click calls onSegmentClick when TTS is playing (seek)", () => {
     const onSegmentClick = jest.fn();
-    const onSentenceClick = jest.fn();
     const { container } = render(
       <SentenceReader
         text="Seekable sentence."
         duration={10}
         currentTime={0}
         isPlaying={true}
-        onSegmentClick={onSegmentClick}
-        onSentenceClick={onSentenceClick}
-      />
-    );
-
-    const segs = getSegments(container);
-    fireEvent.click(segs[0]);
-
-    expect(onSegmentClick).toHaveBeenCalledTimes(1);
-    expect(onSentenceClick).not.toHaveBeenCalled();
-  });
-
-  it("single click calls onSegmentClick when no onSentenceClick provided", () => {
-    const onSegmentClick = jest.fn();
-    const { container } = render(
-      <SentenceReader
-        text="Fallback sentence."
-        duration={0}
-        currentTime={0}
-        isPlaying={false}
         onSegmentClick={onSegmentClick}
       />
     );
@@ -561,7 +536,6 @@ describe("SentenceReader click interactions", () => {
 
   it("click does not fire when disabled", () => {
     const onSegmentClick = jest.fn();
-    const onSentenceClick = jest.fn();
     const { container } = render(
       <SentenceReader
         text="Disabled sentence."
@@ -569,7 +543,6 @@ describe("SentenceReader click interactions", () => {
         currentTime={0}
         isPlaying={false}
         onSegmentClick={onSegmentClick}
-        onSentenceClick={onSentenceClick}
         disabled
       />
     );
@@ -578,12 +551,10 @@ describe("SentenceReader click interactions", () => {
     fireEvent.click(segs[0]);
 
     expect(onSegmentClick).not.toHaveBeenCalled();
-    expect(onSentenceClick).not.toHaveBeenCalled();
   });
 
   it("click does not fire when user has made a text selection (drag-to-select)", () => {
     const onSegmentClick = jest.fn();
-    const onSentenceClick = jest.fn();
     const { container } = render(
       <SentenceReader
         text="Select this text."
@@ -591,12 +562,9 @@ describe("SentenceReader click interactions", () => {
         currentTime={5}
         isPlaying={true}
         onSegmentClick={onSegmentClick}
-        onSentenceClick={onSentenceClick}
       />
     );
 
-    // Simulate browser behaviour: user dragged to select text, then mouseup fires click.
-    // Mock window.getSelection to return a non-empty selection string.
     const origGetSelection = window.getSelection;
     window.getSelection = () => ({ toString: () => "Select this" } as Selection);
 
@@ -606,7 +574,6 @@ describe("SentenceReader click interactions", () => {
     window.getSelection = origGetSelection;
 
     expect(onSegmentClick).not.toHaveBeenCalled();
-    expect(onSentenceClick).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -285,18 +285,6 @@ interface Props {
     chapterIndex: number;
     translationText?: string;
   }) => void;
-  /**
-   * Single-click handler (when TTS is NOT playing). Fires with the clicked
-   * sentence text, its TTS start time, the click position, and optional
-   * translation. The parent opens a quick-action popup (read, note, chat).
-   */
-  onSentenceClick?: (info: {
-    sentenceText: string;
-    startTime: number;
-    position: { x: number; y: number };
-    translationText?: string;
-    chapterIndex: number;
-  }) => void;
   /** When false, annotation underlines and note dots are hidden. Default true. */
   showAnnotations?: boolean;
 }
@@ -338,7 +326,6 @@ export default function SentenceReader({
   annotations,
   scrollTargetSentence,
   onWordTap,
-  onSentenceClick,
   showAnnotations = true,
 }: Props) {
   const [flashTarget, setFlashTarget] = useState<string | null>(null);
@@ -543,10 +530,6 @@ export default function SentenceReader({
                 // Ignore clicks that are the tail of a text-selection drag
                 if (window.getSelection()?.toString().length) return;
                 if (isPlaying || duration > 0) {
-                  onSegmentClick(seg.startTime, seg.text);
-                } else if (onSentenceClick) {
-                  onSentenceClick({ sentenceText: seg.text, startTime: seg.startTime, position: { x: e.clientX, y: e.clientY }, translationText: translationText || undefined, chapterIndex });
-                } else {
                   onSegmentClick(seg.startTime, seg.text);
                 }
               }}


### PR DESCRIPTION
## Summary

- Removed `onSentenceClick` prop and the `else`/`else if` branches from the segment click handler in `SentenceReader`
- Single click now only seeks (calls `onSegmentClick`) when TTS is already playing; clicking while idle does nothing
- Updated unit tests: "calls onSegmentClick when no onSentenceClick" → "does nothing when TTS is idle"

## Test plan

- [ ] Start reading a book; click a sentence → nothing happens
- [ ] Start TTS playback, click a different sentence → seeks to that sentence
- [ ] `npm --prefix frontend test -- --no-coverage --ci --testPathPatterns=SentenceReader` passes (36 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
