### PR TITLE
fix: 404 for bulk translation delete and queue item operations on missing entities

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -340,7 +340,9 @@ async def delete_book_translations(book_id: int, _admin: dict = Depends(_require
     async with aiosqlite.connect(DB_PATH) as db:
         cursor = await db.execute("DELETE FROM translations WHERE book_id = ?", (book_id,))
         await db.commit()
-        return {"ok": True, "deleted": cursor.rowcount}
+    if cursor.rowcount == 0:
+        raise HTTPException(status_code=404, detail="No translations found for this book")
+    return {"ok": True, "deleted": cursor.rowcount}
 
 
 @router.delete("/translations/{book_id}/{chapter_index}/{target_language}")
@@ -953,6 +955,8 @@ async def queue_delete_item(
     item_id: int, _admin: dict = Depends(_require_admin),
 ):
     deleted = await delete_queue_item(item_id)
+    if deleted == 0:
+        raise HTTPException(status_code=404, detail="Queue item not found")
     return {"ok": True, "deleted": deleted}
 
 
@@ -997,6 +1001,8 @@ async def queue_retry_item(
         )
         await db.commit()
     queue_worker().wake()
+    if cursor.rowcount == 0:
+        raise HTTPException(status_code=404, detail="Queue item not found")
     return {"ok": True, "updated": cursor.rowcount}
 
 

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -342,6 +342,15 @@ async def test_delete_specific_translation_not_found_returns_404(admin_client):
     assert res.status_code == 404
 
 
+async def test_delete_book_translations_no_translations_returns_404(admin_client):
+    """DELETE /admin/translations/{book_id} with no translations must return 404.
+
+    The sibling specific-translation endpoint already checks rowcount; bulk
+    delete must be consistent."""
+    res = await admin_client.delete("/api/admin/translations/99999")
+    assert res.status_code == 404
+
+
 # ── Audio ────────────────────────────────────────────────────────────────────
 
 async def test_get_audio_empty(admin_client, admin_db):
@@ -584,6 +593,18 @@ async def test_seed_popular_refuses_concurrent_start(admin_client, admin_db, mon
 
         # Clean up — stop the job
         await admin_client.post("/api/admin/books/seed-popular/stop")
+
+
+async def test_delete_queue_item_not_found_returns_404(admin_client):
+    """DELETE /admin/queue/items/{id} for a non-existent item must return 404."""
+    res = await admin_client.delete("/api/admin/queue/items/99999")
+    assert res.status_code == 404
+
+
+async def test_retry_queue_item_not_found_returns_404(admin_client):
+    """POST /admin/queue/items/{id}/retry for a non-existent item must return 404."""
+    res = await admin_client.post("/api/admin/queue/items/99999/retry")
+    assert res.status_code == 404
 
 
 async def test_enqueue_book_nonexistent_returns_404(admin_client):

--- a/backend/tests/test_router_admin_extended.py
+++ b/backend/tests/test_router_admin_extended.py
@@ -511,8 +511,7 @@ async def test_queue_delete_item(admin_client, admin_db):
 
 async def test_queue_delete_nonexistent_item(admin_client, admin_db):
     res = await admin_client.delete("/api/admin/queue/items/99999")
-    assert res.status_code == 200
-    assert res.json()["deleted"] == 0
+    assert res.status_code == 404
 
 
 # ── Queue clear ──────────────────────────────────────────────────────────────
@@ -603,8 +602,7 @@ async def test_queue_retry_item(admin_client, admin_db):
 
 async def test_queue_retry_nonexistent_item(admin_client, admin_db):
     res = await admin_client.post("/api/admin/queue/items/99999/retry")
-    assert res.status_code == 200
-    assert res.json()["updated"] == 0
+    assert res.status_code == 404
 
 
 # ── Queue cost estimate ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `DELETE /admin/translations/{book_id}` now returns 404 when no translations exist for that book (was silently returning 200/deleted=0), consistent with the specific-translation sibling endpoint
- `DELETE /admin/queue/items/{id}` now returns 404 for non-existent queue items (was 200/deleted=0)
- `POST /admin/queue/items/{id}/retry` now returns 404 for non-existent queue items (was 200/updated=0)

## Test plan

- `test_delete_book_translations_no_translations_returns_404` — confirms bulk delete 404
- `test_delete_queue_item_not_found_returns_404` — confirms queue delete 404
- `test_retry_queue_item_not_found_returns_404` — confirms queue retry 404
- Updated two existing `test_router_admin_extended.py` tests that expected the old silent-200 behavior
- Full suite: 865 tests pass
