### PR TITLE
fix: 404/400 for translate with missing book or negative chapter; 400 for empty vocabulary sentence

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -187,6 +187,13 @@ async def translate(req: TranslateRequest, user: dict = Depends(get_current_user
             if cached:
                 return {"paragraphs": cached, "cached": True}
 
+        # Validate book/chapter before spending API quota on translation.
+        if req.book_id is not None:
+            if not await get_cached_book(req.book_id):
+                raise HTTPException(status_code=404, detail="Book not found")
+        if req.chapter_index is not None and req.chapter_index < 0:
+            raise HTTPException(status_code=400, detail="chapter_index must be >= 0")
+
         # Resolve "auto" to a concrete provider
         raw_key = user.get("gemini_key")
         try:

--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -34,6 +34,8 @@ class ExportRequest(BaseModel):
 
 @router.post("")
 async def save(req: WordSave, user: dict = Depends(get_current_user)):
+    if not req.sentence_text or not req.sentence_text.strip():
+        raise HTTPException(status_code=400, detail="sentence_text cannot be empty")
     if not await get_cached_book(req.book_id):
         raise HTTPException(status_code=404, detail="Book not found")
     return await save_word(

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -12,12 +12,14 @@ Focuses on:
 
 import pytest
 from unittest.mock import AsyncMock, patch
-from services.db import save_translation, get_cached_translation, set_user_gemini_key
+from services.db import save_book, save_translation, get_cached_translation, set_user_gemini_key
 from services.auth import encrypt_api_key
 
 
 CHAPTER_TEXT = "Es war einmal ein König."
 TRANSLATED = ["Once upon a time there was a king."]
+_BOOK_META = {"title": "Faust", "authors": ["Goethe"], "languages": ["de"],
+              "subjects": [], "download_count": 0, "cover": ""}
 
 
 async def _set_key(test_user):
@@ -71,6 +73,7 @@ async def test_translate_cache_hit_works_without_key(client):
 
 async def test_translate_cache_miss_without_key_uses_google_free(client):
     """Without a Gemini key, translation falls back to Google Translate (free)."""
+    await save_book(1342, _BOOK_META, "text")
     with patch("services.translate._google_translate", new_callable=AsyncMock, return_value=TRANSLATED):
         resp = await client.post("/api/ai/translate", json={
             "text": CHAPTER_TEXT,
@@ -86,6 +89,7 @@ async def test_translate_cache_miss_without_key_uses_google_free(client):
 
 async def test_translate_cache_miss_with_key_uses_gemini(client, test_user):
     await _set_key(test_user)
+    await save_book(1342, _BOOK_META, "text")
 
     with patch("services.translate._gemini_translate", new_callable=AsyncMock, return_value=TRANSLATED):
         resp = await client.post("/api/ai/translate", json={
@@ -281,6 +285,40 @@ async def test_tts_accepts_male_gender(client):
     ) as mock_synth:
         await client.post("/api/ai/tts", json={"text": "x", "language": "en", "rate": 1.0, "gender": "male"})
     assert mock_synth.call_args.kwargs["gender"] == "male"
+
+
+async def test_translate_rejects_nonexistent_book(client, test_user):
+    """POST /ai/translate with a non-existent book_id must return 404.
+
+    Without this check, the translation is saved as an orphaned row referencing
+    a non-existent book (SQLite FK enforcement is OFF)."""
+    resp = await client.post("/api/ai/translate", json={
+        "text": CHAPTER_TEXT,
+        "source_language": "de",
+        "target_language": "en",
+        "book_id": 999999,
+        "chapter_index": 0,
+    })
+    assert resp.status_code == 404
+
+
+async def test_translate_rejects_negative_chapter_index(client, test_user):
+    """POST /ai/translate with chapter_index < 0 must return 400.
+
+    A negative chapter_index would create a translation row with a nonsense
+    index that can never correspond to a real chapter."""
+    from services.db import save_book
+    _META = {"title": "T", "authors": [], "languages": ["de"], "subjects": [],
+              "download_count": 0, "cover": ""}
+    await save_book(88, _META, "text")
+    resp = await client.post("/api/ai/translate", json={
+        "text": CHAPTER_TEXT,
+        "source_language": "de",
+        "target_language": "en",
+        "book_id": 88,
+        "chapter_index": -1,
+    })
+    assert resp.status_code == 400
 
 
 # ── /api/ai/tts/chunks endpoint ───────────────────────────────────────────────

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -167,6 +167,33 @@ async def test_save_word_rejects_nonexistent_book(client, test_user):
     assert resp.status_code == 404
 
 
+async def test_save_word_rejects_empty_sentence(client, test_user):
+    """POST /vocabulary with empty sentence_text must return 400.
+
+    An occurrence with no sentence context cannot be displayed and
+    represents a client error."""
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    resp = await client.post("/api/vocabulary", json={
+        "word": "spectre",
+        "book_id": BOOK_ID,
+        "chapter_index": 0,
+        "sentence_text": "",
+    })
+    assert resp.status_code == 400
+
+
+async def test_save_word_rejects_whitespace_only_sentence(client, test_user):
+    """POST /vocabulary with whitespace-only sentence_text must return 400."""
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    resp = await client.post("/api/vocabulary", json={
+        "word": "spectre",
+        "book_id": BOOK_ID,
+        "chapter_index": 0,
+        "sentence_text": "   ",
+    })
+    assert resp.status_code == 400
+
+
 # ── Export endpoint ───────────────────────────────────────────────────────────
 
 async def _setup_export(test_user, book_id=BOOK_ID):


### PR DESCRIPTION
## What changed

- `POST /ai/translate`: returns 404 when `book_id` references a non-existent book (translation was previously saved as an orphaned row — SQLite FK enforcement OFF)
- `POST /ai/translate`: returns 400 when `chapter_index < 0` (negative index creates a nonsense DB row)
- `POST /vocabulary`: returns 400 when `sentence_text` is empty or whitespace-only (an occurrence with no context is meaningless)
- Two existing translate tests updated to `save_book(1342, ...)` first, since the book existence check now applies

## Test plan

- `test_translate_rejects_nonexistent_book` — new, was failing
- `test_translate_rejects_negative_chapter_index` — new, was failing
- `test_save_word_rejects_empty_sentence` — new, was failing
- `test_save_word_rejects_whitespace_only_sentence` — new, was failing
- Full suite: 875 passed
