### PR TITLE
feat: immersive reading mode — focus mode, typography panel, paragraph reading

### DIFF
--- a/frontend/e2e/ux-reading.spec.ts
+++ b/frontend/e2e/ux-reading.spec.ts
@@ -143,22 +143,21 @@ test.describe("Display customisation (desktop)", () => {
     await expect(page.getByText(MOCK_CHAPTERS[0].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 10000 });
   });
 
-  test("font size button is visible in header", async ({ page }) => {
-    const fontBtn = page.locator('button[title^="Font size:"]');
-    await expect(fontBtn).toBeVisible();
+  test("typography button is visible in header", async ({ page }) => {
+    const aaBtn = page.locator('button[title="Typography settings"]');
+    await expect(aaBtn).toBeVisible();
   });
 
-  test("font size button cycles through sizes on click", async ({ page }) => {
-    const fontBtn = page.locator('button[title^="Font size:"]');
-    // Default is "base" — clicking advances to "lg"
-    await fontBtn.click();
-    await expect(fontBtn).toHaveAttribute("title", /Font size: lg/);
-    await fontBtn.click();
-    await expect(fontBtn).toHaveAttribute("title", /Font size: xl/);
-    await fontBtn.click();
-    await expect(fontBtn).toHaveAttribute("title", /Font size: sm/);
-    await fontBtn.click();
-    await expect(fontBtn).toHaveAttribute("title", /Font size: base/);
+  test("typography panel opens and allows font size selection", async ({ page }) => {
+    const aaBtn = page.locator('button[title="Typography settings"]');
+    await aaBtn.click();
+    const panel = page.getByTestId("typography-panel");
+    await expect(panel).toBeVisible();
+    // Click "L" (lg) font size option
+    await panel.getByRole("button", { name: "L" }).click();
+    // data-font-size attribute should update on <html>
+    const fontSize = await page.evaluate(() => document.documentElement.getAttribute("data-font-size"));
+    expect(fontSize).toBe("lg");
   });
 
   test("theme button is visible in header", async ({ page }) => {
@@ -198,14 +197,19 @@ test.describe("Display customisation (desktop)", () => {
   });
 
   test("font size change persists across chapter navigation", async ({ page }) => {
-    const fontBtn = page.locator('button[title^="Font size:"]');
-    await fontBtn.click(); // base → lg
-    await expect(fontBtn).toHaveAttribute("title", /Font size: lg/);
+    // Open typography panel and select "L" (lg)
+    const aaBtn = page.locator('button[title="Typography settings"]');
+    await aaBtn.click();
+    const panel = page.getByTestId("typography-panel");
+    await panel.getByRole("button", { name: "L" }).click();
+    // Close panel by clicking outside
+    await page.keyboard.press("Escape");
 
     await page.keyboard.press("ArrowRight");
     await expect(page.getByText(MOCK_CHAPTERS[1].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 5000 });
     // Font size should still be "lg" after navigation
-    await expect(fontBtn).toHaveAttribute("title", /Font size: lg/);
+    const fontSize = await page.evaluate(() => document.documentElement.getAttribute("data-font-size"));
+    expect(fontSize).toBe("lg");
   });
 
   test("desktop header shows chapter selector dropdown", async ({ page }) => {

--- a/frontend/e2e/ux-reading.spec.ts
+++ b/frontend/e2e/ux-reading.spec.ts
@@ -153,8 +153,8 @@ test.describe("Display customisation (desktop)", () => {
     await aaBtn.click();
     const panel = page.getByTestId("typography-panel");
     await expect(panel).toBeVisible();
-    // Click "L" (lg) font size option
-    await panel.getByRole("button", { name: "L" }).click();
+    // Click "L" (lg) font size option — use exact to avoid matching XL/Normal/Relaxed
+    await panel.getByRole("button", { name: "L", exact: true }).click();
     // data-font-size attribute should update on <html>
     const fontSize = await page.evaluate(() => document.documentElement.getAttribute("data-font-size"));
     expect(fontSize).toBe("lg");
@@ -201,7 +201,7 @@ test.describe("Display customisation (desktop)", () => {
     const aaBtn = page.locator('button[title="Typography settings"]');
     await aaBtn.click();
     const panel = page.getByTestId("typography-panel");
-    await panel.getByRole("button", { name: "L" }).click();
+    await panel.getByRole("button", { name: "L", exact: true }).click();
     // Close panel by clicking outside
     await page.keyboard.press("Escape");
 

--- a/frontend/src/__tests__/ReaderPage.branches2.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches2.test.tsx
@@ -16,7 +16,7 @@
  *   1571-1572 mobile notes panel: same-chapter annotation click
  */
 import React from "react";
-import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor, act, fireEvent, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 // ─── next-auth ────────────────────────────────────────────────────────────────
@@ -1387,17 +1387,20 @@ describe("ReaderPage.branches2 — theme cycling through sepia and dark", () => 
 
 // ─── Font size: xl → sm wrap-around ──────────────────────────────────────────
 
-describe("ReaderPage.branches2 — font size: xl wraps to sm", () => {
-  it("cycles xl → sm when font size is xl", async () => {
-    mockGetSettings.mockReturnValue({ ...DEFAULT_SETTINGS, fontSize: "xl" });
+describe("ReaderPage.branches2 — font size: xl via typography panel", () => {
+  it("sets font size to xl via typography panel", async () => {
+    mockGetSettings.mockReturnValue({ ...DEFAULT_SETTINGS, fontSize: "base" });
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
     render(<ReaderPage />);
     await flushPromises();
 
-    const fontBtn = await screen.findByTitle(/font size/i);
-    await userEvent.click(fontBtn); // xl → sm
+    const aaBtn = await screen.findByTitle("Typography settings");
+    await userEvent.click(aaBtn);
+    const panel = await screen.findByTestId("typography-panel");
+    const xlBtn = within(panel).getByText("XL");
+    await userEvent.click(xlBtn);
 
-    expect(mockSaveSettings).toHaveBeenLastCalledWith(expect.objectContaining({ fontSize: "sm" }));
+    expect(mockSaveSettings).toHaveBeenLastCalledWith(expect.objectContaining({ fontSize: "xl" }));
   });
 });
 

--- a/frontend/src/__tests__/ReaderPage.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.test.tsx
@@ -3,7 +3,7 @@
  * Mocks all external dependencies heavily to test render paths and interactions.
  */
 import React from "react";
-import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor, act, fireEvent, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 // ─── next-auth ────────────────────────────────────────────────────────────────
@@ -492,29 +492,38 @@ describe("ReaderPage — sidebar tabs", () => {
   });
 });
 
-describe("ReaderPage — font size cycling", () => {
-  it("cycles font size when Aa button is clicked", async () => {
+describe("ReaderPage — typography panel", () => {
+  it("opens typography panel and changes font size", async () => {
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
     render(<ReaderPage />);
     await flushPromises();
 
-    // Find the font-size button (title includes "Font size:")
-    const fontBtn = await screen.findByTitle(/font size/i);
-    await userEvent.click(fontBtn);
+    // Open the typography panel
+    const aaBtn = await screen.findByTitle("Typography settings");
+    await userEvent.click(aaBtn);
+
+    // Panel opens — pick a font size
+    const panel = await screen.findByTestId("typography-panel");
+    expect(panel).toBeInTheDocument();
+    const lgBtn = within(panel).getByText("L");
+    await userEvent.click(lgBtn);
 
     expect(mockSaveSettings).toHaveBeenCalledWith(
-      expect.objectContaining({ fontSize: expect.any(String) }),
+      expect.objectContaining({ fontSize: "lg" }),
     );
   });
 
-  it("cycles through sm → base → lg → xl → sm", async () => {
+  it("changes font size to base when M is clicked in typography panel", async () => {
     mockGetSettings.mockReturnValue({ ...DEFAULT_SETTINGS, fontSize: "sm" });
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
     render(<ReaderPage />);
     await flushPromises();
 
-    const fontBtn = await screen.findByTitle(/font size/i);
-    await userEvent.click(fontBtn); // sm → base
+    const aaBtn = await screen.findByTitle("Typography settings");
+    await userEvent.click(aaBtn);
+    const panel = await screen.findByTestId("typography-panel");
+    const mBtn = within(panel).getByText("M");
+    await userEvent.click(mBtn);
     expect(mockSaveSettings).toHaveBeenLastCalledWith(expect.objectContaining({ fontSize: "base" }));
   });
 });

--- a/frontend/src/__tests__/SentenceReader.focus.test.tsx
+++ b/frontend/src/__tests__/SentenceReader.focus.test.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import SentenceReader from "@/components/SentenceReader";
+
+const TEXT = "First paragraph text here.\n\nSecond paragraph text here.\n\nThird paragraph text here.";
+const noop = () => {};
+
+describe("SentenceReader — paragraph focus", () => {
+  it("applies para-dim to non-focused paragraphs and para-active to focused", () => {
+    render(
+      <SentenceReader
+        text={TEXT}
+        duration={0}
+        currentTime={0}
+        isPlaying={false}
+        onSegmentClick={noop}
+        focusParagraphIdx={1}
+      />
+    );
+
+    const paras = document.querySelectorAll("[data-para-idx]");
+    expect(paras).toHaveLength(3);
+    expect(paras[0]).toHaveClass("para-dim");
+    expect(paras[1]).toHaveClass("para-active");
+    expect(paras[2]).toHaveClass("para-dim");
+  });
+
+  it("applies no focus classes when focusParagraphIdx is undefined", () => {
+    render(
+      <SentenceReader
+        text={TEXT}
+        duration={0}
+        currentTime={0}
+        isPlaying={false}
+        onSegmentClick={noop}
+      />
+    );
+
+    const paras = document.querySelectorAll("[data-para-idx]");
+    paras.forEach((p) => {
+      expect(p).not.toHaveClass("para-dim");
+      expect(p).not.toHaveClass("para-active");
+    });
+  });
+
+  it("focuses paragraph 0 correctly", () => {
+    render(
+      <SentenceReader
+        text={TEXT}
+        duration={0}
+        currentTime={0}
+        isPlaying={false}
+        onSegmentClick={noop}
+        focusParagraphIdx={0}
+      />
+    );
+
+    const paras = document.querySelectorAll("[data-para-idx]");
+    expect(paras[0]).toHaveClass("para-active");
+    expect(paras[1]).toHaveClass("para-dim");
+    expect(paras[2]).toHaveClass("para-dim");
+  });
+
+  it("fires onParagraphTimingsUpdate on mount", () => {
+    const onTimings = jest.fn();
+    render(
+      <SentenceReader
+        text={TEXT}
+        duration={10}
+        currentTime={0}
+        isPlaying={false}
+        onSegmentClick={noop}
+        onParagraphTimingsUpdate={onTimings}
+      />
+    );
+
+    expect(onTimings).toHaveBeenCalledTimes(1);
+    const timings = onTimings.mock.calls[0][0];
+    expect(timings).toHaveLength(3);
+    expect(timings[0]).toHaveProperty("startTime");
+    expect(timings[0]).toHaveProperty("stopTime");
+    // First para starts at 0, stop = second para start
+    expect(timings[0].startTime).toBe(0);
+    expect(timings[1].startTime).toBeGreaterThan(0);
+  });
+
+  it("fires onActiveParagraphChange when currentIdx crosses paragraph boundary", () => {
+    const onActiveChange = jest.fn();
+    // duration=10, 3 equal paragraphs → each ~3.33s
+    // Para 0: 0-3.33, Para 1: 3.33-6.67, Para 2: 6.67-10
+    const { rerender } = render(
+      <SentenceReader
+        text={TEXT}
+        duration={10}
+        currentTime={0}
+        isPlaying={true}
+        onSegmentClick={noop}
+        onActiveParagraphChange={onActiveChange}
+      />
+    );
+
+    // Advance into second paragraph (>3.33s)
+    rerender(
+      <SentenceReader
+        text={TEXT}
+        duration={10}
+        currentTime={5}
+        isPlaying={true}
+        onSegmentClick={noop}
+        onActiveParagraphChange={onActiveChange}
+      />
+    );
+
+    // Should have been called with paragraph 1
+    expect(onActiveChange).toHaveBeenCalledWith(1);
+  });
+
+  it("adds data-para-idx to each paragraph div", () => {
+    render(
+      <SentenceReader
+        text={TEXT}
+        duration={0}
+        currentTime={0}
+        isPlaying={false}
+        onSegmentClick={noop}
+      />
+    );
+
+    expect(document.querySelector("[data-para-idx='0']")).toBeInTheDocument();
+    expect(document.querySelector("[data-para-idx='1']")).toBeInTheDocument();
+    expect(document.querySelector("[data-para-idx='2']")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/TTSControls.stopAt.test.tsx
+++ b/frontend/src/__tests__/TTSControls.stopAt.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Tests for TTSControls stopAtTime / onStopAtReached behaviour.
+ */
+
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import TTSControls from "@/components/TTSControls";
+
+jest.mock("@/lib/api", () => ({
+  synthesizeSpeech: jest.fn(),
+  getTtsChunks: jest.fn(),
+}));
+
+jest.mock("@/lib/settings", () => ({
+  getSettings: jest.fn(() => ({ ttsGender: "female" })),
+  saveSettings: jest.fn(),
+}));
+
+jest.mock("@/lib/audio", () => ({
+  getAudioPosition: jest.fn(() => 0),
+  saveAudioPosition: jest.fn(),
+  clearAudioPosition: jest.fn(),
+}));
+
+import { synthesizeSpeech, getTtsChunks } from "@/lib/api";
+
+const mockSynthesize = synthesizeSpeech as jest.Mock;
+const mockGetChunks = getTtsChunks as jest.Mock;
+
+class MockAudio {
+  src: string;
+  preload = "auto";
+  playbackRate = 1;
+  currentTime = 0;
+  duration = 5;
+  private _listeners: Record<string, (() => void)[]> = {};
+
+  constructor(src: string) { this.src = src; }
+
+  addEventListener(ev: string, handler: () => void) {
+    if (!this._listeners[ev]) this._listeners[ev] = [];
+    this._listeners[ev].push(handler);
+    if (ev === "loadedmetadata") setTimeout(() => handler(), 0);
+  }
+  removeEventListener() {}
+  play() { return Promise.resolve(); }
+  pause() {}
+
+  emit(ev: string) {
+    (this._listeners[ev] || []).forEach((h) => h());
+  }
+}
+
+let audioInstances: MockAudio[] = [];
+
+beforeEach(() => {
+  audioInstances = [];
+  // @ts-ignore
+  global.Audio = jest.fn().mockImplementation((src: string) => {
+    const inst = new MockAudio(src);
+    audioInstances.push(inst);
+    return inst;
+  });
+  global.URL.createObjectURL = jest.fn(() => "blob:test");
+  global.URL.revokeObjectURL = jest.fn();
+  window.speechSynthesis = { cancel: jest.fn() } as unknown as SpeechSynthesis;
+});
+
+afterEach(() => jest.clearAllMocks());
+
+const DEFAULT_PROPS = {
+  text: "Hello world.",
+  language: "en",
+  bookId: 1,
+  chapterIndex: 0,
+};
+
+test("onStopAtReached fires when currentTime reaches stopAtTime", async () => {
+  mockGetChunks.mockResolvedValue(["Hello world."]);
+  mockSynthesize.mockResolvedValue({ url: "blob:audio", wordBoundaries: [] });
+
+  const onStopAtReached = jest.fn();
+
+  render(
+    <TTSControls
+      {...DEFAULT_PROPS}
+      stopAtTime={3}
+      onStopAtReached={onStopAtReached}
+    />
+  );
+
+  // Start playback
+  const playBtn = screen.getByText(/Read/i);
+  await act(async () => { playBtn.click(); });
+  await act(async () => { await new Promise((r) => setTimeout(r, 50)); });
+
+  // Simulate audio timeupdate past stopAtTime
+  await act(async () => {
+    const audio = audioInstances[0];
+    if (audio) {
+      audio.currentTime = 3.5; // past stopAtTime=3
+      audio.emit("timeupdate");
+    }
+  });
+
+  expect(onStopAtReached).toHaveBeenCalled();
+});
+
+test("does not auto-pause when stopAtTime is undefined", async () => {
+  mockGetChunks.mockResolvedValue(["Hello world."]);
+  mockSynthesize.mockResolvedValue({ url: "blob:audio", wordBoundaries: [] });
+
+  const onStopAtReached = jest.fn();
+
+  render(
+    <TTSControls
+      {...DEFAULT_PROPS}
+      stopAtTime={undefined}
+      onStopAtReached={onStopAtReached}
+    />
+  );
+
+  const playBtn = screen.getByText(/Read/i);
+  await act(async () => { playBtn.click(); });
+  await act(async () => { await new Promise((r) => setTimeout(r, 50)); });
+
+  await act(async () => {
+    const audio = audioInstances[0];
+    if (audio) {
+      audio.currentTime = 10;
+      audio.emit("timeupdate");
+    }
+  });
+
+  expect(onStopAtReached).not.toHaveBeenCalled();
+});

--- a/frontend/src/__tests__/TypographyPanel.test.tsx
+++ b/frontend/src/__tests__/TypographyPanel.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import TypographyPanel from "@/components/TypographyPanel";
+import * as settings from "@/lib/settings";
+
+jest.mock("@/lib/settings", () => ({
+  saveSettings: jest.fn(),
+}));
+
+const DEFAULT_PROPS = {
+  fontSize: "base" as settings.FontSize,
+  lineHeight: "normal" as settings.LineHeight,
+  contentWidth: "normal" as settings.ContentWidth,
+  fontFamily: "serif" as settings.FontFamily,
+  paragraphFocus: false,
+  onFontSize: jest.fn(),
+  onLineHeight: jest.fn(),
+  onContentWidth: jest.fn(),
+  onFontFamily: jest.fn(),
+  onParagraphFocus: jest.fn(),
+  onClose: jest.fn(),
+};
+
+afterEach(() => jest.clearAllMocks());
+
+describe("TypographyPanel", () => {
+  it("renders the panel with all controls", () => {
+    render(<TypographyPanel {...DEFAULT_PROPS} />);
+    expect(screen.getByTestId("typography-panel")).toBeInTheDocument();
+    expect(screen.getByText("S")).toBeInTheDocument();
+    expect(screen.getByText("M")).toBeInTheDocument();
+    expect(screen.getByText("L")).toBeInTheDocument();
+    expect(screen.getByText("XL")).toBeInTheDocument();
+    expect(screen.getByText("Serif")).toBeInTheDocument();
+    expect(screen.getByText("Sans")).toBeInTheDocument();
+    expect(screen.getByText("Tight")).toBeInTheDocument();
+    expect(screen.getAllByText("Normal")).toHaveLength(2); // line height + content width
+    expect(screen.getByText("Relaxed")).toBeInTheDocument();
+    expect(screen.getByText("Narrow")).toBeInTheDocument();
+    expect(screen.getByText("Wide")).toBeInTheDocument();
+    expect(screen.getByText("Paragraph focus")).toBeInTheDocument();
+  });
+
+  it("calls onFontSize and saveSettings when a size is clicked", () => {
+    render(<TypographyPanel {...DEFAULT_PROPS} />);
+    fireEvent.click(screen.getByText("L"));
+    expect(DEFAULT_PROPS.onFontSize).toHaveBeenCalledWith("lg");
+    expect(settings.saveSettings).toHaveBeenCalledWith(expect.objectContaining({ fontSize: "lg" }));
+  });
+
+  it("calls onLineHeight when spacing option is clicked", () => {
+    render(<TypographyPanel {...DEFAULT_PROPS} />);
+    fireEvent.click(screen.getByText("Relaxed"));
+    expect(DEFAULT_PROPS.onLineHeight).toHaveBeenCalledWith("relaxed");
+    expect(settings.saveSettings).toHaveBeenCalledWith(expect.objectContaining({ lineHeight: "relaxed" }));
+  });
+
+  it("calls onContentWidth when width option is clicked", () => {
+    render(<TypographyPanel {...DEFAULT_PROPS} />);
+    fireEvent.click(screen.getByText("Wide"));
+    expect(DEFAULT_PROPS.onContentWidth).toHaveBeenCalledWith("wide");
+    expect(settings.saveSettings).toHaveBeenCalledWith(expect.objectContaining({ contentWidth: "wide" }));
+  });
+
+  it("calls onFontFamily when font is clicked", () => {
+    render(<TypographyPanel {...DEFAULT_PROPS} />);
+    fireEvent.click(screen.getByText("Sans"));
+    expect(DEFAULT_PROPS.onFontFamily).toHaveBeenCalledWith("sans");
+    expect(settings.saveSettings).toHaveBeenCalledWith(expect.objectContaining({ fontFamily: "sans" }));
+  });
+
+  it("toggles paragraph focus and calls saveSettings", () => {
+    render(<TypographyPanel {...DEFAULT_PROPS} />);
+    const toggle = screen.getByRole("switch", { name: /paragraph focus/i });
+    fireEvent.click(toggle);
+    expect(DEFAULT_PROPS.onParagraphFocus).toHaveBeenCalledWith(true);
+    expect(settings.saveSettings).toHaveBeenCalledWith(expect.objectContaining({ paragraphFocus: true }));
+  });
+
+  it("shows paragraph focus as active when paragraphFocus=true", () => {
+    render(<TypographyPanel {...DEFAULT_PROPS} paragraphFocus={true} />);
+    const toggle = screen.getByRole("switch", { name: /paragraph focus/i });
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("calls onClose when clicking outside", () => {
+    render(
+      <div>
+        <TypographyPanel {...DEFAULT_PROPS} />
+        <div data-testid="outside">outside</div>
+      </div>
+    );
+    fireEvent.mouseDown(screen.getByTestId("outside"));
+    expect(DEFAULT_PROPS.onClose).toHaveBeenCalled();
+  });
+
+  it("does not call onClose when clicking inside panel", () => {
+    render(<TypographyPanel {...DEFAULT_PROPS} />);
+    fireEvent.mouseDown(screen.getByTestId("typography-panel"));
+    expect(DEFAULT_PROPS.onClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -86,6 +86,26 @@ body, [data-theme="light"] {
 [data-font-size="xl"] .prose-reader,
 [data-font-size="xl"] .font-serif { font-size: 1.5rem; }
 
+/* Line height variants */
+[data-line-height="tight"] .prose-reader { line-height: 1.5; }
+[data-line-height="normal"] .prose-reader { line-height: 1.9; }
+[data-line-height="relaxed"] .prose-reader { line-height: 2.3; }
+
+/* Content width variants */
+[data-content-width="narrow"] .prose-reader { max-width: 52ch; }
+[data-content-width="normal"] .prose-reader { max-width: 68ch; }
+[data-content-width="wide"] .prose-reader { max-width: 90ch; }
+
+/* Font family variant */
+[data-font-family="sans"] .prose-reader,
+[data-font-family="sans"] .prose-reader .font-serif {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+/* Paragraph focus dimming */
+.para-dim { opacity: 0.2; transition: opacity 0.4s ease; }
+.para-active { opacity: 1; transition: opacity 0.4s ease; }
+
 .highlighted-sentence {
   background-color: #fde68a;
   border-radius: 2px;

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -48,6 +48,10 @@ export default function ProfilePage() {
     translationProvider: "auto",
     fontSize: "base",
     theme: "light",
+    lineHeight: "normal",
+    contentWidth: "normal",
+    fontFamily: "serif",
+    paragraphFocus: false,
   });
   const [prefsSaved, setPrefsSaved] = useState(false);
 

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -4,7 +4,8 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { getBookChapters, deleteTranslationCache, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, getChapterTranslation, getChapterQueueStatus, retryChapterTranslation, enqueueBookTranslation, saveReadingProgress, getAnnotations, getVocabulary, saveVocabularyWord, exportVocabularyToObsidian, saveInsight, TranslationStatus, BookMeta, BookChapter, ApiError, Annotation, VocabularyWord } from "@/lib/api";
 import { recordRecentBook, saveLastChapter, getLastChapter } from "@/lib/recentBooks";
-import { getSettings, saveSettings, FontSize, Theme } from "@/lib/settings";
+import { getSettings, saveSettings, FontSize, Theme, LineHeight, ContentWidth, FontFamily } from "@/lib/settings";
+import TypographyPanel from "@/components/TypographyPanel";
 import InsightChat, { LANGUAGES } from "@/components/InsightChat";
 import TTSControls from "@/components/TTSControls";
 import TranslationView from "@/components/TranslationView";
@@ -232,7 +233,18 @@ export default function ReaderPage() {
   // Reader display settings
   const [fontSize, setFontSize] = useState<FontSize>("base");
   const [theme, setTheme] = useState<Theme>("light");
+  const [lineHeight, setLineHeight] = useState<LineHeight>("normal");
+  const [contentWidth, setContentWidth] = useState<ContentWidth>("normal");
+  const [fontFamily, setFontFamily] = useState<FontFamily>("serif");
   const [scrollProgress, setScrollProgress] = useState(0);
+
+  // Immersive reading state
+  const [focusMode, setFocusMode] = useState(false);
+  const [paragraphFocus, setParagraphFocus] = useState(false);
+  const [focusParagraphIdx, setFocusParagraphIdx] = useState(0);
+  const [paragraphTimings, setParagraphTimings] = useState<{ startTime: number; stopTime: number }[]>([]);
+  const [ttsStopAt, setTtsStopAt] = useState<number | undefined>();
+  const [showTypographyPanel, setShowTypographyPanel] = useState(false);
 
   // Read settings on mount (translationLang uses lazy useState above)
   useEffect(() => {
@@ -240,17 +252,27 @@ export default function ReaderPage() {
     // translationProvider setting is retained for back-compat but no longer read here.
     setFontSize(s.fontSize);
     setTheme(s.theme);
+    setLineHeight(s.lineHeight ?? "normal");
+    setContentWidth(s.contentWidth ?? "normal");
+    setFontFamily(s.fontFamily ?? "serif");
+    setParagraphFocus(s.paragraphFocus ?? false);
   }, []);
 
-  // Apply theme and font size to the document
+  // Apply theme and display settings to the document
   useEffect(() => {
     document.documentElement.setAttribute("data-theme", theme);
     document.documentElement.setAttribute("data-font-size", fontSize);
+    document.documentElement.setAttribute("data-line-height", lineHeight);
+    document.documentElement.setAttribute("data-content-width", contentWidth);
+    document.documentElement.setAttribute("data-font-family", fontFamily);
     return () => {
       document.documentElement.removeAttribute("data-theme");
       document.documentElement.removeAttribute("data-font-size");
+      document.documentElement.removeAttribute("data-line-height");
+      document.documentElement.removeAttribute("data-content-width");
+      document.documentElement.removeAttribute("data-font-family");
     };
-  }, [theme, fontSize]);
+  }, [theme, fontSize, lineHeight, contentWidth, fontFamily]);
 
   // Track scroll progress
   useEffect(() => {
@@ -640,11 +662,18 @@ export default function ReaderPage() {
       } else if (e.key === "ArrowRight" && chapterIndex < chapters.length - 1) {
         e.preventDefault();
         goToChapter(chapterIndex + 1);
+      } else if (e.key === "f" || e.key === "F") {
+        e.preventDefault();
+        setFocusMode((v) => !v);
+        setShowTypographyPanel(false);
+      } else if (e.key === "Escape") {
+        if (focusMode) { e.preventDefault(); setFocusMode(false); }
+        setShowTypographyPanel(false);
       }
     }
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [chapterIndex, chapters]);
+  }, [chapterIndex, chapters, focusMode]);
 
   function goToChapter(index: number) {
     setChapterIndex(index);
@@ -681,6 +710,22 @@ export default function ReaderPage() {
     } catch {
       // silently ignore (user may not be logged in)
     }
+  }
+
+  // Paragraph focus handlers
+  function handleParagraphVisible(idx: number) {
+    if (!ttsIsPlaying) setFocusParagraphIdx(idx);
+  }
+  function handleActiveParagraphChange(idx: number) {
+    if (ttsIsPlaying) setFocusParagraphIdx(idx);
+  }
+  function readFocusedParagraph() {
+    const timing = paragraphTimings[focusParagraphIdx];
+    if (!timing) return;
+    const startTime = Number.isFinite(timing.startTime) ? timing.startTime : 0;
+    const stopTime = Number.isFinite(timing.stopTime) ? timing.stopTime : undefined;
+    setTtsStopAt(stopTime);
+    ttsSeekRef.current(startTime);
   }
 
   // Obsidian export handler
@@ -737,10 +782,57 @@ export default function ReaderPage() {
         </div>
       )}
 
+      {/* ── Focus Mode HUD (desktop) ────────────────────────────────────── */}
+      {focusMode && (
+        <div className="fixed top-0 left-0 right-0 z-50 flex justify-center pointer-events-none">
+          <div className="pointer-events-auto mt-2 flex items-center gap-1 bg-white/90 backdrop-blur-sm border border-amber-200 rounded-full px-3 py-1.5 shadow-lg text-xs text-ink">
+            <button
+              onClick={() => chapterIndex > 0 && goToChapter(chapterIndex - 1)}
+              disabled={chapterIndex === 0}
+              className="px-2 py-1 rounded-full hover:bg-amber-50 disabled:opacity-30 transition-colors"
+            >← Prev</button>
+            <span className="text-stone-400 mx-0.5">|</span>
+            <span className="text-stone-600 max-w-[180px] truncate font-medium">
+              {chapters[chapterIndex]?.title || `Ch. ${chapterIndex + 1}`}
+            </span>
+            <span className="text-stone-400 mx-0.5">|</span>
+            <button
+              onClick={() => chapterIndex < chapters.length - 1 && goToChapter(chapterIndex + 1)}
+              disabled={chapterIndex === chapters.length - 1}
+              className="px-2 py-1 rounded-full hover:bg-amber-50 disabled:opacity-30 transition-colors"
+            >Next →</button>
+            {paragraphFocus && (
+              <>
+                <span className="text-stone-400 mx-0.5">|</span>
+                <button
+                  onClick={ttsIsPlaying ? undefined : readFocusedParagraph}
+                  className="px-2 py-1 rounded-full hover:bg-amber-50 transition-colors"
+                  title={ttsIsPlaying ? "Playing…" : "Read focused paragraph"}
+                >
+                  {ttsIsPlaying ? "⏸ Playing" : "▶ Read para"}
+                </button>
+              </>
+            )}
+            <span className="text-stone-400 mx-0.5">|</span>
+            <button
+              onClick={() => setShowTypographyPanel((v) => !v)}
+              className="px-2 py-1 rounded-full hover:bg-amber-50 transition-colors font-bold"
+              title="Typography"
+            >Aa</button>
+            <span className="text-stone-400 mx-0.5">|</span>
+            <button
+              onClick={() => setFocusMode(false)}
+              className="px-2 py-1 rounded-full hover:bg-red-50 text-stone-500 hover:text-red-600 transition-colors"
+              title="Exit focus mode (F)"
+            >✕ Focus</button>
+          </div>
+        </div>
+      )}
+
       {/* ── Header ──────────────────────────────────────────────────────── */}
       <header className={`border-b border-amber-200 bg-white/70 backdrop-blur shrink-0 transition-all duration-300 ${
         !toolbarVisible ? "max-h-0 overflow-hidden opacity-0 border-b-0" : "max-h-[300px] opacity-100"
-      } md:!max-h-none md:!opacity-100 md:!overflow-visible md:!border-b`}>
+      } ${focusMode ? "" : "md:!max-h-none md:!opacity-100 md:!overflow-visible md:!border-b"}`}>
         {/* Row 1: nav + title + controls */}
         <div className="flex items-center gap-2 md:gap-3 px-3 md:px-4 py-2 md:py-3">
           <button
@@ -801,17 +893,35 @@ export default function ReaderPage() {
             )}
           </div>
 
-          {/* Font size — desktop only */}
-          <button
-            onClick={cycleFontSize}
-            title={`Font size: ${fontSize} — click to cycle`}
-            className="hidden md:flex shrink-0 items-center gap-1 px-2 py-1 rounded-lg border border-amber-300 hover:bg-amber-100 text-xs font-bold text-amber-700 transition-colors"
-          >
-            <span className="font-serif">A</span>
-            <span className="hidden lg:inline text-[9px] text-amber-500 font-sans font-normal">
-              {fontSize === "sm" ? "S" : fontSize === "base" ? "M" : fontSize === "lg" ? "L" : "XL"}
-            </span>
-          </button>
+          {/* Typography panel — desktop only */}
+          <div className="relative hidden md:block">
+            <button
+              onClick={() => setShowTypographyPanel((v) => !v)}
+              title="Typography settings"
+              className={`flex shrink-0 items-center gap-1 px-2 py-1 rounded-lg border text-xs font-bold transition-colors ${
+                showTypographyPanel || paragraphFocus
+                  ? "bg-amber-100 border-amber-400 text-amber-800"
+                  : "border-amber-300 hover:bg-amber-100 text-amber-700"
+              }`}
+            >
+              <span className="font-serif">Aa</span>
+            </button>
+            {showTypographyPanel && (
+              <TypographyPanel
+                fontSize={fontSize}
+                lineHeight={lineHeight}
+                contentWidth={contentWidth}
+                fontFamily={fontFamily}
+                paragraphFocus={paragraphFocus}
+                onFontSize={setFontSize}
+                onLineHeight={setLineHeight}
+                onContentWidth={setContentWidth}
+                onFontFamily={setFontFamily}
+                onParagraphFocus={setParagraphFocus}
+                onClose={() => setShowTypographyPanel(false)}
+              />
+            )}
+          </div>
 
           {/* Theme — desktop only */}
           <button
@@ -944,6 +1054,19 @@ export default function ReaderPage() {
               Obsidian
             </button>
           )}
+
+          {/* Focus mode toggle — desktop only */}
+          <button
+            onClick={() => { setFocusMode((v) => !v); setShowTypographyPanel(false); }}
+            title="Focus mode (F)"
+            className={`hidden md:flex shrink-0 items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-medium transition-colors ${
+              focusMode
+                ? "bg-amber-700 text-white border-amber-700"
+                : "border-amber-300 text-amber-700 hover:bg-amber-50"
+            }`}
+          >
+            🎯 Focus
+          </button>
 
           {/* Profile — always rightmost */}
           <button
@@ -1080,9 +1203,13 @@ export default function ReaderPage() {
                   scrollTargetWord={searchParams?.get("word") ? decodeURIComponent(searchParams.get("word")!) : undefined}
                   vocabWords={vocabWordsSet}
                   onSegmentClick={(startTime) => {
-                    // Called only when TTS is playing (seek)
                     ttsSeekRef.current(startTime);
                   }}
+                  focusParagraphIdx={paragraphFocus ? focusParagraphIdx : undefined}
+                  paragraphFocusEnabled={paragraphFocus}
+                  onParagraphVisible={handleParagraphVisible}
+                  onActiveParagraphChange={handleActiveParagraphChange}
+                  onParagraphTimingsUpdate={setParagraphTimings}
                 />
                 <div className={`mt-10 flex justify-between ${translationEnabled && displayMode === "parallel" ? "max-w-7xl mx-auto" : "prose-reader mx-auto"}`}>
                   <button
@@ -1233,6 +1360,8 @@ export default function ReaderPage() {
               onSeekRegister={(seekFn) => {
                 ttsSeekRef.current = seekFn;
               }}
+              stopAtTime={paragraphFocus ? ttsStopAt : undefined}
+              onStopAtReached={() => setTtsStopAt(undefined)}
             />
           </div>
         </div>

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -291,6 +291,16 @@ interface Props {
   scrollTargetWord?: string;
   /** Vocabulary words to show with a subtle dotted underline in all segments. */
   vocabWords?: Set<string>;
+  /** When set, dims all paragraphs except this index. */
+  focusParagraphIdx?: number;
+  /** When true, fires onParagraphVisible as the user scrolls. */
+  paragraphFocusEnabled?: boolean;
+  /** Fired when a paragraph scrolls into the viewport center (scroll-driven). */
+  onParagraphVisible?: (idx: number) => void;
+  /** Fired when audio playback crosses into a new paragraph. */
+  onActiveParagraphChange?: (idx: number) => void;
+  /** Fired when paragraph start/stop times are computed or updated. */
+  onParagraphTimingsUpdate?: (timings: { startTime: number; stopTime: number }[]) => void;
 }
 
 const ANNOTATION_COLOR_CLASS: Record<string, string> = {
@@ -394,6 +404,11 @@ export default function SentenceReader({
   showAnnotations = true,
   scrollTargetWord,
   vocabWords,
+  focusParagraphIdx,
+  paragraphFocusEnabled = false,
+  onParagraphVisible,
+  onActiveParagraphChange,
+  onParagraphTimingsUpdate,
 }: Props) {
   const [flashTarget, setFlashTarget] = useState<string | null>(null);
   const [expandedNoteFlatIdx, setExpandedNoteFlatIdx] = useState<number | null>(null);
@@ -447,6 +462,64 @@ export default function SentenceReader({
       activeRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
     }
   }, [currentIdx, isPlaying]);
+
+  // Expose paragraph timings to parent whenever paragraphs recompute (chunks load)
+  useEffect(() => {
+    if (!onParagraphTimingsUpdate) return;
+    onParagraphTimingsUpdate(
+      paragraphs.map((p, i) => ({
+        startTime: p.segments[0]?.startTime ?? 0,
+        stopTime: paragraphs[i + 1]?.segments[0]?.startTime ?? Infinity,
+      }))
+    );
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [paragraphs]);
+
+  // Track which paragraph contains the currently-playing segment and notify parent
+  const currentParagraphIdx = useMemo(() => {
+    if (currentIdx < 0) return -1;
+    for (let i = 0; i < paragraphs.length; i++) {
+      if (paragraphs[i].segments.some((s) => s.flatIdx === currentIdx)) return i;
+    }
+    return -1;
+  }, [currentIdx, paragraphs]);
+
+  const prevActiveParagraphRef = useRef(-1);
+  useEffect(() => {
+    if (currentParagraphIdx >= 0 && currentParagraphIdx !== prevActiveParagraphRef.current) {
+      prevActiveParagraphRef.current = currentParagraphIdx;
+      onActiveParagraphChange?.(currentParagraphIdx);
+    }
+  }, [currentParagraphIdx, onActiveParagraphChange]);
+
+  // Scroll-based paragraph focus: fire onParagraphVisible with the paragraph
+  // nearest the viewport center while the user scrolls (and on mount)
+  useEffect(() => {
+    if (!paragraphFocusEnabled || !onParagraphVisible) return;
+    const container = document.getElementById("reader-scroll");
+    if (!container) return;
+
+    function update() {
+      const containerRect = container!.getBoundingClientRect();
+      const center = containerRect.top + containerRect.height / 2;
+      let bestIdx = 0;
+      let bestDist = Infinity;
+      containerRef.current?.querySelectorAll<HTMLElement>("[data-para-idx]").forEach((el) => {
+        const rect = el.getBoundingClientRect();
+        const dist = Math.abs(rect.top + rect.height / 2 - center);
+        if (dist < bestDist) {
+          bestDist = dist;
+          bestIdx = Number(el.getAttribute("data-para-idx"));
+        }
+      });
+      onParagraphVisible!(bestIdx);
+    }
+
+    container.addEventListener("scroll", update, { passive: true });
+    update();
+    return () => container.removeEventListener("scroll", update);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [paragraphFocusEnabled, paragraphs]);
 
   // Scroll to and flash the target sentence when scrollTargetSentence changes.
   // We capture the sentence in a closure so rapid re-triggers (< 80ms apart)
@@ -657,10 +730,14 @@ export default function SentenceReader({
           </div>
         ) : null;
 
+        const focusClass = focusParagraphIdx !== undefined
+          ? (pIdx === focusParagraphIdx ? "para-active" : "para-dim")
+          : "";
+
         // ── No translation: render original only ──
         if (!hasTranslations) {
           return (
-            <div key={pIdx}>
+            <div key={pIdx} data-para-idx={pIdx} className={focusClass}>
               {originalContent}
               {noteCard}
             </div>
@@ -670,7 +747,7 @@ export default function SentenceReader({
         // ── Translation: parallel (side by side) ──
         if (isParallel) {
           return (
-            <div key={pIdx} className="py-4 first:pt-0 last:pb-0">
+            <div key={pIdx} data-para-idx={pIdx} className={`py-4 first:pt-0 last:pb-0 ${focusClass}`}>
               <div className="flex flex-col md:grid md:grid-cols-2 md:gap-6 gap-2">
                 <div>
                   {originalContent}
@@ -696,7 +773,7 @@ export default function SentenceReader({
 
         // ── Translation: inline (below) ──
         return (
-          <div key={pIdx}>
+          <div key={pIdx} data-para-idx={pIdx} className={focusClass}>
             {originalContent}
             {noteCard}
             {translationLoading && textParaIdx === 0 && !translationText && (

--- a/frontend/src/components/TTSControls.tsx
+++ b/frontend/src/components/TTSControls.tsx
@@ -20,6 +20,10 @@ interface Props {
   onLoadingChange?: (isLoading: boolean) => void;
   onChunksUpdate?: (chunks: ChunkSnapshot[]) => void;
   onSeekRegister?: (seekAndPlay: (time: number) => void) => void;
+  /** Auto-pause when globalCurrentTime reaches this value. */
+  stopAtTime?: number;
+  /** Called when stopAtTime is reached and audio is auto-paused. */
+  onStopAtReached?: () => void;
 }
 
 type Status = "idle" | "loading" | "paused" | "playing" | "error";
@@ -47,6 +51,8 @@ export default function TTSControls({
   onLoadingChange,
   onChunksUpdate,
   onSeekRegister,
+  stopAtTime,
+  onStopAtReached,
 }: Props) {
   const [status, setStatus] = useState<Status>("idle");
   const [rate, setRate] = useState(1.0);
@@ -70,10 +76,14 @@ export default function TTSControls({
   const onLoadingChangeRef = useRef(onLoadingChange);
   const onChunksUpdateRef = useRef(onChunksUpdate);
   const onSeekRegisterRef = useRef(onSeekRegister);
+  const onStopAtReachedRef = useRef(onStopAtReached);
+  const stopAtTimeRef = useRef(stopAtTime);
   useEffect(() => { onPlaybackUpdateRef.current = onPlaybackUpdate; }, [onPlaybackUpdate]);
   useEffect(() => { onLoadingChangeRef.current = onLoadingChange; }, [onLoadingChange]);
   useEffect(() => { onChunksUpdateRef.current = onChunksUpdate; }, [onChunksUpdate]);
   useEffect(() => { onSeekRegisterRef.current = onSeekRegister; }, [onSeekRegister]);
+  useEffect(() => { onStopAtReachedRef.current = onStopAtReached; }, [onStopAtReached]);
+  useEffect(() => { stopAtTimeRef.current = stopAtTime; }, [stopAtTime]);
 
   useEffect(() => {
     onLoadingChangeRef.current?.(status === "loading");
@@ -255,7 +265,15 @@ export default function TTSControls({
         audio.addEventListener("timeupdate", () => {
           if (myGen !== genRef.current) return;
           if (chunksRef.current[activeIndexRef.current]?.audio === audio) {
-            setGlobalCurrentTime(computeGlobalCurrentTime());
+            const t = computeGlobalCurrentTime();
+            setGlobalCurrentTime(t);
+            const stopAt = stopAtTimeRef.current;
+            if (stopAt !== undefined && Number.isFinite(stopAt) && t >= stopAt) {
+              audio.pause();
+              setStatus("paused");
+              saveAudioPosition(bookId, chapterIndex, t);
+              onStopAtReachedRef.current?.();
+            }
           }
         });
 

--- a/frontend/src/components/TypographyPanel.tsx
+++ b/frontend/src/components/TypographyPanel.tsx
@@ -1,0 +1,174 @@
+"use client";
+import { useEffect, useRef } from "react";
+import { FontSize, LineHeight, ContentWidth, FontFamily, saveSettings } from "@/lib/settings";
+
+interface Props {
+  fontSize: FontSize;
+  lineHeight: LineHeight;
+  contentWidth: ContentWidth;
+  fontFamily: FontFamily;
+  paragraphFocus: boolean;
+  onFontSize: (v: FontSize) => void;
+  onLineHeight: (v: LineHeight) => void;
+  onContentWidth: (v: ContentWidth) => void;
+  onFontFamily: (v: FontFamily) => void;
+  onParagraphFocus: (v: boolean) => void;
+  onClose: () => void;
+}
+
+type Option<T> = { value: T; label: string };
+
+const FONT_SIZES: Option<FontSize>[] = [
+  { value: "sm", label: "S" },
+  { value: "base", label: "M" },
+  { value: "lg", label: "L" },
+  { value: "xl", label: "XL" },
+];
+
+const LINE_HEIGHTS: Option<LineHeight>[] = [
+  { value: "tight", label: "Tight" },
+  { value: "normal", label: "Normal" },
+  { value: "relaxed", label: "Relaxed" },
+];
+
+const CONTENT_WIDTHS: Option<ContentWidth>[] = [
+  { value: "narrow", label: "Narrow" },
+  { value: "normal", label: "Normal" },
+  { value: "wide", label: "Wide" },
+];
+
+const FONT_FAMILIES: Option<FontFamily>[] = [
+  { value: "serif", label: "Serif" },
+  { value: "sans", label: "Sans" },
+];
+
+function SegmentedControl<T extends string>({
+  options,
+  value,
+  onChange,
+}: {
+  options: Option<T>[];
+  value: T;
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div className="flex rounded-lg border border-amber-200 overflow-hidden">
+      {options.map((opt) => (
+        <button
+          key={opt.value}
+          onClick={() => onChange(opt.value)}
+          className={`flex-1 px-2 py-1.5 text-xs font-medium transition-colors ${
+            value === opt.value
+              ? "bg-amber-700 text-white"
+              : "bg-white text-amber-700 hover:bg-amber-50"
+          }`}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default function TypographyPanel({
+  fontSize,
+  lineHeight,
+  contentWidth,
+  fontFamily,
+  paragraphFocus,
+  onFontSize,
+  onLineHeight,
+  onContentWidth,
+  onFontFamily,
+  onParagraphFocus,
+  onClose,
+}: Props) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [onClose]);
+
+  function set<T extends string>(setter: (v: T) => void, key: keyof Parameters<typeof saveSettings>[0]) {
+    return (v: T) => {
+      setter(v);
+      saveSettings({ [key]: v } as Parameters<typeof saveSettings>[0]);
+    };
+  }
+
+  return (
+    <div
+      ref={panelRef}
+      className="absolute top-full right-0 mt-1 z-50 bg-white border border-amber-200 rounded-xl shadow-lg p-4 w-64 animate-fade-in"
+      data-testid="typography-panel"
+    >
+      <div className="space-y-4">
+        <Row label="Font size">
+          <SegmentedControl
+            options={FONT_SIZES}
+            value={fontSize}
+            onChange={set(onFontSize, "fontSize")}
+          />
+        </Row>
+        <Row label="Font">
+          <SegmentedControl
+            options={FONT_FAMILIES}
+            value={fontFamily}
+            onChange={set(onFontFamily, "fontFamily")}
+          />
+        </Row>
+        <Row label="Spacing">
+          <SegmentedControl
+            options={LINE_HEIGHTS}
+            value={lineHeight}
+            onChange={set(onLineHeight, "lineHeight")}
+          />
+        </Row>
+        <Row label="Width">
+          <SegmentedControl
+            options={CONTENT_WIDTHS}
+            value={contentWidth}
+            onChange={set(onContentWidth, "contentWidth")}
+          />
+        </Row>
+        <div className="flex items-center justify-between pt-1 border-t border-amber-100">
+          <span className="text-xs text-stone-600">Paragraph focus</span>
+          <button
+            onClick={() => {
+              const next = !paragraphFocus;
+              onParagraphFocus(next);
+              saveSettings({ paragraphFocus: next });
+            }}
+            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+              paragraphFocus ? "bg-amber-700" : "bg-stone-200"
+            }`}
+            role="switch"
+            aria-label="Paragraph focus"
+            aria-checked={paragraphFocus}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                paragraphFocus ? "translate-x-4" : "translate-x-0.5"
+              }`}
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1.5">
+      <span className="text-xs text-stone-500 font-medium">{label}</span>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/lib/settings.ts
+++ b/frontend/src/lib/settings.ts
@@ -3,6 +3,9 @@ export type FontSize = "sm" | "base" | "lg" | "xl";
 export type ChatFontSize = "xs" | "sm";
 export type Theme = "light" | "dark" | "sepia";
 export type TTSGender = "female" | "male";
+export type LineHeight = "tight" | "normal" | "relaxed";
+export type ContentWidth = "narrow" | "normal" | "wide";
+export type FontFamily = "serif" | "sans";
 
 export interface AppSettings {
   insightLang: string;
@@ -13,6 +16,10 @@ export interface AppSettings {
   fontSize: FontSize;
   chatFontSize: ChatFontSize;
   theme: Theme;
+  lineHeight: LineHeight;
+  contentWidth: ContentWidth;
+  fontFamily: FontFamily;
+  paragraphFocus: boolean;
 }
 
 const DEFAULTS: AppSettings = {
@@ -24,6 +31,10 @@ const DEFAULTS: AppSettings = {
   fontSize: "base",
   chatFontSize: "xs",
   theme: "light",
+  lineHeight: "normal",
+  contentWidth: "normal",
+  fontFamily: "serif",
+  paragraphFocus: false,
 };
 
 const KEY = "book-reader-settings";


### PR DESCRIPTION
## Summary

- **Focus Mode**: Press `F` or click "🎯 Focus" in the feature row to hide the header and feature bar on desktop. A minimal floating HUD appears with chapter navigation, "▶ Read para" (when paragraph focus is on), Aa typography access, and ✕ to exit. `Esc` also exits.
- **Typography Panel**: The old cycling `A` button is replaced by `Aa` which opens a popover with four controls — font size (S/M/L/XL), font family (Serif/Sans), line spacing (Tight/Normal/Relaxed), and content width (Narrow/Normal/Wide). All settings persist to localStorage.
- **Paragraph Focus**: Toggle in the typography panel. Dims all paragraphs to 20% opacity except the one in the viewport center (scroll-driven when audio is paused, audio-driven when playing). Smooth 0.4s transitions.
- **Paragraph Reading**: When paragraph focus is active, "▶ Read para" in the focus HUD seeks TTS to the focused paragraph's start time and auto-pauses at the next paragraph boundary. The focused paragraph tracks the voice as it reads.

## Test plan

- [x] 9 TypographyPanel tests (renders, each control fires callback + saveSettings, toggle, outside-click closes)
- [x] 6 SentenceReader.focus tests (para-dim/para-active classes, data-para-idx, onParagraphTimingsUpdate, onActiveParagraphChange)
- [x] 2 TTSControls.stopAt tests (auto-pause when time reached, no-op when undefined)
- [x] ReaderPage font-size tests updated to use new panel workflow
- [x] 1519 frontend tests passing, 908 backend tests passing

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
