### PR TITLE
fix: get_or_create_user_apple returns stale profile when linking by email

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -214,7 +214,9 @@ async def get_or_create_user_apple(apple_id: str, email: str, name: str) -> dict
                     (apple_id, row["id"]),
                 )
                 await db.commit()
-                return dict(row)
+                updated = dict(row)
+                updated["apple_id"] = apple_id
+                return updated
 
         # New user
         async with db.execute("SELECT COUNT(*) FROM users") as cursor:

--- a/backend/tests/test_db_extended.py
+++ b/backend/tests/test_db_extended.py
@@ -131,6 +131,14 @@ async def test_apple_links_to_existing_google_user_by_email():
     assert apple_user["id"] == google_user["id"]
 
 
+async def test_apple_existing_by_email_returns_updated_profile():
+    # Regression: linking Apple ID to an existing account must return the
+    # post-UPDATE profile (with apple_id set), not the stale pre-UPDATE row.
+    await get_or_create_user("g202", "apple-link@example.com", "Google User", "")
+    result = await get_or_create_user_apple("ap4b", "apple-link@example.com", "")
+    assert result["apple_id"] == "ap4b"
+
+
 async def test_apple_no_email_skips_linking():
     await get_or_create_user("g201", "existing@example.com", "Existing", "")
     new_user = await get_or_create_user_apple("ap5", "", "NoEmail")


### PR DESCRIPTION
## What changed

`get_or_create_user_apple` had a stale-return bug in the email-linking code path. When an Apple login matched an existing account by email, the function:
1. Executed `UPDATE users SET apple_id=? WHERE id=?`
2. Committed the change
3. **Returned the pre-UPDATE `row` dict** — with `apple_id=NULL`

This meant NextAuth received a session token with `apple_id=null`, causing inconsistent account state and potential re-linking loops on subsequent logins.

The fix mirrors the pattern already applied to Google (`get_or_create_user`) and GitHub (`get_or_create_user_github`) in PR #228: patch the returned dict's `apple_id` field directly after the UPDATE rather than doing an extra SELECT round-trip.

## Test plan

- New regression test `test_apple_existing_by_email_returns_updated_profile`: creates a Google account, links it via Apple by email, asserts the returned dict has `apple_id` set to the new value (was `None` before this fix)
- Full backend suite: 834 ✓
