### PR TITLE
fix: retranslate endpoints reject 409 when queue worker is running (closes #333)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -414,6 +414,24 @@ async def retranslate(
 
     chapter_text = chapters[chapter_index].text
 
+    # Reject if a queue worker is actively translating this chapter — the
+    # worker's save_translation (INSERT OR REPLACE) would silently overwrite
+    # whatever we write here. (#333)
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "SELECT 1 FROM translation_queue "
+            "WHERE book_id=? AND chapter_index=? AND target_language=? AND status='running'",
+            (book_id, chapter_index, target_language),
+        ) as cur:
+            if await cur.fetchone():
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"A translation job is currently running for chapter {chapter_index}. "
+                        "Wait for it to finish before retranslating."
+                    ),
+                )
+
     # 2. Detect source language from book metadata
     source_language = (book.get("languages") or ["en"])[0]
 
@@ -530,6 +548,27 @@ async def retranslate_all(
     from services.book_chapters import split_with_html_preference
     chapters = await split_with_html_preference(book_id, book["text"])
     source_language = (book.get("languages") or ["en"])[0]
+
+    # Pre-check: reject before translating any chapter if any have a running
+    # queue job. The worker would overwrite whatever we write. (#333)
+    chapter_indices = list(range(len(chapters)))
+    async with aiosqlite.connect(DB_PATH) as db:
+        placeholders = ",".join("?" * len(chapter_indices))
+        async with db.execute(
+            f"SELECT chapter_index FROM translation_queue "
+            f"WHERE book_id=? AND target_language=? AND status='running' "
+            f"AND chapter_index IN ({placeholders})",
+            [book_id, target_language, *chapter_indices],
+        ) as cur:
+            running = [row[0] for row in await cur.fetchall()]
+    if running:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Translation job(s) currently running for chapter(s) {sorted(running)}. "
+                "Wait for them to finish before retranslating."
+            ),
+        )
 
     raw_key = admin.get("gemini_key")
     try:

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -1245,3 +1245,55 @@ async def test_delete_book_removes_orphaned_vocabulary(admin_client, admin_db, a
     assert "orphan" not in words_after, "orphaned vocab entry survived delete_book"
     # Shared word (also in book 200) must survive
     assert "shared" in words_after
+
+
+# ── Retranslate running-row guard ─────────────────────────────────────────────
+
+async def test_retranslate_rejects_409_when_chapter_is_running(admin_client, admin_db):
+    """Regression #333: retranslate must reject 409 when a queue worker is
+    actively translating the same chapter, to prevent the worker from
+    overwriting the admin's fresh result when it finishes."""
+    from services.translation_queue import enqueue
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    await save_translation(100, 0, "de", ["Old translation."])
+    await enqueue(100, 0, "de")
+    async with aiosqlite.connect(admin_db) as db:
+        await db.execute(
+            "UPDATE translation_queue SET status='running' WHERE book_id=100 AND chapter_index=0",
+        )
+        await db.commit()
+
+    with patch("routers.admin.do_translate", new_callable=AsyncMock, return_value=["New."]):
+        res = await admin_client.post("/api/admin/translations/100/0/de/retranslate")
+
+    assert res.status_code == 409
+    # Existing translation must be untouched
+    from services.db import get_cached_translation
+    assert await get_cached_translation(100, 0, "de") == ["Old translation."]
+
+
+async def test_retranslate_all_rejects_409_when_any_chapter_is_running(admin_client, admin_db):
+    """Regression #333: retranslate-all must reject 409 before translating
+    any chapter if a running queue row exists for one of them."""
+    from services.translation_queue import enqueue
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    await save_translation(100, 0, "de", ["Chapter 0 old."])
+    await enqueue(100, 0, "de")
+    async with aiosqlite.connect(admin_db) as db:
+        await db.execute(
+            "UPDATE translation_queue SET status='running' WHERE book_id=100 AND chapter_index=0",
+        )
+        await db.commit()
+
+    with patch("routers.admin.do_translate", new_callable=AsyncMock, return_value=["New."]):
+        res = await admin_client.post(
+            "/api/admin/translations/100/retranslate-all",
+            json={"target_language": "de"},
+        )
+
+    assert res.status_code == 409
+    detail = res.json()["detail"]
+    assert "0" in detail  # blocked chapter index mentioned
+    # Chapter 0 translation must be untouched
+    from services.db import get_cached_translation
+    assert await get_cached_translation(100, 0, "de") == ["Chapter 0 old."]


### PR DESCRIPTION
## Summary

- `POST /admin/translations/{id}/{idx}/{lang}/retranslate` and `POST /admin/translations/{id}/retranslate-all` call `save_translation` (INSERT OR REPLACE) without checking whether a queue worker is already translating the same chapter
- If a worker is mid-batch, it will call `save_translation` when it finishes and overwrite the admin's fresh translation silently
- The same running-row guard pattern applied in #319, #325, #326, #328 was missing from these two endpoints

## Fix

- `retranslate`: added a pre-check before translation — returns 409 if a running queue row exists for the target chapter
- `retranslate_all`: added a pre-check over all chapter indices before starting any translation — returns 409 with the list of blocked chapters if any are running

## Test plan

- [x] `test_retranslate_rejects_409_when_chapter_is_running` — failed before fix (200 returned, race condition present), passes after (409 returned, existing translation preserved)
- [x] `test_retranslate_all_rejects_409_when_any_chapter_is_running` — failed before fix (200 returned), passes after (409 returned, chapter index listed in detail)
- [x] Full backend suite: 926 passed, 0 failed

Closes #333
