### PR TITLE
feat(notes): add context quote to AI insights in notes page

### DIFF
--- a/backend/migrations/016_insight_context.sql
+++ b/backend/migrations/016_insight_context.sql
@@ -1,0 +1,2 @@
+-- Store the passage/selected text that was used as context when the insight was generated
+ALTER TABLE book_insights ADD COLUMN context_text TEXT;

--- a/backend/routers/insights.py
+++ b/backend/routers/insights.py
@@ -11,6 +11,7 @@ class InsightCreate(BaseModel):
     chapter_index: int | None = None
     question: str
     answer: str
+    context_text: str | None = None
 
 
 @router.post("")
@@ -21,6 +22,7 @@ async def create(req: InsightCreate, user: dict = Depends(get_current_user)):
         req.chapter_index,
         req.question,
         req.answer,
+        req.context_text,
     )
 
 

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -691,13 +691,14 @@ async def save_insight(
     chapter_index: int | None,
     question: str,
     answer: str,
+    context_text: str | None = None,
 ) -> dict:
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         cursor = await db.execute(
-            """INSERT INTO book_insights (user_id, book_id, chapter_index, question, answer)
-               VALUES (?, ?, ?, ?, ?)""",
-            (user_id, book_id, chapter_index, question, answer),
+            """INSERT INTO book_insights (user_id, book_id, chapter_index, question, answer, context_text)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (user_id, book_id, chapter_index, question, answer, context_text),
         )
         await db.commit()
         row_id = cursor.lastrowid

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -81,6 +81,7 @@ function buildMarkdown(
         lines.push("### Book-level");
         lines.push("");
         for (const i of bookLevel) {
+          if (i.context_text) { lines.push(`> "${truncate(i.context_text, 200)}"`); lines.push(""); }
           lines.push(`**Q:** ${i.question}`);
           lines.push(`**A:** ${i.answer}`);
           lines.push("");
@@ -90,6 +91,7 @@ function buildMarkdown(
         lines.push(`### ${chapterLabel(chapters, ch)}`);
         lines.push("");
         for (const i of ins) {
+          if (i.context_text) { lines.push(`> "${truncate(i.context_text, 200)}"`); lines.push(""); }
           lines.push(`**Q:** ${i.question}`);
           lines.push(`**A:** ${i.answer}`);
           lines.push("");
@@ -133,6 +135,7 @@ function buildMarkdown(
 
       const chIns = insights.filter((i) => i.chapter_index === ch);
       for (const i of chIns) {
+        if (i.context_text) { lines.push(`> "${truncate(i.context_text, 200)}"`); lines.push(""); }
         lines.push(`**Q:** ${i.question}`);
         lines.push(`**A:** ${i.answer}`);
         lines.push("");
@@ -155,6 +158,7 @@ function buildMarkdown(
       lines.push("## Book-level Insights");
       lines.push("");
       for (const i of bookLevelInsights) {
+        if (i.context_text) { lines.push(`> "${truncate(i.context_text, 200)}"`); lines.push(""); }
         lines.push(`**Q:** ${i.question}`);
         lines.push(`**A:** ${i.answer}`);
         lines.push("");

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1201,8 +1201,8 @@ export default function ReaderPage() {
                   bookLanguage={bookLanguage}
                   onAIUsed={notifyAIUsed}
                   chapterIndex={chapterIndex}
-                  onSaveInsight={session?.backendToken ? (question, answer) => {
-                    saveInsight({ book_id: Number(bookId), chapter_index: chapterIndex, question, answer })
+                  onSaveInsight={session?.backendToken ? (question, answer, context) => {
+                    saveInsight({ book_id: Number(bookId), chapter_index: chapterIndex, question, answer, context_text: context })
                       .then(() => setObsidianToast("Insight saved to book notes"))
                       .catch(() => setObsidianToast("Failed to save insight"))
                       .finally(() => setTimeout(() => setObsidianToast(null), 3000));

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -46,7 +46,7 @@ interface Props {
   author: string;
   bookLanguage: string;
   onAIUsed?: () => void;    // called whenever an AI (non-cached) call is made
-  onSaveInsight?: (question: string, answer: string) => void;
+  onSaveInsight?: (question: string, answer: string, context?: string) => void;
   chapterIndex?: number;
 }
 
@@ -359,7 +359,7 @@ export default function InsightChat({
                         const absIdx = loadedFrom + i;
                         if (savedInsights.has(absIdx)) return;
                         setSavedInsights((prev) => new Set(prev).add(absIdx));
-                        onSaveInsight(prevUserMsg.content, msg.content);
+                        onSaveInsight(prevUserMsg.content, msg.content, prevUserMsg.context);
                       }}
                       title={savedInsights.has(loadedFrom + i) ? "Already saved to notes" : "Save this insight to book notes"}
                       className={`mt-2 flex items-center gap-1 text-xs transition-colors ${savedInsights.has(loadedFrom + i) ? "text-amber-300 cursor-default" : "text-amber-500 hover:text-amber-800"}`}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -601,6 +601,7 @@ export interface BookInsight {
   chapter_index: number | null;
   question: string;
   answer: string;
+  context_text?: string | null;
   created_at: string;
 }
 
@@ -621,6 +622,7 @@ export function saveInsight(data: {
   chapter_index?: number;
   question: string;
   answer: string;
+  context_text?: string;
 }) {
   return request<BookInsight>("/insights", {
     method: "POST",


### PR DESCRIPTION
## Summary

- **`context_text` stored with insights**: when a user saves an AI insight from the reading companion, the selected passage they had attached is now persisted alongside the Q&A
- **Notes page renders context as blockquote**: in `/notes/[bookId]`, every insight that has a `context_text` now shows it as an indented italic blockquote above the Q/A — in both "By section" and "By chapter" views, including book-level insights
- **Migration 016** adds a nullable `context_text TEXT` column to `book_insights`; existing rows are unaffected

## How it works

1. `InsightChat` already had `prevUserMsg.context` (the selected passage) stored on the message object
2. The save button now passes that as a third arg: `onSaveInsight(question, answer, context)`
3. The reader `onSaveInsight` callback forwards it as `context_text` to the API
4. Backend `InsightCreate` + `save_insight()` accept and persist it

## Test plan

- [ ] 1260 frontend tests pass
- [ ] 216 backend tests pass
- [ ] Manually: ask a question with selected text in reading companion → save → open `/notes/[bookId]` → confirm blockquote appears above the Q/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
