### PR TITLE
fix: enqueue(reset_failed=True) must not reset running rows

### DIFF
--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -210,7 +210,8 @@ async def enqueue(
                          last_error=NULL,
                          priority=MIN(priority, excluded.priority),
                          queued_by=COALESCE(excluded.queued_by, queued_by),
-                         updated_at=CURRENT_TIMESTAMP""",
+                         updated_at=CURRENT_TIMESTAMP
+                   WHERE translation_queue.status != 'running'""",
                 (book_id, chapter_index, target_language, priority, queued_by),
             )
         else:

--- a/backend/tests/test_translation_queue_unit.py
+++ b/backend/tests/test_translation_queue_unit.py
@@ -170,6 +170,35 @@ async def test_enqueue_reset_failed_revives_failed_row():
     assert row[1] == 0
 
 
+async def test_enqueue_reset_failed_does_not_touch_running_row():
+    """Regression #321: enqueue(reset_failed=True) must not reset a running row.
+
+    A running row's worker holds its ID; if the row is reset to 'pending'
+    the worker's _mark_done(id) will delete the re-enqueued row when it
+    finishes, silently voiding the retranslation.
+    """
+    import aiosqlite
+    await enqueue(20, 0, "zh")
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            "UPDATE translation_queue SET status='running', attempts=1 "
+            "WHERE book_id=20 AND chapter_index=0 AND target_language='zh'"
+        )
+        await db.commit()
+
+    count = await enqueue(20, 0, "zh", reset_failed=True)
+    assert count == 0  # no update happened
+
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        async with db.execute(
+            "SELECT status, attempts FROM translation_queue "
+            "WHERE book_id=20 AND chapter_index=0 AND target_language='zh'"
+        ) as cursor:
+            row = await cursor.fetchone()
+    assert row[0] == "running"  # still running
+    assert row[1] == 1          # attempts not zeroed
+
+
 async def test_enqueue_preserves_lower_priority():
     await enqueue(3, 0, "fr", priority=100, reset_failed=True)
     # Try to re-enqueue with higher priority (lower number = higher priority)


### PR DESCRIPTION
## Summary

- `enqueue(reset_failed=True)` used an `ON CONFLICT DO UPDATE` with no `WHERE` clause, so it reset **any** existing row to `status='pending', attempts=0` — including `running` rows
- The docstring said it only revives `'failed'` or `'done'` rows, but the SQL had no such guard
- Call-site guards added in PRs #295 and #318 protected `queue_retry_item` and `retry_chapter_translation`, but `queue_enqueue_book(reset_failed=True)` called `enqueue_for_book(reset_failed=True)` for every chapter with **no per-chapter running check**
- Data-loss path: worker holds row ID for a running chapter → `enqueue(reset_failed=True)` resets it to `pending` (same ID) → worker finishes → `_mark_done(id)` deletes the now-pending row → retranslation is silently destroyed
- Fix: add `WHERE translation_queue.status != 'running'` to the `ON CONFLICT DO UPDATE` clause; SQLite falls back to IGNORE when false, so running rows are left untouched and `rowcount=0` is returned

## Test plan

- [x] `test_enqueue_reset_failed_does_not_touch_running_row` — newly added; failed before fix (rowcount=1, row reset to pending), passes after (rowcount=0, row stays running)
- [x] `test_enqueue_reset_failed_revives_failed_row` — still passes (failed → pending revived correctly)
- [x] `test_enqueue_preserves_lower_priority` — still passes
- [x] Full backend suite: 921 passed, 0 failed; frontend: 1528 passed, 0 failed

Closes #321
