### PR TITLE
fix(db): return updated profile on Google/GitHub login (stale pre-UPDATE row)

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -104,7 +104,11 @@ async def get_or_create_user(google_id: str, email: str, name: str, picture: str
                 (email, name, picture, google_id),
             )
             await db.commit()
-            return dict(row)
+            updated = dict(row)
+            updated["email"] = email
+            updated["name"] = name
+            updated["picture"] = picture
+            return updated
 
         # New user — check if this is the very first user (auto-admin)
         async with db.execute("SELECT COUNT(*) FROM users") as cursor:
@@ -138,7 +142,11 @@ async def get_or_create_user_github(github_id: str, email: str, name: str, pictu
                 (email, name, picture, github_id),
             )
             await db.commit()
-            return dict(row)
+            updated = dict(row)
+            updated["email"] = email
+            updated["name"] = name
+            updated["picture"] = picture
+            return updated
 
         # Try linking to existing account by email (user signed in via Google before)
         if email:
@@ -150,7 +158,11 @@ async def get_or_create_user_github(github_id: str, email: str, name: str, pictu
                     (github_id, name, picture, row["id"]),
                 )
                 await db.commit()
-                return dict(row)
+                updated = dict(row)
+                updated["github_id"] = github_id
+                updated["name"] = name
+                updated["picture"] = picture
+                return updated
 
         # New user
         async with db.execute("SELECT COUNT(*) FROM users") as cursor:

--- a/backend/tests/test_db_extended.py
+++ b/backend/tests/test_db_extended.py
@@ -66,6 +66,28 @@ async def test_github_existing_by_github_id_updates_fields():
     assert refreshed["name"] == "New"
 
 
+async def test_google_existing_user_returns_updated_profile():
+    """Regression: get_or_create_user must return the updated profile, not stale data.
+
+    The function updated the DB but returned the pre-UPDATE row, so the login
+    response showed the old name/picture for the entire session.
+    """
+    await get_or_create_user("gupdate1", "old@example.com", "Old Name", "old.jpg")
+    u2 = await get_or_create_user("gupdate1", "new@example.com", "New Name", "new.jpg")
+    assert u2["email"] == "new@example.com"
+    assert u2["name"] == "New Name"
+    assert u2["picture"] == "new.jpg"
+
+
+async def test_github_existing_by_github_id_returns_updated_profile():
+    """Regression: get_or_create_user_github must return the updated profile."""
+    await get_or_create_user_github("ghupdate1", "old@g.com", "Old", "old.jpg")
+    u2 = await get_or_create_user_github("ghupdate1", "new@g.com", "New", "new.jpg")
+    assert u2["email"] == "new@g.com"
+    assert u2["name"] == "New"
+    assert u2["picture"] == "new.jpg"
+
+
 async def test_github_links_to_existing_google_user_by_email():
     google_user = await get_or_create_user("g99", "shared@example.com", "Shared", "")
     gh_user = await get_or_create_user_github("gh4", "shared@example.com", "Shared2", "")


### PR DESCRIPTION
## Summary

`get_or_create_user` and `get_or_create_user_github` both updated `email/name/picture` in the database on every login, but then returned `dict(row)` — the snapshot fetched **before** the UPDATE. This meant:

- After a Google or GitHub profile change (name, avatar, or email), the **first login after the change** would return stale data in the login response
- NextAuth caches the login response in its session JWT, so the user would see their old name/picture for the entire session
- Only after logging out and back in a **second time** would the updated profile appear

The Apple auth was already correct — it re-fetches the row with `SELECT * WHERE apple_id = ?` after updating.

**Fix:** Update the in-memory dict with the new field values before returning, avoiding a redundant DB round-trip.

## Test plan

- [ ] `test_google_existing_user_returns_updated_profile` — was returning stale old email/name/picture, now asserts fresh values
- [ ] `test_github_existing_by_github_id_returns_updated_profile` — same
- [ ] All 43 `test_db_extended.py` tests pass
- [ ] Full backend suite: 830 tests pass
- [ ] Full frontend suite: 1496 tests pass
