### PR TITLE
fix: delete_queue_for_book skips running items (closes #325)

### DIFF
--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -620,12 +620,12 @@ async def delete_queue_for_book(
     async with aiosqlite.connect(db_module.DB_PATH) as db:
         if target_language:
             cursor = await db.execute(
-                "DELETE FROM translation_queue WHERE book_id=? AND target_language=?",
+                "DELETE FROM translation_queue WHERE book_id=? AND target_language=? AND status != 'running'",
                 (book_id, target_language),
             )
         else:
             cursor = await db.execute(
-                "DELETE FROM translation_queue WHERE book_id=?", (book_id,),
+                "DELETE FROM translation_queue WHERE book_id=? AND status != 'running'", (book_id,),
             )
         await db.commit()
         return cursor.rowcount

--- a/backend/tests/test_translation_queue.py
+++ b/backend/tests/test_translation_queue.py
@@ -9,6 +9,7 @@ import services.db as db_module
 from services.db import init_db, save_book, get_cached_translation, set_setting
 from services.translation_queue import (
     clear_queue,
+    delete_queue_for_book,
     enqueue,
     enqueue_for_book,
     list_queue,
@@ -466,6 +467,31 @@ async def test_clear_queue_preserves_running_items(tmp_db):
         await db.commit()
 
     removed = await clear_queue()
+    # Pending chapter 1 should be deleted; running chapter 0 must survive.
+    assert removed == 1
+    remaining = await list_queue()
+    assert len(remaining) == 1
+    assert remaining[0]["chapter_index"] == 0
+    assert remaining[0]["status"] == "running"
+
+
+async def test_delete_queue_for_book_preserves_running_items(tmp_db):
+    """Regression #325: delete_queue_for_book() must not delete running items.
+
+    Deleting a running row gives false cancellation: mark_queue_row_done
+    (called by save_translation) deletes by composite key, so it would
+    silently destroy a re-enqueued pending row for the same chapter.
+    """
+    await enqueue(1, 0, "zh")
+    await enqueue(1, 1, "zh")
+    # Simulate chapter 0 being actively translated by the worker.
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute(
+            "UPDATE translation_queue SET status='running' WHERE chapter_index=0",
+        )
+        await db.commit()
+
+    removed = await delete_queue_for_book(1, target_language="zh")
     # Pending chapter 1 should be deleted; running chapter 0 must survive.
     assert removed == 1
     remaining = await list_queue()


### PR DESCRIPTION
## Summary

- Fixes issue #325: `delete_queue_for_book()` now excludes running rows from deletion, matching the fix applied to `clear_queue()` (#319)

## Root cause

`delete_queue_for_book()` had no `status != 'running'` guard, so the admin's "clear language queue" action could delete in-flight chapter rows. The data-loss scenario:

1. Chapter 5 is `status='running'` (worker translating it)
2. Admin calls `DELETE /admin/queue/book/1?target_language=zh` — running row deleted
3. Admin re-enqueues the book → new pending row created
4. Worker finishes its translation → `save_translation` → `mark_queue_row_done` deletes **by composite key** `(book_id, chapter_index, lang)` → silently destroys the new pending row
5. Fresh retranslation never runs

## Fix

Add `AND status != 'running'` to both DELETE branches in `delete_queue_for_book()` (with and without `target_language` filter). Running rows are preserved and the returned count reflects only actually-deleted rows.

## Test plan

- [x] `test_delete_queue_for_book_preserves_running_items` — new regression test (was failing before fix)
- [x] Full backend suite: 922 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
