### PR TITLE
fix: normalize target_language in admin delete-translation and ai translate-cache

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -353,6 +353,7 @@ async def delete_translation(
     _admin: dict = Depends(_require_admin),
 ):
     """Delete a specific cached translation."""
+    target_language = target_language.lower().split("-")[0]
     async with aiosqlite.connect(DB_PATH) as db:
         cursor = await db.execute(
             "DELETE FROM translations WHERE book_id=? AND chapter_index=? AND target_language=?",

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -139,6 +139,7 @@ async def translate_cache(
     _user: dict = Depends(get_current_user),
 ):
     """Check if a translation is cached. Returns paragraphs + provider/model if yes, 404 if not."""
+    target_language = target_language.lower().split("-")[0]
     from services.db import get_cached_translation_with_meta
     cached = await get_cached_translation_with_meta(book_id, chapter_index, target_language)
     if cached:
@@ -165,8 +166,9 @@ async def save_translate_cache(req: SaveTranslationRequest, _user: dict = Depend
     """Save a completed progressive translation to the backend cache."""
     if not await get_cached_book(req.book_id):
         raise HTTPException(status_code=404, detail="Book not found")
+    target_language = req.target_language.lower().split("-")[0]
     await save_translation(
-        req.book_id, req.chapter_index, req.target_language, req.paragraphs,
+        req.book_id, req.chapter_index, target_language, req.paragraphs,
         provider=req.provider, model=req.model,
     )
     return {"ok": True}

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -342,6 +342,17 @@ async def test_delete_specific_translation_not_found_returns_404(admin_client):
     assert res.status_code == 404
 
 
+async def test_delete_specific_translation_normalizes_language(admin_client, admin_db):
+    """DELETE .../ZH-CN must delete a row stored under 'zh'.
+
+    Without normalization the lookup uses 'ZH-CN' as-is and returns 404
+    even though the translation exists."""
+    await save_translation(100, 0, "zh", ["翻译"])
+    res = await admin_client.delete("/api/admin/translations/100/0/ZH-CN")
+    assert res.status_code == 200
+    assert res.json()["deleted"] == 1
+
+
 async def test_delete_book_translations_no_translations_returns_404(admin_client):
     """DELETE /admin/translations/{book_id} with no translations must return 404.
 

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -160,6 +160,33 @@ async def test_translate_cache_get_returns_404_when_missing(client):
     assert resp.status_code == 404
 
 
+async def test_translate_cache_get_normalizes_language(client):
+    """GET /translate/cache?target_language=ZH must hit a 'zh' row.
+
+    Without normalization the lookup uses 'ZH' as-is and misses 'zh'."""
+    await save_translation(5, 0, "zh", ["翻译"])
+    resp = await client.get("/api/ai/translate/cache?book_id=5&chapter_index=0&target_language=ZH")
+    assert resp.status_code == 200
+    assert resp.json()["paragraphs"] == ["翻译"]
+
+
+async def test_translate_cache_put_normalizes_language(client, test_user):
+    """PUT /translate/cache with 'ZH-CN' must save under 'zh'.
+
+    Without normalization, a later GET with 'zh' would miss the entry."""
+    from services.db import save_book as _save_book, get_cached_translation
+    _META = {"title": "T", "authors": [], "languages": ["de"], "subjects": [],
+              "download_count": 0, "cover": ""}
+    await _save_book(7, _META, "text")
+    resp = await client.put("/api/ai/translate/cache", json={
+        "book_id": 7, "chapter_index": 0, "target_language": "ZH-CN",
+        "paragraphs": ["翻译"],
+    })
+    assert resp.status_code == 200
+    cached = await get_cached_translation(7, 0, "zh")
+    assert cached == ["翻译"], "PUT with 'ZH-CN' must be stored under normalized 'zh'"
+
+
 async def test_translate_cache_put_rejects_nonexistent_book(client, test_user):
     """PUT /translate/cache for a non-existent book must return 404.
 


### PR DESCRIPTION
## What changed

Three endpoints that accept `target_language` now normalize it (e.g. `"ZH-CN"` → `"zh"`) before DB operations:

- `DELETE /admin/translations/{book_id}/{chapter_index}/{lang}` — without normalization, `DELETE .../ZH-CN` returned 404 even when a `"zh"` row existed
- `GET /ai/translate/cache?target_language=ZH` — without normalization, lookup with `"ZH"` missed a stored `"zh"` entry
- `PUT /ai/translate/cache` — without normalization, saving with `"ZH-CN"` stored under that code; later `GET` with `"zh"` would miss it

## Test plan

- `test_delete_specific_translation_normalizes_language` — new, was failing
- `test_translate_cache_get_normalizes_language` — new, was failing
- `test_translate_cache_put_normalizes_language` — new, was failing
- Full suite: 884 passed
