### PR TITLE
fix: normalize language codes in POST /ai/translate before cache lookup and save

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -180,9 +180,10 @@ async def translate(req: TranslateRequest, user: dict = Depends(get_current_user
     if src == tgt:
         raise HTTPException(status_code=400, detail="Source and target language are the same.")
     try:
-        # Check shared DB cache first — cache hits don't need any key
+        # Check shared DB cache first — cache hits don't need any key.
+        # Use normalized codes so "ZH" and "zh-CN" both hit a "zh" cache entry.
         if req.book_id is not None and req.chapter_index is not None:
-            cached = await get_cached_translation(req.book_id, req.chapter_index, req.target_language)
+            cached = await get_cached_translation(req.book_id, req.chapter_index, tgt)
             if cached:
                 return {"paragraphs": cached, "cached": True}
 
@@ -211,8 +212,8 @@ async def translate(req: TranslateRequest, user: dict = Depends(get_current_user
         try:
             paragraphs = await do_translate(
                 req.text,
-                req.source_language,
-                req.target_language,
+                src,
+                tgt,
                 provider=chosen,
                 gemini_key=decrypted_key,
             )
@@ -222,8 +223,8 @@ async def translate(req: TranslateRequest, user: dict = Depends(get_current_user
             if chosen == "gemini":
                 paragraphs = await do_translate(
                     req.text,
-                    req.source_language,
-                    req.target_language,
+                    src,
+                    tgt,
                     provider="google",
                 )
                 chosen = "google"
@@ -231,10 +232,10 @@ async def translate(req: TranslateRequest, user: dict = Depends(get_current_user
             else:
                 raise
 
-        # Save to shared cache, tagged with provider so the reader can show origin
+        # Save to shared cache with normalized language codes so any casing variant hits it.
         if req.book_id is not None and req.chapter_index is not None:
             await save_translation(
-                req.book_id, req.chapter_index, req.target_language, paragraphs,
+                req.book_id, req.chapter_index, tgt, paragraphs,
                 provider=chosen,
             )
 

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -26,6 +26,29 @@ async def _set_key(test_user):
 
 # ── Translation ───────────────────────────────────────────────────────────────
 
+async def test_translate_normalizes_language_codes(client):
+    """target_language must be normalized before cache lookup and save.
+
+    Translation stored under 'zh' must be a cache hit when the client
+    sends 'ZH' or 'zh-CN'.  Without normalization, 'tgt' is computed but
+    discarded — the raw req.target_language hits the DB and misses."""
+    await save_translation(1342, 0, "zh", TRANSLATED)
+
+    with patch("routers.ai.gemini") as mock_gemini:
+        resp = await client.post("/api/ai/translate", json={
+            "text": CHAPTER_TEXT,
+            "source_language": "de",
+            "target_language": "ZH",  # uppercase — must normalize to "zh"
+            "book_id": 1342,
+            "chapter_index": 0,
+        })
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["cached"] is True, "uppercase 'ZH' must hit cache stored as 'zh'"
+    mock_gemini.translate_text.assert_not_called()
+
+
 async def test_translate_cache_hit_works_without_key(client):
     """Cache hits return the stored result without hitting Gemini at all."""
     await save_translation(1342, 0, "en", TRANSLATED)


### PR DESCRIPTION
## Summary

`POST /ai/translate` computed normalized language codes (`tgt = target_language.lower().split("-")[0]`) for the same-language guard but then discarded them — using the original `req.target_language` in the cache lookup, `do_translate` calls, and `save_translation`. This caused:

- **Cache misses**: "ZH" or "zh-CN" sent by client would miss a "zh" cache entry, re-translating an already-cached chapter and wasting API quota
- **Duplicate DB rows**: Different casings stored as separate translation rows (e.g., both "zh" and "ZH")

Both `src` and `tgt` are now used consistently everywhere after they are computed.

## Test plan

- `test_translate_normalizes_language_codes` — saves translation under "zh", calls endpoint with "ZH", asserts cache hit
- Full suite: 869 tests pass
