### PR TITLE
feat: reading statistics dashboard with activity heatmap

### DIFF
--- a/backend/migrations/019_reading_history.sql
+++ b/backend/migrations/019_reading_history.sql
@@ -1,0 +1,12 @@
+-- Append-only log of chapter navigation events.
+-- One row per chapter visited. Used to compute reading streak and activity heatmap.
+-- The existing user_reading_progress table only keeps the latest chapter per book.
+-- This table preserves the full timeline for analytics.
+CREATE TABLE IF NOT EXISTS reading_history (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    book_id       INTEGER NOT NULL,
+    chapter_index INTEGER NOT NULL,
+    read_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS reading_history_user_date ON reading_history(user_id, read_at);

--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -5,6 +5,7 @@ from services.auth import get_current_user, encrypt_api_key, decrypt_api_key
 from services.db import (
     set_user_gemini_key, get_user_by_id, get_reading_progress, upsert_reading_progress,
     get_obsidian_settings, update_obsidian_settings, get_cached_book,
+    log_reading_event, get_user_stats,
 )
 
 router = APIRouter(prefix="/user", tags=["user"])
@@ -67,7 +68,14 @@ async def update_reading_progress(
     if req.chapter_index < 0:
         raise HTTPException(status_code=400, detail="chapter_index must be >= 0")
     await upsert_reading_progress(user["id"], book_id, req.chapter_index)
+    await log_reading_event(user["id"], book_id, req.chapter_index)
     return {"ok": True}
+
+
+@router.get("/stats")
+async def user_stats(user: dict = Depends(get_current_user)):
+    """Return aggregated reading statistics: totals, streak, activity heatmap."""
+    return await get_user_stats(user["id"])
 
 
 @router.get("/obsidian-settings")

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -499,6 +499,99 @@ async def upsert_reading_progress(user_id: int, book_id: int, chapter_index: int
         await db.commit()
 
 
+async def log_reading_event(user_id: int, book_id: int, chapter_index: int) -> None:
+    """Append one row to reading_history for streak / heatmap analytics."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "INSERT INTO reading_history (user_id, book_id, chapter_index) VALUES (?, ?, ?)",
+            (user_id, book_id, chapter_index),
+        )
+        await db.commit()
+
+
+async def get_user_stats(user_id: int) -> dict:
+    """Return aggregated reading statistics for a user."""
+    from datetime import date, timedelta
+
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+
+        # ── Totals ────────────────────────────────────────────────────────────
+        async with db.execute(
+            "SELECT COUNT(DISTINCT book_id) FROM user_reading_progress WHERE user_id=?",
+            (user_id,),
+        ) as cur:
+            books_started = (await cur.fetchone())[0]
+
+        async with db.execute(
+            "SELECT COUNT(*) FROM vocabulary WHERE user_id=?", (user_id,)
+        ) as cur:
+            vocab_words = (await cur.fetchone())[0]
+
+        async with db.execute(
+            "SELECT COUNT(*) FROM annotations WHERE user_id=?", (user_id,)
+        ) as cur:
+            annotations = (await cur.fetchone())[0]
+
+        async with db.execute(
+            "SELECT COUNT(*) FROM book_insights WHERE user_id=?", (user_id,)
+        ) as cur:
+            insights = (await cur.fetchone())[0]
+
+        # ── Activity per day (last 365 days) — union of all event types ──────
+        activity_sql = """
+            SELECT DATE(ts) AS day, COUNT(*) AS cnt FROM (
+                SELECT created_at AS ts FROM vocabulary WHERE user_id=?
+                UNION ALL SELECT created_at FROM annotations WHERE user_id=?
+                UNION ALL SELECT created_at FROM book_insights WHERE user_id=?
+                UNION ALL SELECT read_at FROM reading_history WHERE user_id=?
+            ) WHERE ts >= DATE('now', '-365 days')
+            GROUP BY day ORDER BY day DESC
+        """
+        async with db.execute(activity_sql, (user_id, user_id, user_id, user_id)) as cur:
+            activity_rows = await cur.fetchall()
+
+    activity = [{"date": r["day"], "count": r["cnt"]} for r in activity_rows]
+
+    # ── Streak (consecutive days ending today or yesterday) ───────────────────
+    dates_set = {a["date"] for a in activity}
+    today = date.today().isoformat()
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+
+    streak = 0
+    if today in dates_set or yesterday in dates_set:
+        check = date.today() if today in dates_set else date.today() - timedelta(days=1)
+        while check.isoformat() in dates_set:
+            streak += 1
+            check -= timedelta(days=1)
+
+    # Longest streak in the available data
+    sorted_dates = sorted(dates_set)
+    longest = 0
+    run = 0
+    prev: date | None = None
+    for ds in sorted_dates:
+        d = date.fromisoformat(ds)
+        if prev is None or (d - prev).days == 1:
+            run += 1
+        else:
+            run = 1
+        longest = max(longest, run)
+        prev = d
+
+    return {
+        "totals": {
+            "books_started": books_started,
+            "vocabulary_words": vocab_words,
+            "annotations": annotations,
+            "insights": insights,
+        },
+        "streak": streak,
+        "longest_streak": longest,
+        "activity": activity,
+    }
+
+
 async def list_cached_books() -> list[dict]:
     """Return all cached books (without text field)."""
     async with aiosqlite.connect(DB_PATH) as db:

--- a/backend/services/migrations.py
+++ b/backend/services/migrations.py
@@ -93,6 +93,8 @@ async def run(db_path: str) -> list[str]:
              "SELECT 1 FROM pragma_table_info('book_insights') WHERE name='context_text'"),
             ("017_vocabulary_lemma_language",
              "SELECT 1 FROM pragma_table_info('vocabulary') WHERE name='lemma'"),
+            ("019_reading_history",
+             "SELECT name FROM sqlite_master WHERE type='table' AND name='reading_history'"),
         ]
         bootstrapped: list[str] = []
         for version, check_sql in bootstrap_checks:

--- a/backend/tests/test_router_stats.py
+++ b/backend/tests/test_router_stats.py
@@ -1,0 +1,160 @@
+"""
+Tests for GET /user/stats and the reading_history logging hook.
+
+Covers:
+- Stats endpoint returns correct totals
+- Reading streak: today, yesterday, gap breaks streak
+- Longest streak calculation
+- Activity heatmap from all event types
+- log_reading_event called on PUT /user/reading-progress
+- Zero state: fresh user returns zeros
+"""
+
+import pytest
+from datetime import date, timedelta
+from services.db import (
+    save_book, upsert_reading_progress, log_reading_event,
+    get_user_stats, save_word, create_annotation, save_insight,
+)
+import aiosqlite
+import services.db as db_module
+
+_BOOK_META = {
+    "title": "Test Book",
+    "authors": ["Author"],
+    "languages": ["en"],
+    "subjects": [],
+    "download_count": 0,
+    "cover": "",
+}
+BOOK_ID = 5001
+
+
+# ── Zero state ────────────────────────────────────────────────────────────────
+
+async def test_stats_fresh_user_returns_zeros(client, tmp_db):
+    resp = await client.get("/api/user/stats")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["totals"]["books_started"] == 0
+    assert data["totals"]["vocabulary_words"] == 0
+    assert data["totals"]["annotations"] == 0
+    assert data["totals"]["insights"] == 0
+    assert data["streak"] == 0
+    assert data["longest_streak"] == 0
+    assert data["activity"] == []
+
+
+# ── Totals ────────────────────────────────────────────────────────────────────
+
+async def test_stats_totals_reflect_user_data(client, test_user, tmp_db):
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    await upsert_reading_progress(test_user["id"], BOOK_ID, 2)
+    await save_word(test_user["id"], "serendipity", BOOK_ID, 0, "It was serendipity.")
+    await save_word(test_user["id"], "ephemeral", BOOK_ID, 1, "An ephemeral moment.")
+    await create_annotation(test_user["id"], BOOK_ID, 0, "A sentence.", "A note.", "yellow")
+
+    resp = await client.get("/api/user/stats")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["totals"]["books_started"] == 1
+    assert data["totals"]["vocabulary_words"] == 2
+    assert data["totals"]["annotations"] == 1
+    assert data["totals"]["insights"] == 0
+
+
+# ── Streak calculation ────────────────────────────────────────────────────────
+
+async def _insert_history_at(db_path, user_id, book_id, day_offset):
+    """Insert a reading_history row with a synthetic timestamp."""
+    target_date = date.today() - timedelta(days=day_offset)
+    ts = f"{target_date.isoformat()} 12:00:00"
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT INTO reading_history (user_id, book_id, chapter_index, read_at) VALUES (?, ?, 0, ?)",
+            (user_id, book_id, ts),
+        )
+        await db.commit()
+
+
+async def test_streak_today_only(client, test_user, tmp_db):
+    await _insert_history_at(tmp_db, test_user["id"], BOOK_ID, 0)  # today
+    resp = await client.get("/api/user/stats")
+    assert resp.json()["streak"] == 1
+
+
+async def test_streak_yesterday_only(client, test_user, tmp_db):
+    await _insert_history_at(tmp_db, test_user["id"], BOOK_ID, 1)  # yesterday
+    resp = await client.get("/api/user/stats")
+    assert resp.json()["streak"] == 1
+
+
+async def test_streak_consecutive_days(client, test_user, tmp_db):
+    for offset in range(5):  # today, yesterday, 2 days ago, 3, 4
+        await _insert_history_at(tmp_db, test_user["id"], BOOK_ID, offset)
+    resp = await client.get("/api/user/stats")
+    assert resp.json()["streak"] == 5
+
+
+async def test_streak_gap_breaks_streak(client, test_user, tmp_db):
+    # Today and 2 days ago — missing yesterday → streak = 1
+    await _insert_history_at(tmp_db, test_user["id"], BOOK_ID, 0)
+    await _insert_history_at(tmp_db, test_user["id"], BOOK_ID, 2)
+    resp = await client.get("/api/user/stats")
+    assert resp.json()["streak"] == 1
+
+
+async def test_streak_zero_when_last_activity_was_two_days_ago(client, test_user, tmp_db):
+    await _insert_history_at(tmp_db, test_user["id"], BOOK_ID, 2)
+    resp = await client.get("/api/user/stats")
+    assert resp.json()["streak"] == 0
+
+
+async def test_longest_streak(client, test_user, tmp_db):
+    # 3-day run 10 days ago, 5-day run 3 days ago (which includes today)
+    for offset in [10, 11, 12]:   # old 3-day run
+        await _insert_history_at(tmp_db, test_user["id"], BOOK_ID, offset)
+    for offset in [0, 1, 2, 3, 4]:   # current 5-day run
+        await _insert_history_at(tmp_db, test_user["id"], BOOK_ID, offset)
+    resp = await client.get("/api/user/stats")
+    data = resp.json()
+    assert data["longest_streak"] == 5
+    assert data["streak"] == 5
+
+
+# ── Activity heatmap ──────────────────────────────────────────────────────────
+
+async def test_activity_includes_vocabulary_events(client, test_user, tmp_db):
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_word(test_user["id"], "loquacious", BOOK_ID, 0, "A loquacious narrator.")
+    resp = await client.get("/api/user/stats")
+    activity = resp.json()["activity"]
+    today = date.today().isoformat()
+    counts = {a["date"]: a["count"] for a in activity}
+    assert today in counts
+    assert counts[today] >= 1
+
+
+# ── Reading progress hook ─────────────────────────────────────────────────────
+
+async def test_progress_update_logs_reading_event(client, test_user, tmp_db):
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    resp = await client.put(f"/api/user/reading-progress/{BOOK_ID}", json={"chapter_index": 3})
+    assert resp.status_code == 200
+
+    # Stats should now show streak = 1 (today has a reading event)
+    stats_resp = await client.get("/api/user/stats")
+    assert stats_resp.json()["streak"] == 1
+    assert stats_resp.json()["totals"]["books_started"] == 1
+
+
+async def test_progress_update_multiple_chapters_all_logged(client, test_user, tmp_db):
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    for ch in range(4):
+        await client.put(f"/api/user/reading-progress/{BOOK_ID}", json={"chapter_index": ch})
+
+    # 4 reading events → activity count for today >= 4
+    resp = await client.get("/api/user/stats")
+    today = date.today().isoformat()
+    activity = {a["date"]: a["count"] for a in resp.json()["activity"]}
+    assert activity.get(today, 0) >= 4

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,0 +1,243 @@
+# Book Reader AI — Feature Roadmap
+
+## Session 3 — 2026-04-22
+
+### Implemented this session
+- [ ] AI Chapter Summary (in progress)
+
+### Proposed (design docs below)
+- [ ] Vocabulary Flashcards / Spaced Repetition System (SRS)
+
+---
+
+## Feature 1: AI Chapter Summary ✅ (implementing now)
+
+### Overview
+When a user wants to recall what happened in a chapter before continuing, they can click "Summarize" in the reader sidebar to get a concise AI-generated summary. Summaries are cached in the database and shared across all users — just like translations.
+
+### User Story
+> "I put down War and Peace for two weeks. I need a quick 30-second refresher on Chapter 12 before I continue."
+
+### Design
+
+**Backend**
+
+New migration `018_chapter_summaries.sql`:
+```sql
+CREATE TABLE IF NOT EXISTS chapter_summaries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    book_id INTEGER NOT NULL,
+    chapter_index INTEGER NOT NULL,
+    model TEXT,
+    content TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(book_id, chapter_index)
+);
+```
+
+New endpoint: `POST /ai/summary`
+```json
+Request:
+{
+  "book_id": 2600,
+  "chapter_index": 12,
+  "chapter_text": "...",
+  "book_title": "War and Peace",
+  "author": "Leo Tolstoy",
+  "chapter_title": "Chapter XII"
+}
+
+Response:
+{
+  "summary": "**Overview**: ...\n\n**Key Events**: ...",
+  "cached": true,
+  "model": "gemini-3.1-flash-lite-preview"
+}
+```
+
+Caching behaviour: If a summary for (book_id, chapter_index) already exists, return it immediately without calling Gemini. First user to read a chapter generates the summary for everyone.
+
+**Uses the queue API key** (no personal key required) — making summaries freely available to all users.
+
+**Frontend**
+
+New "Summary" tab in the reader sidebar (alongside Chat, Notes, Vocab, Translate):
+- Shows a loading skeleton while generating
+- Renders the markdown summary using existing styles
+- "Regenerate" button (admin only) to refresh stale summaries
+
+### Summary Format (Gemini prompt)
+```
+Summarize Chapter {title} of "{book_title}" by {author} in a structured format:
+
+**Overview** (2-3 sentences)
+**Key Events** (3-5 bullet points)  
+**Characters** (who appears and what they do)
+**Themes** (1-2 literary themes or motifs)
+
+Be concise. Focus on plot and character development. No spoilers beyond this chapter.
+```
+
+### Tests
+- Backend: cached vs uncached flow, Gemini mock, 404 for missing book
+- Frontend: render summary, loading state, error state
+
+---
+
+## Feature 2: Vocabulary Flashcards (SRS) — PROPOSAL
+
+### Overview
+Add Anki-style spaced repetition to the vocabulary system. After saving words while reading, users can review them daily with flashcards. The SM-2 algorithm schedules each card based on how well the user remembered it, surfacing cards at the optimal moment for retention.
+
+### Inspiration
+- **Anki** — gold standard for SRS
+- **Duolingo** — gamified daily review streaks
+- **Readwise** — review your highlights/vocabulary daily
+
+### User Story
+> "I've been reading German classics and saving words I don't know. I want a 5-minute daily review session so I actually remember them."
+
+### Database Schema (PROPOSAL — no breaking changes, additive only)
+
+```sql
+CREATE TABLE flashcard_reviews (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    vocabulary_id INTEGER NOT NULL REFERENCES vocabulary(id) ON DELETE CASCADE,
+    -- SM-2 fields
+    interval_days INTEGER NOT NULL DEFAULT 1,
+    ease_factor REAL NOT NULL DEFAULT 2.5,
+    repetitions INTEGER NOT NULL DEFAULT 0,
+    due_date DATE NOT NULL DEFAULT (date('now')),
+    last_reviewed_at TIMESTAMP,
+    UNIQUE(user_id, vocabulary_id)
+);
+CREATE INDEX flashcard_reviews_due ON flashcard_reviews(user_id, due_date);
+```
+
+### SM-2 Algorithm (per review)
+```
+grade: 0-5 (0=blackout, 3=correct with difficulty, 5=perfect)
+
+if grade < 3:
+    interval = 1 day (reset)
+    repetitions = 0
+else:
+    if repetitions == 0: interval = 1
+    elif repetitions == 1: interval = 6
+    else: interval = round(interval * ease_factor)
+    repetitions += 1
+
+ease_factor = max(1.3, ease_factor + 0.1 - (5-grade)*(0.08 + (5-grade)*0.02))
+due_date = today + interval
+```
+
+### API Endpoints (PROPOSAL)
+```
+GET  /vocabulary/flashcards/due       → [{vocab_id, word, lemma, occurrences, definition}, ...]
+POST /vocabulary/flashcards/{id}/review  body:{grade:0-5} → {next_due, interval, ease_factor}
+GET  /vocabulary/flashcards/stats     → {total, due_today, streak, reviewed_today}
+```
+
+### Frontend (PROPOSAL)
+- New route `/vocabulary/flashcards`
+- Card front: word + example sentence from reading context
+- Card back: definition (Wiktionary) + language + occurrences in books read
+- Grade buttons: **Again** (0) | **Hard** (2) | **Good** (3) | **Easy** (5)
+- Progress bar: reviewed_today / due_today
+- Daily streak counter
+- Confetti on completing all due cards
+
+### Pros
+- Dramatically increases vocabulary retention (proven pedagogy)
+- Natural extension of existing vocabulary system
+- No third-party dependency (SM-2 is simple math)
+- Works offline (due cards can be fetched once, graded locally, synced later)
+
+### Cons / Risks
+- Adds a daily habit loop — if we don't polish the UX, users won't return
+- Cold-start: new words must be "seen" once before SRS kicks in
+- Definition fetch latency on first review (Wiktionary API)
+- If a word is deleted, its review history should cascade-delete
+
+### Proposal Decision
+**Awaiting approval.** Implementation would take ~6 hours (backend + frontend + tests).
+
+---
+
+## Feature 3: Reading Statistics Dashboard ✅ (implementing now)
+
+### Overview
+A lightweight personal stats view shown on the Profile page. Shows how much a user has read, saved, and annotated — with a GitHub-style activity heatmap and a daily reading streak.
+
+**Key insight:** `vocabulary.created_at`, `annotations.created_at`, and `book_insights.created_at` already exist in the DB, so the heatmap has real historical data from day 1. A new `reading_history` table adds chapter navigation events going forward.
+
+### User Story
+> "I've been using the app for two months. I want to see how consistent I've been, whether my vocabulary is growing, and which books I've spent the most time with."
+
+### Design
+
+**New DB table — `reading_history`** (migration 019, additive only)
+```sql
+CREATE TABLE reading_history (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    book_id      INTEGER NOT NULL,
+    chapter_index INTEGER NOT NULL,
+    read_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX reading_history_user_date ON reading_history(user_id, read_at);
+```
+
+**Hook:** `PUT /user/reading-progress/{book_id}` calls `log_reading_event()` after upserting progress — one log row per chapter navigation. Lightweight, append-only.
+
+**New endpoint: `GET /user/stats`**
+```json
+{
+  "totals": {
+    "books_started": 12,
+    "vocabulary_words": 247,
+    "annotations": 89,
+    "insights": 34
+  },
+  "streak": 7,
+  "longest_streak": 14,
+  "activity": [
+    { "date": "2026-04-22", "count": 5 },
+    { "date": "2026-04-21", "count": 3 }
+  ]
+}
+```
+
+**Activity data** aggregates across all event types:
+```sql
+SELECT DATE(ts) as day, COUNT(*) as events FROM (
+    SELECT created_at AS ts FROM vocabulary WHERE user_id=?
+    UNION ALL SELECT created_at FROM annotations WHERE user_id=?
+    UNION ALL SELECT created_at FROM book_insights WHERE user_id=?
+    UNION ALL SELECT read_at FROM reading_history WHERE user_id=?
+) WHERE ts >= DATE('now', '-365 days') GROUP BY day ORDER BY day DESC
+```
+
+**Streak algorithm** (Python):
+- Count consecutive days ending today (or yesterday if today has no activity yet)
+
+**Frontend — `ReadingStats.tsx` component**
+- 4 stat cards: Books / Words / Annotations / Insights
+- Streak badge with 🔥 icon
+- Activity heatmap: 52-week × 7-day CSS grid, 4 intensity levels
+- Embedded in `/profile` page (below preferences, above sign-out)
+
+### Tests
+- Backend: streak calculation edge cases (gap, today, yesterday, zero), stat totals, logging hook
+- Frontend: renders stats, heatmap cell colors, zero-state
+
+### Estimated effort: 3 hours
+
+---
+
+## Feature 4: Chapter Comprehension Quiz (FUTURE)
+
+After reading a chapter, ask 3-5 AI-generated multiple-choice questions to test comprehension. Results stored per user/chapter.
+
+Estimated: 4 hours. Requires approval for DB schema.

--- a/frontend/src/__tests__/ProfilePage.coverage.test.tsx
+++ b/frontend/src/__tests__/ProfilePage.coverage.test.tsx
@@ -41,6 +41,7 @@ jest.mock("@/lib/api", () => ({
     obsidian_path: "Notes/Books",
   }),
   saveObsidianSettings: jest.fn().mockResolvedValue({}),
+  getUserStats: jest.fn().mockResolvedValue({ totals: { books_started: 0, vocabulary_words: 0, annotations: 0, insights: 0 }, streak: 0, longest_streak: 0, activity: [] }),
 }));
 
 jest.mock("@/lib/settings", () => ({

--- a/frontend/src/__tests__/ProfilePage.coverage2.test.tsx
+++ b/frontend/src/__tests__/ProfilePage.coverage2.test.tsx
@@ -34,6 +34,7 @@ jest.mock("@/lib/api", () => ({
   getMe: jest.fn().mockResolvedValue({ hasGeminiKey: false, role: "user" }),
   getObsidianSettings: jest.fn().mockResolvedValue({ obsidian_repo: "u/v", obsidian_path: "Notes" }),
   saveObsidianSettings: jest.fn().mockResolvedValue({}),
+  getUserStats: jest.fn().mockResolvedValue({ totals: { books_started: 0, vocabulary_words: 0, annotations: 0, insights: 0 }, streak: 0, longest_streak: 0, activity: [] }),
 }));
 
 jest.mock("@/lib/settings", () => ({

--- a/frontend/src/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/__tests__/ProfilePage.test.tsx
@@ -26,6 +26,7 @@ jest.mock("@/lib/api", () => ({
     obsidian_path: "Notes/Books",
   }),
   saveObsidianSettings: jest.fn().mockResolvedValue({}),
+  getUserStats: jest.fn().mockResolvedValue({ totals: { books_started: 0, vocabulary_words: 0, annotations: 0, insights: 0 }, streak: 0, longest_streak: 0, activity: [] }),
 }));
 
 jest.mock("@/lib/settings", () => ({

--- a/frontend/src/__tests__/ReadingStats.test.tsx
+++ b/frontend/src/__tests__/ReadingStats.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Tests for components/ReadingStats.tsx
+ *
+ * Covers:
+ * - Shows loading skeleton when active=true and fetch pending
+ * - Renders stat cards with correct values
+ * - Shows streak banner when streak > 0
+ * - Hides streak banner when streak = 0
+ * - Activity grid renders correct number of cells
+ * - Zero state (all zeros): no streak banner, cards show 0
+ * - Does not fetch when active=false
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import ReadingStats from "@/components/ReadingStats";
+
+jest.mock("@/lib/api", () => ({
+  getUserStats: jest.fn(),
+}));
+
+import { getUserStats } from "@/lib/api";
+const mockGetStats = getUserStats as jest.Mock;
+
+const STATS_WITH_STREAK = {
+  totals: { books_started: 12, vocabulary_words: 247, annotations: 89, insights: 34 },
+  streak: 7,
+  longest_streak: 14,
+  activity: [
+    { date: "2026-04-22", count: 5 },
+    { date: "2026-04-21", count: 3 },
+    { date: "2026-04-20", count: 1 },
+  ],
+};
+
+const STATS_ZERO = {
+  totals: { books_started: 0, vocabulary_words: 0, annotations: 0, insights: 0 },
+  streak: 0,
+  longest_streak: 0,
+  activity: [],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ── Loading skeleton ───────────────────────────────────────────────────────
+
+test("shows loading skeleton while fetching", () => {
+  mockGetStats.mockImplementation(() => new Promise(() => {})); // never resolves
+  render(<ReadingStats active={true} />);
+  expect(document.querySelector(".animate-pulse")).toBeInTheDocument();
+});
+
+// ── Stat cards ─────────────────────────────────────────────────────────────
+
+test("renders stat cards with correct values", async () => {
+  mockGetStats.mockResolvedValue(STATS_WITH_STREAK);
+  render(<ReadingStats active={true} />);
+
+  await waitFor(() => {
+    expect(screen.getByText("12")).toBeInTheDocument();  // books started
+    expect(screen.getByText("247")).toBeInTheDocument(); // words saved
+    expect(screen.getByText("89")).toBeInTheDocument();  // annotations
+    expect(screen.getByText("34")).toBeInTheDocument();  // insights
+  });
+});
+
+test("renders stat labels", async () => {
+  mockGetStats.mockResolvedValue(STATS_WITH_STREAK);
+  render(<ReadingStats active={true} />);
+
+  await waitFor(() => {
+    expect(screen.getByText("Books started")).toBeInTheDocument();
+    expect(screen.getByText("Words saved")).toBeInTheDocument();
+    expect(screen.getByText("Annotations")).toBeInTheDocument();
+    expect(screen.getByText("Insights")).toBeInTheDocument();
+  });
+});
+
+// ── Streak banner ──────────────────────────────────────────────────────────
+
+test("shows streak banner when streak > 0", async () => {
+  mockGetStats.mockResolvedValue(STATS_WITH_STREAK);
+  render(<ReadingStats active={true} />);
+
+  await waitFor(() => {
+    expect(screen.getByText("7-day reading streak!")).toBeInTheDocument();
+    expect(screen.getByText("Longest: 14 days")).toBeInTheDocument();
+  });
+});
+
+test("hides streak banner when streak = 0", async () => {
+  mockGetStats.mockResolvedValue(STATS_ZERO);
+  render(<ReadingStats active={true} />);
+
+  await waitFor(() => {
+    expect(screen.queryByText(/reading streak/)).not.toBeInTheDocument();
+  });
+});
+
+// ── Zero state ─────────────────────────────────────────────────────────────
+
+test("renders zero values correctly", async () => {
+  mockGetStats.mockResolvedValue(STATS_ZERO);
+  render(<ReadingStats active={true} />);
+
+  await waitFor(() => {
+    // Four "0" stat cards
+    const zeros = screen.getAllByText("0");
+    expect(zeros.length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+// ── Inactive state ─────────────────────────────────────────────────────────
+
+test("does not call API when active=false", async () => {
+  render(<ReadingStats active={false} />);
+  expect(mockGetStats).not.toHaveBeenCalled();
+});
+
+// ── Activity section ───────────────────────────────────────────────────────
+
+test("shows activity heatmap section label", async () => {
+  mockGetStats.mockResolvedValue(STATS_WITH_STREAK);
+  render(<ReadingStats active={true} />);
+
+  await waitFor(() => {
+    expect(screen.getByText("Activity — last year")).toBeInTheDocument();
+  });
+});
+
+test("shows active days count", async () => {
+  mockGetStats.mockResolvedValue(STATS_WITH_STREAK);
+  render(<ReadingStats active={true} />);
+
+  await waitFor(() => {
+    // 3 activity days in mock data
+    expect(screen.getByText("3 active days")).toBeInTheDocument();
+  });
+});
+
+test("shows 0 active days for zero stats", async () => {
+  mockGetStats.mockResolvedValue(STATS_ZERO);
+  render(<ReadingStats active={true} />);
+
+  await waitFor(() => {
+    expect(screen.getByText("0 active days")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { saveGeminiKey, deleteGeminiKey, getMe, getObsidianSettings, saveObsidianSettings } from "@/lib/api";
 import { getSettings, saveSettings, AppSettings } from "@/lib/settings";
+import ReadingStats from "@/components/ReadingStats";
 
 const LANGUAGES = [
   { code: "en", label: "English" },
@@ -464,6 +465,14 @@ export default function ProfilePage() {
             {prefsSaved ? "Saved!" : "Save preferences"}
           </button>
         </section>
+
+        {/* ── Reading Statistics ───────────────────────────────────────────── */}
+        {session?.backendToken && (
+          <section className="bg-white rounded-2xl border border-amber-100 p-6">
+            <h2 className="font-serif text-lg font-semibold text-ink mb-5">Reading Statistics</h2>
+            <ReadingStats active={!!session?.backendToken} />
+          </section>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/ReadingStats.tsx
+++ b/frontend/src/components/ReadingStats.tsx
@@ -1,0 +1,200 @@
+"use client";
+import { useEffect, useState } from "react";
+import { getUserStats, UserStats } from "@/lib/api";
+
+// Build a 365-day grid (52 weeks × 7 days) aligned to Sunday columns.
+function buildGrid(activity: { date: string; count: number }[]): {
+  weeks: { date: string; count: number }[][];
+  months: { label: string; colStart: number }[];
+} {
+  const countMap = new Map(activity.map((a) => [a.date, a.count]));
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  // Start from the Sunday 52 weeks before today
+  const start = new Date(today);
+  start.setDate(start.getDate() - 364 - start.getDay()); // align to Sunday
+
+  const weeks: { date: string; count: number }[][] = [];
+  let current = new Date(start);
+  let week: { date: string; count: number }[] = [];
+  const months: { label: string; colStart: number }[] = [];
+  let lastMonth = -1;
+  let weekIndex = 0;
+
+  while (current <= today) {
+    const iso = current.toISOString().slice(0, 10);
+    const month = current.getMonth();
+    if (month !== lastMonth) {
+      months.push({
+        label: current.toLocaleString("default", { month: "short" }),
+        colStart: weekIndex,
+      });
+      lastMonth = month;
+    }
+    week.push({ date: iso, count: countMap.get(iso) ?? 0 });
+    if (week.length === 7) {
+      weeks.push(week);
+      week = [];
+      weekIndex++;
+    }
+    current.setDate(current.getDate() + 1);
+  }
+  if (week.length > 0) {
+    // Pad the last partial week with empty days
+    while (week.length < 7) week.push({ date: "", count: 0 });
+    weeks.push(week);
+  }
+  return { weeks, months };
+}
+
+function intensityClass(count: number): string {
+  if (count === 0) return "bg-stone-100";
+  if (count <= 2) return "bg-amber-200";
+  if (count <= 5) return "bg-amber-400";
+  if (count <= 10) return "bg-amber-600";
+  return "bg-amber-800";
+}
+
+interface StatCardProps {
+  label: string;
+  value: number;
+  icon: string;
+}
+
+function StatCard({ label, value, icon }: StatCardProps) {
+  return (
+    <div className="bg-white rounded-xl border border-amber-100 px-5 py-4 flex items-center gap-4">
+      <span className="text-2xl">{icon}</span>
+      <div>
+        <p className="text-2xl font-bold text-stone-800">{value.toLocaleString()}</p>
+        <p className="text-xs text-stone-500 mt-0.5">{label}</p>
+      </div>
+    </div>
+  );
+}
+
+interface Props {
+  /** If false, show a skeleton placeholder instead of fetching. */
+  active: boolean;
+}
+
+export default function ReadingStats({ active }: Props) {
+  const [stats, setStats] = useState<UserStats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!active) return;
+    getUserStats()
+      .then(setStats)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [active]);
+
+  if (!active || (loading && !stats)) {
+    return (
+      <div className="space-y-4 animate-pulse">
+        <div className="grid grid-cols-2 gap-3">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="h-20 bg-amber-50 rounded-xl border border-amber-100" />
+          ))}
+        </div>
+        <div className="h-28 bg-amber-50 rounded-xl border border-amber-100" />
+      </div>
+    );
+  }
+
+  if (!stats) return null;
+
+  const { weeks, months } = buildGrid(stats.activity);
+  const totalDays = stats.activity.length;
+  const activeDays = stats.activity.filter((a) => a.count > 0).length;
+
+  return (
+    <div className="space-y-5">
+      {/* Streak banner */}
+      {stats.streak > 0 && (
+        <div className="flex items-center gap-3 bg-amber-50 border border-amber-200 rounded-xl px-5 py-3">
+          <span className="text-2xl">🔥</span>
+          <div>
+            <p className="text-sm font-semibold text-amber-900">
+              {stats.streak}-day reading streak!
+            </p>
+            <p className="text-xs text-amber-600">
+              Longest: {stats.longest_streak} days
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Stat cards */}
+      <div className="grid grid-cols-2 gap-3">
+        <StatCard label="Books started" value={stats.totals.books_started} icon="📖" />
+        <StatCard label="Words saved" value={stats.totals.vocabulary_words} icon="📚" />
+        <StatCard label="Annotations" value={stats.totals.annotations} icon="📝" />
+        <StatCard label="Insights" value={stats.totals.insights} icon="💡" />
+      </div>
+
+      {/* Activity heatmap */}
+      <div className="bg-white border border-amber-100 rounded-xl p-4">
+        <div className="flex items-center justify-between mb-3">
+          <p className="text-sm font-medium text-stone-700">Activity — last year</p>
+          <p className="text-xs text-stone-400">
+            {activeDays} active {activeDays === 1 ? "day" : "days"}
+          </p>
+        </div>
+
+        {/* Month labels */}
+        <div
+          className="grid mb-1"
+          style={{ gridTemplateColumns: `repeat(${weeks.length}, minmax(0, 1fr))` }}
+        >
+          {weeks.map((_, wi) => {
+            const m = months.find((m) => m.colStart === wi);
+            return (
+              <div key={wi} className="text-[9px] text-stone-400 truncate">
+                {m?.label ?? ""}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Grid: columns = weeks, rows = days (Sun–Sat) */}
+        <div
+          className="grid gap-[2px]"
+          style={{ gridTemplateColumns: `repeat(${weeks.length}, minmax(0, 1fr))` }}
+        >
+          {/* Render day-by-day transposed: row = day-of-week, col = week */}
+          {[0, 1, 2, 3, 4, 5, 6].map((dow) => (
+            <div
+              key={dow}
+              className="contents"
+              style={{ gridRow: dow + 1 }}
+            >
+              {weeks.map((week, wi) => {
+                const cell = week[dow];
+                return (
+                  <div
+                    key={`${wi}-${dow}`}
+                    title={cell.date ? `${cell.date}: ${cell.count} event${cell.count !== 1 ? "s" : ""}` : ""}
+                    className={`rounded-[2px] aspect-square ${cell.date ? intensityClass(cell.count) : "bg-transparent"}`}
+                    style={{ gridColumn: wi + 1, gridRow: dow + 1 }}
+                  />
+                );
+              })}
+            </div>
+          ))}
+        </div>
+
+        {/* Legend */}
+        <div className="flex items-center gap-1 mt-2 justify-end">
+          <span className="text-[9px] text-stone-400 mr-1">Less</span>
+          {["bg-stone-100", "bg-amber-200", "bg-amber-400", "bg-amber-600", "bg-amber-800"].map((c) => (
+            <div key={c} className={`w-3 h-3 rounded-[2px] ${c}`} />
+          ))}
+          <span className="text-[9px] text-stone-400 ml-1">More</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -499,6 +499,22 @@ export function saveReadingProgress(bookId: number, chapterIndex: number) {
   });
 }
 
+export interface UserStats {
+  totals: {
+    books_started: number;
+    vocabulary_words: number;
+    annotations: number;
+    insights: number;
+  };
+  streak: number;
+  longest_streak: number;
+  activity: { date: string; count: number }[];
+}
+
+export function getUserStats() {
+  return request<UserStats>("/user/stats");
+}
+
 // ── Annotations ───────────────────────────────────────────────────────────────
 
 export interface Annotation {


### PR DESCRIPTION
## Summary

- Add `GET /user/stats` endpoint returning totals, reading streak, longest streak, and 365-day activity
- New `reading_history` table logs every chapter navigation for forward-looking streak/heatmap data
- Activity heatmap aggregates **existing** data (vocabulary saves, annotations, insights) so users have history from day 1 — no cold-start problem
- Frontend adds a **Reading Statistics** section to the Profile page: stat cards, 🔥 streak banner, and a GitHub-style CSS activity heatmap

## What changed

**Backend**
- `backend/migrations/019_reading_history.sql` — new append-only log table
- `backend/services/db.py` — `log_reading_event()` + `get_user_stats()` with streak algorithm and union activity query
- `backend/routers/user.py` — `GET /user/stats` endpoint + reading event logging hook on `PUT /reading-progress/{book_id}`

**Frontend**
- `frontend/src/components/ReadingStats.tsx` — stat cards, streak banner, 52-week × 7-day CSS activity grid, intensity coloring
- `frontend/src/app/profile/page.tsx` — embeds ReadingStats section at bottom of profile
- `frontend/src/lib/api.ts` — `getUserStats()` + `UserStats` interface

## Test plan

- [x] Backend: 11 new tests in `test_router_stats.py` — zero state, totals, streak (today/yesterday/consecutive/gap/old), longest streak, heatmap from vocabulary events, progress update logging hook
- [x] Frontend: 10 new component tests in `ReadingStats.test.tsx` — loading, cards, streak banner, zero state, inactive=no fetch, heatmap label, active days count
- [x] Existing ProfilePage tests updated to include `getUserStats` mock (3 files)
- [x] Full backend suite: 897 passed
- [x] Full frontend suite: 1492 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
