### PR TITLE
fix: 404 for delete_book, enqueue-book, translation-status on non-existent books

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -214,6 +214,8 @@ async def import_book(req: ImportBookRequest, _admin: dict = Depends(_require_ad
 @router.delete("/books/{book_id}")
 async def delete_book(book_id: int, _admin: dict = Depends(_require_admin)):
     """Delete a cached book and all its associated audio + translation cache."""
+    if not await get_cached_book(book_id):
+        raise HTTPException(status_code=404, detail="Book not found")
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute("DELETE FROM books WHERE id = ?", (book_id,))
         await db.execute("DELETE FROM translations WHERE book_id = ?", (book_id,))
@@ -933,6 +935,8 @@ async def queue_enqueue_book(
     req: EnqueueBookRequest,
     admin: dict = Depends(_require_admin),
 ):
+    if not await get_cached_book(req.book_id):
+        raise HTTPException(status_code=404, detail="Book not found")
     added = await enqueue_for_book(
         req.book_id,
         target_languages=req.target_languages,

--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -105,8 +105,10 @@ async def translation_status(book_id: int, target_language: str):
     from services.bulk_translate import manager as bulk_manager
 
     cached = await get_cached_book(book_id)
+    if not cached:
+        raise HTTPException(status_code=404, detail="Book not found")
     total_chapters = 0
-    if cached and cached.get("text"):
+    if cached.get("text"):
         # Use the shared resolver so total_chapters matches what the reader
         # displays (and what the queue worker processes).
         from services.book_chapters import split_with_html_preference

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -224,6 +224,12 @@ async def test_delete_book(admin_client, admin_db):
     assert res.status_code == 200
 
 
+async def test_delete_book_nonexistent_returns_404(admin_client):
+    """DELETE /admin/books/{id} for a non-existent book must return 404, not 200."""
+    res = await admin_client.delete("/api/admin/books/99999")
+    assert res.status_code == 404
+
+
 async def test_delete_book_removes_queue_entries(admin_client, admin_db):
     """Regression: delete_book must also delete translation_queue entries.
 
@@ -578,6 +584,18 @@ async def test_seed_popular_refuses_concurrent_start(admin_client, admin_db, mon
 
         # Clean up — stop the job
         await admin_client.post("/api/admin/books/seed-popular/stop")
+
+
+async def test_enqueue_book_nonexistent_returns_404(admin_client):
+    """POST /admin/queue/enqueue-book for a non-existent book must return 404.
+
+    Without this check enqueue_for_book returns 0 (no chapters to enqueue)
+    and the endpoint silently returns 200 with enqueued=0."""
+    res = await admin_client.post("/api/admin/queue/enqueue-book", json={
+        "book_id": 99999,
+        "target_languages": ["de"],
+    })
+    assert res.status_code == 404
 
 
 # ── Retry-failed bulk endpoint ───────────────────────────────────────────────

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -369,12 +369,18 @@ async def test_retry_chapter_translation_inserts_if_no_row(client):
 
 # ── Translation status endpoint ──────────────────────────────────────────────
 
-async def test_translation_status_uncached_book(client):
-    """Book not in cache → total_chapters=0, translated_chapters=0."""
-    resp = await client.get("/api/books/9999/translation-status?target_language=en")
+async def test_translation_status_nonexistent_book_returns_404(client):
+    """translation-status for a book that doesn't exist must return 404."""
+    resp = await client.get("/api/books/99999/translation-status?target_language=de")
+    assert resp.status_code == 404
+
+
+async def test_translation_status_cached_book_no_translations(client):
+    """Cached book with no translations → total_chapters≥0, translated_chapters=0."""
+    await save_book(9998, MOCK_META, "Chapter I\n\nSome text here.")
+    resp = await client.get("/api/books/9998/translation-status?target_language=de")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["total_chapters"] == 0
     assert data["translated_chapters"] == 0
     assert data["bulk_active"] is False
 


### PR DESCRIPTION
## What changed

Three endpoints returned HTTP 200 even when the target book didn't exist in the database:

- `DELETE /admin/books/{book_id}` — all DELETE statements ran with zero rows affected; endpoint returned `{"ok": true}`
- `POST /admin/queue/enqueue-book` — `enqueue_for_book()` returned 0 (no chapters to queue); endpoint returned `{"ok": true, "enqueued": 0}`
- `GET /books/{book_id}/translation-status` — returned `{"total_chapters": 0, ...}` indistinguishable from a book with no translations

## Fix

Each endpoint now calls `get_cached_book(book_id)` and raises `HTTP 404` when the book is not found.

## Test plan
- `test_delete_book_nonexistent_returns_404`
- `test_enqueue_book_nonexistent_returns_404`
- `test_translation_status_nonexistent_book_returns_404`
- Existing `test_translation_status_uncached_book` renamed+updated to use a real saved book (tests 200 path)
- All 862 backend tests pass
