### PR TITLE
fix: 404 for queue-status on missing book; reject negative chapter_index

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -164,6 +164,8 @@ async def chapter_queue_status(
     on-demand translate to avoid duplicating work the background worker is
     already scheduled to do.
     """
+    if not await get_cached_book(book_id):
+        raise HTTPException(status_code=404, detail="Book not found")
     from services.translation_queue import queue_status_for_chapter
     return await queue_status_for_chapter(book_id, chapter_index, target_language)
 

--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -64,6 +64,8 @@ async def update_reading_progress(
 ):
     if not await get_cached_book(book_id):
         raise HTTPException(status_code=404, detail="Book not found")
+    if req.chapter_index < 0:
+        raise HTTPException(status_code=400, detail="chapter_index must be >= 0")
     await upsert_reading_progress(user["id"], book_id, req.chapter_index)
     return {"ok": True}
 

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -408,8 +408,20 @@ async def test_translation_status_with_translations(client):
 
 # ── Chapter queue-status endpoint ────────────────────────────────────────────
 
+async def test_chapter_queue_status_nonexistent_book_returns_404(client):
+    """GET queue-status for a book that isn't cached must return 404.
+
+    Without this check the endpoint returns 200/{queued:false} for any
+    book_id — indistinguishable from a real book with nothing queued."""
+    resp = await client.get(
+        "/api/books/99999/chapters/0/queue-status?target_language=zh"
+    )
+    assert resp.status_code == 404
+
+
 async def test_chapter_queue_status_no_row(client):
-    """Chapter not in queue → queued=False, status=null."""
+    """Chapter not in queue → queued=False, status=null (book must exist)."""
+    await save_book(1342, MOCK_META, "text")
     resp = await client.get(
         "/api/books/1342/chapters/0/queue-status?target_language=en"
     )

--- a/backend/tests/test_router_user.py
+++ b/backend/tests/test_router_user.py
@@ -93,6 +93,19 @@ async def test_reading_progress_rejects_nonexistent_book(client, test_user):
     assert resp.status_code == 404
 
 
+async def test_reading_progress_rejects_negative_chapter_index(client, test_user):
+    """PUT reading-progress with chapter_index < 0 must return 400.
+
+    Negative indices are not valid chapter positions. Storing them would
+    silently corrupt the user's resume position."""
+    from services.db import save_book
+    _META = {"title": "T", "authors": [], "languages": ["en"], "subjects": [],
+              "download_count": 0, "cover": ""}
+    await save_book(BOOK_ID, _META, "text")
+    resp = await client.put(f"/api/user/reading-progress/{BOOK_ID}", json={"chapter_index": -1})
+    assert resp.status_code == 400
+
+
 async def test_get_obsidian_settings_returns_defaults_initially(client, test_user):
     resp = await client.get("/api/user/obsidian-settings")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary

- `GET /books/{id}/chapters/{n}/queue-status` now returns 404 for non-existent books. Previously returned 200/`{queued: false}` for any book_id, indistinguishable from a real book with no queued chapter. Reader could misinterpret this as "chapter can be enqueued" and proceed to call the enqueue endpoint (which would then 404).
- `PUT /user/reading-progress/{id}` now returns 400 when `chapter_index < 0`. Negative indices are not valid chapter positions and storing them silently corrupted the user's resume position.

## Test plan

- `test_chapter_queue_status_nonexistent_book_returns_404` — confirms 404 for missing book
- Updated `test_chapter_queue_status_no_row` — now saves book first (tests "book exists but nothing queued")
- `test_reading_progress_rejects_negative_chapter_index` — confirms 400 for negative chapter index
- Full suite: 870 tests pass
