### PR TITLE
fix: serialize concurrent split_with_html_preference calls to prevent divergent chapter lists

### DIFF
--- a/backend/services/book_chapters.py
+++ b/backend/services/book_chapters.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections import defaultdict
 
 from services.gutenberg import get_book_html
 from services.splitter import Chapter, build_chapters, build_chapters_from_html
@@ -28,6 +29,11 @@ logger = logging.getLogger(__name__)
 # reader previously had its own cache in routers/books.py — merged here
 # so reader + worker share the same result.
 _chapter_cache: dict[int, list[Chapter]] = {}
+
+# One lock per book_id: serializes concurrent cache-miss requests so the
+# second waiter reuses the result written by the first instead of running
+# a different split path and returning a divergent chapter list.
+_split_locks: dict[int, asyncio.Lock] = defaultdict(asyncio.Lock)
 
 
 async def split_with_html_preference(book_id: int, text: str) -> list[Chapter]:
@@ -45,21 +51,28 @@ async def split_with_html_preference(book_id: int, text: str) -> list[Chapter]:
     if cached is not None:
         return cached
 
-    try:
-        html = await get_book_html(book_id)
-        if html:
-            chapters = await asyncio.to_thread(build_chapters_from_html, html)
-            if len(chapters) >= 2:
-                _chapter_cache[book_id] = chapters
-                return chapters
-    except Exception:
-        logger.exception(
-            "HTML split failed for book %s, falling back to text", book_id,
-        )
+    async with _split_locks[book_id]:
+        # Double-check: a concurrent request may have populated the cache
+        # while we were waiting for the lock.
+        cached = _chapter_cache.get(book_id)
+        if cached is not None:
+            return cached
 
-    chapters = await asyncio.to_thread(build_chapters, text)
-    _chapter_cache[book_id] = chapters
-    return chapters
+        try:
+            html = await get_book_html(book_id)
+            if html:
+                chapters = await asyncio.to_thread(build_chapters_from_html, html)
+                if len(chapters) >= 2:
+                    _chapter_cache[book_id] = chapters
+                    return chapters
+        except Exception:
+            logger.exception(
+                "HTML split failed for book %s, falling back to text", book_id,
+            )
+
+        chapters = await asyncio.to_thread(build_chapters, text)
+        _chapter_cache[book_id] = chapters
+        return chapters
 
 
 def clear_cache(book_id: int | None = None) -> None:

--- a/backend/tests/test_book_chapters.py
+++ b/backend/tests/test_book_chapters.py
@@ -2,6 +2,8 @@
 Tests for services/book_chapters.py — split_with_html_preference and clear_cache.
 """
 
+import asyncio
+
 import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
 
@@ -158,3 +160,43 @@ async def test_clear_cache_specific_does_not_affect_other_books():
     clear_cache(40)
     assert 40 not in book_chapters_module._chapter_cache
     assert 41 in book_chapters_module._chapter_cache
+
+
+# ── Concurrency ───────────────────────────────────────────────────────────────
+
+async def test_concurrent_calls_return_identical_chapter_list():
+    """Two concurrent cache-miss calls must resolve to the same chapter list.
+
+    Without a lock, one call can take the HTML path (returning 3 chapters) and
+    the other can take the text-fallback path (returning 2 chapters), causing
+    translation index misalignment between the reader and the queue worker.
+    """
+    html_chapters = _make_chapters("HTML Ch 1", "HTML Ch 2", "HTML Ch 3")
+    text_chapters = _make_chapters("Text Ch 1", "Text Ch 2")
+
+    call_count = {"n": 0}
+
+    async def _slow_html_fetch(_book_id):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # First caller: yield so the second caller enters before HTML arrives
+            await asyncio.sleep(0)
+            return "<html>...</html>"
+        # Second caller: HTML not available
+        return None
+
+    with (
+        patch("services.book_chapters.get_book_html", side_effect=_slow_html_fetch),
+        patch("services.book_chapters.build_chapters_from_html", return_value=html_chapters),
+        patch("services.book_chapters.build_chapters", return_value=text_chapters),
+    ):
+        results = await asyncio.gather(
+            split_with_html_preference(50, "plain text"),
+            split_with_html_preference(50, "plain text"),
+        )
+
+    # Both callers must return the same list
+    assert results[0] is results[1], (
+        f"Concurrent calls returned different chapter lists: "
+        f"{[c.title for c in results[0]]} vs {[c.title for c in results[1]]}"
+    )


### PR DESCRIPTION
## Summary

- `split_with_html_preference` had no lock around its cache-miss path
- Two concurrent calls for the same `book_id` could both observe a cache miss, independently execute different split paths (HTML parse vs text fallback), and return divergent chapter lists to their callers
- Last writer would overwrite the cache, so the reader and translation queue worker could disagree on chapter count and indices — causing translated text to appear under the wrong chapter from the first divergent index onward
- Fixed by adding a `defaultdict(asyncio.Lock)` keyed by `book_id` with a double-check after acquiring the lock (same pattern as `_summary_locks` in `routers/ai.py`)

## Test plan

- [ ] New regression test `test_concurrent_calls_return_identical_chapter_list` — simulates two concurrent cache-miss calls where the first gets HTML and the second does not; asserts both callers receive the identical list object. Failed before fix, passes after.
- [ ] All 12 `test_book_chapters` tests pass
- [ ] Full backend suite: 912 passed, 0 failed

Closes #304
