### PR TITLE
fix: verify GitHub OAuth access token server-side (closes #300)

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-from services.auth import verify_google_id_token, verify_apple_id_token, create_jwt
+from services.auth import verify_google_id_token, verify_apple_id_token, verify_github_access_token, create_jwt
 from services.db import get_or_create_user, get_or_create_user_github, get_or_create_user_apple
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -43,23 +43,27 @@ async def google_login(req: GoogleAuthRequest):
 
 
 class GitHubAuthRequest(BaseModel):
-    github_id: str
-    email: str = ""
-    name: str = ""
-    picture: str = ""
+    access_token: str
 
 
 @router.post("/github")
 async def github_login(req: GitHubAuthRequest):
-    """Exchange GitHub profile info for our own backend JWT."""
-    if not req.github_id:
-        raise HTTPException(status_code=400, detail="github_id is required")
+    """Verify a GitHub OAuth access token server-side and issue our own JWT."""
+    if not req.access_token:
+        raise HTTPException(status_code=400, detail="access_token is required")
+
+    try:
+        profile = await verify_github_access_token(req.access_token)
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=401, detail=str(e))
 
     user = await get_or_create_user_github(
-        github_id=req.github_id,
-        email=req.email,
-        name=req.name,
-        picture=req.picture,
+        github_id=profile["id"],
+        email=profile["email"],
+        name=profile["name"],
+        picture=profile["picture"],
     )
     return _user_response(user)
 

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -62,6 +62,36 @@ def decode_jwt(token: str) -> dict:
         raise HTTPException(status_code=401, detail=f"Invalid token: {e}")
 
 
+# ── GitHub access token verification ─────────────────────────────────────────
+
+async def verify_github_access_token(access_token: str) -> dict:
+    """Verify a GitHub OAuth access token and return verified profile data.
+
+    Calls https://api.github.com/user with the token.  Raises 401 on failure.
+    Returns dict with keys: id (str), email, name, picture.
+    """
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(
+            "https://api.github.com/user",
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+    if resp.status_code != 200:
+        raise HTTPException(status_code=401, detail="Invalid GitHub access token")
+    data = resp.json()
+    github_id = data.get("id")
+    if not github_id:
+        raise HTTPException(status_code=401, detail="GitHub token missing user id")
+    return {
+        "id": str(github_id),
+        "email": data.get("email") or "",
+        "name": data.get("name") or data.get("login") or "",
+        "picture": data.get("avatar_url") or "",
+    }
+
+
 # ── Google ID token verification ──────────────────────────────────────────────
 
 async def verify_google_id_token(id_token: str) -> dict:

--- a/backend/tests/test_router_auth.py
+++ b/backend/tests/test_router_auth.py
@@ -13,6 +13,13 @@ FAKE_GOOGLE_INFO = {
     "picture": "https://pic.example.com/a.jpg",
 }
 
+FAKE_GITHUB_PROFILE = {
+    "id": "gh-123",
+    "email": "gh@example.com",
+    "name": "GH User",
+    "picture": "https://avatars.github.com/1",
+}
+
 
 async def test_google_login_returns_token_and_user(client):
     with patch("routers.auth.verify_google_id_token", new_callable=AsyncMock, return_value=FAKE_GOOGLE_INFO):
@@ -62,12 +69,8 @@ async def test_google_login_missing_optional_fields(client):
 # ── GitHub login ──────────────────────────────────────────────────────────────
 
 async def test_github_login_returns_token_and_user(client):
-    resp = await client.post("/api/auth/github", json={
-        "github_id": "gh-123",
-        "email": "gh@example.com",
-        "name": "GH User",
-        "picture": "https://avatars.github.com/1",
-    })
+    with patch("routers.auth.verify_github_access_token", new_callable=AsyncMock, return_value=FAKE_GITHUB_PROFILE):
+        resp = await client.post("/api/auth/github", json={"access_token": "ghp_valid"})
     assert resp.status_code == 200
     data = resp.json()
     assert "token" in data
@@ -76,19 +79,31 @@ async def test_github_login_returns_token_and_user(client):
     assert "hasGeminiKey" in data["user"]
 
 
-async def test_github_login_missing_github_id_returns_400(client):
-    resp = await client.post("/api/auth/github", json={
-        "github_id": "",
-        "email": "gh@example.com",
-    })
+async def test_github_login_missing_access_token_returns_400(client):
+    resp = await client.post("/api/auth/github", json={"access_token": ""})
     assert resp.status_code == 400
-    assert "github_id is required" in resp.json()["detail"]
+    assert "access_token is required" in resp.json()["detail"]
+
+
+async def test_github_login_invalid_token_returns_401(client):
+    from fastapi import HTTPException as FastAPIHTTPException
+    with patch(
+        "routers.auth.verify_github_access_token",
+        new_callable=AsyncMock,
+        side_effect=FastAPIHTTPException(status_code=401, detail="Invalid GitHub access token"),
+    ):
+        resp = await client.post("/api/auth/github", json={"access_token": "bad-token"})
+    assert resp.status_code == 401
+    assert "Invalid GitHub access token" in resp.json()["detail"]
 
 
 async def test_github_login_idempotent(client, tmp_db):
-    payload = {"github_id": "gh-456", "email": "repeat@example.com", "name": "Repeat"}
-    resp1 = await client.post("/api/auth/github", json=payload)
-    resp2 = await client.post("/api/auth/github", json=payload)
+    with patch("routers.auth.verify_github_access_token", new_callable=AsyncMock,
+               return_value={"id": "gh-456", "email": "repeat@example.com", "name": "Repeat", "picture": ""}):
+        resp1 = await client.post("/api/auth/github", json={"access_token": "ghp_tok1"})
+    with patch("routers.auth.verify_github_access_token", new_callable=AsyncMock,
+               return_value={"id": "gh-456", "email": "repeat@example.com", "name": "Repeat", "picture": ""}):
+        resp2 = await client.post("/api/auth/github", json={"access_token": "ghp_tok2"})
     assert resp1.status_code == 200
     assert resp2.status_code == 200
     assert resp1.json()["user"]["id"] == resp2.json()["user"]["id"]

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -35,17 +35,11 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ id_token: account.id_token }),
             });
-          } else if (account.provider === "github") {
-            const ghProfile = profile as { id?: number; login?: string; avatar_url?: string; email?: string; name?: string } | undefined;
+          } else if (account.provider === "github" && account.access_token) {
             res = await fetch(`${API}/auth/github`, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                github_id: String(ghProfile?.id ?? account.providerAccountId),
-                email: ghProfile?.email ?? token.email ?? "",
-                name: ghProfile?.name ?? ghProfile?.login ?? "",
-                picture: ghProfile?.avatar_url ?? "",
-              }),
+              body: JSON.stringify({ access_token: account.access_token }),
             });
           } else if (account.provider === "apple" && account.id_token) {
             const appleProfile = profile as { name?: { firstName?: string; lastName?: string } } | undefined;


### PR DESCRIPTION
## Summary

Fixes a critical account-takeover vulnerability where `POST /auth/github` accepted raw profile claims (`github_id`, `email`, etc.) from the client with no server-side verification.  Any attacker who knew a victim's email could forge a request and receive a valid JWT for the victim's account.

**Root cause:** the endpoint trusted client-supplied `github_id` and `email` directly.

**Fix:**
- `POST /auth/github` now accepts only `{ access_token }` (a GitHub OAuth access token)
- Backend verifies the token server-side via `GET https://api.github.com/user` using `verify_github_access_token()` in `services/auth.py`
- Only the verified profile data from GitHub's API is used to create/link the user
- Frontend (`auth.ts`) now sends `account.access_token` from NextAuth instead of client-supplied profile fields

## Affected files
- `backend/services/auth.py` — new `verify_github_access_token()` function
- `backend/routers/auth.py` — updated `GitHubAuthRequest` model and route handler
- `frontend/src/auth.ts` — sends `access_token` instead of raw profile data
- `backend/tests/test_router_auth.py` — updated tests mock `verify_github_access_token`

## Test plan

- [x] All 918 backend tests pass
- [x] All 1528 frontend tests pass
- [x] New test: `test_github_login_invalid_token_returns_401` — verifies 401 on bad token
- [x] Existing tests updated to mock server-side verification

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)
