### PR TITLE
fix: reject empty/whitespace words in POST /vocabulary; strip whitespace in db layer

### DIFF
--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -34,6 +34,8 @@ class ExportRequest(BaseModel):
 
 @router.post("")
 async def save(req: WordSave, user: dict = Depends(get_current_user)):
+    if not req.word or not req.word.strip():
+        raise HTTPException(status_code=400, detail="Word cannot be empty")
     if not req.sentence_text or not req.sentence_text.strip():
         raise HTTPException(status_code=400, detail="sentence_text cannot be empty")
     if not await get_cached_book(req.book_id):

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -641,7 +641,7 @@ async def save_word(
     sentence_text: str,
 ) -> dict:
     import asyncio
-    word = word.lower()
+    word = word.strip().lower()
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         await db.execute(
@@ -703,7 +703,7 @@ async def get_vocabulary(user_id: int) -> list[dict]:
 
 
 async def delete_word(user_id: int, word: str) -> bool:
-    word = word.lower()
+    word = word.strip().lower()
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute(
             """DELETE FROM word_occurrences WHERE vocabulary_id IN (

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -153,6 +153,29 @@ async def test_delete_word_case_insensitive(client, test_user):
     assert not any(v["word"].lower() == "apple" for v in vocab)
 
 
+async def test_save_word_rejects_empty_word(client, test_user):
+    """POST /vocabulary with an empty word must return 400.
+
+    An empty-string word stored in the vocabulary is unusable — the user
+    can never delete it via DELETE /vocabulary/ (no path segment) and
+    the UNIQUE(user_id, word) constraint allows exactly one empty entry
+    per user, polluting the vocabulary silently."""
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    resp = await client.post("/api/vocabulary", json={
+        "word": "", "book_id": BOOK_ID, "chapter_index": 0, "sentence_text": "Some text."
+    })
+    assert resp.status_code == 400
+
+
+async def test_save_word_strips_and_rejects_whitespace_only_word(client, test_user):
+    """POST /vocabulary with whitespace-only word must return 400."""
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    resp = await client.post("/api/vocabulary", json={
+        "word": "   ", "book_id": BOOK_ID, "chapter_index": 0, "sentence_text": "Some text."
+    })
+    assert resp.status_code == 400
+
+
 async def test_save_word_rejects_nonexistent_book(client, test_user):
     """POST /vocabulary for a book that doesn't exist must return 404.
 


### PR DESCRIPTION
## Summary

- `POST /vocabulary` now returns 400 when `word` is empty or whitespace-only
- An empty/whitespace word stored in the DB is undeleteable via `DELETE /vocabulary/` (FastAPI won't match an empty path segment) and occupies the one allowed slot in `UNIQUE(user_id, word)` per user
- `save_word()` and `delete_word()` in `services/db.py` now use `word.strip().lower()` — previously only lowercased, which let `"  "` (spaces) through

## Test plan

- `test_save_word_rejects_empty_word` — `word: ""` returns 400
- `test_save_word_strips_and_rejects_whitespace_only_word` — `word: "   "` returns 400
- Full suite: 872 tests pass
