### PR TITLE
fix: delete_book rejects and SQL-guards running translation_queue rows

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -224,10 +224,32 @@ async def delete_book(book_id: int, _admin: dict = Depends(_require_admin)):
     if not await get_cached_book(book_id):
         raise HTTPException(status_code=404, detail="Book not found")
     async with aiosqlite.connect(DB_PATH) as db:
+        # Reject if any worker is running — deleting the queue row would cause
+        # mark_queue_row_done() to no-op and the worker to discard its result. (#370)
+        async with db.execute(
+            "SELECT chapter_index, target_language FROM translation_queue "
+            "WHERE book_id=? AND status='running' LIMIT 1",
+            (book_id,),
+        ) as cur:
+            running = await cur.fetchone()
+        if running:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"A translation job is currently running for this book "
+                    f"(chapter {running[0]}, language '{running[1]}'). "
+                    "Wait for it to finish before deleting."
+                ),
+            )
         await db.execute("DELETE FROM books WHERE id = ?", (book_id,))
         await db.execute("DELETE FROM translations WHERE book_id = ?", (book_id,))
         await db.execute("DELETE FROM audio_cache WHERE book_id = ?", (book_id,))
-        await db.execute("DELETE FROM translation_queue WHERE book_id = ?", (book_id,))
+        # SQL guard: skip running rows in case a job transitioned after the
+        # Python check above (same pattern as delete_book_translations, #335).
+        await db.execute(
+            "DELETE FROM translation_queue WHERE book_id=? AND status != 'running'",
+            (book_id,),
+        )
         await db.execute("DELETE FROM word_occurrences WHERE book_id = ?", (book_id,))
         await db.execute(
             "DELETE FROM vocabulary WHERE id NOT IN (SELECT DISTINCT vocabulary_id FROM word_occurrences)"

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -1571,3 +1571,72 @@ async def test_queue_delete_item_sql_guard_prevents_running_delete(admin_client,
         ) as cur:
             row = await cur.fetchone()
     assert row is not None and row[0] == "running", "Running row must not be deleted"
+
+
+# ── delete_book running-queue guard (#370) ────────────────────────────────────
+
+_BOOK_META = {"title": "T", "authors": [], "languages": ["en"], "subjects": [], "download_count": 0, "cover": ""}
+
+
+async def test_delete_book_rejects_when_translation_running(admin_client, admin_db):
+    """Regression #370: DELETE /admin/books/{id} must return 409 if a queue row
+    is currently running — deleting it would silently discard the in-flight job."""
+    await save_book(1, _BOOK_META, "text")
+
+    async with aiosqlite.connect(admin_db) as db:
+        await db.execute(
+            """INSERT INTO translation_queue
+               (book_id, chapter_index, target_language, status, priority)
+               VALUES (1, 0, 'de', 'running', 100)"""
+        )
+        await db.commit()
+
+    res = await admin_client.delete("/api/admin/books/1")
+    assert res.status_code == 409, (
+        "delete_book must return 409 when a translation job is running (#370)"
+    )
+
+    async with aiosqlite.connect(admin_db) as db:
+        async with db.execute("SELECT id FROM books WHERE id=1") as cur:
+            row = await cur.fetchone()
+    assert row is not None, "Book must not be deleted when a queue job is running"
+
+
+async def test_delete_book_sql_guard_preserves_running_queue_row(admin_client, admin_db):
+    """Regression #370: even if the Python 409 check races, SQL guard must
+    preserve running translation_queue rows when deleting a book."""
+    await save_book(2, _BOOK_META, "text")
+
+    async with aiosqlite.connect(admin_db) as db:
+        cursor = await db.execute(
+            """INSERT INTO translation_queue
+               (book_id, chapter_index, target_language, status, priority)
+               VALUES (2, 0, 'fr', 'running', 100)"""
+        )
+        running_id = cursor.lastrowid
+        await db.commit()
+
+    # Simulate race: make the SELECT status check see 'pending' so the Python
+    # 409 guard passes, but the actual row in the DB is 'running'
+    import aiosqlite as _real_aio
+    import routers.admin as admin_mod
+
+    monkeypatch_fake = _make_bypass_status_check_aiosqlite(_real_aio, running_id)
+
+    orig_setattr = None
+    import routers.admin as _admin_mod
+    old_aio = _admin_mod.aiosqlite
+    _admin_mod.aiosqlite = monkeypatch_fake
+    try:
+        res = await admin_client.delete("/api/admin/books/2")
+    finally:
+        _admin_mod.aiosqlite = old_aio
+
+    async with aiosqlite.connect(admin_db) as db:
+        async with db.execute(
+            "SELECT status FROM translation_queue WHERE id=?", (running_id,)
+        ) as cur:
+            row = await cur.fetchone()
+    assert row is not None and row[0] == "running", (
+        "SQL guard (AND status != 'running') must preserve running queue row (#370)"
+    )


### PR DESCRIPTION
## Summary

- `DELETE /admin/books/{book_id}` now rejects with 409 if any translation job is `status='running'` for that book
- Added SQL guard `AND status != 'running'` to the `translation_queue` DELETE inside `delete_book`, matching the pattern already used by `delete_book_translations` (PR #335)

## Why

Previously, `delete_book` at line 230 issued `DELETE FROM translation_queue WHERE book_id = ?` with no running check. This silently destroyed the queue row of an in-flight worker. The worker would finish, call `mark_queue_row_done()` (no-op on already-deleted row), then `get_cached_book()` would return None (book deleted) and the translation would be silently discarded.

## Test plan

- `test_delete_book_rejects_when_translation_running` — verifies 409 when a running queue row exists; book is not deleted
- `test_delete_book_sql_guard_preserves_running_queue_row` — bypasses the Python 409 check (simulating a race), verifies SQL guard preserves the running row

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)
