### PR TITLE
fix: add audio_chunks_cached and audio_cache_mb to admin stats

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -649,10 +649,21 @@ async def stats(_admin: dict = Depends(_require_admin)):
     books = await list_cached_books()
 
     translation_count = 0
+    audio_chunks = 0
+    audio_mb: float = 0.0
     async with aiosqlite.connect(DB_PATH) as db:
         try:
             async with db.execute("SELECT COUNT(*) FROM translations") as cur:
                 translation_count = (await cur.fetchone())[0]
+        except Exception:
+            pass
+        try:
+            async with db.execute(
+                "SELECT COUNT(*), COALESCE(SUM(LENGTH(audio)), 0) FROM audio_cache"
+            ) as cur:
+                row = await cur.fetchone()
+                audio_chunks = row[0]
+                audio_mb = round(row[1] / 1_048_576, 2)
         except Exception:
             pass
 
@@ -662,6 +673,8 @@ async def stats(_admin: dict = Depends(_require_admin)):
         "users_pending": sum(1 for u in users if not u.get("approved")),
         "books_cached": len(books),
         "translations_cached": translation_count,
+        "audio_chunks_cached": audio_chunks,
+        "audio_cache_mb": audio_mb,
     }
 
 

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -388,6 +388,17 @@ async def test_stats(admin_client, admin_db):
     assert data["users_total"] >= 1
 
 
+async def test_stats_includes_audio_fields(admin_client, admin_db):
+    """Regression for #269: stats endpoint must return audio_chunks_cached and audio_cache_mb."""
+    res = await admin_client.get("/api/admin/stats")
+    assert res.status_code == 200
+    data = res.json()
+    assert "audio_chunks_cached" in data, "audio_chunks_cached missing from /admin/stats"
+    assert "audio_cache_mb" in data, "audio_cache_mb missing from /admin/stats"
+    assert isinstance(data["audio_chunks_cached"], int)
+    assert isinstance(data["audio_cache_mb"], (int, float))
+
+
 # ── Retranslate ──────────────────────────────────────────────────────────────
 
 async def test_retranslate_creates_new_translation(admin_client, admin_user):


### PR DESCRIPTION
Closes #269

## Summary

`GET /admin/stats` was missing `audio_chunks_cached` and `audio_cache_mb` from its response. The frontend `Stats` interface declared both fields, and the admin layout's Audio Cache tab used them to show a stats banner — but both values were `undefined`, displaying `"undefined MB"` and `"undefined"` chunks.

**Fix**: query `audio_cache` table for row count and total blob size (in MB) and include both in the stats response.

## Test plan

- New test `test_stats_includes_audio_fields`: calls `GET /admin/stats` and asserts both `audio_chunks_cached` (int) and `audio_cache_mb` (float) are present
- Full backend suite: 875 tests pass
