### PR TITLE
fix: reject empty paragraphs in PUT /ai/translate/cache

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -244,6 +244,8 @@ class SaveTranslationRequest(BaseModel):
 @router.put("/translate/cache")
 async def save_translate_cache(req: SaveTranslationRequest, _user: dict = Depends(get_current_user)):
     """Save a completed progressive translation to the backend cache."""
+    if not req.paragraphs:
+        raise HTTPException(status_code=400, detail="paragraphs must not be empty")
     if not await get_cached_book(req.book_id):
         raise HTTPException(status_code=404, detail="Book not found")
     target_language = req.target_language.lower().split("-")[0]

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -200,6 +200,31 @@ async def test_translate_cache_put_rejects_nonexistent_book(client, test_user):
     assert resp.status_code == 404
 
 
+async def test_translate_cache_put_rejects_empty_paragraphs(client, test_user):
+    """Regression #331: PUT /translate/cache must reject empty paragraphs.
+
+    An empty list overwrites a good cached translation; request_chapter_translation
+    then returns status='ready' with no paragraphs, leaving the reader with a
+    blank page and no way to trigger re-translation.
+    """
+    from services.db import save_book, save_translation, get_cached_translation
+    _BOOK_META = {"title": "Faust", "authors": ["Goethe"], "languages": ["de"],
+                  "subjects": [], "download_count": 0, "cover": ""}
+    await save_book(50, _BOOK_META, "text")
+    # Seed a valid cached translation to verify it is NOT overwritten
+    await save_translation(50, 0, "zh", ["existing paragraph"])
+
+    resp = await client.put("/api/ai/translate/cache", json={
+        "book_id": 50, "chapter_index": 0, "target_language": "zh",
+        "paragraphs": [],
+    })
+    assert resp.status_code == 400
+
+    # Existing translation must still be intact
+    cached = await get_cached_translation(50, 0, "zh")
+    assert cached == ["existing paragraph"]
+
+
 async def test_translate_cache_put_saves(client, test_user):
     """PUT /translate/cache saves paragraphs for later retrieval."""
     from services.db import save_book


### PR DESCRIPTION
## Summary

- `PUT /ai/translate/cache` accepts any `paragraphs` list including empty `[]`, and writes it via `save_translation` (INSERT OR REPLACE), overwriting existing cached translations
- `get_cached_translation_with_meta` returns a truthy dict `{"paragraphs": [], ...}` even for empty lists
- Both reader endpoints (`GET /books/{id}/chapters/{idx}/translation` and `POST /books/{id}/chapters/{idx}/translation`) check `if cached:` on the dict — both short-circuit with `status="ready"` and return empty paragraphs
- Reader renders a blank translation page; chapter shows no text, with no way to trigger re-translation (cache exists so it won't re-enqueue)

## Fix

Added a non-empty check at the top of `save_translate_cache`, before the book-existence check:
```python
if not req.paragraphs:
    raise HTTPException(status_code=400, detail="paragraphs must not be empty")
```

## Test plan

- [x] `test_translate_cache_put_rejects_empty_paragraphs` — newly added; failed before fix (200 returned, existing translation overwritten), passes after (400, existing translation preserved)
- [x] Full backend suite: 923 passed, 0 failed; frontend: 1528 passed, 0 failed

Closes #331
