### PR TITLE
fix: SELECT before COMMIT in create_annotation and update_annotation

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -679,12 +679,12 @@ async def create_annotation(
                DO UPDATE SET note_text = excluded.note_text, color = excluded.color""",
             (user_id, book_id, chapter_index, sentence_text, note_text, color),
         )
-        await db.commit()
         async with db.execute(
             "SELECT * FROM annotations WHERE user_id = ? AND book_id = ? AND chapter_index = ? AND sentence_text = ?",
             (user_id, book_id, chapter_index, sentence_text),
         ) as c:
             row = await c.fetchone()
+        await db.commit()
     return dict(row)
 
 
@@ -720,12 +720,12 @@ async def update_annotation(
                 f"UPDATE annotations SET {', '.join(clauses)} WHERE id = ? AND user_id = ?",
                 params,
             )
-            await db.commit()
         async with db.execute(
             "SELECT * FROM annotations WHERE id = ? AND user_id = ?",
             (annotation_id, user_id),
         ) as cursor:
             row = await cursor.fetchone()
+        await db.commit()
     return dict(row) if row else None
 
 

--- a/backend/tests/test_router_annotations.py
+++ b/backend/tests/test_router_annotations.py
@@ -254,3 +254,128 @@ async def test_create_annotation_rejects_negative_chapter_index(client, test_use
         "sentence_text": "Some highlighted text.",
     })
     assert resp.status_code == 400
+
+
+async def test_create_annotation_select_runs_before_commit(tmp_db, test_user, monkeypatch):
+    """Regression #349: SELECT must execute before COMMIT in create_annotation.
+
+    If COMMIT precedes SELECT, a concurrent write on another connection can
+    land between the two operations, causing the function to return data it did
+    not write (stale-return race). Placing SELECT inside the transaction
+    guarantees it only sees the current connection's own uncommitted write.
+    """
+    import aiosqlite as _real_aiosqlite
+    import services.db as db_module
+    from services.db import save_book, create_annotation
+
+    await save_book(BOOK_ID, _BOOK_META, "text")
+
+    events: list[str] = []
+    orig_connect = _real_aiosqlite.connect
+
+    def patched_connect(database, **kwargs):
+        real_cm = orig_connect(database, **kwargs)
+
+        class TrackedConn:
+            def __init__(self):
+                self._conn = None
+
+            async def __aenter__(self):
+                self._conn = await real_cm.__aenter__()
+                return self
+
+            async def __aexit__(self, *args):
+                return await real_cm.__aexit__(*args)
+
+            @property
+            def row_factory(self):
+                return self._conn.row_factory
+
+            @row_factory.setter
+            def row_factory(self, v):
+                self._conn.row_factory = v
+
+            def execute(self, sql, *args, **kwargs):
+                if sql.strip().upper().startswith("SELECT"):
+                    events.append("SELECT")
+                return self._conn.execute(sql, *args, **kwargs)
+
+            async def commit(self):
+                events.append("COMMIT")
+                return await self._conn.commit()
+
+        return TrackedConn()
+
+    class FakeAiosqlite:
+        connect = staticmethod(patched_connect)
+        Row = _real_aiosqlite.Row
+
+    monkeypatch.setattr(db_module, "aiosqlite", FakeAiosqlite)
+
+    await create_annotation(test_user["id"], BOOK_ID, 0, "Sentence", "my-note", "yellow")
+
+    assert "COMMIT" in events and "SELECT" in events, "both operations must fire"
+    assert events.index("SELECT") < events.index("COMMIT"), (
+        "SELECT must run before COMMIT so the return value reflects this "
+        "connection's own write, not a concurrent modification (#349)"
+    )
+
+
+async def test_update_annotation_select_runs_before_commit(tmp_db, test_user, monkeypatch):
+    """Regression #349: SELECT must execute before COMMIT in update_annotation."""
+    import aiosqlite as _real_aiosqlite
+    import services.db as db_module
+    from services.db import save_book, create_annotation, update_annotation
+
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    ann = await create_annotation(test_user["id"], BOOK_ID, 0, "Sentence", "v1", "yellow")
+
+    events: list[str] = []
+    orig_connect = _real_aiosqlite.connect
+
+    def patched_connect(database, **kwargs):
+        real_cm = orig_connect(database, **kwargs)
+
+        class TrackedConn:
+            def __init__(self):
+                self._conn = None
+
+            async def __aenter__(self):
+                self._conn = await real_cm.__aenter__()
+                return self
+
+            async def __aexit__(self, *args):
+                return await real_cm.__aexit__(*args)
+
+            @property
+            def row_factory(self):
+                return self._conn.row_factory
+
+            @row_factory.setter
+            def row_factory(self, v):
+                self._conn.row_factory = v
+
+            def execute(self, sql, *args, **kwargs):
+                if sql.strip().upper().startswith("SELECT"):
+                    events.append("SELECT")
+                return self._conn.execute(sql, *args, **kwargs)
+
+            async def commit(self):
+                events.append("COMMIT")
+                return await self._conn.commit()
+
+        return TrackedConn()
+
+    class FakeAiosqlite:
+        connect = staticmethod(patched_connect)
+        Row = _real_aiosqlite.Row
+
+    monkeypatch.setattr(db_module, "aiosqlite", FakeAiosqlite)
+
+    await update_annotation(ann["id"], test_user["id"], note_text="v2")
+
+    assert "COMMIT" in events and "SELECT" in events, "both operations must fire"
+    assert events.index("SELECT") < events.index("COMMIT"), (
+        "SELECT must run before COMMIT so update_annotation returns its own "
+        "write, not a concurrent modification (#349)"
+    )


### PR DESCRIPTION
## What

`create_annotation` and `update_annotation` in `services/db.py` committed the write BEFORE executing the SELECT that builds the return value.

**Vulnerable sequence:**
1. `await db.execute("INSERT/UPDATE ...")`
2. `await db.commit()` ← write now visible to other connections
3. A concurrent write on another connection modifies the same row
4. `await db.execute("SELECT ...")` ← returns the concurrent modification, not what was written

The function response told the caller "here's what was saved" but actually returned the concurrent modification.

## Fix

Swap the order: SELECT runs before COMMIT. SQLite guarantees a connection sees its own uncommitted writes within a transaction, so the SELECT always returns exactly what this connection wrote — concurrent modifications are not yet visible.

## Test

Two new order-tracking tests (`test_create_annotation_select_runs_before_commit`, `test_update_annotation_select_runs_before_commit`) monkeypatch `aiosqlite` to record the sequence of SELECT and COMMIT calls. The test asserts `SELECT` appears before `COMMIT` in the recorded sequence.

Same pattern as stale-return fixes in OAuth handlers (PRs #228, #233).

Closes #349
