### PR TITLE
fix: null-guard empty dict API response; safe error message extraction

### DIFF
--- a/frontend/src/__tests__/InsightChat.coverage.test.tsx
+++ b/frontend/src/__tests__/InsightChat.coverage.test.tsx
@@ -87,6 +87,18 @@ describe("InsightChat — getInsight failure (line 158)", () => {
       expect(screen.getByText(/Error: Gemini quota exceeded/)).toBeInTheDocument()
     );
   });
+
+  it("shows string error text instead of 'Error: undefined' when non-Error is thrown (issue #266)", async () => {
+    mockGetInsight.mockRejectedValue("quota exceeded"); // plain string, not Error
+
+    render(<InsightChat {...BASE} />);
+
+    await waitFor(() => {
+      // Should show the string content, NOT "Error: undefined"
+      expect(screen.queryByText(/Error: undefined/)).not.toBeInTheDocument();
+      expect(screen.getByText(/quota exceeded/)).toBeInTheDocument();
+    });
+  });
 });
 
 // ── Lines 167-175: manual refresh via ↺ button ───────────────────────────────

--- a/frontend/src/__tests__/WordActionDrawer.branches.test.tsx
+++ b/frontend/src/__tests__/WordActionDrawer.branches.test.tsx
@@ -251,3 +251,15 @@ describe("WordActionDrawer — null meanings fallback", () => {
     );
   });
 });
+
+// ── Issue #265: empty array response doesn't crash ────────────────────────────
+describe("WordActionDrawer — empty API response (issue #265)", () => {
+  it("shows error message instead of crashing when API returns empty array", async () => {
+    jest.useRealTimers();
+    setupFetchMock(true, []); // 200 OK but empty array
+    render(<WordActionDrawer action={BASE_ACTION} onClose={jest.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/no definition found/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -202,7 +202,7 @@ export default function InsightChat({
     onAIUsed?.();
     getInsight(chapterText, bookTitle, author, langRef.current)
       .then((r) => { if (!cancelled) setMessages((prev) => [...prev, { role: "assistant", content: r.insight }]); })
-      .catch((e) => { if (!cancelled) setMessages((prev) => [...prev, { role: "assistant", content: `Error: ${e.message}` }]); })
+      .catch((e) => { if (!cancelled) setMessages((prev) => [...prev, { role: "assistant", content: `Error: ${e instanceof Error ? e.message : String(e)}` }]); })
       .finally(() => { if (!cancelled) setChatLoading(false); });
     return () => { cancelled = true; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -217,7 +217,7 @@ export default function InsightChat({
     onAIUsed?.();
     getInsight(chapterText, bookTitle, author, langRef.current)
       .then((r) => { if (!cancelled) setMessages((prev) => [...prev, { role: "assistant", content: r.insight }]); })
-      .catch((e) => { if (!cancelled) setMessages((prev) => [...prev, { role: "assistant", content: `Error: ${e.message}` }]); })
+      .catch((e) => { if (!cancelled) setMessages((prev) => [...prev, { role: "assistant", content: `Error: ${e instanceof Error ? e.message : String(e)}` }]); })
       .finally(() => { if (!cancelled) setChatLoading(false); });
     return () => { cancelled = true; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -278,7 +278,7 @@ export default function InsightChat({
       const r = await askQuestion(text, passage, bookTitle, author, langRef.current);
       setMessages((prev) => [...prev, { role: "assistant", content: r.answer }]);
     } catch (e: any) {
-      setMessages((prev) => [...prev, { role: "assistant", content: `Error: ${e.message}` }]);
+      setMessages((prev) => [...prev, { role: "assistant", content: `Error: ${e instanceof Error ? e.message : String(e)}` }]);
     } finally {
       setChatLoading(false);
     }

--- a/frontend/src/components/WordActionDrawer.tsx
+++ b/frontend/src/components/WordActionDrawer.tsx
@@ -59,7 +59,8 @@ export default function WordActionDrawer({
         return r.json();
       })
       .then((data) => {
-        const entry = data[0];
+        const entry = data?.[0];
+        if (!entry) { setError("No definition found"); return; }
         setResult({
           word: entry.word,
           phonetic: entry.phonetic || entry.phonetics?.[0]?.text,


### PR DESCRIPTION
Closes #265
Closes #266

## Summary

**#265 — WordActionDrawer: explicit null guard for empty dictionary response**
- The dictionary API could theoretically return `200` with `[]` (empty array)
- Previously `data[0]` was accessed unconditionally; any thrown `TypeError` was silently caught by the catch handler, but the intent was never explicit
- Added `if (!entry) { setError("No definition found"); return; }` for clarity and robustness

**#266 — InsightChat: safe error message extraction in all 3 catch blocks**
- `e.message` is undefined when a non-Error (plain string, object) is thrown, showing `"Error: undefined"` in the chat
- Changed all three catch blocks to `e instanceof Error ? e.message : String(e)`

## Test plan

- `WordActionDrawer.branches.test.tsx` — new test: `setupFetchMock(true, [])` (200 OK, empty array) → shows "No definition found" without crash
- `InsightChat.coverage.test.tsx` — new test: `mockGetInsight.mockRejectedValue("quota exceeded")` (plain string) → chat shows "quota exceeded", not "Error: undefined"
- Full suite: 1480 frontend tests pass
