### PR TITLE
fix(migrations): bootstrap 006_add_apple_id to prevent startup crash on existing DBs

### DIFF
--- a/backend/services/migrations.py
+++ b/backend/services/migrations.py
@@ -71,6 +71,8 @@ async def run(db_path: str) -> list[str]:
              "SELECT 1 FROM pragma_table_info('users') WHERE name='role'"),
             ("005_add_github_id",
              "SELECT 1 FROM pragma_table_info('users') WHERE name='github_id'"),
+            ("006_add_apple_id",
+             "SELECT 1 FROM pragma_table_info('users') WHERE name='apple_id'"),
             ("006_bulk_translation_jobs",
              "SELECT name FROM sqlite_master WHERE type='table' AND name='bulk_translation_jobs'"),
             ("007_translation_provider_info",

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -411,6 +411,67 @@ async def test_migrations_applied_in_filename_order(tmp_db, tmp_migrations, monk
     assert applied == ["001_m", "002_m", "003_m"]
 
 
+# ── 006_add_apple_id bootstrap regression ────────────────────────────────────
+
+async def test_bootstrap_marks_006_add_apple_id_when_column_exists(tmp_db):
+    """Regression: a legacy DB that already has apple_id must not re-apply
+    006_add_apple_id.sql — that ALTER TABLE ADD COLUMN would crash with
+    'duplicate column name: apple_id'.
+
+    Root cause: 006_add_apple_id was missing from bootstrap_checks while
+    006_bulk_translation_jobs was present, so any existing DB with apple_id
+    would crash on startup."""
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute(
+            "CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT, images TEXT)"
+        )
+        await db.execute("""
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                google_id TEXT UNIQUE NOT NULL,
+                email TEXT, name TEXT, picture TEXT, gemini_key TEXT,
+                role TEXT DEFAULT 'user', approved INTEGER DEFAULT 0,
+                github_id TEXT, apple_id TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        await db.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_users_apple_id
+            ON users(apple_id) WHERE apple_id IS NOT NULL
+        """)
+        await db.execute("""
+            CREATE TABLE translations (
+                book_id INTEGER NOT NULL, chapter_index INTEGER NOT NULL,
+                target_language TEXT NOT NULL, paragraphs TEXT NOT NULL,
+                PRIMARY KEY (book_id, chapter_index, target_language)
+            )
+        """)
+        await db.execute(
+            "CREATE TABLE audiobooks (book_id INTEGER PRIMARY KEY, librivox_id TEXT NOT NULL)"
+        )
+        await db.execute("""
+            CREATE TABLE audio_cache (
+                book_id INTEGER NOT NULL, chapter_index INTEGER NOT NULL,
+                chunk_index INTEGER NOT NULL DEFAULT 0,
+                provider TEXT NOT NULL, voice TEXT NOT NULL,
+                content_type TEXT NOT NULL, audio BLOB NOT NULL,
+                PRIMARY KEY (book_id, chapter_index, chunk_index, provider, voice)
+            )
+        """)
+        await db.commit()
+
+    # Must NOT raise "duplicate column name: apple_id"
+    applied = await run_migrations(tmp_db)
+    assert "006_add_apple_id" not in applied  # bootstrapped, not re-applied
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute(
+            "SELECT version FROM schema_migrations WHERE version='006_add_apple_id'"
+        ) as cursor:
+            assert await cursor.fetchone() is not None, \
+                "006_add_apple_id must be bootstrapped in schema_migrations"
+
+
 # ── No migrations directory ──────────────────────────────────────────────────
 
 async def test_missing_migrations_dir_returns_empty(tmp_db, monkeypatch):


### PR DESCRIPTION
## Summary

- `006_add_apple_id.sql` was missing from the migration bootstrap checks, causing a startup crash on any existing database that already had the `apple_id` column
- `006_add_apple_id` sorts alphabetically before `006_bulk_translation_jobs` (which was in the bootstrap list), so the runner would try to re-apply `ALTER TABLE users ADD COLUMN apple_id` and fail with "duplicate column name: apple_id"
- Fix: add `("006_add_apple_id", "SELECT 1 FROM pragma_table_info('users') WHERE name='apple_id'")` to `bootstrap_checks` in `services/migrations.py`

## Test plan

- [ ] Added regression test `test_bootstrap_marks_006_add_apple_id_when_column_exists` — creates a legacy DB with `apple_id` already present, verifies `run_migrations()` does not raise and the version is bootstrapped in `schema_migrations`
- [ ] Test failed before fix (confirmed), passes after fix
- [ ] Full backend suite: 823 passed
