### PR TITLE
fix: atomically write reading progress and analytics event

### DIFF
--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -3,9 +3,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from services.auth import get_current_user, encrypt_api_key, decrypt_api_key
 from services.db import (
-    set_user_gemini_key, get_user_by_id, get_reading_progress, upsert_reading_progress,
+    set_user_gemini_key, get_user_by_id, get_reading_progress,
     get_obsidian_settings, update_obsidian_settings, get_cached_book,
-    log_reading_event, get_user_stats,
+    upsert_progress_and_log_event, get_user_stats,
 )
 
 router = APIRouter(prefix="/user", tags=["user"])
@@ -67,8 +67,7 @@ async def update_reading_progress(
         raise HTTPException(status_code=404, detail="Book not found")
     if req.chapter_index < 0:
         raise HTTPException(status_code=400, detail="chapter_index must be >= 0")
-    await upsert_reading_progress(user["id"], book_id, req.chapter_index)
-    await log_reading_event(user["id"], book_id, req.chapter_index)
+    await upsert_progress_and_log_event(user["id"], book_id, req.chapter_index)
     return {"ok": True}
 
 

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -532,6 +532,31 @@ async def log_reading_event(user_id: int, book_id: int, chapter_index: int) -> N
         await db.commit()
 
 
+async def upsert_progress_and_log_event(
+    user_id: int, book_id: int, chapter_index: int
+) -> None:
+    """Atomically save reading position and append an analytics event.
+
+    Both writes share a single connection and commit so they either both
+    persist or both roll back — eliminating the window where progress is
+    saved but the streak/heatmap event is silently dropped.
+    """
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            """INSERT INTO user_reading_progress (user_id, book_id, chapter_index, last_read)
+               VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+               ON CONFLICT(user_id, book_id) DO UPDATE SET
+                 chapter_index=excluded.chapter_index,
+                 last_read=excluded.last_read""",
+            (user_id, book_id, chapter_index),
+        )
+        await db.execute(
+            "INSERT INTO reading_history (user_id, book_id, chapter_index) VALUES (?, ?, ?)",
+            (user_id, book_id, chapter_index),
+        )
+        await db.commit()
+
+
 async def get_user_stats(user_id: int) -> dict:
     """Return aggregated reading statistics for a user."""
     from datetime import date, timedelta

--- a/backend/tests/test_router_stats.py
+++ b/backend/tests/test_router_stats.py
@@ -148,6 +148,32 @@ async def test_progress_update_logs_reading_event(client, test_user, tmp_db):
     assert stats_resp.json()["totals"]["books_started"] == 1
 
 
+async def test_progress_and_event_written_by_combined_function(test_user, tmp_db):
+    """upsert_progress_and_log_event must atomically save both the bookmark and
+    the analytics event in a single transaction.  This test would fail (ImportError)
+    if the combined function did not exist — i.e. if progress and event were still
+    written via two separate service calls."""
+    from services.db import upsert_progress_and_log_event  # ImportError before the fix
+
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    await upsert_progress_and_log_event(test_user["id"], BOOK_ID, 7)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute(
+            "SELECT chapter_index FROM user_reading_progress WHERE user_id=? AND book_id=?",
+            (test_user["id"], BOOK_ID),
+        ) as cur:
+            progress_row = await cur.fetchone()
+        async with db.execute(
+            "SELECT count(*) FROM reading_history WHERE user_id=? AND book_id=?",
+            (test_user["id"], BOOK_ID),
+        ) as cur:
+            event_count = (await cur.fetchone())[0]
+
+    assert progress_row is not None and progress_row[0] == 7
+    assert event_count == 1, "Analytics event must be saved in the same transaction as progress"
+
+
 async def test_progress_update_multiple_chapters_all_logged(client, test_user, tmp_db):
     await save_book(BOOK_ID, _BOOK_META, "text")
     for ch in range(4):


### PR DESCRIPTION
## Summary

- `PUT /api/user/reading-progress/{book_id}` was calling `upsert_reading_progress` then `log_reading_event` as two separate DB operations, each opening its own connection and committing independently
- If the server was interrupted between the two `await`s (crash, OOM, DB error), reading progress would be persisted but the analytics event (used for streak and heatmap) would be silently dropped
- Fixed by introducing `upsert_progress_and_log_event` in `services/db.py` — a single function that opens one SQLite connection and commits both the progress upsert and the history insert in one atomic transaction

## Test plan

- [ ] New regression test: `test_progress_and_event_written_by_combined_function` — imports `upsert_progress_and_log_event` (ImportError before fix) and verifies both `user_reading_progress` and `reading_history` are saved in one call
- [ ] Full backend suite: 900 tests pass

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)
