### PR TITLE
fix: PUT /translate/cache rejects 409 when queue worker is running (closes #341)

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -249,6 +249,19 @@ async def save_translate_cache(req: SaveTranslationRequest, _user: dict = Depend
     if not await get_cached_book(req.book_id):
         raise HTTPException(status_code=404, detail="Book not found")
     target_language = req.target_language.lower().split("-")[0]
+    # Reject if a queue worker is actively translating this chapter — the
+    # worker's save_translation (INSERT OR REPLACE) would overwrite whatever
+    # we write here when it finishes. (#341)
+    from services.translation_queue import queue_status_for_chapter
+    status = await queue_status_for_chapter(req.book_id, req.chapter_index, target_language)
+    if status["status"] == "running":
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"A translation job is currently running for chapter {req.chapter_index}. "
+                "Wait for it to finish before saving."
+            ),
+        )
     await save_translation(
         req.book_id, req.chapter_index, target_language, req.paragraphs,
         provider=req.provider, model=req.model,

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -240,6 +240,35 @@ async def test_translate_cache_put_saves(client, test_user):
     assert cached == ["Bonjour"]
 
 
+async def test_translate_cache_put_rejects_409_when_running(client, test_user, tmp_db):
+    """Regression #341: PUT /translate/cache must return 409 when a queue worker
+    is actively translating the same chapter — the worker would overwrite the
+    saved translation via save_translation INSERT OR REPLACE when it finishes."""
+    import aiosqlite
+    from services.db import save_book, save_translation, get_cached_translation
+    from services.translation_queue import enqueue
+    _BOOK_META_LOCAL = {"title": "Faust", "authors": ["Goethe"], "languages": ["de"],
+                        "subjects": [], "download_count": 0, "cover": ""}
+    await save_book(60, _BOOK_META_LOCAL, "text")
+    await save_translation(60, 0, "zh", ["existing paragraph"])
+    await enqueue(60, 0, "zh")
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute(
+            "UPDATE translation_queue SET status='running' WHERE book_id=60 AND chapter_index=0 AND target_language='zh'"
+        )
+        await db.commit()
+
+    resp = await client.put("/api/ai/translate/cache", json={
+        "book_id": 60, "chapter_index": 0, "target_language": "zh",
+        "paragraphs": ["new paragraph"],
+    })
+    assert resp.status_code == 409
+
+    # Existing translation must be untouched
+    cached = await get_cached_translation(60, 0, "zh")
+    assert cached == ["existing paragraph"]
+
+
 # ── Insight ───────────────────────────────────────────────────────────────────
 
 async def test_insight_without_key_returns_400(client):


### PR DESCRIPTION
## Summary

- `PUT /ai/translate/cache` (reader frontend saves a completed progressive translation) calls `save_translation` (INSERT OR REPLACE) without checking whether a queue worker is currently translating the same chapter
- If a worker is mid-batch, it will call `save_translation` when it finishes, overwriting the user's saved translation silently — or the user's translation can overwrite the worker's result if the user saves last
- The same running-row guard applied to admin `retranslate` (#334) and DELETE endpoints (#338) was missing here

## Fix

Added a `queue_status_for_chapter` check before writing. Returns 409 if the chapter's queue row has status='running'.

## Test plan

- [x] `test_translate_cache_put_rejects_409_when_running` — failed before fix (200 returned, existing translation overwritten), passes after (409, existing translation preserved)
- [x] Existing tests for `test_translate_cache_put_rejects_empty_paragraphs` and `test_translate_cache_put_saves` still pass
- [x] Full backend suite: 932 passed, 0 failed

Closes #341
