### PR TITLE
fix: reject retry of running translation queue item (reader endpoint)

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -350,6 +350,18 @@ async def retry_chapter_translation(
     from services.translation_queue import enqueue, queue_status_for_chapter, worker
 
     target_language = req.target_language.lower().split("-")[0]
+
+    # Guard: reject retry of a running item. enqueue(reset_failed=True) resets
+    # status='pending' in-place — same row ID. When the worker finishes it calls
+    # mark_queue_row_done which DELETEs by (book,ch,lang), silently eating the
+    # retry. Consistent with the admin queue_retry_item guard (PR #295, issue #294).
+    current = await queue_status_for_chapter(book_id, chapter_index, target_language)
+    if current.get("status") == "running":
+        raise HTTPException(
+            status_code=409,
+            detail="Cannot retry a running translation; wait for it to finish or fail",
+        )
+
     queued_by = user.get("email") or user.get("name") or f"user#{user.get('id')}"
     await enqueue(
         book_id, chapter_index, target_language,

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -769,3 +769,50 @@ async def test_import_stream_uses_html_splitter_chapter_count(client):
         "(HTML splitter); build_chapters on the plain text would return 2"
     )
     clear_cache(book_id)
+
+
+# ── reader retry running-guard (issue #316) ───────────────────────────────────
+
+async def test_reader_retry_rejects_running_item(client):
+    """POST /chapters/{idx}/translation/retry must return 409 when the row is
+    already 'running'.
+
+    Before the fix, enqueue(reset_failed=True) silently reset 'running' → 'pending'
+    in-place, then mark_queue_row_done (called by the worker on success) deleted the
+    re-queued pending row — making the retry a no-op and corrupting the attempt counter.
+
+    After the fix the endpoint returns 409, consistent with the admin
+    queue_retry_item endpoint (PR #295).
+    """
+    import aiosqlite
+    import services.db as db_module
+
+    await save_book(1342, MOCK_META, "text")
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        await conn.execute(
+            """INSERT INTO translation_queue
+                   (book_id, chapter_index, target_language, priority, status, attempts)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (1342, 0, "zh", 10, "running", 1),
+        )
+        await conn.commit()
+
+    resp = await client.post(
+        "/api/books/1342/chapters/0/translation/retry",
+        json={"target_language": "zh"},
+    )
+    assert resp.status_code == 409, (
+        f"Expected 409 for running item, got {resp.status_code}: {resp.text}"
+    )
+    assert "running" in resp.json()["detail"].lower()
+
+    # Row must remain 'running' — not reset
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        conn.row_factory = aiosqlite.Row
+        async with conn.execute(
+            "SELECT status, attempts FROM translation_queue "
+            "WHERE book_id=1342 AND chapter_index=0 AND target_language='zh'",
+        ) as cursor:
+            row = await cursor.fetchone()
+    assert row["status"] == "running"
+    assert row["attempts"] == 1


### PR DESCRIPTION
## Summary

- `POST /books/{id}/chapters/{ch}/translation/retry` (reader-side) did not guard against retrying a `running` item, unlike the admin `POST /admin/queue/items/{id}/retry` endpoint fixed in PR #295
- When called on a running item, `enqueue(reset_failed=True)` reset the row to `'pending'` in-place (same row ID); on success the worker called `mark_queue_row_done` which DELETEs by `(book_id, chapter_index, target_language)` — silently eating the re-queued pending row
- Additionally, the `attempts=0` reset corrupted the failure count for a chapter already at MAX_ATTEMPTS − 1, allowing indefinite retries
- Fix: check `queue_status_for_chapter` before enqueuing; return `409` if `status == 'running'`

## Safety for existing deployments

The change is additive — it only rejects calls that would have silently misbehaved before. All existing successful retry flows (failed/pending rows) are unaffected.

## Test plan

- [x] `test_reader_retry_rejects_running_item` — newly added; failed before fix (got 200, row reset to pending), passes after (got 409, row stays running)
- [x] `test_retry_chapter_translation_revives_failed_row` — still passes (failed → pending)
- [x] `test_retry_chapter_translation_inserts_if_no_row` — still passes (no row → pending)
- [x] Full backend suite: 919 passed, 0 failed

Closes #316
