### PR TITLE
feat: add Project Gutenberg source link to reader and book detail modal

### DIFF
--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -718,7 +718,16 @@ export default function ReaderPage() {
           <div className="min-w-0 flex-1">
             {meta ? (
               <>
-                <h1 className="font-serif font-bold text-ink truncate text-sm">{meta.title}</h1>
+                <div className="flex items-baseline gap-1.5 min-w-0">
+                  <h1 className="font-serif font-bold text-ink truncate text-sm">{meta.title}</h1>
+                  <a
+                    href={`https://www.gutenberg.org/ebooks/${meta.id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="shrink-0 text-xs text-amber-500 hover:text-amber-700"
+                    title="View on Project Gutenberg"
+                  >↗</a>
+                </div>
                 <p className="text-xs text-amber-700 truncate">{meta.authors.join(", ")}</p>
               </>
             ) : (

--- a/frontend/src/components/BookDetailModal.tsx
+++ b/frontend/src/components/BookDetailModal.tsx
@@ -125,11 +125,21 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
             : "Start Reading"}
         </button>
 
-        {book.download_count > 0 && (
-          <p className="text-center text-xs text-stone-400 mt-3">
-            {book.download_count.toLocaleString()} downloads on Project Gutenberg
-          </p>
-        )}
+        <div className="flex items-center justify-between mt-3">
+          {book.download_count > 0 && (
+            <p className="text-xs text-stone-400">
+              {book.download_count.toLocaleString()} downloads
+            </p>
+          )}
+          <a
+            href={`https://www.gutenberg.org/ebooks/${book.id}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-amber-600 hover:text-amber-800 hover:underline ml-auto"
+          >
+            View on Project Gutenberg ↗
+          </a>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Add a small `↗` link next to the book title in the reader page header, pointing to the book's Project Gutenberg page
- Add a "View on Project Gutenberg ↗" link at the bottom of the BookDetailModal, alongside the download count
- No backend or DB changes needed — the Gutenberg URL is derived directly from `book.id` (the book's primary key is the Gutenberg book ID)

## Test plan

- [ ] Open a book in the reader — confirm `↗` appears after the title and opens the correct Gutenberg URL in a new tab
- [ ] Open the book detail popup from the library — confirm "View on Project Gutenberg ↗" appears at the bottom and links correctly
- [ ] Verify download count still displays when present, left-aligned next to the link

🤖 Generated with [Claude Code](https://claude.com/claude-code)
