### PR TITLE
fix: worker skips save_translation if book was deleted during Gemini call

### DIFF
--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -956,6 +956,15 @@ class TranslationQueueWorker:
                 chain=chain,
                 max_output_tokens=max_output_tokens,
             )
+            # Guard: delete_book may have fired during the Gemini call.
+            # Re-check existence before saving to avoid orphaned translation
+            # rows that would silently block re-translation after re-import.
+            if not await get_cached_book(book_id):
+                batch_rows = [rows_by_idx[c.chapter_index] for c in batch
+                              if c.chapter_index in rows_by_idx]
+                await self._mark_skipped(batch_rows, reason="book deleted during translation")
+                mark_handled(batch_rows)
+                continue
             for c in batch:
                 row = rows_by_idx[c.chapter_index]
                 paragraphs = translations.get(c.chapter_index)

--- a/backend/tests/test_translation_queue.py
+++ b/backend/tests/test_translation_queue.py
@@ -500,6 +500,45 @@ async def test_delete_queue_for_book_preserves_running_items(tmp_db):
     assert remaining[0]["status"] == "running"
 
 
+async def test_worker_does_not_save_translation_for_deleted_book(tmp_db):
+    """Regression #327: worker must not save translations after book is deleted.
+
+    delete_book fires during the Gemini call window (30-60s). The pre-translation
+    get_cached_book check already passed — without a post-translation guard,
+    save_translation writes orphaned rows for a non-existent book. If the admin
+    then re-imports the same book, enqueue_for_book finds the stale translations
+    and silently skips re-translation.
+    """
+    from services.auth import encrypt_api_key
+    from services.rate_limiter import AsyncRateLimiter
+    import services.db as db_module
+
+    await set_setting(SETTING_API_KEY, encrypt_api_key("fake-key"))
+    await set_setting(SETTING_ENABLED, "1")
+    await save_book(1, BOOK_META, BOOK_TEXT)
+    await enqueue(1, 0, "zh")
+
+    async def fake_translate_then_delete(api_key, chapters, src, tgt, *, model=None, **kwargs):
+        # Simulate delete_book firing while Gemini is processing
+        async with aiosqlite.connect(db_module.DB_PATH) as db:
+            await db.execute("DELETE FROM books WHERE id=1")
+            await db.execute("DELETE FROM translations WHERE book_id=1")
+            await db.execute("DELETE FROM translation_queue WHERE book_id=1")
+            await db.commit()
+        return {idx: ["translated paragraph"] for idx, _ in chapters}
+
+    w = TranslationQueueWorker()
+    w._stop_event = __import__("asyncio").Event()
+    with patch("services.translation_queue.translate_chapters_batch", side_effect=fake_translate_then_delete):
+        with patch.object(AsyncRateLimiter, "acquire", new=AsyncMock(return_value=None)):
+            await w._tick()
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute("SELECT COUNT(*) FROM translations WHERE book_id=1") as cursor:
+            (count,) = await cursor.fetchone()
+    assert count == 0, "worker must not save translations for a deleted book"
+
+
 async def test_worker_idles_without_api_key(tmp_db):
     """With no queue_api_key configured, the worker must idle — not crash."""
     await set_setting(SETTING_ENABLED, "1")


### PR DESCRIPTION
## Summary

- `_process_batch_inner` checked `get_cached_book(book_id)` once at the START of each batch, then spent 30-60s calling Gemini — `delete_book` could fire during that window
- After the delete, `delete_book` removes the book row AND translation rows AND running queue rows; but the worker had already passed the existence check
- Worker finished the Gemini call and called `save_translation(book_id, …)` — INSERT OR REPLACE wrote translation rows for a `book_id` that no longer exists in `books`
- If the admin re-imported the same book later, `enqueue_for_book` found the stale orphaned translations and silently skipped those chapters — reader saw stale/incorrect content

## Fix

Added a post-translation `get_cached_book` check in `_process_batch_inner` — once per batch, after `_translate_with_retry` returns but before the per-chapter `save_translation` loop. If the book was deleted during the Gemini call, the batch rows are marked skipped (the `_mark_skipped` UPDATE is a no-op on already-deleted rows) and the batch is skipped without saving.

## Test plan

- [x] `test_worker_does_not_save_translation_for_deleted_book` — newly added; failed before fix (count=1, orphaned translation written), passes after (count=0, save skipped)
- [x] Full backend suite: 923 passed, 0 failed; frontend: 1528 passed, 0 failed

Closes #327
