### PR TITLE
fix: sanitize Obsidian export filenames to prevent path traversal in GitHub API

### DIFF
--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -64,6 +64,13 @@ async def remove_word(word: str, user: dict = Depends(get_current_user)):
 
 # ── Obsidian export ───────────────────────────────────────────────────────────
 
+def _sanitize_filename(name: str) -> str:
+    """Replace characters that are invalid in GitHub filenames or URL paths."""
+    for ch in r'/\:*?"<>|':
+        name = name.replace(ch, "_")
+    return name.strip("_ ") or "untitled"
+
+
 async def _github_put(
     token: str,
     repo: str,
@@ -306,7 +313,7 @@ async def export_obsidian(
             book, words_for_book, annotations, connected, book_insights,
             bid, export_date, ann_translations,
         )
-        filename = f"{title}.md"
+        filename = f"{_sanitize_filename(title)}.md"
         return await _github_put(
             github_token, repo, obs_path, filename, content, f"Update {filename}"
         )
@@ -333,7 +340,7 @@ async def export_obsidian(
             for entry in all_vocab:
                 word = entry["word"]
                 word_md = _build_word_markdown(word, entry["occurrences"])
-                filename = f"{word}.md"
+                filename = f"{_sanitize_filename(word)}.md"
                 url = await _github_put(
                     github_token, repo, vocab_path, filename, word_md, f"Update {filename}"
                 )

--- a/backend/tests/test_router_vocabulary_extended.py
+++ b/backend/tests/test_router_vocabulary_extended.py
@@ -23,6 +23,7 @@ from routers.vocabulary import (
     _build_word_markdown,
     _find_connected_books,
     _github_put,
+    _sanitize_filename,
 )
 
 
@@ -637,3 +638,29 @@ async def test_export_corrupted_github_token_returns_400(client, test_user):
 
     resp = await client.post("/api/vocabulary/export/obsidian", json={"book_id": BOOK_ID})
     assert resp.status_code == 400
+
+
+# ── _sanitize_filename ────────────────────────────────────────────────────────
+
+def test_sanitize_filename_replaces_slash():
+    assert _sanitize_filename("A/B") == "A_B"
+
+
+def test_sanitize_filename_replaces_backslash():
+    assert _sanitize_filename("A\\B") == "A_B"
+
+
+def test_sanitize_filename_replaces_colon():
+    assert _sanitize_filename("Beowulf: An Epic") == "Beowulf_ An Epic"
+
+
+def test_sanitize_filename_replaces_other_invalid_chars():
+    assert _sanitize_filename('A*B?C"D<E>F|G') == "A_B_C_D_E_F_G"
+
+
+def test_sanitize_filename_strips_leading_trailing_underscores_and_spaces():
+    assert _sanitize_filename("/leading") == "leading"
+
+
+def test_sanitize_filename_empty_result_returns_untitled():
+    assert _sanitize_filename("///") == "untitled"


### PR DESCRIPTION
## What changed

The Obsidian export was constructing filenames directly from book titles and vocabulary words without sanitizing invalid characters. 

The most dangerous case: a book title like `"A History / Of Something"` would generate:
```
filename = "A History / Of Something.md"
url = "https://api.github.com/repos/{repo}/contents/{path}/A History / Of Something.md"
```
GitHub's Contents API interprets the `/` as a path separator, silently creating the file as `Of Something.md` inside the subdirectory `A History `, rather than the intended location. No error is returned — the export appears to succeed but the file lands in the wrong place.

Other invalid characters (`:`, `*`, `?`, `"`, `<`, `>`, `|`, `\`) would cause GitHub API errors or Windows-incompatible filenames.

## Fix

Added `_sanitize_filename()` that replaces all invalid characters with `_`. Applied to both book-note and word-note filename construction.

## Test plan

- 6 unit tests for `_sanitize_filename`: slash, backslash, colon, all invalid chars, leading/trailing trim, fully-invalid input → "untitled"
- Full backend suite: 841 ✓
