### PR TITLE
fix: make PATCH /obsidian-settings atomic to prevent stale-token clobber

### DIFF
--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -98,18 +98,22 @@ async def patch_obsidian(
     req: ObsidianSettingsUpdate,
     user: dict = Depends(get_current_user),
 ):
-    existing = await get_obsidian_settings(user["id"])
-    # None = not supplied → keep existing; "" = explicit clear → set NULL; non-empty = update
+    # None = not supplied → skip the column entirely (avoids a stale-read race).
+    # "" = explicit clear → set NULL.  non-empty = encrypt and store.
     if req.github_token is None:
-        token_enc = existing.get("github_token")
-    elif req.github_token.strip():
-        token_enc = encrypt_api_key(req.github_token.strip())
+        await update_obsidian_settings(
+            user["id"],
+            github_token_encrypted=None,
+            repo=req.obsidian_repo.strip() or None,
+            path=req.obsidian_path.strip() or None,
+            token_explicitly_set=False,
+        )
     else:
-        token_enc = None
-    await update_obsidian_settings(
-        user["id"],
-        github_token_encrypted=token_enc,
-        repo=req.obsidian_repo.strip() or None,
-        path=req.obsidian_path.strip() or None,
-    )
+        token_enc = encrypt_api_key(req.github_token.strip()) if req.github_token.strip() else None
+        await update_obsidian_settings(
+            user["id"],
+            github_token_encrypted=token_enc,
+            repo=req.obsidian_repo.strip() or None,
+            path=req.obsidian_path.strip() or None,
+        )
     return {"ok": True}

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -869,12 +869,21 @@ async def update_obsidian_settings(
     github_token_encrypted: str | None,
     repo: str | None,
     path: str | None,
+    *,
+    token_explicitly_set: bool = True,
 ) -> None:
     async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute(
-            "UPDATE users SET github_token = ?, obsidian_repo = ?, obsidian_path = ? WHERE id = ?",
-            (github_token_encrypted, repo, path, user_id),
-        )
+        if token_explicitly_set:
+            await db.execute(
+                "UPDATE users SET github_token = ?, obsidian_repo = ?, obsidian_path = ? WHERE id = ?",
+                (github_token_encrypted, repo, path, user_id),
+            )
+        else:
+            # github_token omitted intentionally — avoid a non-atomic read-then-write race.
+            await db.execute(
+                "UPDATE users SET obsidian_repo = ?, obsidian_path = ? WHERE id = ?",
+                (repo, path, user_id),
+            )
         await db.commit()
 
 

--- a/backend/tests/test_router_user.py
+++ b/backend/tests/test_router_user.py
@@ -189,3 +189,45 @@ async def test_patch_obsidian_settings_clears_token_with_empty_string(client, te
 
     settings = await get_obsidian_settings(test_user["id"])
     assert settings["github_token"] is None, "empty-string token must clear the stored token"
+
+
+async def test_patch_obsidian_settings_token_not_clobbered_by_stale_read(client, test_user, monkeypatch):
+    """Regression #344: PATCH without github_token must not overwrite a token
+    that was written between the read and write of a concurrent request.
+
+    With the bug: the handler reads the old token, a concurrent write upgrades
+    it to v2, then the handler writes back the stale v1 — silently deleting the
+    user's GitHub credential.
+    With the fix: when github_token is absent the handler never reads or writes
+    the github_token column at all, so the DB value is always preserved.
+    """
+    from services.db import update_obsidian_settings, get_obsidian_settings
+    from services.auth import encrypt_api_key, decrypt_api_key
+    import routers.user as user_router_module
+
+    # Set v1 token in DB.
+    await update_obsidian_settings(test_user["id"], encrypt_api_key("token-v1"), "r/v", "/p")
+
+    # Simulate a concurrent request that already wrote token-v2 BEFORE our
+    # handler's write, but AFTER its read — by monkeypatching get_obsidian_settings
+    # in the router namespace to return stale v1 data while the DB has v2.
+    await update_obsidian_settings(test_user["id"], encrypt_api_key("token-v2"), "r/v", "/p")
+
+    async def stale_get(user_id):
+        return {"github_token": encrypt_api_key("token-v1"), "obsidian_repo": "r/v", "obsidian_path": "/p"}
+
+    monkeypatch.setattr(user_router_module, "get_obsidian_settings", stale_get)
+
+    resp = await client.patch("/api/user/obsidian-settings", json={
+        "obsidian_repo": "r/v-updated",
+    })
+    assert resp.status_code == 200
+
+    # Undo only our patch so get_obsidian_settings goes back to the real impl.
+    monkeypatch.setattr(user_router_module, "get_obsidian_settings", get_obsidian_settings)
+    settings = await get_obsidian_settings(test_user["id"])
+    # With the bug: token would be v1 (stale read overwrote v2).
+    # With the fix: token stays v2 because the UPDATE skips the github_token column.
+    assert decrypt_api_key(settings["github_token"]) == "token-v2", \
+        "concurrent token update must not be silently overwritten by a PATCH that omits github_token"
+    assert settings["obsidian_repo"] == "r/v-updated"


### PR DESCRIPTION
## What

`PATCH /obsidian-settings` performed a non-atomic read-then-write when `github_token` was absent from the request body.

**Vulnerable sequence:**
1. Request A reads `github_token = "old-token"` from DB
2. Request B writes `github_token = "new-token"` (concurrent PATCH that includes a new token)
3. Request A writes back `github_token = "old-token"` — silently deleting the user's GitHub credential

## Fix

- Added `token_explicitly_set: bool = True` parameter to `update_obsidian_settings` in `services/db.py`
- When `False`, the SQL UPDATE omits the `github_token` column entirely — the DB value is never touched
- Router no longer calls `get_obsidian_settings` when `github_token` is absent (eliminates the read half of the race)

## Test

`test_patch_obsidian_settings_token_not_clobbered_by_stale_read` — monkeypatches `get_obsidian_settings` in the router to return stale v1 data while the DB already has v2. Asserts that the token remains v2 after the PATCH.

Closes #344
