### PR TITLE
fix: DELETE translation endpoints clean up non-running queue rows (closes #335)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -348,9 +348,15 @@ async def delete_book_translations(book_id: int, _admin: dict = Depends(_require
     """Delete all translations for a book."""
     async with aiosqlite.connect(DB_PATH) as db:
         cursor = await db.execute("DELETE FROM translations WHERE book_id = ?", (book_id,))
+        if cursor.rowcount == 0:
+            raise HTTPException(status_code=404, detail="No translations found for this book")
+        # Clear non-running queue rows so enqueue() can re-add chapters.
+        # Running rows are left alone — the worker holds them. (#335)
+        await db.execute(
+            "DELETE FROM translation_queue WHERE book_id=? AND status != 'running'",
+            (book_id,),
+        )
         await db.commit()
-    if cursor.rowcount == 0:
-        raise HTTPException(status_code=404, detail="No translations found for this book")
     return {"ok": True, "deleted": cursor.rowcount}
 
 
@@ -367,9 +373,14 @@ async def delete_language_translations(
             "DELETE FROM translations WHERE book_id=? AND target_language=?",
             (book_id, target_language),
         )
+        if cursor.rowcount == 0:
+            raise HTTPException(status_code=404, detail="No translations found for this language")
+        await db.execute(
+            "DELETE FROM translation_queue "
+            "WHERE book_id=? AND target_language=? AND status != 'running'",
+            (book_id, target_language),
+        )
         await db.commit()
-    if cursor.rowcount == 0:
-        raise HTTPException(status_code=404, detail="No translations found for this language")
     return {"ok": True, "deleted": cursor.rowcount}
 
 
@@ -387,9 +398,14 @@ async def delete_translation(
             "DELETE FROM translations WHERE book_id=? AND chapter_index=? AND target_language=?",
             (book_id, chapter_index, target_language),
         )
+        if cursor.rowcount == 0:
+            raise HTTPException(status_code=404, detail="Translation not found")
+        await db.execute(
+            "DELETE FROM translation_queue "
+            "WHERE book_id=? AND chapter_index=? AND target_language=? AND status != 'running'",
+            (book_id, chapter_index, target_language),
+        )
         await db.commit()
-    if cursor.rowcount == 0:
-        raise HTTPException(status_code=404, detail="Translation not found")
     return {"ok": True, "deleted": cursor.rowcount}
 
 

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -456,6 +456,101 @@ async def test_delete_language_translations_normalizes_language(admin_client, ad
     assert res.json()["deleted"] == 1
 
 
+# ── Delete translation queue cleanup (regression #335) ───────────────────────
+
+async def test_delete_specific_translation_clears_queue_row(admin_client, admin_db):
+    """Regression #335: DELETE /translations/{id}/{idx}/{lang} must also remove
+    non-running queue rows so enqueue() can re-add the chapter later."""
+    from services.translation_queue import enqueue
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    await save_translation(100, 0, "de", ["paragraph"])
+    await enqueue(100, 0, "de")  # pending queue row
+    async with aiosqlite.connect(admin_db) as db:
+        await db.execute(
+            "UPDATE translation_queue SET status='failed' WHERE book_id=100 AND chapter_index=0"
+        )
+        await db.commit()
+
+    res = await admin_client.delete("/api/admin/translations/100/0/de")
+    assert res.status_code == 200
+
+    # After deletion, enqueue must succeed (rowcount=1), not no-op
+    from services.translation_queue import enqueue as enqueue2
+    added = await enqueue2(100, 0, "de")
+    assert added == 1, "enqueue must return 1 after orphan queue row is cleaned up"
+
+
+async def test_delete_language_translations_clears_queue_rows(admin_client, admin_db):
+    """Regression #335: DELETE /translations/{id}/{lang} must remove non-running
+    queue rows for that language so subsequent enqueue calls can proceed."""
+    from services.translation_queue import enqueue
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    await save_translation(100, 0, "zh", ["第一章"])
+    await save_translation(100, 1, "zh", ["第二章"])
+    await enqueue(100, 0, "zh")
+    await enqueue(100, 1, "zh")
+    # Simulate a pending and a failed row
+    async with aiosqlite.connect(admin_db) as db:
+        await db.execute(
+            "UPDATE translation_queue SET status='failed' WHERE book_id=100 AND chapter_index=1 AND target_language='zh'"
+        )
+        await db.commit()
+
+    res = await admin_client.delete("/api/admin/translations/100/zh")
+    assert res.status_code == 200
+
+    from services.translation_queue import enqueue as enqueue2
+    added_0 = await enqueue2(100, 0, "zh")
+    added_1 = await enqueue2(100, 1, "zh")
+    assert added_0 == 1, "ch0 must be re-enqueueable after cleanup"
+    assert added_1 == 1, "ch1 must be re-enqueueable after cleanup"
+
+
+async def test_delete_book_translations_clears_queue_rows(admin_client, admin_db):
+    """Regression #335: DELETE /translations/{id} must remove non-running queue
+    rows for all languages so subsequent enqueue calls can proceed."""
+    from services.translation_queue import enqueue
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    await save_translation(100, 0, "de", ["paragraph"])
+    await save_translation(100, 0, "zh", ["第一章"])
+    await enqueue(100, 0, "de")
+    await enqueue(100, 0, "zh")
+
+    res = await admin_client.delete("/api/admin/translations/100")
+    assert res.status_code == 200
+
+    from services.translation_queue import enqueue as enqueue2
+    added_de = await enqueue2(100, 0, "de")
+    added_zh = await enqueue2(100, 0, "zh")
+    assert added_de == 1, "de must be re-enqueueable after full book translation delete"
+    assert added_zh == 1, "zh must be re-enqueueable after full book translation delete"
+
+
+async def test_delete_translation_preserves_running_queue_row(admin_client, admin_db):
+    """Regression #335: queue cleanup must NOT delete running rows — the worker
+    holds them and will call mark_queue_row_done when done."""
+    from services.translation_queue import enqueue
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    await save_translation(100, 0, "de", ["paragraph"])
+    await enqueue(100, 0, "de")
+    async with aiosqlite.connect(admin_db) as db:
+        await db.execute(
+            "UPDATE translation_queue SET status='running' WHERE book_id=100 AND chapter_index=0"
+        )
+        await db.commit()
+
+    res = await admin_client.delete("/api/admin/translations/100/0/de")
+    assert res.status_code == 200
+
+    async with aiosqlite.connect(admin_db) as db:
+        async with db.execute(
+            "SELECT status FROM translation_queue WHERE book_id=100 AND chapter_index=0 AND target_language='de'"
+        ) as cur:
+            row = await cur.fetchone()
+    assert row is not None, "running queue row must survive translation deletion"
+    assert row[0] == "running"
+
+
 # ── Audio ────────────────────────────────────────────────────────────────────
 
 async def test_get_audio_empty(admin_client, admin_db):


### PR DESCRIPTION
## Summary

- `DELETE /admin/translations/{book_id}`, `/{book_id}/{lang}`, and `/{book_id}/{idx}/{lang}` removed rows from the `translations` table but left corresponding `translation_queue` rows untouched
- Orphan pending/failed queue rows block `enqueue()` permanently via `INSERT OR IGNORE` — the chapter appears stuck in queue and can never be re-translated
- Mirrors the cascade pattern already in `delete_book` (line 230) which deletes queue rows

## Fix

Each endpoint now deletes non-running queue rows for the same key in the same transaction, after verifying the translations row exists. Running rows are skipped — the worker holds them and will call `mark_queue_row_done` on completion.

## Test plan

- [x] `test_delete_specific_translation_clears_queue_row` — failed before fix (enqueue returned 0), passes after (returns 1)
- [x] `test_delete_language_translations_clears_queue_rows` — same
- [x] `test_delete_book_translations_clears_queue_rows` — same
- [x] `test_delete_translation_preserves_running_queue_row` — running rows must survive deletion
- [x] Full backend suite: 929 passed, 0 failed

Closes #335
