### PR TITLE
feat(ux-008): Home dashboard — stats strip, continue reading, greeting

### DIFF
--- a/frontend/e2e/home.spec.ts
+++ b/frontend/e2e/home.spec.ts
@@ -15,7 +15,7 @@ test("home page renders header and search input", async ({ page }) => {
   await expect(page.getByPlaceholder(/Search by title or author/)).toBeVisible();
 });
 
-test("Your Library shows books from localStorage recentBooks", async ({ page }) => {
+test("Home tab shows books from localStorage recentBooks", async ({ page }) => {
   // Seed a recent book in localStorage (simulates a book the user has opened)
   await page.goto("/");
   await page.evaluate((book) => {
@@ -25,8 +25,8 @@ test("Your Library shows books from localStorage recentBooks", async ({ page }) 
   }, MOCK_BOOK);
   await page.reload();
 
-  // Click the Library tab to ensure it's active
-  await page.getByRole("button", { name: "Your Library" }).click();
+  // Click the Home tab to ensure it's active
+  await page.getByRole("button", { name: "Home" }).click();
   await expect(page.getByText("Pride and Prejudice").first()).toBeVisible();
   await expect(page.getByText(/Ch\. 3/)).toBeVisible(); // badge with chapter
 });
@@ -62,14 +62,10 @@ test("clicking a library book navigates to reader page", async ({ page }) => {
   }, MOCK_BOOK);
   await page.reload();
 
-  // Explicitly open the Library tab in case the session effect flipped to Discover
-  await page.getByRole("button", { name: "Your Library" }).click();
-  // Click the book card — this opens the detail modal
-  const bookCard = page.getByRole("button").filter({ hasText: "Jane Austen" });
-  await expect(bookCard).toBeVisible();
-  await bookCard.click();
-  // Click the CTA in the modal to navigate
-  await page.getByRole("button", { name: /Continue Reading|Start Reading/ }).click();
+  // Explicitly open the Home tab in case the session effect flipped to Discover
+  await page.getByRole("button", { name: "Home" }).click();
+  // The Continue Reading button at the top navigates directly to the reader
+  await page.getByRole("button", { name: "Continue reading" }).click();
   await page.waitForURL(/\/reader\/1342/);
   expect(page.url()).toContain("/reader/1342");
 });

--- a/frontend/e2e/modal.spec.ts
+++ b/frontend/e2e/modal.spec.ts
@@ -39,8 +39,9 @@ test("modal shows Continue Reading for a book in the library", async ({ page }) 
   }, MOCK_BOOK);
   await page.reload();
 
-  await page.getByRole("button", { name: "Your Library" }).click();
-  const bookCard = page.getByRole("button").filter({ hasText: "Jane Austen" });
+  await page.getByRole("button", { name: "Home" }).click();
+  // Use data-testid to target the grid BookCard, not the Continue Reading banner
+  const bookCard = page.getByTestId("book-card").filter({ hasText: "Jane Austen" });
   await bookCard.click();
 
   await expect(page.getByRole("button", { name: /Continue Reading.*Ch\. 4/ })).toBeVisible();

--- a/frontend/e2e/reader.spec.ts
+++ b/frontend/e2e/reader.spec.ts
@@ -153,8 +153,8 @@ test("Your Library shows chapter badge from recent-read data", async ({ page }) 
   });
   await page.reload();
 
-  // Click the Library tab to ensure it's active
-  await page.getByRole("button", { name: "Your Library" }).click();
+  // Click the Home tab to ensure it's active
+  await page.getByRole("button", { name: "Home" }).click();
   // Badge format: "Ch. 5 · just now" (1-indexed display)
   await expect(page.getByText(/Ch\. 5/)).toBeVisible();
 });

--- a/frontend/src/__tests__/HomePage.branches.test.tsx
+++ b/frontend/src/__tests__/HomePage.branches.test.tsx
@@ -35,6 +35,7 @@ jest.mock("@/lib/api", () => ({
   getMe: (...args: unknown[]) => mockGetMe(...args),
   searchBooks: (...args: unknown[]) => mockSearchBooks(...args),
   getReadingProgress: (...args: unknown[]) => mockGetReadingProgress(...args),
+  getUserStats: () => Promise.resolve({ streak: 0, longest_streak: 0, totals: { books_started: 0, vocabulary_words: 0, annotations: 0, insights: 0 }, activity: [] }),
 }));
 
 const mockGetRecentBooks = jest.fn();
@@ -148,9 +149,8 @@ describe("HomePage — timeAgo d ago branch (line 35)", () => {
     await act(flushPromises);
     await act(flushPromises);
 
-    // Badge should show "2d ago" (or similar)
-    const badge = screen.getByText(/\dd ago/i);
-    expect(badge).toBeInTheDocument();
+    // Badge should show "2d ago" (or similar) — appears in both Continue Reading card and book grid
+    expect(screen.getAllByText(/\dd ago/i).length).toBeGreaterThan(0);
   });
 
   it("shows 'just now' for books read less than 1 minute ago", async () => {
@@ -176,7 +176,7 @@ describe("HomePage — timeAgo d ago branch (line 35)", () => {
     await act(flushPromises);
     await act(flushPromises);
 
-    expect(screen.getByText(/just now/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/just now/i).length).toBeGreaterThan(0);
   });
 
   it("shows 'h ago' for books read 2 hours ago", async () => {
@@ -202,7 +202,7 @@ describe("HomePage — timeAgo d ago branch (line 35)", () => {
     await act(flushPromises);
     await act(flushPromises);
 
-    expect(screen.getByText(/2h ago/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/2h ago/i).length).toBeGreaterThan(0);
   });
 });
 

--- a/frontend/src/__tests__/HomePage.test.tsx
+++ b/frontend/src/__tests__/HomePage.test.tsx
@@ -24,12 +24,14 @@ const mockGetPopularBooks = jest.fn();
 const mockGetMe = jest.fn();
 const mockSearchBooks = jest.fn();
 const mockGetReadingProgress = jest.fn();
+const mockGetUserStats = jest.fn();
 
 jest.mock("@/lib/api", () => ({
   getPopularBooks: (...args: unknown[]) => mockGetPopularBooks(...args),
   getMe: (...args: unknown[]) => mockGetMe(...args),
   searchBooks: (...args: unknown[]) => mockSearchBooks(...args),
   getReadingProgress: (...args: unknown[]) => mockGetReadingProgress(...args),
+  getUserStats: (...args: unknown[]) => mockGetUserStats(...args),
 }));
 
 // ─── @/lib/recentBooks ───────────────────────────────────────────────────────
@@ -111,6 +113,7 @@ beforeEach(() => {
   mockGetPopularBooks.mockResolvedValue(makePopularResponse());
   mockSearchBooks.mockResolvedValue({ books: [] });
   mockGetReadingProgress.mockResolvedValue([]);
+  mockGetUserStats.mockResolvedValue({ streak: 0, longest_streak: 0, totals: { books_started: 0, vocabulary_words: 0, annotations: 0, insights: 0 }, activity: [] });
   mockUseSession.mockReturnValue({ data: null, status: "unauthenticated" });
 });
 
@@ -153,7 +156,7 @@ describe("HomePage — initial render", () => {
 
   it("renders Library and Discover tab buttons", async () => {
     await renderHome();
-    expect(screen.getByRole("button", { name: /Your Library/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Home/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Discover/i })).toBeInTheDocument();
   });
 });
@@ -256,14 +259,15 @@ describe("HomePage — Library tab with books", () => {
 
   it("shows library books when recent books exist", async () => {
     await renderHome();
-    expect(screen.getByText("Moby Dick")).toBeInTheDocument();
+    // Moby Dick appears in Continue Reading card + grid; Hamlet appears in grid only
+    expect(screen.getAllByText("Moby Dick").length).toBeGreaterThan(0);
     expect(screen.getByText("Hamlet")).toBeInTheDocument();
   });
 
   it("shows Library tab active when recent books exist", async () => {
     await renderHome();
     // Library tab is active by default when books exist
-    expect(screen.getByText("Moby Dick")).toBeInTheDocument();
+    expect(screen.getAllByText("Moby Dick").length).toBeGreaterThan(0);
   });
 
   it("shows book count badge in Library tab", async () => {
@@ -274,14 +278,15 @@ describe("HomePage — Library tab with books", () => {
   it("clicking a book card opens BookDetailModal", async () => {
     const user = userEvent.setup();
     await renderHome();
-    await user.click(screen.getByText("Moby Dick"));
+    // Use Hamlet (grid-only, single occurrence) to avoid the Continue Reading card
+    await user.click(screen.getByText("Hamlet"));
     expect(await screen.findByTestId("book-detail-modal")).toBeInTheDocument();
   });
 
   it("closing BookDetailModal removes it", async () => {
     const user = userEvent.setup();
     await renderHome();
-    await user.click(screen.getByText("Moby Dick"));
+    await user.click(screen.getByText("Hamlet"));
     await user.click(await screen.findByRole("button", { name: "Close" }));
     expect(screen.queryByTestId("book-detail-modal")).not.toBeInTheDocument();
   });
@@ -289,9 +294,9 @@ describe("HomePage — Library tab with books", () => {
   it("clicking Read in modal navigates to reader (book in library)", async () => {
     const user = userEvent.setup();
     await renderHome();
-    await user.click(screen.getByText("Moby Dick"));
+    await user.click(screen.getByText("Hamlet"));
     await user.click(await screen.findByRole("button", { name: "Read" }));
-    expect(mockPush).toHaveBeenCalledWith("/reader/1");
+    expect(mockPush).toHaveBeenCalledWith("/reader/2");
   });
 
   it("shows 'Your library is empty' message when no recent books", async () => {
@@ -304,7 +309,7 @@ describe("HomePage — Library tab with books", () => {
     await act(flushPromises);
     // Tab should switch to discover automatically, but manual click to Library shows empty
     // Switch to library tab
-    await userEvent.click(screen.getByRole("button", { name: /Your Library/i }));
+    await userEvent.click(screen.getByRole("button", { name: /Home/i }));
     expect(screen.getByText("Your library is empty")).toBeInTheDocument();
   });
 
@@ -317,7 +322,7 @@ describe("HomePage — Library tab with books", () => {
     const user = userEvent.setup();
     render(<Home />);
     await act(flushPromises);
-    await user.click(screen.getByRole("button", { name: /Your Library/i }));
+    await user.click(screen.getByRole("button", { name: /Home/i }));
     await user.click(screen.getByRole("button", { name: "Discover Books" }));
     expect(screen.getByRole("button", { name: /Search/i })).toBeInTheDocument();
   });
@@ -499,11 +504,11 @@ describe("HomePage — tab switching", () => {
   it("clicking Library tab shows library content", async () => {
     const user = userEvent.setup();
     await renderHome();
-    await user.click(screen.getByRole("button", { name: /Your Library/i }));
+    await user.click(screen.getByRole("button", { name: /Home/i }));
     // Library tab is now active; heading or empty state visible
     expect(
       screen.getByText("Your library is empty") ||
-      screen.queryByText(/Your Library/i)
+      screen.queryByText(/Home/i)
     ).toBeTruthy();
   });
 });
@@ -513,5 +518,69 @@ describe("HomePage — unauthenticated always sees discover", () => {
     await renderHome();
     // Search section should be visible (discover tab is active)
     expect(screen.getByRole("heading", { name: "Search" })).toBeInTheDocument();
+  });
+});
+
+describe("HomePage — Home dashboard (UX-008)", () => {
+  const RECENT_BOOKS = [
+    { id: 1, title: "Moby Dick", authors: ["Melville"], languages: ["en"], lastChapter: 2, lastRead: Date.now() - 60000 },
+    { id: 2, title: "Hamlet", authors: ["Shakespeare"], languages: ["en"], lastChapter: 0, lastRead: Date.now() - 3600000 },
+  ];
+
+  beforeEach(() => {
+    mockGetRecentBooks.mockReturnValue(RECENT_BOOKS);
+    mockUseSession.mockReturnValue({
+      data: { backendToken: "tok", backendUser: { id: 1, name: "Alice Smith", picture: "" } },
+      status: "authenticated",
+    });
+    mockGetReadingProgress.mockResolvedValue([]);
+  });
+
+  it("shows personalized greeting with first name", async () => {
+    await renderHome();
+    expect(screen.getByText(/Welcome back, Alice/i)).toBeInTheDocument();
+  });
+
+  it("shows Continue Reading card for most recent book", async () => {
+    await renderHome();
+    expect(screen.getByText("Continue Reading")).toBeInTheDocument();
+    // Moby Dick is recentBooks[0] — appears in both the Continue Reading card and the grid
+    expect(screen.getAllByText("Moby Dick").length).toBeGreaterThan(1);
+  });
+
+  it("clicking Continue Reading card navigates directly to reader", async () => {
+    const user = userEvent.setup();
+    await renderHome();
+    // The Continue Reading button is the first interactive element with the book title
+    const continueBtn = screen.getByRole("button", { name: /Continue Reading/i });
+    await user.click(continueBtn);
+    expect(mockPush).toHaveBeenCalledWith("/reader/1");
+  });
+
+  it("shows stats strip with user progress when stats loaded", async () => {
+    mockGetUserStats.mockResolvedValue({
+      streak: 5,
+      longest_streak: 10,
+      totals: { books_started: 3, vocabulary_words: 42, annotations: 7, insights: 2 },
+      activity: [],
+    });
+    await renderHome();
+    await waitFor(() => expect(screen.getByText("Your Progress")).toBeInTheDocument());
+    expect(screen.getByText("5")).toBeInTheDocument(); // streak count
+    expect(screen.getByText("3")).toBeInTheDocument(); // books started
+  });
+
+  it("'Show activity' toggle reveals and hides the heatmap", async () => {
+    await renderHome();
+    await waitFor(() => expect(screen.getByText("Your Progress")).toBeInTheDocument());
+    const toggle = screen.getByRole("button", { name: /Show activity/i });
+    await userEvent.click(toggle);
+    expect(screen.getByRole("button", { name: /Hide activity/i })).toBeInTheDocument();
+  });
+
+  it("tab is labelled Home not Your Library", async () => {
+    await renderHome();
+    expect(screen.getByRole("button", { name: /^Home/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Your Library/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { searchBooks, getPopularBooks, getMe, getReadingProgress, BookMeta } from "@/lib/api";
+import { searchBooks, getPopularBooks, getMe, getReadingProgress, getUserStats, UserStats, BookMeta } from "@/lib/api";
 import { getRecentBooks, removeRecentBook, RecentBook } from "@/lib/recentBooks";
 import BookCard from "@/components/BookCard";
 import BookDetailModal from "@/components/BookDetailModal";
-import { BookCoverPlaceholderIcon } from "@/components/Icons";
+import ReadingStats from "@/components/ReadingStats";
+import { FireIcon, ArrowRightIcon, BookOpenIcon, NoteIcon, InsightIcon, VocabIcon, BookCoverPlaceholderIcon } from "@/components/Icons";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 
@@ -46,8 +47,10 @@ export default function Home() {
   const [isAdmin, setIsAdmin] = useState(false);
   const [selectedBook, setSelectedBook] = useState<BookMeta | null>(null);
 
-  // ── Library state ──
+  // ── Library / Home state ──
   const [recentBooks, setRecentBooks] = useState<RecentBook[]>([]);
+  const [userStats, setUserStats] = useState<UserStats | null>(null);
+  const [statsExpanded, setStatsExpanded] = useState(false);
 
   useEffect(() => {
     const books = getRecentBooks();
@@ -66,6 +69,7 @@ export default function Home() {
     getMe().then((me) => {
       setIsAdmin(me.role === "admin");
     }).catch(() => {});
+    getUserStats().then(setUserStats).catch(() => {});
     getReadingProgress().then((entries) => {
       const local = getRecentBooks();
       let changed = false;
@@ -198,7 +202,7 @@ export default function Home() {
       <nav className="border-b border-amber-200 bg-white/40 backdrop-blur">
         <div className="max-w-5xl mx-auto px-4 md:px-6 flex gap-1 items-center overflow-x-auto scrollbar-none" style={{ scrollbarWidth: "none" }}>
           {([
-            { key: "library" as Tab, label: "Your Library", count: recentBooks.length || undefined },
+            { key: "library" as Tab, label: "Home", count: recentBooks.length || undefined },
             { key: "discover" as Tab, label: "Discover" },
           ]).map(({ key, label, count }) => (
             <button
@@ -251,25 +255,132 @@ export default function Home() {
 
       <div className="max-w-5xl mx-auto px-4 md:px-6 py-6 md:py-8">
 
-        {/* ════════════ Library Tab ════════════ */}
+        {/* ════════════ Home Tab ════════════ */}
         {tab === "library" && (
-          <>
+          <div className="space-y-8">
+
+            {/* Greeting */}
+            {status === "authenticated" && session?.backendUser?.name && (
+              <p className="font-serif text-xl text-ink">
+                Welcome back, {session.backendUser.name.split(" ")[0]}
+              </p>
+            )}
+
+            {/* Continue Reading */}
+            {recentBooks.length > 0 && (
+              <section>
+                <p className="text-xs font-semibold uppercase tracking-widest text-stone-400 mb-2">
+                  Continue Reading
+                </p>
+                <button
+                  aria-label="Continue reading"
+                  onClick={() => router.push(`/reader/${recentBooks[0].id}`)}
+                  className="w-full text-left rounded-xl border border-amber-200 bg-white p-3 flex items-center gap-3 hover:-translate-y-0.5 transition-all duration-200"
+                  style={{ boxShadow: "var(--shadow-card)" }}
+                  onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card-hover)"; }}
+                  onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card)"; }}
+                >
+                  {recentBooks[0].cover ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={recentBooks[0].cover} alt="" className="w-12 h-16 object-cover rounded-lg shrink-0" />
+                  ) : (
+                    <div className="w-12 h-16 bg-gradient-to-br from-amber-50 to-amber-100 rounded-lg border border-amber-100 flex items-center justify-center shrink-0">
+                      <BookCoverPlaceholderIcon className="w-6 h-8 text-amber-500" />
+                    </div>
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <p className="font-serif font-semibold text-sm text-ink line-clamp-1">{recentBooks[0].title}</p>
+                    <p className="text-xs text-amber-700 mt-0.5 line-clamp-1">{recentBooks[0].authors?.join(", ")}</p>
+                    <p className="text-xs text-stone-400 mt-1">
+                      Chapter {recentBooks[0].lastChapter + 1} · {timeAgo(recentBooks[0].lastRead)}
+                    </p>
+                  </div>
+                  <ArrowRightIcon className="w-4 h-4 text-amber-400 shrink-0" />
+                </button>
+              </section>
+            )}
+
+            {/* Stats strip */}
+            {status === "authenticated" && userStats && (
+              <section>
+                <div className="flex items-center gap-2 mb-3">
+                  <p className="text-xs font-semibold uppercase tracking-widest text-stone-400 flex-1">
+                    Your Progress
+                  </p>
+                  <button
+                    onClick={() => setStatsExpanded((v) => !v)}
+                    className="text-xs text-amber-600 hover:text-amber-800 transition-colors"
+                  >
+                    {statsExpanded ? "Hide activity" : "Show activity"}
+                  </button>
+                </div>
+
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                  {userStats.streak > 0 && (
+                    <div className="bg-white rounded-xl border border-amber-100 px-4 py-3 flex items-center gap-3">
+                      <FireIcon className="w-5 h-5 text-amber-600 shrink-0" />
+                      <div>
+                        <p className="text-lg font-bold text-amber-900 leading-none">{userStats.streak}</p>
+                        <p className="text-[10px] text-stone-400 mt-0.5">day streak</p>
+                      </div>
+                    </div>
+                  )}
+                  <div className="bg-white rounded-xl border border-amber-100 px-4 py-3 flex items-center gap-3">
+                    <BookOpenIcon className="w-5 h-5 text-amber-600 shrink-0" />
+                    <div>
+                      <p className="text-lg font-bold text-stone-800 leading-none">{userStats.totals.books_started}</p>
+                      <p className="text-[10px] text-stone-400 mt-0.5">books started</p>
+                    </div>
+                  </div>
+                  <div className="bg-white rounded-xl border border-amber-100 px-4 py-3 flex items-center gap-3">
+                    <VocabIcon className="w-5 h-5 text-amber-600 shrink-0" />
+                    <div>
+                      <p className="text-lg font-bold text-stone-800 leading-none">{userStats.totals.vocabulary_words}</p>
+                      <p className="text-[10px] text-stone-400 mt-0.5">words saved</p>
+                    </div>
+                  </div>
+                  <div className="bg-white rounded-xl border border-amber-100 px-4 py-3 flex items-center gap-3">
+                    <NoteIcon className="w-5 h-5 text-amber-600 shrink-0" />
+                    <div>
+                      <p className="text-lg font-bold text-stone-800 leading-none">{userStats.totals.annotations}</p>
+                      <p className="text-[10px] text-stone-400 mt-0.5">annotations</p>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Collapsible full activity view */}
+                {statsExpanded && (
+                  <div className="mt-4">
+                    <ReadingStats active heatmapOnly />
+                  </div>
+                )}
+              </section>
+            )}
+
+            {/* Book grid */}
             {recentBooks.length > 0 ? (
-              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-                {recentBooks.map((book) => (
-                  <BookCard
-                    key={book.id}
-                    book={book}
-                    onClick={() => handleBookClick(book)}
-                    badge={`Ch. ${book.lastChapter + 1} · ${timeAgo(book.lastRead)}`}
-                    onRemove={() => {
-                      if (!confirm(`Remove "${book.title}" from your library?`)) return;
-                      removeRecentBook(book.id);
-                      setRecentBooks(getRecentBooks());
-                    }}
-                  />
-                ))}
-              </div>
+              <section>
+                {recentBooks.length > 1 && (
+                  <p className="text-xs font-semibold uppercase tracking-widest text-stone-400 mb-3">
+                    Your Library
+                  </p>
+                )}
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+                  {recentBooks.map((book) => (
+                    <BookCard
+                      key={book.id}
+                      book={book}
+                      onClick={() => handleBookClick(book)}
+                      badge={`Ch. ${book.lastChapter + 1} · ${timeAgo(book.lastRead)}`}
+                      onRemove={() => {
+                        if (!confirm(`Remove "${book.title}" from your library?`)) return;
+                        removeRecentBook(book.id);
+                        setRecentBooks(getRecentBooks());
+                      }}
+                    />
+                  ))}
+                </div>
+              </section>
             ) : (
               <div className="text-center py-20">
                 <div className="inline-flex items-end justify-center gap-1.5 mb-6 opacity-30">
@@ -293,7 +404,7 @@ export default function Home() {
                 </button>
               </div>
             )}
-          </>
+          </div>
         )}
 
         {/* ════════════ Discover Tab ════════════ */}

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation";
 import { saveGeminiKey, deleteGeminiKey, getMe, getObsidianSettings, saveObsidianSettings } from "@/lib/api";
 import { ArrowLeftIcon } from "@/components/Icons";
 import { getSettings, saveSettings, AppSettings } from "@/lib/settings";
-import ReadingStats from "@/components/ReadingStats";
 
 const LANGUAGES = [
   { code: "en", label: "English" },
@@ -494,13 +493,6 @@ export default function ProfilePage() {
           </button>
         </section>
 
-        {/* ── Reading Statistics ───────────────────────────────────────────── */}
-        {session?.backendToken && (
-          <section className="bg-white rounded-2xl border border-amber-100 p-6">
-            <h2 className="font-serif text-lg font-semibold text-ink mb-5">Reading Statistics</h2>
-            <ReadingStats active={!!session?.backendToken} />
-          </section>
-        )}
       </div>
     </div>
   );

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -29,6 +29,7 @@ export default function BookCard({ book, onClick, badge, onRemove }: Props) {
         </button>
       )}
       <button
+        data-testid="book-card"
         onClick={onClick}
         className="text-left rounded-xl border border-amber-200 bg-white p-3 flex flex-col w-full transition-all duration-200 hover:-translate-y-0.5"
         style={{ boxShadow: "var(--shadow-card)" }}

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -8,12 +8,29 @@ interface IconProps {
   className?: string;
 }
 
+export function FireIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z"/>
+    </svg>
+  );
+}
+
 export function SpeakerIcon({ className = "w-4 h-4" }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
       <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/>
       <path d="M15.54 8.46a5 5 0 0 1 0 7.07"/>
       <path d="M19.07 4.93a10 10 0 0 1 0 14.14"/>
+    </svg>
+  );
+}
+
+export function ArrowRightIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <line x1="5" y1="12" x2="19" y2="12"/>
+      <polyline points="12 5 19 12 12 19"/>
     </svg>
   );
 }
@@ -226,6 +243,7 @@ export function EmptyNotesIcon({ className = "w-12 h-12" }: IconProps) {
   );
 }
 
+
 export function BookCoverPlaceholderIcon({ className = "w-8 h-8" }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 48 64" fill="none" aria-hidden="true">
@@ -245,18 +263,14 @@ export function BookCoverPlaceholderIcon({ className = "w-8 h-8" }: IconProps) {
 export function EmptyVocabIcon({ className = "w-14 h-14" }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 56 56" fill="none" aria-hidden="true">
-      {/* Open book base */}
       <path d="M28 14 C28 14 16 10 8 12 L8 44 C16 42 28 46 28 46 C28 46 40 42 48 44 L48 12 C40 10 28 14 28 14Z" fill="currentColor" fillOpacity="0.08" stroke="currentColor" strokeOpacity="0.25" strokeWidth="1.5" strokeLinejoin="round"/>
       <line x1="28" y1="14" x2="28" y2="46" stroke="currentColor" strokeOpacity="0.25" strokeWidth="1.5"/>
-      {/* Left page lines */}
       <rect x="11" y="18" width="13" height="1.5" rx="0.75" fill="currentColor" fillOpacity="0.3"/>
       <rect x="11" y="22" width="10" height="1.5" rx="0.75" fill="currentColor" fillOpacity="0.2"/>
       <rect x="11" y="26" width="13" height="1.5" rx="0.75" fill="currentColor" fillOpacity="0.2"/>
-      {/* Right page lines — show question marks for "no definition" */}
       <rect x="32" y="18" width="13" height="1.5" rx="0.75" fill="currentColor" fillOpacity="0.15"/>
       <rect x="32" y="22" width="8" height="1.5" rx="0.75" fill="currentColor" fillOpacity="0.1"/>
       <rect x="32" y="26" width="11" height="1.5" rx="0.75" fill="currentColor" fillOpacity="0.1"/>
-      {/* + badge indicating "add words" */}
       <circle cx="42" cy="40" r="8" fill="currentColor" fillOpacity="0.12" stroke="currentColor" strokeOpacity="0.3" strokeWidth="1.5"/>
       <line x1="42" y1="36.5" x2="42" y2="43.5" stroke="currentColor" strokeOpacity="0.5" strokeWidth="1.5" strokeLinecap="round"/>
       <line x1="38.5" y1="40" x2="45.5" y2="40" stroke="currentColor" strokeOpacity="0.5" strokeWidth="1.5" strokeLinecap="round"/>

--- a/frontend/src/components/ReadingStats.tsx
+++ b/frontend/src/components/ReadingStats.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { getUserStats, UserStats } from "@/lib/api";
+import { BookOpenIcon, NoteIcon, InsightIcon, VocabIcon, FireIcon } from "@/components/Icons";
 
 // Build a 365-day grid (52 weeks × 7 days) aligned to Sunday columns.
 function buildGrid(activity: { date: string; count: number }[]): {
@@ -59,13 +60,13 @@ function intensityClass(count: number): string {
 interface StatCardProps {
   label: string;
   value: number;
-  icon: string;
+  icon: React.ReactNode;
 }
 
 function StatCard({ label, value, icon }: StatCardProps) {
   return (
     <div className="bg-white rounded-xl border border-amber-100 px-5 py-4 flex items-center gap-4">
-      <span className="text-2xl">{icon}</span>
+      <span className="text-amber-600">{icon}</span>
       <div>
         <p className="text-2xl font-bold text-stone-800">{value.toLocaleString()}</p>
         <p className="text-xs text-stone-500 mt-0.5">{label}</p>
@@ -77,9 +78,11 @@ function StatCard({ label, value, icon }: StatCardProps) {
 interface Props {
   /** If false, show a skeleton placeholder instead of fetching. */
   active: boolean;
+  /** When true, renders only the activity heatmap (no streak banner or stat cards). */
+  heatmapOnly?: boolean;
 }
 
-export default function ReadingStats({ active }: Props) {
+export default function ReadingStats({ active, heatmapOnly = false }: Props) {
   const [stats, setStats] = useState<UserStats | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -94,11 +97,13 @@ export default function ReadingStats({ active }: Props) {
   if (!active || (loading && !stats)) {
     return (
       <div className="space-y-4 animate-pulse">
-        <div className="grid grid-cols-2 gap-3">
-          {[...Array(4)].map((_, i) => (
-            <div key={i} className="h-20 bg-amber-50 rounded-xl border border-amber-100" />
-          ))}
-        </div>
+        {!heatmapOnly && (
+          <div className="grid grid-cols-2 gap-3">
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className="h-20 bg-amber-50 rounded-xl border border-amber-100" />
+            ))}
+          </div>
+        )}
         <div className="h-28 bg-amber-50 rounded-xl border border-amber-100" />
       </div>
     );
@@ -107,33 +112,36 @@ export default function ReadingStats({ active }: Props) {
   if (!stats) return null;
 
   const { weeks, months } = buildGrid(stats.activity);
-  const totalDays = stats.activity.length;
   const activeDays = stats.activity.filter((a) => a.count > 0).length;
 
   return (
     <div className="space-y-5">
-      {/* Streak banner */}
-      {stats.streak > 0 && (
-        <div className="flex items-center gap-3 bg-amber-50 border border-amber-200 rounded-xl px-5 py-3">
-          <span className="text-2xl">🔥</span>
-          <div>
-            <p className="text-sm font-semibold text-amber-900">
-              {stats.streak}-day reading streak!
-            </p>
-            <p className="text-xs text-amber-600">
-              Longest: {stats.longest_streak} days
-            </p>
-          </div>
-        </div>
-      )}
+      {!heatmapOnly && (
+        <>
+          {/* Streak banner */}
+          {stats.streak > 0 && (
+            <div className="flex items-center gap-3 bg-amber-50 border border-amber-200 rounded-xl px-5 py-3">
+              <FireIcon className="w-6 h-6 text-amber-600 shrink-0" />
+              <div>
+                <p className="text-sm font-semibold text-amber-900">
+                  {stats.streak}-day reading streak!
+                </p>
+                <p className="text-xs text-amber-600">
+                  Longest: {stats.longest_streak} days
+                </p>
+              </div>
+            </div>
+          )}
 
-      {/* Stat cards */}
-      <div className="grid grid-cols-2 gap-3">
-        <StatCard label="Books started" value={stats.totals.books_started} icon="📖" />
-        <StatCard label="Words saved" value={stats.totals.vocabulary_words} icon="📚" />
-        <StatCard label="Annotations" value={stats.totals.annotations} icon="📝" />
-        <StatCard label="Insights" value={stats.totals.insights} icon="💡" />
-      </div>
+          {/* Stat cards */}
+          <div className="grid grid-cols-2 gap-3">
+            <StatCard label="Books started" value={stats.totals.books_started} icon={<BookOpenIcon className="w-5 h-5" />} />
+            <StatCard label="Words saved" value={stats.totals.vocabulary_words} icon={<VocabIcon className="w-5 h-5" />} />
+            <StatCard label="Annotations" value={stats.totals.annotations} icon={<NoteIcon className="w-5 h-5" />} />
+            <StatCard label="Insights" value={stats.totals.insights} icon={<InsightIcon className="w-5 h-5" />} />
+          </div>
+        </>
+      )}
 
       {/* Activity heatmap */}
       <div className="bg-white border border-amber-100 rounded-xl p-4">
@@ -164,7 +172,6 @@ export default function ReadingStats({ active }: Props) {
           className="grid gap-[2px]"
           style={{ gridTemplateColumns: `repeat(${weeks.length}, minmax(0, 1fr))` }}
         >
-          {/* Render day-by-day transposed: row = day-of-week, col = week */}
           {[0, 1, 2, 3, 4, 5, 6].map((dow) => (
             <div
               key={dow}


### PR DESCRIPTION
## Summary

Implements [UX-008 / GitHub issue #283](https://github.com/alfmunny/book-reader-ai/issues/283): moves reading statistics out of the Profile page and turns the Library tab into a personal Home dashboard.

- **Tab renamed**: "Your Library" → "Home"
- **Greeting**: "Welcome back, {firstName}" shown to authenticated users
- **Continue Reading card**: most recent book shown above the grid with a direct-navigate button (skips the modal)
- **Stats strip**: compact 4-tile row (streak, books started, words saved, annotations) using SVG icons — no emoji
- **Show activity toggle**: collapses/expands the full activity heatmap (ReadingStats)
- **Profile page**: Reading Statistics section removed — Profile is now settings-only
- **ReadingStats**: replaced emoji icons in stat cards with SVG icons; added `heatmapOnly` prop for the collapsible view

## Test plan

- [x] 1508 Jest tests pass
- [x] New test suite: `HomePage — Home dashboard (UX-008)` (6 tests covering greeting, continue reading card, stats strip, toggle, tab label)
- [x] Existing HomePage tests updated for duplicate title occurrences (Continue Reading + grid) and new tab name
- [x] ProfilePage tests pass (ReadingStats removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
