### PR TITLE
fix: reject delete of running queue item with 409

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -958,10 +958,26 @@ async def queue_enqueue_book(
 async def queue_delete_item(
     item_id: int, _admin: dict = Depends(_require_admin),
 ):
-    deleted = await delete_queue_item(item_id)
-    if deleted == 0:
-        raise HTTPException(status_code=404, detail="Queue item not found")
-    return {"ok": True, "deleted": deleted}
+    # Reject deletion of running items: the worker will still save its result,
+    # so silently "succeeding" here gives the admin a false sense of cancellation (#296).
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT status FROM translation_queue WHERE id=?", (item_id,)
+        ) as cur:
+            row = await cur.fetchone()
+        if row is None:
+            raise HTTPException(status_code=404, detail="Queue item not found")
+        if row["status"] == "running":
+            raise HTTPException(
+                status_code=409,
+                detail="Cannot delete a running item; wait for it to finish or fail",
+            )
+        cursor = await db.execute(
+            "DELETE FROM translation_queue WHERE id=?", (item_id,)
+        )
+        await db.commit()
+    return {"ok": True, "deleted": cursor.rowcount}
 
 
 @router.delete("/queue")

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -716,6 +716,27 @@ async def test_delete_queue_item_not_found_returns_404(admin_client):
     assert res.status_code == 404
 
 
+async def test_delete_running_queue_item_returns_409(admin_client, admin_db):
+    """Regression #296: deleting a running item must be rejected (409), not silently accepted.
+
+    Without this guard the queue row is removed but the worker continues
+    writing the translation, so the admin's cancellation intent is silently ignored.
+    """
+    async with aiosqlite.connect(admin_db) as db:
+        cursor = await db.execute(
+            """INSERT INTO translation_queue
+               (book_id, chapter_index, target_language, status, priority)
+               VALUES (999, 0, 'de', 'running', 100)""",
+        )
+        item_id = cursor.lastrowid
+        await db.commit()
+
+    res = await admin_client.delete(f"/api/admin/queue/items/{item_id}")
+    assert res.status_code == 409, (
+        "Deleting a running queue item must return 409 Conflict, not 200"
+    )
+
+
 async def test_retry_queue_item_not_found_returns_404(admin_client):
     """POST /admin/queue/items/{id}/retry for a non-existent item must return 404."""
     res = await admin_client.post("/api/admin/queue/items/99999/retry")


### PR DESCRIPTION
## Summary

- `DELETE /admin/queue/items/{id}` removed the queue row unconditionally, with no check on the item's current state
- If the item was `'running'`, the worker continued and saved the translation anyway — the admin saw 200 OK but the cancellation was silently ignored
- Fixed with the same pattern used for the retry endpoint (#294/#295): fetch status first, return 409 Conflict if `'running'`

## Test plan

- [ ] New regression test `test_delete_running_queue_item_returns_409` — inserts a queue row with `status='running'`, calls DELETE, asserts 409. Failed before fix (got 200), passes after.
- [ ] Existing delete/404 test still passes
- [ ] Full backend suite: 239 passed, 0 failed

Closes #296
