### PR TITLE
fix(auth): raise 401 instead of KeyError→500 for JWT missing sub claim

### DIFF
--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -157,7 +157,10 @@ async def get_current_user(request: Request) -> dict:
         raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
     token = auth_header.removeprefix("Bearer ").strip()
     payload = decode_jwt(token)
-    user_id = int(payload["sub"])
+    sub = payload.get("sub")
+    if not sub:
+        raise HTTPException(status_code=401, detail="Invalid token: missing sub claim")
+    user_id = int(sub)
     user = await get_user_by_id(user_id)
     if not user:
         raise HTTPException(status_code=401, detail="User not found")

--- a/backend/tests/test_auth_service_branches.py
+++ b/backend/tests/test_auth_service_branches.py
@@ -187,3 +187,36 @@ async def test_get_optional_user_valid_approved_user_returns_user():
     assert result is not None
     assert result["id"] == 42
     assert result["email"] == "alice@example.com"
+
+
+# ── Missing "sub" claim ───────────────────────────────────────────────────────
+
+def _make_token_without_sub() -> str:
+    """Craft a validly-signed JWT that intentionally omits the 'sub' claim."""
+    from jose import jwt as jose_jwt
+    return jose_jwt.encode(
+        {"email": "nosub@example.com"},
+        auth_module.JWT_SECRET,
+        algorithm=auth_module.JWT_ALGORITHM,
+    )
+
+
+async def test_get_current_user_raises_401_for_token_missing_sub():
+    """Regression: a JWT signed with correct secret but missing 'sub' must return
+    401, not crash with KeyError → 500."""
+    token = _make_token_without_sub()
+    request = _make_request(token=token)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(request)
+
+    assert exc_info.value.status_code == 401
+
+
+async def test_get_optional_user_returns_none_for_token_missing_sub():
+    """get_optional_user must return None (not raise) for a token missing 'sub'."""
+    token = _make_token_without_sub()
+    request = _make_request(token=token)
+
+    result = await get_optional_user(request)
+    assert result is None


### PR DESCRIPTION
## Summary

`get_current_user()` accessed `payload["sub"]` directly after decoding a JWT. A validly-signed token that lacks the `sub` claim (e.g. from an external system or a misconfigured issuer) would pass signature verification in `decode_jwt()` but then crash with `KeyError` → HTTP 500, leaking an internal exception to the client.

**Fix:** Use `payload.get("sub")` and raise `HTTPException(401)` if the claim is absent.

**Root cause verified with a regression test:** `_make_token_without_sub()` crafts a real HS256-signed JWT without `sub` using the same secret, confirming the crash before the fix.

## Test plan

- [ ] `test_get_current_user_raises_401_for_token_missing_sub` — was raising `KeyError`, now asserts 401
- [ ] `test_get_optional_user_returns_none_for_token_missing_sub` — already handled by broad except, still passes
- [ ] Full backend suite: 825+ tests pass
- [ ] Full frontend suite: 1488 tests pass
