### PR TITLE
feat: guest reading experience — open cached translations + auth prompts

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -169,7 +169,7 @@ async def get_chapter_translation(
     book_id: int,
     chapter_index: int,
     target_language: str,
-    user: dict = Depends(get_current_user),
+    user: dict | None = Depends(get_optional_user),
 ):
     """Return the cached translation if available, 404 otherwise. Never enqueues."""
     target_language = target_language.lower().split("-")[0]

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -524,10 +524,21 @@ async def test_get_chapter_translation_not_cached(client):
     assert resp.status_code == 404
 
 
-async def test_get_chapter_translation_requires_login(anon_client):
-    """GET requires authentication."""
+async def test_get_chapter_translation_no_cache_returns_404_for_guest(anon_client):
+    """GET returns 404 (not 401) when no cached translation exists — public endpoint."""
     resp = await anon_client.get("/api/books/9999/chapters/0/translation?target_language=de")
-    assert resp.status_code == 401
+    assert resp.status_code == 404
+
+
+async def test_get_chapter_translation_cached_served_to_guest(anon_client):
+    """GET serves cached translation to unauthenticated users."""
+    from services.db import save_translation
+    await save_translation(9999, 0, "es", ["Hola mundo"])
+    resp = await anon_client.get("/api/books/9999/chapters/0/translation?target_language=es")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ready"
+    assert data["paragraphs"] == ["Hola mundo"]
 
 
 async def test_chapter_translation_requires_gemini_key(client):

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -533,6 +533,7 @@ async def test_get_chapter_translation_no_cache_returns_404_for_guest(anon_clien
 async def test_get_chapter_translation_cached_served_to_guest(anon_client):
     """GET serves cached translation to unauthenticated users."""
     from services.db import save_translation
+    await save_book(9999, MOCK_META, "text")
     await save_translation(9999, 0, "es", ["Hola mundo"])
     resp = await anon_client.get("/api/books/9999/chapters/0/translation?target_language=es")
     assert resp.status_code == 200

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -264,3 +264,107 @@ A distraction-free reading experience with typography customisation and paragrap
 After reading a chapter, ask 3-5 AI-generated multiple-choice questions to test comprehension. Results stored per user/chapter.
 
 Estimated: 4 hours. Requires approval for DB schema.
+
+---
+
+## Session 4 — 2026-04-22
+
+### Implementing this session
+- [x] Feature 6: Guest Reading Experience
+- [ ] Feature 7: User-Uploaded Books (.txt / .epub)
+- [ ] Feature 8: Pre-Translation Tooling (design only — v1 chosen)
+
+---
+
+## Feature 6: Guest Reading Experience ✅ (merged)
+
+### Overview
+Non-logged-in users can browse and read any book, and view existing cached translations for free. They cannot generate new translations or access AI features. Reading progress lives in `localStorage` only.
+
+### What shipped
+- `GET /books/{id}/chapters/{idx}/translation` now serves cached translations without auth (`get_optional_user`)
+- `AuthPromptModal`: bottom-sheet sign-in prompt triggered by locked features on mobile
+- Reader: Notes and Vocab toolbar buttons visible for guests — clicking opens sign-in modal instead of hiding
+- Reader: Mobile Notes bar button always shown; auth prompt for guests
+- Reader: Mobile auto-shows auth modal when translation requires login (no cache + guest)
+- Reader: Profile button replaced with "Sign in" link for unauthenticated users
+
+### What guests can do
+| Feature | Guest | Logged-in |
+|---|---|---|
+| Read any book | ✅ | ✅ |
+| View cached translations | ✅ | ✅ |
+| Generate new translations | ❌ → sign-in prompt | ✅ |
+| TTS playback | ✅ | ✅ |
+| Reading progress | localStorage (chapter index) | Server + localStorage |
+| Vocabulary / Annotations | ❌ → sign-in prompt | ✅ |
+| AI Chat / Insights / Summary | ❌ → sign-in prompt | ✅ |
+
+### Tests
+- Backend: `test_get_chapter_translation_no_cache_returns_404_for_guest`, `test_get_chapter_translation_cached_served_to_guest`
+- Frontend: `AuthPromptModal.test.tsx` — 6 tests
+
+---
+
+## Feature 7: User-Uploaded Books (.txt / .epub) — IN PROGRESS
+
+### Overview
+Logged-in users can upload their own books as `.txt` or `.epub` files. Each uploaded book is private — only the uploader and admins can read it. Auto-detection followed by a manual chapter editor before the book is readable.
+
+### Constraints
+- Max 10 books per user
+- Max file size: 3 MB (.txt), 15 MB (.epub)
+- Accepted: `.txt`, `.epub`
+
+### Database (migration 021)
+```sql
+ALTER TABLE books ADD COLUMN source TEXT NOT NULL DEFAULT 'gutenberg';
+ALTER TABLE books ADD COLUMN owner_user_id INTEGER REFERENCES users(id) ON DELETE CASCADE;
+
+CREATE TABLE book_uploads (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    book_id INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    filename TEXT NOT NULL, file_size INTEGER NOT NULL, format TEXT NOT NULL,
+    uploaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### API Endpoints
+- `POST /books/upload` — parse file, store draft, return detected chapters
+- `GET /books/{id}/chapters/draft` — return detected chapter list for editing
+- `POST /books/{id}/chapters/confirm` — write final chapters, make book readable
+- `GET /books/upload/quota` — `{used, max, bytes_used, bytes_max}`
+- `DELETE /books/upload/{id}` — delete uploaded book
+
+### Chapter Detection
+- **epub**: `ebooklib` spine/TOC — each spine item = one chapter
+- **txt**: regex heuristics (`CHAPTER I`, `Chapter 1`, all-caps short lines, Roman numerals)
+- Hard cap: 200 chapters max; <2 detected → split every 5000 words
+
+### Chapter Editor UI (`/upload/[bookId]/chapters`)
+Two-panel layout: chapter list (left) + text preview (right).
+Each chapter row shows title, first line preview, word count.
+Actions: merge with next, add split, edit title.
+Word count warnings: >8000 words (amber) or <100 words (amber).
+
+---
+
+## Feature 8: Pre-Translation Tooling — Design (v1 decided)
+
+### Decision: MarianMT (primary) + Ollama (fallback)
+
+Helsinki-NLP/MarianMT for common EU language pairs (en→de/fr/es/it/ru/nl/pt/pl/zh/ja), Ollama fallback for others. Both free, offline, no API keys.
+
+### Script: `scripts/pretranslate.py`
+
+```bash
+python scripts/pretranslate.py --book-id 1342 --lang de           # MarianMT default
+python scripts/pretranslate.py --all --lang fr --provider ollama  # Ollama
+python scripts/pretranslate.py --book-id 1342 --lang de --dry-run # preview only
+python scripts/pretranslate.py --book-id 1342 --lang de --force   # overwrite cache
+```
+
+**Dependencies:** `transformers`, `sentencepiece`, `torch` (CPU), `requests` (for Ollama).  
+**Chunking:** split at sentence boundaries to stay under MarianMT's 512-token limit.  
+**Estimated effort:** ~6 hours.

--- a/frontend/src/__tests__/AuthPromptModal.test.tsx
+++ b/frontend/src/__tests__/AuthPromptModal.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import AuthPromptModal from "@/components/AuthPromptModal";
+
+describe("AuthPromptModal", () => {
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <AuthPromptModal open={false} feature="translate books" onClose={jest.fn()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows feature name when open", () => {
+    render(<AuthPromptModal open feature="save vocabulary" onClose={jest.fn()} />);
+    expect(screen.getByText(/sign in to save vocabulary/i)).toBeInTheDocument();
+  });
+
+  it("has a Sign in link pointing to auth", () => {
+    render(<AuthPromptModal open feature="save annotations and notes" onClose={jest.fn()} />);
+    const link = screen.getByRole("link", { name: /sign in/i });
+    expect(link).toHaveAttribute("href", "/api/auth/signin");
+  });
+
+  it("calls onClose when backdrop is clicked", () => {
+    const onClose = jest.fn();
+    const { container } = render(
+      <AuthPromptModal open feature="translate books" onClose={onClose} />
+    );
+    // Click the backdrop (first child of the modal container)
+    const backdrop = container.querySelector(".absolute.inset-0");
+    fireEvent.click(backdrop!);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when Maybe later is clicked", () => {
+    const onClose = jest.fn();
+    render(<AuthPromptModal open feature="translate books" onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /maybe later/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose on Escape key", () => {
+    const onClose = jest.fn();
+    render(<AuthPromptModal open feature="translate books" onClose={onClose} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/__tests__/ReaderPage.branches.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches.test.tsx
@@ -837,7 +837,7 @@ describe("ReaderPage.branches — profile picture display", () => {
     });
   });
 
-  it("shows ? when session has no backendUser", async () => {
+  it("shows Sign in link when session has no backendToken", async () => {
     mockUseSession.mockReturnValue({
       data: { backendToken: null, backendUser: null, user: null },
       status: "unauthenticated",
@@ -846,9 +846,9 @@ describe("ReaderPage.branches — profile picture display", () => {
     render(<ReaderPage />);
     await flushPromises();
 
-    // "?" placeholder should show
+    // Guest sees "Sign in" link instead of profile avatar
     await waitFor(() => {
-      expect(screen.queryByText("?")).toBeTruthy();
+      expect(screen.getByRole("link", { name: /sign in/i })).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/__tests__/ReaderPage.branches2.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches2.test.tsx
@@ -1524,7 +1524,7 @@ describe("ReaderPage.branches2 — profile avatar variants", () => {
     });
   });
 
-  it("shows '?' when session has no backendUser", async () => {
+  it("shows 'Sign in' link when session has no backendToken", async () => {
     mockUseSession.mockReturnValue({
       data: { backendToken: null, backendUser: null, user: null },
       status: "unauthenticated",
@@ -1534,7 +1534,7 @@ describe("ReaderPage.branches2 — profile avatar variants", () => {
     await flushPromises();
 
     await waitFor(() => {
-      expect(screen.getByText("?")).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /sign in/i })).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/__tests__/ReaderPage.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.test.tsx
@@ -697,14 +697,16 @@ describe("ReaderPage — API data loading", () => {
 });
 
 describe("ReaderPage — unauthenticated session", () => {
-  it("does not show Notes/Vocab/Marks buttons when not authenticated", async () => {
+  it("shows Notes and Vocab buttons for guests (they show auth prompt on click)", async () => {
     mockUseSession.mockReturnValue({ data: null, status: "unauthenticated" });
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
     render(<ReaderPage />);
     await flushPromises();
 
-    expect(screen.queryByTitle("Annotations & notes")).not.toBeInTheDocument();
-    expect(screen.queryByTitle("Vocabulary")).not.toBeInTheDocument();
+    // Notes and Vocab are visible for guests — clicking shows auth prompt
+    expect(screen.getByTitle("Annotations & notes")).toBeInTheDocument();
+    expect(screen.getByTitle("Vocabulary")).toBeInTheDocument();
+    // Obsidian export and annotation marks toggle remain hidden (no auth)
     expect(screen.queryByTitle(/annotation marks/i)).not.toBeInTheDocument();
   });
 

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -17,6 +17,7 @@ import VocabularyToast from "@/components/VocabularyToast";
 import UndoToast from "@/components/UndoToast";
 import VocabWordTooltip from "@/components/VocabWordTooltip";
 import ChapterSummary from "@/components/ChapterSummary";
+import AuthPromptModal from "@/components/AuthPromptModal";
 import { SunIcon, MoonIcon, SepiaIcon, ChatIcon, GlobeIcon, NoteIcon, BookmarkIcon, BookOpenIcon, ExportIcon, SummaryIcon, PlayIcon, PauseIcon, CloseIcon, KeyboardIcon, FocusIcon, ArrowLeftIcon, ArrowRightIcon, ChevronDownIcon } from "@/components/Icons";
 
 // In-memory cache: bookId → chapters (survives client-side navigation)
@@ -260,6 +261,7 @@ export default function ReaderPage() {
   const [ttsStopAt, setTtsStopAt] = useState<number | undefined>();
   const [showTypographyPanel, setShowTypographyPanel] = useState(false);
   const [showShortcuts, setShowShortcuts] = useState(false);
+  const [authPrompt, setAuthPrompt] = useState<string | null>(null);
 
   // Read settings on mount (translationLang uses lazy useState above)
   useEffect(() => {
@@ -738,6 +740,14 @@ export default function ReaderPage() {
     }
   }
 
+  // On mobile: auto-show auth modal when translation is blocked for guests
+  useEffect(() => {
+    if (session?.backendToken) return;
+    if (translationUsedProvider !== "login required") return;
+    const isMobile = window.innerWidth < 768;
+    if (isMobile) setAuthPrompt("translate books");
+  }, [translationUsedProvider, session?.backendToken]);
+
   // Paragraph focus handlers
   function handleParagraphVisible(idx: number) {
     if (!ttsIsPlaying) setFocusParagraphIdx(idx);
@@ -1023,25 +1033,26 @@ export default function ReaderPage() {
           </button>
 
           {/* Notes sidebar toggle */}
-          {session?.backendToken && (
-            <button
-              onClick={() => { setSidebarTab("notes"); setSidebarOpen((v) => sidebarTab === "notes" ? !v : true); }}
-              title="Annotations & notes"
-              className={`relative hidden md:flex shrink-0 items-center gap-1.5 px-2 lg:px-3 py-1.5 rounded-lg border text-xs font-medium transition-colors ${
-                sidebarOpen && sidebarTab === "notes"
-                  ? "bg-amber-700 text-white border-amber-700"
-                  : "border-amber-300 text-amber-700 hover:bg-amber-50"
-              }`}
-            >
-              <NoteIcon className="w-3.5 h-3.5 shrink-0" />
-              <span className="hidden lg:inline">Notes</span>
-              {annotations.length > 0 && (
-                <span className="absolute -top-1.5 -right-1.5 min-w-[16px] h-4 flex items-center justify-center rounded-full bg-amber-600 text-white text-[9px] font-bold px-1">
-                  {annotations.length}
-                </span>
-              )}
-            </button>
-          )}
+          <button
+            onClick={() => {
+              if (!session?.backendToken) { setAuthPrompt("save annotations and notes"); return; }
+              setSidebarTab("notes"); setSidebarOpen((v) => sidebarTab === "notes" ? !v : true);
+            }}
+            title="Annotations & notes"
+            className={`relative hidden md:flex shrink-0 items-center gap-1.5 px-2 lg:px-3 py-1.5 rounded-lg border text-xs font-medium transition-colors ${
+              sidebarOpen && sidebarTab === "notes"
+                ? "bg-amber-700 text-white border-amber-700"
+                : "border-amber-300 text-amber-700 hover:bg-amber-50"
+            }`}
+          >
+            <NoteIcon className="w-3.5 h-3.5 shrink-0" />
+            <span className="hidden lg:inline">Notes</span>
+            {annotations.length > 0 && (
+              <span className="absolute -top-1.5 -right-1.5 min-w-[16px] h-4 flex items-center justify-center rounded-full bg-amber-600 text-white text-[9px] font-bold px-1">
+                {annotations.length}
+              </span>
+            )}
+          </button>
 
           {/* Show/hide annotation marks — lg+ only */}
           {session?.backendToken && (
@@ -1066,25 +1077,26 @@ export default function ReaderPage() {
           )}
 
           {/* Vocabulary sidebar */}
-          {session?.backendToken && (
-            <button
-              onClick={() => { setSidebarTab("vocab"); setSidebarOpen((v) => sidebarTab === "vocab" ? !v : true); }}
-              title="Vocabulary"
-              className={`relative hidden md:flex shrink-0 items-center gap-1.5 px-2 lg:px-3 py-1.5 rounded-lg border text-xs font-medium transition-colors ${
-                sidebarOpen && sidebarTab === "vocab"
-                  ? "bg-amber-700 text-white border-amber-700"
-                  : "border-amber-300 text-amber-700 hover:bg-amber-50"
-              }`}
-            >
-              <BookOpenIcon className="w-3.5 h-3.5 shrink-0" />
-              <span className="hidden lg:inline">Vocab</span>
-              {vocabWords.length > 0 && (
-                <span className="absolute -top-1.5 -right-1.5 min-w-[16px] h-4 flex items-center justify-center rounded-full bg-amber-600 text-white text-[9px] font-bold px-1">
-                  {vocabWords.length}
-                </span>
-              )}
-            </button>
-          )}
+          <button
+            onClick={() => {
+              if (!session?.backendToken) { setAuthPrompt("save vocabulary"); return; }
+              setSidebarTab("vocab"); setSidebarOpen((v) => sidebarTab === "vocab" ? !v : true);
+            }}
+            title="Vocabulary"
+            className={`relative hidden md:flex shrink-0 items-center gap-1.5 px-2 lg:px-3 py-1.5 rounded-lg border text-xs font-medium transition-colors ${
+              sidebarOpen && sidebarTab === "vocab"
+                ? "bg-amber-700 text-white border-amber-700"
+                : "border-amber-300 text-amber-700 hover:bg-amber-50"
+            }`}
+          >
+            <BookOpenIcon className="w-3.5 h-3.5 shrink-0" />
+            <span className="hidden lg:inline">Vocab</span>
+            {vocabWords.length > 0 && (
+              <span className="absolute -top-1.5 -right-1.5 min-w-[16px] h-4 flex items-center justify-center rounded-full bg-amber-600 text-white text-[9px] font-bold px-1">
+                {vocabWords.length}
+              </span>
+            )}
+          </button>
 
           {/* Export vocabulary to Obsidian — lg+ only */}
           {session?.backendToken && (
@@ -1151,21 +1163,30 @@ export default function ReaderPage() {
             )}
           </div>
 
-          {/* Profile — always rightmost */}
-          <button
-            onClick={() => router.push("/profile")}
-            title={session?.backendUser?.name ?? "Profile"}
-            className="shrink-0 w-10 h-10 md:w-8 md:h-8 rounded-full overflow-hidden border border-amber-300 hover:border-amber-500 transition-colors ml-auto md:ml-0"
-          >
-            {session?.backendUser?.picture ? (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img src={session.backendUser.picture} alt="profile" className="w-full h-full object-cover" />
-            ) : (
-              <span className="w-full h-full flex items-center justify-center bg-amber-100 text-amber-700 text-xs font-bold">
-                {session?.backendUser?.name?.[0] ?? "?"}
-              </span>
-            )}
-          </button>
+          {/* Profile / Sign-in — always rightmost */}
+          {session?.backendToken ? (
+            <button
+              onClick={() => router.push("/profile")}
+              title={session.backendUser?.name ?? "Profile"}
+              className="shrink-0 w-10 h-10 md:w-8 md:h-8 rounded-full overflow-hidden border border-amber-300 hover:border-amber-500 transition-colors ml-auto md:ml-0"
+            >
+              {session.backendUser?.picture ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={session.backendUser.picture} alt="profile" className="w-full h-full object-cover" />
+              ) : (
+                <span className="w-full h-full flex items-center justify-center bg-amber-100 text-amber-700 text-xs font-bold">
+                  {session.backendUser?.name?.[0] ?? "?"}
+                </span>
+              )}
+            </button>
+          ) : (
+            <a
+              href="/api/auth/signin"
+              className="shrink-0 ml-auto md:ml-0 px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-xs font-medium transition-colors"
+            >
+              Sign in
+            </a>
+          )}
         </div>
       </header>
 
@@ -2117,24 +2138,25 @@ export default function ReaderPage() {
               <ChevronDownIcon className="pointer-events-none absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 text-amber-500" />
             </div>
 
-            {session?.backendToken && (
-              <button
-                onClick={() => setNotesExpanded((v) => !v)}
-                className={`relative h-10 w-10 flex items-center justify-center rounded-lg border transition-colors ${
-                  notesExpanded
-                    ? "bg-amber-700 text-white border-amber-700"
-                    : "text-amber-700 bg-amber-50 border-amber-200"
-                }`}
-                aria-label="Notes"
-              >
-                <NoteIcon className="w-5 h-5" />
-                {annotations.length > 0 && (
-                  <span className="absolute -top-1 -right-1 min-w-[14px] h-3.5 flex items-center justify-center rounded-full bg-amber-600 text-white text-[8px] font-bold px-0.5">
-                    {annotations.length}
-                  </span>
-                )}
-              </button>
-            )}
+            <button
+              onClick={() => {
+                if (!session?.backendToken) { setAuthPrompt("save annotations and notes"); return; }
+                setNotesExpanded((v) => !v);
+              }}
+              className={`relative h-10 w-10 flex items-center justify-center rounded-lg border transition-colors ${
+                notesExpanded
+                  ? "bg-amber-700 text-white border-amber-700"
+                  : "text-amber-700 bg-amber-50 border-amber-200"
+              }`}
+              aria-label="Notes"
+            >
+              <NoteIcon className="w-5 h-5" />
+              {annotations.length > 0 && (
+                <span className="absolute -top-1 -right-1 min-w-[14px] h-3.5 flex items-center justify-center rounded-full bg-amber-600 text-white text-[8px] font-bold px-0.5">
+                  {annotations.length}
+                </span>
+              )}
+            </button>
 
             <button
               onClick={() => setSidebarOpen((v) => !v)}
@@ -2148,6 +2170,12 @@ export default function ReaderPage() {
           </div>
         </div>
       )}
+
+      <AuthPromptModal
+        open={authPrompt !== null}
+        feature={authPrompt ?? ""}
+        onClose={() => setAuthPrompt(null)}
+      />
     </div>
   );
 }

--- a/frontend/src/components/AuthPromptModal.tsx
+++ b/frontend/src/components/AuthPromptModal.tsx
@@ -1,0 +1,43 @@
+"use client";
+import { useEffect } from "react";
+
+interface Props {
+  open: boolean;
+  feature: string;
+  onClose: () => void;
+}
+
+export default function AuthPromptModal({ open, feature, onClose }: Props) {
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) { if (e.key === "Escape") onClose(); }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[200] flex items-end md:items-center justify-center">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="relative bg-white rounded-t-2xl md:rounded-2xl shadow-xl p-6 w-full max-w-sm animate-slide-up">
+        <p className="font-serif text-lg text-ink mb-1">Sign in to {feature}</p>
+        <p className="text-sm text-stone-500 mb-5">
+          Create a free account or sign in to unlock this feature.
+        </p>
+        <a
+          href="/api/auth/signin"
+          className="block w-full py-3 bg-amber-700 hover:bg-amber-800 text-white text-center rounded-xl font-medium transition-colors"
+        >
+          Sign in
+        </a>
+        <button
+          onClick={onClose}
+          className="block w-full py-2 text-sm text-stone-500 mt-2 hover:text-stone-700 transition-colors"
+        >
+          Maybe later
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Cached translations now served to unauthenticated users via `GET /books/{id}/chapters/{idx}/translation` (changed `get_current_user` → `get_optional_user`)
- New `AuthPromptModal` component: bottom-sheet sign-in prompt for guests trying locked features
- Reader toolbar: Notes and Vocab buttons now visible for guests (click → auth prompt instead of hidden)
- Reader mobile bar: Notes button always shown; auth prompt for guests
- Reader: auto-shows auth modal on mobile when translation requires login and no cache exists
- Reader: profile button replaced with "Sign in" link for unauthenticated users
- Feature 6/7/8 design docs restored to `docs/FEATURES.md`

## Test plan
- [x] Backend: `test_get_chapter_translation_cached_served_to_guest` — 200 without auth token
- [x] Backend: `test_get_chapter_translation_no_cache_returns_404_for_guest` — 404 not 401
- [x] Frontend: `AuthPromptModal.test.tsx` — 6 tests (render, sign-in link, backdrop close, Escape, Maybe later)
- [x] Frontend: existing reader tests updated for new guest UX (Notes/Vocab visible, Sign in link)
- [x] 1534 frontend + 932 backend tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
