### PR TITLE
fix: 404 for PUT /ai/translate/cache when book does not exist

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -7,6 +7,7 @@ from services.auth import get_current_user, decrypt_api_key
 from services.db import (
     get_cached_translation,
     save_translation,
+    get_cached_book,
 )
 from services import gemini
 from services.tts import synthesize, chunk_text
@@ -162,6 +163,8 @@ class SaveTranslationRequest(BaseModel):
 @router.put("/translate/cache")
 async def save_translate_cache(req: SaveTranslationRequest, _user: dict = Depends(get_current_user)):
     """Save a completed progressive translation to the backend cache."""
+    if not await get_cached_book(req.book_id):
+        raise HTTPException(status_code=404, detail="Book not found")
     await save_translation(
         req.book_id, req.chapter_index, req.target_language, req.paragraphs,
         provider=req.provider, model=req.model,

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -133,8 +133,24 @@ async def test_translate_cache_get_returns_404_when_missing(client):
     assert resp.status_code == 404
 
 
-async def test_translate_cache_put_saves(client):
+async def test_translate_cache_put_rejects_nonexistent_book(client, test_user):
+    """PUT /translate/cache for a non-existent book must return 404.
+
+    Without this check a user can save an orphaned translation row that
+    references a book_id not in the books table (SQLite FK OFF)."""
+    resp = await client.put("/api/ai/translate/cache", json={
+        "book_id": 77777, "chapter_index": 0, "target_language": "fr",
+        "paragraphs": ["Bonjour"],
+    })
+    assert resp.status_code == 404
+
+
+async def test_translate_cache_put_saves(client, test_user):
     """PUT /translate/cache saves paragraphs for later retrieval."""
+    from services.db import save_book
+    _BOOK_META = {"title": "Faust", "authors": ["Goethe"], "languages": ["de"],
+                  "subjects": [], "download_count": 0, "cover": ""}
+    await save_book(2, _BOOK_META, "text")
     resp = await client.put("/api/ai/translate/cache", json={
         "book_id": 2, "chapter_index": 1, "target_language": "fr",
         "paragraphs": ["Bonjour"],


### PR DESCRIPTION
## Summary

- `PUT /ai/translate/cache` now returns 404 when the `book_id` in the request does not exist in the database
- Without this check, a user finishing a progressive Gemini translation for a since-deleted book would silently create an orphaned `translations` row (SQLite FK enforcement is OFF)
- Same pattern as the fixes applied to annotations, insights, vocabulary, reading-progress, and admin endpoints

## Test plan

- `test_translate_cache_put_rejects_nonexistent_book` — confirms 404 for missing book
- `test_translate_cache_put_saves` — updated to save book first; confirms happy path still works
- Full suite: 865 tests pass
