### PR TITLE
fix(insight-chat): remove font-serif from context chip

### DIFF
--- a/backend/migrations/017_vocabulary_lemma_language.sql
+++ b/backend/migrations/017_vocabulary_lemma_language.sql
@@ -1,0 +1,4 @@
+-- Add lemma (base/dictionary form) and language to vocabulary.
+-- lemma is populated asynchronously by the Wiktionary lookup service.
+ALTER TABLE vocabulary ADD COLUMN lemma TEXT;
+ALTER TABLE vocabulary ADD COLUMN language TEXT;

--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -48,6 +48,12 @@ async def list_vocabulary(user: dict = Depends(get_current_user)):
     return await get_vocabulary(user["id"])
 
 
+@router.get("/definition/{word}")
+async def get_definition(word: str, lang: str = "en", user: dict = Depends(get_current_user)):
+    from services import wiktionary
+    return await wiktionary.lookup(word, lang)
+
+
 @router.delete("/{word}")
 async def remove_word(word: str, user: dict = Depends(get_current_user)):
     deleted = await delete_word(user["id"], word)
@@ -94,6 +100,14 @@ async def _github_put(
     return put_resp.json()["content"]["html_url"]
 
 
+_LANG_NAMES: dict[str, str] = {
+    "en": "English", "de": "German", "fr": "French", "es": "Spanish",
+    "it": "Italian", "pt": "Portuguese", "ru": "Russian", "ja": "Japanese",
+    "zh": "Chinese", "nl": "Dutch", "pl": "Polish", "sv": "Swedish",
+    "fi": "Finnish", "da": "Danish", "no": "Norwegian", "la": "Latin",
+}
+
+
 def _build_book_markdown(
     book: dict,
     words_for_book: list[dict],
@@ -104,53 +118,77 @@ def _build_book_markdown(
     export_date: str,
     ann_translations: dict[int, str] | None = None,
 ) -> str:
-    authors = ", ".join(book.get("authors", [])) if book else "Unknown"
+    authors_list: list[str] = book.get("authors", []) if book else []
+    authors = ", ".join(authors_list) if authors_list else "Unknown"
     title = book.get("title", f"Book {book_id}") if book else f"Book {book_id}"
+    langs: list[str] = book.get("languages", ["en"]) if book else ["en"]
+    language = ", ".join(_LANG_NAMES.get(l, l) for l in langs) if langs else "English"
+    safe_title = title.replace('"', '\\"')
 
     lines = [
         "---",
-        f"Author: {authors}",
-        "Language: English",
-        f"Source: gutenberg.org/ebooks/{book_id}",
-        f"Export-Date: {export_date}",
+        f'title: "{safe_title}"',
+        f"author: {authors}",
+        f"language: {language}",
+        f"source: https://www.gutenberg.org/ebooks/{book_id}",
+        "tags:",
+        "  - reading",
+        "  - books",
+        f"export_date: {export_date}",
         "---",
-        "#reading #books",
         "",
-        "## Vocabulary",
     ]
 
-    for entry in words_for_book:
-        word = entry["word"]
-        for occ in entry["occurrences"]:
-            if occ["book_id"] == book_id:
-                lines.append(
-                    f"- [[{word}]] — Ch.{occ['chapter_index']}: \"{occ['sentence_text']}\""
-                )
+    if words_for_book:
+        lines.append("## Vocabulary")
+        lines.append("")
+        for entry in words_for_book:
+            word = entry["word"]
+            for occ in entry["occurrences"]:
+                if occ["book_id"] == book_id:
+                    lines.append(
+                        f"- [[{word}]] — Ch.{occ['chapter_index'] + 1}: \"{occ['sentence_text']}\""
+                    )
+        lines.append("")
 
-    lines += ["", "## Connected Books (shared vocabulary)"]
-    for conn in connected:
-        shared_words = ", ".join(f"[[{w}]]" for w in conn["shared_words"])
-        lines.append(f"- [[{conn['title']}]] — shared: {shared_words}")
+    if connected:
+        lines.append("## Connected Books")
+        lines.append("")
+        for conn in connected:
+            shared_words = ", ".join(f"[[{w}]]" for w in conn["shared_words"])
+            lines.append(f"- [[{conn['title']}]] — shared: {shared_words}")
+        lines.append("")
 
-    lines += ["", "## Annotations"]
-    chapters: dict[int, list] = {}
-    for ann in annotations:
-        chapters.setdefault(ann["chapter_index"], []).append(ann)
-    for ch_idx in sorted(chapters):
-        lines.append(f"\n### Chapter {ch_idx + 1}")
-        for ann in chapters[ch_idx]:
-            lines.append(f"\n> \"{ann['sentence_text']}\"")
-            if ann_translations and ann["id"] in ann_translations:
-                lines.append(f"> *{ann_translations[ann['id']]}*")
-            if ann.get("note_text"):
-                lines.append(f"\n{ann['note_text']}")
+    if annotations:
+        lines.append("## Annotations")
+        chapters: dict[int, list] = {}
+        for ann in annotations:
+            chapters.setdefault(ann["chapter_index"], []).append(ann)
+        for ch_idx in sorted(chapters):
+            lines.append(f"\n### Chapter {ch_idx + 1}")
+            for ann in chapters[ch_idx]:
+                lines.append(f"\n> [!quote] Ch.{ch_idx + 1}")
+                lines.append(f"> {ann['sentence_text']}")
+                if ann_translations and ann["id"] in ann_translations:
+                    lines.append(f"> ")
+                    lines.append(f"> *{ann_translations[ann['id']]}*")
+                if ann.get("note_text"):
+                    lines.append(f"\n{ann['note_text']}")
+        lines.append("")
 
     if insights:
-        lines += ["", "## Reading Insights"]
+        lines.append("## Reading Insights")
+        lines.append("")
         for ins in insights:
             ch_label = f" (Ch.{ins['chapter_index'] + 1})" if ins.get("chapter_index") is not None else ""
-            lines.append(f"\n**Q{ch_label}:** {ins['question']}")
-            lines.append(f"\n{ins['answer']}")
+            if ins.get("context_text"):
+                lines.append(f"> [!quote]{ch_label}")
+                lines.append(f"> {ins['context_text']}")
+                lines.append("")
+            lines.append(f"**Q{ch_label}:** {ins['question']}")
+            lines.append("")
+            lines.append(ins["answer"])
+            lines.append("")
 
     return "\n".join(lines) + "\n"
 

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -583,6 +583,24 @@ async def get_all_annotations(user_id: int) -> list[dict]:
 
 # ── Vocabulary ────────────────────────────────────────────────────────────────
 
+async def _update_lemma(vocab_id: int, word: str, book_id: int) -> None:
+    try:
+        book = await get_cached_book(book_id)
+        langs = book.get("languages", ["en"]) if book else ["en"]
+        lang = langs[0] if langs else "en"
+        from services import wiktionary
+        result = await wiktionary.lookup(word, lang)
+        async with aiosqlite.connect(DB_PATH) as db:
+            await db.execute(
+                "UPDATE vocabulary SET lemma = ?, language = ? WHERE id = ?",
+                (result["lemma"], result["language"], vocab_id),
+            )
+            await db.commit()
+    except Exception:
+        import logging
+        logging.getLogger(__name__).warning("Lemma update failed for %s", word, exc_info=True)
+
+
 async def save_word(
     user_id: int,
     word: str,
@@ -590,6 +608,7 @@ async def save_word(
     chapter_index: int,
     sentence_text: str,
 ) -> dict:
+    import asyncio
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         await db.execute(
@@ -614,6 +633,8 @@ async def save_word(
 
         async with db.execute("SELECT * FROM vocabulary WHERE id = ?", (vocab_id,)) as cursor:
             row = await cursor.fetchone()
+
+    asyncio.create_task(_update_lemma(vocab_id, word, book_id))
     return dict(row)
 
 
@@ -621,7 +642,7 @@ async def get_vocabulary(user_id: int) -> list[dict]:
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         async with db.execute(
-            "SELECT id, word, created_at FROM vocabulary WHERE user_id = ? ORDER BY word",
+            "SELECT id, word, lemma, language, created_at FROM vocabulary WHERE user_id = ? ORDER BY word",
             (user_id,),
         ) as cursor:
             vocab_rows = await cursor.fetchall()
@@ -640,6 +661,8 @@ async def get_vocabulary(user_id: int) -> list[dict]:
             result.append({
                 "id": v["id"],
                 "word": v["word"],
+                "lemma": v["lemma"],
+                "language": v["language"],
                 "created_at": v["created_at"],
                 "occurrences": occurrences,
             })

--- a/backend/services/wiktionary.py
+++ b/backend/services/wiktionary.py
@@ -1,0 +1,112 @@
+"""Wiktionary REST API integration for word definitions and lemma extraction."""
+import re
+
+import httpx
+
+_BASE = "https://en.wiktionary.org/api/rest_v1/page/definition"
+_HEADERS = {"User-Agent": "BookReaderAI/1.0 (https://github.com/alfmunny/book-reader-ai)"}
+
+# Keywords that signal a "form of" definition entry
+_FORM_KEYWORDS = frozenset({
+    "participle", "tense", "plural", "singular", "genitive", "dative",
+    "accusative", "nominative", "inflection", "form", "comparative",
+    "superlative", "conjugation", "imperative", "infinitive",
+})
+
+
+def _extract_lemma(raw_html: str, current_word: str) -> str | None:
+    """Try to extract the base form from a Wiktionary 'form of' definition.
+
+    Examples handled:
+      "past participle of <b class='Latn'>gehen</b>"
+      "plural of <a href='./Buch'>Buch</a>"
+    """
+    lower = re.sub(r"<[^>]+>", "", raw_html).lower()
+    if " of " not in lower and not any(k in lower for k in _FORM_KEYWORDS):
+        return None
+
+    # Extract text node immediately after "of " followed by one or more tags
+    m = re.search(r"\bof\s+(?:<[^>]+>)+([^<\s,;.]+)", raw_html, re.IGNORECASE)
+    if m:
+        candidate = m.group(1).strip(" .,;")
+        if candidate and candidate.lower() != current_word.lower():
+            return candidate
+
+    # Fallback: plain "of word" without HTML tags
+    m = re.search(r"\bof\s+([A-Za-zÀ-öø-ÿ\u0400-\u04FF\-]+)", raw_html, re.IGNORECASE)
+    if m:
+        candidate = m.group(1).strip()
+        if candidate and candidate.lower() != current_word.lower():
+            return candidate
+
+    return None
+
+
+def _strip_html(text: str) -> str:
+    return re.sub(r"<[^>]+>", "", text).strip()
+
+
+async def lookup(word: str, lang: str = "en") -> dict:
+    """Fetch definition and lemma for *word* in *lang* from English Wiktionary.
+
+    Returns::
+
+        {
+            "lemma": str,           # base form (== word if no form-of found)
+            "language": str,        # the lang code used
+            "definitions": [        # up to 3
+                {"pos": str, "text": str}
+            ],
+            "url": str,             # canonical Wiktionary URL
+        }
+    """
+    url = f"{_BASE}/{word.lower()}"
+    wikt_url = f"https://en.wiktionary.org/wiki/{word}"
+
+    empty = {"lemma": word, "language": lang, "definitions": [], "url": wikt_url}
+
+    try:
+        async with httpx.AsyncClient(timeout=6.0) as client:
+            resp = await client.get(url, headers=_HEADERS)
+    except Exception:
+        return empty
+
+    if resp.status_code != 200:
+        return empty
+
+    try:
+        data = resp.json()
+    except Exception:
+        return empty
+
+    entries = data.get(lang) or data.get("en") or []
+
+    definitions: list[dict] = []
+    lemma: str = word
+
+    for entry in entries[:3]:
+        pos = entry.get("partOfSpeech", "")
+        for defn in entry.get("definitions", [])[:2]:
+            raw = defn.get("definition", "")
+            clean = _strip_html(raw)
+            if not clean:
+                continue
+
+            # Try lemma extraction on first definition only
+            if lemma == word:
+                candidate = _extract_lemma(raw, word)
+                if candidate:
+                    lemma = candidate
+
+            definitions.append({"pos": pos, "text": clean})
+            if len(definitions) >= 3:
+                break
+        if len(definitions) >= 3:
+            break
+
+    return {
+        "lemma": lemma,
+        "language": lang,
+        "definitions": definitions,
+        "url": wikt_url,
+    }

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,6 +7,7 @@ Provides:
 """
 
 import pytest
+from unittest.mock import AsyncMock, patch
 import services.db as db_module
 from services.db import init_db, get_or_create_user, get_user_by_id
 from services.auth import create_jwt, get_current_user, get_optional_user
@@ -20,6 +21,12 @@ TEST_USER = {
     "name": "Test User",
     "picture": "",
 }
+
+
+@pytest.fixture(autouse=True)
+def no_wiktionary_http(monkeypatch):
+    """Prevent _update_lemma from making real HTTP calls in every test."""
+    monkeypatch.setattr(db_module, "_update_lemma", AsyncMock(return_value=None))
 
 
 @pytest.fixture

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -201,5 +201,48 @@ async def test_export_calls_github_with_correct_content(client, test_user):
     content = captured_content["content"]
     assert "## Vocabulary" in content
     assert "leviathan" in content
-    assert "## Annotations" in content
-    assert "gutenberg.org/ebooks/" in content
+    # Sections only present when data exists; no annotations in this fixture
+    assert "## Annotations" not in content
+    assert "https://www.gutenberg.org/ebooks/" in content
+    # YAML frontmatter
+    assert 'title:' in content
+    assert "tags:" in content
+
+
+def test_build_book_markdown_format():
+    from routers.vocabulary import _build_book_markdown
+    book = {"title": "Moby Dick", "authors": ["Herman Melville"], "languages": ["en"]}
+    words = [{"word": "whale", "occurrences": [
+        {"book_id": 1, "book_title": "Moby Dick", "chapter_index": 0, "sentence_text": "The whale breached."}
+    ]}]
+    annotations = [{"id": 1, "chapter_index": 0, "sentence_text": "Call me Ishmael.", "note_text": "Famous opening.", "color": "yellow"}]
+    insights = [
+        {"chapter_index": 0, "question": "What is the white whale?", "answer": "A symbol of obsession.", "context_text": "The pale whale loomed."},
+        {"chapter_index": None, "question": "Book theme?", "answer": "Man vs nature.", "context_text": None},
+    ]
+    content = _build_book_markdown(book, words, annotations, [], insights, 1, "2026-04-22")
+
+    # YAML frontmatter
+    assert 'title: "Moby Dick"' in content
+    assert "author: Herman Melville" in content
+    assert "language: English" in content
+    assert "https://www.gutenberg.org/ebooks/1" in content
+    assert "tags:" in content
+    assert "  - reading" in content
+
+    # Vocabulary uses [[word]] backlinks and 1-indexed chapters
+    assert "[[whale]]" in content
+    assert "Ch.1" in content
+
+    # Annotations use [!quote] callouts
+    assert "> [!quote] Ch.1" in content
+    assert "> Call me Ishmael." in content
+    assert "Famous opening." in content
+
+    # Insight with context renders [!quote] callout
+    assert "> [!quote] (Ch.1)" in content
+    assert "> The pale whale loomed." in content
+    assert "**Q (Ch.1):** What is the white whale?" in content
+
+    # Insight without context skips callout
+    assert "**Q:** Book theme?" in content

--- a/backend/tests/test_router_vocabulary_extended.py
+++ b/backend/tests/test_router_vocabulary_extended.py
@@ -587,3 +587,42 @@ async def test_save_word_same_sentence_different_chapter_creates_separate_occurr
     chapters = {occ["chapter_index"] for occ in entry["occurrences"]}
     assert 0 in chapters
     assert 5 in chapters
+
+
+# ── GET /vocabulary/definition/{word} ────────────────────────────────────────
+
+async def test_get_definition_returns_wiktionary_result(client, test_user):
+    fake_result = {
+        "lemma": "whale",
+        "language": "en",
+        "definitions": [{"pos": "noun", "text": "A large marine mammal."}],
+        "url": "https://en.wiktionary.org/wiki/whale",
+    }
+    from services import wiktionary as wikt_mod
+    with patch.object(wikt_mod, "lookup", new_callable=AsyncMock, return_value=fake_result):
+        resp = await client.get("/api/vocabulary/definition/whale?lang=en")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["lemma"] == "whale"
+    assert len(data["definitions"]) == 1
+
+
+async def test_get_definition_requires_auth(anon_client):
+    resp = await anon_client.get("/api/vocabulary/definition/whale")
+    assert resp.status_code == 401
+
+
+# ── Lemma + language fields in vocabulary list ────────────────────────────────
+
+async def test_get_vocabulary_includes_lemma_language_fields(client, test_user):
+    """GET /vocabulary returns lemma and language fields (even if null initially)."""
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_word(test_user["id"], "swam", BOOK_ID, 0, "The fish swam.")
+
+    resp = await client.get("/api/vocabulary")
+    assert resp.status_code == 200
+    vocab = resp.json()
+    entry = next(v for v in vocab if v["word"] == "swam")
+    assert "lemma" in entry
+    assert "language" in entry

--- a/backend/tests/test_wiktionary.py
+++ b/backend/tests/test_wiktionary.py
@@ -1,0 +1,167 @@
+"""Tests for services/wiktionary.py."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from services.wiktionary import lookup, _extract_lemma, _strip_html
+
+
+# ── _strip_html ────────────────────────────────────────────────────────────────
+
+def test_strip_html_removes_tags():
+    assert _strip_html("<b>hello</b> world") == "hello world"
+
+
+def test_strip_html_empty():
+    assert _strip_html("") == ""
+
+
+# ── _extract_lemma ─────────────────────────────────────────────────────────────
+
+def test_extract_lemma_bold_tag():
+    html = "past participle of <b class='Latn'>gehen</b>"
+    assert _extract_lemma(html, "gegangen") == "gehen"
+
+
+def test_extract_lemma_anchor_tag():
+    html = "plural of <a href='./Buch'>Buch</a>"
+    assert _extract_lemma(html, "bücher") == "Buch"
+
+
+def test_extract_lemma_no_form_of():
+    html = "a large marine mammal"
+    assert _extract_lemma(html, "whale") is None
+
+
+def test_extract_lemma_same_as_current_word():
+    html = "plural of <b>whale</b>"
+    assert _extract_lemma(html, "whale") is None
+
+
+def test_extract_lemma_plain_of():
+    html = "simple past of run"
+    assert _extract_lemma(html, "ran") == "run"
+
+
+# ── lookup ─────────────────────────────────────────────────────────────────────
+
+def _make_mock_response(status_code: int, json_data: dict):
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = json_data
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_lookup_returns_empty_on_http_error():
+    with patch("services.wiktionary.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=_make_mock_response(404, {}))
+
+        result = await lookup("nonexistent", "en")
+        assert result["lemma"] == "nonexistent"
+        assert result["definitions"] == []
+
+
+@pytest.mark.asyncio
+async def test_lookup_returns_empty_on_exception():
+    with patch("services.wiktionary.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(side_effect=Exception("network error"))
+
+        result = await lookup("word", "en")
+        assert result["lemma"] == "word"
+        assert result["definitions"] == []
+
+
+@pytest.mark.asyncio
+async def test_lookup_extracts_definitions():
+    json_data = {
+        "en": [
+            {
+                "partOfSpeech": "noun",
+                "definitions": [
+                    {"definition": "A large aquatic mammal."},
+                    {"definition": "An overwhelming amount."},
+                ],
+            }
+        ]
+    }
+    with patch("services.wiktionary.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=_make_mock_response(200, json_data))
+
+        result = await lookup("whale", "en")
+        assert result["lemma"] == "whale"
+        assert len(result["definitions"]) == 2
+        assert result["definitions"][0]["pos"] == "noun"
+        assert "aquatic" in result["definitions"][0]["text"]
+        assert result["url"] == "https://en.wiktionary.org/wiki/whale"
+
+
+@pytest.mark.asyncio
+async def test_lookup_extracts_lemma_from_form_of():
+    json_data = {
+        "de": [
+            {
+                "partOfSpeech": "verb",
+                "definitions": [
+                    {"definition": "past participle of <b class='Latn'>gehen</b>"},
+                ],
+            }
+        ]
+    }
+    with patch("services.wiktionary.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=_make_mock_response(200, json_data))
+
+        result = await lookup("gegangen", "de")
+        assert result["lemma"] == "gehen"
+        assert result["language"] == "de"
+
+
+@pytest.mark.asyncio
+async def test_lookup_caps_definitions_at_three():
+    json_data = {
+        "en": [
+            {
+                "partOfSpeech": "noun",
+                "definitions": [{"definition": f"Def {i}"} for i in range(5)],
+            }
+        ]
+    }
+    with patch("services.wiktionary.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=_make_mock_response(200, json_data))
+
+        result = await lookup("word", "en")
+        assert len(result["definitions"]) <= 3
+
+
+@pytest.mark.asyncio
+async def test_lookup_falls_back_to_en_if_lang_missing():
+    json_data = {
+        "en": [
+            {
+                "partOfSpeech": "noun",
+                "definitions": [{"definition": "A test word."}],
+            }
+        ]
+    }
+    with patch("services.wiktionary.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=_make_mock_response(200, json_data))
+
+        result = await lookup("word", "fr")
+        assert len(result["definitions"]) == 1

--- a/frontend/src/__tests__/VocabularyPage.branches.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.branches.test.tsx
@@ -22,12 +22,14 @@ jest.mock("next-auth/react", () => ({
 const mockPush = jest.fn();
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => ({ get: () => null }),
 }));
 
 jest.mock("@/lib/api", () => ({
   getVocabulary: jest.fn(),
   deleteVocabularyWord: jest.fn(),
   exportVocabularyToObsidian: jest.fn(),
+  getWordDefinition: jest.fn(),
 }));
 
 import * as api from "@/lib/api";

--- a/frontend/src/__tests__/VocabularyPage.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.test.tsx
@@ -13,12 +13,14 @@ jest.mock("next-auth/react", () => ({
 // Mock next/navigation
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: jest.fn() }),
+  useSearchParams: () => ({ get: () => null }),
 }));
 
 jest.mock("@/lib/api", () => ({
   getVocabulary: jest.fn(),
   deleteVocabularyWord: jest.fn(),
   exportVocabularyToObsidian: jest.fn(),
+  getWordDefinition: jest.fn(),
 }));
 
 import * as api from "@/lib/api";

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState, useMemo, useCallback, useRef } from "react";
+import { useEffect, useState, useMemo, useCallback, useRef, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import {
@@ -120,7 +120,7 @@ function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
   );
 }
 
-export default function VocabularyPage() {
+function VocabularyPageContent() {
   const { data: session } = useSession();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -365,5 +365,13 @@ export default function VocabularyPage() {
         />
       )}
     </div>
+  );
+}
+
+export default function VocabularyPage() {
+  return (
+    <Suspense>
+      <VocabularyPageContent />
+    </Suspense>
   );
 }

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -1,12 +1,130 @@
 "use client";
-import { useEffect, useState, useMemo } from "react";
-import { useRouter } from "next/navigation";
+import { useEffect, useState, useMemo, useCallback, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { getVocabulary, deleteVocabularyWord, exportVocabularyToObsidian, VocabularyWord } from "@/lib/api";
+import {
+  getVocabulary,
+  deleteVocabularyWord,
+  exportVocabularyToObsidian,
+  getWordDefinition,
+  VocabularyWord,
+  WordDefinition,
+} from "@/lib/api";
+
+interface LemmaGroup {
+  lemma: string;
+  language: string | null;
+  forms: VocabularyWord[];
+}
+
+function buildGroups(words: VocabularyWord[]): LemmaGroup[] {
+  const map = new Map<string, LemmaGroup>();
+  for (const w of words) {
+    const key = (w.lemma || w.word).toLowerCase();
+    if (!map.has(key)) {
+      map.set(key, { lemma: w.lemma || w.word, language: w.language ?? null, forms: [] });
+    }
+    map.get(key)!.forms.push(w);
+  }
+  return Array.from(map.values()).sort((a, b) => a.lemma.localeCompare(b.lemma));
+}
+
+interface DefinitionSheetProps {
+  word: string;
+  lang: string | null;
+  onClose: () => void;
+}
+
+function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
+  const [def, setDef] = useState<WordDefinition | null>(null);
+  const [loading, setLoading] = useState(true);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    getWordDefinition(word, lang ?? undefined)
+      .then(setDef)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [word, lang]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) { if (e.key === "Escape") onClose(); }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      function onDown(e: MouseEvent) {
+        if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+      }
+      document.addEventListener("mousedown", onDown);
+      return () => document.removeEventListener("mousedown", onDown);
+    }, 100);
+    return () => clearTimeout(t);
+  }, [onClose]);
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40 bg-black/10" onClick={onClose} />
+      <div
+        ref={ref}
+        className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl border-t border-amber-200 max-h-[60vh] overflow-y-auto animate-slide-up"
+      >
+        <div className="flex justify-center py-2">
+          <div className="w-10 h-1 bg-amber-200 rounded-full" />
+        </div>
+        <div className="px-5 pb-6 space-y-3">
+          <div className="flex items-baseline justify-between gap-2">
+            <span className="font-serif font-bold text-ink text-xl">{word}</span>
+            {def && def.lemma !== word && (
+              <span className="text-sm text-amber-600">← {def.lemma}</span>
+            )}
+          </div>
+
+          {loading && (
+            <div className="flex items-center gap-2 text-amber-600 text-sm">
+              <span className="w-3 h-3 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+              Looking up…
+            </div>
+          )}
+
+          {!loading && (!def || def.definitions.length === 0) && (
+            <p className="text-sm text-stone-400 italic">No definition found.</p>
+          )}
+
+          {def && def.definitions.length > 0 && (
+            <div className="space-y-2">
+              {def.definitions.map((d, i) => (
+                <div key={i}>
+                  {d.pos && <span className="text-xs font-medium text-amber-700 italic">{d.pos}</span>}
+                  <p className="text-sm text-ink leading-relaxed mt-0.5">{d.text}</p>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {def && (
+            <a
+              href={def.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block text-xs text-amber-600 hover:text-amber-800 hover:underline"
+            >
+              View on Wiktionary ↗
+            </a>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
 
 export default function VocabularyPage() {
   const { data: session } = useSession();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const targetWord = searchParams.get("word");
 
   const [words, setWords] = useState<VocabularyWord[]>([]);
   const [loading, setLoading] = useState(true);
@@ -14,6 +132,8 @@ export default function VocabularyPage() {
   const [exporting, setExporting] = useState(false);
   const [deleting, setDeleting] = useState<string | null>(null);
   const [search, setSearch] = useState("");
+  const [activeWord, setActiveWord] = useState<{ word: string; lang: string | null } | null>(null);
+  const highlightRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     getVocabulary()
@@ -22,21 +142,36 @@ export default function VocabularyPage() {
       .finally(() => setLoading(false));
   }, [session?.backendToken]);
 
-  // Filter + group alphabetically
+  const groups = useMemo(() => buildGroups(words), [words]);
+
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
-    return q ? words.filter((w) => w.word.toLowerCase().includes(q)) : words;
-  }, [words, search]);
+    if (!q) return groups;
+    return groups.filter(
+      (g) =>
+        g.lemma.toLowerCase().includes(q) ||
+        g.forms.some((f) => f.word.toLowerCase().includes(q)),
+    );
+  }, [groups, search]);
 
-  const grouped = useMemo(() =>
-    filtered.reduce<Record<string, VocabularyWord[]>>((acc, w) => {
-      const letter = w.word[0]?.toUpperCase() ?? "#";
-      (acc[letter] ??= []).push(w);
+  const letterGroups = useMemo(() =>
+    filtered.reduce<Record<string, LemmaGroup[]>>((acc, g) => {
+      const letter = g.lemma[0]?.toUpperCase() ?? "#";
+      (acc[letter] ??= []).push(g);
       return acc;
     }, {}),
     [filtered]
   );
-  const letters = Object.keys(grouped).sort();
+  const letters = Object.keys(letterGroups).sort();
+
+  // Scroll to the target word on first load
+  useEffect(() => {
+    if (!targetWord || loading) return;
+    const t = setTimeout(() => {
+      highlightRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, 200);
+    return () => clearTimeout(t);
+  }, [targetWord, loading]);
 
   async function handleDelete(word: string) {
     setDeleting(word);
@@ -65,6 +200,16 @@ export default function VocabularyPage() {
 
   const totalOccurrences = words.reduce((sum, w) => sum + w.occurrences.length, 0);
 
+  function isTarget(group: LemmaGroup) {
+    if (!targetWord) return false;
+    return (
+      group.lemma.toLowerCase() === targetWord.toLowerCase() ||
+      group.forms.some((f) => f.word.toLowerCase() === targetWord.toLowerCase())
+    );
+  }
+
+  const closeSheet = useCallback(() => setActiveWord(null), []);
+
   return (
     <div className="min-h-screen bg-parchment">
       <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
@@ -92,7 +237,6 @@ export default function VocabularyPage() {
         </button>
       </header>
 
-      {/* Export result */}
       {exportMsg && (
         <div className="mx-6 mt-4 border border-amber-300 bg-amber-50 rounded-xl px-4 py-3 text-sm text-ink">
           {exportMsg.startsWith("http") ? (
@@ -104,7 +248,6 @@ export default function VocabularyPage() {
       )}
 
       <div className="max-w-2xl mx-auto px-4 md:px-6 py-6 md:py-8">
-        {/* Search */}
         {words.length > 5 && (
           <div className="mb-6">
             <input
@@ -139,47 +282,88 @@ export default function VocabularyPage() {
                   {letter}
                 </h2>
                 <div className="space-y-4">
-                  {grouped[letter].map((item) => (
-                    <div key={item.word} className="bg-white rounded-xl border border-amber-100 p-4">
-                      <div className="flex items-center justify-between mb-2">
-                        <div className="flex items-center gap-2">
-                          <h3 className="font-serif font-semibold text-ink text-base">{item.word}</h3>
-                          <span className="text-xs text-stone-400 bg-stone-100 rounded-full px-2 py-0.5">
-                            {item.occurrences.length}×
-                          </span>
-                        </div>
-                        <button
-                          onClick={() => handleDelete(item.word)}
-                          disabled={deleting === item.word}
-                          className="text-xs text-red-400 hover:text-red-600 disabled:opacity-50 transition-colors min-h-[44px] md:min-h-0 flex items-center px-2"
-                          data-testid={`delete-${item.word}`}
-                        >
-                          {deleting === item.word ? "Deleting…" : "Delete"}
-                        </button>
-                      </div>
-                      <div className="space-y-1.5">
-                        {item.occurrences.map((occ, i) => (
-                          <div key={i} className="text-sm text-stone-600">
-                            <a
-                              href={`/reader/${occ.book_id}?chapter=${occ.chapter_index}`}
-                              className="text-amber-700 font-medium hover:underline"
+                  {letterGroups[letter].map((group) => {
+                    const target = isTarget(group);
+                    const occurrenceCount = group.forms.reduce((s, f) => s + f.occurrences.length, 0);
+                    const alternateForms = group.forms.filter(
+                      (f) => f.word.toLowerCase() !== group.lemma.toLowerCase(),
+                    );
+                    return (
+                      <div
+                        key={group.lemma}
+                        ref={target ? highlightRef : undefined}
+                        className={`bg-white rounded-xl border p-4 transition-colors ${
+                          target ? "border-amber-400 ring-2 ring-amber-300" : "border-amber-100"
+                        }`}
+                      >
+                        <div className="flex items-center justify-between mb-2">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <button
+                              onClick={() => setActiveWord({ word: group.lemma, lang: group.language })}
+                              className="font-serif font-semibold text-ink text-base hover:text-amber-700 transition-colors text-left"
                             >
-                              {occ.book_title}
-                            </a>{" "}
-                            <span className="text-stone-400">{`Ch.${occ.chapter_index + 1}`}</span>
-                            {" — "}
-                            <span className="italic">&ldquo;{occ.sentence_text}&rdquo;</span>
+                              {group.lemma}
+                            </button>
+                            {alternateForms.length > 0 && (
+                              <span className="text-xs text-stone-400">
+                                ({alternateForms.map((f) => f.word).join(", ")})
+                              </span>
+                            )}
+                            <span className="text-xs text-stone-400 bg-stone-100 rounded-full px-2 py-0.5">
+                              {occurrenceCount}×
+                            </span>
                           </div>
-                        ))}
+                          <div className="flex items-center gap-1">
+                            {group.forms.map((f) => (
+                              <button
+                                key={f.word}
+                                onClick={() => handleDelete(f.word)}
+                                disabled={deleting === f.word}
+                                className="text-xs text-red-400 hover:text-red-600 disabled:opacity-50 transition-colors min-h-[44px] md:min-h-0 flex items-center px-2"
+                                data-testid={`delete-${f.word}`}
+                              >
+                                {deleting === f.word ? "…" : "Delete"}
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+                        <div className="space-y-1.5">
+                          {group.forms.flatMap((f) =>
+                            f.occurrences.map((occ, i) => (
+                              <div key={`${f.word}-${i}`} className="text-sm text-stone-600">
+                                {f.word !== group.lemma && (
+                                  <span className="text-xs text-amber-600 font-medium mr-1.5">{f.word}</span>
+                                )}
+                                <a
+                                  href={`/reader/${occ.book_id}?chapter=${occ.chapter_index}`}
+                                  className="text-amber-700 font-medium hover:underline"
+                                >
+                                  {occ.book_title}
+                                </a>{" "}
+                                <span className="text-stone-400">{`Ch.${occ.chapter_index + 1}`}</span>
+                                {" — "}
+                                <span className="italic">&ldquo;{occ.sentence_text}&rdquo;</span>
+                              </div>
+                            ))
+                          )}
+                        </div>
                       </div>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               </div>
             ))}
           </div>
         )}
       </div>
+
+      {activeWord && (
+        <DefinitionSheet
+          word={activeWord.word}
+          lang={activeWord.lang}
+          onClose={closeSheet}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -63,7 +63,7 @@ function ContextChip({
   const needsToggle = text.length > CTX_COLLAPSE_AT;
   const shown = !needsToggle || expanded ? text : text.slice(0, CTX_COLLAPSE_AT);
   return (
-    <div className="rounded-lg bg-amber-50 border border-amber-200 px-3 py-2 text-xs text-amber-800 font-serif">
+    <div className="rounded-lg bg-amber-50 border border-amber-200 px-3 py-2 text-xs text-amber-800">
       <div className="flex items-start gap-1.5">
         <span className="shrink-0 mt-px text-amber-400">📎</span>
         <div className="flex-1 min-w-0">
@@ -540,7 +540,7 @@ function MsgContextBlock({
   return (
     <div className="flex items-start gap-1.5 rounded-lg bg-amber-50/80 border border-amber-100 px-2.5 py-1.5">
       <span className="text-amber-400 text-xs shrink-0 mt-px">📎</span>
-      <p className="text-xs text-amber-700 font-serif italic leading-relaxed flex-1">
+      <p className="text-xs text-amber-700 italic leading-relaxed flex-1">
         &ldquo;{shown}{!expanded && needsToggle ? "…" : ""}&rdquo;
         {needsToggle && (
           <button

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -556,7 +556,16 @@ export interface VocabularyOccurrence {
 export interface VocabularyWord {
   id: number;
   word: string;
+  lemma?: string | null;
+  language?: string | null;
   occurrences: VocabularyOccurrence[];
+}
+
+export interface WordDefinition {
+  lemma: string;
+  language: string;
+  definitions: Array<{ pos: string; text: string }>;
+  url: string;
 }
 
 export function getVocabulary() {
@@ -580,6 +589,11 @@ export function deleteVocabularyWord(word: string) {
   return request<{ ok: boolean }>(`/vocabulary/${encodeURIComponent(word)}`, {
     method: "DELETE",
   });
+}
+
+export function getWordDefinition(word: string, lang?: string) {
+  const params = lang ? `?lang=${encodeURIComponent(lang)}` : "";
+  return request<WordDefinition>(`/vocabulary/definition/${encodeURIComponent(word)}${params}`);
 }
 
 export function exportVocabularyToObsidian(bookId?: number, targetLanguage = "zh") {


### PR DESCRIPTION
## Summary

The context chip (selected text quote shown in the chat input area) was using `font-serif`, which inherits the large book-reading serif font. Removed `font-serif` from both the input-area `ContextChip` and the in-message `MsgContextBlock` so they use the standard UI sans-serif font at `text-xs` size.

## Test plan

- [ ] Select text → context chip appears in chat input with normal small sans-serif text
- [ ] No visual regressions in chat messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
