### PR TITLE
fix: move_translation rejects 409 when destination is running (closes #328)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -630,18 +630,34 @@ async def move_translation(
                         "Delete it first, then retry the move."
                     ),
                 )
+        # Reject if the destination chapter's queue row is running: the worker
+        # will save a new translation that would silently overwrite the move.
+        async with db.execute(
+            "SELECT 1 FROM translation_queue "
+            "WHERE book_id=? AND chapter_index=? AND target_language=? AND status='running'",
+            (book_id, new_idx, target_language),
+        ) as cursor:
+            if await cursor.fetchone() is not None:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"Chapter {new_idx} is currently being translated. "
+                        "Wait for it to finish, then retry the move."
+                    ),
+                )
         await db.execute(
             "UPDATE translations "
             "SET chapter_index=? "
             "WHERE book_id=? AND chapter_index=? AND target_language=?",
             (new_idx, book_id, chapter_index, target_language),
         )
-        # A queue row at the destination (pending/running/failed) would
-        # let the worker later translate over the top. Clear it — the
-        # move means we're asserting this chapter is now done.
+        # A queue row at the destination (pending/failed) would let the worker
+        # later translate over the top. Clear it — the move means we're
+        # asserting this chapter is now done. Running rows are already rejected
+        # above, so only non-running rows can remain here.
         await db.execute(
             "DELETE FROM translation_queue "
-            "WHERE book_id=? AND chapter_index=? AND target_language=?",
+            "WHERE book_id=? AND chapter_index=? AND target_language=? AND status != 'running'",
             (book_id, new_idx, target_language),
         )
         await db.commit()

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -1036,6 +1036,36 @@ async def test_move_translation_clears_queue_at_destination(admin_client, admin_
     assert count == 0
 
 
+async def test_move_translation_rejects_when_destination_is_running(admin_client, admin_db):
+    """Regression #328: move must return 409 if the destination chapter's queue
+    row is running — otherwise the worker overwrites the admin-moved translation."""
+    await save_book(100, BOOK_META, MOVE_BOOK_TEXT)
+    await save_translation(100, 1, "en", ["From slot 1."])
+    # Seed a running row at the destination
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        await conn.execute(
+            """INSERT INTO translation_queue
+                   (book_id, chapter_index, target_language, priority, status)
+               VALUES (100, 0, 'en', 100, 'running')""",
+        )
+        await conn.commit()
+
+    res = await admin_client.post(
+        "/api/admin/translations/100/1/en/move",
+        json={"new_chapter_index": 0},
+    )
+    assert res.status_code == 409
+    # Running row must still be in the queue (not deleted)
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        async with conn.execute(
+            "SELECT status FROM translation_queue "
+            "WHERE book_id=100 AND chapter_index=0 AND target_language='en'",
+        ) as cursor:
+            row = await cursor.fetchone()
+    assert row is not None
+    assert row[0] == "running"
+
+
 async def test_admin_retry_failed_without_filters_retries_all(admin_client, admin_db):
     await _seed_failed(100, 0, "zh")
     await _seed_failed(200, 0, "fr")


### PR DESCRIPTION
## Summary

- Fixes issue #328: `move_translation` now rejects with 409 if the destination chapter has a `status='running'` queue row

## Root cause

The destination queue row cleanup in `move_translation` had no `status != 'running'` guard. If the destination chapter was being actively translated, the running row would be deleted. The worker would then finish and call `save_translation`, overwriting the admin-moved translation — silently voiding the move.

## Fix

Added a pre-flight check: if the destination chapter has a `running` queue row, return 409 with a clear message ("Chapter N is currently being translated. Wait for it to finish, then retry the move."). Also narrowed the cleanup `DELETE` to `AND status != 'running'` as belt-and-suspenders.

## Test plan

- [x] `test_move_translation_rejects_when_destination_is_running` — new regression test (was failing before fix)
- [x] `test_move_translation_clears_queue_at_destination` — existing test still passes (pending/failed rows still cleared)
- [x] Full backend suite: 922 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
