### PR TITLE
fix: 404 for admin operations on non-existent user/translation

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -12,6 +12,7 @@ from services.bulk_translate import manager as bulk_manager, plan_work, group_ch
 from services.db import (
     DB_PATH,
     list_users,
+    get_user_by_id,
     set_user_approved,
     set_user_role,
     delete_user,
@@ -71,6 +72,8 @@ class ApproveRequest(BaseModel):
 
 @router.put("/users/{user_id}/approve")
 async def approve_user(user_id: int, req: ApproveRequest, _admin: dict = Depends(_require_admin)):
+    if not await get_user_by_id(user_id):
+        raise HTTPException(status_code=404, detail="User not found")
     await set_user_approved(user_id, req.approved)
     return {"ok": True}
 
@@ -85,6 +88,8 @@ async def change_role(user_id: int, req: RoleRequest, admin: dict = Depends(_req
         raise HTTPException(status_code=400, detail="Role must be 'admin' or 'user'")
     if user_id == admin["id"] and req.role != "admin":
         raise HTTPException(status_code=400, detail="Cannot demote yourself")
+    if not await get_user_by_id(user_id):
+        raise HTTPException(status_code=404, detail="User not found")
     await set_user_role(user_id, req.role)
     return {"ok": True}
 
@@ -93,6 +98,8 @@ async def change_role(user_id: int, req: RoleRequest, admin: dict = Depends(_req
 async def remove_user(user_id: int, admin: dict = Depends(_require_admin)):
     if user_id == admin["id"]:
         raise HTTPException(status_code=400, detail="Cannot delete yourself")
+    if not await get_user_by_id(user_id):
+        raise HTTPException(status_code=404, detail="User not found")
     await delete_user(user_id)
     return {"ok": True}
 
@@ -348,7 +355,9 @@ async def delete_translation(
             (book_id, chapter_index, target_language),
         )
         await db.commit()
-        return {"ok": True, "deleted": cursor.rowcount}
+    if cursor.rowcount == 0:
+        raise HTTPException(status_code=404, detail="Translation not found")
+    return {"ok": True, "deleted": cursor.rowcount}
 
 
 @router.post("/translations/{book_id}/{chapter_index}/{target_language}/retranslate")

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -106,6 +106,24 @@ async def test_change_role(admin_client, admin_db):
     assert updated["role"] == "admin"
 
 
+async def test_approve_nonexistent_user_returns_404(admin_client):
+    """Approving a user that doesn't exist must return 404, not 200."""
+    res = await admin_client.put("/api/admin/users/99999/approve", json={"approved": True})
+    assert res.status_code == 404
+
+
+async def test_change_role_nonexistent_user_returns_404(admin_client):
+    """Changing role for a user that doesn't exist must return 404, not 200."""
+    res = await admin_client.put("/api/admin/users/99999/role", json={"role": "admin"})
+    assert res.status_code == 404
+
+
+async def test_remove_nonexistent_user_returns_404(admin_client):
+    """Deleting a user that doesn't exist must return 404, not 200."""
+    res = await admin_client.delete("/api/admin/users/99999")
+    assert res.status_code == 404
+
+
 async def test_change_role_invalid(admin_client):
     res = await admin_client.put("/api/admin/users/1/role", json={"role": "superuser"})
     assert res.status_code == 400
@@ -310,6 +328,12 @@ async def test_delete_specific_translation(admin_client, admin_db):
     res = await admin_client.delete("/api/admin/translations/100/0/en")
     assert res.status_code == 200
     assert res.json()["deleted"] == 1
+
+
+async def test_delete_specific_translation_not_found_returns_404(admin_client):
+    """DELETE specific translation that doesn't exist must return 404, not 200."""
+    res = await admin_client.delete("/api/admin/translations/99999/0/de")
+    assert res.status_code == 404
 
 
 # ── Audio ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What changed

Three admin user endpoints and one translation delete endpoint returned HTTP 200 even when the target resource didn't exist.

**Endpoints fixed:**
- `PUT /admin/users/{user_id}/approve` → 404 if user not found
- `PUT /admin/users/{user_id}/role` → 404 if user not found
- `DELETE /admin/users/{user_id}` → 404 if user not found
- `DELETE /admin/translations/{book_id}/{chapter_index}/{lang}` → 404 when no row deleted

**Why wrong:** The underlying `UPDATE users SET ... WHERE id=?` and `DELETE ... WHERE id=?` ran silently with zero rows affected; the endpoint returned `{"ok": true}` regardless. For the translation endpoint, `{"ok": true, "deleted": 0}` was indistinguishable from a successful deletion.

## Fix
- User endpoints now call `get_user_by_id()` first and raise 404 if None.
- Translation delete endpoint checks `cursor.rowcount == 0` after commit and raises 404.

## Test plan
- `test_approve_nonexistent_user_returns_404`
- `test_change_role_nonexistent_user_returns_404`
- `test_remove_nonexistent_user_returns_404`
- `test_delete_specific_translation_not_found_returns_404`
- All 859 backend tests pass
