### PR TITLE
fix: annotation delete shows 3-second undo toast

### DIFF
--- a/frontend/src/__tests__/ReaderPage.branches2.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches2.test.tsx
@@ -42,6 +42,7 @@ jest.mock("next/navigation", () => ({
 const mockGetBookChapters = jest.fn();
 const mockGetMe = jest.fn();
 const mockGetAnnotations = jest.fn();
+const mockCreateAnnotation = jest.fn();
 const mockGetVocabulary = jest.fn();
 const mockGetBookTranslationStatus = jest.fn();
 const mockGetChapterTranslation = jest.fn();
@@ -60,6 +61,7 @@ jest.mock("@/lib/api", () => ({
   getBookChapters: (...a: unknown[]) => mockGetBookChapters(...a),
   getMe: (...a: unknown[]) => mockGetMe(...a),
   getAnnotations: (...a: unknown[]) => mockGetAnnotations(...a),
+  createAnnotation: (...a: unknown[]) => mockCreateAnnotation(...a),
   getVocabulary: (...a: unknown[]) => mockGetVocabulary(...a),
   getBookTranslationStatus: (...a: unknown[]) => mockGetBookTranslationStatus(...a),
   getChapterTranslation: (...a: unknown[]) => mockGetChapterTranslation(...a),
@@ -294,6 +296,18 @@ jest.mock("@/components/VocabularyToast", () => {
   );
   VocabularyToast.displayName = "VocabularyToast";
   return { __esModule: true, default: VocabularyToast };
+});
+
+// ─── UndoToast: exposes onUndo / onDone ──────────────────────────────────────
+jest.mock("@/components/UndoToast", () => {
+  const UndoToast = ({ onUndo, onDone }: { message?: string; onUndo?: () => void; onDone?: () => void }) => (
+    <div data-testid="undo-toast">
+      <button data-testid="undo-btn" onClick={() => onUndo?.()}>Undo</button>
+      <button data-testid="undo-done" onClick={() => onDone?.()}>done</button>
+    </div>
+  );
+  UndoToast.displayName = "UndoToast";
+  return { __esModule: true, default: UndoToast };
 });
 
 // ─── SentenceReader: exposes onAnnotate / onSegmentClick / onAnnotationClick ──
@@ -2654,12 +2668,10 @@ describe("ReaderPage.branches2 — SelectionToolbar onRead pauses chapter TTS", 
   });
 
   it("pauses chapter TTS before playing selection when TTS is playing, resumes on end", async () => {
-    let capturedResume: (() => void) | null = null;
     const audioMock = {
       play: jest.fn().mockResolvedValue(undefined),
       onended: null as (() => void) | null,
       onerror: null as (() => void) | null,
-      set onended(fn: (() => void) | null) { capturedResume = fn; },
     };
     jest.spyOn(global, "Audio" as keyof typeof global).mockImplementation(
       () => audioMock as unknown as HTMLAudioElement,
@@ -2735,5 +2747,79 @@ describe("ReaderPage.branches2 — spacebar toggles TTS play/pause", () => {
     document.body.removeChild(input);
     // No crash
     await waitFor(() => expect(screen.getByTestId("tts-controls")).toBeInTheDocument());
+  });
+});
+
+// ─── Annotation delete undo toast ─────────────────────────────────────────────
+
+describe("ReaderPage.branches2 — annotation delete shows undo toast", () => {
+  // id: 77 matches what SentenceReader mock sends in trigger-annotation-click
+  const SAMPLE_ANN = {
+    id: 77,
+    book_id: 42,
+    chapter_index: 0,
+    sentence_text: "Test sentence",
+    note_text: "",
+    color: "yellow",
+  };
+
+  beforeEach(() => {
+    mockGetAnnotations.mockResolvedValue([SAMPLE_ANN]);
+    mockCreateAnnotation.mockResolvedValue({ ...SAMPLE_ANN, id: 100 });
+  });
+
+  it("shows UndoToast when QuickHighlightPanel onDeleted fires", async () => {
+    mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
+    render(<ReaderPage />);
+    await flushPromises();
+
+    // Open quick highlight panel via annotation click trigger
+    const annClickTrigger = await screen.findByTestId("trigger-annotation-click");
+    await userEvent.click(annClickTrigger);
+
+    // Click delete in QuickHighlightPanel
+    const deleteBtn = await screen.findByTestId("qhp-delete");
+    await userEvent.click(deleteBtn);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("undo-toast")).toBeInTheDocument()
+    );
+  });
+
+  it("clicking Undo calls createAnnotation to restore the annotation", async () => {
+    mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
+    render(<ReaderPage />);
+    await flushPromises();
+
+    // Open quick highlight panel
+    const annClickTrigger = await screen.findByTestId("trigger-annotation-click");
+    await userEvent.click(annClickTrigger);
+
+    const deleteBtn = await screen.findByTestId("qhp-delete");
+    await userEvent.click(deleteBtn);
+
+    await waitFor(() => expect(screen.getByTestId("undo-toast")).toBeInTheDocument());
+
+    const undoBtn = screen.getByTestId("undo-btn");
+    await userEvent.click(undoBtn);
+
+    await waitFor(() => expect(mockCreateAnnotation).toHaveBeenCalled());
+  });
+
+  it("shows UndoToast when AnnotationToolbar onDeleted fires", async () => {
+    mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
+    render(<ReaderPage />);
+    await flushPromises();
+
+    // Open annotation toolbar via long-press trigger
+    const longPressTrigger = await screen.findByTestId("trigger-annotate");
+    await userEvent.click(longPressTrigger);
+
+    const deleteBtn = await screen.findByTestId("annotation-delete");
+    await userEvent.click(deleteBtn);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("undo-toast")).toBeInTheDocument()
+    );
   });
 });

--- a/frontend/src/__tests__/UndoToast.test.tsx
+++ b/frontend/src/__tests__/UndoToast.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { render, screen, act, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UndoToast from "@/components/UndoToast";
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.clearAllMocks();
+});
+
+describe("UndoToast", () => {
+  it("renders the message and Undo button", () => {
+    render(<UndoToast message="Highlight deleted" onUndo={jest.fn()} onDone={jest.fn()} />);
+    expect(screen.getByText("Highlight deleted")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Undo" })).toBeInTheDocument();
+  });
+
+  it("calls onUndo and onDone when Undo is clicked", async () => {
+    const onUndo = jest.fn();
+    const onDone = jest.fn();
+    render(<UndoToast message="Highlight deleted" onUndo={onUndo} onDone={onDone} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Undo" }));
+
+    expect(onUndo).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(onDone).toHaveBeenCalledTimes(1), { timeout: 500 });
+  });
+
+  it("auto-dismisses after 3 seconds by calling onDone", async () => {
+    jest.useFakeTimers();
+    const onDone = jest.fn();
+    render(<UndoToast message="Highlight deleted" onUndo={jest.fn()} onDone={onDone} />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(3300);
+    });
+
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call onUndo when auto-dismissed", async () => {
+    jest.useFakeTimers();
+    const onUndo = jest.fn();
+    const onDone = jest.fn();
+    render(<UndoToast message="Highlight deleted" onUndo={onUndo} onDone={onDone} />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(3300);
+    });
+
+    expect(onUndo).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { getBookChapters, deleteTranslationCache, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, getChapterTranslation, getChapterQueueStatus, retryChapterTranslation, enqueueBookTranslation, saveReadingProgress, getAnnotations, getVocabulary, saveVocabularyWord, exportVocabularyToObsidian, saveInsight, TranslationStatus, BookMeta, BookChapter, ApiError, Annotation, VocabularyWord } from "@/lib/api";
+import { getBookChapters, deleteTranslationCache, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, getChapterTranslation, getChapterQueueStatus, retryChapterTranslation, enqueueBookTranslation, saveReadingProgress, getAnnotations, createAnnotation, getVocabulary, saveVocabularyWord, exportVocabularyToObsidian, saveInsight, TranslationStatus, BookMeta, BookChapter, ApiError, Annotation, VocabularyWord } from "@/lib/api";
 import { recordRecentBook, saveLastChapter, getLastChapter } from "@/lib/recentBooks";
 import { getSettings, saveSettings, FontSize, Theme, LineHeight, ContentWidth, FontFamily } from "@/lib/settings";
 import TypographyPanel from "@/components/TypographyPanel";
@@ -14,6 +14,7 @@ import SelectionToolbar from "@/components/SelectionToolbar";
 import AnnotationToolbar from "@/components/AnnotationToolbar";
 import QuickHighlightPanel from "@/components/QuickHighlightPanel";
 import VocabularyToast from "@/components/VocabularyToast";
+import UndoToast from "@/components/UndoToast";
 import VocabWordTooltip from "@/components/VocabWordTooltip";
 import ChapterSummary from "@/components/ChapterSummary";
 import { SunIcon, MoonIcon, SepiaIcon, ChatIcon, GlobeIcon, NoteIcon, BookmarkIcon, BookOpenIcon, ExportIcon, SummaryIcon, PlayIcon, PauseIcon, CloseIcon, KeyboardIcon, FocusIcon, ArrowLeftIcon, ArrowRightIcon, ChevronDownIcon } from "@/components/Icons";
@@ -69,6 +70,9 @@ export default function ReaderPage() {
 
   // Obsidian export toast
   const [obsidianToast, setObsidianToast] = useState<string | null>(null);
+
+  // Annotation delete undo toast
+  const [deletedAnnotationToast, setDeletedAnnotationToast] = useState<Annotation | null>(null);
 
   // TTS Read-button playback state — fed by TTSControls via callback props.
   const [ttsCurrentTime, setTtsCurrentTime] = useState(0);
@@ -1391,7 +1395,9 @@ export default function ReaderPage() {
                 });
               }}
               onDeleted={(id) => {
+                const ann = annotations.find((a) => a.id === id);
                 setAnnotations((prev) => prev.filter((a) => a.id !== id));
+                if (ann) setDeletedAnnotationToast(ann);
               }}
             />
           )}
@@ -1417,7 +1423,9 @@ export default function ReaderPage() {
                 });
               }}
               onDeleted={(id) => {
+                const ann = annotations.find((a) => a.id === id);
                 setAnnotations((prev) => prev.filter((a) => a.id !== id));
+                if (ann) setDeletedAnnotationToast(ann);
               }}
               onOpenNote={() => {
                 setQuickHighlightPanel(null);
@@ -1441,6 +1449,29 @@ export default function ReaderPage() {
                 handleWordSave(vocabTooltip.word, vocabTooltip.context);
                 setVocabTooltip(null);
               }}
+            />
+          )}
+
+          {/* Annotation delete undo toast */}
+          {deletedAnnotationToast && (
+            <UndoToast
+              message="Highlight deleted"
+              onUndo={() => {
+                const ann = deletedAnnotationToast;
+                setDeletedAnnotationToast(null);
+                if (ann && session?.backendToken) {
+                  createAnnotation({
+                    book_id: ann.book_id,
+                    chapter_index: ann.chapter_index,
+                    sentence_text: ann.sentence_text,
+                    note_text: ann.note_text,
+                    color: ann.color,
+                  }).then((restored) => {
+                    setAnnotations((prev) => [...prev, restored]);
+                  }).catch(() => {});
+                }
+              }}
+              onDone={() => setDeletedAnnotationToast(null)}
             />
           )}
 

--- a/frontend/src/components/UndoToast.tsx
+++ b/frontend/src/components/UndoToast.tsx
@@ -1,0 +1,47 @@
+"use client";
+import { useEffect, useState } from "react";
+
+const DURATION_MS = 3000;
+
+interface Props {
+  message: string;
+  onUndo: () => void;
+  onDone: () => void;
+}
+
+export default function UndoToast({ message, onUndo, onDone }: Props) {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setVisible(false);
+      setTimeout(onDone, 300);
+    }, DURATION_MS);
+    return () => clearTimeout(timer);
+  }, [onDone]);
+
+  function handleUndo() {
+    setVisible(false);
+    onUndo();
+    setTimeout(onDone, 300);
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className={`fixed bottom-6 left-1/2 -translate-x-1/2 z-50 bg-stone-800 text-white rounded-xl shadow-xl px-4 py-3 text-sm flex items-center gap-3 transition-all duration-300 ${
+        visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+      }`}
+    >
+      <span>{message}</span>
+      <button
+        onClick={handleUndo}
+        className="font-semibold text-amber-300 hover:text-amber-200 transition-colors shrink-0"
+      >
+        Undo
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Annotation delete no longer permanent-on-click**: instead of immediately and silently deleting, a 3-second undo toast appears at the bottom of the screen.
- **Undo restores the annotation**: clicking "Undo" within 3 seconds calls `createAnnotation` to recreate it and re-adds it to the local list.
- **Auto-dismiss**: after 3 seconds with no undo, the toast disappears (the annotation was already deleted server-side, so no further action needed).

## Implementation

- New `UndoToast` component: dark bottom-center pill with slide-out transition, calls `onDone` on auto-dismiss or after undo.
- Both `QuickHighlightPanel.onDeleted` and `AnnotationToolbar.onDeleted` in the reader page now set `deletedAnnotationToast` state instead of just filtering the annotation from the list.
- `createAnnotation` added to the static import in `page.tsx`.

## Test plan

- [x] `UndoToast.test.tsx`: renders correctly, undo click fires both callbacks, auto-dismiss fires onDone without onUndo
- [x] `ReaderPage.branches2`: QHP delete → UndoToast appears; undo click → `createAnnotation` called; AnnotationToolbar delete → UndoToast appears
- [x] Full frontend suite: 1536 tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
