### PR TITLE
feat(import): require explicit translation confirmation with cost estimate

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -12,11 +12,8 @@ from services.db import (
     get_cached_book,
     save_book,
     list_cached_books,
-    get_cached_translation,
-    save_translation,
 )
 from services.splitter import build_chapters, build_chapters_from_html
-from services.translate import translate_text
 from services.auth import get_current_user, get_optional_user, decrypt_api_key
 
 logger = logging.getLogger(__name__)
@@ -420,7 +417,6 @@ def _sse(event: str, data: dict) -> str:
 @router.get("/{book_id}/import-stream")
 async def import_stream(
     book_id: int,
-    target_language: str = Query("", description="Target language for pre-translation (empty = skip)"),
     user: dict | None = Depends(get_optional_user),
 ):
     """Stream import progress for a book via Server-Sent Events.
@@ -428,15 +424,15 @@ async def import_stream(
     Stages:
       fetching   — downloading book text from Gutenberg (if not cached)
       splitting  — computing chapter structure
-      translating — translating each chapter into target_language
       done       — all steps complete
 
-    Idempotent: skips already-cached work (same as preseed_translations.py).
+    Translation is NOT started here. After import the client shows a cost-
+    confirmation panel; the user explicitly enqueues via POST
+    /books/{id}/translations/enqueue-all.
+
+    Idempotent: skips already-cached work.
     All books are publicly accessible without login.
     """
-    # Resolve Gemini key once up front
-    raw_key = user.get("gemini_key") if user else None
-    decrypted_key: str | None = decrypt_api_key(raw_key) if raw_key else None
 
     async def generator() -> AsyncIterator[str]:
         try:
@@ -466,94 +462,12 @@ async def import_stream(
             # ── 2. Split chapters ───────────────────────────────────────────
             yield _sse("stage", {"stage": "splitting", "message": "Splitting chapters…"})
             chapters = build_chapters(text)
+            total_words = sum(len(c.text.split()) for c in chapters)
             yield _sse("chapters", {
                 "total": len(chapters),
+                "total_words": total_words,
                 "titles": [c.title or f"Chapter {i + 1}" for i, c in enumerate(chapters)],
             })
-
-            # ── 3. Translate each chapter ───────────────────────────────────
-            should_translate = (
-                target_language
-                and target_language != source_language
-                and len(chapters) > 0
-            )
-            if should_translate:
-                # Enqueue this book for the user's target language BEFORE the
-                # inline stream runs. Rationale: if the user closes their tab
-                # or the connection drops, the background worker picks up
-                # whatever chapters the stream didn't finish. The save_translation
-                # -> mark-queue-row-done hook clears rows as the inline stream
-                # completes them, so there's no double work in the happy path.
-                try:
-                    from services.translation_queue import enqueue_for_book, worker
-                    queued_by = (user.get("email") or user.get("name") or f"user#{user.get('id')}") if user else "anon"
-                    added = await enqueue_for_book(
-                        book_id,
-                        target_languages=[target_language],
-                        queued_by=queued_by,
-                    )
-                    if added:
-                        worker().wake()
-                except Exception:
-                    logger.warning(
-                        "Failed to pre-enqueue user import for book %s → %s",
-                        book_id, target_language, exc_info=True,
-                    )
-
-                # Resolve provider: prefer Gemini if user has a key, else Google (free)
-                provider = "gemini" if decrypted_key else "google"
-                yield _sse("stage", {
-                    "stage": "translating",
-                    "message": f"Translating to {target_language} ({provider})…",
-                    "total": len(chapters),
-                    "provider": provider,
-                })
-                for i, ch in enumerate(chapters):
-                    if not ch.text.strip():
-                        yield _sse("progress", {"stage": "translating", "current": i + 1,
-                                                "total": len(chapters), "skipped": True})
-                        continue
-
-                    existing = await get_cached_translation(book_id, i, target_language)
-                    if existing:
-                        yield _sse("progress", {"stage": "translating", "current": i + 1,
-                                                "total": len(chapters), "cached": True,
-                                                "title": ch.title})
-                        continue
-
-                    try:
-                        paragraphs = await translate_text(
-                            ch.text, source_language, target_language,
-                            provider=provider, gemini_key=decrypted_key,
-                        )
-                    except Exception as e:
-                        # Fall back to Google if Gemini hits quota/etc.
-                        if provider == "gemini":
-                            try:
-                                paragraphs = await translate_text(
-                                    ch.text, source_language, target_language,
-                                    provider="google",
-                                )
-                            except Exception as e2:
-                                yield _sse("progress", {
-                                    "stage": "translating", "current": i + 1,
-                                    "total": len(chapters), "title": ch.title,
-                                    "error": str(e2)[:120],
-                                })
-                                continue
-                        else:
-                            yield _sse("progress", {
-                                "stage": "translating", "current": i + 1,
-                                "total": len(chapters), "title": ch.title,
-                                "error": str(e)[:120],
-                            })
-                            continue
-
-                    await save_translation(book_id, i, target_language, paragraphs)
-                    yield _sse("progress", {
-                        "stage": "translating", "current": i + 1,
-                        "total": len(chapters), "title": ch.title,
-                    })
 
             yield _sse("done", {"book_id": book_id})
 

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -219,48 +219,33 @@ async def test_import_stream_cached_book_skips_fetch(client):
     assert done[0]["book_id"] == 1342
 
 
-async def test_import_stream_translates_chapters(client):
+async def test_import_stream_does_not_translate(client):
+    """Translation is NOT done during import — user must confirm separately."""
     text = ("CHAPTER I\n\n" + ("Erster Absatz. " * 40)
             + "\n\nCHAPTER II\n\n" + ("Zweiter Absatz. " * 40))
     meta = {**MOCK_META, "languages": ["de"]}
     await save_book(1342, meta, text)
 
-    with patch(
-        "routers.books.translate_text",
-        new_callable=AsyncMock,
-        return_value=["Translated paragraph."],
-    ) as mock_translate:
-        resp = await client.get("/api/books/1342/import-stream?target_language=en")
+    resp = await client.get("/api/books/1342/import-stream")
 
     assert resp.status_code == 200
     events = _parse_sse(resp.text)
     stages = [e["stage"] for e in events if e["event"] == "stage"]
-    assert "translating" in stages
-    # translate_text should have been called at least once (per chapter)
-    assert mock_translate.await_count >= 1
+    assert "translating" not in stages
+    assert any(e["event"] == "done" for e in events)
 
 
-async def test_import_stream_skips_already_translated(client):
-    """Chapters with existing translation cache are reported as cached."""
-    from services.db import save_translation
-    text = ("CHAPTER I\n\n" + ("Erster. " * 40)
-            + "\n\nCHAPTER II\n\n" + ("Zweiter. " * 40))
-    meta = {**MOCK_META, "languages": ["de"]}
-    await save_book(1342, meta, text)
-    # Pre-seed chapter 0 translation
-    await save_translation(1342, 0, "en", ["Already done."])
+async def test_import_stream_chapters_event_has_total_words(client):
+    """chapters event includes total_words for cost estimation in the frontend."""
+    text = ("CHAPTER I\n\n" + ("Word " * 100) + "\n\nCHAPTER II\n\n" + ("Word " * 100))
+    await save_book(1342, MOCK_META, text)
 
-    with patch("routers.books.translate_text",
-               new_callable=AsyncMock, return_value=["x"]) as mock_translate:
-        resp = await client.get("/api/books/1342/import-stream?target_language=en")
+    resp = await client.get("/api/books/1342/import-stream")
 
     events = _parse_sse(resp.text)
-    translating = [e for e in events
-                   if e["event"] == "progress" and e.get("stage") == "translating"]
-    cached_count = sum(1 for e in translating if e.get("cached"))
-    assert cached_count >= 1
-    # Only chapter 1 should have been actually translated (0 was cached)
-    assert mock_translate.await_count <= 1
+    chapters_ev = next(e for e in events if e["event"] == "chapters")
+    assert "total_words" in chapters_ev
+    assert chapters_ev["total_words"] > 0
 
 
 async def test_import_stream_done_event_on_uncached_book(client):

--- a/frontend/src/__tests__/ImportPage.test.tsx
+++ b/frontend/src/__tests__/ImportPage.test.tsx
@@ -18,6 +18,7 @@ jest.mock("@/lib/api", () => {
   return {
     ...actual,
     importBookStream: jest.fn(),
+    enqueueBookTranslation: jest.fn().mockResolvedValue({ ok: true, enqueued: 5 }),
     ApiError: actual.ApiError,
   };
 });
@@ -26,7 +27,7 @@ jest.mock("@/lib/settings", () => ({
   getSettings: jest.fn().mockReturnValue({ translationLang: "de" }),
 }));
 
-const { importBookStream } = require("@/lib/api");
+const { importBookStream, enqueueBookTranslation } = require("@/lib/api");
 
 async function* makeStream(events: object[]) {
   for (const ev of events) yield ev;

--- a/frontend/src/__tests__/importBookStream.test.ts
+++ b/frontend/src/__tests__/importBookStream.test.ts
@@ -39,7 +39,7 @@ test("yields parsed SSE events in order", async () => {
   );
 
   const events = [];
-  for await (const ev of importBookStream(1342, "en")) {
+  for await (const ev of importBookStream(1342)) {
     events.push(ev);
   }
 
@@ -50,20 +50,21 @@ test("yields parsed SSE events in order", async () => {
   ]);
 });
 
-test("passes target_language as query param", async () => {
+test("calls the correct URL without target_language param", async () => {
   global.fetch = jest.fn().mockResolvedValue(sseStream([]));
 
-  const gen = importBookStream(1342, "de");
+  const gen = importBookStream(1342);
   await gen.next();
 
   const [url] = (global.fetch as jest.Mock).mock.calls[0];
-  expect(url).toContain("target_language=de");
+  expect(url).toContain("/books/1342/import-stream");
+  expect(url).not.toContain("target_language");
 });
 
 test("sends Authorization header from auth token", async () => {
   global.fetch = jest.fn().mockResolvedValue(sseStream([]));
 
-  const gen = importBookStream(1342, "en");
+  const gen = importBookStream(1342);
   await gen.next();
 
   const headers = (global.fetch as jest.Mock).mock.calls[0][1].headers;
@@ -71,7 +72,6 @@ test("sends Authorization header from auth token", async () => {
 });
 
 test("handles SSE frame split across chunks", async () => {
-  // Split a frame across two chunks to exercise the buffer logic
   global.fetch = jest.fn().mockResolvedValue(
     sseStream([
       `event: stage\ndata: {"sta`,
@@ -80,7 +80,7 @@ test("handles SSE frame split across chunks", async () => {
   );
 
   const events = [];
-  for await (const ev of importBookStream(1, "en")) {
+  for await (const ev of importBookStream(1)) {
     events.push(ev);
   }
   expect(events.length).toBe(2);
@@ -96,6 +96,6 @@ test("throws on non-ok response", async () => {
     json: jest.fn().mockResolvedValue({ detail: "Access denied" }),
   });
 
-  const gen = importBookStream(1342, "en");
+  const gen = importBookStream(1342);
   await expect(gen.next()).rejects.toThrow("Access denied");
 });

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -196,7 +196,7 @@ export default function BookImportPage() {
     chapterCount > 0 &&
     !!tl &&
     tl !== sourceLanguage &&
-    translateState === "idle";
+    !translationActioned;
   const readyToRedirect = isDone && (translationActioned || !showTranslatePrompt);
 
   useEffect(() => {

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -1,18 +1,16 @@
 "use client";
-/**
- * Interactive book import page.
- *
- * Consumes the /api/books/:id/import-stream SSE endpoint and shows
- * progress for each stage (fetching → splitting → translating → tts).
- * Used when a user opens a book that hasn't been imported yet.
- */
 
 import { useEffect, useRef, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { importBookStream, ImportEvent, ApiError } from "@/lib/api";
+import {
+  importBookStream,
+  enqueueBookTranslation,
+  ImportEvent,
+  ApiError,
+} from "@/lib/api";
 import { getSettings } from "@/lib/settings";
 
-type Stage = "fetching" | "splitting" | "translating" | "tts";
+type Stage = "fetching" | "splitting";
 
 interface StageState {
   status: "pending" | "active" | "done" | "error";
@@ -22,18 +20,38 @@ interface StageState {
 }
 
 const INITIAL: Record<Stage, StageState> = {
-  fetching:    { status: "pending", total: 1, current: 0, message: "" },
-  splitting:   { status: "pending", total: 1, current: 0, message: "" },
-  translating: { status: "pending", total: 1, current: 0, message: "" },
-  tts:         { status: "pending", total: 1, current: 0, message: "" },
+  fetching: { status: "pending", total: 1, current: 0, message: "" },
+  splitting: { status: "pending", total: 1, current: 0, message: "" },
 };
 
 const STAGE_LABELS: Record<Stage, string> = {
-  fetching:    "Download text",
-  splitting:   "Split chapters",
-  translating: "Pre-translate",
-  tts:         "Pre-generate audio",
+  fetching: "Download text",
+  splitting: "Split chapters",
 };
+
+// Gemini Flash paid-tier pricing for cost estimate display only.
+const FLASH_OUTPUT_COST_PER_M = 2.5; // USD per 1M output tokens
+const WORDS_PER_CHAPTER_AVG = 2000;
+const TOKENS_PER_WORD = 1.4;
+
+function estimateCost(
+  chapters: number,
+  totalWords?: number,
+): { tokens: number; usd: number } {
+  const words = totalWords ?? chapters * WORDS_PER_CHAPTER_AVG;
+  const tokens = Math.round(words * TOKENS_PER_WORD);
+  const usd = (tokens / 1_000_000) * FLASH_OUTPUT_COST_PER_M;
+  return { tokens, usd };
+}
+
+function fmtCost(usd: number): string {
+  if (usd < 0.005) return "< $0.01";
+  return `~$${usd.toFixed(2)}`;
+}
+
+function fmtNum(n: number): string {
+  return n.toLocaleString();
+}
 
 export default function BookImportPage() {
   const { bookId } = useParams<{ bookId: string }>();
@@ -46,12 +64,18 @@ export default function BookImportPage() {
   const [stages, setStages] = useState<Record<Stage, StageState>>(INITIAL);
   const [bookTitle, setBookTitle] = useState("");
   const [chapterCount, setChapterCount] = useState(0);
+  const [totalWords, setTotalWords] = useState<number | undefined>();
+  const [sourceLanguage, setSourceLanguage] = useState("");
   const [error, setError] = useState("");
   const [loginRequired, setLoginRequired] = useState(false);
   const [isDone, setIsDone] = useState(false);
   const [started, setStarted] = useState(false);
+  // "idle" | "pending" | "enqueued" | "skipped"
+  const [translateState, setTranslateState] = useState<
+    "idle" | "pending" | "enqueued" | "skipped"
+  >("idle");
+  const [translateError, setTranslateError] = useState("");
 
-  // Target language from user settings
   const targetLangRef = useRef("");
   const abortRef = useRef<AbortController | null>(null);
 
@@ -75,11 +99,7 @@ export default function BookImportPage() {
     updateStage("fetching", { status: "active", message: "Starting…" });
 
     try {
-      for await (const ev of importBookStream(
-        Number(bookId),
-        targetLangRef.current,
-        abort.signal,
-      )) {
+      for await (const ev of importBookStream(Number(bookId), abort.signal)) {
         handleEvent(ev);
       }
     } catch (e: unknown) {
@@ -101,11 +121,13 @@ export default function BookImportPage() {
 
     if (ev.event === "meta") {
       if (ev.title) setBookTitle(ev.title);
+      if (ev.source_language) setSourceLanguage(ev.source_language);
       return;
     }
 
     if (ev.event === "chapters") {
       setChapterCount(ev.total || 0);
+      setTotalWords(ev.total_words);
       updateStage("splitting", {
         status: "done",
         total: ev.total || 0,
@@ -117,11 +139,9 @@ export default function BookImportPage() {
 
     if (ev.event === "stage" && ev.stage) {
       const stage = ev.stage as Stage;
-      // Transition previous stage to "done" if we're moving forward
       setStages((prev) => {
         const next = { ...prev };
-        // Walk in order; any stage before the current one that's still active → done
-        const order: Stage[] = ["fetching", "splitting", "translating", "tts"];
+        const order: Stage[] = ["fetching", "splitting"];
         const currentIdx = order.indexOf(stage);
         for (let i = 0; i < currentIdx; i++) {
           if (next[order[i]].status === "active") {
@@ -140,7 +160,7 @@ export default function BookImportPage() {
     }
 
     if (ev.event === "progress" && ev.stage) {
-      updateStage(ev.stage as Stage, {
+      updateStage(ev.stage, {
         current: ev.current || 0,
         message: ev.title || ev.message || "",
       });
@@ -167,27 +187,51 @@ export default function BookImportPage() {
     return () => abortRef.current?.abort();
   }, []);
 
-  // Auto-redirect when done (with small delay so the user sees "Done")
+  // Redirect once done AND user has acted on the translation prompt (or it doesn't apply).
+  const translationActioned =
+    translateState === "enqueued" || translateState === "skipped";
+  const tl = targetLangRef.current;
+  const showTranslatePrompt =
+    isDone &&
+    chapterCount > 0 &&
+    !!tl &&
+    tl !== sourceLanguage &&
+    translateState === "idle";
+  const readyToRedirect = isDone && (translationActioned || !showTranslatePrompt);
+
   useEffect(() => {
-    if (!isDone) return;
-    const t = setTimeout(() => router.push(nextUrl), 1500);
+    if (!readyToRedirect) return;
+    const t = setTimeout(() => router.push(nextUrl), 1200);
     return () => clearTimeout(t);
-  }, [isDone, nextUrl, router]);
+  }, [readyToRedirect, nextUrl, router]);
 
   function cancel() {
     abortRef.current?.abort();
     router.push("/");
   }
 
-  // Skip-ahead: start reading now, let remaining stages run in background
-  // (the SSE will keep flowing even if we navigate away — but we abort to be clean).
   function skipToReading() {
     abortRef.current?.abort();
     router.push(nextUrl);
   }
 
+  async function handleTranslate() {
+    setTranslateState("pending");
+    setTranslateError("");
+    try {
+      await enqueueBookTranslation(Number(bookId), tl);
+      setTranslateState("enqueued");
+    } catch (e) {
+      setTranslateError(
+        e instanceof Error ? e.message : "Failed to enqueue translation",
+      );
+      setTranslateState("idle");
+    }
+  }
+
   const canStartReading =
     stages.splitting.status === "done" && chapterCount > 0;
+  const cost = estimateCost(chapterCount, totalWords);
 
   return (
     <main className="min-h-screen bg-parchment flex items-center justify-center px-4 py-8">
@@ -205,12 +249,8 @@ export default function BookImportPage() {
           {!started && (
             <div className="space-y-4 mb-6">
               <p className="text-sm text-stone-600">
-                We&apos;ll download the book, split it into chapters, and
-                pre-translate everything to{" "}
-                <span className="font-medium text-ink">
-                  {targetLangRef.current}
-                </span>{" "}
-                so your first read is instant.
+                We&apos;ll download the book and split it into chapters so you
+                can start reading right away.
               </p>
               <div className="flex gap-2 pt-2">
                 <button
@@ -234,23 +274,30 @@ export default function BookImportPage() {
               {(Object.keys(STAGE_LABELS) as Stage[]).map((stage) => {
                 const s = stages[stage];
                 const icon =
-                  s.status === "done" ? "✓"
-                  : s.status === "active" ? "…"
-                  : s.status === "error" ? "!"
-                  : "·";
+                  s.status === "done"
+                    ? "✓"
+                    : s.status === "active"
+                      ? "…"
+                      : s.status === "error"
+                        ? "!"
+                        : "·";
                 const iconColor =
-                  s.status === "done" ? "text-emerald-600"
-                  : s.status === "active" ? "text-amber-700 animate-pulse"
-                  : s.status === "error" ? "text-red-600"
-                  : "text-stone-300";
-                const pct = s.total > 0
-                  ? Math.round((s.current / s.total) * 100)
-                  : 0;
+                  s.status === "done"
+                    ? "text-emerald-600"
+                    : s.status === "active"
+                      ? "text-amber-700 animate-pulse"
+                      : s.status === "error"
+                        ? "text-red-600"
+                        : "text-stone-300";
+                const pct =
+                  s.total > 0 ? Math.round((s.current / s.total) * 100) : 0;
 
                 return (
-                  <div key={stage} className="">
+                  <div key={stage}>
                     <div className="flex items-baseline gap-3 mb-1">
-                      <span className={`font-bold text-base w-4 text-center ${iconColor}`}>
+                      <span
+                        className={`font-bold text-base w-4 text-center ${iconColor}`}
+                      >
                         {icon}
                       </span>
                       <span className="flex-1 text-sm font-medium text-ink">
@@ -262,16 +309,21 @@ export default function BookImportPage() {
                         </span>
                       )}
                     </div>
-                    {(s.status === "active" || s.status === "done") && s.total > 0 && (
-                      <div className="ml-7 h-1 bg-amber-100 rounded-full overflow-hidden">
-                        <div
-                          className={`h-full rounded-full transition-all duration-150 ${
-                            s.status === "done" ? "bg-emerald-500" : "bg-amber-500"
-                          }`}
-                          style={{ width: `${s.status === "done" ? 100 : pct}%` }}
-                        />
-                      </div>
-                    )}
+                    {(s.status === "active" || s.status === "done") &&
+                      s.total > 0 && (
+                        <div className="ml-7 h-1 bg-amber-100 rounded-full overflow-hidden">
+                          <div
+                            className={`h-full rounded-full transition-all duration-150 ${
+                              s.status === "done"
+                                ? "bg-emerald-500"
+                                : "bg-amber-500"
+                            }`}
+                            style={{
+                              width: `${s.status === "done" ? 100 : pct}%`,
+                            }}
+                          />
+                        </div>
+                      )}
                     {s.message && s.status === "active" && (
                       <p className="ml-7 mt-1 text-xs text-stone-500 truncate">
                         {s.message}
@@ -281,6 +333,80 @@ export default function BookImportPage() {
                 );
               })}
             </div>
+          )}
+
+          {/* Translation cost confirmation panel — shown after import completes */}
+          {showTranslatePrompt && (
+            <div className="border border-amber-200 rounded-xl p-5 mb-4 bg-amber-50/50">
+              <p className="text-sm font-semibold text-ink mb-1">
+                Pre-translate this book?
+              </p>
+              <p className="text-xs text-stone-500 mb-3">
+                {chapterCount} chapters
+                {totalWords ? ` · ~${fmtNum(totalWords)} words` : ""}
+                {" · target: "}
+                <span className="font-medium text-ink">{tl}</span>
+              </p>
+
+              <div className="space-y-2 mb-4 text-xs text-stone-600">
+                <div className="flex gap-2">
+                  <span className="text-amber-700 font-medium w-4">▸</span>
+                  <div>
+                    <span className="font-medium text-ink">Gemini Flash</span>
+                    {" — "}
+                    <span className="font-medium">{fmtCost(cost.usd)}</span>
+                    {" on paid tier "}
+                    <span className="text-stone-400">
+                      (~{fmtNum(cost.tokens)} output tokens · $2.50/M)
+                    </span>
+                    <br />
+                    <span className="text-emerald-700">
+                      Free on Gemini free tier
+                    </span>
+                    {" — translation runs in the background via the queue."}
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  <span className="text-stone-400 font-medium w-4">▸</span>
+                  <div>
+                    <span className="font-medium text-ink">
+                      Google Translate
+                    </span>
+                    {" — always free, lower quality. "}
+                    Available chapter-by-chapter in the reader sidebar.
+                  </div>
+                </div>
+              </div>
+
+              {translateError && (
+                <p className="text-xs text-red-600 mb-2">{translateError}</p>
+              )}
+
+              <div className="flex gap-2">
+                <button
+                  onClick={handleTranslate}
+                  disabled={translateState === "pending"}
+                  className="flex-1 rounded-lg bg-amber-700 text-white py-2 text-xs font-medium hover:bg-amber-800 disabled:opacity-50"
+                >
+                  {translateState === "pending"
+                    ? "Enqueuing…"
+                    : "Translate in background"}
+                </button>
+                <button
+                  onClick={() => setTranslateState("skipped")}
+                  className="rounded-lg border border-stone-300 text-stone-600 px-3 py-2 text-xs hover:bg-stone-50"
+                >
+                  Skip for now
+                </button>
+              </div>
+            </div>
+          )}
+
+          {translateState === "enqueued" && (
+            <p className="text-xs text-emerald-700 mb-3">
+              Translation queued — you can read now while it runs in the
+              background.
+            </p>
           )}
 
           {loginRequired && (
@@ -304,15 +430,15 @@ export default function BookImportPage() {
             </div>
           )}
 
-          {started && isDone && (
+          {readyToRedirect && (
             <p className="text-sm text-emerald-700 mb-4">
               Done — opening your book…
             </p>
           )}
 
-          {started && !isDone && (
+          {started && !readyToRedirect && (
             <div className="flex gap-2">
-              {canStartReading && (
+              {canStartReading && !showTranslatePrompt && (
                 <button
                   onClick={skipToReading}
                   className="flex-1 rounded-lg bg-amber-700 text-white py-2 text-sm font-medium hover:bg-amber-800"
@@ -331,8 +457,8 @@ export default function BookImportPage() {
         </div>
 
         <p className="text-center text-xs text-stone-400 mt-4">
-          Translations and audio are cached, so the next person who opens this
-          book hits the cache instantly.
+          Translations are cached — other readers of the same book share the
+          result.
         </p>
       </div>
     </main>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -110,10 +110,11 @@ export interface BookChapter {
 /** An event streamed from GET /books/:id/import-stream. */
 export interface ImportEvent {
   event: "stage" | "meta" | "chapters" | "progress" | "done" | "error";
-  stage?: "fetching" | "splitting" | "translating" | "tts";
+  stage?: "fetching" | "splitting";
   message?: string;
   progress?: number;
   total?: number;
+  total_words?: number;
   current?: number;
   title?: string;
   cached?: boolean;
@@ -122,8 +123,6 @@ export interface ImportEvent {
   book_id?: number;
   source_language?: string;
   titles?: string[];
-  provider?: string;
-  voice?: string;
 }
 
 /**
@@ -133,18 +132,14 @@ export interface ImportEvent {
  */
 export async function* importBookStream(
   bookId: number,
-  targetLanguage: string,
   signal?: AbortSignal,
 ): AsyncGenerator<ImportEvent> {
   await awaitSession();
-  const params = new URLSearchParams({
-    target_language: targetLanguage,
-  });
   const headers: Record<string, string> = {
     Accept: "text/event-stream",
     ...(_authToken ? { Authorization: `Bearer ${_authToken}` } : {}),
   };
-  const res = await fetch(`${BASE}/books/${bookId}/import-stream?${params}`, {
+  const res = await fetch(`${BASE}/books/${bookId}/import-stream`, {
     headers,
     signal,
   });


### PR DESCRIPTION
## Summary
- Translation during book import was automatic and silent — it consumed Gemini API tokens without user awareness or consent
- Import stream now covers **fetch + split only** (no inline translation)
- After splitting, a **cost-confirmation panel** appears showing:
  - Chapter count and estimated word count
  - Gemini Flash estimate (~$2.50/M output tokens) with note that free-tier users pay nothing
  - Google Translate as the always-free lower-quality alternative
  - **[Translate in background]** → calls `enqueueBookTranslation` (priority=20, queue handles it)
  - **[Skip for now]** → go straight to reader; translate later chapter-by-chapter or via "Translate remaining"
- Stale UI copy removed: "pre-translate everything to…", "Pre-generate audio" stage, "Translations and audio are cached" footer
- Backend: `import-stream` no longer accepts `target_language`; `chapters` event gains `total_words` for cost estimation

## Test plan
- [ ] `npm --prefix frontend test -- --no-coverage --ci` — all tests pass
- [ ] `/Users/alfmunny/Projects/AI/book-reader-ai/backend/venv/bin/pytest backend/tests/test_router_books.py --tb=short -q --no-cov` — 39 pass
- [ ] Import a new book: only "Download text" and "Split chapters" stages appear
- [ ] After split completes, the cost panel appears with chapter count and Gemini cost estimate
- [ ] "Translate in background" enqueues translation; "Translation queued" message appears; auto-redirect fires
- [ ] "Skip for now" dismisses panel and auto-redirects immediately
- [ ] Footer says "Translations are cached" (no more "audio")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
