### PR TITLE
fix: allow clearing stored GitHub token in Obsidian settings

### DIFF
--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -72,6 +72,7 @@ async def get_obsidian(user: dict = Depends(get_current_user)):
     return {
         "obsidian_repo": settings.get("obsidian_repo") or "",
         "obsidian_path": settings.get("obsidian_path") or "",
+        "has_github_token": bool(settings.get("github_token")),
     }
 
 
@@ -87,11 +88,13 @@ async def patch_obsidian(
     user: dict = Depends(get_current_user),
 ):
     existing = await get_obsidian_settings(user["id"])
-    # Only update the token if a new one was supplied; keep the encrypted one otherwise
-    if req.github_token is not None and req.github_token.strip():
+    # None = not supplied → keep existing; "" = explicit clear → set NULL; non-empty = update
+    if req.github_token is None:
+        token_enc = existing.get("github_token")
+    elif req.github_token.strip():
         token_enc = encrypt_api_key(req.github_token.strip())
     else:
-        token_enc = existing.get("github_token")
+        token_enc = None
     await update_obsidian_settings(
         user["id"],
         github_token_encrypted=token_enc,

--- a/backend/tests/test_router_user.py
+++ b/backend/tests/test_router_user.py
@@ -134,3 +134,38 @@ async def test_obsidian_settings_require_auth(anon_client):
 
     resp = await anon_client.patch("/api/user/obsidian-settings", json={"obsidian_repo": "r/v", "obsidian_path": "p"})
     assert resp.status_code == 401
+
+
+async def test_get_obsidian_settings_has_github_token_field(client, test_user):
+    """GET /obsidian-settings must report whether a token is configured
+    so the frontend can show a 'configured' indicator without leaking the token."""
+    from services.db import update_obsidian_settings
+    from services.auth import encrypt_api_key
+
+    resp = await client.get("/api/user/obsidian-settings")
+    assert resp.status_code == 200
+    assert resp.json()["has_github_token"] is False
+
+    await update_obsidian_settings(test_user["id"], encrypt_api_key("ghp_abc"), "u/r", None)
+
+    resp = await client.get("/api/user/obsidian-settings")
+    assert resp.json()["has_github_token"] is True
+
+
+async def test_patch_obsidian_settings_clears_token_with_empty_string(client, test_user):
+    """Sending github_token='' must clear the stored token — users have
+    no other way to revoke their GitHub credentials from the app."""
+    from services.db import update_obsidian_settings, get_obsidian_settings
+    from services.auth import encrypt_api_key
+
+    await update_obsidian_settings(test_user["id"], encrypt_api_key("ghp_abc"), "u/r", None)
+
+    resp = await client.patch("/api/user/obsidian-settings", json={
+        "github_token": "",
+        "obsidian_repo": "u/r",
+        "obsidian_path": "",
+    })
+    assert resp.status_code == 200
+
+    settings = await get_obsidian_settings(test_user["id"])
+    assert settings["github_token"] is None, "empty-string token must clear the stored token"

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -30,6 +30,7 @@ export default function ProfilePage() {
 
   // ── Obsidian settings state ────────────────────────────────────────────────
   const [obsidianToken, setObsidianToken] = useState("");
+  const [hasObsidianToken, setHasObsidianToken] = useState(false);
   const [obsidianRepo, setObsidianRepo] = useState("");
   const [obsidianPath, setObsidianPath] = useState("All Notes/002 Literature Notes/000 Books");
   const [obsidianSaving, setObsidianSaving] = useState(false);
@@ -62,6 +63,7 @@ export default function ProfilePage() {
     getObsidianSettings().then((s) => {
       setObsidianRepo(s.obsidian_repo ?? "");
       setObsidianPath(s.obsidian_path ?? "All Notes/002 Literature Notes/000 Books");
+      setHasObsidianToken(s.has_github_token ?? false);
     }).catch(() => {});
   }, [session?.backendToken]);
 
@@ -105,10 +107,29 @@ export default function ProfilePage() {
         obsidian_repo: obsidianRepo.trim(),
         obsidian_path: obsidianPath.trim(),
       });
+      if (obsidianToken.trim()) setHasObsidianToken(true);
       setObsidianToken("");
       setObsidianMsg({ text: "Obsidian settings saved.", ok: true });
     } catch (e: unknown) {
       setObsidianMsg({ text: e instanceof Error ? e.message : "Failed to save", ok: false });
+    } finally {
+      setObsidianSaving(false);
+    }
+  }
+
+  async function handleRemoveObsidianToken() {
+    setObsidianSaving(true);
+    setObsidianMsg(null);
+    try {
+      await saveObsidianSettings({
+        github_token: "",
+        obsidian_repo: obsidianRepo.trim(),
+        obsidian_path: obsidianPath.trim(),
+      });
+      setHasObsidianToken(false);
+      setObsidianMsg({ text: "GitHub token removed.", ok: true });
+    } catch (e: unknown) {
+      setObsidianMsg({ text: e instanceof Error ? e.message : "Failed to remove token", ok: false });
     } finally {
       setObsidianSaving(false);
     }
@@ -246,12 +267,26 @@ export default function ProfilePage() {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-ink mb-1">
-              GitHub Token
-            </label>
+            <div className="flex items-center justify-between mb-1">
+              <label className="block text-sm font-medium text-ink">
+                GitHub Token
+              </label>
+              {hasObsidianToken && (
+                <span className="flex items-center gap-2">
+                  <span className="text-xs text-emerald-600 font-medium">Token configured ✓</span>
+                  <button
+                    onClick={handleRemoveObsidianToken}
+                    disabled={obsidianSaving}
+                    className="text-xs text-red-500 hover:text-red-700 underline disabled:opacity-50"
+                  >
+                    Remove
+                  </button>
+                </span>
+              )}
+            </div>
             <input
               type="password"
-              placeholder="ghp_… (never shown back)"
+              placeholder={hasObsidianToken ? "Enter new token to replace existing" : "ghp_… (never shown back)"}
               value={obsidianToken}
               onChange={(e) => setObsidianToken(e.target.value)}
               className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-amber-400"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -659,6 +659,7 @@ export function deleteInsight(id: number) {
 export interface ObsidianSettings {
   obsidian_repo: string;
   obsidian_path: string;
+  has_github_token: boolean;
 }
 
 export function getObsidianSettings() {


### PR DESCRIPTION
## Summary

- Once a GitHub token was saved in Obsidian settings, it could never be removed: the backend treated both "not provided" and "empty string" as "keep existing token"
- Users also had no way to see whether a token was configured (the token is intentionally never echoed back)

**Backend changes:**
- `PATCH /user/obsidian-settings`: empty string `github_token` now sets to `NULL`; `null`/missing still means "no change"
- `GET /user/obsidian-settings`: adds `has_github_token: bool` field

**Frontend changes:**
- Profile page shows "Token configured ✓" badge when `has_github_token` is true
- "Remove" button appears next to the badge; sends `github_token: ""` to clear
- Placeholder text adapts: "Enter new token to replace existing" vs "ghp_…"

## Test plan

- `test_get_obsidian_settings_has_github_token_field`: GET returns `has_github_token: false` initially, `true` after a token is set
- `test_patch_obsidian_settings_clears_token_with_empty_string`: PATCH with `github_token: ""` sets stored token to NULL
- Existing `test_patch_obsidian_settings_preserves_token_when_not_supplied` still passes (null/missing = no change)
