### PR TITLE
fix: normalize vocabulary words to lowercase on save and delete

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -641,6 +641,7 @@ async def save_word(
     sentence_text: str,
 ) -> dict:
     import asyncio
+    word = word.lower()
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         await db.execute(
@@ -702,6 +703,7 @@ async def get_vocabulary(user_id: int) -> list[dict]:
 
 
 async def delete_word(user_id: int, word: str) -> bool:
+    word = word.lower()
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute(
             """DELETE FROM word_occurrences WHERE vocabulary_id IN (

--- a/backend/tests/test_db_extended.py
+++ b/backend/tests/test_db_extended.py
@@ -296,7 +296,7 @@ async def test_delete_annotation_wrong_user_returns_false():
 async def test_save_word_creates_entry():
     user = await get_or_create_user("g40", "vocab@example.com", "Vocab", "")
     result = await save_word(user["id"], "Schadenfreude", 1, 0, "He felt Schadenfreude.")
-    assert result["word"] == "Schadenfreude"
+    assert result["word"] == "schadenfreude"
     assert result["user_id"] == user["id"]
 
 
@@ -320,7 +320,7 @@ async def test_get_vocabulary_includes_occurrences():
     user = await get_or_create_user("g43", "vocab4@example.com", "V4", "")
     await save_word(user["id"], "Zeitgeist", 42, 3, "The Zeitgeist was clear.")
     vocab = await get_vocabulary(user["id"])
-    assert vocab[0]["word"] == "Zeitgeist"
+    assert vocab[0]["word"] == "zeitgeist"
     occ = vocab[0]["occurrences"][0]
     assert occ["book_id"] == 42
     assert occ["chapter_index"] == 3

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -126,6 +126,33 @@ async def test_vocabulary_requires_auth(anon_client):
     assert resp.status_code == 401
 
 
+async def test_save_word_normalizes_case(client, test_user):
+    """'Apple' and 'apple' must deduplicate to one vocabulary entry.
+
+    SQLite UNIQUE(user_id, word) is case-sensitive, so without explicit
+    lowercasing they produce two separate rows."""
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    await client.post("/api/vocabulary", json={
+        "word": "Apple", "book_id": BOOK_ID, "chapter_index": 0, "sentence_text": "Apple pie."
+    })
+    await client.post("/api/vocabulary", json={
+        "word": "apple", "book_id": BOOK_ID, "chapter_index": 1, "sentence_text": "An apple a day."
+    })
+    vocab = (await client.get("/api/vocabulary")).json()
+    apple_entries = [v for v in vocab if v["word"].lower() == "apple"]
+    assert len(apple_entries) == 1, "mixed-case saves must deduplicate to one entry"
+
+
+async def test_delete_word_case_insensitive(client, test_user):
+    """DELETE /vocabulary/Apple must remove 'apple' saved as lowercase."""
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_word(test_user["id"], "apple", BOOK_ID, 0, "An apple.")
+    resp = await client.delete("/api/vocabulary/Apple")
+    assert resp.status_code == 200
+    vocab = (await client.get("/api/vocabulary")).json()
+    assert not any(v["word"].lower() == "apple" for v in vocab)
+
+
 async def test_save_word_rejects_nonexistent_book(client, test_user):
     """POST /vocabulary for a book that doesn't exist must return 404.
 


### PR DESCRIPTION
## Summary

- `save_word()` now calls `word.lower()` before every INSERT/SELECT so "Apple" and "apple" map to the same vocabulary row
- `delete_word()` applies the same normalization so `DELETE /vocabulary/Apple` removes a word stored as "apple"
- SQLite's `UNIQUE(user_id, word)` constraint is case-sensitive, causing silent duplicate rows without this fix

## Test plan

- `test_save_word_normalizes_case` — saves "Apple" + "apple", asserts one vocabulary entry
- `test_delete_word_case_insensitive` — saves "apple", deletes via "Apple", asserts gone
- Updated two `test_db_extended.py` assertions that expected the original capitalized form
- Full suite: 861 tests pass
