### PR TITLE
fix(reader): TTS highlight freezes at unloaded chunk boundary

### DIFF
--- a/frontend/src/__tests__/SentenceReader.timing.test.tsx
+++ b/frontend/src/__tests__/SentenceReader.timing.test.tsx
@@ -102,4 +102,85 @@ describe("SentenceReader timing estimation", () => {
     const active = container.querySelector(".bg-amber-300");
     expect(active?.textContent).toContain("Second chunk");
   });
+
+  it("highlight advances past a mid-sequence Infinity segment (unloaded middle chunk)", () => {
+    // Regression: when a middle chunk has duration=0 (not yet loaded), its segments
+    // get startTime=Infinity. The previous `else break` in currentIdx caused the
+    // highlight to freeze on the last loaded segment before that Infinity.
+    // Setup: chunk 0 loaded (2s), chunk 1 NOT loaded (0s), chunk 2 loaded (2s).
+    // At t=2.5 the highlight should advance to "Third sentence" (chunk 2),
+    // not stay frozen on "First sentence" (chunk 0).
+    const sentA = "First sentence here.";
+    const sentB = "Middle sentence here.";
+    const sentC = "Third sentence here.";
+    // Separate paragraphs so each sentence is its own chunk
+    const text = `${sentA}\n\n${sentB}\n\n${sentC}`;
+    const chunks: ChunkInfo[] = [
+      { text: sentA, duration: 2 },   // loaded
+      { text: sentB, duration: 0 },   // NOT yet loaded — startTime = Infinity
+      { text: sentC, duration: 2 },   // loaded; starts at chunkStartTime = 2
+    ];
+
+    const { container, rerender } = render(
+      <SentenceReader
+        text={text}
+        duration={4}
+        currentTime={0}
+        isPlaying={false}
+        onSegmentClick={noop}
+        chunks={chunks}
+      />
+    );
+
+    // Without the fix, highlight freezes on sentA at t=2.5 (else-break stops at Infinity).
+    // With the fix, sentC (startTime=2) is correctly highlighted.
+    rerender(
+      <SentenceReader
+        text={text}
+        duration={4}
+        currentTime={2.5}
+        isPlaying={true}
+        onSegmentClick={noop}
+        chunks={chunks}
+      />
+    );
+    const active = container.querySelector(".bg-amber-300");
+    expect(active?.textContent).toContain("Third sentence");
+  });
+
+  it("handles \\r\\n line endings in chunk text without breaking indexOf matching", () => {
+    // Regression: chunks[].text.replace(/\n/g, " ") left \\r, causing indexOf
+    // to fail for segments after Windows-style line endings in Gutenberg text.
+    const sentA = "Il avait les cheveux.";
+    const sentB = "Quoiqu il ne fut pas.";
+    // Simulate Windows \\r\\n inside the chunk text (as if the source file had CRLF)
+    const chunkWithCrlf = `${sentA}\r\n${sentB}`;
+    const chunks: ChunkInfo[] = [{ text: chunkWithCrlf, duration: 4 }];
+    const text = `${sentA}\n${sentB}`;  // same text, Unix line endings
+
+    const { container, rerender } = render(
+      <SentenceReader
+        text={text}
+        duration={4}
+        currentTime={3}
+        isPlaying={true}
+        onSegmentClick={noop}
+        chunks={chunks}
+      />
+    );
+
+    rerender(
+      <SentenceReader
+        text={text}
+        duration={4}
+        currentTime={3}
+        isPlaying={true}
+        onSegmentClick={noop}
+        chunks={chunks}
+      />
+    );
+    // Both sentences should be matched; at t=3 the second sentence should be highlighted.
+    const active = container.querySelector(".bg-amber-300");
+    expect(active?.textContent).toContain("Quoiqu");
+  });
 });

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useLayoutEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { getBookChapters, deleteTranslationCache, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, getChapterTranslation, getChapterQueueStatus, retryChapterTranslation, enqueueBookTranslation, saveReadingProgress, getAnnotations, getVocabulary, saveVocabularyWord, exportVocabularyToObsidian, saveInsight, TranslationStatus, BookMeta, BookChapter, ApiError, Annotation, VocabularyWord } from "@/lib/api";
@@ -77,6 +77,10 @@ export default function ReaderPage() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [sidebarTab, setSidebarTab] = useState<"chat" | "notes" | "vocab" | "translate">("chat");
   const [vocabWords, setVocabWords] = useState<VocabularyWord[]>([]);
+  const vocabWordsSet = useMemo(
+    () => new Set(vocabWords.map((v) => v.word.toLowerCase())),
+    [vocabWords],
+  );
   const [vocabView, setVocabView] = useState<"chapter" | "book">("chapter");
   // Word definition tooltip (shown when "Word" is clicked in SelectionToolbar)
   const [vocabTooltip, setVocabTooltip] = useState<{ word: string; context: string; rect: DOMRect } | null>(null);
@@ -1043,7 +1047,7 @@ export default function ReaderPage() {
                   showAnnotations={showAnnotations}
                   scrollTargetSentence={scrollTargetSentence}
                   scrollTargetWord={searchParams?.get("word") ? decodeURIComponent(searchParams.get("word")!) : undefined}
-                  vocabWords={new Set(vocabWords.map((v) => v.word.toLowerCase()))}
+                  vocabWords={vocabWordsSet}
                   onSegmentClick={(startTime) => {
                     // Called only when TTS is playing (seek)
                     ttsSeekRef.current(startTime);

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -108,7 +108,7 @@ function parseIntoSegments(
       const seg = allTexts[s];
       // Find this segment within the remaining chunk text
       while (chunkIdx < chunks.length) {
-        const chunkText = chunks[chunkIdx].text.replace(/\n/g, " ");
+        const chunkText = chunks[chunkIdx].text.replace(/\r?\n/g, " ");
         const pos = chunkText.indexOf(seg, cursor);
         if (pos >= 0) {
           segmentChunkIdx[s] = chunkIdx;
@@ -167,7 +167,7 @@ function parseIntoSegments(
         // Path a: locate each segment's start position in the (newline-normalised)
         // chunk text, count preceding words, and map to the corresponding word
         // boundary's offset_ms for exact TTS timing.
-        const normalised = chunk.text.replace(/\n/g, " ");
+        const normalised = chunk.text.replace(/\r?\n/g, " ");
         let cursor = 0;
         for (const idx of segIndices) {
           const seg = allTexts[idx];
@@ -428,13 +428,14 @@ export default function SentenceReader({
     [paragraphs]
   );
 
-  // Current segment: last one whose startTime ≤ currentTime
+  // Current segment: last one whose startTime ≤ currentTime.
+  // Do NOT break early on Infinity values — unmatched segments create holes
+  // in the sorted order, so scanning all segments is required.
   const currentIdx = useMemo(() => {
     if (duration === 0 || currentTime === 0) return -1;
     let best = -1;
     for (let i = 0; i < allSegments.length; i++) {
       if (allSegments[i].startTime <= currentTime) best = i;
-      else break;
     }
     return best;
   }, [allSegments, currentTime, duration]);


### PR DESCRIPTION
## Summary

- **Highlight froze at sentence boundary**: `currentIdx` used `else break` when it hit a segment with `Infinity` startTime (unloaded chunk), halting the scan. All later loaded segments were invisible to the loop, so the highlight stayed stuck on the last sentence before the unloaded chunk. Removed the break — the loop now scans all segments and finds the correct active one even when there are Infinity holes.
- **`\r\n` caused chunk→segment mismatch**: `replace(/\n/g, " ")` left stray `\r` characters from CRLF-encoded Gutenberg source files. `indexOf` then failed to find the sentence (which had been normalized to no `\r`), assigning `Infinity` to that segment and triggering the freeze. Changed to `replace(/\r?\n/g, " ")` in both matching passes inside `parseIntoSegments`.
- **Memoized `vocabWordsSet`** in the reader page to prevent a new `Set` being created on every render, which was causing SentenceReader to recompute `paragraphs` on every TTS tick.

## Test plan

- [x] New regression test: 3-sentence chapter with unloaded middle chunk — verifies highlight advances to 3rd sentence at t=2.5 (was stuck on 1st)
- [x] New regression test: chunk text with `\r\n` line endings — verifies 2nd sentence is highlighted at t=3 (was getting Infinity and freezing)
- [x] Full test suite: 1344 tests pass
