### PR TITLE
feat(reader): vocab sidebar shows lemma, form, context, jump to line

### DIFF
--- a/backend/tests/test_wiktionary.py
+++ b/backend/tests/test_wiktionary.py
@@ -15,6 +15,38 @@ def test_strip_html_empty():
     assert _strip_html("") == ""
 
 
+def test_strip_html_removes_style_block_with_css():
+    """CSS inside <style> must not appear in output — this is the bug fix for
+    Wiktionary returning inline <style> blocks whose class names bled into text."""
+    html = (
+        'to assist'
+        '<style>.mw-parser-output .object-usage-tag{font-style:italic}'
+        '.mw-parser-output .deprecated{color:var(--wikt,olivedrab)}</style>'
+        '{with dative}'
+    )
+    result = _strip_html(html)
+    assert ".mw-parser-output" not in result
+    assert "font-style" not in result
+    assert "to assist" in result
+    assert "{with dative}" in result
+
+
+def test_strip_html_removes_script_block():
+    html = 'safe text<script>alert("xss")</script> more text'
+    result = _strip_html(html)
+    assert "alert" not in result
+    assert "safe text" in result
+    assert "more text" in result
+
+
+def test_strip_html_multiline_style_block():
+    html = 'word<style>\n.cls { color: red; }\n</style>definition'
+    result = _strip_html(html)
+    assert "color" not in result
+    assert "word" in result
+    assert "definition" in result
+
+
 # ── _extract_lemma ─────────────────────────────────────────────────────────────
 
 def test_extract_lemma_bold_tag():

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -130,4 +130,40 @@ export async function mockBackend(page: Page) {
       route.fulfill({ json: { ok: true } });
     }
   });
+
+  await page.route("**/api/vocabulary$", (route) => {
+    if (route.request().method() === "GET") {
+      route.fulfill({
+        json: [
+          {
+            id: 1,
+            word: "universally",
+            lemma: "universal",
+            language: "en",
+            occurrences: [{ book_id: 1342, book_title: "Pride and Prejudice", chapter_index: 0, sentence_text: "It is a truth universally acknowledged" }],
+          },
+          {
+            id: 2,
+            word: "acknowledged",
+            lemma: "acknowledge",
+            language: "en",
+            occurrences: [{ book_id: 1342, book_title: "Pride and Prejudice", chapter_index: 1, sentence_text: "that a single man" }],
+          },
+        ],
+      });
+    } else {
+      route.fulfill({ json: { ok: true } });
+    }
+  });
+
+  await page.route(/\/api\/vocabulary\/definition\//, (route) =>
+    route.fulfill({
+      json: {
+        lemma: "universal",
+        language: "en",
+        definitions: [{ pos: "adjective", text: "relating to or done by all" }],
+        url: "https://en.wiktionary.org/wiki/universal",
+      },
+    })
+  );
 }

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -131,7 +131,7 @@ export async function mockBackend(page: Page) {
     }
   });
 
-  await page.route("**/api/vocabulary$", (route) => {
+  await page.route(/\/api\/vocabulary$/, (route) => {
     if (route.request().method() === "GET") {
       route.fulfill({
         json: [

--- a/frontend/e2e/vocab-sidebar.spec.ts
+++ b/frontend/e2e/vocab-sidebar.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * E2E: Vocab sidebar — chapter filter toggle and vocabulary page highlight.
+ */
+import { test, expect } from "./base";
+import { mockBackend } from "./fixtures";
+
+test.beforeEach(async ({ page }) => {
+  await mockBackend(page);
+});
+
+test("vocab sidebar opens with 'This chapter' and 'All chapters' toggles", async ({ page }) => {
+  await page.goto("/reader/1342");
+
+  const vocabBtn = page.getByTitle("Vocabulary");
+  await vocabBtn.click();
+
+  await expect(page.getByRole("button", { name: "This chapter" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "All chapters" })).toBeVisible();
+});
+
+test("vocab sidebar chapter filter: default shows only chapter-0 word", async ({ page }) => {
+  await page.goto("/reader/1342");
+
+  const vocabBtn = page.getByTitle("Vocabulary");
+  await vocabBtn.click();
+
+  // "universally" is chapter 0 — should be visible in default "This chapter" view
+  await expect(page.getByRole("button", { name: /universally/i })).toBeVisible();
+  // "acknowledged" is chapter 1 — should be hidden
+  await expect(page.getByRole("button", { name: /acknowledged/i })).not.toBeVisible();
+});
+
+test("vocab sidebar 'All chapters' toggle shows words from every chapter", async ({ page }) => {
+  await page.goto("/reader/1342");
+
+  const vocabBtn = page.getByTitle("Vocabulary");
+  await vocabBtn.click();
+
+  // Switch to all chapters
+  await page.getByRole("button", { name: "All chapters" }).click();
+
+  await expect(page.getByRole("button", { name: /universally/i })).toBeVisible();
+  await expect(page.getByRole("button", { name: /acknowledged/i })).toBeVisible();
+});
+
+test("vocab page: target word card has amber highlight ring", async ({ page }) => {
+  await page.goto("/vocabulary?word=universally");
+
+  // Wait for the word card to appear
+  await expect(page.getByText("universal").first()).toBeVisible({ timeout: 5000 });
+
+  // The card should have the ring-2 highlight class
+  const card = page.locator("[class*='ring-2']").first();
+  await expect(card).toBeVisible();
+});

--- a/frontend/e2e/vocab-sidebar.spec.ts
+++ b/frontend/e2e/vocab-sidebar.spec.ts
@@ -11,7 +11,7 @@ test.beforeEach(async ({ page }) => {
 test("vocab sidebar opens with 'This chapter' and 'All chapters' toggles", async ({ page }) => {
   await page.goto("/reader/1342");
 
-  const vocabBtn = page.getByTitle("Vocabulary");
+  const vocabBtn = page.getByTitle("Vocabulary", { exact: true });
   await vocabBtn.click();
 
   await expect(page.getByRole("button", { name: "This chapter" })).toBeVisible();
@@ -21,35 +21,36 @@ test("vocab sidebar opens with 'This chapter' and 'All chapters' toggles", async
 test("vocab sidebar chapter filter: default shows only chapter-0 word", async ({ page }) => {
   await page.goto("/reader/1342");
 
-  const vocabBtn = page.getByTitle("Vocabulary");
+  const vocabBtn = page.getByTitle("Vocabulary", { exact: true });
   await vocabBtn.click();
 
-  // "universally" is chapter 0 — should be visible in default "This chapter" view
-  await expect(page.getByRole("button", { name: /universally/i })).toBeVisible();
-  // "acknowledged" is chapter 1 — should be hidden
-  await expect(page.getByRole("button", { name: /acknowledged/i })).not.toBeVisible();
+  // Word card header buttons start with the lemma — "universal universally" for chapter-0 word
+  await expect(page.getByRole("button", { name: "universal universally" })).toBeVisible();
+  // "acknowledged" word card (chapter 1) should be absent — its header is "acknowledge acknowledged"
+  await expect(page.getByRole("button", { name: "acknowledge acknowledged" })).not.toBeVisible();
 });
 
 test("vocab sidebar 'All chapters' toggle shows words from every chapter", async ({ page }) => {
   await page.goto("/reader/1342");
 
-  const vocabBtn = page.getByTitle("Vocabulary");
+  const vocabBtn = page.getByTitle("Vocabulary", { exact: true });
   await vocabBtn.click();
 
   // Switch to all chapters
   await page.getByRole("button", { name: "All chapters" }).click();
 
-  await expect(page.getByRole("button", { name: /universally/i })).toBeVisible();
-  await expect(page.getByRole("button", { name: /acknowledged/i })).toBeVisible();
+  // Both word cards should now be visible
+  await expect(page.getByRole("button", { name: "universal universally" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "acknowledge acknowledged" })).toBeVisible();
 });
 
 test("vocab page: target word card has amber highlight ring", async ({ page }) => {
   await page.goto("/vocabulary?word=universally");
 
-  // Wait for the word card to appear
-  await expect(page.getByText("universal").first()).toBeVisible({ timeout: 5000 });
+  // Wait for the lemma card to appear (lemma "universal" for form "universally")
+  await expect(page.getByText("universal").first()).toBeVisible({ timeout: 10000 });
 
-  // The card should have the ring-2 highlight class
-  const card = page.locator("[class*='ring-2']").first();
+  // The card should have the ring-2 ring-amber-300 highlight class (isTarget = true)
+  const card = page.locator(".ring-2.ring-amber-300").first();
   await expect(card).toBeVisible();
 });

--- a/frontend/src/__tests__/BookNotesPage.test.tsx
+++ b/frontend/src/__tests__/BookNotesPage.test.tsx
@@ -138,7 +138,7 @@ test("annotation has reader link to correct chapter", async () => {
   render(<BookNotesPage />);
   await waitFor(() => screen.getByText(/Call me Ishmael/));
   const readerLink = screen.getByRole("link", { name: /Chapter 2/i });
-  expect(readerLink).toHaveAttribute("href", "/reader/10?chapter=1");
+  expect(readerLink).toHaveAttribute("href", expect.stringContaining("/reader/10?chapter=1"));
 });
 
 // ── Collapse ───────────────────────────────────────────────────────────────────

--- a/frontend/src/__tests__/BookNotesPage.test.tsx
+++ b/frontend/src/__tests__/BookNotesPage.test.tsx
@@ -253,6 +253,30 @@ test("chapter view renders content under chapter heading", async () => {
   expect(screen.getByRole("button", { name: /Chapter 1/i })).toBeInTheDocument();
 });
 
+// ── Jump links ─────────────────────────────────────────────────────────────────
+
+test("vocab sentence is a reader link with sentence and word params", async () => {
+  mockGetAnnotations.mockResolvedValue([]);
+  mockGetVocabulary.mockResolvedValue([makeVocabWord()]);
+  render(<BookNotesPage />);
+  await waitFor(() => screen.getByText(/The great leviathan/));
+  const sentenceLink = screen.getByRole("link", { name: /The great leviathan/ });
+  const href = sentenceLink.getAttribute("href") ?? "";
+  expect(href).toContain("/reader/10?chapter=0");
+  expect(href).toContain("sentence=");
+  expect(href).toContain("word=leviathan");
+});
+
+test("insight with context_text has reader link", async () => {
+  mockGetAnnotations.mockResolvedValue([]);
+  mockGetInsights.mockResolvedValue([makeInsight({ context_text: "The pale whale loomed." })]);
+  render(<BookNotesPage />);
+  await waitFor(() => screen.getByText(/What is the white whale/));
+  const link = screen.getByRole("link", { name: /Chapter 1/i });
+  expect(link.getAttribute("href")).toContain("/reader/10?chapter=0");
+  expect(link.getAttribute("href")).toContain("sentence=");
+});
+
 // ── Navigation ─────────────────────────────────────────────────────────────────
 
 test("← Notes button navigates to /notes", async () => {

--- a/frontend/src/__tests__/ReaderPage.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.test.tsx
@@ -39,6 +39,7 @@ const mockEnqueueBookTranslation = jest.fn();
 const mockDeleteTranslationCache = jest.fn();
 const mockSaveReadingProgress = jest.fn();
 const mockSaveVocabularyWord = jest.fn();
+const mockGetWordDefinition = jest.fn();
 const mockExportVocabularyToObsidian = jest.fn();
 const mockSaveInsight = jest.fn();
 const mockSynthesizeSpeech = jest.fn();
@@ -57,6 +58,7 @@ jest.mock("@/lib/api", () => ({
   deleteTranslationCache: (...a: unknown[]) => mockDeleteTranslationCache(...a),
   saveReadingProgress: (...a: unknown[]) => mockSaveReadingProgress(...a),
   saveVocabularyWord: (...a: unknown[]) => mockSaveVocabularyWord(...a),
+  getWordDefinition: (...a: unknown[]) => mockGetWordDefinition(...a),
   exportVocabularyToObsidian: (...a: unknown[]) => mockExportVocabularyToObsidian(...a),
   saveInsight: (...a: unknown[]) => mockSaveInsight(...a),
   synthesizeSpeech: (...a: unknown[]) => mockSynthesizeSpeech(...a),
@@ -141,6 +143,12 @@ jest.mock("@/components/VocabularyToast", () => {
   const VocabularyToast = () => null;
   VocabularyToast.displayName = "VocabularyToast";
   return { __esModule: true, default: VocabularyToast };
+});
+
+jest.mock("@/components/VocabWordTooltip", () => {
+  const VocabWordTooltip = () => <div data-testid="vocab-word-tooltip" />;
+  VocabWordTooltip.displayName = "VocabWordTooltip";
+  return { __esModule: true, default: VocabWordTooltip };
 });
 
 // ─── Data fixtures ────────────────────────────────────────────────────────────
@@ -1442,5 +1450,86 @@ describe("ReaderPage — book translation status banner", () => {
       const statusEl = screen.queryByText(/chapters translated/);
       if (statusEl) expect(statusEl).toBeInTheDocument();
     });
+  });
+});
+
+// ── Vocab sidebar chapter filter ──────────────────────────────────────────────
+
+describe("ReaderPage — vocab sidebar chapter filter", () => {
+  it("shows 'This chapter' and 'All chapters' toggle buttons", async () => {
+    const bid = bookIdCounter;
+    mockGetBookChapters.mockResolvedValue({ meta: { ...SAMPLE_META, id: bid }, chapters: SAMPLE_CHAPTERS });
+    mockGetVocabulary.mockResolvedValue([]);
+    render(<ReaderPage />);
+    await flushPromises();
+
+    const vocabBtn = await screen.findByTitle("Vocabulary");
+    await userEvent.click(vocabBtn);
+
+    expect(await screen.findByText("This chapter")).toBeInTheDocument();
+    expect(screen.getByText("All chapters")).toBeInTheDocument();
+  });
+
+  it("defaults to chapter view — hides words from other chapters", async () => {
+    const bid = bookIdCounter;
+    const words = [
+      { id: 1, word: "inChapter", occurrences: [{ book_id: bid, chapter_index: 0, sentence_text: "s" }] },
+      { id: 2, word: "otherChapter", occurrences: [{ book_id: bid, chapter_index: 2, sentence_text: "s" }] },
+    ];
+    mockGetVocabulary.mockResolvedValue(words);
+    mockGetBookChapters.mockResolvedValue({ meta: { ...SAMPLE_META, id: bid }, chapters: SAMPLE_CHAPTERS });
+    render(<ReaderPage />);
+    await flushPromises();
+
+    const vocabBtn = await screen.findByTitle("Vocabulary");
+    await userEvent.click(vocabBtn);
+
+    expect(await screen.findByText("inChapter")).toBeInTheDocument();
+    expect(screen.queryByText("otherChapter")).not.toBeInTheDocument();
+  });
+
+  it("switching to 'All chapters' shows words from every chapter", async () => {
+    const bid = bookIdCounter;
+    const words = [
+      { id: 1, word: "inChapter", occurrences: [{ book_id: bid, chapter_index: 0, sentence_text: "s" }] },
+      { id: 2, word: "otherChapter", occurrences: [{ book_id: bid, chapter_index: 2, sentence_text: "s" }] },
+    ];
+    mockGetVocabulary.mockResolvedValue(words);
+    mockGetBookChapters.mockResolvedValue({ meta: { ...SAMPLE_META, id: bid }, chapters: SAMPLE_CHAPTERS });
+    render(<ReaderPage />);
+    await flushPromises();
+
+    const vocabBtn = await screen.findByTitle("Vocabulary");
+    await userEvent.click(vocabBtn);
+
+    // Switch to "All chapters"
+    const allBtn = await screen.findByText("All chapters");
+    await userEvent.click(allBtn);
+
+    expect(await screen.findByText("inChapter")).toBeInTheDocument();
+    expect(await screen.findByText("otherChapter")).toBeInTheDocument();
+  });
+
+  it("shows count label reflecting filtered words", async () => {
+    const bid = bookIdCounter;
+    const words = [
+      { id: 1, word: "wordOne", occurrences: [{ book_id: bid, chapter_index: 0, sentence_text: "s" }] },
+      { id: 2, word: "wordTwo", occurrences: [{ book_id: bid, chapter_index: 0, sentence_text: "s" }] },
+      { id: 3, word: "wordThree", occurrences: [{ book_id: bid, chapter_index: 1, sentence_text: "s" }] },
+    ];
+    mockGetVocabulary.mockResolvedValue(words);
+    mockGetBookChapters.mockResolvedValue({ meta: { ...SAMPLE_META, id: bid }, chapters: SAMPLE_CHAPTERS });
+    render(<ReaderPage />);
+    await flushPromises();
+
+    const vocabBtn = await screen.findByTitle("Vocabulary");
+    await userEvent.click(vocabBtn);
+
+    // Chapter view: 2 words
+    expect(await screen.findByText("2 words")).toBeInTheDocument();
+
+    // All chapters: 3 words
+    await userEvent.click(screen.getByText("All chapters"));
+    expect(await screen.findByText("3 words")).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/VocabWordTooltip.test.tsx
+++ b/frontend/src/__tests__/VocabWordTooltip.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for VocabWordTooltip component.
+ */
+import React from "react";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockGetWordDefinition = jest.fn();
+
+jest.mock("@/lib/api", () => ({
+  getWordDefinition: (...args: any[]) => mockGetWordDefinition(...args),
+}));
+
+import VocabWordTooltip from "@/components/VocabWordTooltip";
+
+const RECT = {
+  left: 100,
+  top: 200,
+  right: 200,
+  bottom: 220,
+  width: 100,
+  height: 20,
+  x: 100,
+  y: 200,
+  toJSON: () => ({}),
+} as DOMRect;
+
+const BASE = {
+  word: "beistehen",
+  lang: "de",
+  rect: RECT,
+  onClose: jest.fn(),
+  onSave: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetWordDefinition.mockResolvedValue({
+    lemma: "beistehen",
+    language: "de",
+    definitions: [{ pos: "Verb", text: "to assist" }],
+    url: "https://en.wiktionary.org/wiki/beistehen",
+  });
+});
+
+const flushPromises = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe("VocabWordTooltip — rendering", () => {
+  it("shows the word in the header", () => {
+    render(<VocabWordTooltip {...BASE} />);
+    expect(screen.getByText("beistehen")).toBeInTheDocument();
+  });
+
+  it("shows a loading spinner while fetching", () => {
+    mockGetWordDefinition.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<VocabWordTooltip {...BASE} />);
+    expect(screen.getByText(/Looking up/i)).toBeInTheDocument();
+  });
+
+  it("shows definition after load", async () => {
+    render(<VocabWordTooltip {...BASE} />);
+    await waitFor(() => expect(screen.getByText("to assist")).toBeInTheDocument());
+    expect(screen.getByText("Verb")).toBeInTheDocument();
+  });
+
+  it("shows base form when lemma differs from word", async () => {
+    mockGetWordDefinition.mockResolvedValue({
+      lemma: "gehen",
+      language: "de",
+      definitions: [{ pos: "Verb", text: "past participle of gehen" }],
+      url: "https://en.wiktionary.org/wiki/gegangen",
+    });
+    render(<VocabWordTooltip {...BASE} word="gegangen" />);
+    await waitFor(() => expect(screen.getByText(/Base form/i)).toBeInTheDocument());
+    expect(screen.getByText("gehen")).toBeInTheDocument();
+  });
+
+  it("shows 'No definition found' when API returns empty", async () => {
+    mockGetWordDefinition.mockResolvedValue({
+      lemma: "xyz",
+      language: "de",
+      definitions: [],
+      url: "https://en.wiktionary.org/wiki/xyz",
+    });
+    render(<VocabWordTooltip {...BASE} word="xyz" />);
+    await waitFor(() => expect(screen.getByText(/No definition found/i)).toBeInTheDocument());
+  });
+
+  it("shows 'No definition found' when API rejects", async () => {
+    mockGetWordDefinition.mockRejectedValue(new Error("network error"));
+    render(<VocabWordTooltip {...BASE} />);
+    await waitFor(() => expect(screen.getByText(/No definition found/i)).toBeInTheDocument());
+  });
+
+  it("shows Wiktionary link after load", async () => {
+    render(<VocabWordTooltip {...BASE} />);
+    await waitFor(() =>
+      expect(screen.getByRole("link", { name: /Wiktionary/i })).toBeInTheDocument()
+    );
+  });
+});
+
+describe("VocabWordTooltip — save behaviour", () => {
+  it("calls onSave when 'Save to vocab' is clicked", async () => {
+    render(<VocabWordTooltip {...BASE} />);
+    await waitFor(() => expect(screen.getByText("to assist")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: /Save to vocab/i }));
+    expect(BASE.onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("changes button to 'Saved ✓' after click", async () => {
+    render(<VocabWordTooltip {...BASE} />);
+    await waitFor(() => expect(screen.getByText("to assist")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: /Save to vocab/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Saved/i })).toBeInTheDocument()
+    );
+    expect(screen.queryByRole("button", { name: /Save to vocab/i })).not.toBeInTheDocument();
+  });
+
+  it("does not call onSave a second time when already saved", async () => {
+    render(<VocabWordTooltip {...BASE} />);
+    await waitFor(() => expect(screen.getByText("to assist")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: /Save to vocab/i }));
+    await userEvent.click(screen.getByRole("button", { name: /Saved/i }));
+
+    expect(BASE.onSave).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("VocabWordTooltip — dismiss behaviour", () => {
+  it("calls onClose when × button is clicked", async () => {
+    render(<VocabWordTooltip {...BASE} />);
+    await userEvent.click(screen.getByRole("button", { name: "×" }));
+    expect(BASE.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose on Escape key", async () => {
+    render(<VocabWordTooltip {...BASE} />);
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(BASE.onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/__tests__/VocabularyPage.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.test.tsx
@@ -11,9 +11,10 @@ jest.mock("next-auth/react", () => ({
 }));
 
 // Mock next/navigation
+const mockUseSearchParams = jest.fn(() => ({ get: () => null }));
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: jest.fn() }),
-  useSearchParams: () => ({ get: () => null }),
+  useSearchParams: () => mockUseSearchParams(),
 }));
 
 jest.mock("@/lib/api", () => ({
@@ -124,4 +125,29 @@ test("shows empty state when no words", async () => {
   render(<VocabularyPage />);
   await flushPromises();
   expect(await screen.findByText(/No saved words yet/i)).toBeInTheDocument();
+});
+
+// ── Flash highlight on target word ───────────────────────────────────────────
+
+test("target word card gets animate-vocab-flash class when ?word= matches", async () => {
+  mockUseSearchParams.mockReturnValue({ get: (k: string) => (k === "word" ? "ephemeral" : null) });
+
+  render(<VocabularyPage />);
+  await flushPromises();
+  await screen.findByText("ephemeral");
+
+  // The card wrapping the target word should have the flash class
+  const card = screen.getByText("ephemeral").closest("[class*='rounded-xl']");
+  expect(card?.className).toContain("animate-vocab-flash");
+});
+
+test("non-target word cards do NOT get animate-vocab-flash", async () => {
+  mockUseSearchParams.mockReturnValue({ get: (k: string) => (k === "word" ? "ephemeral" : null) });
+
+  render(<VocabularyPage />);
+  await flushPromises();
+  await screen.findByText("ardent");
+
+  const card = screen.getByText("ardent").closest("[class*='rounded-xl']");
+  expect(card?.className).not.toContain("animate-vocab-flash");
 });

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -242,7 +242,7 @@ function AnnotationCard({
       {!isEditing && (
         <div className="flex items-center gap-3 mt-2">
           <a
-            href={`/reader/${bookId}?chapter=${ann.chapter_index}`}
+            href={`/reader/${bookId}?chapter=${ann.chapter_index}&sentence=${encodeURIComponent(ann.sentence_text)}`}
             className="text-xs text-amber-600 hover:text-amber-800 hover:underline transition-colors"
           >
             → {chapterLabel(chapters, ann.chapter_index)}
@@ -271,14 +271,20 @@ function AnnotationCard({
 function InsightCard({
   ins,
   chapters,
+  bookId,
   onDelete,
   isDeleting,
 }: {
   ins: BookInsight;
   chapters: BookChapter[];
+  bookId: number;
   onDelete: () => void;
   isDeleting: boolean;
 }) {
+  const readerHref = ins.chapter_index !== null
+    ? `/reader/${bookId}?chapter=${ins.chapter_index}${ins.context_text ? `&sentence=${encodeURIComponent(ins.context_text)}` : ""}`
+    : null;
+
   return (
     <div className="my-3 space-y-1.5">
       {ins.context_text && (
@@ -291,8 +297,13 @@ function InsightCard({
       </p>
       <p className="text-sm text-ink leading-relaxed">{ins.answer}</p>
       <div className="flex items-center gap-3 pt-0.5">
-        {ins.chapter_index !== null && (
-          <span className="text-xs text-stone-400">{chapterLabel(chapters, ins.chapter_index)}</span>
+        {readerHref && (
+          <a
+            href={readerHref}
+            className="text-xs text-amber-600 hover:text-amber-800 hover:underline transition-colors"
+          >
+            → {chapterLabel(chapters, ins.chapter_index as number)}
+          </a>
         )}
         <button
           onClick={onDelete}
@@ -313,9 +324,10 @@ function VocabRow({
   chapters,
 }: {
   word: string;
-  occurrence: { chapter_index: number; sentence_text: string };
+  occurrence: { book_id: number; chapter_index: number; sentence_text: string };
   chapters: BookChapter[];
 }) {
+  const readerHref = `/reader/${occurrence.book_id}?chapter=${occurrence.chapter_index}&sentence=${encodeURIComponent(occurrence.sentence_text)}&word=${encodeURIComponent(word)}`;
   return (
     <li className="flex gap-2 text-sm leading-relaxed before:content-['·'] before:text-amber-400 before:font-bold before:shrink-0">
       <span>
@@ -327,7 +339,12 @@ function VocabRow({
         </a>{" "}
         <span className="text-stone-400 text-xs">({chapterLabel(chapters, occurrence.chapter_index)})</span>
         {" — "}
-        <span className="italic text-stone-600">&ldquo;{truncate(occurrence.sentence_text, 90)}&rdquo;</span>
+        <a
+          href={readerHref}
+          className="italic text-stone-600 hover:text-amber-700 hover:underline transition-colors"
+        >
+          &ldquo;{truncate(occurrence.sentence_text, 90)}&rdquo;
+        </a>
       </span>
     </li>
   );
@@ -503,6 +520,7 @@ export default function BookNotesPage() {
         key={ins.id}
         ins={ins}
         chapters={chapters}
+        bookId={bookId}
         onDelete={() => handleDeleteInsight(ins.id)}
         isDeleting={deletingIns.has(ins.id)}
       />

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1380,19 +1380,50 @@ export default function ReaderPage() {
                         <p className="mt-1 text-xs">Select text to save words to vocabulary.</p>
                       </div>
                     ) : (
-                      <div className="space-y-1.5">
-                        {filteredVocab.map((w) => (
-                          <button
-                            key={w.id}
-                            onClick={() => router.push(`/vocabulary?word=${encodeURIComponent(w.word)}`)}
-                            className="w-full flex items-center justify-between gap-2 px-3 py-2 rounded-lg bg-amber-50 border border-amber-200 hover:bg-amber-100 transition-colors text-left"
-                          >
-                            <span className="text-sm font-medium text-ink">{w.word}</span>
-                            <span className="text-[10px] text-stone-400 shrink-0">
-                              {w.occurrences.filter((o) => o.book_id === Number(bookId)).length}×
-                            </span>
-                          </button>
-                        ))}
+                      <div className="space-y-2">
+                        {filteredVocab.map((w) => {
+                          const lemma = w.lemma || w.word;
+                          const isForm = w.lemma && w.lemma.toLowerCase() !== w.word.toLowerCase();
+                          const relevantOccs = vocabView === "chapter"
+                            ? w.occurrences.filter((o) => o.book_id === Number(bookId) && o.chapter_index === chapterIndex)
+                            : w.occurrences.filter((o) => o.book_id === Number(bookId));
+                          return (
+                            <div key={w.id} className="rounded-lg bg-amber-50 border border-amber-200 overflow-hidden">
+                              {/* Lemma header */}
+                              <button
+                                onClick={() => router.push(`/vocabulary?word=${encodeURIComponent(w.word)}`)}
+                                className="w-full flex items-center justify-between gap-2 px-3 py-2 hover:bg-amber-100 transition-colors text-left"
+                              >
+                                <span className="text-sm font-semibold text-ink">{lemma}</span>
+                                {isForm && (
+                                  <span className="text-[10px] text-amber-600 shrink-0 italic">{w.word}</span>
+                                )}
+                              </button>
+                              {/* Context occurrences */}
+                              {relevantOccs.map((occ, i) => (
+                                <button
+                                  key={i}
+                                  onClick={() => {
+                                    if (occ.chapter_index !== chapterIndex) {
+                                      goToChapter(occ.chapter_index);
+                                      setTimeout(() => setScrollTargetSentence(occ.sentence_text), 400);
+                                    } else {
+                                      setScrollTargetSentence(undefined);
+                                      setTimeout(() => setScrollTargetSentence(occ.sentence_text), 10);
+                                    }
+                                    setSidebarOpen(false);
+                                  }}
+                                  className="w-full text-left border-t border-amber-200 px-3 py-1.5 hover:bg-amber-100 transition-colors"
+                                >
+                                  {vocabView === "book" && (
+                                    <span className="text-[10px] text-stone-400 mr-1">Ch.{occ.chapter_index + 1}</span>
+                                  )}
+                                  <span className="text-xs text-stone-500 italic line-clamp-2">&ldquo;{occ.sentence_text}&rdquo;</span>
+                                </button>
+                              ))}
+                            </div>
+                          );
+                        })}
                       </div>
                     )}
                   </div>

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -51,6 +51,7 @@ export default function ReaderPage() {
     position: { x: number; y: number };
   } | null>(null);
   const [scrollTargetSentence, setScrollTargetSentence] = useState<string | undefined>();
+  const didUrlScrollRef = useRef(false);
 
   // Vocabulary toast
   const [vocabToastWord, setVocabToastWord] = useState<string | null>(null);
@@ -306,6 +307,20 @@ export default function ReaderPage() {
       setVocabWords(words.filter((w) => w.occurrences.some((o) => o.book_id === Number(bookId))));
     }).catch(() => {});
   }, [bookId, session?.backendToken]);
+
+  // On initial chapter load, scroll to sentence specified in ?sentence= URL param
+  useEffect(() => {
+    if (loading || didUrlScrollRef.current) return;
+    const sentence = searchParams?.get("sentence");
+    if (!sentence) return;
+    didUrlScrollRef.current = true;
+    const decoded = decodeURIComponent(sentence);
+    setTimeout(() => {
+      setScrollTargetSentence(undefined);
+      setTimeout(() => setScrollTargetSentence(decoded), 50);
+    }, 500);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading]);
 
   const bookLanguage = meta?.languages[0] || "en";
 
@@ -1027,6 +1042,8 @@ export default function ReaderPage() {
                   } : undefined}
                   showAnnotations={showAnnotations}
                   scrollTargetSentence={scrollTargetSentence}
+                  scrollTargetWord={searchParams?.get("word") ? decodeURIComponent(searchParams.get("word")!) : undefined}
+                  vocabWords={new Set(vocabWords.map((v) => v.word.toLowerCase()))}
                   onSegmentClick={(startTime) => {
                     // Called only when TTS is playing (seek)
                     ttsSeekRef.current(startTime);

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import type { Annotation, WordBoundary } from "@/lib/api";
 
 // ── Text parsing ────────────────────────────────────────────────────────────
@@ -287,6 +287,10 @@ interface Props {
   }) => void;
   /** When false, annotation underlines and note dots are hidden. Default true. */
   showAnnotations?: boolean;
+  /** Word to highlight (amber pulse) inside the flash-target sentence. */
+  scrollTargetWord?: string;
+  /** Vocabulary words to show with a subtle dotted underline in all segments. */
+  vocabWords?: Set<string>;
 }
 
 const ANNOTATION_COLOR_CLASS: Record<string, string> = {
@@ -310,6 +314,67 @@ const NOTE_CARD_CLASS: Record<string, string> = {
   pink: "bg-pink-50 text-pink-800 border-pink-200",
 };
 
+/** Render segment text with target-word pulse and vocab-word dotted underlines. */
+function buildSegContent(
+  text: string,
+  targetWord: string | undefined,
+  vocabWords: Set<string> | undefined,
+): React.ReactNode {
+  if (!targetWord && !vocabWords?.size) return text;
+
+  type Match = { start: number; end: number; type: "target" | "vocab" };
+  const matches: Match[] = [];
+
+  const addMatches = (needle: string, type: Match["type"]) => {
+    const lc = text.toLowerCase();
+    const nl = needle.toLowerCase();
+    let i = 0;
+    while (i < lc.length) {
+      const idx = lc.indexOf(nl, i);
+      if (idx === -1) break;
+      const pre = idx === 0 || !/\w/.test(text[idx - 1]);
+      const post = idx + nl.length >= text.length || !/\w/.test(text[idx + nl.length]);
+      if (pre && post) matches.push({ start: idx, end: idx + nl.length, type });
+      i = idx + nl.length;
+    }
+  };
+
+  if (targetWord) addMatches(targetWord, "target");
+  vocabWords?.forEach((w) => addMatches(w, "vocab"));
+
+  if (!matches.length) return text;
+
+  matches.sort((a, b) => a.start - b.start);
+  const deduped: Match[] = [];
+  let lastEnd = 0;
+  for (const m of matches) {
+    if (m.start >= lastEnd) { deduped.push(m); lastEnd = m.end; }
+  }
+
+  const nodes: React.ReactNode[] = [];
+  let pos = 0;
+  for (const m of deduped) {
+    if (m.start > pos) nodes.push(text.slice(pos, m.start));
+    const word = text.slice(m.start, m.end);
+    if (m.type === "target") {
+      nodes.push(
+        <mark key={m.start} className="bg-amber-300 text-inherit rounded px-0.5 not-italic animate-pulse">
+          {word}
+        </mark>,
+      );
+    } else {
+      nodes.push(
+        <span key={m.start} className="underline decoration-amber-400 decoration-dotted decoration-2 underline-offset-2">
+          {word}
+        </span>,
+      );
+    }
+    pos = m.end;
+  }
+  if (pos < text.length) nodes.push(text.slice(pos));
+  return <>{nodes}</>;
+}
+
 export default function SentenceReader({
   text,
   duration,
@@ -327,6 +392,8 @@ export default function SentenceReader({
   scrollTargetSentence,
   onWordTap,
   showAnnotations = true,
+  scrollTargetWord,
+  vocabWords,
 }: Props) {
   const [flashTarget, setFlashTarget] = useState<string | null>(null);
   const [expandedNoteFlatIdx, setExpandedNoteFlatIdx] = useState<number | null>(null);
@@ -539,7 +606,7 @@ export default function SentenceReader({
               onPointerMove={handlePointerMove}
               className={`rounded px-0.5 -mx-0.5 transition-colors duration-200 ${segClass(seg)} ${annotationClass} ${flashClass} ${extraClass}`}
             >
-              {seg.text}
+              {buildSegContent(seg.text, isJumpTarget ? scrollTargetWord : undefined, vocabWords)}
               {annotation?.note_text && (
                 <button
                   onClick={(e) => { e.stopPropagation(); setExpandedNoteFlatIdx((prev) => prev === seg.flatIdx ? null : seg.flatIdx); }}


### PR DESCRIPTION
## Summary
- Vocab sidebar card now shows the lemma (base form) as the main title
- If the saved word differs from the lemma (e.g. "gegangen" vs "gehen"), the saved form appears in italic beside the title
- Each occurrence sentence is listed below the word as a clickable context line — clicking jumps to that exact sentence in the reader (switches chapter if needed)
- "This chapter" filter shows only occurrences from the current chapter; "All chapters" shows all with a Ch.N prefix

## Test plan
- [ ] Save a declined/conjugated German word; verify sidebar shows the lemma title with the form in italic
- [ ] Click a context line in same chapter → sentence highlights and scrolls into view
- [ ] Click a context line from a different chapter → navigates to that chapter and scrolls to sentence
- [ ] "This chapter" filter hides occurrences from other chapters

🤖 Generated with [Claude Code](https://claude.com/claude-code)
