### PR TITLE
fix: cache-bust favicon by using Next.js content-hashed icon URL

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,7 +5,6 @@ import { Providers } from "./providers";
 export const metadata: Metadata = {
   title: "Book Reader AI",
   description: "Read public domain classics with AI assistance",
-  icons: { icon: "/icon.svg" },
 };
 
 export const viewport: Viewport = {


### PR DESCRIPTION
## Problem

The old icon was still showing because `icons: { icon: "/icon.svg" }` in layout.tsx pointed to `public/icon.svg` at the fixed URL `/icon.svg`. Browsers cache favicons aggressively by URL — since the URL never changed, they kept serving the old icon.

## Fix

Remove the explicit `icons` metadata. Next.js App Router automatically serves `app/icon.svg` at a **content-hashed URL** (e.g. `/_next/static/media/icon.abc123.svg`). When the file changes, the hash changes, and browsers are forced to fetch the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
