### PR TITLE
fix: reject empty sentence_text/question/answer in annotations and insights

### DIFF
--- a/backend/routers/annotations.py
+++ b/backend/routers/annotations.py
@@ -25,6 +25,8 @@ class AnnotationUpdate(BaseModel):
 
 @router.post("")
 async def create(req: AnnotationCreate, user: dict = Depends(get_current_user)):
+    if not req.sentence_text or not req.sentence_text.strip():
+        raise HTTPException(status_code=400, detail="sentence_text cannot be empty")
     if not await get_cached_book(req.book_id):
         raise HTTPException(status_code=404, detail="Book not found")
     return await create_annotation(

--- a/backend/routers/insights.py
+++ b/backend/routers/insights.py
@@ -16,6 +16,10 @@ class InsightCreate(BaseModel):
 
 @router.post("")
 async def create(req: InsightCreate, user: dict = Depends(get_current_user)):
+    if not req.question or not req.question.strip():
+        raise HTTPException(status_code=400, detail="question cannot be empty")
+    if not req.answer or not req.answer.strip():
+        raise HTTPException(status_code=400, detail="answer cannot be empty")
     if not await get_cached_book(req.book_id):
         raise HTTPException(status_code=404, detail="Book not found")
     return await save_insight(

--- a/backend/tests/test_router_annotations.py
+++ b/backend/tests/test_router_annotations.py
@@ -227,3 +227,17 @@ async def test_create_annotation_rejects_nonexistent_book(client, test_user):
         "sentence_text": "Orphan sentence.",
     })
     assert resp.status_code == 404
+
+
+async def test_create_annotation_rejects_empty_sentence(client, test_user):
+    """POST /annotations with empty sentence_text must return 400.
+
+    An annotation with no text context is meaningless and represents a
+    client error."""
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    resp = await client.post("/api/annotations", json={
+        "book_id": BOOK_ID,
+        "chapter_index": 0,
+        "sentence_text": "",
+    })
+    assert resp.status_code == 400

--- a/backend/tests/test_router_insights.py
+++ b/backend/tests/test_router_insights.py
@@ -175,3 +175,23 @@ async def test_post_insight_rejects_nonexistent_book(client: AsyncClient):
         json={"book_id": 777777, "question": "Q?", "answer": "A."},
     )
     assert resp.status_code == 404
+
+
+async def test_post_insight_rejects_empty_question(client: AsyncClient):
+    """POST /insights with empty question must return 400."""
+    await save_book(1, _META, "text")
+    resp = await client.post(
+        "/api/insights",
+        json={"book_id": 1, "question": "", "answer": "Some answer."},
+    )
+    assert resp.status_code == 400
+
+
+async def test_post_insight_rejects_empty_answer(client: AsyncClient):
+    """POST /insights with empty answer must return 400."""
+    await save_book(1, _META, "text")
+    resp = await client.post(
+        "/api/insights",
+        json={"book_id": 1, "question": "What is the theme?", "answer": ""},
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
## What changed

- `POST /annotations`: returns 400 if `sentence_text` is empty or whitespace-only
- `POST /insights`: returns 400 if `question` or `answer` is empty or whitespace-only

## Why

Whitespace-only strings pass Pydantic validation but produce meaningless stored records that cannot be meaningfully displayed or searched.

## Test plan

- `test_create_annotation_rejects_empty_sentence` — was failing, now passes
- `test_post_insight_rejects_empty_question` — was failing, now passes
- `test_post_insight_rejects_empty_answer` — was failing, now passes
- Full suite: 874 passed
