### PR TITLE
fix: serialize concurrent chapter summary generation with asyncio.Lock

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -1,3 +1,5 @@
+import asyncio
+from collections import defaultdict
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -15,6 +17,11 @@ from services import gemini
 from services.tts import synthesize, chunk_text
 
 router = APIRouter(prefix="/ai", tags=["ai"])
+
+# One lock per (book_id, chapter_index) — serializes concurrent summary requests
+# so the second waiter hits the cache written by the first, not Gemini again.
+# Note: in-process only; sufficient for single-process deployment.
+_summary_locks: dict[tuple, asyncio.Lock] = defaultdict(asyncio.Lock)
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -156,29 +163,36 @@ async def summary(req: SummaryRequest, _user: dict = Depends(get_current_user)):
     if cached:
         return {"summary": cached["content"], "cached": True, "model": cached["model"]}
 
-    # Use the queue API key so no personal key is required.
-    from services.db import get_setting
-    from services.auth import decrypt_api_key as _decrypt
-    raw = await get_setting("queue_api_key")
-    if not raw:
-        raise HTTPException(
-            status_code=503,
-            detail="Chapter summaries are not available yet — the admin has not configured a Gemini API key.",
-        )
-    try:
-        api_key = _decrypt(raw)
-    except Exception:
-        raise HTTPException(status_code=503, detail="Summary service configuration error.")
+    async with _summary_locks[(req.book_id, req.chapter_index)]:
+        # Double-check: a concurrent request may have written the summary while
+        # we were waiting for the lock.
+        cached = await get_chapter_summary(req.book_id, req.chapter_index)
+        if cached:
+            return {"summary": cached["content"], "cached": True, "model": cached["model"]}
 
-    try:
-        content = await gemini.generate_chapter_summary(
-            api_key, req.chapter_text, req.book_title, req.author, req.chapter_title
-        )
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        # Use the queue API key so no personal key is required.
+        from services.db import get_setting
+        from services.auth import decrypt_api_key as _decrypt
+        raw = await get_setting("queue_api_key")
+        if not raw:
+            raise HTTPException(
+                status_code=503,
+                detail="Chapter summaries are not available yet — the admin has not configured a Gemini API key.",
+            )
+        try:
+            api_key = _decrypt(raw)
+        except Exception:
+            raise HTTPException(status_code=503, detail="Summary service configuration error.")
 
-    await save_chapter_summary(req.book_id, req.chapter_index, content, model=gemini.MODEL)
-    return {"summary": content, "cached": False, "model": gemini.MODEL}
+        try:
+            content = await gemini.generate_chapter_summary(
+                api_key, req.chapter_text, req.book_title, req.author, req.chapter_title
+            )
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
+
+        await save_chapter_summary(req.book_id, req.chapter_index, content, model=gemini.MODEL)
+        return {"summary": content, "cached": False, "model": gemini.MODEL}
 
 
 @router.delete("/summary")

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -10,9 +10,10 @@ Focuses on:
   - Error paths: upstream Gemini failure → 500
 """
 
+import asyncio
 import pytest
 from unittest.mock import AsyncMock, patch
-from services.db import save_book, save_translation, get_cached_translation, set_user_gemini_key
+from services.db import save_book, save_translation, get_cached_translation, set_user_gemini_key, set_setting
 from services.auth import encrypt_api_key
 
 
@@ -491,4 +492,49 @@ async def test_insight_with_corrupted_key_returns_400(client, test_user):
         "author": "Goethe",
     })
     assert resp.status_code == 400
+
+
+# ── Chapter summary concurrent generation ────────────────────────────────────
+
+async def test_summary_concurrent_requests_call_gemini_once(client, test_user, tmp_db):
+    """Regression #298: two concurrent requests for the same uncached chapter
+    must trigger only one Gemini call; the second waits and hits the cache.
+
+    Without the per-key asyncio.Lock in routers/ai.py, both requests race
+    past the cache-miss check and both call generate_chapter_summary().
+    """
+    from services.auth import encrypt_api_key as _enc
+    await save_book(8888, _BOOK_META, "text")
+    await set_setting("queue_api_key", _enc("test-gemini-key"))
+
+    call_count = 0
+
+    async def _fake_generate(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        await asyncio.sleep(0.01)  # simulate latency so both requests overlap
+        return "A generated summary."
+
+    payload = {
+        "book_id": 8888,
+        "chapter_index": 0,
+        "chapter_text": "Some text here.",
+        "book_title": "Faust",
+        "author": "Goethe",
+        "chapter_title": "Chapter 1",
+    }
+
+    with patch("routers.ai.gemini") as mock_gemini:
+        mock_gemini.generate_chapter_summary = _fake_generate
+        mock_gemini.MODEL = "gemini-pro"
+        results = await asyncio.gather(
+            client.post("/api/ai/summary", json=payload),
+            client.post("/api/ai/summary", json=payload),
+        )
+
+    assert all(r.status_code == 200 for r in results)
+    assert call_count == 1, (
+        f"Expected 1 Gemini call for concurrent requests to the same chapter, "
+        f"got {call_count}. Missing per-key asyncio.Lock in the summary endpoint."
+    )
 


### PR DESCRIPTION
## Summary

- `POST /ai/summary` had a check-then-act race: two concurrent requests for the same uncached `(book_id, chapter_index)` both got a cache miss and both called Gemini before either could write the result
- Summaries are shared and designed as "first reader pays" — the race doubled the Gemini API cost for any chapter that was first requested by two users at the same time
- Fixed by adding a per-`(book_id, chapter_index)` `asyncio.Lock` at the router module level; the second waiter checks the cache again inside the lock and returns immediately if the first request already wrote the summary

## Test plan

- [ ] New regression test `test_summary_concurrent_requests_call_gemini_once` — fires two concurrent requests via `asyncio.gather`, asserts `call_count == 1`. Failed before fix (got 2 calls), passes after.
- [ ] All existing AI endpoint tests (37) still pass
- [ ] Full backend suite: 239 passed, 0 failed

Closes #298
