### PR TITLE
fix: delete_book cleans up orphaned vocabulary entries

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -213,6 +213,9 @@ async def delete_book(book_id: int, _admin: dict = Depends(_require_admin)):
         await db.execute("DELETE FROM audio_cache WHERE book_id = ?", (book_id,))
         await db.execute("DELETE FROM translation_queue WHERE book_id = ?", (book_id,))
         await db.execute("DELETE FROM word_occurrences WHERE book_id = ?", (book_id,))
+        await db.execute(
+            "DELETE FROM vocabulary WHERE id NOT IN (SELECT DISTINCT vocabulary_id FROM word_occurrences)"
+        )
         await db.execute("DELETE FROM annotations WHERE book_id = ?", (book_id,))
         await db.execute("DELETE FROM book_insights WHERE book_id = ?", (book_id,))
         await db.execute("DELETE FROM user_reading_progress WHERE book_id = ?", (book_id,))

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -9,7 +9,7 @@ import routers.admin as admin_module
 from services.db import (
     init_db, get_or_create_user, get_user_by_id, save_book,
     save_translation, set_user_approved, create_annotation, save_insight,
-    upsert_reading_progress,
+    upsert_reading_progress, save_word, get_vocabulary,
 )
 from services.auth import get_current_user, create_jwt
 from main import app
@@ -767,3 +767,37 @@ async def test_admin_retry_failed_without_filters_retries_all(admin_client, admi
         ) as cursor:
             (count,) = await cursor.fetchone()
     assert count == 0
+
+
+async def test_delete_book_removes_orphaned_vocabulary(admin_client, admin_db, admin_user):
+    """Vocab entries whose only occurrences were in the deleted book must be
+    removed; a word shared with another book must survive."""
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    await save_book(
+        200,
+        {**BOOK_META, "id": 200, "title": "Second Book"},
+        BOOK_TEXT,
+    )
+
+    with patch("services.db._update_lemma", new_callable=AsyncMock):
+        # "orphan" only appears in book 100
+        await save_word(admin_user["id"], "orphan", 100, 0, "An orphan word.")
+        # "shared" appears in both books
+        await save_word(admin_user["id"], "shared", 100, 0, "A shared word in book 100.")
+        await save_word(admin_user["id"], "shared", 200, 0, "A shared word in book 200.")
+
+    vocab_before = await get_vocabulary(admin_user["id"])
+    words_before = {v["word"] for v in vocab_before}
+    assert "orphan" in words_before
+    assert "shared" in words_before
+
+    res = await admin_client.delete("/api/admin/books/100")
+    assert res.status_code == 200
+
+    vocab_after = await get_vocabulary(admin_user["id"])
+    words_after = {v["word"] for v in vocab_after}
+
+    # Orphaned word (only in deleted book) must be gone
+    assert "orphan" not in words_after, "orphaned vocab entry survived delete_book"
+    # Shared word (also in book 200) must survive
+    assert "shared" in words_after


### PR DESCRIPTION
## Summary

- `delete_book` deletes `word_occurrences` for the book but previously left `vocabulary` rows with no remaining occurrences
- These orphaned rows appeared in `get_vocabulary` as words with an empty `occurrences: []` list, polluting the vocabulary page and notes overview with ghost words
- Added `DELETE FROM vocabulary WHERE id NOT IN (SELECT DISTINCT vocabulary_id FROM word_occurrences)` immediately after the `word_occurrences` cleanup to sweep out any newly-orphaned entries
- Words that also appeared in other books (still have occurrences) are unaffected

## Test plan

- `test_delete_book_removes_orphaned_vocabulary`: saves "orphan" (only in book 100) and "shared" (in books 100 and 200), deletes book 100, verifies "orphan" is gone and "shared" survives
