### PR TITLE
fix(admin): delete translation_queue entries when a book is deleted

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -211,6 +211,7 @@ async def delete_book(book_id: int, _admin: dict = Depends(_require_admin)):
         await db.execute("DELETE FROM books WHERE id = ?", (book_id,))
         await db.execute("DELETE FROM translations WHERE book_id = ?", (book_id,))
         await db.execute("DELETE FROM audio_cache WHERE book_id = ?", (book_id,))
+        await db.execute("DELETE FROM translation_queue WHERE book_id = ?", (book_id,))
         await db.commit()
     # Invalidate the in-memory chapter split so a future import of the same
     # id doesn't accidentally reuse stale chapter boundaries.

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -165,6 +165,32 @@ async def test_delete_book(admin_client, admin_db):
     assert res.status_code == 200
 
 
+async def test_delete_book_removes_queue_entries(admin_client, admin_db):
+    """Regression: delete_book must also delete translation_queue entries.
+
+    If queue entries are left behind with status='skipped' (set by the worker
+    when it finds the book missing), a subsequent re-import of the same book_id
+    cannot enqueue new translations — INSERT OR IGNORE is blocked by the old
+    skipped rows. The re-imported book would never be translated.
+    """
+    from services.translation_queue import enqueue, queue_status_for_chapter
+
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    await enqueue(100, 0, "de")  # Add a pending queue entry
+
+    # Confirm the entry exists before deletion
+    status = await queue_status_for_chapter(100, 0, "de")
+    assert status["queued"]
+
+    # Delete the book
+    res = await admin_client.delete("/api/admin/books/100")
+    assert res.status_code == 200
+
+    # Queue entry should be gone — not just skipped, but deleted
+    status = await queue_status_for_chapter(100, 0, "de")
+    assert not status["queued"]
+
+
 # ── Translations ─────────────────────────────────────────────────────────────
 
 async def test_get_translations(admin_client, admin_db):


### PR DESCRIPTION
## Summary

`DELETE /api/admin/books/{book_id}` cleaned up `books`, `translations`, and `audio_cache` rows but left `translation_queue` entries behind.

**What breaks:** When the queue worker runs next, it tries to process the stale queue entries, finds no book, and marks them `status='skipped'`. The (book_id, chapter_index, target_language) UNIQUE constraint means these skipped rows now permanently block new entries for the same coordinates. If an admin re-imports the same book (same Gutenberg ID), `enqueue_for_book` calls `INSERT OR IGNORE` for each chapter — all silently no-op because the skipped rows already exist — and the re-imported book **never gets translated**.

**Fix:** Add `DELETE FROM translation_queue WHERE book_id = ?` to the `delete_book` transaction, alongside the existing cleanup of `books`, `translations`, and `audio_cache`.

## Test plan

- [ ] `test_delete_book_removes_queue_entries` — was leaving queue row after delete, now asserts it's gone
- [ ] All 36 `test_router_admin.py` tests pass
- [ ] Full backend suite: 830 tests pass
