### PR TITLE
feat(ux-wave9): replace emoji/symbol icons in notes, admin, and sidebar

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -122,21 +122,21 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 
 ## UX Issues (Opened for Later)
 
-- [ ] **UX-001**: Reader header button overflow on mid-size screens — needs a "More" overflow menu or collapsible toolbar
-- [ ] **UX-002**: Chapter select dropdown is native HTML `<select>` — consider custom dropdown or at minimum better styling
+- [x] **UX-001**: Reader header button overflow on mid-size screens *(fixed Wave 7.2: icon-only on md, icon+text on lg)*
+- [x] **UX-002**: Chapter select dropdown — `appearance-none` + ChevronDown overlay + SVG prev/next *(fixed Wave 8.2)*
 - [ ] **UX-003**: Long-press annotation on mobile conflicts with native text selection — needs review
-- [ ] **UX-004**: Mobile tab bar with 5 tabs (Library, Discover, Notes, Word List, Admin) clips on 375px screens
-- [ ] **UX-005**: Translation sidebar panels open/close without animation on desktop — could use smooth slide transition
-- [ ] **UX-006**: No keyboard shortcut shown anywhere — discoverable features hidden
+- [x] **UX-004**: Mobile tab bar with 5 tabs clips on 375px screens *(fixed Wave 7.4: `overflow-x-auto scrollbar-none`)*
+- [x] **UX-005**: Translation sidebar panels open/close without animation *(fixed Wave 7.3: `transition-[width] duration-200`)*
+- [x] **UX-006**: No keyboard shortcut shown anywhere *(fixed Wave 8.1: `?` button opens shortcuts panel in reader)*
 - [x] **UX-007**: "Remove from library" × button is 24px — below 44px touch target minimum on mobile *(fixed Wave 7.1)*
 - [x] **UX-008**: Reading stats buried in Profile page — move to Home tab as personal dashboard *(fixed PR #290)*
 - [x] **UX-009**: `WordActionDrawer` action buttons use emoji (`🔊 💾 📝`) — should be SVG icons *(fixed Wave 8.2)*
 - [x] **UX-010**: `SentenceActionPopup` action buttons use emoji (`🔊 📝 💬`) — inconsistent with icon system *(fixed Wave 8.3)*
 - [x] **UX-011**: `ChapterSummary` uses `📋` emoji in header and empty state — replace with `SummaryIcon` SVG *(fixed Wave 8.4)*
 - [x] **UX-012**: `InsightChat` context snippet uses `📎` emoji — replace with `PaperclipIcon` SVG *(fixed Wave 8.5)*
-- [ ] **UX-013**: Profile page gender selector shows `♀ Female / ♂ Male` Unicode symbols — replace with text-only labels
-- [ ] **UX-014**: Import page status cells use `✓` / `…` / `!` text characters as status icons — replace with SVG
-- [ ] **UX-015**: Vocabulary page back button uses `←` text character — replace with `ArrowLeftIcon` SVG
+- [x] **UX-013**: Profile page gender selector shows `♀ Female / ♂ Male` — text-only labels *(fixed Wave 8.6)*
+- [x] **UX-014**: Import page status cells use `✓` / `…` / `!` — SVG icons via CheckCircle/Retry/AlertCircle/CircleDot *(fixed Wave 8.7)*
+- [x] **UX-015**: Vocabulary page back button uses `←` — replaced with `ArrowLeftIcon` SVG *(fixed Wave 8.8)*
 
 ---
 

--- a/frontend/e2e/notes-page.spec.ts
+++ b/frontend/e2e/notes-page.spec.ts
@@ -140,7 +140,7 @@ test("notes page: annotation chapter link points to reader URL with sentence", a
 
   await page.goto("/notes/1342");
 
-  const link = page.getByRole("link", { name: /→ Chapter/ });
+  const link = page.getByRole("link", { name: /Chapter/ });
   await expect(link).toBeVisible();
 
   const href = await link.getAttribute("href");

--- a/frontend/src/__tests__/AdminBooksPage.branches.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.branches.test.tsx
@@ -94,7 +94,7 @@ async function renderWithLangExpanded() {
   await waitFor(() => screen.getByText("zh"));
   const allBtns = screen.getAllByRole("button");
   const langArrow = allBtns.find(
-    (b) => (b.textContent === "▶" || b.textContent === "▼") && !b.title,
+    (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
   );
   if (langArrow) await userEvent.click(langArrow);
 
@@ -252,7 +252,7 @@ describe("AdminBooksPage — queue status badges", () => {
     await flushPromises();
 
     await waitFor(() =>
-      expect(screen.getByText(/▶1/)).toBeInTheDocument(),
+      expect(screen.getByText(/▸1/)).toBeInTheDocument(),
     );
   });
 
@@ -278,7 +278,7 @@ describe("AdminBooksPage — queue status badges", () => {
     await flushPromises();
 
     await waitFor(() =>
-      expect(screen.getByText(/⏳3/)).toBeInTheDocument(),
+      expect(screen.getByText(/·3/)).toBeInTheDocument(),
     );
   });
 });

--- a/frontend/src/__tests__/AdminBooksPage.branches2.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.branches2.test.tsx
@@ -260,7 +260,7 @@ describe("AdminBooksPage — retryFailedForLang non-Error catch (line 208)", () 
     render(<BooksPage />);
     await flushPromises();
 
-    const retryBtn = await screen.findByRole("button", { name: "↻" });
+    const retryBtn = await screen.findByRole("button", { name: /Retry.*failed.*chapter/i });
     await userEvent.click(retryBtn);
 
     await waitFor(() =>

--- a/frontend/src/__tests__/AdminBooksPage.branches2.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.branches2.test.tsx
@@ -209,7 +209,7 @@ describe("AdminBooksPage — handleMove non-Error catch (line 190)", () => {
     await waitFor(() => screen.getByText("zh"));
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.textContent === "▶" || b.textContent === "▼") && !b.title,
+      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
     );
     if (langArrow) await userEvent.click(langArrow);
     await waitFor(() => screen.getByText("Ch. 1"));
@@ -385,7 +385,7 @@ describe("AdminBooksPage — language row expand/collapse toggle (line 423)", ()
     // Find the lang arrow and click it to expand
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.textContent === "▶" || b.textContent === "▼") && !b.title,
+      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
     );
     if (langArrow) {
       await userEvent.click(langArrow);
@@ -394,7 +394,7 @@ describe("AdminBooksPage — language row expand/collapse toggle (line 423)", ()
 
       // Click again to collapse
       const collapsedArrow = screen.getAllByRole("button").find(
-        (b) => b.textContent === "▼" && !b.title,
+        (b) => b.getAttribute("aria-label") === "Collapse" && !b.title,
       );
       if (collapsedArrow) {
         await userEvent.click(collapsedArrow);
@@ -519,7 +519,7 @@ describe("AdminBooksPage — empty chapter rows message (line 480)", () => {
     await waitFor(() => screen.getByText("zh"));
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.textContent === "▶" || b.textContent === "▼") && !b.title,
+      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
     );
     if (langArrow) await userEvent.click(langArrow);
 
@@ -548,7 +548,7 @@ describe("AdminBooksPage — moveInput onChange (lines 512-518)", () => {
     await waitFor(() => screen.getByText("zh"));
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.textContent === "▶" || b.textContent === "▼") && !b.title,
+      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
     );
     if (langArrow) await userEvent.click(langArrow);
     await waitFor(() => screen.getByText("Ch. 1"));

--- a/frontend/src/__tests__/AdminBooksPage.branches3.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.branches3.test.tsx
@@ -281,7 +281,7 @@ describe("AdminBooksPage — moveInput ?? '' false branch (lines 512, 518)", () 
     await waitFor(() => screen.getByText("zh"));
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.textContent === "▶" || b.textContent === "▼") && !b.title,
+      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
     );
     if (langArrow) await userEvent.click(langArrow);
     await waitFor(() => screen.getByText("Ch. 1"));

--- a/frontend/src/__tests__/AdminBooksPage.coverage.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.coverage.test.tsx
@@ -202,7 +202,7 @@ describe("AdminBooksPage — handleRetranslate (lines 118-136)", () => {
     // Expand zh language row
     await waitFor(() => screen.getByText("zh"));
     const langExpandBtns = screen.getAllByRole("button", {
-      name: (name) => name === "▶" || name === "▼",
+      name: (name) => name === "Expand" || name === "Collapse",
     });
     // The language expand chevron is inside the expanded book section
     const innerExpand = langExpandBtns.find(
@@ -228,7 +228,7 @@ describe("AdminBooksPage — handleRetranslate (lines 118-136)", () => {
     // Click the small arrow to expand the language
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.textContent === "▶" || b.textContent === "▼") && !b.title,
+      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
     );
     if (langArrow) await userEvent.click(langArrow);
 
@@ -271,7 +271,7 @@ describe("AdminBooksPage — handleRetranslate (lines 118-136)", () => {
     await waitFor(() => screen.getByText("zh"));
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.textContent === "▶" || b.textContent === "▼") && !b.title,
+      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
     );
     if (langArrow) await userEvent.click(langArrow);
 
@@ -359,7 +359,7 @@ describe("AdminBooksPage — book expansion and metadata (lines 161-210)", () =>
     await waitFor(() => screen.getByText("zh"));
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.textContent === "▶" || b.textContent === "▼") && !b.title,
+      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
     );
     if (langArrow) await userEvent.click(langArrow);
 
@@ -639,7 +639,7 @@ describe("AdminBooksPage — chapter-level delete (lines 530-543)", () => {
     await waitFor(() => screen.getByText("zh"));
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.textContent === "▶" || b.textContent === "▼") && !b.title,
+      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
     );
     if (langArrow) await userEvent.click(langArrow);
     await waitFor(() => screen.getByText("Ch. 1"));
@@ -689,7 +689,7 @@ describe("AdminBooksPage — chapter move (lines 496-519)", () => {
     await waitFor(() => screen.getByText("zh"));
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.textContent === "▶" || b.textContent === "▼") && !b.title,
+      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
     );
     if (langArrow) await userEvent.click(langArrow);
     await waitFor(() => screen.getByText("Ch. 1"));

--- a/frontend/src/__tests__/AdminBooksPage.coverage.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.coverage.test.tsx
@@ -445,7 +445,7 @@ describe("AdminBooksPage — retryFailedForLang (line 350)", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const retryBtn = await screen.findByRole("button", { name: "↻" });
+    const retryBtn = await screen.findByRole("button", { name: /Retry.*failed.*chapter/i });
     await userEvent.click(retryBtn);
 
     await waitFor(() =>
@@ -468,7 +468,7 @@ describe("AdminBooksPage — retryFailedForLang (line 350)", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const retryBtn = await screen.findByRole("button", { name: "↻" });
+    const retryBtn = await screen.findByRole("button", { name: /Retry.*failed.*chapter/i });
     await userEvent.click(retryBtn);
 
     expect(mockAdminFetch).toHaveBeenCalledTimes(2);
@@ -484,7 +484,7 @@ describe("AdminBooksPage — retryFailedForLang (line 350)", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const retryBtn = await screen.findByRole("button", { name: "↻" });
+    const retryBtn = await screen.findByRole("button", { name: /Retry.*failed.*chapter/i });
     await userEvent.click(retryBtn);
 
     await waitFor(() =>

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { adminFetch } from "@/lib/adminFetch";
 import SeedPopularButton from "@/components/SeedPopularButton";
 import { fuzzyMatchAny } from "@/lib/fuzzyMatch";
+import { ChevronDownIcon, ChevronRightIcon } from "@/components/Icons";
 
 interface TranslationStat {
   chapters: number;
@@ -282,10 +283,11 @@ export default function BooksPage() {
                     setExpandedBookId(isExpanded ? null : b.id);
                     setExpandedLang(null);
                   }}
-                  className="text-stone-400 hover:text-amber-700 text-sm w-4 text-center"
+                  className="text-stone-400 hover:text-amber-700 flex items-center"
                   title={isExpanded ? "Collapse" : "Expand"}
+                  aria-label={isExpanded ? "Collapse" : "Expand"}
                 >
-                  {isExpanded ? "▼" : "▶"}
+                  {isExpanded ? <ChevronDownIcon className="w-3.5 h-3.5" /> : <ChevronRightIcon className="w-3.5 h-3.5" />}
                 </button>
 
                 <div className="flex-1 min-w-0">
@@ -339,9 +341,9 @@ export default function BooksPage() {
                             {lang} · {count}
                             {pending + running + failed > 0 && (
                               <span className="ml-1 opacity-70">
-                                {running > 0 && `▶${running}`}
-                                {pending > 0 && `⏳${pending}`}
-                                {failed > 0 && `!${failed}`}
+                                {running > 0 && `▸${running}`}
+                                {pending > 0 && `·${pending}`}
+                                {failed > 0 && `×${failed}`}
                               </span>
                             )}
                           </span>
@@ -421,9 +423,10 @@ export default function BooksPage() {
                             <div className="px-3 py-2 flex items-center gap-2">
                               <button
                                 onClick={() => setExpandedLang(isLangExpanded ? null : bulkKey)}
-                                className="text-xs text-stone-400 hover:text-amber-700 w-4 text-center"
+                                className="text-xs text-stone-400 hover:text-amber-700 flex items-center"
+                                aria-label={isLangExpanded ? "Collapse" : "Expand"}
                               >
-                                {isLangExpanded ? "▼" : "▶"}
+                                {isLangExpanded ? <ChevronDownIcon className="w-3 h-3" /> : <ChevronRightIcon className="w-3 h-3" />}
                               </button>
                               <span className="text-sm font-medium text-ink">{lang}</span>
                               <span className="text-xs text-stone-500">

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import { adminFetch } from "@/lib/adminFetch";
 import SeedPopularButton from "@/components/SeedPopularButton";
 import { fuzzyMatchAny } from "@/lib/fuzzyMatch";
-import { ChevronDownIcon, ChevronRightIcon } from "@/components/Icons";
+import { ChevronDownIcon, ChevronRightIcon, RetryIcon } from "@/components/Icons";
 
 interface TranslationStat {
   chapters: number;
@@ -352,9 +352,10 @@ export default function BooksPage() {
                               onClick={() => retryFailedForLang(b, lang, failed)}
                               disabled={retryingFailed === retryKey}
                               title={`Retry ${failed} failed ${lang} chapter${failed === 1 ? "" : "s"}`}
-                              className="text-xs px-1 rounded border border-red-300 text-red-600 hover:bg-red-50 disabled:opacity-50"
+                              aria-label={`Retry ${failed} failed ${lang} chapter${failed === 1 ? "" : "s"}`}
+                              className="text-xs px-1 rounded border border-red-300 text-red-600 hover:bg-red-50 disabled:opacity-50 inline-flex items-center"
                             >
-                              {retryingFailed === retryKey ? "…" : "↻"}
+                              <RetryIcon className={`w-3 h-3 ${retryingFailed === retryKey ? "animate-spin" : ""}`} />
                             </button>
                           )}
                         </span>

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/lib/api";
 
 import { chapterLabel, truncate } from "@/lib/notesMarkdown";
-import { ArrowLeftIcon } from "@/components/Icons";
+import { ArrowLeftIcon, TrashIcon, EditIcon, ChevronRightIcon, ChevronDownIcon, ArrowRightIcon, RetryIcon } from "@/components/Icons";
 
 type ViewMode = "section" | "chapter";
 
@@ -48,7 +48,7 @@ function CollapseHeading({
           : "mt-5 mb-2"
       }`}
     >
-      <span className="text-amber-400 text-xs shrink-0">{isCollapsed ? "▶" : "▼"}</span>
+      {isCollapsed ? <ChevronRightIcon className="w-3 h-3 text-amber-400 shrink-0" /> : <ChevronDownIcon className="w-3 h-3 text-amber-400 shrink-0" />}
       <Tag className={level === 2
         ? "text-lg font-serif font-semibold text-ink group-hover:text-amber-800 transition-colors"
         : "text-sm font-semibold text-amber-800 uppercase tracking-wide group-hover:text-amber-900 transition-colors"
@@ -132,24 +132,26 @@ function AnnotationCard({
         <div className="flex items-center gap-3 mt-2">
           <a
             href={`/reader/${bookId}?chapter=${ann.chapter_index}&sentence=${encodeURIComponent(ann.sentence_text)}`}
-            className="text-xs text-amber-600 hover:text-amber-800 hover:underline transition-colors"
+            className="inline-flex items-center gap-1 text-xs text-amber-600 hover:text-amber-800 hover:underline transition-colors"
           >
-            → {chapterLabel(chapters, ann.chapter_index)}
+            <ArrowRightIcon className="w-3 h-3 shrink-0" /> {chapterLabel(chapters, ann.chapter_index)}
           </a>
           <button
             onClick={onEdit}
-            className="text-xs text-stone-400 hover:text-stone-600 transition-colors"
+            className="text-stone-400 hover:text-stone-600 transition-colors"
             title="Edit note"
+            aria-label="Edit note"
           >
-            ✏️
+            <EditIcon className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={onDelete}
             disabled={isDeleting}
-            className="text-xs text-red-400 hover:text-red-600 disabled:opacity-40 transition-colors"
+            className="text-red-400 hover:text-red-600 disabled:opacity-40 transition-colors"
             title="Delete annotation"
+            aria-label="Delete annotation"
           >
-            {isDeleting ? "…" : "🗑"}
+            {isDeleting ? <RetryIcon className="w-3.5 h-3.5 animate-spin" /> : <TrashIcon className="w-3.5 h-3.5" />}
           </button>
         </div>
       )}
@@ -189,18 +191,19 @@ function InsightCard({
         {readerHref && (
           <a
             href={readerHref}
-            className="text-xs text-amber-600 hover:text-amber-800 hover:underline transition-colors"
+            className="inline-flex items-center gap-1 text-xs text-amber-600 hover:text-amber-800 hover:underline transition-colors"
           >
-            → {chapterLabel(chapters, ins.chapter_index as number)}
+            <ArrowRightIcon className="w-3 h-3 shrink-0" /> {chapterLabel(chapters, ins.chapter_index as number)}
           </a>
         )}
         <button
           onClick={onDelete}
           disabled={isDeleting}
-          className="text-xs text-red-400 hover:text-red-600 disabled:opacity-40 transition-colors"
+          className="text-red-400 hover:text-red-600 disabled:opacity-40 transition-colors"
           title="Delete insight"
+          aria-label="Delete insight"
         >
-          {isDeleting ? "…" : "🗑"}
+          {isDeleting ? <RetryIcon className="w-3.5 h-3.5 animate-spin" /> : <TrashIcon className="w-3.5 h-3.5" />}
         </button>
       </div>
     </div>

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import type { Annotation } from "@/lib/api";
+import { ArrowRightIcon } from "@/components/Icons";
 
 const COLOR_BADGE: Record<string, string> = {
   yellow: "bg-yellow-100 border-yellow-300 text-yellow-800",
@@ -145,9 +146,9 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
             <a
               href={bookId ? `/notes/${bookId}` : "/notes"}
               onClick={() => setOpen(false)}
-              className="text-xs text-amber-700 hover:text-amber-900 font-medium transition-colors"
+              className="inline-flex items-center gap-1 text-xs text-amber-700 hover:text-amber-900 font-medium transition-colors"
             >
-              {bookId ? "Book notes →" : "All notes →"}
+              {bookId ? "Book notes" : "All notes"} <ArrowRightIcon className="w-3 h-3 shrink-0" />
             </a>
             <a
               href="/notes"

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -191,6 +191,43 @@ export function ExportIcon({ className = "w-4 h-4" }: IconProps) {
   );
 }
 
+export function EditIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+      <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+    </svg>
+  );
+}
+
+export function TrashIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <polyline points="3 6 5 6 21 6"/>
+      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
+      <path d="M10 11v6"/>
+      <path d="M14 11v6"/>
+      <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/>
+    </svg>
+  );
+}
+
+export function ChevronRightIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <polyline points="9 18 15 12 9 6"/>
+    </svg>
+  );
+}
+
+export function CheckIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <polyline points="20 6 9 17 4 12"/>
+    </svg>
+  );
+}
+
 export function CheckCircleIcon({ className = "w-4 h-4" }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">


### PR DESCRIPTION
## Summary

Wave 9 emoji and symbol removal — replaces remaining `▼`/`▶`, `✏️`, `🗑`, `⏳`, and `→` text characters with SVG icons or neutral text.

**Notes page (`notes/[bookId]/page.tsx`)**
- `▶`/`▼` collapse toggle → `<ChevronRightIcon>`/`<ChevronDownIcon>` SVG
- `✏️` edit button → `<EditIcon>` SVG with `aria-label`
- `🗑` delete button → `<TrashIcon>` SVG with `aria-label`; spinner while deleting
- `→` chapter link prefix → `<ArrowRightIcon>` SVG

**Admin books page (`admin/books/page.tsx`)**
- `▼`/`▶` book expand toggle → `<ChevronDownIcon>`/`<ChevronRightIcon>` SVG + `aria-label`
- `▼`/`▶` language expand toggle → `<ChevronDownIcon>`/`<ChevronRightIcon>` SVG + `aria-label`
- `⏳` status badge → `·` neutral text

**Annotations sidebar (`AnnotationsSidebar.tsx`)**
- `"Book notes →"` → `"Book notes" + <ArrowRightIcon>` SVG

**Icons.tsx**: adds `EditIcon`, `TrashIcon`, `ChevronRightIcon`, `CheckIcon`

## Tests

- AdminBooksPage tests updated to select expand/collapse buttons via `aria-label` instead of `textContent === "▶"`
- All 1528 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
