### PR TITLE
fix: 404 for create/translate on non-existent books (6 endpoints)

### DIFF
--- a/backend/routers/annotations.py
+++ b/backend/routers/annotations.py
@@ -2,7 +2,7 @@ from typing import Literal, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from services.auth import get_current_user
-from services.db import create_annotation, get_annotations, get_all_annotations, update_annotation, delete_annotation
+from services.db import create_annotation, get_annotations, get_all_annotations, update_annotation, delete_annotation, get_cached_book
 
 router = APIRouter(prefix="/annotations", tags=["annotations"])
 
@@ -25,6 +25,8 @@ class AnnotationUpdate(BaseModel):
 
 @router.post("")
 async def create(req: AnnotationCreate, user: dict = Depends(get_current_user)):
+    if not await get_cached_book(req.book_id):
+        raise HTTPException(status_code=404, detail="Book not found")
     return await create_annotation(
         user["id"],
         req.book_id,

--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -215,17 +215,9 @@ async def request_chapter_translation(
         enqueue, queue_status_for_chapter, worker,
     )
 
-    # 0. Guard: reject same-language translation.
-    book_meta = await get_cached_book(book_id)
-    if book_meta:
-        source = (book_meta.get("languages") or [None])[0]
-        if source and source.lower().split("-")[0] == req.target_language.lower().split("-")[0]:
-            raise HTTPException(
-                status_code=400,
-                detail="Cannot translate to the same language as the original.",
-            )
-
-    # 1. Already cached? Served to anyone — no auth required for cache hits.
+    # 0. Already cached? Served to anyone — no auth required for cache hits.
+    # Book existence is not checked for cache hits (book may have been removed
+    # after translation was stored).
     cached = await get_cached_translation_with_meta(
         book_id, chapter_index, req.target_language,
     )
@@ -238,7 +230,20 @@ async def request_chapter_translation(
             "title_translation": cached.get("title_translation"),
         }
 
-    # 2. New translation requires login.
+    # 0a. Book must exist before we can enqueue a new translation.
+    book_meta = await get_cached_book(book_id)
+    if not book_meta:
+        raise HTTPException(status_code=404, detail="Book not found")
+
+    # 0b. Guard: reject same-language translation.
+    source = (book_meta.get("languages") or [None])[0]
+    if source and source.lower().split("-")[0] == req.target_language.lower().split("-")[0]:
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot translate to the same language as the original.",
+        )
+
+    # 1. New translation requires login.
     if user is None:
         raise HTTPException(
             status_code=401,
@@ -304,13 +309,14 @@ async def enqueue_all_chapters(
     currently staring at still wins.
     """
     book_meta = await get_cached_book(book_id)
-    if book_meta:
-        source = (book_meta.get("languages") or [None])[0]
-        if source and source.lower().split("-")[0] == req.target_language.lower().split("-")[0]:
-            raise HTTPException(
-                status_code=400,
-                detail="Cannot translate to the same language as the original.",
-            )
+    if not book_meta:
+        raise HTTPException(status_code=404, detail="Book not found")
+    source = (book_meta.get("languages") or [None])[0]
+    if source and source.lower().split("-")[0] == req.target_language.lower().split("-")[0]:
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot translate to the same language as the original.",
+        )
 
     from services.translation_queue import enqueue_for_book, worker
 
@@ -339,6 +345,9 @@ async def retry_chapter_translation(
     explicit action: admin or reader clicks a button. Resets the queue row
     to pending + attempts=0 and bumps priority to 10 (reader-initiated).
     """
+    if not await get_cached_book(book_id):
+        raise HTTPException(status_code=404, detail="Book not found")
+
     from services.translation_queue import enqueue, queue_status_for_chapter, worker
 
     queued_by = user.get("email") or user.get("name") or f"user#{user.get('id')}"

--- a/backend/routers/insights.py
+++ b/backend/routers/insights.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from services.auth import get_current_user
-from services.db import save_insight, get_insights, get_all_insights, delete_insight
+from services.db import save_insight, get_insights, get_all_insights, delete_insight, get_cached_book
 
 router = APIRouter(prefix="/insights", tags=["insights"])
 
@@ -16,6 +16,8 @@ class InsightCreate(BaseModel):
 
 @router.post("")
 async def create(req: InsightCreate, user: dict = Depends(get_current_user)):
+    if not await get_cached_book(req.book_id):
+        raise HTTPException(status_code=404, detail="Book not found")
     return await save_insight(
         user["id"],
         req.book_id,

--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -34,6 +34,8 @@ class ExportRequest(BaseModel):
 
 @router.post("")
 async def save(req: WordSave, user: dict = Depends(get_current_user)):
+    if not await get_cached_book(req.book_id):
+        raise HTTPException(status_code=404, detail="Book not found")
     return await save_word(
         user["id"],
         req.word,

--- a/backend/tests/test_router_annotations.py
+++ b/backend/tests/test_router_annotations.py
@@ -214,3 +214,16 @@ async def test_get_all_returns_own_annotations_only(client, test_user):
 async def test_get_all_requires_auth(anon_client):
     resp = await anon_client.get("/api/annotations/all")
     assert resp.status_code == 401
+
+
+async def test_create_annotation_rejects_nonexistent_book(client, test_user):
+    """POST /annotations for a book that doesn't exist must return 404.
+
+    SQLite FK enforcement is OFF so the INSERT would otherwise silently
+    succeed and store an orphaned row referencing a non-existent book."""
+    resp = await client.post("/api/annotations", json={
+        "book_id": 777777,
+        "chapter_index": 0,
+        "sentence_text": "Orphan sentence.",
+    })
+    assert resp.status_code == 404

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -513,6 +513,7 @@ async def test_get_chapter_translation_requires_login(anon_client):
 
 async def test_chapter_translation_requires_gemini_key(client):
     """Logged-in user without a Gemini key cannot enqueue new translation."""
+    await save_book(9999, MOCK_META, "text")
     resp = await client.post(
         "/api/books/9999/chapters/0/translation",
         json={"target_language": "de"},
@@ -525,6 +526,7 @@ async def test_chapter_translation_allowed_with_gemini_key(client, test_user):
     """Logged-in user with a Gemini key can enqueue translation."""
     from services.db import set_user_gemini_key
     from services.auth import encrypt_api_key
+    await save_book(9999, MOCK_META, "text")
     await set_user_gemini_key(test_user["id"], encrypt_api_key("my-key"))
     resp = await client.post(
         "/api/books/9999/chapters/0/translation",
@@ -549,6 +551,7 @@ async def test_chapter_translation_cache_served_without_login(anon_client):
 
 async def test_chapter_translation_requires_login_when_not_cached(anon_client):
     """Unauthenticated request for a non-cached chapter → 401."""
+    await save_book(9999, MOCK_META, "text")
     resp = await anon_client.post(
         "/api/books/9999/chapters/0/translation",
         json={"target_language": "de"},
@@ -586,6 +589,7 @@ async def test_chapter_translation_corrupted_gemini_key_returns_403(client, test
     InvalidToken raises HTTPException(500) instead of falling through to 403.
     """
     from services.db import set_user_gemini_key
+    await save_book(9999, MOCK_META, "text")
     # Store a raw string that is not valid Fernet ciphertext
     await set_user_gemini_key(test_user["id"], "not-valid-fernet-ciphertext")
     resp = await client.post(
@@ -594,3 +598,36 @@ async def test_chapter_translation_corrupted_gemini_key_returns_403(client, test
     )
     assert resp.status_code == 403
     assert "Gemini" in resp.json()["detail"]
+
+
+async def test_chapter_translation_rejects_nonexistent_book(client, test_user):
+    """POST translation for a non-existent book must return 404 (not 403/500).
+
+    SQLite FK enforcement is OFF — without this check the endpoint would
+    either leak auth status or silently enqueue work for a ghost book."""
+    from services.db import set_user_gemini_key
+    from services.auth import encrypt_api_key
+    await set_user_gemini_key(test_user["id"], encrypt_api_key("my-key"))
+    resp = await client.post(
+        "/api/books/888888/chapters/0/translation",
+        json={"target_language": "de"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_enqueue_all_rejects_nonexistent_book(client):
+    """POST enqueue-all for a non-existent book must return 404."""
+    resp = await client.post(
+        "/api/books/888888/translations/enqueue-all",
+        json={"target_language": "de"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_retry_translation_rejects_nonexistent_book(client):
+    """POST retry for a non-existent book must return 404."""
+    resp = await client.post(
+        "/api/books/888888/chapters/0/translation/retry",
+        json={"target_language": "de"},
+    )
+    assert resp.status_code == 404

--- a/backend/tests/test_router_insights.py
+++ b/backend/tests/test_router_insights.py
@@ -2,9 +2,13 @@
 
 import pytest
 from httpx import AsyncClient
+from services.db import save_book, save_insight
+
+_META = {"title": "Test", "authors": [], "languages": ["en"], "subjects": [], "download_count": 0, "cover": ""}
 
 
 async def test_post_creates_insight_and_returns_it(client: AsyncClient):
+    await save_book(1, _META, "text")
     payload = {
         "book_id": 1,
         "chapter_index": 2,
@@ -22,6 +26,7 @@ async def test_post_creates_insight_and_returns_it(client: AsyncClient):
 
 
 async def test_post_with_null_chapter_index(client: AsyncClient):
+    await save_book(5, _META, "text")
     payload = {
         "book_id": 5,
         "chapter_index": None,
@@ -36,7 +41,8 @@ async def test_post_with_null_chapter_index(client: AsyncClient):
 
 
 async def test_get_returns_insights_for_book_id(client: AsyncClient):
-    # Create two insights for book 10 and one for book 99
+    await save_book(10, _META, "text")
+    await save_book(99, _META, "text")
     for i in range(2):
         await client.post(
             "/api/insights",
@@ -56,16 +62,13 @@ async def test_get_returns_insights_for_book_id(client: AsyncClient):
 
 async def test_get_returns_only_current_users_insights(client: AsyncClient, test_user):
     """A second authenticated client should not see the first user's insights."""
-    import services.db as db_module
-    from services.db import save_insight
+    await save_book(7, _META, "text")
 
-    # Create insight for test_user (via client fixture)
     await client.post(
         "/api/insights",
         json={"book_id": 7, "question": "Q1", "answer": "A1"},
     )
 
-    # Create insight for a different user directly in DB
     from services.db import get_or_create_user
     other_user = await get_or_create_user(
         google_id="other-google",
@@ -78,12 +81,12 @@ async def test_get_returns_only_current_users_insights(client: AsyncClient, test
     resp = await client.get("/api/insights", params={"book_id": 7})
     assert resp.status_code == 200
     data = resp.json()
-    # Only the current user's insight should be returned
     assert len(data) == 1
     assert data[0]["question"] == "Q1"
 
 
 async def test_delete_returns_ok(client: AsyncClient):
+    await save_book(3, _META, "text")
     resp = await client.post(
         "/api/insights",
         json={"book_id": 3, "question": "Delete me", "answer": "Yes"},
@@ -102,7 +105,7 @@ async def test_delete_returns_404_if_not_found(client: AsyncClient):
 
 async def test_delete_returns_404_if_wrong_user(client: AsyncClient, test_user):
     """Insight belonging to another user should not be deletable."""
-    from services.db import save_insight, get_or_create_user
+    from services.db import get_or_create_user
 
     other_user = await get_or_create_user(
         google_id="other-google-2",
@@ -119,6 +122,8 @@ async def test_delete_returns_404_if_wrong_user(client: AsyncClient, test_user):
 
 async def test_get_all_returns_insights_across_books(client: AsyncClient, test_user):
     """GET /api/insights/all returns all of the user's insights with book_title."""
+    await save_book(20, _META, "text")
+    await save_book(21, _META, "text")
     await client.post("/api/insights", json={"book_id": 20, "question": "Q-A", "answer": "A-A"})
     await client.post("/api/insights", json={"book_id": 21, "question": "Q-B", "answer": "A-B"})
 
@@ -133,7 +138,8 @@ async def test_get_all_returns_insights_across_books(client: AsyncClient, test_u
 
 async def test_get_all_returns_own_insights_only(client: AsyncClient, test_user):
     """GET /api/insights/all must not return other users' insights."""
-    from services.db import save_insight, get_or_create_user
+    await save_book(30, _META, "text")
+    from services.db import get_or_create_user
 
     other = await get_or_create_user(
         google_id="other-all-g", email="other-all@example.com", name="Other", picture=""
@@ -157,3 +163,15 @@ async def test_insights_require_auth(anon_client):
 
     resp = await anon_client.post("/api/insights", json={"book_id": 1, "question": "Q", "answer": "A"})
     assert resp.status_code == 401
+
+
+async def test_post_insight_rejects_nonexistent_book(client: AsyncClient):
+    """POST /insights for a book that doesn't exist must return 404.
+
+    SQLite FK enforcement is OFF so the INSERT would otherwise silently
+    succeed and store an orphaned row referencing a non-existent book."""
+    resp = await client.post(
+        "/api/insights",
+        json={"book_id": 777777, "question": "Q?", "answer": "A."},
+    )
+    assert resp.status_code == 404

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -126,6 +126,20 @@ async def test_vocabulary_requires_auth(anon_client):
     assert resp.status_code == 401
 
 
+async def test_save_word_rejects_nonexistent_book(client, test_user):
+    """POST /vocabulary for a book that doesn't exist must return 404.
+
+    SQLite FK enforcement is OFF so the INSERT would otherwise silently
+    succeed and store an orphaned word occurrence."""
+    resp = await client.post("/api/vocabulary", json={
+        "word": "ghost",
+        "book_id": 777777,
+        "chapter_index": 0,
+        "sentence_text": "A ghost of a chance.",
+    })
+    assert resp.status_code == 404
+
+
 # ── Export endpoint ───────────────────────────────────────────────────────────
 
 async def _setup_export(test_user, book_id=BOOK_ID):


### PR DESCRIPTION
## What changed

Six POST endpoints returned HTTP 200 and silently inserted orphaned rows when given a `book_id` that doesn't exist in the `books` table. SQLite's foreign-key enforcement is OFF by default, so the FK constraints never fired.

**Endpoints fixed:**
- `POST /annotations` → 404 if book missing
- `POST /insights` → 404 if book missing
- `POST /vocabulary` → 404 if book missing
- `POST /books/{id}/chapters/{i}/translation` (new-enqueue path) → 404 if book missing
- `POST /books/{id}/translations/enqueue-all` → 404 if book missing
- `POST /books/{id}/chapters/{i}/translation/retry` → 404 if book missing

The translation endpoint's **cache-hit path** is intentionally exempt: pre-translated text can still be served after the source book record is removed.

## Why

Without these checks, clients received a success response for operations that stored data pointing at a ghost book, leading to orphaned rows and confusing downstream reads.

## Test plan
- Regression test added to each of the 6 endpoints (777777 / 888888 book IDs never exist)
- Existing insight tests that relied on the broken behaviour updated to `save_book` first
- Four translation tests that omitted `save_book(9999)` likewise fixed
- All 855 backend tests pass
