### PR TITLE
feat(vocab): chapter filter, word definition tooltip, CSS fix, highlight animation

### DIFF
--- a/backend/services/wiktionary.py
+++ b/backend/services/wiktionary.py
@@ -43,6 +43,9 @@ def _extract_lemma(raw_html: str, current_word: str) -> str | None:
 
 
 def _strip_html(text: str) -> str:
+    # Remove <style> and <script> blocks entirely (including their CSS/JS content)
+    text = re.sub(r"<style[^>]*>.*?</style>", "", text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"<script[^>]*>.*?</script>", "", text, flags=re.DOTALL | re.IGNORECASE)
     return re.sub(r"<[^>]+>", "", text).strip()
 
 

--- a/frontend/src/__tests__/ReaderPage.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.test.tsx
@@ -461,7 +461,7 @@ describe("ReaderPage — sidebar tabs", () => {
     const vocabBtn = await screen.findByTitle("Vocabulary");
     await userEvent.click(vocabBtn);
 
-    expect(await screen.findByText("No words saved yet.")).toBeInTheDocument();
+    expect(await screen.findByText("No words saved in this chapter yet.")).toBeInTheDocument();
   });
 
   it("toggling the same sidebar button twice closes it", async () => {
@@ -1089,7 +1089,7 @@ describe("ReaderPage — vocab sidebar content", () => {
     const bid = bookIdCounter;
     const vocabWords = [
       { id: 10, word: "ephemeral", occurrences: [{ book_id: bid, chapter_index: 0, sentence_text: "test" }] },
-      { id: 11, word: "sublime", occurrences: [{ book_id: bid, chapter_index: 1, sentence_text: "test" }] },
+      { id: 11, word: "sublime", occurrences: [{ book_id: bid, chapter_index: 0, sentence_text: "test" }] },
     ];
     mockGetVocabulary.mockResolvedValue(vocabWords);
     mockGetBookChapters.mockResolvedValue({ meta: { ...SAMPLE_META, id: bid }, chapters: SAMPLE_CHAPTERS });

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -95,3 +95,13 @@ body, [data-theme="light"] {
 .animate-fade-in {
   animation: fade-in 0.15s ease-out;
 }
+
+/* Vocab word highlight flash */
+@keyframes vocab-flash {
+  0%   { background-color: rgb(251 191 36 / 0.5); }
+  40%  { background-color: rgb(251 191 36 / 0.3); }
+  100% { background-color: transparent; }
+}
+.animate-vocab-flash {
+  animation: vocab-flash 1.8s ease-out forwards;
+}

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -12,6 +12,7 @@ import SentenceReader from "@/components/SentenceReader";
 import SelectionToolbar from "@/components/SelectionToolbar";
 import AnnotationToolbar from "@/components/AnnotationToolbar";
 import VocabularyToast from "@/components/VocabularyToast";
+import VocabWordTooltip from "@/components/VocabWordTooltip";
 
 // In-memory cache: bookId → chapters (survives client-side navigation)
 const chaptersCache = new Map<string, BookChapter[]>();
@@ -75,6 +76,9 @@ export default function ReaderPage() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [sidebarTab, setSidebarTab] = useState<"chat" | "notes" | "vocab" | "translate">("chat");
   const [vocabWords, setVocabWords] = useState<VocabularyWord[]>([]);
+  const [vocabView, setVocabView] = useState<"chapter" | "book">("chapter");
+  // Word definition tooltip (shown when "Word" is clicked in SelectionToolbar)
+  const [vocabTooltip, setVocabTooltip] = useState<{ word: string; context: string; rect: DOMRect } | null>(null);
   const [sidebarWidth, setSidebarWidth] = useState(320);
   const isResizing = useRef(false);
   const resizeStartX = useRef(0);
@@ -643,6 +647,10 @@ export default function ReaderPage() {
         sentence_text: sentenceText,
       });
       setVocabToastWord(word);
+      // Refresh sidebar word list
+      getVocabulary().then((words) => {
+        setVocabWords(words.filter((w) => w.occurrences.some((o) => o.book_id === Number(bookId))));
+      }).catch(() => {});
     } catch {
       // silently ignore (user may not be logged in)
     }
@@ -1080,7 +1088,7 @@ export default function ReaderPage() {
               setSidebarTab("chat");
               setSidebarOpen(true);
             }}
-            onVocab={session?.backendToken ? (word, context) => handleWordSave(word, context) : undefined}
+            onVocab={session?.backendToken ? (word, context, rect) => setVocabTooltip({ word, context, rect }) : undefined}
           />
 
           {/* Annotation toolbar */}
@@ -1109,6 +1117,20 @@ export default function ReaderPage() {
               }}
               onDeleted={(id) => {
                 setAnnotations((prev) => prev.filter((a) => a.id !== id));
+              }}
+            />
+          )}
+
+          {/* Word definition tooltip */}
+          {vocabTooltip && (
+            <VocabWordTooltip
+              word={vocabTooltip.word}
+              lang={bookLanguage}
+              rect={vocabTooltip.rect}
+              onClose={() => setVocabTooltip(null)}
+              onSave={() => {
+                handleWordSave(vocabTooltip.word, vocabTooltip.context);
+                setVocabTooltip(null);
               }}
             />
           )}
@@ -1306,40 +1328,59 @@ export default function ReaderPage() {
               )}
 
               {/* Vocab tab */}
-              {sidebarTab === "vocab" && (
-                <div className="flex-1 overflow-y-auto p-4 space-y-4">
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs font-semibold text-stone-400 uppercase tracking-wide">
-                      This book · {vocabWords.length} word{vocabWords.length !== 1 ? "s" : ""}
-                    </span>
-                    <button onClick={() => router.push("/vocabulary")} className="text-xs text-amber-600 hover:text-amber-800 font-medium">
-                      View all →
-                    </button>
-                  </div>
-                  {vocabWords.length === 0 ? (
-                    <div className="text-center text-stone-400 mt-10 text-sm">
-                      <p className="text-3xl mb-2">📚</p>
-                      <p>No words saved yet.</p>
-                      <p className="mt-1 text-xs">Select text to save words to vocabulary.</p>
-                    </div>
-                  ) : (
-                    <div className="space-y-1.5">
-                      {vocabWords.map((w) => (
+              {sidebarTab === "vocab" && (() => {
+                const filteredVocab = vocabView === "chapter"
+                  ? vocabWords.filter((w) => w.occurrences.some((o) => o.book_id === Number(bookId) && o.chapter_index === chapterIndex))
+                  : vocabWords;
+                return (
+                  <div className="flex-1 overflow-y-auto p-4 space-y-3">
+                    {/* Filter toggle */}
+                    <div className="flex items-center gap-1 bg-stone-100 rounded-lg p-0.5">
+                      {(["chapter", "book"] as const).map((v) => (
                         <button
-                          key={w.id}
-                          onClick={() => router.push(`/vocabulary?word=${encodeURIComponent(w.word)}`)}
-                          className="w-full flex items-center justify-between gap-2 px-3 py-2 rounded-lg bg-amber-50 border border-amber-200 hover:bg-amber-100 transition-colors text-left"
+                          key={v}
+                          onClick={() => setVocabView(v)}
+                          className={`flex-1 text-xs py-1 rounded-md font-medium transition-colors ${
+                            vocabView === v ? "bg-white text-amber-700 shadow-sm" : "text-stone-400 hover:text-stone-600"
+                          }`}
                         >
-                          <span className="text-sm font-medium text-ink">{w.word}</span>
-                          <span className="text-[10px] text-stone-400 shrink-0">
-                            {w.occurrences.filter((o) => o.book_id === Number(bookId)).length}×
-                          </span>
+                          {v === "chapter" ? "This chapter" : "All chapters"}
                         </button>
                       ))}
                     </div>
-                  )}
-                </div>
-              )}
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-stone-400">
+                        {filteredVocab.length} word{filteredVocab.length !== 1 ? "s" : ""}
+                      </span>
+                      <button onClick={() => router.push("/vocabulary")} className="text-xs text-amber-600 hover:text-amber-800 font-medium">
+                        View all →
+                      </button>
+                    </div>
+                    {filteredVocab.length === 0 ? (
+                      <div className="text-center text-stone-400 mt-10 text-sm">
+                        <p className="text-3xl mb-2">📚</p>
+                        <p>No words saved{vocabView === "chapter" ? " in this chapter" : ""} yet.</p>
+                        <p className="mt-1 text-xs">Select text to save words to vocabulary.</p>
+                      </div>
+                    ) : (
+                      <div className="space-y-1.5">
+                        {filteredVocab.map((w) => (
+                          <button
+                            key={w.id}
+                            onClick={() => router.push(`/vocabulary?word=${encodeURIComponent(w.word)}`)}
+                            className="w-full flex items-center justify-between gap-2 px-3 py-2 rounded-lg bg-amber-50 border border-amber-200 hover:bg-amber-100 transition-colors text-left"
+                          >
+                            <span className="text-sm font-medium text-ink">{w.word}</span>
+                            <span className="text-[10px] text-stone-400 shrink-0">
+                              {w.occurrences.filter((o) => o.book_id === Number(bookId)).length}×
+                            </span>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                );
+              })()}
 
               {/* Translate tab */}
               {sidebarTab === "translate" && (

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -292,8 +292,10 @@ function VocabularyPageContent() {
                       <div
                         key={group.lemma}
                         ref={target ? highlightRef : undefined}
-                        className={`bg-white rounded-xl border p-4 transition-colors ${
-                          target ? "border-amber-400 ring-2 ring-amber-300" : "border-amber-100"
+                        className={`rounded-xl border p-4 transition-colors ${
+                          target
+                            ? "bg-white border-amber-400 ring-2 ring-amber-300 animate-vocab-flash"
+                            : "bg-white border-amber-100"
                         }`}
                       >
                         <div className="flex items-center justify-between mb-2">

--- a/frontend/src/components/SelectionToolbar.tsx
+++ b/frontend/src/components/SelectionToolbar.tsx
@@ -12,7 +12,7 @@ interface Props {
   onHighlight?: (text: string) => void;
   onNote?: (text: string) => void;
   onChat?: (text: string) => void;
-  onVocab?: (word: string, context: string) => void;
+  onVocab?: (word: string, context: string, rect: DOMRect) => void;
 }
 
 /** Walk up from a node to find the nearest sentence span (data-seg) or paragraph. */
@@ -105,7 +105,7 @@ export default function SelectionToolbar({ onRead, onHighlight, onNote, onChat, 
 
   function handleVocabAction() {
     if (!onVocab || !selection) return;
-    onVocab(selection.text, selection.context || selection.text);
+    onVocab(selection.text, selection.context || selection.text, selection.rect);
     window.getSelection()?.removeAllRanges();
     setSelection(null);
   }

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -1,0 +1,130 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import { getWordDefinition, WordDefinition } from "@/lib/api";
+
+interface Props {
+  word: string;
+  lang: string;
+  rect: DOMRect;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: Props) {
+  const [def, setDef] = useState<WordDefinition | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saved, setSaved] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setDef(null);
+    setSaved(false);
+    getWordDefinition(word, lang)
+      .then(setDef)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [word, lang]);
+
+  // Close on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [onClose]);
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  // Position near the selection, keep within viewport
+  const tooltipW = 288;
+  const tooltipH = 220;
+  let left = rect.left + rect.width / 2 - tooltipW / 2;
+  let top = rect.bottom + 8;
+  if (left < 8) left = 8;
+  if (left + tooltipW > window.innerWidth - 8) left = window.innerWidth - tooltipW - 8;
+  if (top + tooltipH > window.innerHeight - 8) top = rect.top - tooltipH - 8;
+
+  function handleSave() {
+    if (saved) return;
+    setSaved(true);
+    onSave();
+  }
+
+  return (
+    <div
+      ref={ref}
+      className="fixed z-50 w-72 rounded-xl border border-amber-200 bg-white shadow-xl overflow-hidden"
+      style={{ left, top }}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 pt-2.5 pb-1.5 border-b border-amber-100">
+        <span className="font-semibold text-ink text-sm">{word}</span>
+        <button onClick={onClose} className="text-stone-400 hover:text-stone-600 text-base leading-none px-1">×</button>
+      </div>
+
+      {/* Body */}
+      <div className="px-3 py-2.5 max-h-40 overflow-y-auto">
+        {loading && (
+          <div className="flex items-center gap-2 text-amber-600 text-xs py-1">
+            <span className="w-3 h-3 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin shrink-0" />
+            Looking up definition…
+          </div>
+        )}
+        {!loading && (!def || def.definitions.length === 0) && (
+          <p className="text-xs text-stone-400 italic">No definition found.</p>
+        )}
+        {!loading && def && def.definitions.length > 0 && (
+          <div className="space-y-2">
+            {def.lemma && def.lemma !== word && (
+              <p className="text-[11px] text-stone-400">
+                Base form: <span className="font-medium text-stone-600">{def.lemma}</span>
+              </p>
+            )}
+            {def.definitions.slice(0, 2).map((d, i) => (
+              <div key={i}>
+                {d.pos && (
+                  <span className="text-[11px] font-medium text-amber-700 italic">{d.pos}</span>
+                )}
+                <p className="text-xs text-ink leading-relaxed mt-0.5">{d.text}</p>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between px-3 py-2 border-t border-amber-100 bg-amber-50/40">
+        {def?.url ? (
+          <a
+            href={def.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[11px] text-amber-600 hover:text-amber-800"
+          >
+            Wiktionary ↗
+          </a>
+        ) : <span />}
+        <button
+          onClick={handleSave}
+          disabled={saved}
+          className={`text-xs font-medium px-3 py-1 rounded-lg transition-colors ${
+            saved
+              ? "bg-stone-100 text-stone-400 cursor-default"
+              : "bg-amber-600 text-white hover:bg-amber-700"
+          }`}
+        >
+          {saved ? "Saved ✓" : "Save to vocab"}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Chapter filter**: Vocab sidebar defaults to "This chapter" words; toggle button switches to "All chapters"
- **Sidebar refresh**: Adding a word immediately updates the sidebar (no reload needed)
- **Word tooltip**: Clicking "Word" in the selection toolbar now shows a floating `VocabWordTooltip` with a definition spinner, lemma, part-of-speech, and "Save to vocab" button — instead of silently saving
- **Definition CSS fix**: Wiktionary definitions were leaking CSS class names (e.g. `.mw-parser-output ...`) because `<style>` blocks weren't stripped; now removed before HTML tag stripping
- **Jump highlight**: On the vocabulary page, the targeted word card flashes amber for 1.8s so it's obvious which word you navigated to

## Test plan

- [ ] Frontend tests pass (1280 tests)
- [ ] Select a word → click "Word" → tooltip appears with spinner then definition
- [ ] Click "Save to vocab" in tooltip → toast shows, sidebar updates
- [ ] Vocab sidebar shows chapter-filtered words by default; toggle shows all
- [ ] Navigate to `/vocabulary?word=beistehen` — card flashes amber
- [ ] Definition text no longer contains `.mw-parser-output` CSS noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)
