### PR TITLE
fix: bulk redirect, drop orphaned table, fix BookCard touch target

### DIFF
--- a/backend/migrations/018_drop_bulk_translation_jobs.sql
+++ b/backend/migrations/018_drop_bulk_translation_jobs.sql
@@ -1,0 +1,3 @@
+-- Bulk translate system was removed in PR #257 (2026-04-22).
+-- Drop the orphaned table so existing installs are cleaned up.
+DROP TABLE IF EXISTS bulk_translation_jobs;

--- a/frontend/src/__tests__/AdminTinyPages.test.tsx
+++ b/frontend/src/__tests__/AdminTinyPages.test.tsx
@@ -74,3 +74,32 @@ describe("Admin queue page (admin/queue/page.tsx)", () => {
     expect(screen.getByTestId("queue-tab")).toBeInTheDocument();
   });
 });
+
+describe("Admin bulk redirect page (admin/bulk/page.tsx)", () => {
+  let BulkRedirect: React.ComponentType;
+
+  beforeAll(async () => {
+    const mod = await import("@/app/admin/bulk/page");
+    BulkRedirect = mod.default;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders without crashing", () => {
+    render(<BulkRedirect />);
+  });
+
+  it("calls router.replace('/admin/queue') on mount", async () => {
+    render(<BulkRedirect />);
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/admin/queue");
+    });
+  });
+
+  it("renders nothing visible (returns null)", () => {
+    const { container } = render(<BulkRedirect />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/BookCard.test.tsx
+++ b/frontend/src/__tests__/BookCard.test.tsx
@@ -85,3 +85,10 @@ test("calls onRemove when remove button is clicked", async () => {
   // The main card onClick must NOT fire — stopPropagation is called
   expect(onClick).not.toHaveBeenCalled();
 });
+
+test("remove button meets 44px minimum touch target size", () => {
+  render(<BookCard book={BOOK} onClick={jest.fn()} onRemove={jest.fn()} />);
+  const removeBtn = screen.getByRole("button", { name: /remove from library/i });
+  expect(removeBtn.className).toContain("min-w-[44px]");
+  expect(removeBtn.className).toContain("min-h-[44px]");
+});

--- a/frontend/src/app/admin/bulk/page.tsx
+++ b/frontend/src/app/admin/bulk/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export default function BulkRedirect() {
+  const router = useRouter();
+  useEffect(() => {
+    router.replace("/admin/queue");
+  }, [router]);
+  return null;
+}

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -22,7 +22,7 @@ export default function BookCard({ book, onClick, badge, onRemove }: Props) {
           }}
           title="Remove from library"
           aria-label="Remove from library"
-          className="absolute top-1 right-1 z-10 w-6 h-6 rounded-full bg-white/80 text-stone-500 border border-amber-200 text-xs hover:bg-red-50 hover:text-red-600 hover:border-red-200"
+          className="absolute top-0 right-0 z-10 min-w-[44px] min-h-[44px] inline-flex items-center justify-center rounded-full bg-white/80 text-stone-500 border border-amber-200 text-sm hover:bg-red-50 hover:text-red-600 hover:border-red-200"
         >
           ×
         </button>


### PR DESCRIPTION
## Summary

- **#259**: `BookCard` remove button was 24×24px — below WCAG/HIG 44×44px minimum. Fixed to `min-w-[44px] min-h-[44px] inline-flex`.
- **#260**: `bulk_translation_jobs` table left orphaned after bulk-translate removal (PR #257). New migration `018` drops it with `IF EXISTS`.
- **#261**: `/admin/bulk` returned 404 after its page was removed. Added client-side redirect to `/admin/queue`.

## Test plan

- `BookCard.test.tsx` — new test verifies remove button className includes `min-w-[44px]` and `min-h-[44px]`
- `AdminTinyPages.test.tsx` — new `describe` block for bulk redirect: renders null, calls `router.replace('/admin/queue')` on mount
- Migration verified locally: `bulk_translation_jobs exists: False` after `init_db()`
- Full suite: 874 backend + 1475 frontend tests pass
