### PR TITLE
fix: reject retry on running queue item with 409

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -995,7 +995,22 @@ async def queue_retry_item(
 ):
     # Reset priority too — without this, a row that was bumped to the back
     # on failure would be retried but still sit behind everything else.
+    # Guard against retrying a running item: _mark_done() deletes rows by ID,
+    # so resetting status='pending' while the worker holds the row as 'running'
+    # would cause _mark_done() to silently delete the re-enqueued item (#294).
     async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT status FROM translation_queue WHERE id=?", (item_id,)
+        ) as cur:
+            row = await cur.fetchone()
+        if row is None:
+            raise HTTPException(status_code=404, detail="Queue item not found")
+        if row["status"] == "running":
+            raise HTTPException(
+                status_code=409,
+                detail="Cannot retry a running item; wait for it to finish or fail",
+            )
         cursor = await db.execute(
             """UPDATE translation_queue
                SET status='pending', attempts=0, last_error=NULL,
@@ -1006,8 +1021,6 @@ async def queue_retry_item(
         )
         await db.commit()
     queue_worker().wake()
-    if cursor.rowcount == 0:
-        raise HTTPException(status_code=404, detail="Queue item not found")
     return {"ok": True, "updated": cursor.rowcount}
 
 

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -722,6 +722,28 @@ async def test_retry_queue_item_not_found_returns_404(admin_client):
     assert res.status_code == 404
 
 
+async def test_retry_running_item_returns_409(admin_client, admin_db):
+    """Regression #294: retrying a running item must be rejected (409), not silently accepted.
+
+    If the endpoint resets status='pending' while the worker holds the row as
+    'running', _mark_done() will DELETE the newly-re-enqueued row when the
+    translation finishes — the retry is silently lost.
+    """
+    async with aiosqlite.connect(admin_db) as db:
+        cursor = await db.execute(
+            """INSERT INTO translation_queue
+               (book_id, chapter_index, target_language, status, priority)
+               VALUES (999, 0, 'de', 'running', 100)""",
+        )
+        item_id = cursor.lastrowid
+        await db.commit()
+
+    res = await admin_client.post(f"/api/admin/queue/items/{item_id}/retry")
+    assert res.status_code == 409, (
+        "Retrying a running queue item must return 409 Conflict, not 200"
+    )
+
+
 async def test_enqueue_book_nonexistent_returns_404(admin_client):
     """POST /admin/queue/enqueue-book for a non-existent book must return 404.
 


### PR DESCRIPTION
## Summary

- `POST /admin/queue/items/{id}/retry` reset status to `'pending'` unconditionally, with no check on the item's current state
- If the item was `'running'` (being actively translated), the worker's `_mark_done()` would later DELETE the row by ID — silently discarding the re-enqueued item; the admin saw `{"ok": true}` but the retry was lost
- Fixed by fetching the item's status first and returning 409 Conflict when it is `'running'`, giving a clear error instead of silent data loss

## Test plan

- [ ] New regression test `test_retry_running_item_returns_409` — inserts a queue row with `status='running'`, calls retry, asserts 409. Failed before fix (got 200), passes after.
- [ ] Existing retry/delete tests still pass
- [ ] Full backend suite: 239 passed, 0 failed

Closes #294
