### PR TITLE
fix: DELETE translation endpoints reject 409 when queue worker is running (closes #338)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -347,6 +347,22 @@ async def get_translations(_admin: dict = Depends(_require_admin)):
 async def delete_book_translations(book_id: int, _admin: dict = Depends(_require_admin)):
     """Delete all translations for a book."""
     async with aiosqlite.connect(DB_PATH) as db:
+        # Reject if any worker is running — it would re-insert via INSERT OR REPLACE. (#338)
+        async with db.execute(
+            "SELECT chapter_index, target_language FROM translation_queue "
+            "WHERE book_id=? AND status='running' LIMIT 1",
+            (book_id,),
+        ) as cur:
+            running = await cur.fetchone()
+        if running:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"A translation job is currently running for this book "
+                    f"(chapter {running[0]}, language '{running[1]}'). "
+                    "Wait for it to finish before deleting."
+                ),
+            )
         cursor = await db.execute("DELETE FROM translations WHERE book_id = ?", (book_id,))
         if cursor.rowcount == 0:
             raise HTTPException(status_code=404, detail="No translations found for this book")
@@ -369,6 +385,20 @@ async def delete_language_translations(
     """Delete all cached translations for one language of a book."""
     target_language = target_language.lower().split("-")[0]
     async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "SELECT chapter_index FROM translation_queue "
+            "WHERE book_id=? AND target_language=? AND status='running' LIMIT 1",
+            (book_id, target_language),
+        ) as cur:
+            running = await cur.fetchone()
+        if running:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"A translation job is currently running for chapter {running[0]}. "
+                    "Wait for it to finish before deleting."
+                ),
+            )
         cursor = await db.execute(
             "DELETE FROM translations WHERE book_id=? AND target_language=?",
             (book_id, target_language),
@@ -394,6 +424,19 @@ async def delete_translation(
     """Delete a specific cached translation."""
     target_language = target_language.lower().split("-")[0]
     async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "SELECT 1 FROM translation_queue "
+            "WHERE book_id=? AND chapter_index=? AND target_language=? AND status='running'",
+            (book_id, chapter_index, target_language),
+        ) as cur:
+            if await cur.fetchone():
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"A translation job is currently running for chapter {chapter_index}. "
+                        "Wait for it to finish before deleting."
+                    ),
+                )
         cursor = await db.execute(
             "DELETE FROM translations WHERE book_id=? AND chapter_index=? AND target_language=?",
             (book_id, chapter_index, target_language),

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -456,7 +456,7 @@ async def test_delete_language_translations_normalizes_language(admin_client, ad
     assert res.json()["deleted"] == 1
 
 
-# ── Delete translation queue cleanup (regression #335) ───────────────────────
+# ── Delete translation queue cleanup + running guard (regression #335, #338) ──
 
 async def test_delete_specific_translation_clears_queue_row(admin_client, admin_db):
     """Regression #335: DELETE /translations/{id}/{idx}/{lang} must also remove
@@ -480,6 +480,26 @@ async def test_delete_specific_translation_clears_queue_row(admin_client, admin_
     assert added == 1, "enqueue must return 1 after orphan queue row is cleaned up"
 
 
+async def test_delete_specific_translation_rejects_409_when_running(admin_client, admin_db):
+    """Regression #338: DELETE /translations/{id}/{idx}/{lang} must return 409
+    when a queue worker is actively translating the chapter — the worker would
+    re-insert the deleted translation via save_translation INSERT OR REPLACE."""
+    from services.translation_queue import enqueue
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    await save_translation(100, 0, "de", ["paragraph"])
+    await enqueue(100, 0, "de")
+    async with aiosqlite.connect(admin_db) as db:
+        await db.execute(
+            "UPDATE translation_queue SET status='running' WHERE book_id=100 AND chapter_index=0 AND target_language='de'"
+        )
+        await db.commit()
+
+    res = await admin_client.delete("/api/admin/translations/100/0/de")
+    assert res.status_code == 409
+    from services.db import get_cached_translation
+    assert await get_cached_translation(100, 0, "de") == ["paragraph"]
+
+
 async def test_delete_language_translations_clears_queue_rows(admin_client, admin_db):
     """Regression #335: DELETE /translations/{id}/{lang} must remove non-running
     queue rows for that language so subsequent enqueue calls can proceed."""
@@ -489,7 +509,6 @@ async def test_delete_language_translations_clears_queue_rows(admin_client, admi
     await save_translation(100, 1, "zh", ["第二章"])
     await enqueue(100, 0, "zh")
     await enqueue(100, 1, "zh")
-    # Simulate a pending and a failed row
     async with aiosqlite.connect(admin_db) as db:
         await db.execute(
             "UPDATE translation_queue SET status='failed' WHERE book_id=100 AND chapter_index=1 AND target_language='zh'"
@@ -504,6 +523,28 @@ async def test_delete_language_translations_clears_queue_rows(admin_client, admi
     added_1 = await enqueue2(100, 1, "zh")
     assert added_0 == 1, "ch0 must be re-enqueueable after cleanup"
     assert added_1 == 1, "ch1 must be re-enqueueable after cleanup"
+
+
+async def test_delete_language_translations_rejects_409_when_running(admin_client, admin_db):
+    """Regression #338: DELETE /translations/{id}/{lang} must return 409 when
+    any queue worker is actively translating a chapter for that language."""
+    from services.translation_queue import enqueue
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    await save_translation(100, 0, "zh", ["章节0"])
+    await save_translation(100, 1, "zh", ["章节1"])
+    await enqueue(100, 1, "zh")
+    async with aiosqlite.connect(admin_db) as db:
+        await db.execute(
+            "UPDATE translation_queue SET status='running' WHERE book_id=100 AND chapter_index=1 AND target_language='zh'"
+        )
+        await db.commit()
+
+    res = await admin_client.delete("/api/admin/translations/100/zh")
+    assert res.status_code == 409
+    detail = res.json()["detail"]
+    assert "1" in detail  # blocked chapter index mentioned
+    from services.db import get_cached_translation
+    assert await get_cached_translation(100, 0, "zh") == ["章节0"]
 
 
 async def test_delete_book_translations_clears_queue_rows(admin_client, admin_db):
@@ -526,29 +567,23 @@ async def test_delete_book_translations_clears_queue_rows(admin_client, admin_db
     assert added_zh == 1, "zh must be re-enqueueable after full book translation delete"
 
 
-async def test_delete_translation_preserves_running_queue_row(admin_client, admin_db):
-    """Regression #335: queue cleanup must NOT delete running rows — the worker
-    holds them and will call mark_queue_row_done when done."""
+async def test_delete_book_translations_rejects_409_when_running(admin_client, admin_db):
+    """Regression #338: DELETE /translations/{id} must return 409 when any
+    queue worker is actively translating any chapter of the book."""
     from services.translation_queue import enqueue
     await save_book(100, BOOK_META, BOOK_TEXT)
     await save_translation(100, 0, "de", ["paragraph"])
     await enqueue(100, 0, "de")
     async with aiosqlite.connect(admin_db) as db:
         await db.execute(
-            "UPDATE translation_queue SET status='running' WHERE book_id=100 AND chapter_index=0"
+            "UPDATE translation_queue SET status='running' WHERE book_id=100"
         )
         await db.commit()
 
-    res = await admin_client.delete("/api/admin/translations/100/0/de")
-    assert res.status_code == 200
-
-    async with aiosqlite.connect(admin_db) as db:
-        async with db.execute(
-            "SELECT status FROM translation_queue WHERE book_id=100 AND chapter_index=0 AND target_language='de'"
-        ) as cur:
-            row = await cur.fetchone()
-    assert row is not None, "running queue row must survive translation deletion"
-    assert row[0] == "running"
+    res = await admin_client.delete("/api/admin/translations/100")
+    assert res.status_code == 409
+    from services.db import get_cached_translation
+    assert await get_cached_translation(100, 0, "de") == ["paragraph"]
 
 
 # ── Audio ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Three admin DELETE /translations/* endpoints preserved running queue rows (correct per #336), but the worker finishing later still calls `save_translation()` (INSERT OR REPLACE), silently re-inserting the translation the admin just deleted
- Same running-row guard pattern as `move_translation` (#330) and `retranslate` (#334) was missing from deletion endpoints
- Also consolidates the queue cleanup tests from PR #336 and the new 409 tests into a single test section

## Fix

Each DELETE endpoint now checks for a running queue row for the same key before deleting. Returns 409 with a clear message telling the admin to wait. The non-running queue cleanup from PR #336 is preserved.

## Test plan

- [x] `test_delete_specific_translation_rejects_409_when_running` — failed before fix, passes after
- [x] `test_delete_language_translations_rejects_409_when_running` — same
- [x] `test_delete_book_translations_rejects_409_when_running` — same
- [x] All 3 queue-cleanup tests from #335 (#336) still pass
- [x] Full backend suite: 933 passed, 0 failed

Closes #338
