### PR TITLE
fix: clear_queue status-filter path preserves running rows

### DIFF
--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -595,7 +595,8 @@ async def clear_queue(status: str | None = None) -> int:
     async with aiosqlite.connect(db_module.DB_PATH) as db:
         if status:
             cursor = await db.execute(
-                "DELETE FROM translation_queue WHERE status=?", (status,),
+                "DELETE FROM translation_queue WHERE status=? AND status != 'running'",
+                (status,),
             )
         else:
             cursor = await db.execute(

--- a/backend/tests/test_translation_queue.py
+++ b/backend/tests/test_translation_queue.py
@@ -897,3 +897,32 @@ async def test_worker_processes_batch(tmp_db):
         ) as cursor:
             (count,) = await cursor.fetchone()
     assert count == 0
+
+
+async def test_clear_queue_status_filter_preserves_running_items(tmp_db):
+    """Regression #373: clear_queue(status='running') must not delete running rows.
+
+    PR #320 added the guard only to the status=None path. The status-filter path
+    (WHERE status=?) had no AND status != 'running' guard, so passing
+    status='running' deleted all in-flight worker rows — giving false cancellation
+    and breaking mark_queue_row_done semantics.
+    """
+    await enqueue(1, 0, "zh")
+    await enqueue(1, 1, "zh")
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute(
+            "UPDATE translation_queue SET status='running' WHERE chapter_index=0"
+        )
+        await db.commit()
+
+    # Even if someone explicitly asks to clear running items, the guard must
+    # prevent it and return 0 rows deleted.
+    removed = await clear_queue(status="running")
+    assert removed == 0, (
+        "clear_queue(status='running') must not delete running rows (#373)"
+    )
+
+    remaining = await list_queue()
+    running = [r for r in remaining if r["status"] == "running"]
+    assert len(running) == 1, "Running row must survive clear_queue(status='running')"
+    assert running[0]["chapter_index"] == 0


### PR DESCRIPTION
## Summary

`clear_queue(status)` in `services/translation_queue.py` had a guard only on the no-filter path:

```python
# no-filter path — correct
"DELETE FROM translation_queue WHERE status != 'running'"

# status-filter path — MISSING AND status != 'running'
"DELETE FROM translation_queue WHERE status=?"
```

Calling `DELETE /admin/queue?status=running` deleted all running queue rows.

## Why this is a bug

The docstring states *"Running items are always excluded"*, but the status-filter SQL had no guard. This allowed an admin to wipe in-flight worker rows, causing `mark_queue_row_done()` to silently no-op and leaving the queue in an inconsistent state.

PR #320 fixed the `status=None` path but missed the `status=?` path.

## Fix

Added `AND status != 'running'` to the WHERE clause on line 598, matching the no-filter path.

## Test plan

- `test_clear_queue_status_filter_preserves_running_items` — calls `clear_queue(status='running')`, verifies 0 rows deleted and the running row survives

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)
