### PR TITLE
fix: delete_book now removes annotations and book_insights for deleted book

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -213,6 +213,8 @@ async def delete_book(book_id: int, _admin: dict = Depends(_require_admin)):
         await db.execute("DELETE FROM audio_cache WHERE book_id = ?", (book_id,))
         await db.execute("DELETE FROM translation_queue WHERE book_id = ?", (book_id,))
         await db.execute("DELETE FROM word_occurrences WHERE book_id = ?", (book_id,))
+        await db.execute("DELETE FROM annotations WHERE book_id = ?", (book_id,))
+        await db.execute("DELETE FROM book_insights WHERE book_id = ?", (book_id,))
         await db.commit()
     # Invalidate the in-memory chapter split so a future import of the same
     # id doesn't accidentally reuse stale chapter boundaries.

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -8,7 +8,7 @@ import services.db as db_module
 import routers.admin as admin_module
 from services.db import (
     init_db, get_or_create_user, get_user_by_id, save_book,
-    save_translation, set_user_approved,
+    save_translation, set_user_approved, create_annotation, save_insight,
 )
 from services.auth import get_current_user, create_jwt
 from main import app
@@ -206,6 +206,30 @@ async def test_delete_book_removes_word_occurrences(admin_client, admin_db):
     async with aiosqlite.connect(admin_db) as db:
         async with db.execute(
             "SELECT COUNT(*) FROM word_occurrences WHERE book_id = 100"
+        ) as cur:
+            count = (await cur.fetchone())[0]
+    assert count == 0
+
+
+async def test_delete_book_removes_annotations(admin_client, admin_db, admin_user):
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    await create_annotation(admin_user["id"], 100, 0, "A great line.", "The full quote.", "yellow")
+    await admin_client.delete("/api/admin/books/100")
+    async with aiosqlite.connect(admin_db) as db:
+        async with db.execute(
+            "SELECT COUNT(*) FROM annotations WHERE book_id = 100"
+        ) as cur:
+            count = (await cur.fetchone())[0]
+    assert count == 0
+
+
+async def test_delete_book_removes_book_insights(admin_client, admin_db, admin_user):
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    await save_insight(admin_user["id"], 100, 0, "What is the theme?", "The theme is...", None)
+    await admin_client.delete("/api/admin/books/100")
+    async with aiosqlite.connect(admin_db) as db:
+        async with db.execute(
+            "SELECT COUNT(*) FROM book_insights WHERE book_id = 100"
         ) as cur:
             count = (await cur.fetchone())[0]
     assert count == 0


### PR DESCRIPTION
## What changed

`delete_book` was not cleaning up `annotations` and `book_insights` rows for the deleted book. These records:
- Have a `book_id` column with no foreign-key CASCADE
- Showed up in the `/notes` page with a `"Book #N"` fallback title instead of the real title
- Created dead read-links — clicking through to a deleted book's reader would 404

Two new DELETE statements added alongside the existing translations/queue/word_occurrences cleanup.

## Test plan

- `test_delete_book_removes_annotations` — creates an annotation for book 100, deletes book, asserts `annotations WHERE book_id=100` count = 0
- `test_delete_book_removes_book_insights` — creates an insight for book 100, deletes book, asserts `book_insights WHERE book_id=100` count = 0
- Full backend suite: 836 ✓
