### PR TITLE
fix: retranslate endpoints no longer delete translations before confirming success

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -414,18 +414,10 @@ async def retranslate(
 
     chapter_text = chapters[chapter_index].text
 
-    # 2. Delete old cached translation
-    async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute(
-            "DELETE FROM translations WHERE book_id=? AND chapter_index=? AND target_language=?",
-            (book_id, chapter_index, target_language),
-        )
-        await db.commit()
-
-    # 3. Detect source language from book metadata
+    # 2. Detect source language from book metadata
     source_language = (book.get("languages") or ["en"])[0]
 
-    # 4. Resolve provider — use admin's Gemini key if available, else Google
+    # 3. Resolve provider — use admin's Gemini key if available, else Google
     raw_key = admin.get("gemini_key")
     try:
         decrypted_key: str | None = decrypt_api_key(raw_key) if raw_key else None
@@ -433,7 +425,7 @@ async def retranslate(
         decrypted_key = None  # corrupted key → fall back to Google
     provider = "gemini" if decrypted_key else "google"
 
-    # 5. Translate
+    # 4. Translate
     try:
         paragraphs = await do_translate(
             chapter_text,
@@ -451,7 +443,7 @@ async def retranslate(
         else:
             raise
 
-    # 6. Cache the new translation
+    # 5. Cache the new translation
     await save_translation(book_id, chapter_index, target_language, paragraphs)
 
     return {
@@ -524,7 +516,12 @@ async def retranslate_all(
     req: BulkRetranslateRequest,
     admin: dict = Depends(_require_admin),
 ):
-    """Delete and retranslate ALL chapters of a book for a target language."""
+    """Retranslate ALL chapters of a book for a target language.
+
+    save_translation uses INSERT OR REPLACE, so each successful chapter
+    overwrites the old row atomically. Old translations survive if their
+    chapter fails — no upfront DELETE needed.
+    """
     target_language = req.target_language.lower().split("-")[0]
     book = await get_cached_book(book_id)
     if not book or not book.get("text"):
@@ -540,14 +537,6 @@ async def retranslate_all(
     except HTTPException:
         decrypted_key = None  # corrupted key → fall back to Google
     provider = "gemini" if decrypted_key else "google"
-
-    # Delete all existing translations for this language
-    async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute(
-            "DELETE FROM translations WHERE book_id=? AND target_language=?",
-            (book_id, target_language),
-        )
-        await db.commit()
 
     results = []
     for i, ch in enumerate(chapters):

--- a/backend/tests/test_router_admin_extended.py
+++ b/backend/tests/test_router_admin_extended.py
@@ -823,3 +823,63 @@ async def test_retranslate_all_with_corrupted_key_falls_back_to_google(admin_cli
 
     assert res.status_code == 200
     assert captured and all(p == "google" for p in captured)
+
+
+# ── Retranslate preserves old translation on failure (regression #306) ────────
+
+async def test_retranslate_preserves_old_translation_on_failure(admin_client, admin_db):
+    """When translation fails, the old cached translation must not be deleted.
+
+    Previously: DELETE old translation → try translate → on failure, old is gone.
+    Fixed: translate first; save_translation (INSERT OR REPLACE) overwrites on success;
+    on failure, old row is never touched.
+    """
+    await save_book(200, BOOK_META, BOOK_TEXT)
+    await save_translation(200, 0, "fr", ["original paragraph"])
+
+    from services.db import get_cached_translation
+
+    async def always_fail(text, src, tgt, provider="google", gemini_key=None):
+        raise Exception("simulated network error")
+
+    with patch("routers.admin.do_translate", side_effect=always_fail):
+        # The unhandled exception propagates through the ASGI transport in tests.
+        with pytest.raises(Exception, match="simulated network error"):
+            await admin_client.post("/api/admin/translations/200/0/fr/retranslate")
+
+    # Old translation must survive regardless of the translate failure
+    cached = await get_cached_translation(200, 0, "fr")
+    assert cached == ["original paragraph"], (
+        "Old translation was deleted before confirming the new one succeeded"
+    )
+
+
+async def test_retranslate_all_preserves_old_translations_on_failure(admin_client, admin_db):
+    """When translation fails for every chapter, old translations must not be deleted.
+
+    Previously: DELETE ALL → loop → all fail → old translations gone.
+    Fixed: no upfront DELETE; save_translation only called on success.
+    """
+    await save_book(200, BOOK_META, BOOK_TEXT)
+    await save_translation(200, 0, "fr", ["original ch0"])
+    await save_translation(200, 1, "fr", ["original ch1"])
+
+    from services.db import get_cached_translation
+
+    async def always_fail(text, src, tgt, provider="google", gemini_key=None):
+        raise Exception("simulated network error")
+
+    with patch("routers.admin.do_translate", side_effect=always_fail):
+        res = await admin_client.post(
+            "/api/admin/translations/200/retranslate-all",
+            json={"target_language": "fr"},
+        )
+
+    assert res.status_code == 200
+    # All chapters failed to translate — original rows must remain intact
+    assert await get_cached_translation(200, 0, "fr") == ["original ch0"], (
+        "Chapter 0 old translation was deleted before confirming new one succeeded"
+    )
+    assert await get_cached_translation(200, 1, "fr") == ["original ch1"], (
+        "Chapter 1 old translation was deleted before confirming new one succeeded"
+    )


### PR DESCRIPTION
## Summary

- Both retranslate endpoints (`POST /admin/translations/{id}/{idx}/{lang}/retranslate` and `POST /admin/translations/{id}/retranslate-all`) deleted existing cached translations **before** attempting to generate new ones
- If translation failed (network error, both Gemini and Google unavailable), the old translation was permanently gone — no recovery possible
- `save_translation` already uses `INSERT OR REPLACE`, so the explicit `DELETE` was never necessary: a successful translation naturally overwrites the old row, and a failed translation never reaches `save_translation`, leaving the old row intact
- Fixed by removing the upfront `DELETE` from both endpoints

## Test plan

- [ ] New regression test `test_retranslate_preserves_old_translation_on_failure` — patches `do_translate` to raise on every call, asserts old translation survives. Failed before fix (row deleted), passes after.
- [ ] New regression test `test_retranslate_all_preserves_old_translations_on_failure` — same for retranslate-all. Failed before fix (all rows deleted), passes after.
- [ ] All existing retranslate tests still pass (successful translation still overwrites old row as expected)
- [ ] Full backend suite: 915 passed, 0 failed

Closes #306
