### PR TITLE
test(e2e): notes page, vocab definition sheet, sidebar occurrence click

### DIFF
--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -166,4 +166,20 @@ export async function mockBackend(page: Page) {
       },
     })
   );
+
+  // Default: insights returns empty array; DELETE returns ok
+  await page.route(/\/api\/insights/, (route) => {
+    if (route.request().method() === "GET") {
+      route.fulfill({ json: [] });
+    } else if (route.request().method() === "DELETE") {
+      route.fulfill({ json: { ok: true } });
+    } else {
+      route.fallback();
+    }
+  });
+
+  // Default: obsidian export returns no URL (tests override as needed)
+  await page.route(/\/api\/vocabulary\/export/, (route) =>
+    route.fulfill({ json: { urls: [] } })
+  );
 }

--- a/frontend/e2e/notes-page.spec.ts
+++ b/frontend/e2e/notes-page.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * E2E: Book notes page — render, edit, delete, collapse, view modes, export, deep-links.
+ */
+import { test, expect } from "./base";
+import { mockBackend } from "./fixtures";
+
+const ANNOTATION = {
+  id: 1,
+  book_id: 1342,
+  chapter_index: 0,
+  sentence_text: "It is a truth universally acknowledged",
+  note_text: "Opening line",
+  color: "yellow",
+};
+
+function withAnnotation(page: import("@playwright/test").Page, patchNoteText = ANNOTATION.note_text) {
+  // Use regex so /api/annotations/1 (PATCH/DELETE) is also matched, not just the list endpoint.
+  return page.route(/\/api\/annotations/, (route) => {
+    const method = route.request().method();
+    if (method === "GET") {
+      route.fulfill({ json: [ANNOTATION] });
+    } else if (method === "PATCH") {
+      route.fulfill({ json: { ...ANNOTATION, note_text: patchNoteText } });
+    } else {
+      route.fulfill({ json: { ok: true } });
+    }
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await mockBackend(page);
+});
+
+test("notes page: empty state when there are no notes", async ({ page }) => {
+  // Override vocab to return empty so all counts are 0
+  await page.route(/\/api\/vocabulary$/, (route) =>
+    route.fulfill({ json: [] })
+  );
+
+  await page.goto("/notes/1342");
+
+  await expect(page.getByText("No notes yet")).toBeVisible();
+  await expect(page.getByRole("button", { name: /Open reader/ })).toBeVisible();
+});
+
+test("notes page: renders book title and annotation sentence", async ({ page }) => {
+  await withAnnotation(page);
+
+  await page.goto("/notes/1342");
+
+  await expect(page.getByRole("heading", { name: "Pride and Prejudice" })).toBeVisible();
+  await expect(page.getByText(/1 annotations/)).toBeVisible();
+  await expect(page.getByText(/It is a truth universally acknowledged/).first()).toBeVisible();
+  await expect(page.getByText("Opening line")).toBeVisible();
+});
+
+test("notes page: edit annotation saves updated note text", async ({ page }) => {
+  await withAnnotation(page, "Famous opening line");
+
+  await page.goto("/notes/1342");
+  await expect(page.getByText("Opening line")).toBeVisible();
+
+  await page.getByTitle("Edit note").click();
+
+  const textarea = page.locator("textarea");
+  await expect(textarea).toBeVisible();
+  await expect(textarea).toHaveValue("Opening line");
+
+  await textarea.clear();
+  await textarea.fill("Famous opening line");
+  await page.getByRole("button", { name: "Save" }).click();
+
+  await expect(textarea).not.toBeVisible();
+  await expect(page.getByText("Famous opening line")).toBeVisible();
+});
+
+test("notes page: cancel edit restores original note text", async ({ page }) => {
+  await withAnnotation(page);
+
+  await page.goto("/notes/1342");
+  await page.getByTitle("Edit note").click();
+
+  const textarea = page.locator("textarea");
+  await textarea.clear();
+  await textarea.fill("Discarded change");
+  await page.getByRole("button", { name: "Cancel" }).click();
+
+  await expect(textarea).not.toBeVisible();
+  await expect(page.getByText("Opening line")).toBeVisible();
+  await expect(page.getByText("Discarded change")).not.toBeVisible();
+});
+
+test("notes page: delete annotation removes it from the list", async ({ page }) => {
+  await withAnnotation(page);
+
+  await page.goto("/notes/1342");
+  await expect(page.getByText(/It is a truth universally acknowledged/).first()).toBeVisible();
+
+  page.once("dialog", (dialog) => dialog.accept());
+  await page.getByTitle("Delete annotation").click();
+
+  // Sentence quote gone; only vocab words remain (no annotation heading)
+  await expect(page.getByText(/^"It is a truth universally acknowledged"$/).first()).not.toBeVisible();
+});
+
+test("notes page: collapse all hides content; expand all reveals it", async ({ page }) => {
+  await withAnnotation(page);
+
+  await page.goto("/notes/1342");
+  // Content visible before collapse
+  await expect(page.getByText("Opening line")).toBeVisible();
+
+  await page.getByRole("button", { name: "Collapse all" }).click();
+  await expect(page.getByText("Opening line")).not.toBeVisible();
+  // Button label flips
+  await expect(page.getByRole("button", { name: "Expand all" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Expand all" }).click();
+  await expect(page.getByText("Opening line")).toBeVisible();
+});
+
+test("notes page: 'By chapter' view shows chapter heading instead of section heading", async ({ page }) => {
+  await withAnnotation(page);
+
+  await page.goto("/notes/1342");
+
+  // Section view: "Annotations" section heading is visible
+  await expect(page.getByRole("button", { name: /Annotations/ })).toBeVisible();
+
+  await page.getByRole("button", { name: "By chapter" }).click();
+
+  // Chapter view: "Annotations" section heading gone; chapter heading appears
+  await expect(page.getByRole("button", { name: /Annotations/ })).not.toBeVisible();
+  // chapters[0].title = "Chapter I" in mock; \b ensures "Chapter II" is not matched
+  await expect(page.getByRole("button", { name: /\bChapter I\b/ })).toBeVisible();
+});
+
+test("notes page: annotation chapter link points to reader URL with sentence", async ({ page }) => {
+  await withAnnotation(page);
+
+  await page.goto("/notes/1342");
+
+  const link = page.getByRole("link", { name: /→ Chapter/ });
+  await expect(link).toBeVisible();
+
+  const href = await link.getAttribute("href");
+  expect(href).toContain("/reader/1342");
+  expect(href).toContain("chapter=0");
+  expect(href).toContain(encodeURIComponent("It is a truth universally acknowledged"));
+});
+
+test("notes page: export button shows obsidian URL on success", async ({ page }) => {
+  await withAnnotation(page);
+
+  // Override export to return a URL
+  await page.route(/\/api\/vocabulary\/export/, (route) =>
+    route.fulfill({ json: { urls: ["obsidian://open?vault=MyVault&file=vocab.md"] } })
+  );
+
+  await page.goto("/notes/1342");
+
+  await page.getByRole("button", { name: /Export/ }).click();
+
+  await expect(page.getByText(/Exported → obsidian:\/\//)).toBeVisible();
+});

--- a/frontend/e2e/vocab-definition.spec.ts
+++ b/frontend/e2e/vocab-definition.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * E2E: Vocabulary page — definition sheet open/close and content.
+ */
+import { test, expect } from "./base";
+import { mockBackend } from "./fixtures";
+
+test.beforeEach(async ({ page }) => {
+  await mockBackend(page);
+});
+
+test("clicking a lemma button opens the definition sheet", async ({ page }) => {
+  await page.goto("/vocabulary");
+
+  // Wait for vocab list to render (lemma "universal" from mock fixture)
+  await expect(page.getByRole("button", { name: "universal" })).toBeVisible({ timeout: 10000 });
+
+  await page.getByRole("button", { name: "universal" }).click();
+
+  // Slide-up sheet appears with the word title
+  await expect(page.locator(".animate-slide-up")).toBeVisible();
+  await expect(page.locator(".animate-slide-up").getByText("universal")).toBeVisible();
+});
+
+test("definition sheet shows part-of-speech, definition text, and Wiktionary link", async ({ page }) => {
+  await page.goto("/vocabulary");
+  await expect(page.getByRole("button", { name: "universal" })).toBeVisible({ timeout: 10000 });
+  await page.getByRole("button", { name: "universal" }).click();
+
+  // POS label and definition from fixture mock
+  await expect(page.getByText("adjective")).toBeVisible();
+  await expect(page.getByText("relating to or done by all")).toBeVisible();
+
+  // Wiktionary link
+  await expect(page.getByRole("link", { name: /View on Wiktionary/ })).toBeVisible();
+});
+
+test("Escape key closes the definition sheet", async ({ page }) => {
+  await page.goto("/vocabulary");
+  await expect(page.getByRole("button", { name: "universal" })).toBeVisible({ timeout: 10000 });
+  await page.getByRole("button", { name: "universal" }).click();
+  await expect(page.locator(".animate-slide-up")).toBeVisible();
+
+  await page.keyboard.press("Escape");
+
+  await expect(page.locator(".animate-slide-up")).not.toBeVisible();
+});
+
+test("clicking the backdrop closes the definition sheet", async ({ page }) => {
+  await page.goto("/vocabulary");
+  await expect(page.getByRole("button", { name: "universal" })).toBeVisible({ timeout: 10000 });
+  await page.getByRole("button", { name: "universal" }).click();
+  await expect(page.locator(".animate-slide-up")).toBeVisible();
+
+  // Click at the top of the screen, well away from the bottom sheet
+  await page.mouse.click(200, 80);
+
+  await expect(page.locator(".animate-slide-up")).not.toBeVisible();
+});

--- a/frontend/e2e/vocab-sidebar.spec.ts
+++ b/frontend/e2e/vocab-sidebar.spec.ts
@@ -44,6 +44,36 @@ test("vocab sidebar 'All chapters' toggle shows words from every chapter", async
   await expect(page.getByRole("button", { name: "acknowledge acknowledged" })).toBeVisible();
 });
 
+test("vocab sidebar: clicking an occurrence closes the sidebar", async ({ page }) => {
+  await page.goto("/reader/1342");
+
+  const vocabBtn = page.getByTitle("Vocabulary", { exact: true });
+  await vocabBtn.click();
+
+  // The filter toggle is the landmark for "sidebar is open"
+  await expect(page.getByRole("button", { name: "This chapter" })).toBeVisible();
+
+  // Click the context occurrence for "universally" (chapter 0, same chapter as reader)
+  // Occurrence button is the only <button> containing this quoted sentence text
+  await page.getByRole("button", { name: /It is a truth universally acknowledged/ }).click();
+
+  // Sidebar closes
+  await expect(page.getByRole("button", { name: "This chapter" })).not.toBeVisible();
+});
+
+test("vocab sidebar: 'All chapters' view shows chapter labels on occurrences", async ({ page }) => {
+  await page.goto("/reader/1342");
+
+  const vocabBtn = page.getByTitle("Vocabulary", { exact: true });
+  await vocabBtn.click();
+
+  await page.getByRole("button", { name: "All chapters" }).click();
+
+  // "universally" is chapter_index=0 → Ch.1; "acknowledged" is chapter_index=1 → Ch.2
+  await expect(page.getByText("Ch.1")).toBeVisible();
+  await expect(page.getByText("Ch.2")).toBeVisible();
+});
+
 test("vocab page: target word card has amber highlight ring", async ({ page }) => {
   await page.goto("/vocabulary?word=universally");
 


### PR DESCRIPTION
## Summary

- Add `notes-page.spec.ts`: 8 E2E tests covering the book notes page — empty state, annotation render, inline edit/cancel, delete with confirm dialog, collapse-all/expand-all, by-chapter view toggle, chapter deep-link, and Obsidian export message
- Add `vocab-definition.spec.ts`: 4 tests covering the vocabulary definition sheet — open on lemma click, definition content, Escape-to-close, and backdrop-click-to-close
- Extend `vocab-sidebar.spec.ts`: 2 new tests — occurrence click closes the sidebar, "All chapters" view shows chapter labels
- Update `fixtures.ts`: add default empty stubs for `GET /api/insights` and `POST /api/vocabulary/export/obsidian` so notes-page tests don't hit the network

## Test plan

- [x] All 96 Playwright tests pass locally on chromium (1 skipped — real TTS)
- [x] No regressions in existing annotation, translation, reader, home, or vocab tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
