### PR TITLE
fix: per-language translation delete was deleting all languages

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -352,6 +352,25 @@ async def delete_book_translations(book_id: int, _admin: dict = Depends(_require
     return {"ok": True, "deleted": cursor.rowcount}
 
 
+@router.delete("/translations/{book_id}/{target_language}")
+async def delete_language_translations(
+    book_id: int,
+    target_language: str,
+    _admin: dict = Depends(_require_admin),
+):
+    """Delete all cached translations for one language of a book."""
+    target_language = target_language.lower().split("-")[0]
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "DELETE FROM translations WHERE book_id=? AND target_language=?",
+            (book_id, target_language),
+        )
+        await db.commit()
+    if cursor.rowcount == 0:
+        raise HTTPException(status_code=404, detail="No translations found for this language")
+    return {"ok": True, "deleted": cursor.rowcount}
+
+
 @router.delete("/translations/{book_id}/{chapter_index}/{target_language}")
 async def delete_translation(
     book_id: int,

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -362,6 +362,35 @@ async def test_delete_book_translations_no_translations_returns_404(admin_client
     assert res.status_code == 404
 
 
+async def test_delete_language_translations(admin_client, admin_db):
+    """DELETE /translations/{book_id}/{lang} deletes only that language (issue #271)."""
+    await save_translation(100, 0, "zh", ["中文"])
+    await save_translation(100, 1, "zh", ["中文2"])
+    await save_translation(100, 0, "de", ["Deutsch"])
+    res = await admin_client.delete("/api/admin/translations/100/zh")
+    assert res.status_code == 200
+    assert res.json()["deleted"] == 2
+    # German translation must still exist
+    remaining = await admin_client.get("/api/admin/translations")
+    langs = {t["target_language"] for t in remaining.json() if t["book_id"] == 100}
+    assert "zh" not in langs
+    assert "de" in langs
+
+
+async def test_delete_language_translations_not_found(admin_client):
+    """DELETE /translations/{book_id}/{lang} with no rows returns 404 (issue #271)."""
+    res = await admin_client.delete("/api/admin/translations/99999/zh")
+    assert res.status_code == 404
+
+
+async def test_delete_language_translations_normalizes_language(admin_client, admin_db):
+    """DELETE /translations/{book_id}/{lang} normalises e.g. ZH-CN → zh (issue #271)."""
+    await save_translation(100, 0, "zh", ["中文"])
+    res = await admin_client.delete("/api/admin/translations/100/ZH-CN")
+    assert res.status_code == 200
+    assert res.json()["deleted"] == 1
+
+
 # ── Audio ────────────────────────────────────────────────────────────────────
 
 async def test_get_audio_empty(admin_client, admin_db):

--- a/frontend/src/__tests__/AdminBooksPage.coverage.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.coverage.test.tsx
@@ -497,7 +497,7 @@ describe("AdminBooksPage — retryFailedForLang (line 350)", () => {
 // Line 373: "Delete all" translations per-lang button
 // ─────────────────────────────────────────────────────────────────────────────
 describe("AdminBooksPage — Delete all translations per-lang (line 373)", () => {
-  it("calls DELETE /admin/translations/:id when Delete all confirmed", async () => {
+  it("calls DELETE /admin/translations/:id/:lang when Delete all confirmed", async () => {
     jest.spyOn(window, "confirm").mockReturnValue(true);
     mockAdminFetch
       .mockResolvedValueOnce(SAMPLE_BOOKS)
@@ -519,7 +519,7 @@ describe("AdminBooksPage — Delete all translations per-lang (line 373)", () =>
 
     await waitFor(() =>
       expect(mockAdminFetch).toHaveBeenCalledWith(
-        "/admin/translations/1",
+        "/admin/translations/1/zh",
         expect.objectContaining({ method: "DELETE" }),
       ),
     );

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -464,7 +464,7 @@ export default function BooksPage() {
                                   if (!confirm(`Delete all ${count} cached ${lang} translations for "${b.title}"?`))
                                     return;
                                   act(() =>
-                                    adminFetch(`/admin/translations/${b.id}`, {
+                                    adminFetch(`/admin/translations/${b.id}/${lang}`, {
                                       method: "DELETE",
                                     }),
                                   );


### PR DESCRIPTION
## Summary

- Admin "Delete all" button for a language section was calling `DELETE /translations/{book_id}` — the endpoint that deletes **all** languages for a book
- Added new `DELETE /translations/{book_id}/{target_language}` backend endpoint to delete only one language
- Fixed the frontend to call the correct URL: `/admin/translations/${bookId}/${lang}`

## Impact

A book with zh + de translations — clicking "Delete all" next to zh would silently delete the de translations too. Data loss bug.

## Test plan

- [ ] Three new backend tests: delete-by-language success, 404 on missing, language normalisation (ZH-CN → zh)
- [ ] Updated existing frontend test to assert the correct URL is called
- [ ] Full backend suite: 889 tests pass
- [ ] Full frontend suite: 1490 tests pass

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
