### PR TITLE
fix: delete_book now removes reading_history rows

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -235,6 +235,7 @@ async def delete_book(book_id: int, _admin: dict = Depends(_require_admin)):
         await db.execute("DELETE FROM annotations WHERE book_id = ?", (book_id,))
         await db.execute("DELETE FROM book_insights WHERE book_id = ?", (book_id,))
         await db.execute("DELETE FROM chapter_summaries WHERE book_id = ?", (book_id,))
+        await db.execute("DELETE FROM reading_history WHERE book_id = ?", (book_id,))
         await db.execute("DELETE FROM user_reading_progress WHERE book_id = ?", (book_id,))
         await db.commit()
     # Invalidate the in-memory chapter split so a future import of the same

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -358,6 +358,25 @@ async def test_delete_book_removes_chapter_summaries(admin_client, admin_db):
     assert count == 0, "chapter_summaries must be removed when the book is deleted"
 
 
+async def test_delete_book_removes_reading_history(admin_client, admin_db, admin_user):
+    """Regression for #289: delete_book must remove reading_history rows.
+
+    Orphaned rows would contaminate analytics for a re-imported book with the same ID.
+    """
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    await log_reading_event(admin_user["id"], 100, 0)
+    await log_reading_event(admin_user["id"], 100, 1)
+
+    await admin_client.delete("/api/admin/books/100")
+
+    async with aiosqlite.connect(admin_db) as db:
+        async with db.execute(
+            "SELECT COUNT(*) FROM reading_history WHERE book_id = 100"
+        ) as cur:
+            count = (await cur.fetchone())[0]
+    assert count == 0, "reading_history rows must be removed when the book is deleted"
+
+
 # ── Translations ─────────────────────────────────────────────────────────────
 
 async def test_get_translations(admin_client, admin_db):


### PR DESCRIPTION
## Summary

- `DELETE /admin/books/{book_id}` cleaned up translations, annotations, word_occurrences, book_insights, chapter_summaries, and user_reading_progress — but **not** `reading_history` rows for that book
- Since `reading_history.book_id` has no FK `ON DELETE CASCADE` (PRAGMA foreign_keys is off), orphaned rows persisted indefinitely after deletion
- If a book was deleted and re-imported with the same Gutenberg ID, analytics (streak, heatmap) would include stale events from the old import, producing incorrect stats
- Fixed with one line: `DELETE FROM reading_history WHERE book_id = ?` added to the atomic cleanup block

## Test plan

- [ ] New regression test: `test_delete_book_removes_reading_history` — logs 2 reading events for a book, deletes the book, verifies 0 rows remain in `reading_history`
- [ ] Full backend suite: 907 tests pass

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)
