### PR TITLE
fix(books): handle corrupted Gemini key gracefully (500 → 403)

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -258,7 +258,11 @@ async def request_chapter_translation(
 
     # 4. Require user's own Gemini key — do not drain the admin queue key.
     raw_key = user.get("gemini_key")
-    if not (raw_key and decrypt_api_key(raw_key)):
+    try:
+        decrypted_key = decrypt_api_key(raw_key) if raw_key else None
+    except HTTPException:
+        decrypted_key = None
+    if not decrypted_key:
         raise HTTPException(
             status_code=403,
             detail="A Gemini API key is required to translate chapters. Please add one in your profile settings.",

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -577,3 +577,20 @@ async def test_enqueue_all_same_language_returns_400(client):
         json={"target_language": "en"},
     )
     assert resp.status_code == 400
+
+
+async def test_chapter_translation_corrupted_gemini_key_returns_403(client, test_user):
+    """Regression: a corrupted (non-Fernet) Gemini key must return 403, not 500.
+
+    books.py line 261 calls decrypt_api_key() without a try/except, so an
+    InvalidToken raises HTTPException(500) instead of falling through to 403.
+    """
+    from services.db import set_user_gemini_key
+    # Store a raw string that is not valid Fernet ciphertext
+    await set_user_gemini_key(test_user["id"], "not-valid-fernet-ciphertext")
+    resp = await client.post(
+        "/api/books/9999/chapters/0/translation",
+        json={"target_language": "de"},
+    )
+    assert resp.status_code == 403
+    assert "Gemini" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

`request_chapter_translation` in `books.py` checked whether a user has a Gemini key with:

```python
if not (raw_key and decrypt_api_key(raw_key)):
```

`decrypt_api_key()` raises `HTTPException(500)` on `InvalidToken` (corrupted Fernet ciphertext). The bare expression propagated the 500 to the client instead of falling through to the 403 "key required" response.

**Fix:** mirror the pattern already used in `ai.py` — wrap in `try/except HTTPException`, treat decryption failure as "no key", then raise 403.

## Test plan

- [ ] `test_chapter_translation_corrupted_gemini_key_returns_403` — was returning 500, now asserts 403
- [ ] All 40 `test_router_books.py` tests pass
- [ ] Full backend suite: 829 tests pass
