### PR TITLE
fix: delete_word cascades to word_occurrences; fix export test mock

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -692,6 +692,11 @@ async def get_vocabulary(user_id: int) -> list[dict]:
 
 async def delete_word(user_id: int, word: str) -> bool:
     async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            """DELETE FROM word_occurrences WHERE vocabulary_id IN (
+               SELECT id FROM vocabulary WHERE user_id = ? AND word = ?)""",
+            (user_id, word),
+        )
         cursor = await db.execute(
             "DELETE FROM vocabulary WHERE user_id = ? AND word = ?",
             (user_id, word),

--- a/backend/tests/test_db_extended.py
+++ b/backend/tests/test_db_extended.py
@@ -327,6 +327,24 @@ async def test_delete_word():
     assert await get_vocabulary(user["id"]) == []
 
 
+async def test_delete_word_cascades_to_word_occurrences():
+    import aiosqlite
+    user = await get_or_create_user("g44b", "vocab5b@example.com", "V5b", "")
+    await save_word(user["id"], "Weltanschauung", 99, 0, "A Weltanschauung emerged.")
+    vocab = await get_vocabulary(user["id"])
+    vocab_id = vocab[0]["id"]
+    assert len(vocab[0]["occurrences"]) == 1
+
+    await delete_word(user["id"], "Weltanschauung")
+
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        async with db.execute(
+            "SELECT COUNT(*) FROM word_occurrences WHERE vocabulary_id = ?", (vocab_id,)
+        ) as cur:
+            count = (await cur.fetchone())[0]
+    assert count == 0
+
+
 async def test_delete_word_nonexistent_returns_false():
     user = await get_or_create_user("g45", "vocab6@example.com", "V6", "")
     result = await delete_word(user["id"], "nonexistent")

--- a/frontend/src/__tests__/VocabularyPage.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.test.tsx
@@ -129,7 +129,7 @@ test("delete button calls deleteVocabularyWord and removes word", async () => {
 });
 
 test("export button calls exportVocabularyToObsidian with no book_id", async () => {
-  mockExportVocabularyToObsidian.mockResolvedValue({ url: "https://github.com/example/pr/1" });
+  mockExportVocabularyToObsidian.mockResolvedValue({ urls: ["https://github.com/example/pr/1"] });
 
   render(<VocabularyPage />);
   await flushPromises();
@@ -140,6 +140,37 @@ test("export button calls exportVocabularyToObsidian with no book_id", async () 
 
   await waitFor(() => {
     expect(mockExportVocabularyToObsidian).toHaveBeenCalledWith(undefined);
+  });
+});
+
+test("export shows URL link when export succeeds", async () => {
+  mockExportVocabularyToObsidian.mockResolvedValue({ urls: ["https://github.com/example/pr/1"] });
+
+  render(<VocabularyPage />);
+  await flushPromises();
+  await screen.findByText("ephemeral");
+
+  const exportBtn = screen.getByTestId("export-all-btn");
+  await userEvent.click(exportBtn);
+
+  await waitFor(() => {
+    const link = screen.getByRole("link", { name: "https://github.com/example/pr/1" });
+    expect(link).toHaveAttribute("href", "https://github.com/example/pr/1");
+  });
+});
+
+test("export shows error message when export fails", async () => {
+  mockExportVocabularyToObsidian.mockRejectedValue(new Error("GitHub API error"));
+
+  render(<VocabularyPage />);
+  await flushPromises();
+  await screen.findByText("ephemeral");
+
+  const exportBtn = screen.getByTestId("export-all-btn");
+  await userEvent.click(exportBtn);
+
+  await waitFor(() => {
+    expect(screen.getByText("GitHub API error")).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## What changed

- **`delete_word` now cascades to `word_occurrences`**: deleting a vocabulary word previously left orphaned `word_occurrences` rows in the DB. These rows are now deleted first (DELETE … WHERE vocabulary_id IN (SELECT id FROM vocabulary …)) before the vocabulary row itself is removed.
- **Fixed export test mock**: `mockExportVocabularyToObsidian.mockResolvedValue` was using `{ url: "..." }` (singular, wrong shape) instead of `{ urls: ["..."] }` (the actual API contract). The old mock didn't trigger any assertion failure because the test only checked that the function was called — not what happened with the result.
- **Added two new export tests**: one asserts the exported URL link is rendered in the UI; one asserts the error message is shown when export throws.

## Test plan

- `test_delete_word_cascades_to_word_occurrences` — saves a word with an occurrence, deletes the word, queries `word_occurrences` directly and asserts count = 0
- `"export shows URL link when export succeeds"` — clicks export, waits for the rendered link with correct href
- `"export shows error message when export fails"` — clicks export with rejected mock, asserts error text appears
- Full test suites: 833 backend ✓ / 1490 frontend ✓
