### PR TITLE
feat: pretranslate CLI script for offline book translation

### DIFF
--- a/backend/tests/test_pretranslate.py
+++ b/backend/tests/test_pretranslate.py
@@ -1,0 +1,185 @@
+"""Tests for scripts/pretranslate.py — chunking, chapter extraction, CLI parsing."""
+import asyncio
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Bootstrap the same way the script does
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "scripts")
+BACKEND_DIR = os.path.join(os.path.dirname(__file__), "..")
+sys.path.insert(0, os.path.abspath(SCRIPTS_DIR))
+sys.path.insert(0, os.path.abspath(BACKEND_DIR))
+
+import pretranslate as pt
+
+
+# ── Sentence splitting ────────────────────────────────────────────────────────
+
+def test_split_sentences_basic():
+    text = "Hello world. This is a test. Another sentence here."
+    parts = pt._split_sentences(text)
+    assert len(parts) == 3
+    assert parts[0] == "Hello world."
+
+
+def test_split_sentences_empty():
+    assert pt._split_sentences("") == []
+    assert pt._split_sentences("   ") == []
+
+
+def test_split_sentences_single():
+    text = "Just one sentence with no period"
+    parts = pt._split_sentences(text)
+    assert parts == [text]
+
+
+# ── MarianMT chunk splitting ──────────────────────────────────────────────────
+
+def _fake_tokenizer(max_tokens: int = 100):
+    """Returns a mock tokenizer that counts tokens as words."""
+    tok = MagicMock()
+    tok.encode = lambda text: text.split()  # 1 token per word
+    return tok
+
+
+def test_chunk_for_marian_short_text():
+    tok = _fake_tokenizer()
+    text = "Short sentence. Another one."
+    chunks = pt._chunk_for_marian(tok, text)
+    assert len(chunks) == 1
+    assert "Short sentence" in chunks[0]
+
+
+def test_chunk_for_marian_long_text():
+    tok = _fake_tokenizer()
+    # 3 sentences of 200 "tokens" (words) each — must split.
+    # Regex requires uppercase after ". " so capitalize first word of each sentence.
+    sentence = "Word " + " ".join(["word"] * 199)
+    text = f"{sentence}. {sentence}. {sentence}."
+    # Override MARIAN_MAX_TOKENS temporarily
+    original = pt.MARIAN_MAX_TOKENS
+    pt.MARIAN_MAX_TOKENS = 250
+    try:
+        chunks = pt._chunk_for_marian(tok, text)
+        assert len(chunks) >= 2
+    finally:
+        pt.MARIAN_MAX_TOKENS = original
+
+
+def test_chunk_for_marian_empty():
+    tok = _fake_tokenizer()
+    assert pt._chunk_for_marian(tok, "") == []
+    assert pt._chunk_for_marian(tok, "   ") == []
+
+
+# ── Chapter extraction from book rows ─────────────────────────────────────────
+
+def test_get_chapters_from_confirmed_json():
+    chapters = [
+        {"title": "Chapter I", "text": "First chapter text."},
+        {"title": "Chapter II", "text": "Second chapter text."},
+    ]
+    book = {"text_content": json.dumps({"draft": False, "chapters": chapters})}
+    result = pt._get_chapters(book)
+    assert len(result) == 2
+    assert result[0]["title"] == "Chapter I"
+    assert result[1]["text"] == "Second chapter text."
+
+
+def test_get_chapters_skips_draft_json():
+    book = {"text_content": json.dumps({"draft": True, "chapters": []})}
+    # Draft books fall back to splitter — patch at source module
+    with patch("services.splitter.build_chapters", return_value=[]) as mock_split:
+        result = pt._get_chapters(book)
+    mock_split.assert_called_once()
+
+
+def test_get_chapters_from_gutenberg_text():
+    book = {"text_content": "Chapter I\n\nSome text here.\n\nChapter II\n\nMore text."}
+    with patch("services.splitter.build_chapters") as mock_split:
+        mock_split.return_value = [
+            MagicMock(title="Chapter I", text="Some text here."),
+            MagicMock(title="Chapter II", text="More text."),
+        ]
+        result = pt._get_chapters(book)
+    assert len(result) == 2
+    assert result[0]["title"] == "Chapter I"
+
+
+def test_get_chapters_empty_text():
+    book = {"text_content": ""}
+    with patch("services.splitter.build_chapters", return_value=[]):
+        result = pt._get_chapters(book)
+    assert result == []
+
+
+# ── Marian language guard ─────────────────────────────────────────────────────
+
+def test_marian_raises_for_unsupported_language():
+    with pytest.raises(ValueError, match="MarianMT does not have"):
+        # "xx" is not in MARIAN_PAIRS — will raise before trying to load model
+        # We mock the import to avoid needing transformers installed
+        with patch.dict("sys.modules", {"transformers": MagicMock()}):
+            pt.MarianTranslator("xx")
+
+
+def test_marian_supported_languages_listed():
+    assert "de" in pt.MARIAN_PAIRS
+    assert "fr" in pt.MARIAN_PAIRS
+    assert "zh" in pt.MARIAN_PAIRS
+    assert len(pt.MARIAN_PAIRS) >= 10
+
+
+# ── OllamaTranslator ─────────────────────────────────────────────────────────
+
+def test_ollama_connection_failure_raises():
+    import requests
+    with patch("requests.get", side_effect=requests.exceptions.ConnectionError("refused")):
+        with pytest.raises(RuntimeError, match="Cannot connect to Ollama"):
+            pt.OllamaTranslator("llama3:8b", "de")
+
+
+def test_ollama_translate_paragraph():
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"response": "Hallo Welt"}
+    mock_resp.raise_for_status = MagicMock()
+
+    with patch("requests.get"):  # silence connection check
+        translator = pt.OllamaTranslator.__new__(pt.OllamaTranslator)
+        translator.model = "llama3:8b"
+        translator.lang = "de"
+        translator.base_url = "http://localhost:11434"
+
+    with patch("requests.post", return_value=mock_resp):
+        result = translator.translate_paragraph("Hello world")
+    assert result == "Hallo Welt"
+
+
+def test_ollama_skips_empty_paragraph():
+    with patch("requests.get"):
+        translator = pt.OllamaTranslator.__new__(pt.OllamaTranslator)
+        translator.model = "llama3:8b"
+        translator.lang = "de"
+        translator.base_url = "http://localhost:11434"
+    result = translator.translate_paragraph("   ")
+    assert result == "   "
+
+
+# ── Provider tags ─────────────────────────────────────────────────────────────
+
+def test_marian_provider_tag():
+    t = pt.MarianTranslator.__new__(pt.MarianTranslator)
+    t.model_name = "Helsinki-NLP/opus-mt-en-de"
+    assert "marian" in pt.MarianTranslator.provider_tag(t)
+
+
+def test_ollama_provider_tag():
+    t = pt.OllamaTranslator.__new__(pt.OllamaTranslator)
+    t.model = "llama3:8b"
+    t.lang = "de"
+    t.base_url = "http://localhost:11434"
+    assert t.provider_tag() == "ollama"
+    assert t.model_tag() == "llama3:8b"

--- a/scripts/pretranslate.py
+++ b/scripts/pretranslate.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""
+Pre-translate books offline and write results to the translations cache.
+
+Primary:  Helsinki-NLP/MarianMT  (free, CPU-friendly, ~300 MB/language pair)
+Fallback: Ollama local LLM       (free, needs GPU for speed, any language)
+
+Install extra dependencies first:
+    pip install torch --index-url https://download.pytorch.org/whl/cpu
+    pip install -r scripts/requirements-pretranslate.txt
+
+Usage:
+    # Translate one book into German (MarianMT default)
+    python scripts/pretranslate.py --book-id 1342 --lang de
+
+    # Translate all books into French using Ollama
+    python scripts/pretranslate.py --all --lang fr --provider ollama --model llama3:8b
+
+    # Preview only — no DB writes
+    python scripts/pretranslate.py --book-id 1342 --lang de --dry-run
+
+    # Re-translate even if cache exists
+    python scripts/pretranslate.py --book-id 1342 --lang de --force
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import sys
+import time
+
+# ── Bootstrap: add backend to sys.path so we can import services ─────────────
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+BACKEND_DIR = os.path.join(SCRIPT_DIR, "..", "backend")
+sys.path.insert(0, BACKEND_DIR)
+
+# ── Language pairs supported by MarianMT with good quality ───────────────────
+# Model name pattern: Helsinki-NLP/opus-mt-{src}-{tgt}
+# Priority order: zh > de > fr > it (future) > es (future)
+MARIAN_PAIRS: dict[str, str] = {
+    "zh": "Helsinki-NLP/opus-mt-en-zh",   # priority 1
+    "de": "Helsinki-NLP/opus-mt-en-de",   # priority 2
+    "fr": "Helsinki-NLP/opus-mt-en-fr",   # priority 3
+    "it": "Helsinki-NLP/opus-mt-en-it",   # priority 4 (optional, future)
+    "es": "Helsinki-NLP/opus-mt-en-es",   # priority 5 (optional, future)
+    "ru": "Helsinki-NLP/opus-mt-en-ru",
+    "nl": "Helsinki-NLP/opus-mt-en-nl",
+    "pt": "Helsinki-NLP/opus-mt-en-pt",
+    "pl": "Helsinki-NLP/opus-mt-en-pl",
+    "ja": "Helsinki-NLP/opus-mt-en-jap",
+}
+
+MARIAN_MAX_TOKENS = 480  # Leave headroom below the 512-token limit
+SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+(?=[A-ZÀ-ɏ一-鿿])")
+
+
+# ── Text chunking ─────────────────────────────────────────────────────────────
+
+def _split_sentences(text: str) -> list[str]:
+    parts = SENTENCE_SPLIT_RE.split(text.strip())
+    return [p.strip() for p in parts if p.strip()]
+
+
+def _chunk_for_marian(tokenizer, text: str) -> list[str]:
+    """Split text into chunks that fit within MARIAN_MAX_TOKENS tokens."""
+    sentences = _split_sentences(text)
+    if not sentences:
+        return [text] if text.strip() else []
+
+    chunks: list[str] = []
+    current: list[str] = []
+    current_len = 0
+
+    for sent in sentences:
+        sent_len = len(tokenizer.encode(sent))
+        if current and current_len + sent_len > MARIAN_MAX_TOKENS:
+            chunks.append(" ".join(current))
+            current = [sent]
+            current_len = sent_len
+        else:
+            current.append(sent)
+            current_len += sent_len
+
+    if current:
+        chunks.append(" ".join(current))
+
+    return chunks if chunks else [text]
+
+
+# ── MarianMT provider ─────────────────────────────────────────────────────────
+
+class MarianTranslator:
+    def __init__(self, lang: str):
+        model_name = MARIAN_PAIRS.get(lang)
+        if not model_name:
+            raise ValueError(
+                f"MarianMT does not have a quality model for '{lang}'. "
+                f"Supported: {', '.join(sorted(MARIAN_PAIRS))}. "
+                f"Use --provider ollama for other languages."
+            )
+        try:
+            from transformers import MarianMTModel, MarianTokenizer
+        except ImportError:
+            _missing_deps("transformers sentencepiece")
+
+        print(f"  Loading MarianMT model: {model_name}")
+        self.tokenizer = MarianTokenizer.from_pretrained(model_name)
+        self.model = MarianMTModel.from_pretrained(model_name)
+        self.model_name = model_name
+
+    def translate_paragraph(self, text: str) -> str:
+        if not text.strip():
+            return text
+        chunks = _chunk_for_marian(self.tokenizer, text)
+        translated_chunks: list[str] = []
+        for chunk in chunks:
+            inputs = self.tokenizer([chunk], return_tensors="pt", padding=True, truncation=True)
+            outputs = self.model.generate(**inputs)
+            translated = self.tokenizer.decode(outputs[0], skip_special_tokens=True)
+            translated_chunks.append(translated)
+        return " ".join(translated_chunks)
+
+    def provider_tag(self) -> str:
+        return "marian"
+
+    def model_tag(self) -> str:
+        return self.model_name
+
+
+# ── Ollama provider ───────────────────────────────────────────────────────────
+
+class OllamaTranslator:
+    def __init__(self, model: str, lang: str, base_url: str = "http://localhost:11434"):
+        self.model = model
+        self.lang = lang
+        self.base_url = base_url.rstrip("/")
+        self._check_connection()
+
+    def _check_connection(self) -> None:
+        try:
+            import requests
+            resp = requests.get(f"{self.base_url}/api/tags", timeout=5)
+            resp.raise_for_status()
+        except Exception as exc:
+            raise RuntimeError(
+                f"Cannot connect to Ollama at {self.base_url}. "
+                f"Start Ollama with: ollama serve\n  Error: {exc}"
+            )
+
+    def translate_paragraph(self, text: str) -> str:
+        if not text.strip():
+            return text
+        try:
+            import requests
+        except ImportError:
+            _missing_deps("requests")
+
+        lang_names = {
+            "de": "German", "fr": "French", "es": "Spanish", "it": "Italian",
+            "ru": "Russian", "nl": "Dutch", "pt": "Portuguese", "pl": "Polish",
+            "zh": "Chinese", "ja": "Japanese", "ko": "Korean", "ar": "Arabic",
+        }
+        target = lang_names.get(self.lang, self.lang)
+        prompt = (
+            f"Translate the following text to {target}. "
+            f"Return ONLY the translated text, no commentary, no explanation.\n\n"
+            f"{text}"
+        )
+        resp = requests.post(
+            f"{self.base_url}/api/generate",
+            json={"model": self.model, "prompt": prompt, "stream": False},
+            timeout=120,
+        )
+        resp.raise_for_status()
+        return resp.json().get("response", "").strip()
+
+    def provider_tag(self) -> str:
+        return "ollama"
+
+    def model_tag(self) -> str:
+        return self.model
+
+
+# ── DB helpers ────────────────────────────────────────────────────────────────
+
+async def _get_books(book_ids: list[int] | None) -> list[dict]:
+    """Return list of {id, meta, text_content} dicts."""
+    import aiosqlite
+    from services.db import DB_PATH
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        if book_ids:
+            placeholders = ",".join("?" * len(book_ids))
+            async with db.execute(
+                f"SELECT id, meta_json, text_content FROM books WHERE id IN ({placeholders})",
+                book_ids,
+            ) as cur:
+                return [dict(r) for r in await cur.fetchall()]
+        else:
+            async with db.execute(
+                "SELECT id, meta_json, text_content FROM books"
+            ) as cur:
+                return [dict(r) for r in await cur.fetchall()]
+
+
+async def _is_cached(book_id: int, chapter_index: int, lang: str) -> bool:
+    import aiosqlite
+    from services.db import DB_PATH
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "SELECT 1 FROM translations WHERE book_id=? AND chapter_index=? AND target_language=?",
+            (book_id, chapter_index, lang),
+        ) as cur:
+            return await cur.fetchone() is not None
+
+
+async def _save(book_id: int, chapter_index: int, lang: str,
+                paragraphs: list[str], provider: str, model: str) -> None:
+    from services.db import save_translation
+    await save_translation(
+        book_id, chapter_index, lang, paragraphs,
+        provider=provider, model=model,
+    )
+
+
+# ── Chapter extraction ────────────────────────────────────────────────────────
+
+def _get_chapters(book: dict) -> list[dict]:
+    """Return [{title, text}, ...] for a book row."""
+    text = book.get("text_content") or ""
+
+    # Uploaded book with confirmed chapters stored as JSON
+    if text.startswith("{"):
+        try:
+            data = json.loads(text)
+            if not data.get("draft", True):
+                return data.get("chapters", [])
+        except json.JSONDecodeError:
+            pass
+
+    # Gutenberg book — use splitter
+    from services.splitter import build_chapters
+    chapters = build_chapters(text)
+    return [{"title": ch.title, "text": ch.text} for ch in chapters]
+
+
+# ── Main translation loop ─────────────────────────────────────────────────────
+
+async def run(args: argparse.Namespace) -> None:
+    book_ids = [args.book_id] if args.book_id else None
+    books = await _get_books(book_ids)
+
+    if not books:
+        print("No books found.")
+        return
+
+    # Build translator
+    if args.provider == "marian":
+        translator = MarianTranslator(args.lang)
+    else:
+        translator = OllamaTranslator(args.model, args.lang,
+                                      base_url=args.ollama_url)
+
+    total_chapters = 0
+    translated_count = 0
+    skipped_count = 0
+
+    for book in books:
+        meta = json.loads(book.get("meta_json") or "{}")
+        title = meta.get("title", f"Book #{book['id']}")
+        chapters = _get_chapters(book)
+
+        print(f"\nBook {book['id']}: {title} — {len(chapters)} chapter(s)")
+
+        for idx, ch in enumerate(chapters):
+            already = not args.force and await _is_cached(book["id"], idx, args.lang)
+            total_chapters += 1
+
+            if already:
+                skipped_count += 1
+                print(f"  [{idx + 1}/{len(chapters)}] {ch['title'][:50]} — already cached, skipping")
+                continue
+
+            paragraphs = [p.strip() for p in ch["text"].split("\n\n") if p.strip()]
+            if not paragraphs:
+                print(f"  [{idx + 1}/{len(chapters)}] {ch['title'][:50]} — empty, skipping")
+                skipped_count += 1
+                continue
+
+            word_count = len(ch["text"].split())
+            print(f"  [{idx + 1}/{len(chapters)}] {ch['title'][:50]} ({word_count} words) ...", end="", flush=True)
+
+            if args.dry_run:
+                print(" [dry-run, skipped]")
+                skipped_count += 1
+                continue
+
+            t0 = time.time()
+            translated: list[str] = []
+            for para in paragraphs:
+                translated.append(translator.translate_paragraph(para))
+
+            elapsed = time.time() - t0
+            await _save(
+                book["id"], idx, args.lang, translated,
+                provider=translator.provider_tag(),
+                model=translator.model_tag(),
+            )
+            translated_count += 1
+            print(f" done ({elapsed:.1f}s)")
+
+    print(f"\nDone. {translated_count} translated, {skipped_count} skipped, {total_chapters} total.")
+
+
+# ── Error helpers ─────────────────────────────────────────────────────────────
+
+def _missing_deps(packages: str) -> None:
+    print(
+        f"\nMissing dependencies: {packages}\n"
+        f"Install with:\n"
+        f"  pip install torch --index-url https://download.pytorch.org/whl/cpu\n"
+        f"  pip install -r scripts/requirements-pretranslate.txt\n",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Pre-translate books offline and write results to the cache.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--book-id", type=int, metavar="N", help="Translate a single book by ID")
+    group.add_argument("--all", action="store_true", help="Translate all books in the DB")
+
+    parser.add_argument("--lang", required=True, metavar="LANG",
+                        help="Target language code (e.g. de, fr, es, zh)")
+    parser.add_argument("--provider", choices=["marian", "ollama"], default="marian",
+                        help="Translation provider (default: marian)")
+    parser.add_argument("--model", default="llama3:8b",
+                        help="Ollama model name (default: llama3:8b, ignored for marian)")
+    parser.add_argument("--ollama-url", default="http://localhost:11434",
+                        help="Ollama base URL (default: http://localhost:11434)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Preview what would be translated without writing to DB")
+    parser.add_argument("--force", action="store_true",
+                        help="Re-translate even if a cached translation exists")
+    parser.add_argument("--db", metavar="PATH",
+                        help="Override DB_PATH (defaults to backend/books.db or DB_PATH env)")
+
+    args = parser.parse_args()
+
+    if args.db:
+        os.environ["DB_PATH"] = args.db
+
+    if args.all:
+        args.book_id = None
+
+    if args.provider == "marian" and args.lang not in MARIAN_PAIRS:
+        print(
+            f"Warning: no MarianMT model for '{args.lang}'. "
+            f"Supported: {', '.join(sorted(MARIAN_PAIRS))}.\n"
+            f"Use --provider ollama for other languages.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/requirements-pretranslate.txt
+++ b/scripts/requirements-pretranslate.txt
@@ -1,0 +1,10 @@
+# Extra dependencies for scripts/pretranslate.py
+# Install with: pip install -r scripts/requirements-pretranslate.txt
+#
+# Note: torch CPU-only build is much smaller (~250 MB vs 2+ GB for GPU):
+#   pip install torch --index-url https://download.pytorch.org/whl/cpu
+#   pip install -r scripts/requirements-pretranslate.txt
+
+transformers>=4.40.0
+sentencepiece>=0.2.0
+requests>=2.28.0


### PR DESCRIPTION
## Summary

- Adds `scripts/pretranslate.py` — a standalone CLI to pre-translate books into the translations cache without running the web server
- Supports **MarianMT** (Helsinki-NLP, CPU-friendly, ~300 MB/language pair) and **Ollama** (local LLM, any language) as translation providers
- Language priority order: zh → de → fr → it (optional) → es (optional)
- Sentence-boundary chunking keeps MarianMT inputs under 480 tokens (below the 512-token limit)
- Separate `scripts/requirements-pretranslate.txt` keeps torch/transformers out of the production Docker image

## Features

- `--book-id N | --all` — translate a single book or every book in the DB
- `--lang LANG` — target language code (e.g. `zh`, `de`, `fr`)
- `--provider marian | ollama` — choose translation backend
- `--model` — Ollama model name (ignored for MarianMT)
- `--dry-run` — preview what would be translated without writing to DB
- `--force` — re-translate even if a cached translation exists
- `--db PATH` — override the DB path

## Test plan

- [x] 17 unit tests in `backend/tests/test_pretranslate.py`
  - Sentence splitting (basic, empty, single-sentence)
  - MarianMT chunk splitting (short text, long text requiring split, empty)
  - Chapter extraction (confirmed JSON, draft JSON fallback, Gutenberg text, empty)
  - Language guard (unsupported language raises ValueError)
  - Ollama connection failure raises RuntimeError
  - Ollama translate paragraph and empty-skip
  - Provider tag methods for both providers
- [x] Full backend test suite: 952 passed
- [x] Full frontend test suite: 1528 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
