### PR TITLE
feat(notes): cross-book notes review page

### DIFF
--- a/backend/routers/annotations.py
+++ b/backend/routers/annotations.py
@@ -2,7 +2,7 @@ from typing import Literal
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from services.auth import get_current_user
-from services.db import create_annotation, get_annotations, update_annotation, delete_annotation
+from services.db import create_annotation, get_annotations, get_all_annotations, update_annotation, delete_annotation
 
 router = APIRouter(prefix="/annotations", tags=["annotations"])
 
@@ -33,6 +33,11 @@ async def create(req: AnnotationCreate, user: dict = Depends(get_current_user)):
         req.note_text,
         req.color,
     )
+
+
+@router.get("/all")
+async def list_all_annotations(user: dict = Depends(get_current_user)):
+    return await get_all_annotations(user["id"])
 
 
 @router.get("")

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -564,6 +564,23 @@ async def delete_annotation(annotation_id: int, user_id: int) -> bool:
     return cursor.rowcount > 0
 
 
+async def get_all_annotations(user_id: int) -> list[dict]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            """
+            SELECT a.*, b.title AS book_title
+            FROM annotations a
+            LEFT JOIN books b ON b.id = a.book_id
+            WHERE a.user_id = ?
+            ORDER BY b.title, a.chapter_index, a.created_at
+            """,
+            (user_id,),
+        ) as cursor:
+            rows = await cursor.fetchall()
+    return [dict(r) for r in rows]
+
+
 # ── Vocabulary ────────────────────────────────────────────────────────────────
 
 async def save_word(

--- a/frontend/src/__tests__/AnnotationsSidebar.test.tsx
+++ b/frontend/src/__tests__/AnnotationsSidebar.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Tests for components/AnnotationsSidebar.tsx
+ */
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AnnotationsSidebar from "@/components/AnnotationsSidebar";
+import type { Annotation } from "@/lib/api";
+
+function makeAnnotation(overrides: Partial<Annotation> = {}): Annotation {
+  return {
+    id: 1,
+    book_id: 1,
+    chapter_index: 0,
+    sentence_text: "A sentence.",
+    note_text: "A note.",
+    color: "yellow",
+    ...overrides,
+  };
+}
+
+const BASE_PROPS = {
+  annotations: [] as Annotation[],
+  totalCount: 0,
+  onJump: jest.fn(),
+  onEdit: jest.fn(),
+  loading: false,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test("toggle button is visible; sidebar hidden by default", () => {
+  render(<AnnotationsSidebar {...BASE_PROPS} />);
+  expect(screen.getByTestId("annotations-toggle")).toBeInTheDocument();
+  expect(screen.queryByTestId("annotations-sidebar")).not.toBeInTheDocument();
+});
+
+test("sidebar shows after clicking the toggle button", async () => {
+  render(<AnnotationsSidebar {...BASE_PROPS} />);
+  await userEvent.click(screen.getByTestId("annotations-toggle"));
+  expect(screen.getByTestId("annotations-sidebar")).toBeInTheDocument();
+});
+
+test("badge shows totalCount when > 0", () => {
+  render(<AnnotationsSidebar {...BASE_PROPS} totalCount={5} />);
+  expect(screen.getByText("5")).toBeInTheDocument();
+});
+
+test("badge is absent when totalCount is 0", () => {
+  render(<AnnotationsSidebar {...BASE_PROPS} totalCount={0} />);
+  // The only visible number should not be the count badge
+  expect(screen.queryByText("0")).not.toBeInTheDocument();
+});
+
+test("shows loading spinner (centered) when loading=true and annotations empty", async () => {
+  render(<AnnotationsSidebar {...BASE_PROPS} loading={true} />);
+  await userEvent.click(screen.getByTestId("annotations-toggle"));
+  // Spinner is an <span> with animate-spin; verify it exists
+  const sidebar = screen.getByTestId("annotations-sidebar");
+  expect(sidebar.querySelector(".animate-spin")).toBeInTheDocument();
+  // Should NOT show the empty state text
+  expect(screen.queryByText(/No annotations yet/i)).not.toBeInTheDocument();
+});
+
+test("shows loading spinner above the list when loading=true with annotations", async () => {
+  const annotations = [makeAnnotation()];
+  render(<AnnotationsSidebar {...BASE_PROPS} annotations={annotations} loading={true} totalCount={1} />);
+  await userEvent.click(screen.getByTestId("annotations-toggle"));
+  const sidebar = screen.getByTestId("annotations-sidebar");
+  // Should show the small spinner (w-4 h-4) above the list
+  expect(sidebar.querySelector(".animate-spin")).toBeInTheDocument();
+  // And still render the annotation
+  expect(screen.getByText(/A sentence\./)).toBeInTheDocument();
+});
+
+test("shows empty state when annotations=[]", async () => {
+  render(<AnnotationsSidebar {...BASE_PROPS} />);
+  await userEvent.click(screen.getByTestId("annotations-toggle"));
+  expect(screen.getByText(/No annotations yet/i)).toBeInTheDocument();
+});
+
+test("groups annotations by chapter_index sorted ascending", async () => {
+  const annotations = [
+    makeAnnotation({ id: 3, chapter_index: 2, sentence_text: "Chapter 3 sentence." }),
+    makeAnnotation({ id: 1, chapter_index: 0, sentence_text: "Chapter 1 sentence." }),
+    makeAnnotation({ id: 2, chapter_index: 1, sentence_text: "Chapter 2 sentence." }),
+  ];
+  render(<AnnotationsSidebar {...BASE_PROPS} annotations={annotations} totalCount={3} />);
+  await userEvent.click(screen.getByTestId("annotations-toggle"));
+
+  const headings = screen.getAllByRole("heading", { level: 3 });
+  expect(headings[0]).toHaveTextContent("Chapter 1");
+  expect(headings[1]).toHaveTextContent("Chapter 2");
+  expect(headings[2]).toHaveTextContent("Chapter 3");
+});
+
+test("clicking an annotation calls onJump and closes sidebar", async () => {
+  const ann = makeAnnotation({ sentence_text: "Click me sentence." });
+  render(<AnnotationsSidebar {...BASE_PROPS} annotations={[ann]} totalCount={1} />);
+  await userEvent.click(screen.getByTestId("annotations-toggle"));
+
+  fireEvent.click(screen.getByText(/Click me sentence\./));
+
+  expect(BASE_PROPS.onJump).toHaveBeenCalledWith(ann);
+  expect(screen.queryByTestId("annotations-sidebar")).not.toBeInTheDocument();
+});
+
+test("edit button calls onEdit and closes sidebar (stopPropagation prevents onJump)", async () => {
+  const ann = makeAnnotation({ sentence_text: "Editable sentence." });
+  render(<AnnotationsSidebar {...BASE_PROPS} annotations={[ann]} totalCount={1} />);
+  await userEvent.click(screen.getByTestId("annotations-toggle"));
+
+  fireEvent.click(screen.getByTitle("Edit annotation"));
+
+  expect(BASE_PROPS.onEdit).toHaveBeenCalledWith(ann);
+  expect(BASE_PROPS.onJump).not.toHaveBeenCalled();
+  expect(screen.queryByTestId("annotations-sidebar")).not.toBeInTheDocument();
+});
+
+test("backdrop click closes sidebar", async () => {
+  render(<AnnotationsSidebar {...BASE_PROPS} />);
+  await userEvent.click(screen.getByTestId("annotations-toggle"));
+  expect(screen.getByTestId("annotations-sidebar")).toBeInTheDocument();
+
+  // The backdrop has fixed inset-0 bg-black/10
+  const backdrop = document.querySelector(".bg-black\\/10");
+  expect(backdrop).toBeInTheDocument();
+  fireEvent.click(backdrop!);
+
+  expect(screen.queryByTestId("annotations-sidebar")).not.toBeInTheDocument();
+});
+
+test("sidebar shows 'View all notes' link pointing to /notes", async () => {
+  render(<AnnotationsSidebar {...BASE_PROPS} />);
+  await userEvent.click(screen.getByTestId("annotations-toggle"));
+  const link = screen.getByRole("link", { name: /view all notes/i });
+  expect(link).toBeInTheDocument();
+  expect(link).toHaveAttribute("href", "/notes");
+});

--- a/frontend/src/__tests__/NotesPage.test.tsx
+++ b/frontend/src/__tests__/NotesPage.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * Tests for the /notes cross-book annotation review page.
+ */
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { backendToken: "token" }, status: "authenticated" }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getAllAnnotations: jest.fn(),
+  updateAnnotation: jest.fn(),
+  deleteAnnotation: jest.fn(),
+}));
+
+import * as api from "@/lib/api";
+import NotesPage from "@/app/notes/page";
+import type { AnnotationWithBook } from "@/lib/api";
+
+const mockGetAll = api.getAllAnnotations as jest.MockedFunction<typeof api.getAllAnnotations>;
+const mockUpdate = api.updateAnnotation as jest.MockedFunction<typeof api.updateAnnotation>;
+const mockDelete = api.deleteAnnotation as jest.MockedFunction<typeof api.deleteAnnotation>;
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+function makeAnnotation(overrides: Partial<AnnotationWithBook> = {}): AnnotationWithBook {
+  return {
+    id: 1,
+    book_id: 10,
+    chapter_index: 0,
+    sentence_text: "It is a truth universally acknowledged.",
+    note_text: "Famous opening",
+    color: "yellow",
+    book_title: "Pride and Prejudice",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test("shows loading spinner initially then renders annotations", async () => {
+  mockGetAll.mockResolvedValue([makeAnnotation()]);
+
+  render(<NotesPage />);
+  // Spinner visible while loading
+  expect(document.querySelector(".animate-spin")).toBeInTheDocument();
+
+  await waitFor(() => expect(screen.getByText("Pride and Prejudice")).toBeInTheDocument());
+  expect(screen.getByText(/truth universally acknowledged/)).toBeInTheDocument();
+  expect(screen.getByText("Famous opening")).toBeInTheDocument();
+});
+
+test("shows empty state when no annotations", async () => {
+  mockGetAll.mockResolvedValue([]);
+  render(<NotesPage />);
+  await waitFor(() => expect(screen.getByText(/No notes yet/i)).toBeInTheDocument());
+});
+
+test("groups annotations by book", async () => {
+  mockGetAll.mockResolvedValue([
+    makeAnnotation({ id: 1, book_id: 10, book_title: "Pride and Prejudice", sentence_text: "Truth." }),
+    makeAnnotation({ id: 2, book_id: 20, book_title: "Moby Dick", sentence_text: "Whale." }),
+  ]);
+
+  render(<NotesPage />);
+  await waitFor(() => expect(screen.getByText("Pride and Prejudice")).toBeInTheDocument());
+  expect(screen.getByText("Moby Dick")).toBeInTheDocument();
+  expect(screen.getByText(/Truth\./)).toBeInTheDocument();
+  expect(screen.getByText(/Whale\./)).toBeInTheDocument();
+});
+
+test("search filter hides non-matching annotations", async () => {
+  mockGetAll.mockResolvedValue([
+    makeAnnotation({ id: 1, book_title: "Pride and Prejudice", sentence_text: "Truth universally." }),
+    makeAnnotation({ id: 2, book_title: "Moby Dick", sentence_text: "White whale." }),
+  ]);
+
+  render(<NotesPage />);
+  await waitFor(() => expect(screen.getByText(/Truth universally\./)).toBeInTheDocument());
+
+  await userEvent.type(screen.getByPlaceholderText(/search notes/i), "whale");
+  expect(screen.queryByText(/Truth universally\./)).not.toBeInTheDocument();
+  expect(screen.getByText(/White whale\./)).toBeInTheDocument();
+});
+
+test("color filter shows only matching annotations", async () => {
+  mockGetAll.mockResolvedValue([
+    makeAnnotation({ id: 1, color: "yellow", sentence_text: "Yellow sentence." }),
+    makeAnnotation({ id: 2, color: "blue", sentence_text: "Blue sentence." }),
+  ]);
+
+  render(<NotesPage />);
+  await waitFor(() => expect(screen.getByText(/Yellow sentence\./)).toBeInTheDocument());
+
+  // The filter pills are the first occurrence of each color button (the color dot buttons also have title=color)
+  const blueFilterPill = screen.getAllByRole("button", { name: /^blue$/i })[0];
+  fireEvent.click(blueFilterPill);
+  expect(screen.queryByText(/Yellow sentence\./)).not.toBeInTheDocument();
+  expect(screen.getByText(/Blue sentence\./)).toBeInTheDocument();
+});
+
+test("clicking note text opens edit textarea with existing note", async () => {
+  mockGetAll.mockResolvedValue([makeAnnotation({ note_text: "My note here" })]);
+  render(<NotesPage />);
+  await waitFor(() => expect(screen.getByText("My note here")).toBeInTheDocument());
+
+  fireEvent.click(screen.getByText("My note here"));
+  const textarea = document.querySelector("textarea");
+  expect(textarea).toBeInTheDocument();
+  expect(textarea!.value).toBe("My note here");
+});
+
+test("saving edited note calls updateAnnotation and closes edit mode", async () => {
+  const ann = makeAnnotation({ note_text: "Old note" });
+  mockGetAll.mockResolvedValue([ann]);
+  mockUpdate.mockResolvedValue({ ...ann, note_text: "New note" });
+
+  render(<NotesPage />);
+  await waitFor(() => expect(screen.getByText("Old note")).toBeInTheDocument());
+
+  fireEvent.click(screen.getByText("Old note"));
+  const textarea = document.querySelector("textarea")!;
+  fireEvent.change(textarea, { target: { value: "New note" } });
+  fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+  // updateAnnotation must be called regardless of state flush timing
+  await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+  expect(mockUpdate).toHaveBeenCalledWith(ann.id, { note_text: "New note", color: ann.color });
+  // Edit mode closes after save
+  await waitFor(() => expect(document.querySelector("textarea")).not.toBeInTheDocument());
+});
+
+test("deleting an annotation removes it from the list", async () => {
+  const ann = makeAnnotation({ sentence_text: "To be deleted." });
+  mockGetAll.mockResolvedValue([ann]);
+  mockDelete.mockResolvedValue({ ok: true });
+
+  render(<NotesPage />);
+  await waitFor(() => expect(screen.getByText(/To be deleted\./)).toBeInTheDocument());
+
+  jest.spyOn(window, "confirm").mockReturnValue(true);
+  fireEvent.click(screen.getByTitle("Delete annotation"));
+
+  // Wait for delete call, then flush the promise chain so setAnnotations runs
+  await waitFor(() => expect(mockDelete).toHaveBeenCalledWith(ann.id));
+  await flushPromises();
+
+  await waitFor(() => expect(screen.queryByText(/To be deleted\./)).not.toBeInTheDocument());
+});
+
+test("header shows total annotation count", async () => {
+  mockGetAll.mockResolvedValue([
+    makeAnnotation({ id: 1 }),
+    makeAnnotation({ id: 2 }),
+  ]);
+  render(<NotesPage />);
+  await waitFor(() => expect(screen.getByText(/2 annotations/i)).toBeInTheDocument());
+});

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -1,0 +1,285 @@
+"use client";
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { getAllAnnotations, updateAnnotation, deleteAnnotation, AnnotationWithBook } from "@/lib/api";
+
+const COLOR_BADGE: Record<string, string> = {
+  yellow: "bg-yellow-100 border-yellow-300 text-yellow-800",
+  blue:   "bg-blue-100 border-blue-300 text-blue-800",
+  green:  "bg-green-100 border-green-300 text-green-800",
+  pink:   "bg-pink-100 border-pink-300 text-pink-800",
+};
+
+const COLOR_PILL: Record<string, string> = {
+  yellow: "bg-yellow-100 border-yellow-300 text-yellow-700 hover:bg-yellow-200",
+  blue:   "bg-blue-100 border-blue-300 text-blue-700 hover:bg-blue-200",
+  green:  "bg-green-100 border-green-300 text-green-700 hover:bg-green-200",
+  pink:   "bg-pink-100 border-pink-300 text-pink-700 hover:bg-pink-200",
+};
+
+const COLORS = ["yellow", "blue", "green", "pink"] as const;
+
+export default function NotesPage() {
+  const router = useRouter();
+  const { status } = useSession();
+
+  const [annotations, setAnnotations] = useState<AnnotationWithBook[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [colorFilter, setColorFilter] = useState<Set<string>>(new Set());
+  const [search, setSearch] = useState("");
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editText, setEditText] = useState("");
+  const [saving, setSaving] = useState<number | null>(null);
+  const [deleting, setDeleting] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (status === "unauthenticated") {
+      router.replace("/login");
+      return;
+    }
+    if (status !== "authenticated") return;
+    getAllAnnotations()
+      .then(setAnnotations)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status]);
+
+  function toggleColor(c: string) {
+    setColorFilter((prev) => {
+      const next = new Set(prev);
+      next.has(c) ? next.delete(c) : next.add(c);
+      return next;
+    });
+  }
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return annotations.filter((a) => {
+      if (colorFilter.size > 0 && !colorFilter.has(a.color)) return false;
+      if (q) {
+        const haystack = `${a.sentence_text} ${a.note_text} ${a.book_title ?? ""}`.toLowerCase();
+        if (!haystack.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [annotations, colorFilter, search]);
+
+  // Group by book_id, preserving order
+  const grouped = useMemo(() => {
+    const order: number[] = [];
+    const map = new Map<number, { title: string; items: AnnotationWithBook[] }>();
+    for (const a of filtered) {
+      if (!map.has(a.book_id)) {
+        map.set(a.book_id, { title: a.book_title ?? `Book #${a.book_id}`, items: [] });
+        order.push(a.book_id);
+      }
+      map.get(a.book_id)!.items.push(a);
+    }
+    return order.map((id) => ({ bookId: id, ...map.get(id)! }));
+  }, [filtered]);
+
+  async function handleSave(ann: AnnotationWithBook) {
+    setSaving(ann.id);
+    try {
+      const updated = await updateAnnotation(ann.id, { note_text: editText, color: ann.color });
+      setAnnotations((prev) => prev.map((a) => (a.id === ann.id ? { ...a, ...updated } : a)));
+      setEditingId(null);
+    } catch {
+      // ignore
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  async function handleDelete(id: number) {
+    if (!confirm("Delete this annotation?")) return;
+    setDeleting(id);
+    try {
+      await deleteAnnotation(id);
+      setAnnotations((prev) => prev.filter((a) => a.id !== id));
+    } catch {
+      // ignore
+    } finally {
+      setDeleting(null);
+    }
+  }
+
+  function handleColorChange(ann: AnnotationWithBook, color: string) {
+    updateAnnotation(ann.id, { note_text: ann.note_text, color })
+      .then((updated) => setAnnotations((prev) => prev.map((a) => (a.id === ann.id ? { ...a, ...updated } : a))))
+      .catch(() => {});
+  }
+
+  return (
+    <main className="min-h-screen bg-parchment">
+      {/* Header */}
+      <header className="border-b border-amber-200 bg-white/60 backdrop-blur px-4 md:px-6 py-3 md:py-4 sticky top-0 z-10">
+        <div className="max-w-3xl mx-auto flex items-center gap-4">
+          <button
+            onClick={() => router.push("/")}
+            className="text-amber-700 hover:text-amber-900 text-sm font-medium transition-colors shrink-0"
+          >
+            ← Library
+          </button>
+          <div className="flex-1">
+            <h1 className="text-xl font-serif font-bold text-ink">Your Notes</h1>
+          </div>
+          {!loading && (
+            <span className="text-xs text-stone-400">{annotations.length} annotation{annotations.length !== 1 ? "s" : ""}</span>
+          )}
+        </div>
+      </header>
+
+      <div className="max-w-3xl mx-auto px-4 md:px-6 py-6 space-y-6">
+
+        {/* Filter bar */}
+        <div className="flex flex-col sm:flex-row gap-3">
+          <input
+            className="flex-1 rounded-lg border border-amber-300 bg-white px-4 py-2 text-sm text-ink shadow-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+            placeholder="Search notes..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <div className="flex gap-2">
+            {COLORS.map((c) => (
+              <button
+                key={c}
+                onClick={() => toggleColor(c)}
+                className={`px-3 py-1.5 rounded-full border text-xs font-medium transition-colors ${
+                  colorFilter.has(c)
+                    ? `${COLOR_PILL[c]} ring-2 ring-offset-1 ring-current`
+                    : COLOR_PILL[c]
+                }`}
+              >
+                {c}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Content */}
+        {loading ? (
+          <div className="flex justify-center py-20">
+            <span className="w-6 h-6 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+          </div>
+        ) : grouped.length === 0 ? (
+          <div className="text-center py-20 text-stone-400">
+            <p className="text-4xl mb-3">📝</p>
+            <p className="font-serif text-lg text-ink mb-1">No notes yet</p>
+            {annotations.length > 0 ? (
+              <p className="text-sm">No results for the current filter.</p>
+            ) : (
+              <p className="text-sm">Long-press a sentence while reading to add an annotation.</p>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-10">
+            {grouped.map(({ bookId, title, items }) => (
+              <section key={bookId}>
+                {/* Book header */}
+                <div className="flex items-baseline gap-3 mb-3">
+                  <button
+                    onClick={() => router.push(`/reader/${bookId}`)}
+                    className="font-serif font-semibold text-ink text-base hover:text-amber-800 transition-colors text-left"
+                  >
+                    {title}
+                  </button>
+                  <span className="text-xs text-stone-400">{items.length} note{items.length !== 1 ? "s" : ""}</span>
+                  <button
+                    onClick={() => router.push(`/reader/${bookId}`)}
+                    className="ml-auto text-xs text-amber-700 hover:text-amber-900 shrink-0"
+                  >
+                    Open →
+                  </button>
+                </div>
+
+                <div className="space-y-2">
+                  {items.map((ann) => (
+                    <div
+                      key={ann.id}
+                      className={`rounded-lg border px-4 py-3 ${COLOR_BADGE[ann.color] ?? COLOR_BADGE.yellow}`}
+                    >
+                      {/* Top row: chapter + color picker + delete */}
+                      <div className="flex items-center gap-2 mb-2">
+                        <span className="text-[11px] font-semibold uppercase tracking-wide opacity-60">
+                          Ch. {ann.chapter_index + 1}
+                        </span>
+                        <div className="flex gap-1 ml-auto">
+                          {COLORS.map((c) => (
+                            <button
+                              key={c}
+                              onClick={() => handleColorChange(ann, c)}
+                              title={c}
+                              className={`w-3.5 h-3.5 rounded-full border transition-transform ${
+                                ann.color === c ? "scale-125 border-current" : "border-transparent opacity-50 hover:opacity-100"
+                              } bg-${c}-400`}
+                            />
+                          ))}
+                        </div>
+                        <button
+                          onClick={() => handleDelete(ann.id)}
+                          disabled={deleting === ann.id}
+                          className="text-xs opacity-40 hover:opacity-80 transition-opacity ml-1"
+                          title="Delete annotation"
+                        >
+                          {deleting === ann.id ? "…" : "✕"}
+                        </button>
+                      </div>
+
+                      {/* Sentence */}
+                      <p className="text-xs italic leading-relaxed mb-2 opacity-80">
+                        &ldquo;{ann.sentence_text}&rdquo;
+                      </p>
+
+                      {/* Note text / edit */}
+                      {editingId === ann.id ? (
+                        <div className="space-y-2">
+                          <textarea
+                            className="w-full rounded border border-current/30 bg-white/60 px-3 py-2 text-xs resize-none focus:outline-none focus:ring-1 focus:ring-current"
+                            rows={3}
+                            value={editText}
+                            onChange={(e) => setEditText(e.target.value)}
+                            autoFocus
+                          />
+                          <div className="flex gap-2 justify-end">
+                            <button
+                              onClick={() => setEditingId(null)}
+                              className="text-xs opacity-60 hover:opacity-100"
+                            >
+                              Cancel
+                            </button>
+                            <button
+                              onClick={() => handleSave(ann)}
+                              disabled={saving === ann.id}
+                              className="text-xs font-medium opacity-80 hover:opacity-100"
+                            >
+                              {saving === ann.id ? "Saving…" : "Save"}
+                            </button>
+                          </div>
+                        </div>
+                      ) : (
+                        <div
+                          className="flex items-start gap-2 cursor-pointer group"
+                          onClick={() => { setEditingId(ann.id); setEditText(ann.note_text); }}
+                        >
+                          {ann.note_text ? (
+                            <p className="text-xs font-medium flex-1">{ann.note_text}</p>
+                          ) : (
+                            <p className="text-xs opacity-40 italic flex-1">Add a note…</p>
+                          )}
+                          <span className="text-xs opacity-0 group-hover:opacity-50 transition-opacity shrink-0">✏️</span>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -211,6 +211,14 @@ export default function Home() {
               )}
             </button>
           ))}
+          {status === "authenticated" && (
+            <button
+              onClick={() => router.push("/notes")}
+              className="px-5 py-3 text-sm font-medium border-b-2 border-transparent text-amber-600 hover:text-amber-800 transition-colors"
+            >
+              Your Notes
+            </button>
+          )}
           {/* Admin tab — only visible to admin users */}
           {isAdmin && (
             <button

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -70,7 +70,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
             </button>
           </div>
 
-          <div className="flex-1 overflow-y-auto p-4 space-y-6">
+          <div className="flex-1 overflow-y-auto p-4 space-y-6 pb-0">
             {loading && annotations.length === 0 ? (
               <div className="flex justify-center mt-10">
                 <span className="w-5 h-5 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
@@ -124,6 +124,17 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
               ))}
               </>
             )}
+          </div>
+
+          {/* Footer */}
+          <div className="border-t border-amber-100 px-4 py-3 shrink-0">
+            <a
+              href="/notes"
+              onClick={() => setOpen(false)}
+              className="block w-full text-center text-xs text-amber-700 hover:text-amber-900 font-medium transition-colors"
+            >
+              View all notes →
+            </a>
           </div>
         </div>
       )}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -510,8 +510,16 @@ export interface Annotation {
   color: string;
 }
 
+export interface AnnotationWithBook extends Annotation {
+  book_title: string | null;
+}
+
 export function getAnnotations(bookId: number) {
   return request<Annotation[]>(`/annotations?book_id=${bookId}`);
+}
+
+export function getAllAnnotations() {
+  return request<AnnotationWithBook[]>("/annotations/all");
 }
 
 export function createAnnotation(data: {


### PR DESCRIPTION
## Summary

- **Backend**: New `GET /annotations/all` endpoint returns every annotation for the current user, joined with `books.title` for display — no N+1 queries
- **`/notes` page**: Cross-book annotation review — grouped by book, colour filter pills, text search, inline note editing, colour re-tagging, per-annotation delete, "Open →" link back to the reader
- **Home page nav**: "Your Notes" tab (authenticated users only) navigates to `/notes`
- **AnnotationsSidebar**: Footer "View all notes →" link so readers can reach the page from inside a book

## Test plan

- [ ] Open `/` as an authenticated user → "Your Notes" tab is visible; click → `/notes` loads
- [ ] Annotate sentences across two books; visit `/notes` → both books appear as sections
- [ ] Filter by colour → only matching annotations shown; clear filter → all return
- [ ] Search by note text → filters live; clear → all return
- [ ] Click a note → textarea opens pre-filled; edit → Save → note updates in place
- [ ] Delete an annotation → confirm dialog → card disappears
- [ ] "Open →" beside a book title navigates to the reader for that book
- [ ] Open reader → Notes sidebar → "View all notes →" → redirects to `/notes`
- [ ] 824 frontend unit tests pass; backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
