### PR TITLE
feat: V5-B woodcut icon + homepage header logo

### DIFF
--- a/frontend/public/icon-variants/v1-pact.svg
+++ b/frontend/public/icon-variants/v1-pact.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- V1 — THE PACT
+       One flame. Two natures. Left: angular + dark (Mephisto).
+       Right: curved + amber (Faust/knowledge). Divided by a seam.  -->
+  <defs>
+    <linearGradient id="fire" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%"   stop-color="#FEF3C7"/>
+      <stop offset="45%"  stop-color="#F59E0B"/>
+      <stop offset="100%" stop-color="#92400E"/>
+    </linearGradient>
+    <radialGradient id="apex" cx="50%" cy="0%" r="80%">
+      <stop offset="0%"   stop-color="#FEF3C7" stop-opacity="0.45"/>
+      <stop offset="100%" stop-color="#F59E0B" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="512" height="512" rx="88" fill="#0C0300"/>
+
+  <!-- Apex glow -->
+  <ellipse cx="256" cy="78" rx="38" ry="62" fill="url(#apex)"/>
+
+  <!-- Dark half — angular, hard-edged (the shadow, the pact) -->
+  <path d="M 256 72
+    L 194 192
+    L 160 308
+    L 170 386
+    L 214 430
+    L 256 440
+    Z"
+    fill="#180600"/>
+
+  <!-- Amber half — organic, curved (the flame, the knowledge) -->
+  <path d="M 256 72
+    C 284 102, 320 144, 338 194
+    C 360 258, 356 322, 338 370
+    C 320 414, 294 436, 256 440
+    Z"
+    fill="url(#fire)"/>
+
+  <!-- Seam between the two halves -->
+  <line x1="256" y1="72" x2="256" y2="440"
+        stroke="#0C0300" stroke-width="2.5"/>
+
+  <!-- Base ember -->
+  <ellipse cx="256" cy="437" rx="42" ry="9" fill="#F59E0B" opacity="0.22"/>
+</svg>

--- a/frontend/public/icon-variants/v2-oculus.svg
+++ b/frontend/public/icon-variants/v2-oculus.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- V2 — THE OCULUS
+       A single watching eye. References the all-seeing aspect of
+       deep reading — and the Faustian eye that sees too much.
+       Pure geometry: almond form, dark pupil, amber iris.  -->
+  <defs>
+    <radialGradient id="iris" cx="50%" cy="45%" r="52%">
+      <stop offset="0%"   stop-color="#FEF3C7"/>
+      <stop offset="38%"  stop-color="#F59E0B"/>
+      <stop offset="100%" stop-color="#7C2D12"/>
+    </radialGradient>
+    <radialGradient id="halo" cx="50%" cy="50%" r="50%">
+      <stop offset="0%"   stop-color="#F59E0B" stop-opacity="0.30"/>
+      <stop offset="100%" stop-color="#F59E0B" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="512" height="512" rx="88" fill="#0C0300"/>
+
+  <!-- Outer amber halo -->
+  <ellipse cx="256" cy="256" rx="218" ry="136" fill="url(#halo)"/>
+
+  <!-- Eye form — pointed at both ends, full amber iris -->
+  <path d="M 78 256
+    C 136 168, 194 144, 256 144
+    C 318 144, 376 168, 434 256
+    C 376 344, 318 368, 256 368
+    C 194 368, 136 344, 78 256 Z"
+    fill="url(#iris)"/>
+
+  <!-- Pupil -->
+  <circle cx="256" cy="256" r="74" fill="#080200"/>
+
+  <!-- Iris ring details -->
+  <circle cx="256" cy="256" r="92"
+          fill="none" stroke="#FDE68A" stroke-width="0.8" opacity="0.20"/>
+  <circle cx="256" cy="256" r="112"
+          fill="none" stroke="#FDE68A" stroke-width="0.5" opacity="0.12"/>
+
+  <!-- Specular catch-light on pupil -->
+  <ellipse cx="232" cy="228" rx="17" ry="11"
+           fill="white" opacity="0.10"
+           transform="rotate(-25 232 228)"/>
+</svg>

--- a/frontend/public/icon-variants/v3-codex.svg
+++ b/frontend/public/icon-variants/v3-codex.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- V3 — THE CODEX MARK
+       Two calligraphic strokes diverging from a base point (the open
+       book), joined at the top by a gentle arc, with a single ember
+       above. Negative space is the book. Maximum reduction.  -->
+  <defs>
+    <linearGradient id="stroke-g" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%"   stop-color="#92400E"/>
+      <stop offset="100%" stop-color="#FCD34D"/>
+    </linearGradient>
+    <radialGradient id="ember-g" cx="50%" cy="50%" r="50%">
+      <stop offset="0%"   stop-color="#FEF3C7"/>
+      <stop offset="55%"  stop-color="#F59E0B"/>
+      <stop offset="100%" stop-color="#D97706"/>
+    </radialGradient>
+    <radialGradient id="ember-halo" cx="50%" cy="50%" r="50%">
+      <stop offset="0%"   stop-color="#F59E0B" stop-opacity="0.40"/>
+      <stop offset="100%" stop-color="#F59E0B" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="512" height="512" rx="88" fill="#0C0300"/>
+
+  <!-- Left page stroke — thick calligraphic line -->
+  <line x1="256" y1="404" x2="84" y2="156"
+        stroke="url(#stroke-g)" stroke-width="10" stroke-linecap="round"/>
+
+  <!-- Right page stroke — mirror -->
+  <line x1="256" y1="404" x2="428" y2="156"
+        stroke="url(#stroke-g)" stroke-width="10" stroke-linecap="round"/>
+
+  <!-- Arc joining the two page tops -->
+  <path d="M 84 156 Q 256 96 428 156"
+        fill="none" stroke="url(#stroke-g)"
+        stroke-width="7.5" stroke-linecap="round"/>
+
+  <!-- Ember halo -->
+  <circle cx="256" cy="94" r="38" fill="url(#ember-halo)"/>
+
+  <!-- Ember — single flame-point above the arc -->
+  <circle cx="256" cy="94" r="17" fill="url(#ember-g)"/>
+
+  <!-- Book base — faint closing line -->
+  <path d="M 84 404 Q 256 422 428 404"
+        fill="none" stroke="#4C1506" stroke-width="4.5"
+        stroke-linecap="round"/>
+</svg>

--- a/frontend/public/icon-variants/v4-mephisto-book.svg
+++ b/frontend/public/icon-variants/v4-mephisto-book.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- V4 — MEPHISTO + BOOK (revised)
+       Hat and book share the same dark geometric silhouette language.
+       The eye is the only source of light.                          -->
+
+  <!-- ░ BACKGROUND ░ -->
+  <rect width="512" height="512" rx="88" fill="#0C0300"/>
+
+  <!-- Thin border -->
+  <rect x="18" y="18" width="476" height="476" rx="74"
+        fill="none" stroke="#3D1004" stroke-width="1.4"/>
+
+  <!-- ░ MEPHISTO HAT ░ -->
+  <!-- Crown — tall pointed triangle -->
+  <path d="M 256 68 L 194 246 L 318 246 Z"
+        fill="#170600" stroke="#4A1506" stroke-width="1.4"
+        stroke-linejoin="round"/>
+
+  <!-- Brim — slightly wider than crown base -->
+  <path d="M 166 246 L 346 246 L 340 270 L 172 270 Z"
+        fill="#1C0800" stroke="#4A1506" stroke-width="1.4"
+        stroke-linejoin="round"/>
+
+  <!-- Feather — single curved stroke, right side -->
+  <path d="M 312 218 C 328 202, 348 188, 364 174
+           C 350 182, 332 198, 318 214 Z"
+        fill="#260C02"/>
+
+  <!-- ░ THE EYE ░
+       The only light in the icon. Sits in the gap between hat and book. -->
+  <circle cx="256" cy="268" r="34" fill="#F59E0B" opacity="0.09"/>
+  <circle cx="256" cy="268" r="11" fill="#F59E0B" opacity="0.93"/>
+  <circle cx="256" cy="268" r="5"  fill="#FEF3C7" opacity="0.97"/>
+
+  <!-- ░ OPEN BOOK ░
+       Same language as the hat: flat dark geometry, subtle amber stroke.
+       Two trapezoidal pages meeting at the spine — no fill variation,
+       no text lines, pure form.                                        -->
+
+  <!-- Left page — slightly angled outward (perspective) -->
+  <path d="M 256 286 L 256 454 L 62 442 L 62 290 Z"
+        fill="#170600" stroke="#4A1506" stroke-width="1.4"
+        stroke-linejoin="round"/>
+
+  <!-- Right page — mirror -->
+  <path d="M 256 286 L 450 290 L 450 442 L 256 454 Z"
+        fill="#1C0800" stroke="#4A1506" stroke-width="1.4"
+        stroke-linejoin="round"/>
+
+  <!-- Spine — the crease between the pages -->
+  <line x1="256" y1="286" x2="256" y2="454"
+        stroke="#4A1506" stroke-width="1.8"/>
+
+  <!-- Very faint amber glow at spine top — eye-light falling onto the book -->
+  <ellipse cx="256" cy="290" rx="52" ry="10" fill="#F59E0B" opacity="0.10"/>
+</svg>

--- a/frontend/public/icon-variants/v5-bright-a.svg
+++ b/frontend/public/icon-variants/v5-bright-a.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- BRIGHT A — Warm fills, amber strokes. Hat slightly darker than book. -->
+  <rect width="512" height="512" rx="88" fill="#160600"/>
+  <rect x="18" y="18" width="476" height="476" rx="74"
+        fill="none" stroke="#D97706" stroke-width="1.6"/>
+
+  <!-- Hat crown -->
+  <path d="M 256 68 L 194 246 L 318 246 Z"
+        fill="#3D1206" stroke="#D97706" stroke-width="2"
+        stroke-linejoin="round"/>
+  <!-- Hat brim -->
+  <path d="M 166 246 L 346 246 L 340 270 L 172 270 Z"
+        fill="#4C1808" stroke="#D97706" stroke-width="2"
+        stroke-linejoin="round"/>
+  <!-- Feather -->
+  <path d="M 312 218 C 328 202, 348 188, 364 174
+           C 350 182, 332 198, 318 214 Z"
+        fill="#6B2B0C"/>
+
+  <!-- Eye -->
+  <circle cx="256" cy="268" r="38" fill="#F59E0B" opacity="0.14"/>
+  <circle cx="256" cy="268" r="13" fill="#F59E0B"/>
+  <circle cx="256" cy="268" r="6"  fill="#FEF3C7"/>
+
+  <!-- Book left page -->
+  <path d="M 256 286 L 256 454 L 62 442 L 62 290 Z"
+        fill="#3D1206" stroke="#D97706" stroke-width="2"
+        stroke-linejoin="round"/>
+  <!-- Book right page -->
+  <path d="M 256 286 L 450 290 L 450 442 L 256 454 Z"
+        fill="#4C1808" stroke="#D97706" stroke-width="2"
+        stroke-linejoin="round"/>
+  <!-- Spine -->
+  <line x1="256" y1="286" x2="256" y2="454" stroke="#D97706" stroke-width="2"/>
+  <!-- Eye-glow on book -->
+  <ellipse cx="256" cy="290" rx="56" ry="11" fill="#F59E0B" opacity="0.13"/>
+</svg>

--- a/frontend/public/icon-variants/v5-bright-b.svg
+++ b/frontend/public/icon-variants/v5-bright-b.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- BRIGHT B — Woodcut / linework. Outlines only in bright amber-gold.
+       Pure amber lines on black — like an etching or a Retzsch plate. -->
+  <rect width="512" height="512" rx="88" fill="#0C0300"/>
+  <rect x="18" y="18" width="476" height="476" rx="74"
+        fill="none" stroke="#F59E0B" stroke-width="1.4" opacity="0.5"/>
+
+  <!-- Hat crown (outline only) -->
+  <path d="M 256 68 L 194 246 L 318 246 Z"
+        fill="none" stroke="#F59E0B" stroke-width="3.5"
+        stroke-linejoin="round"/>
+  <!-- Hat brim (outline only) -->
+  <path d="M 166 246 L 346 246 L 340 270 L 172 270 Z"
+        fill="none" stroke="#F59E0B" stroke-width="3.5"
+        stroke-linejoin="round"/>
+  <!-- Feather line -->
+  <path d="M 310 222 C 330 204, 352 188, 368 172"
+        fill="none" stroke="#F59E0B" stroke-width="2.5"
+        stroke-linecap="round"/>
+
+  <!-- Eye -->
+  <circle cx="256" cy="268" r="42" fill="#F59E0B" opacity="0.10"/>
+  <circle cx="256" cy="268" r="14" fill="#FCD34D"/>
+  <circle cx="256" cy="268" r="6"  fill="#FEF3C7"/>
+
+  <!-- Book left page (outline only) -->
+  <path d="M 256 286 L 256 454 L 62 442 L 62 290 Z"
+        fill="none" stroke="#F59E0B" stroke-width="3.5"
+        stroke-linejoin="round"/>
+  <!-- Book right page (outline only) -->
+  <path d="M 256 286 L 450 290 L 450 442 L 256 454 Z"
+        fill="none" stroke="#F59E0B" stroke-width="3.5"
+        stroke-linejoin="round"/>
+  <!-- Spine -->
+  <line x1="256" y1="286" x2="256" y2="454"
+        stroke="#F59E0B" stroke-width="2.5" opacity="0.7"/>
+</svg>

--- a/frontend/public/icon-variants/v5-bright-c.svg
+++ b/frontend/public/icon-variants/v5-bright-c.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- BRIGHT C — Richly lit. Deep amber fills, gold strokes.
+       Hat darker, book richer. Like burnished leather and candle-brass. -->
+  <rect width="512" height="512" rx="88" fill="#180700"/>
+  <rect x="18" y="18" width="476" height="476" rx="74"
+        fill="none" stroke="#B45309" stroke-width="1.6"/>
+
+  <!-- Corner diamonds -->
+  <g fill="#B45309" opacity="0.8">
+    <polygon points="38,38 46,30 54,38 46,46"/>
+    <polygon points="458,38 466,30 474,38 466,46"/>
+    <polygon points="38,474 46,466 54,474 46,482"/>
+    <polygon points="458,474 466,466 474,474 466,482"/>
+  </g>
+
+  <!-- Hat crown -->
+  <path d="M 256 68 L 194 246 L 318 246 Z"
+        fill="#6B2C0A" stroke="#B45309" stroke-width="1.8"
+        stroke-linejoin="round"/>
+  <!-- Hat brim -->
+  <path d="M 166 246 L 346 246 L 340 270 L 172 270 Z"
+        fill="#7C3410" stroke="#B45309" stroke-width="1.8"
+        stroke-linejoin="round"/>
+  <!-- Feather -->
+  <path d="M 312 218 C 328 202, 348 188, 364 174
+           C 350 182, 332 198, 318 214 Z"
+        fill="#9A4218"/>
+
+  <!-- Eye -->
+  <circle cx="256" cy="268" r="40" fill="#F59E0B" opacity="0.16"/>
+  <circle cx="256" cy="268" r="13" fill="#FCD34D"/>
+  <circle cx="256" cy="268" r="6"  fill="#FFFBEB"/>
+
+  <!-- Book left page -->
+  <path d="M 256 286 L 256 454 L 62 442 L 62 290 Z"
+        fill="#7C3410" stroke="#B45309" stroke-width="1.8"
+        stroke-linejoin="round"/>
+  <!-- Book right page -->
+  <path d="M 256 286 L 450 290 L 450 442 L 256 454 Z"
+        fill="#92400E" stroke="#B45309" stroke-width="1.8"
+        stroke-linejoin="round"/>
+  <!-- Spine -->
+  <line x1="256" y1="286" x2="256" y2="454" stroke="#B45309" stroke-width="2.2"/>
+  <!-- Eye glow on book -->
+  <ellipse cx="256" cy="290" rx="60" ry="12" fill="#FCD34D" opacity="0.14"/>
+</svg>

--- a/frontend/public/icon.svg
+++ b/frontend/public/icon.svg
@@ -1,133 +1,37 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
-  <title>Book Reader AI</title>
-  <defs>
-    <!-- Page glow — left: warm light from spine outward -->
-    <radialGradient id="pg-l" cx="72%" cy="50%" r="72%">
-      <stop offset="0%"   stop-color="#FEF3C7"/>
-      <stop offset="55%"  stop-color="#FDE68A"/>
-      <stop offset="100%" stop-color="#B45309"/>
-    </radialGradient>
-    <!-- Page glow — right: mirror -->
-    <radialGradient id="pg-r" cx="28%" cy="50%" r="72%">
-      <stop offset="0%"   stop-color="#FEF3C7"/>
-      <stop offset="55%"  stop-color="#FDE68A"/>
-      <stop offset="100%" stop-color="#B45309"/>
-    </radialGradient>
-    <!-- Hellfire rising from below the figure -->
-    <radialGradient id="inferno" cx="50%" cy="100%" r="65%">
-      <stop offset="0%"   stop-color="#FCD34D" stop-opacity="0.55"/>
-      <stop offset="28%"  stop-color="#F59E0B" stop-opacity="0.30"/>
-      <stop offset="65%"  stop-color="#D97706" stop-opacity="0.12"/>
-      <stop offset="100%" stop-color="#92400E" stop-opacity="0"/>
-    </radialGradient>
-  </defs>
-
-  <!-- ░░ BACKGROUND — near-black cognac leather ░░ -->
+  <!-- BRIGHT B — Woodcut / linework. Outlines only in bright amber-gold.
+       Pure amber lines on black — like an etching or a Retzsch plate. -->
   <rect width="512" height="512" rx="88" fill="#0C0300"/>
-
-  <!-- Ambient hellfire glow (behind everything) -->
-  <ellipse cx="256" cy="480" rx="260" ry="170" fill="url(#inferno)"/>
-
-  <!-- ░░ DOUBLE ORNAMENTAL BORDER ░░ -->
   <rect x="18" y="18" width="476" height="476" rx="74"
-        fill="none" stroke="#6B2B08" stroke-width="1.8" opacity="0.9"/>
-  <rect x="27" y="27" width="458" height="458" rx="67"
-        fill="none" stroke="#6B2B08" stroke-width="0.7" opacity="0.45"/>
+        fill="none" stroke="#F59E0B" stroke-width="1.4" opacity="0.5"/>
 
-  <!-- Corner diamonds -->
-  <g fill="#92400E" opacity="0.95">
-    <polygon points="38,38  46,30  54,38  46,46"/>
-    <polygon points="458,38 466,30 474,38 466,46"/>
-    <polygon points="38,474 46,466 54,474 46,482"/>
-    <polygon points="458,474 466,466 474,474 466,482"/>
-  </g>
+  <!-- Hat crown (outline only) -->
+  <path d="M 256 68 L 194 246 L 318 246 Z"
+        fill="none" stroke="#F59E0B" stroke-width="3.5"
+        stroke-linejoin="round"/>
+  <!-- Hat brim (outline only) -->
+  <path d="M 166 246 L 346 246 L 340 270 L 172 270 Z"
+        fill="none" stroke="#F59E0B" stroke-width="3.5"
+        stroke-linejoin="round"/>
+  <!-- Feather line -->
+  <path d="M 310 222 C 330 204, 352 188, 368 172"
+        fill="none" stroke="#F59E0B" stroke-width="2.5"
+        stroke-linecap="round"/>
 
-  <!-- Decorative top pip -->
-  <line x1="150" y1="52" x2="220" y2="52" stroke="#6B2B08" stroke-width="1" opacity="0.65"/>
-  <line x1="292" y1="52" x2="362" y2="52" stroke="#6B2B08" stroke-width="1" opacity="0.65"/>
-  <polygon points="256,46 261,52 256,58 251,52" fill="#6B2B08" opacity="0.65"/>
+  <!-- Eye -->
+  <circle cx="256" cy="268" r="42" fill="#F59E0B" opacity="0.10"/>
+  <circle cx="256" cy="268" r="14" fill="#FCD34D"/>
+  <circle cx="256" cy="268" r="6"  fill="#FEF3C7"/>
 
-  <!-- ░░ OPEN BOOK ░░ -->
-  <!-- Left page -->
-  <path d="M 256 434 L 256 296 Q 163 280 68 296 L 68 446 Q 161 458 256 434 Z"
-        fill="url(#pg-l)"/>
-  <!-- Right page -->
-  <path d="M 256 296 Q 349 280 444 296 L 444 446 Q 351 458 256 434 L 256 296 Z"
-        fill="url(#pg-r)"/>
-  <!-- Spine crease -->
-  <line x1="256" y1="296" x2="256" y2="434" stroke="#92400E" stroke-width="2.2" opacity="0.55"/>
-
-  <!-- Text lines — left page (slightly angled toward spine) -->
-  <g stroke="#8B3A0A" stroke-width="1.1" opacity="0.22" stroke-linecap="round">
-    <line x1="90"  y1="323" x2="242" y2="316"/>
-    <line x1="88"  y1="337" x2="243" y2="330"/>
-    <line x1="88"  y1="351" x2="242" y2="344"/>
-    <line x1="89"  y1="365" x2="242" y2="358"/>
-    <line x1="89"  y1="379" x2="240" y2="372"/>
-    <line x1="90"  y1="393" x2="238" y2="386"/>
-    <line x1="90"  y1="407" x2="224" y2="400"/>
-    <line x1="91"  y1="421" x2="227" y2="414"/>
-  </g>
-  <!-- Text lines — right page -->
-  <g stroke="#8B3A0A" stroke-width="1.1" opacity="0.22" stroke-linecap="round">
-    <line x1="270" y1="316" x2="422" y2="323"/>
-    <line x1="269" y1="330" x2="424" y2="337"/>
-    <line x1="270" y1="344" x2="424" y2="351"/>
-    <line x1="270" y1="358" x2="423" y2="365"/>
-    <line x1="272" y1="372" x2="423" y2="379"/>
-    <line x1="274" y1="386" x2="422" y2="393"/>
-    <line x1="288" y1="400" x2="422" y2="407"/>
-    <line x1="285" y1="414" x2="421" y2="421"/>
-  </g>
-
-  <!-- Hot glow at the spine — where Mephisto stands -->
-  <ellipse cx="256" cy="300" rx="78" ry="20" fill="#FCD34D" opacity="0.15"/>
-  <ellipse cx="256" cy="300" rx="40" ry="11" fill="#FFFBEB" opacity="0.18"/>
-
-  <!-- ░░ MEPHISTOPHELES SILHOUETTE ░░
-       Classic Faustian figure: tall pointed hat with feather,
-       dramatic sweeping cloak, standing over the open book.  -->
-  <path d="
-    M 258 76
-    L 273 137
-    L 296 157
-    C 298 163, 294 170, 285 175
-    C 279 178, 271 181, 268 185
-    C 281 191, 298 200, 319 219
-    C 339 238, 357 263, 360 288
-    C 362 305, 355 319, 339 323
-    C 325 327, 306 327, 286 323
-    C 277 321, 269 319, 261 318
-    L 256 318
-    L 251 318
-    C 243 319, 235 321, 226 323
-    C 206 327, 187 327, 173 323
-    C 157 319, 150 305, 152 288
-    C 155 263, 173 238, 193 219
-    C 214 200, 231 191, 244 185
-    C 241 181, 233 178, 227 175
-    C 218 170, 214 163, 216 157
-    L 239 137
-    Z
-  " fill="#080200"/>
-
-  <!-- Hat feather — curves upward from right brim, classic Mephisto detail -->
-  <path d="M 286 150 C 300 135, 318 118, 334 104
-           C 320 112, 304 131, 291 146 Z"
-        fill="#110300"/>
-
-  <!-- Subtle amber rim-light on cape base (hellfire from below) -->
-  <path d="M 175 320 C 200 329, 228 331, 256 330 C 284 331, 312 329, 337 320"
-        fill="none" stroke="#D97706" stroke-width="1.3" opacity="0.28"/>
-
-  <!-- THE EYE — a single ember watching from the darkness -->
-  <circle cx="261" cy="167" r="6.5" fill="#F59E0B" opacity="0.10"/>
-  <circle cx="261" cy="167" r="3.0" fill="#F59E0B" opacity="0.90"/>
-  <circle cx="261" cy="167" r="1.5" fill="#FDE68A" opacity="0.95"/>
-
-  <!-- ░░ BOTTOM ORNAMENT ░░ -->
-  <line x1="150" y1="473" x2="220" y2="473" stroke="#6B2B08" stroke-width="1" opacity="0.55"/>
-  <line x1="292" y1="473" x2="362" y2="473" stroke="#6B2B08" stroke-width="1" opacity="0.55"/>
-  <polygon points="256,467 261,473 256,479 251,473" fill="#6B2B08" opacity="0.55"/>
-
+  <!-- Book left page (outline only) -->
+  <path d="M 256 286 L 256 454 L 62 442 L 62 290 Z"
+        fill="none" stroke="#F59E0B" stroke-width="3.5"
+        stroke-linejoin="round"/>
+  <!-- Book right page (outline only) -->
+  <path d="M 256 286 L 450 290 L 450 442 L 256 454 Z"
+        fill="none" stroke="#F59E0B" stroke-width="3.5"
+        stroke-linejoin="round"/>
+  <!-- Spine -->
+  <line x1="256" y1="286" x2="256" y2="454"
+        stroke="#F59E0B" stroke-width="2.5" opacity="0.7"/>
 </svg>

--- a/frontend/src/app/icon.svg
+++ b/frontend/src/app/icon.svg
@@ -1,133 +1,37 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
-  <title>Book Reader AI</title>
-  <defs>
-    <!-- Page glow — left: warm light from spine outward -->
-    <radialGradient id="pg-l" cx="72%" cy="50%" r="72%">
-      <stop offset="0%"   stop-color="#FEF3C7"/>
-      <stop offset="55%"  stop-color="#FDE68A"/>
-      <stop offset="100%" stop-color="#B45309"/>
-    </radialGradient>
-    <!-- Page glow — right: mirror -->
-    <radialGradient id="pg-r" cx="28%" cy="50%" r="72%">
-      <stop offset="0%"   stop-color="#FEF3C7"/>
-      <stop offset="55%"  stop-color="#FDE68A"/>
-      <stop offset="100%" stop-color="#B45309"/>
-    </radialGradient>
-    <!-- Hellfire rising from below the figure -->
-    <radialGradient id="inferno" cx="50%" cy="100%" r="65%">
-      <stop offset="0%"   stop-color="#FCD34D" stop-opacity="0.55"/>
-      <stop offset="28%"  stop-color="#F59E0B" stop-opacity="0.30"/>
-      <stop offset="65%"  stop-color="#D97706" stop-opacity="0.12"/>
-      <stop offset="100%" stop-color="#92400E" stop-opacity="0"/>
-    </radialGradient>
-  </defs>
-
-  <!-- ░░ BACKGROUND — near-black cognac leather ░░ -->
+  <!-- BRIGHT B — Woodcut / linework. Outlines only in bright amber-gold.
+       Pure amber lines on black — like an etching or a Retzsch plate. -->
   <rect width="512" height="512" rx="88" fill="#0C0300"/>
-
-  <!-- Ambient hellfire glow (behind everything) -->
-  <ellipse cx="256" cy="480" rx="260" ry="170" fill="url(#inferno)"/>
-
-  <!-- ░░ DOUBLE ORNAMENTAL BORDER ░░ -->
   <rect x="18" y="18" width="476" height="476" rx="74"
-        fill="none" stroke="#6B2B08" stroke-width="1.8" opacity="0.9"/>
-  <rect x="27" y="27" width="458" height="458" rx="67"
-        fill="none" stroke="#6B2B08" stroke-width="0.7" opacity="0.45"/>
+        fill="none" stroke="#F59E0B" stroke-width="1.4" opacity="0.5"/>
 
-  <!-- Corner diamonds -->
-  <g fill="#92400E" opacity="0.95">
-    <polygon points="38,38  46,30  54,38  46,46"/>
-    <polygon points="458,38 466,30 474,38 466,46"/>
-    <polygon points="38,474 46,466 54,474 46,482"/>
-    <polygon points="458,474 466,466 474,474 466,482"/>
-  </g>
+  <!-- Hat crown (outline only) -->
+  <path d="M 256 68 L 194 246 L 318 246 Z"
+        fill="none" stroke="#F59E0B" stroke-width="3.5"
+        stroke-linejoin="round"/>
+  <!-- Hat brim (outline only) -->
+  <path d="M 166 246 L 346 246 L 340 270 L 172 270 Z"
+        fill="none" stroke="#F59E0B" stroke-width="3.5"
+        stroke-linejoin="round"/>
+  <!-- Feather line -->
+  <path d="M 310 222 C 330 204, 352 188, 368 172"
+        fill="none" stroke="#F59E0B" stroke-width="2.5"
+        stroke-linecap="round"/>
 
-  <!-- Decorative top pip -->
-  <line x1="150" y1="52" x2="220" y2="52" stroke="#6B2B08" stroke-width="1" opacity="0.65"/>
-  <line x1="292" y1="52" x2="362" y2="52" stroke="#6B2B08" stroke-width="1" opacity="0.65"/>
-  <polygon points="256,46 261,52 256,58 251,52" fill="#6B2B08" opacity="0.65"/>
+  <!-- Eye -->
+  <circle cx="256" cy="268" r="42" fill="#F59E0B" opacity="0.10"/>
+  <circle cx="256" cy="268" r="14" fill="#FCD34D"/>
+  <circle cx="256" cy="268" r="6"  fill="#FEF3C7"/>
 
-  <!-- ░░ OPEN BOOK ░░ -->
-  <!-- Left page -->
-  <path d="M 256 434 L 256 296 Q 163 280 68 296 L 68 446 Q 161 458 256 434 Z"
-        fill="url(#pg-l)"/>
-  <!-- Right page -->
-  <path d="M 256 296 Q 349 280 444 296 L 444 446 Q 351 458 256 434 L 256 296 Z"
-        fill="url(#pg-r)"/>
-  <!-- Spine crease -->
-  <line x1="256" y1="296" x2="256" y2="434" stroke="#92400E" stroke-width="2.2" opacity="0.55"/>
-
-  <!-- Text lines — left page (slightly angled toward spine) -->
-  <g stroke="#8B3A0A" stroke-width="1.1" opacity="0.22" stroke-linecap="round">
-    <line x1="90"  y1="323" x2="242" y2="316"/>
-    <line x1="88"  y1="337" x2="243" y2="330"/>
-    <line x1="88"  y1="351" x2="242" y2="344"/>
-    <line x1="89"  y1="365" x2="242" y2="358"/>
-    <line x1="89"  y1="379" x2="240" y2="372"/>
-    <line x1="90"  y1="393" x2="238" y2="386"/>
-    <line x1="90"  y1="407" x2="224" y2="400"/>
-    <line x1="91"  y1="421" x2="227" y2="414"/>
-  </g>
-  <!-- Text lines — right page -->
-  <g stroke="#8B3A0A" stroke-width="1.1" opacity="0.22" stroke-linecap="round">
-    <line x1="270" y1="316" x2="422" y2="323"/>
-    <line x1="269" y1="330" x2="424" y2="337"/>
-    <line x1="270" y1="344" x2="424" y2="351"/>
-    <line x1="270" y1="358" x2="423" y2="365"/>
-    <line x1="272" y1="372" x2="423" y2="379"/>
-    <line x1="274" y1="386" x2="422" y2="393"/>
-    <line x1="288" y1="400" x2="422" y2="407"/>
-    <line x1="285" y1="414" x2="421" y2="421"/>
-  </g>
-
-  <!-- Hot glow at the spine — where Mephisto stands -->
-  <ellipse cx="256" cy="300" rx="78" ry="20" fill="#FCD34D" opacity="0.15"/>
-  <ellipse cx="256" cy="300" rx="40" ry="11" fill="#FFFBEB" opacity="0.18"/>
-
-  <!-- ░░ MEPHISTOPHELES SILHOUETTE ░░
-       Classic Faustian figure: tall pointed hat with feather,
-       dramatic sweeping cloak, standing over the open book.  -->
-  <path d="
-    M 258 76
-    L 273 137
-    L 296 157
-    C 298 163, 294 170, 285 175
-    C 279 178, 271 181, 268 185
-    C 281 191, 298 200, 319 219
-    C 339 238, 357 263, 360 288
-    C 362 305, 355 319, 339 323
-    C 325 327, 306 327, 286 323
-    C 277 321, 269 319, 261 318
-    L 256 318
-    L 251 318
-    C 243 319, 235 321, 226 323
-    C 206 327, 187 327, 173 323
-    C 157 319, 150 305, 152 288
-    C 155 263, 173 238, 193 219
-    C 214 200, 231 191, 244 185
-    C 241 181, 233 178, 227 175
-    C 218 170, 214 163, 216 157
-    L 239 137
-    Z
-  " fill="#080200"/>
-
-  <!-- Hat feather — curves upward from right brim, classic Mephisto detail -->
-  <path d="M 286 150 C 300 135, 318 118, 334 104
-           C 320 112, 304 131, 291 146 Z"
-        fill="#110300"/>
-
-  <!-- Subtle amber rim-light on cape base (hellfire from below) -->
-  <path d="M 175 320 C 200 329, 228 331, 256 330 C 284 331, 312 329, 337 320"
-        fill="none" stroke="#D97706" stroke-width="1.3" opacity="0.28"/>
-
-  <!-- THE EYE — a single ember watching from the darkness -->
-  <circle cx="261" cy="167" r="6.5" fill="#F59E0B" opacity="0.10"/>
-  <circle cx="261" cy="167" r="3.0" fill="#F59E0B" opacity="0.90"/>
-  <circle cx="261" cy="167" r="1.5" fill="#FDE68A" opacity="0.95"/>
-
-  <!-- ░░ BOTTOM ORNAMENT ░░ -->
-  <line x1="150" y1="473" x2="220" y2="473" stroke="#6B2B08" stroke-width="1" opacity="0.55"/>
-  <line x1="292" y1="473" x2="362" y2="473" stroke="#6B2B08" stroke-width="1" opacity="0.55"/>
-  <polygon points="256,467 261,473 256,479 251,473" fill="#6B2B08" opacity="0.55"/>
-
+  <!-- Book left page (outline only) -->
+  <path d="M 256 286 L 256 454 L 62 442 L 62 290 Z"
+        fill="none" stroke="#F59E0B" stroke-width="3.5"
+        stroke-linejoin="round"/>
+  <!-- Book right page (outline only) -->
+  <path d="M 256 286 L 450 290 L 450 442 L 256 454 Z"
+        fill="none" stroke="#F59E0B" stroke-width="3.5"
+        stroke-linejoin="round"/>
+  <!-- Spine -->
+  <line x1="256" y1="286" x2="256" y2="454"
+        stroke="#F59E0B" stroke-width="2.5" opacity="0.7"/>
 </svg>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -159,9 +159,13 @@ export default function Home() {
       {/* Header */}
       <header className="border-b border-amber-200 bg-white/60 backdrop-blur px-4 md:px-6 py-3 md:py-4">
         <div className="max-w-5xl mx-auto flex items-center justify-between">
-          <div>
-            <h1 className="text-xl md:text-2xl font-serif font-bold text-ink">Book Reader AI</h1>
-            <p className="text-xs md:text-sm text-amber-800 mt-0.5">Public domain classics with AI assistance</p>
+          <div className="flex items-center gap-3">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src="/icon.svg" alt="" className="w-10 h-10 rounded-xl shrink-0" />
+            <div>
+              <h1 className="text-xl md:text-2xl font-serif font-bold text-ink">Book Reader AI</h1>
+              <p className="text-xs md:text-sm text-amber-800 mt-0.5">Public domain classics with AI assistance</p>
+            </div>
           </div>
           {status === "unauthenticated" ? (
             <button


### PR DESCRIPTION
## Summary

- Replaces the previous figurative Mephisto icon with the V5-B woodcut design: amber outlines only on black — hat, eye, open book
- Adds the icon to the homepage header, left of the "Book Reader AI" title (standard logo-mark position)

## Design

Etching/woodcut style (like the Retzsch plates that illustrated the original Faust editions): pure amber-gold outlines on near-black, no fills. Three elements: the pointed hat (Mephisto), the single watching eye, the open book. Abstract but unmistakably literary.

## Test plan

- [ ] Browser tab shows new icon at favicon size
- [ ] Homepage header shows icon beside the title
- [ ] Looks correct on mobile (40×40, rounded-xl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
