### PR TITLE
fix: use book language as source for Obsidian annotation translations

### DIFF
--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -295,6 +295,7 @@ async def export_obsidian(
         ]
         connected = _find_connected_books(bid, all_vocab)
         title = book.get("title", f"Book {bid}") if book else f"Book {bid}"
+        book_lang = (book.get("languages") or ["en"])[0] if book else "en"
 
         # Translate annotation quotes (capped at 10, parallelized with semaphore)
         ann_translations: dict[int, str] = {}
@@ -302,7 +303,7 @@ async def export_obsidian(
         async def _translate_one(ann: dict) -> tuple[int, str]:
             async with sem:
                 translated = await translate_text(
-                    ann["sentence_text"], "en", req.target_language or "zh"
+                    ann["sentence_text"], book_lang, req.target_language or "zh"
                 )
                 return ann["id"], translated[0] if translated else ""
         results = await asyncio.gather(

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -337,3 +337,46 @@ def test_build_book_markdown_format():
 
     # Insight without context skips callout
     assert "**Q:** Book theme?" in content
+
+
+async def test_export_annotation_translation_uses_book_language(client, test_user):
+    """Regression for #285: annotation translations must use the book's actual source
+    language, not hardcoded 'en'.  Before the fix, exporting a German book always
+    passed source='en' to translate_text, producing wrong translations."""
+    german_meta = {
+        **_BOOK_META,
+        "title": "Faust",
+        "authors": ["Goethe"],
+        "languages": ["de"],  # German book
+    }
+    german_book_id = 9099
+    await save_book(german_book_id, german_meta, "text")
+    await save_word(test_user["id"], "Mephisto", german_book_id, 0, "Mephisto erschien.")
+    enc_token = encrypt_api_key("ghp_test_token")
+    await update_obsidian_settings(
+        test_user["id"], enc_token, "user/obsidian-notes",
+        "All Notes/002 Literature Notes/000 Books",
+    )
+
+    from services.db import create_annotation
+    await create_annotation(test_user["id"], german_book_id, 0, "Mephisto erschien.", "A note.", "yellow")
+
+    translate_calls: list[tuple] = []
+
+    async def spy_translate(text, src, tgt, **kwargs):
+        translate_calls.append((src, tgt))
+        return []
+
+    with patch("routers.vocabulary._github_put", new_callable=AsyncMock, return_value="https://url"), \
+         patch("routers.vocabulary.translate_text", side_effect=spy_translate):
+        resp = await client.post("/api/vocabulary/export/obsidian",
+                                 json={"book_id": german_book_id, "target_language": "zh"})
+
+    assert resp.status_code == 200
+    # All translation calls must use "de" as source, not the hardcoded "en"
+    assert translate_calls, "translate_text should have been called for the annotation"
+    for src, tgt in translate_calls:
+        assert src == "de", (
+            f"translate_text called with source={src!r} but book language is 'de'; "
+            "source language must not be hardcoded to 'en'"
+        )


### PR DESCRIPTION
## Summary

- `POST /vocabulary/export/obsidian` translates annotation sentences to the user's target language before embedding them in Obsidian markdown notes
- The source language was hardcoded to `"en"`, so users exporting notes from a German, French, Latin, or other non-English book would get garbled translations — the service was told the input was English when it was actually in the book's language
- Fixed by deriving `book_lang` from the book's `languages` metadata field and passing it as the source language to `translate_text`

## Test plan

- [ ] New regression test: `test_export_annotation_translation_uses_book_language` — creates a German book (`languages: ["de"]`), saves an annotation, exports to Obsidian, and verifies every `translate_text` call uses `source="de"` (not `source="en"`)
- [ ] Full backend suite: 905 tests pass

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)
