### PR TITLE
fix: SELECT before COMMIT in save_insight and save_word

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -806,10 +806,9 @@ async def save_word(
                VALUES (?, ?, ?, ?)""",
             (vocab_id, book_id, chapter_index, sentence_text),
         )
-        await db.commit()  # single atomic commit for both inserts
-
         async with db.execute("SELECT * FROM vocabulary WHERE id = ?", (vocab_id,)) as cursor:
             row = await cursor.fetchone()
+        await db.commit()  # single atomic commit for both inserts
 
     asyncio.create_task(_update_lemma(vocab_id, word, book_id))
     return dict(row)
@@ -915,10 +914,10 @@ async def save_insight(
                VALUES (?, ?, ?, ?, ?, ?)""",
             (user_id, book_id, chapter_index, question, answer, context_text),
         )
-        await db.commit()
         row_id = cursor.lastrowid
         async with db.execute("SELECT * FROM book_insights WHERE id = ?", (row_id,)) as c:
             row = await c.fetchone()
+        await db.commit()
     return dict(row)
 
 

--- a/backend/tests/test_router_insights.py
+++ b/backend/tests/test_router_insights.py
@@ -207,3 +207,67 @@ async def test_post_insight_rejects_negative_chapter_index(client: AsyncClient):
         json={"book_id": 1, "question": "Q?", "answer": "A.", "chapter_index": -5},
     )
     assert resp.status_code == 400
+
+
+async def test_save_insight_select_runs_before_commit(tmp_db, test_user, monkeypatch):
+    """Regression #351: SELECT must execute before COMMIT in save_insight.
+
+    If COMMIT precedes SELECT, a concurrent delete_book (which cascades to
+    book_insights) can remove the just-inserted row between the two operations,
+    causing the SELECT to return None and dict(row) to crash with TypeError.
+    """
+    import aiosqlite as _real_aiosqlite
+    import services.db as db_module
+    from services.db import save_book, save_insight
+
+    await save_book(1, _META, "text")
+
+    events: list[str] = []
+    orig_connect = _real_aiosqlite.connect
+
+    def patched_connect(database, **kwargs):
+        real_cm = orig_connect(database, **kwargs)
+
+        class TrackedConn:
+            def __init__(self):
+                self._conn = None
+
+            async def __aenter__(self):
+                self._conn = await real_cm.__aenter__()
+                return self
+
+            async def __aexit__(self, *args):
+                return await real_cm.__aexit__(*args)
+
+            @property
+            def row_factory(self):
+                return self._conn.row_factory
+
+            @row_factory.setter
+            def row_factory(self, v):
+                self._conn.row_factory = v
+
+            def execute(self, sql, *args, **kwargs):
+                if sql.strip().upper().startswith("SELECT"):
+                    events.append("SELECT")
+                return self._conn.execute(sql, *args, **kwargs)
+
+            async def commit(self):
+                events.append("COMMIT")
+                return await self._conn.commit()
+
+        return TrackedConn()
+
+    class FakeAiosqlite:
+        connect = staticmethod(patched_connect)
+        Row = _real_aiosqlite.Row
+
+    monkeypatch.setattr(db_module, "aiosqlite", FakeAiosqlite)
+
+    await save_insight(test_user["id"], 1, 0, "Q?", "A.")
+
+    assert "COMMIT" in events and "SELECT" in events
+    assert events.index("SELECT") < events.index("COMMIT"), (
+        "SELECT must run before COMMIT in save_insight — otherwise a "
+        "concurrent delete_book can delete the row and crash dict(None) (#351)"
+    )

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -448,3 +448,68 @@ async def test_export_annotation_translation_uses_book_language(client, test_use
             f"translate_text called with source={src!r} but book language is 'de'; "
             "source language must not be hardcoded to 'en'"
         )
+
+
+async def test_save_word_select_runs_before_commit(tmp_db, test_user, monkeypatch):
+    """Regression #351: SELECT must execute before COMMIT in save_word.
+
+    If COMMIT precedes SELECT, a concurrent write (e.g. _update_lemma on
+    another connection) can modify the vocabulary row between the two operations,
+    causing the function to return data it did not write.
+    """
+    import aiosqlite as _real_aiosqlite
+    import services.db as db_module
+    from services.db import save_book, save_word
+
+    _META = {"title": "T", "authors": [], "languages": ["de"], "subjects": [], "download_count": 0, "cover": ""}
+    await save_book(7777, _META, "text")
+
+    events: list[str] = []
+    orig_connect = _real_aiosqlite.connect
+
+    def patched_connect(database, **kwargs):
+        real_cm = orig_connect(database, **kwargs)
+
+        class TrackedConn:
+            def __init__(self):
+                self._conn = None
+
+            async def __aenter__(self):
+                self._conn = await real_cm.__aenter__()
+                return self
+
+            async def __aexit__(self, *args):
+                return await real_cm.__aexit__(*args)
+
+            @property
+            def row_factory(self):
+                return self._conn.row_factory
+
+            @row_factory.setter
+            def row_factory(self, v):
+                self._conn.row_factory = v
+
+            def execute(self, sql, *args, **kwargs):
+                if sql.strip().upper().startswith("SELECT"):
+                    events.append("SELECT")
+                return self._conn.execute(sql, *args, **kwargs)
+
+            async def commit(self):
+                events.append("COMMIT")
+                return await self._conn.commit()
+
+        return TrackedConn()
+
+    class FakeAiosqlite:
+        connect = staticmethod(patched_connect)
+        Row = _real_aiosqlite.Row
+
+    monkeypatch.setattr(db_module, "aiosqlite", FakeAiosqlite)
+
+    await save_word(test_user["id"], "Wort", 7777, 0, "Ein Satz.")
+
+    assert "COMMIT" in events and "SELECT" in events
+    assert events.index("SELECT") < events.index("COMMIT"), (
+        "SELECT must run before COMMIT in save_word to avoid returning data "
+        "from a concurrent _update_lemma write (#351)"
+    )


### PR DESCRIPTION
## What

`save_insight` and `save_word` in `services/db.py` both committed the write BEFORE the SELECT used to build the return value.

**`save_insight` — risk of 500 crash:**
Between the commit and the SELECT, a concurrent `delete_book` call (which explicitly deletes all `book_insights` for the book) can remove the just-inserted row. The SELECT then returns `None`, and `dict(None)` crashes with `TypeError` → 500.

**`save_word` — stale return:**
Same pattern. A concurrent `_update_lemma` call on another connection can modify the vocabulary row between commit and SELECT.

## Fix

Swap the order: SELECT runs before COMMIT. SQLite same-connection reads see own uncommitted writes; concurrent deletes/updates are invisible until after commit.

## Tests

Two new order-tracking tests — same pattern as PR #350:
- `test_save_insight_select_runs_before_commit` 
- `test_save_word_select_runs_before_commit`

Each monkeypatches `aiosqlite` in `services.db` to record the sequence of SELECT and COMMIT calls, then asserts SELECT appears before COMMIT.

Closes #351
