### PR TITLE
fix: 404 for reading-progress update on non-existent book

### DIFF
--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 from services.auth import get_current_user, encrypt_api_key, decrypt_api_key
 from services.db import (
     set_user_gemini_key, get_user_by_id, get_reading_progress, upsert_reading_progress,
-    get_obsidian_settings, update_obsidian_settings,
+    get_obsidian_settings, update_obsidian_settings, get_cached_book,
 )
 
 router = APIRouter(prefix="/user", tags=["user"])
@@ -62,6 +62,8 @@ async def update_reading_progress(
     req: ProgressUpdate,
     user: dict = Depends(get_current_user),
 ):
+    if not await get_cached_book(book_id):
+        raise HTTPException(status_code=404, detail="Book not found")
     await upsert_reading_progress(user["id"], book_id, req.chapter_index)
     return {"ok": True}
 

--- a/backend/tests/test_router_user.py
+++ b/backend/tests/test_router_user.py
@@ -86,6 +86,13 @@ async def test_reading_progress_upserts(client, test_user):
     assert entries[0]["chapter_index"] == 5
 
 
+async def test_reading_progress_rejects_nonexistent_book(client, test_user):
+    """PUT reading-progress for a book that doesn't exist must return 404,
+    not silently insert an orphaned row (FK enforcement is OFF in SQLite)."""
+    resp = await client.put("/api/user/reading-progress/88888", json={"chapter_index": 1})
+    assert resp.status_code == 404
+
+
 async def test_get_obsidian_settings_returns_defaults_initially(client, test_user):
     resp = await client.get("/api/user/obsidian-settings")
     assert resp.status_code == 200


### PR DESCRIPTION
## What changed
`PUT /user/reading-progress/{book_id}` now returns **404** when the given `book_id` does not exist in the `books` table, instead of silently returning `{"ok": true}`.

## Why
SQLite foreign key enforcement is OFF by default. The upsert in `upsert_reading_progress` would therefore succeed even for non-existent book IDs, inserting an orphaned row with a dangling FK. The caller received a 200 success response for an operation that stored data pointing at a non-existent book.

## Fix
Added a `get_cached_book(book_id)` existence check in the route handler; raises `HTTPException(404)` if the book is not in the cache.

## Test plan
- `test_reading_progress_rejects_nonexistent_book` — PUT with book_id=88888 (never inserted) → 404
- All 849 backend tests pass
