### PR TITLE
fix: replace emoji ⏸/▶ in focus HUD with PauseIcon/PlayIcon SVGs

### DIFF
--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -811,10 +811,10 @@ export default function ReaderPage() {
                 <span className="text-stone-400 mx-0.5">|</span>
                 <button
                   onClick={ttsIsPlaying ? undefined : readFocusedParagraph}
-                  className="px-2 py-1 rounded-full hover:bg-amber-50 transition-colors"
+                  className="inline-flex items-center gap-1 px-2 py-1 rounded-full hover:bg-amber-50 transition-colors"
                   title={ttsIsPlaying ? "Playing…" : "Read focused paragraph"}
                 >
-                  {ttsIsPlaying ? "⏸ Playing" : "▶ Read para"}
+                  {ttsIsPlaying ? <><PauseIcon className="w-3 h-3 shrink-0" /> Playing</> : <><PlayIcon className="w-3 h-3 shrink-0" /> Read para</>}
                 </button>
               </>
             )}


### PR DESCRIPTION
## Summary

- Replaces `⏸ Playing` / `▶ Read para` emoji strings in the focus-mode HUD button with `<PauseIcon>`/`<PlayIcon>` SVG components
- Adds `inline-flex items-center gap-1` to the button so icon and label align correctly
- Both icons were already imported on the reader page; no new dependencies

Closes #308

## Test plan

- [x] All 1528 frontend Jest tests pass
- [x] Reader page tests (258) pass including keyboard shortcuts and chapter nav tests
- [ ] Manual: open a book → enable paragraph focus → verify "▶ Read para" button shows SVG play icon; tap to play → verify it shows SVG pause icon
