### PR TITLE
fix: discard stale chapter summary on fast chapter navigation

### DIFF
--- a/frontend/src/__tests__/ChapterSummary.test.tsx
+++ b/frontend/src/__tests__/ChapterSummary.test.tsx
@@ -156,6 +156,46 @@ test("resets summary when chapterIndex changes", async () => {
   });
 });
 
+// ── Stale response guard ───────────────────────────────────────────────────
+
+test("stale chapter response does not overwrite the correct summary on fast navigation", async () => {
+  // ch3Promise resolves slowly (simulates an in-flight Gemini call for chapter 3)
+  let resolveCh3!: (v: { summary: string; cached: boolean }) => void;
+  const ch3Promise = new Promise<{ summary: string; cached: boolean }>(
+    (res) => { resolveCh3 = res; }
+  );
+  // ch4 resolves immediately when called
+  const ch4Result = { summary: "Chapter 4 summary text", cached: false };
+
+  mockGenerate
+    .mockImplementationOnce(() => ch3Promise)  // first call: chapter 3
+    .mockResolvedValueOnce(ch4Result);          // second call: chapter 4
+
+  const { rerender } = render(<ChapterSummary {...DEFAULT_PROPS} chapterIndex={3} />);
+
+  // Chapter 3 load is in flight; navigate to chapter 4.
+  // The chapterIndex effect resets loading=false and bumps the generation counter,
+  // which allows chapter 4's auto-load to start and invalidates chapter 3's response.
+  rerender(<ChapterSummary {...DEFAULT_PROPS} chapterIndex={4} />);
+
+  // Chapter 4 summary loads correctly (after the chapterIndex reset unblocks auto-load)
+  await waitFor(() => {
+    expect(screen.getByText(/Chapter 4 summary text/)).toBeInTheDocument();
+  });
+
+  // Now resolve the stale chapter 3 response — generation counter discards it
+  await act(async () => {
+    resolveCh3({ summary: "Chapter 3 stale summary", cached: false });
+    await new Promise(r => setTimeout(r, 0));
+  });
+
+  // Chapter 3's stale content must NOT appear
+  expect(screen.queryByText(/Chapter 3 stale summary/)).not.toBeInTheDocument();
+  expect(screen.getByText(/Chapter 4 summary text/)).toBeInTheDocument();
+  // API called exactly twice (once per chapter)
+  expect(mockGenerate).toHaveBeenCalledTimes(2);
+});
+
 // ── Empty state ────────────────────────────────────────────────────────────
 
 test("shows generate button when not yet loaded and not visible", async () => {

--- a/frontend/src/components/ChapterSummary.tsx
+++ b/frontend/src/components/ChapterSummary.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { generateChapterSummary } from "@/lib/api";
@@ -27,11 +27,10 @@ export default function ChapterSummary({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [cached, setCached] = useState(false);
-
-  // Track which chapter the summary was generated for so we reset on navigation.
-  const [summaryChapter, setSummaryChapter] = useState<number | null>(null);
+  const genRef = useRef(0);
 
   const load = useCallback(async () => {
+    const gen = ++genRef.current;
     setLoading(true);
     setError(null);
     try {
@@ -43,10 +42,11 @@ export default function ChapterSummary({
         author,
         chapterTitle,
       );
+      if (gen !== genRef.current) return;
       setSummary(data.summary);
       setCached(data.cached);
-      setSummaryChapter(chapterIndex);
     } catch (e: unknown) {
+      if (gen !== genRef.current) return;
       const msg = e instanceof Error ? e.message : String(e);
       if (msg.includes("503")) {
         setError("Chapter summaries are not available — the admin hasn't configured a Gemini API key yet.");
@@ -54,19 +54,18 @@ export default function ChapterSummary({
         setError("Failed to generate summary. Please try again.");
       }
     } finally {
-      setLoading(false);
+      if (gen === genRef.current) setLoading(false);
     }
   }, [bookId, chapterIndex, chapterText, bookTitle, author, chapterTitle]);
 
-  // Reset when navigating to a different chapter.
+  // Reset state and invalidate any in-flight load when navigating to a different chapter.
   useEffect(() => {
-    if (summaryChapter !== null && summaryChapter !== chapterIndex) {
-      setSummary(null);
-      setCached(false);
-      setSummaryChapter(null);
-      setError(null);
-    }
-  }, [chapterIndex, summaryChapter]);
+    genRef.current++;
+    setSummary(null);
+    setCached(false);
+    setError(null);
+    setLoading(false);
+  }, [chapterIndex]);
 
   // Auto-load once when the tab becomes visible.
   useEffect(() => {


### PR DESCRIPTION
## Summary

- `ChapterSummary` used a two-effect pattern where a separate `summaryChapter` state tracked which chapter the displayed summary belonged to, and a reset effect cleared state when `summaryChapter !== chapterIndex`
- This pattern had a race condition: if the user navigated to a new chapter while a Gemini API call was in-flight, `loading=true` suppressed the new chapter's auto-load, the stale response would land and briefly display the wrong chapter's summary, and only then would the reset fire and reload the correct one
- Fixed by replacing the two effects with a single `chapterIndex` effect that (1) bumps a `genRef` generation counter to invalidate the in-flight response, and (2) resets `loading=false` to immediately unblock the new chapter's auto-load

## Test plan

- [ ] New regression test: `stale chapter response does not overwrite the correct summary on fast navigation` — controls chapter 3's promise manually, navigates to chapter 4 while chapter 3 is in-flight, verifies chapter 4 loads correctly, then resolves the stale chapter 3 promise and verifies its content is discarded
- [ ] Full frontend suite: 1502 tests pass

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)
