### PR TITLE
fix: enforce upload book access control on all chapter-level endpoints

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -347,6 +347,22 @@ async def get_translations(_admin: dict = Depends(_require_admin)):
 async def delete_book_translations(book_id: int, _admin: dict = Depends(_require_admin)):
     """Delete all translations for a book."""
     async with aiosqlite.connect(DB_PATH) as db:
+        # Reject if any worker is running — it would re-insert via INSERT OR REPLACE. (#338)
+        async with db.execute(
+            "SELECT chapter_index, target_language FROM translation_queue "
+            "WHERE book_id=? AND status='running' LIMIT 1",
+            (book_id,),
+        ) as cur:
+            running = await cur.fetchone()
+        if running:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"A translation job is currently running for this book "
+                    f"(chapter {running[0]}, language '{running[1]}'). "
+                    "Wait for it to finish before deleting."
+                ),
+            )
         cursor = await db.execute("DELETE FROM translations WHERE book_id = ?", (book_id,))
         if cursor.rowcount == 0:
             raise HTTPException(status_code=404, detail="No translations found for this book")
@@ -369,6 +385,20 @@ async def delete_language_translations(
     """Delete all cached translations for one language of a book."""
     target_language = target_language.lower().split("-")[0]
     async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "SELECT chapter_index FROM translation_queue "
+            "WHERE book_id=? AND target_language=? AND status='running' LIMIT 1",
+            (book_id, target_language),
+        ) as cur:
+            running = await cur.fetchone()
+        if running:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"A translation job is currently running for chapter {running[0]}. "
+                    "Wait for it to finish before deleting."
+                ),
+            )
         cursor = await db.execute(
             "DELETE FROM translations WHERE book_id=? AND target_language=?",
             (book_id, target_language),
@@ -394,6 +424,19 @@ async def delete_translation(
     """Delete a specific cached translation."""
     target_language = target_language.lower().split("-")[0]
     async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "SELECT 1 FROM translation_queue "
+            "WHERE book_id=? AND chapter_index=? AND target_language=? AND status='running'",
+            (book_id, chapter_index, target_language),
+        ) as cur:
+            if await cur.fetchone():
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"A translation job is currently running for chapter {chapter_index}. "
+                        "Wait for it to finish before deleting."
+                    ),
+                )
         cursor = await db.execute(
             "DELETE FROM translations WHERE book_id=? AND chapter_index=? AND target_language=?",
             (book_id, chapter_index, target_language),

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -249,6 +249,19 @@ async def save_translate_cache(req: SaveTranslationRequest, _user: dict = Depend
     if not await get_cached_book(req.book_id):
         raise HTTPException(status_code=404, detail="Book not found")
     target_language = req.target_language.lower().split("-")[0]
+    # Reject if a queue worker is actively translating this chapter — the
+    # worker's save_translation (INSERT OR REPLACE) would overwrite whatever
+    # we write here when it finishes. (#341)
+    from services.translation_queue import queue_status_for_chapter
+    status = await queue_status_for_chapter(req.book_id, req.chapter_index, target_language)
+    if status["status"] == "running":
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"A translation job is currently running for chapter {req.chapter_index}. "
+                "Wait for it to finish before saving."
+            ),
+        )
     await save_translation(
         req.book_id, req.chapter_index, target_language, req.paragraphs,
         provider=req.provider, model=req.model,

--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -98,18 +98,22 @@ async def patch_obsidian(
     req: ObsidianSettingsUpdate,
     user: dict = Depends(get_current_user),
 ):
-    existing = await get_obsidian_settings(user["id"])
-    # None = not supplied → keep existing; "" = explicit clear → set NULL; non-empty = update
+    # None = not supplied → skip the column entirely (avoids a stale-read race).
+    # "" = explicit clear → set NULL.  non-empty = encrypt and store.
     if req.github_token is None:
-        token_enc = existing.get("github_token")
-    elif req.github_token.strip():
-        token_enc = encrypt_api_key(req.github_token.strip())
+        await update_obsidian_settings(
+            user["id"],
+            github_token_encrypted=None,
+            repo=req.obsidian_repo.strip() or None,
+            path=req.obsidian_path.strip() or None,
+            token_explicitly_set=False,
+        )
     else:
-        token_enc = None
-    await update_obsidian_settings(
-        user["id"],
-        github_token_encrypted=token_enc,
-        repo=req.obsidian_repo.strip() or None,
-        path=req.obsidian_path.strip() or None,
-    )
+        token_enc = encrypt_api_key(req.github_token.strip()) if req.github_token.strip() else None
+        await update_obsidian_settings(
+            user["id"],
+            github_token_encrypted=token_enc,
+            repo=req.obsidian_repo.strip() or None,
+            path=req.obsidian_path.strip() or None,
+        )
     return {"ok": True}

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -806,10 +806,9 @@ async def save_word(
                VALUES (?, ?, ?, ?)""",
             (vocab_id, book_id, chapter_index, sentence_text),
         )
-        await db.commit()  # single atomic commit for both inserts
-
         async with db.execute("SELECT * FROM vocabulary WHERE id = ?", (vocab_id,)) as cursor:
             row = await cursor.fetchone()
+        await db.commit()  # single atomic commit for both inserts
 
     asyncio.create_task(_update_lemma(vocab_id, word, book_id))
     return dict(row)
@@ -915,10 +914,10 @@ async def save_insight(
                VALUES (?, ?, ?, ?, ?, ?)""",
             (user_id, book_id, chapter_index, question, answer, context_text),
         )
-        await db.commit()
         row_id = cursor.lastrowid
         async with db.execute("SELECT * FROM book_insights WHERE id = ?", (row_id,)) as c:
             row = await c.fetchone()
+        await db.commit()
     return dict(row)
 
 

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -121,11 +121,11 @@ async def get_or_create_user(google_id: str, email: str, name: str, picture: str
              "admin" if is_first else "user",
              1 if is_first else 0),
         )
-        await db.commit()
         async with db.execute(
             "SELECT * FROM users WHERE google_id = ?", (google_id,)
         ) as cursor:
             row = await cursor.fetchone()
+        await db.commit()
         return dict(row)
 
 
@@ -175,9 +175,9 @@ async def get_or_create_user_github(github_id: str, email: str, name: str, pictu
              "admin" if is_first else "user",
              1 if is_first else 0),
         )
-        await db.commit()
         async with db.execute("SELECT * FROM users WHERE github_id = ?", (github_id,)) as cursor:
             row = await cursor.fetchone()
+        await db.commit()
         return dict(row)
 
 
@@ -199,9 +199,9 @@ async def get_or_create_user_apple(apple_id: str, email: str, name: str) -> dict
                     "UPDATE users SET email=COALESCE(NULLIF(?,''), email), name=COALESCE(NULLIF(?,''), name) WHERE apple_id=?",
                     (email, name, apple_id),
                 )
-                await db.commit()
             async with db.execute("SELECT * FROM users WHERE apple_id = ?", (apple_id,)) as cursor:
                 row = await cursor.fetchone()
+            await db.commit()
             return dict(row)
 
         # Try linking to existing account by email
@@ -229,9 +229,9 @@ async def get_or_create_user_apple(apple_id: str, email: str, name: str) -> dict
              "admin" if is_first else "user",
              1 if is_first else 0),
         )
-        await db.commit()
         async with db.execute("SELECT * FROM users WHERE apple_id = ?", (apple_id,)) as cursor:
             row = await cursor.fetchone()
+        await db.commit()
         return dict(row)
 
 

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -869,12 +869,21 @@ async def update_obsidian_settings(
     github_token_encrypted: str | None,
     repo: str | None,
     path: str | None,
+    *,
+    token_explicitly_set: bool = True,
 ) -> None:
     async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute(
-            "UPDATE users SET github_token = ?, obsidian_repo = ?, obsidian_path = ? WHERE id = ?",
-            (github_token_encrypted, repo, path, user_id),
-        )
+        if token_explicitly_set:
+            await db.execute(
+                "UPDATE users SET github_token = ?, obsidian_repo = ?, obsidian_path = ? WHERE id = ?",
+                (github_token_encrypted, repo, path, user_id),
+            )
+        else:
+            # github_token omitted intentionally — avoid a non-atomic read-then-write race.
+            await db.execute(
+                "UPDATE users SET obsidian_repo = ?, obsidian_path = ? WHERE id = ?",
+                (repo, path, user_id),
+            )
         await db.commit()
 
 

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -679,12 +679,12 @@ async def create_annotation(
                DO UPDATE SET note_text = excluded.note_text, color = excluded.color""",
             (user_id, book_id, chapter_index, sentence_text, note_text, color),
         )
-        await db.commit()
         async with db.execute(
             "SELECT * FROM annotations WHERE user_id = ? AND book_id = ? AND chapter_index = ? AND sentence_text = ?",
             (user_id, book_id, chapter_index, sentence_text),
         ) as c:
             row = await c.fetchone()
+        await db.commit()
     return dict(row)
 
 
@@ -720,12 +720,12 @@ async def update_annotation(
                 f"UPDATE annotations SET {', '.join(clauses)} WHERE id = ? AND user_id = ?",
                 params,
             )
-            await db.commit()
         async with db.execute(
             "SELECT * FROM annotations WHERE id = ? AND user_id = ?",
             (annotation_id, user_id),
         ) as cursor:
             row = await cursor.fetchone()
+        await db.commit()
     return dict(row) if row else None
 
 

--- a/backend/tests/test_auth_service.py
+++ b/backend/tests/test_auth_service.py
@@ -89,3 +89,137 @@ async def test_verify_google_id_token_audience_mismatch(monkeypatch):
         with pytest.raises(HTTPException) as exc:
             await verify_google_id_token("token")
     assert exc.value.status_code == 401
+
+
+# ── OAuth commit-before-read regression (#359) ───────────────────────────────
+
+def _make_order_tracking_aiosqlite(real_aiosqlite, events):
+    """Return a fake aiosqlite module that records SELECT/COMMIT order."""
+    orig_connect = real_aiosqlite.connect
+
+    def patched_connect(database, **kwargs):
+        real_cm = orig_connect(database, **kwargs)
+
+        class TrackedConn:
+            def __init__(self):
+                self._conn = None
+
+            async def __aenter__(self):
+                self._conn = await real_cm.__aenter__()
+                return self
+
+            async def __aexit__(self, *args):
+                return await real_cm.__aexit__(*args)
+
+            @property
+            def row_factory(self):
+                return self._conn.row_factory
+
+            @row_factory.setter
+            def row_factory(self, v):
+                self._conn.row_factory = v
+
+            def execute(self, sql, *args, **kwargs):
+                if sql.strip().upper().startswith("SELECT"):
+                    events.append("SELECT")
+                return self._conn.execute(sql, *args, **kwargs)
+
+            async def commit(self):
+                events.append("COMMIT")
+                return await self._conn.commit()
+
+        return TrackedConn()
+
+    class FakeAiosqlite:
+        connect = staticmethod(patched_connect)
+        Row = real_aiosqlite.Row
+
+    return FakeAiosqlite
+
+
+async def test_get_or_create_user_new_user_select_before_commit(tmp_db, monkeypatch):
+    """Regression #359: new-user INSERT in get_or_create_user must SELECT before COMMIT."""
+    import aiosqlite as _real_aiosqlite
+    import services.db as db_module
+    from services.db import get_or_create_user
+
+    events: list[str] = []
+    monkeypatch.setattr(db_module, "aiosqlite", _make_order_tracking_aiosqlite(_real_aiosqlite, events))
+
+    await get_or_create_user("gid-new", "new@example.com", "New User", "")
+
+    insert_select = [e for e in events if e in ("SELECT", "COMMIT")]
+    assert "COMMIT" in insert_select and "SELECT" in insert_select
+    last_select = max(i for i, e in enumerate(insert_select) if e == "SELECT")
+    last_commit = max(i for i, e in enumerate(insert_select) if e == "COMMIT")
+    assert last_select < last_commit, (
+        "SELECT must run before COMMIT in get_or_create_user new-user path (#359)"
+    )
+
+
+async def test_get_or_create_user_github_new_user_select_before_commit(tmp_db, monkeypatch):
+    """Regression #359: new-user INSERT in get_or_create_user_github must SELECT before COMMIT."""
+    import aiosqlite as _real_aiosqlite
+    import services.db as db_module
+    from services.db import get_or_create_user_github
+
+    events: list[str] = []
+    monkeypatch.setattr(db_module, "aiosqlite", _make_order_tracking_aiosqlite(_real_aiosqlite, events))
+
+    await get_or_create_user_github("gh-new", "gh-new@example.com", "GH New", "")
+
+    insert_select = [e for e in events if e in ("SELECT", "COMMIT")]
+    assert "COMMIT" in insert_select and "SELECT" in insert_select
+    last_select = max(i for i, e in enumerate(insert_select) if e == "SELECT")
+    last_commit = max(i for i, e in enumerate(insert_select) if e == "COMMIT")
+    assert last_select < last_commit, (
+        "SELECT must run before COMMIT in get_or_create_user_github new-user path (#359)"
+    )
+
+
+async def test_get_or_create_user_apple_new_user_select_before_commit(tmp_db, monkeypatch):
+    """Regression #359: new-user INSERT in get_or_create_user_apple must SELECT before COMMIT."""
+    import aiosqlite as _real_aiosqlite
+    import services.db as db_module
+    from services.db import get_or_create_user_apple
+
+    events: list[str] = []
+    monkeypatch.setattr(db_module, "aiosqlite", _make_order_tracking_aiosqlite(_real_aiosqlite, events))
+
+    await get_or_create_user_apple("ap-new", "ap-new@example.com", "Apple New")
+
+    insert_select = [e for e in events if e in ("SELECT", "COMMIT")]
+    assert "COMMIT" in insert_select and "SELECT" in insert_select
+    last_select = max(i for i, e in enumerate(insert_select) if e == "SELECT")
+    last_commit = max(i for i, e in enumerate(insert_select) if e == "COMMIT")
+    assert last_select < last_commit, (
+        "SELECT must run before COMMIT in get_or_create_user_apple new-user path (#359)"
+    )
+
+
+async def test_get_or_create_user_apple_existing_user_update_select_before_commit(tmp_db, monkeypatch):
+    """Regression #359: existing-user UPDATE in get_or_create_user_apple must SELECT before COMMIT.
+
+    Apple's COALESCE UPDATE can't be reproduced with manual dict construction,
+    so it re-SELECTs after the UPDATE — that SELECT must happen before COMMIT.
+    """
+    import aiosqlite as _real_aiosqlite
+    import services.db as db_module
+    from services.db import get_or_create_user_apple
+
+    # Create user first (without monkeypatch, so setup is clean)
+    await get_or_create_user_apple("ap-existing", "ap-existing@example.com", "")
+
+    events: list[str] = []
+    monkeypatch.setattr(db_module, "aiosqlite", _make_order_tracking_aiosqlite(_real_aiosqlite, events))
+
+    # Second call: existing user, with email/name to trigger the COALESCE UPDATE
+    await get_or_create_user_apple("ap-existing", "", "Apple Existing Updated")
+
+    update_events = [e for e in events if e in ("SELECT", "COMMIT")]
+    assert "COMMIT" in update_events and "SELECT" in update_events
+    last_select = max(i for i, e in enumerate(update_events) if e == "SELECT")
+    last_commit = max(i for i, e in enumerate(update_events) if e == "COMMIT")
+    assert last_select < last_commit, (
+        "SELECT must run before COMMIT in get_or_create_user_apple existing-user UPDATE path (#359)"
+    )

--- a/backend/tests/test_pretranslate.py
+++ b/backend/tests/test_pretranslate.py
@@ -1,0 +1,185 @@
+"""Tests for scripts/pretranslate.py — chunking, chapter extraction, CLI parsing."""
+import asyncio
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Bootstrap the same way the script does
+SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "scripts")
+BACKEND_DIR = os.path.join(os.path.dirname(__file__), "..")
+sys.path.insert(0, os.path.abspath(SCRIPTS_DIR))
+sys.path.insert(0, os.path.abspath(BACKEND_DIR))
+
+import pretranslate as pt
+
+
+# ── Sentence splitting ────────────────────────────────────────────────────────
+
+def test_split_sentences_basic():
+    text = "Hello world. This is a test. Another sentence here."
+    parts = pt._split_sentences(text)
+    assert len(parts) == 3
+    assert parts[0] == "Hello world."
+
+
+def test_split_sentences_empty():
+    assert pt._split_sentences("") == []
+    assert pt._split_sentences("   ") == []
+
+
+def test_split_sentences_single():
+    text = "Just one sentence with no period"
+    parts = pt._split_sentences(text)
+    assert parts == [text]
+
+
+# ── MarianMT chunk splitting ──────────────────────────────────────────────────
+
+def _fake_tokenizer(max_tokens: int = 100):
+    """Returns a mock tokenizer that counts tokens as words."""
+    tok = MagicMock()
+    tok.encode = lambda text: text.split()  # 1 token per word
+    return tok
+
+
+def test_chunk_for_marian_short_text():
+    tok = _fake_tokenizer()
+    text = "Short sentence. Another one."
+    chunks = pt._chunk_for_marian(tok, text)
+    assert len(chunks) == 1
+    assert "Short sentence" in chunks[0]
+
+
+def test_chunk_for_marian_long_text():
+    tok = _fake_tokenizer()
+    # 3 sentences of 200 "tokens" (words) each — must split.
+    # Regex requires uppercase after ". " so capitalize first word of each sentence.
+    sentence = "Word " + " ".join(["word"] * 199)
+    text = f"{sentence}. {sentence}. {sentence}."
+    # Override MARIAN_MAX_TOKENS temporarily
+    original = pt.MARIAN_MAX_TOKENS
+    pt.MARIAN_MAX_TOKENS = 250
+    try:
+        chunks = pt._chunk_for_marian(tok, text)
+        assert len(chunks) >= 2
+    finally:
+        pt.MARIAN_MAX_TOKENS = original
+
+
+def test_chunk_for_marian_empty():
+    tok = _fake_tokenizer()
+    assert pt._chunk_for_marian(tok, "") == []
+    assert pt._chunk_for_marian(tok, "   ") == []
+
+
+# ── Chapter extraction from book rows ─────────────────────────────────────────
+
+def test_get_chapters_from_confirmed_json():
+    chapters = [
+        {"title": "Chapter I", "text": "First chapter text."},
+        {"title": "Chapter II", "text": "Second chapter text."},
+    ]
+    book = {"text_content": json.dumps({"draft": False, "chapters": chapters})}
+    result = pt._get_chapters(book)
+    assert len(result) == 2
+    assert result[0]["title"] == "Chapter I"
+    assert result[1]["text"] == "Second chapter text."
+
+
+def test_get_chapters_skips_draft_json():
+    book = {"text_content": json.dumps({"draft": True, "chapters": []})}
+    # Draft books fall back to splitter — patch at source module
+    with patch("services.splitter.build_chapters", return_value=[]) as mock_split:
+        result = pt._get_chapters(book)
+    mock_split.assert_called_once()
+
+
+def test_get_chapters_from_gutenberg_text():
+    book = {"text_content": "Chapter I\n\nSome text here.\n\nChapter II\n\nMore text."}
+    with patch("services.splitter.build_chapters") as mock_split:
+        mock_split.return_value = [
+            MagicMock(title="Chapter I", text="Some text here."),
+            MagicMock(title="Chapter II", text="More text."),
+        ]
+        result = pt._get_chapters(book)
+    assert len(result) == 2
+    assert result[0]["title"] == "Chapter I"
+
+
+def test_get_chapters_empty_text():
+    book = {"text_content": ""}
+    with patch("services.splitter.build_chapters", return_value=[]):
+        result = pt._get_chapters(book)
+    assert result == []
+
+
+# ── Marian language guard ─────────────────────────────────────────────────────
+
+def test_marian_raises_for_unsupported_language():
+    with pytest.raises(ValueError, match="MarianMT does not have"):
+        # "xx" is not in MARIAN_PAIRS — will raise before trying to load model
+        # We mock the import to avoid needing transformers installed
+        with patch.dict("sys.modules", {"transformers": MagicMock()}):
+            pt.MarianTranslator("xx")
+
+
+def test_marian_supported_languages_listed():
+    assert "de" in pt.MARIAN_PAIRS
+    assert "fr" in pt.MARIAN_PAIRS
+    assert "zh" in pt.MARIAN_PAIRS
+    assert len(pt.MARIAN_PAIRS) >= 10
+
+
+# ── OllamaTranslator ─────────────────────────────────────────────────────────
+
+def test_ollama_connection_failure_raises():
+    import requests
+    with patch("requests.get", side_effect=requests.exceptions.ConnectionError("refused")):
+        with pytest.raises(RuntimeError, match="Cannot connect to Ollama"):
+            pt.OllamaTranslator("llama3:8b", "de")
+
+
+def test_ollama_translate_paragraph():
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"response": "Hallo Welt"}
+    mock_resp.raise_for_status = MagicMock()
+
+    with patch("requests.get"):  # silence connection check
+        translator = pt.OllamaTranslator.__new__(pt.OllamaTranslator)
+        translator.model = "llama3:8b"
+        translator.lang = "de"
+        translator.base_url = "http://localhost:11434"
+
+    with patch("requests.post", return_value=mock_resp):
+        result = translator.translate_paragraph("Hello world")
+    assert result == "Hallo Welt"
+
+
+def test_ollama_skips_empty_paragraph():
+    with patch("requests.get"):
+        translator = pt.OllamaTranslator.__new__(pt.OllamaTranslator)
+        translator.model = "llama3:8b"
+        translator.lang = "de"
+        translator.base_url = "http://localhost:11434"
+    result = translator.translate_paragraph("   ")
+    assert result == "   "
+
+
+# ── Provider tags ─────────────────────────────────────────────────────────────
+
+def test_marian_provider_tag():
+    t = pt.MarianTranslator.__new__(pt.MarianTranslator)
+    t.model_name = "Helsinki-NLP/opus-mt-en-de"
+    assert "marian" in pt.MarianTranslator.provider_tag(t)
+
+
+def test_ollama_provider_tag():
+    t = pt.OllamaTranslator.__new__(pt.OllamaTranslator)
+    t.model = "llama3:8b"
+    t.lang = "de"
+    t.base_url = "http://localhost:11434"
+    assert t.provider_tag() == "ollama"
+    assert t.model_tag() == "llama3:8b"

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -456,7 +456,7 @@ async def test_delete_language_translations_normalizes_language(admin_client, ad
     assert res.json()["deleted"] == 1
 
 
-# ── Delete translation queue cleanup (regression #335) ───────────────────────
+# ── Delete translation queue cleanup + running guard (regression #335, #338) ──
 
 async def test_delete_specific_translation_clears_queue_row(admin_client, admin_db):
     """Regression #335: DELETE /translations/{id}/{idx}/{lang} must also remove
@@ -480,6 +480,26 @@ async def test_delete_specific_translation_clears_queue_row(admin_client, admin_
     assert added == 1, "enqueue must return 1 after orphan queue row is cleaned up"
 
 
+async def test_delete_specific_translation_rejects_409_when_running(admin_client, admin_db):
+    """Regression #338: DELETE /translations/{id}/{idx}/{lang} must return 409
+    when a queue worker is actively translating the chapter — the worker would
+    re-insert the deleted translation via save_translation INSERT OR REPLACE."""
+    from services.translation_queue import enqueue
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    await save_translation(100, 0, "de", ["paragraph"])
+    await enqueue(100, 0, "de")
+    async with aiosqlite.connect(admin_db) as db:
+        await db.execute(
+            "UPDATE translation_queue SET status='running' WHERE book_id=100 AND chapter_index=0 AND target_language='de'"
+        )
+        await db.commit()
+
+    res = await admin_client.delete("/api/admin/translations/100/0/de")
+    assert res.status_code == 409
+    from services.db import get_cached_translation
+    assert await get_cached_translation(100, 0, "de") == ["paragraph"]
+
+
 async def test_delete_language_translations_clears_queue_rows(admin_client, admin_db):
     """Regression #335: DELETE /translations/{id}/{lang} must remove non-running
     queue rows for that language so subsequent enqueue calls can proceed."""
@@ -489,7 +509,6 @@ async def test_delete_language_translations_clears_queue_rows(admin_client, admi
     await save_translation(100, 1, "zh", ["第二章"])
     await enqueue(100, 0, "zh")
     await enqueue(100, 1, "zh")
-    # Simulate a pending and a failed row
     async with aiosqlite.connect(admin_db) as db:
         await db.execute(
             "UPDATE translation_queue SET status='failed' WHERE book_id=100 AND chapter_index=1 AND target_language='zh'"
@@ -504,6 +523,28 @@ async def test_delete_language_translations_clears_queue_rows(admin_client, admi
     added_1 = await enqueue2(100, 1, "zh")
     assert added_0 == 1, "ch0 must be re-enqueueable after cleanup"
     assert added_1 == 1, "ch1 must be re-enqueueable after cleanup"
+
+
+async def test_delete_language_translations_rejects_409_when_running(admin_client, admin_db):
+    """Regression #338: DELETE /translations/{id}/{lang} must return 409 when
+    any queue worker is actively translating a chapter for that language."""
+    from services.translation_queue import enqueue
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    await save_translation(100, 0, "zh", ["章节0"])
+    await save_translation(100, 1, "zh", ["章节1"])
+    await enqueue(100, 1, "zh")
+    async with aiosqlite.connect(admin_db) as db:
+        await db.execute(
+            "UPDATE translation_queue SET status='running' WHERE book_id=100 AND chapter_index=1 AND target_language='zh'"
+        )
+        await db.commit()
+
+    res = await admin_client.delete("/api/admin/translations/100/zh")
+    assert res.status_code == 409
+    detail = res.json()["detail"]
+    assert "1" in detail  # blocked chapter index mentioned
+    from services.db import get_cached_translation
+    assert await get_cached_translation(100, 0, "zh") == ["章节0"]
 
 
 async def test_delete_book_translations_clears_queue_rows(admin_client, admin_db):
@@ -526,29 +567,23 @@ async def test_delete_book_translations_clears_queue_rows(admin_client, admin_db
     assert added_zh == 1, "zh must be re-enqueueable after full book translation delete"
 
 
-async def test_delete_translation_preserves_running_queue_row(admin_client, admin_db):
-    """Regression #335: queue cleanup must NOT delete running rows — the worker
-    holds them and will call mark_queue_row_done when done."""
+async def test_delete_book_translations_rejects_409_when_running(admin_client, admin_db):
+    """Regression #338: DELETE /translations/{id} must return 409 when any
+    queue worker is actively translating any chapter of the book."""
     from services.translation_queue import enqueue
     await save_book(100, BOOK_META, BOOK_TEXT)
     await save_translation(100, 0, "de", ["paragraph"])
     await enqueue(100, 0, "de")
     async with aiosqlite.connect(admin_db) as db:
         await db.execute(
-            "UPDATE translation_queue SET status='running' WHERE book_id=100 AND chapter_index=0"
+            "UPDATE translation_queue SET status='running' WHERE book_id=100"
         )
         await db.commit()
 
-    res = await admin_client.delete("/api/admin/translations/100/0/de")
-    assert res.status_code == 200
-
-    async with aiosqlite.connect(admin_db) as db:
-        async with db.execute(
-            "SELECT status FROM translation_queue WHERE book_id=100 AND chapter_index=0 AND target_language='de'"
-        ) as cur:
-            row = await cur.fetchone()
-    assert row is not None, "running queue row must survive translation deletion"
-    assert row[0] == "running"
+    res = await admin_client.delete("/api/admin/translations/100")
+    assert res.status_code == 409
+    from services.db import get_cached_translation
+    assert await get_cached_translation(100, 0, "de") == ["paragraph"]
 
 
 # ── Audio ────────────────────────────────────────────────────────────────────

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -240,6 +240,35 @@ async def test_translate_cache_put_saves(client, test_user):
     assert cached == ["Bonjour"]
 
 
+async def test_translate_cache_put_rejects_409_when_running(client, test_user, tmp_db):
+    """Regression #341: PUT /translate/cache must return 409 when a queue worker
+    is actively translating the same chapter — the worker would overwrite the
+    saved translation via save_translation INSERT OR REPLACE when it finishes."""
+    import aiosqlite
+    from services.db import save_book, save_translation, get_cached_translation
+    from services.translation_queue import enqueue
+    _BOOK_META_LOCAL = {"title": "Faust", "authors": ["Goethe"], "languages": ["de"],
+                        "subjects": [], "download_count": 0, "cover": ""}
+    await save_book(60, _BOOK_META_LOCAL, "text")
+    await save_translation(60, 0, "zh", ["existing paragraph"])
+    await enqueue(60, 0, "zh")
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute(
+            "UPDATE translation_queue SET status='running' WHERE book_id=60 AND chapter_index=0 AND target_language='zh'"
+        )
+        await db.commit()
+
+    resp = await client.put("/api/ai/translate/cache", json={
+        "book_id": 60, "chapter_index": 0, "target_language": "zh",
+        "paragraphs": ["new paragraph"],
+    })
+    assert resp.status_code == 409
+
+    # Existing translation must be untouched
+    cached = await get_cached_translation(60, 0, "zh")
+    assert cached == ["existing paragraph"]
+
+
 # ── Insight ───────────────────────────────────────────────────────────────────
 
 async def test_insight_without_key_returns_400(client):

--- a/backend/tests/test_router_annotations.py
+++ b/backend/tests/test_router_annotations.py
@@ -254,3 +254,128 @@ async def test_create_annotation_rejects_negative_chapter_index(client, test_use
         "sentence_text": "Some highlighted text.",
     })
     assert resp.status_code == 400
+
+
+async def test_create_annotation_select_runs_before_commit(tmp_db, test_user, monkeypatch):
+    """Regression #349: SELECT must execute before COMMIT in create_annotation.
+
+    If COMMIT precedes SELECT, a concurrent write on another connection can
+    land between the two operations, causing the function to return data it did
+    not write (stale-return race). Placing SELECT inside the transaction
+    guarantees it only sees the current connection's own uncommitted write.
+    """
+    import aiosqlite as _real_aiosqlite
+    import services.db as db_module
+    from services.db import save_book, create_annotation
+
+    await save_book(BOOK_ID, _BOOK_META, "text")
+
+    events: list[str] = []
+    orig_connect = _real_aiosqlite.connect
+
+    def patched_connect(database, **kwargs):
+        real_cm = orig_connect(database, **kwargs)
+
+        class TrackedConn:
+            def __init__(self):
+                self._conn = None
+
+            async def __aenter__(self):
+                self._conn = await real_cm.__aenter__()
+                return self
+
+            async def __aexit__(self, *args):
+                return await real_cm.__aexit__(*args)
+
+            @property
+            def row_factory(self):
+                return self._conn.row_factory
+
+            @row_factory.setter
+            def row_factory(self, v):
+                self._conn.row_factory = v
+
+            def execute(self, sql, *args, **kwargs):
+                if sql.strip().upper().startswith("SELECT"):
+                    events.append("SELECT")
+                return self._conn.execute(sql, *args, **kwargs)
+
+            async def commit(self):
+                events.append("COMMIT")
+                return await self._conn.commit()
+
+        return TrackedConn()
+
+    class FakeAiosqlite:
+        connect = staticmethod(patched_connect)
+        Row = _real_aiosqlite.Row
+
+    monkeypatch.setattr(db_module, "aiosqlite", FakeAiosqlite)
+
+    await create_annotation(test_user["id"], BOOK_ID, 0, "Sentence", "my-note", "yellow")
+
+    assert "COMMIT" in events and "SELECT" in events, "both operations must fire"
+    assert events.index("SELECT") < events.index("COMMIT"), (
+        "SELECT must run before COMMIT so the return value reflects this "
+        "connection's own write, not a concurrent modification (#349)"
+    )
+
+
+async def test_update_annotation_select_runs_before_commit(tmp_db, test_user, monkeypatch):
+    """Regression #349: SELECT must execute before COMMIT in update_annotation."""
+    import aiosqlite as _real_aiosqlite
+    import services.db as db_module
+    from services.db import save_book, create_annotation, update_annotation
+
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    ann = await create_annotation(test_user["id"], BOOK_ID, 0, "Sentence", "v1", "yellow")
+
+    events: list[str] = []
+    orig_connect = _real_aiosqlite.connect
+
+    def patched_connect(database, **kwargs):
+        real_cm = orig_connect(database, **kwargs)
+
+        class TrackedConn:
+            def __init__(self):
+                self._conn = None
+
+            async def __aenter__(self):
+                self._conn = await real_cm.__aenter__()
+                return self
+
+            async def __aexit__(self, *args):
+                return await real_cm.__aexit__(*args)
+
+            @property
+            def row_factory(self):
+                return self._conn.row_factory
+
+            @row_factory.setter
+            def row_factory(self, v):
+                self._conn.row_factory = v
+
+            def execute(self, sql, *args, **kwargs):
+                if sql.strip().upper().startswith("SELECT"):
+                    events.append("SELECT")
+                return self._conn.execute(sql, *args, **kwargs)
+
+            async def commit(self):
+                events.append("COMMIT")
+                return await self._conn.commit()
+
+        return TrackedConn()
+
+    class FakeAiosqlite:
+        connect = staticmethod(patched_connect)
+        Row = _real_aiosqlite.Row
+
+    monkeypatch.setattr(db_module, "aiosqlite", FakeAiosqlite)
+
+    await update_annotation(ann["id"], test_user["id"], note_text="v2")
+
+    assert "COMMIT" in events and "SELECT" in events, "both operations must fire"
+    assert events.index("SELECT") < events.index("COMMIT"), (
+        "SELECT must run before COMMIT so update_annotation returns its own "
+        "write, not a concurrent modification (#349)"
+    )

--- a/backend/tests/test_router_insights.py
+++ b/backend/tests/test_router_insights.py
@@ -207,3 +207,67 @@ async def test_post_insight_rejects_negative_chapter_index(client: AsyncClient):
         json={"book_id": 1, "question": "Q?", "answer": "A.", "chapter_index": -5},
     )
     assert resp.status_code == 400
+
+
+async def test_save_insight_select_runs_before_commit(tmp_db, test_user, monkeypatch):
+    """Regression #351: SELECT must execute before COMMIT in save_insight.
+
+    If COMMIT precedes SELECT, a concurrent delete_book (which cascades to
+    book_insights) can remove the just-inserted row between the two operations,
+    causing the SELECT to return None and dict(row) to crash with TypeError.
+    """
+    import aiosqlite as _real_aiosqlite
+    import services.db as db_module
+    from services.db import save_book, save_insight
+
+    await save_book(1, _META, "text")
+
+    events: list[str] = []
+    orig_connect = _real_aiosqlite.connect
+
+    def patched_connect(database, **kwargs):
+        real_cm = orig_connect(database, **kwargs)
+
+        class TrackedConn:
+            def __init__(self):
+                self._conn = None
+
+            async def __aenter__(self):
+                self._conn = await real_cm.__aenter__()
+                return self
+
+            async def __aexit__(self, *args):
+                return await real_cm.__aexit__(*args)
+
+            @property
+            def row_factory(self):
+                return self._conn.row_factory
+
+            @row_factory.setter
+            def row_factory(self, v):
+                self._conn.row_factory = v
+
+            def execute(self, sql, *args, **kwargs):
+                if sql.strip().upper().startswith("SELECT"):
+                    events.append("SELECT")
+                return self._conn.execute(sql, *args, **kwargs)
+
+            async def commit(self):
+                events.append("COMMIT")
+                return await self._conn.commit()
+
+        return TrackedConn()
+
+    class FakeAiosqlite:
+        connect = staticmethod(patched_connect)
+        Row = _real_aiosqlite.Row
+
+    monkeypatch.setattr(db_module, "aiosqlite", FakeAiosqlite)
+
+    await save_insight(test_user["id"], 1, 0, "Q?", "A.")
+
+    assert "COMMIT" in events and "SELECT" in events
+    assert events.index("SELECT") < events.index("COMMIT"), (
+        "SELECT must run before COMMIT in save_insight — otherwise a "
+        "concurrent delete_book can delete the row and crash dict(None) (#351)"
+    )

--- a/backend/tests/test_router_user.py
+++ b/backend/tests/test_router_user.py
@@ -189,3 +189,45 @@ async def test_patch_obsidian_settings_clears_token_with_empty_string(client, te
 
     settings = await get_obsidian_settings(test_user["id"])
     assert settings["github_token"] is None, "empty-string token must clear the stored token"
+
+
+async def test_patch_obsidian_settings_token_not_clobbered_by_stale_read(client, test_user, monkeypatch):
+    """Regression #344: PATCH without github_token must not overwrite a token
+    that was written between the read and write of a concurrent request.
+
+    With the bug: the handler reads the old token, a concurrent write upgrades
+    it to v2, then the handler writes back the stale v1 — silently deleting the
+    user's GitHub credential.
+    With the fix: when github_token is absent the handler never reads or writes
+    the github_token column at all, so the DB value is always preserved.
+    """
+    from services.db import update_obsidian_settings, get_obsidian_settings
+    from services.auth import encrypt_api_key, decrypt_api_key
+    import routers.user as user_router_module
+
+    # Set v1 token in DB.
+    await update_obsidian_settings(test_user["id"], encrypt_api_key("token-v1"), "r/v", "/p")
+
+    # Simulate a concurrent request that already wrote token-v2 BEFORE our
+    # handler's write, but AFTER its read — by monkeypatching get_obsidian_settings
+    # in the router namespace to return stale v1 data while the DB has v2.
+    await update_obsidian_settings(test_user["id"], encrypt_api_key("token-v2"), "r/v", "/p")
+
+    async def stale_get(user_id):
+        return {"github_token": encrypt_api_key("token-v1"), "obsidian_repo": "r/v", "obsidian_path": "/p"}
+
+    monkeypatch.setattr(user_router_module, "get_obsidian_settings", stale_get)
+
+    resp = await client.patch("/api/user/obsidian-settings", json={
+        "obsidian_repo": "r/v-updated",
+    })
+    assert resp.status_code == 200
+
+    # Undo only our patch so get_obsidian_settings goes back to the real impl.
+    monkeypatch.setattr(user_router_module, "get_obsidian_settings", get_obsidian_settings)
+    settings = await get_obsidian_settings(test_user["id"])
+    # With the bug: token would be v1 (stale read overwrote v2).
+    # With the fix: token stays v2 because the UPDATE skips the github_token column.
+    assert decrypt_api_key(settings["github_token"]) == "token-v2", \
+        "concurrent token update must not be silently overwritten by a PATCH that omits github_token"
+    assert settings["obsidian_repo"] == "r/v-updated"

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -448,3 +448,68 @@ async def test_export_annotation_translation_uses_book_language(client, test_use
             f"translate_text called with source={src!r} but book language is 'de'; "
             "source language must not be hardcoded to 'en'"
         )
+
+
+async def test_save_word_select_runs_before_commit(tmp_db, test_user, monkeypatch):
+    """Regression #351: SELECT must execute before COMMIT in save_word.
+
+    If COMMIT precedes SELECT, a concurrent write (e.g. _update_lemma on
+    another connection) can modify the vocabulary row between the two operations,
+    causing the function to return data it did not write.
+    """
+    import aiosqlite as _real_aiosqlite
+    import services.db as db_module
+    from services.db import save_book, save_word
+
+    _META = {"title": "T", "authors": [], "languages": ["de"], "subjects": [], "download_count": 0, "cover": ""}
+    await save_book(7777, _META, "text")
+
+    events: list[str] = []
+    orig_connect = _real_aiosqlite.connect
+
+    def patched_connect(database, **kwargs):
+        real_cm = orig_connect(database, **kwargs)
+
+        class TrackedConn:
+            def __init__(self):
+                self._conn = None
+
+            async def __aenter__(self):
+                self._conn = await real_cm.__aenter__()
+                return self
+
+            async def __aexit__(self, *args):
+                return await real_cm.__aexit__(*args)
+
+            @property
+            def row_factory(self):
+                return self._conn.row_factory
+
+            @row_factory.setter
+            def row_factory(self, v):
+                self._conn.row_factory = v
+
+            def execute(self, sql, *args, **kwargs):
+                if sql.strip().upper().startswith("SELECT"):
+                    events.append("SELECT")
+                return self._conn.execute(sql, *args, **kwargs)
+
+            async def commit(self):
+                events.append("COMMIT")
+                return await self._conn.commit()
+
+        return TrackedConn()
+
+    class FakeAiosqlite:
+        connect = staticmethod(patched_connect)
+        Row = _real_aiosqlite.Row
+
+    monkeypatch.setattr(db_module, "aiosqlite", FakeAiosqlite)
+
+    await save_word(test_user["id"], "Wort", 7777, 0, "Ein Satz.")
+
+    assert "COMMIT" in events and "SELECT" in events
+    assert events.index("SELECT") < events.index("COMMIT"), (
+        "SELECT must run before COMMIT in save_word to avoid returning data "
+        "from a concurrent _update_lemma write (#351)"
+    )

--- a/docs/reader-interaction-design.md
+++ b/docs/reader-interaction-design.md
@@ -1,0 +1,170 @@
+# Reader Page — Interaction Design Model
+
+_Last updated: 2026-04-22_
+
+## Overview
+
+The reader page combines three overlapping input systems: **TTS playback**, **text selection**, and **annotation**. Without clear rules about how they compose, interactions conflict (e.g. selection "Read" playing simultaneously with chapter audio, or long-press on mobile accidentally seeking instead of annotating). This document defines the authoritative interaction model.
+
+---
+
+## 1. Input Taxonomy
+
+| Gesture | Desktop | Mobile |
+|---------|---------|--------|
+| Single click / tap on sentence | Seek TTS (no-op if paused) | Toggle toolbar visibility (center) / prev-next chapter (edge zones) |
+| Single click on annotated sentence | Open QuickHighlightPanel | Same (if toolbar visible) |
+| Click Play button | Start TTS from current position | Same (via bottom bar) |
+| Drag to select text | Open SelectionToolbar | Not supported (touch pointer blocked) |
+| Long-press 400 ms | Open AnnotationToolbar (legacy) | Open AnnotationToolbar |
+| Swipe left / right | — | Navigate chapters |
+| Spacebar | (currently unbound) | — |
+
+---
+
+## 2. TTS Playback States
+
+```
+idle → [Play] → loading → playing → paused
+                              ↑____________↓
+                           [seek while playing: repositions + continues]
+                           [seek while paused: repositions only, no auto-start]
+```
+
+### Click-to-seek rules (implemented in PR #348)
+
+- **Playing**: `seekTo(t)` repositions audio and continues playing.
+- **Paused / idle / loading**: `seekTo(t)` is a no-op. The Play button must be pressed explicitly to start playback. This avoids accidental audio starting when the user merely clicks to read a sentence.
+
+### Pause-on-interaction rule (**not yet implemented — see Issue #UX-004**)
+
+When the user triggers a **one-off "Read selection"** action from the SelectionToolbar:
+
+1. If chapter TTS is **playing**: pause it, play selection, then resume when selection audio ends.
+2. If chapter TTS is **paused / idle**: play selection only (no chapter audio change).
+3. If chapter TTS is **loading**: ignore "Read selection" (disabled=true state).
+
+Currently, (1) plays both streams simultaneously — a bug.
+
+---
+
+## 3. Text Selection → SelectionToolbar
+
+### Desktop
+
+```
+user drags to select text
+       │
+       ▼
+window.selectionchange fires
+       │
+SelectionToolbar mounts at position above/below selection rect
+       │
+user clicks a button:
+   ├─ Read ──────► pause chapter TTS → one-off speech → resume TTS on end
+   ├─ Highlight ─► QuickHighlightPanel (4 color swatches, instant save, close)
+   ├─ Note ──────► AnnotationToolbar (textarea, color, Save/Delete)
+   ├─ Chat ──────► InsightChat sidebar opens, selection pre-filled
+   └─ Word ──────► VocabWordTooltip (definition + Save)
+
+After any button click: selection cleared, toolbar dismissed
+```
+
+### Mobile (touch)
+
+Text selection is **not supported** on mobile because:
+- `SentenceReader` calls `e.preventDefault()` on `pointerdown` (touch) to suppress the browser's native selection loupe.
+- This was intentional (PR #324) to prevent the selection loupe from competing with the 400 ms long-press gesture.
+
+**Current mobile annotation path:**
+- Long-press (400 ms) → `onAnnotate(sentenceText, ci, position)` → AnnotationToolbar (full sentence only, not sub-sentence selection).
+
+**Gap**: Mobile users cannot highlight a sub-sentence phrase. Possible future fix: add a native-like word/phrase selection mode using a custom handle-drag UI after the long-press fires.
+
+---
+
+## 4. Annotation Interactions
+
+### Creating a highlight (desktop)
+
+```
+Select text → Highlight button → QuickHighlightPanel
+    │ pick color ─────────────────────────────────────► saved immediately (no Save button)
+    │ pencil icon ────────────────────────────────────► AnnotationToolbar opens for note
+    │ click outside / Escape ────────────────────────► dismissed, no save
+```
+
+### Editing / deleting a highlight (desktop + mobile)
+
+```
+Click annotated sentence → QuickHighlightPanel (current color selected)
+    │ pick different color ──────────────────────────► color updated immediately
+    │ trash icon ────────────────────────────────────► deleted immediately (no confirm)
+    │ pencil icon ────────────────────────────────────► AnnotationToolbar for note edit
+    │ click outside / Escape ────────────────────────► dismissed
+```
+
+**Issue**: Immediate delete with no undo risks accidental data loss (see Issue #UX-005).
+
+### Creating a note (desktop)
+
+```
+Select text → Note button → AnnotationToolbar
+  OR
+Long-press sentence → AnnotationToolbar
+
+AnnotationToolbar:
+    │ pick color
+    │ type note (optional)
+    │ Save ─────────────────────────────────────────► saved, toolbar dismissed
+    │ Delete (existing only) ────────────────────────► deleted, dismissed
+    │ Close / Escape ────────────────────────────────► dismissed, no save
+```
+
+---
+
+## 5. Interaction Conflict Rules (Priority Order)
+
+When multiple interactions are triggered simultaneously, resolve in this order:
+
+1. **Modal panel open** (QuickHighlightPanel / AnnotationToolbar) → block all other interactions until dismissed.
+2. **Text selection active** → SelectionToolbar shown, click-to-seek is inactive until selection cleared.
+3. **TTS playing** → click-to-seek works, selection allowed, toolbar usable in parallel.
+4. **TTS loading** (`disabled=true` on SentenceReader) → segment clicks ignored, SelectionToolbar still active for highlighting.
+
+---
+
+## 6. Keyboard Shortcuts (Desktop)
+
+| Key | Action |
+|-----|--------|
+| `←` `→` | Prev / next chapter |
+| `F` | Toggle focus mode |
+| `Space` | Play / pause TTS (**not yet implemented — Issue #UX-006**) |
+| `Escape` | Close open panel (AnnotationToolbar / QuickHighlightPanel / TypographyPanel) |
+| `?` | Toggle shortcuts help |
+
+---
+
+## 7. Known Issues (to be filed)
+
+| ID | Title | Severity |
+|----|-------|----------|
+| #UX-001 | Mobile: no text selection path for sub-sentence highlight | Medium |
+| #UX-002 | Empty / error state when chapters fail to load | High |
+| #UX-003 | SelectionToolbar "Read" plays simultaneously with chapter TTS | High |
+| #UX-004 | Pause chapter TTS when selection "Read" fires | High |
+| #UX-005 | Annotation delete has no undo or confirmation | Medium |
+| #UX-006 | Spacebar shortcut for TTS play/pause missing | Medium |
+| #UX-007 | Mobile bottom bar hidden when chapters fail to load | Medium |
+
+---
+
+## 8. Intended UX Principles
+
+1. **Explicit play**: audio never starts without a deliberate user action (click Play, click Read). Seeking is always positioning-only when paused.
+2. **One audio stream**: at most one stream plays at a time. Selection "Read" pauses chapter TTS; chapter TTS pauses one-off streams.
+3. **Instant annotation**: QuickHighlightPanel saves on color click — zero friction for highlights.
+4. **Full note when needed**: AnnotationToolbar is only shown when the user explicitly requests note editing (Note button or pencil icon).
+5. **Non-destructive delete**: deletion of annotations should offer a brief undo window (3 s toast) rather than a confirmation dialog.
+6. **Mobile-first reading**: chapter navigation (swipe, bottom bar), TTS (bottom bar Play), annotations (long-press) all have dedicated mobile paths. Selection-based features are desktop-only for now.

--- a/frontend/src/__tests__/ReaderPage.branches2.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches2.test.tsx
@@ -234,6 +234,46 @@ jest.mock("@/components/AnnotationToolbar", () => {
   return { __esModule: true, default: AnnotationToolbar };
 });
 
+// ─── QuickHighlightPanel: exposes onClose / onSaved / onDeleted / onOpenNote ───
+jest.mock("@/components/QuickHighlightPanel", () => {
+  const QuickHighlightPanel = ({
+    onClose,
+    onSaved,
+    onDeleted,
+    onOpenNote,
+    existingAnnotation,
+  }: {
+    onClose?: () => void;
+    onSaved?: (ann: unknown) => void;
+    onDeleted?: (id: number) => void;
+    onOpenNote?: () => void;
+    existingAnnotation?: { id: number };
+  }) => (
+    <div data-testid="quick-highlight-panel">
+      <button data-testid="qhp-close" onClick={() => onClose?.()}>close</button>
+      <button
+        data-testid="qhp-save"
+        onClick={() =>
+          onSaved?.({
+            id: existingAnnotation?.id ?? 98,
+            sentence_text: "highlight text",
+            chapter_index: 0,
+            color: "blue",
+            note_text: "",
+            book_id: 42,
+          })
+        }
+      >
+        pick-color
+      </button>
+      <button data-testid="qhp-delete" onClick={() => onDeleted?.(existingAnnotation?.id ?? 98)}>delete</button>
+      <button data-testid="qhp-open-note" onClick={() => onOpenNote?.()}>add-note</button>
+    </div>
+  );
+  QuickHighlightPanel.displayName = "QuickHighlightPanel";
+  return { __esModule: true, default: QuickHighlightPanel };
+});
+
 jest.mock("@/components/TranslationView", () => {
   const TranslationView = () => null;
   TranslationView.displayName = "TranslationView";
@@ -251,14 +291,16 @@ jest.mock("@/components/VocabularyToast", () => {
   return { __esModule: true, default: VocabularyToast };
 });
 
-// ─── SentenceReader: exposes onAnnotate / onSegmentClick ─────────────────────
+// ─── SentenceReader: exposes onAnnotate / onSegmentClick / onAnnotationClick ──
 jest.mock("@/components/SentenceReader", () => {
   const SentenceReader = ({
     onAnnotate,
     onSegmentClick,
+    onAnnotationClick,
   }: {
     onAnnotate?: (sentenceText: string, ci: number, position: { x: number; y: number }) => void;
     onSegmentClick?: (startTime: number) => void;
+    onAnnotationClick?: (ann: unknown, position: { x: number; y: number }) => void;
   }) => (
     <div data-testid="sentence-reader">
       <button
@@ -269,6 +311,17 @@ jest.mock("@/components/SentenceReader", () => {
       </button>
       <button data-testid="trigger-segment-click" onClick={() => onSegmentClick?.(1.5)}>
         segment
+      </button>
+      <button
+        data-testid="trigger-annotation-click"
+        onClick={() =>
+          onAnnotationClick?.(
+            { id: 77, sentence_text: "annotated", chapter_index: 0, color: "yellow", note_text: "", book_id: 42 },
+            { x: 150, y: 250 },
+          )
+        }
+      >
+        annotation-click
       </button>
     </div>
   );
@@ -556,7 +609,7 @@ describe("ReaderPage.branches2 — AnnotationToolbar onDeleted", () => {
 // ─── SelectionToolbar opens annotation panel (lines 1054-1072) ───────────────
 
 describe("ReaderPage.branches2 — SelectionToolbar opens annotation panel", () => {
-  it("highlight button opens annotation panel", async () => {
+  it("highlight button opens quick highlight panel", async () => {
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
     render(<ReaderPage />);
     await flushPromises();
@@ -564,7 +617,7 @@ describe("ReaderPage.branches2 — SelectionToolbar opens annotation panel", () 
     const highlightBtn = await screen.findByTestId("trigger-highlight");
     await userEvent.click(highlightBtn);
 
-    expect(await screen.findByTestId("annotation-toolbar")).toBeInTheDocument();
+    expect(await screen.findByTestId("quick-highlight-panel")).toBeInTheDocument();
   });
 
   it("note button opens annotation panel", async () => {

--- a/frontend/src/__tests__/ReaderPage.branches2.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches2.test.tsx
@@ -42,6 +42,7 @@ jest.mock("next/navigation", () => ({
 const mockGetBookChapters = jest.fn();
 const mockGetMe = jest.fn();
 const mockGetAnnotations = jest.fn();
+const mockCreateAnnotation = jest.fn();
 const mockGetVocabulary = jest.fn();
 const mockGetBookTranslationStatus = jest.fn();
 const mockGetChapterTranslation = jest.fn();
@@ -60,6 +61,7 @@ jest.mock("@/lib/api", () => ({
   getBookChapters: (...a: unknown[]) => mockGetBookChapters(...a),
   getMe: (...a: unknown[]) => mockGetMe(...a),
   getAnnotations: (...a: unknown[]) => mockGetAnnotations(...a),
+  createAnnotation: (...a: unknown[]) => mockCreateAnnotation(...a),
   getVocabulary: (...a: unknown[]) => mockGetVocabulary(...a),
   getBookTranslationStatus: (...a: unknown[]) => mockGetBookTranslationStatus(...a),
   getChapterTranslation: (...a: unknown[]) => mockGetChapterTranslation(...a),
@@ -294,6 +296,18 @@ jest.mock("@/components/VocabularyToast", () => {
   );
   VocabularyToast.displayName = "VocabularyToast";
   return { __esModule: true, default: VocabularyToast };
+});
+
+// ─── UndoToast: exposes onUndo / onDone ──────────────────────────────────────
+jest.mock("@/components/UndoToast", () => {
+  const UndoToast = ({ onUndo, onDone }: { message?: string; onUndo?: () => void; onDone?: () => void }) => (
+    <div data-testid="undo-toast">
+      <button data-testid="undo-btn" onClick={() => onUndo?.()}>Undo</button>
+      <button data-testid="undo-done" onClick={() => onDone?.()}>done</button>
+    </div>
+  );
+  UndoToast.displayName = "UndoToast";
+  return { __esModule: true, default: UndoToast };
 });
 
 // ─── SentenceReader: exposes onAnnotate / onSegmentClick / onAnnotationClick ──
@@ -2654,12 +2668,10 @@ describe("ReaderPage.branches2 — SelectionToolbar onRead pauses chapter TTS", 
   });
 
   it("pauses chapter TTS before playing selection when TTS is playing, resumes on end", async () => {
-    let capturedResume: (() => void) | null = null;
     const audioMock = {
       play: jest.fn().mockResolvedValue(undefined),
       onended: null as (() => void) | null,
       onerror: null as (() => void) | null,
-      set onended(fn: (() => void) | null) { capturedResume = fn; },
     };
     jest.spyOn(global, "Audio" as keyof typeof global).mockImplementation(
       () => audioMock as unknown as HTMLAudioElement,
@@ -2735,5 +2747,79 @@ describe("ReaderPage.branches2 — spacebar toggles TTS play/pause", () => {
     document.body.removeChild(input);
     // No crash
     await waitFor(() => expect(screen.getByTestId("tts-controls")).toBeInTheDocument());
+  });
+});
+
+// ─── Annotation delete undo toast ─────────────────────────────────────────────
+
+describe("ReaderPage.branches2 — annotation delete shows undo toast", () => {
+  // id: 77 matches what SentenceReader mock sends in trigger-annotation-click
+  const SAMPLE_ANN = {
+    id: 77,
+    book_id: 42,
+    chapter_index: 0,
+    sentence_text: "Test sentence",
+    note_text: "",
+    color: "yellow",
+  };
+
+  beforeEach(() => {
+    mockGetAnnotations.mockResolvedValue([SAMPLE_ANN]);
+    mockCreateAnnotation.mockResolvedValue({ ...SAMPLE_ANN, id: 100 });
+  });
+
+  it("shows UndoToast when QuickHighlightPanel onDeleted fires", async () => {
+    mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
+    render(<ReaderPage />);
+    await flushPromises();
+
+    // Open quick highlight panel via annotation click trigger
+    const annClickTrigger = await screen.findByTestId("trigger-annotation-click");
+    await userEvent.click(annClickTrigger);
+
+    // Click delete in QuickHighlightPanel
+    const deleteBtn = await screen.findByTestId("qhp-delete");
+    await userEvent.click(deleteBtn);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("undo-toast")).toBeInTheDocument()
+    );
+  });
+
+  it("clicking Undo calls createAnnotation to restore the annotation", async () => {
+    mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
+    render(<ReaderPage />);
+    await flushPromises();
+
+    // Open quick highlight panel
+    const annClickTrigger = await screen.findByTestId("trigger-annotation-click");
+    await userEvent.click(annClickTrigger);
+
+    const deleteBtn = await screen.findByTestId("qhp-delete");
+    await userEvent.click(deleteBtn);
+
+    await waitFor(() => expect(screen.getByTestId("undo-toast")).toBeInTheDocument());
+
+    const undoBtn = screen.getByTestId("undo-btn");
+    await userEvent.click(undoBtn);
+
+    await waitFor(() => expect(mockCreateAnnotation).toHaveBeenCalled());
+  });
+
+  it("shows UndoToast when AnnotationToolbar onDeleted fires", async () => {
+    mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
+    render(<ReaderPage />);
+    await flushPromises();
+
+    // Open annotation toolbar via long-press trigger
+    const longPressTrigger = await screen.findByTestId("trigger-annotate");
+    await userEvent.click(longPressTrigger);
+
+    const deleteBtn = await screen.findByTestId("annotation-delete");
+    await userEvent.click(deleteBtn);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("undo-toast")).toBeInTheDocument()
+    );
   });
 });

--- a/frontend/src/__tests__/ReaderPage.branches2.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches2.test.tsx
@@ -107,14 +107,19 @@ jest.mock("@/components/TTSControls", () => {
     onLoadingChange,
     onChunksUpdate,
     onSeekRegister,
+    onControlsRegister,
   }: {
     onPlaybackUpdate?: (t: number, d: number, p: boolean) => void;
     onLoadingChange?: (l: boolean) => void;
     onChunksUpdate?: (c: { text: string; duration: number }[]) => void;
     onSeekRegister?: (fn: (t: number) => void) => void;
+    onControlsRegister?: (controls: { pause: () => void; play: () => void }) => void;
   }) => {
+    const pauseMock = React.useRef(jest.fn());
+    const playMock = React.useRef(jest.fn());
     React.useEffect(() => {
       onSeekRegister?.(() => {});
+      onControlsRegister?.({ pause: pauseMock.current, play: playMock.current });
       onLoadingChange?.(false);
       onPlaybackUpdate?.(0, 0, false);
       onChunksUpdate?.([]);
@@ -2624,5 +2629,111 @@ describe("ReaderPage.branches2 — sidebar button CSS active state", () => {
     await waitFor(() => {
       expect(chatBtn).toBeInTheDocument();
     });
+  });
+});
+
+// ─── SelectionToolbar onRead: pauses chapter TTS when playing ──────────────────
+
+describe("ReaderPage.branches2 — SelectionToolbar onRead pauses chapter TTS", () => {
+  it("does NOT call synthesizeSpeech pause when TTS is not playing", async () => {
+    const playMock = jest.fn().mockResolvedValue(undefined);
+    const audioMock = { play: playMock, onended: null as (() => void) | null, onerror: null };
+    jest.spyOn(global, "Audio" as keyof typeof global).mockImplementation(
+      () => audioMock as unknown as HTMLAudioElement,
+    );
+    mockSynthesizeSpeech.mockResolvedValue({ url: "blob:http://localhost/audio" });
+    mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
+    render(<ReaderPage />);
+    await flushPromises();
+
+    const readBtn = await screen.findByTestId("trigger-read");
+    await userEvent.click(readBtn);
+
+    await waitFor(() => expect(mockSynthesizeSpeech).toHaveBeenCalled());
+    jest.restoreAllMocks();
+  });
+
+  it("pauses chapter TTS before playing selection when TTS is playing, resumes on end", async () => {
+    let capturedResume: (() => void) | null = null;
+    const audioMock = {
+      play: jest.fn().mockResolvedValue(undefined),
+      onended: null as (() => void) | null,
+      onerror: null as (() => void) | null,
+      set onended(fn: (() => void) | null) { capturedResume = fn; },
+    };
+    jest.spyOn(global, "Audio" as keyof typeof global).mockImplementation(
+      () => audioMock as unknown as HTMLAudioElement,
+    );
+    mockSynthesizeSpeech.mockResolvedValue({ url: "blob:http://localhost/audio" });
+    mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
+    render(<ReaderPage />);
+    await flushPromises();
+
+    // Start TTS playing via mock trigger
+    const playingTrigger = await screen.findByTestId("tts-trigger-playing");
+    await userEvent.click(playingTrigger);
+
+    // Now trigger onRead
+    const readBtn = await screen.findByTestId("trigger-read");
+    await userEvent.click(readBtn);
+
+    await waitFor(() => expect(mockSynthesizeSpeech).toHaveBeenCalled());
+    jest.restoreAllMocks();
+  });
+});
+
+// ─── Spacebar keyboard shortcut: play/pause TTS ───────────────────────────────
+
+describe("ReaderPage.branches2 — spacebar toggles TTS play/pause", () => {
+  it("spacebar fires play when TTS is paused", async () => {
+    mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
+    render(<ReaderPage />);
+    await flushPromises();
+
+    // Default state is not playing — spacebar should trigger play
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+      await flushPromises();
+    });
+
+    // No crash and component still renders
+    await waitFor(() => expect(screen.getByTestId("tts-controls")).toBeInTheDocument());
+  });
+
+  it("spacebar fires pause when TTS is playing", async () => {
+    mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
+    render(<ReaderPage />);
+    await flushPromises();
+
+    // Set TTS to playing state
+    const playingTrigger = await screen.findByTestId("tts-trigger-playing");
+    await userEvent.click(playingTrigger);
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+      await flushPromises();
+    });
+
+    // No crash and component still renders
+    await waitFor(() => expect(screen.getByTestId("tts-controls")).toBeInTheDocument());
+  });
+
+  it("spacebar does nothing when an input is focused", async () => {
+    mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
+    render(<ReaderPage />);
+    await flushPromises();
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+      await flushPromises();
+    });
+
+    document.body.removeChild(input);
+    // No crash
+    await waitFor(() => expect(screen.getByTestId("tts-controls")).toBeInTheDocument());
   });
 });

--- a/frontend/src/__tests__/ReaderPage.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.test.tsx
@@ -339,6 +339,37 @@ describe("ReaderPage — error state", () => {
     await userEvent.click(link);
     expect(mockPush).toHaveBeenCalledWith("/");
   });
+
+  it("shows Retry button in error state", async () => {
+    mockGetBookChapters.mockRejectedValue(new Error("Network failure"));
+    render(<ReaderPage />);
+    await flushPromises();
+    expect(await screen.findByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("clicking Retry re-fetches chapters and clears error on success", async () => {
+    mockGetBookChapters.mockRejectedValueOnce(new Error("Network failure"));
+    render(<ReaderPage />);
+    await flushPromises();
+
+    // Error state visible
+    const retryBtn = await screen.findByRole("button", { name: /retry/i });
+
+    // Second call succeeds
+    mockGetBookChapters.mockResolvedValue({
+      meta: SAMPLE_META,
+      chapters: SAMPLE_CHAPTERS,
+    });
+
+    await userEvent.click(retryBtn);
+    await flushPromises();
+
+    // Error is gone, chapter content appears
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
+    });
+    expect(mockGetBookChapters).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("ReaderPage — chapter navigation", () => {

--- a/frontend/src/__tests__/TTSControls.extra.test.tsx
+++ b/frontend/src/__tests__/TTSControls.extra.test.tsx
@@ -559,8 +559,37 @@ describe("seekTo — seek logic with loaded chunks (lines 300-356)", () => {
     expect(audioInstances.length).toBeGreaterThan(0);
   });
 
-  it("seekTo with no chunks triggers loadAndPlay(globalTime)", async () => {
-    // Don't click play; call onSeekRegister seek function directly
+  it("seekTo with no chunks and playing status triggers loadAndPlay(globalTime)", async () => {
+    // Start playing first, then seek — only then should loadAndPlay be triggered
+    let seekFn: ((t: number) => void) | null = null;
+    mockGetChunks.mockResolvedValue(["Seek text."]);
+    mockSynthesize.mockResolvedValue({ url: "blob:audio", wordBoundaries: [] });
+
+    render(
+      <TTSControls
+        {...DEFAULT_PROPS}
+        onSeekRegister={(fn) => {
+          seekFn = fn;
+        }}
+      />
+    );
+
+    await waitFor(() => expect(seekFn).toBeTruthy());
+
+    // Click play to enter "playing" state so loadAndPlay is triggered on seek
+    const playBtn = Array.from(document.querySelectorAll("button")).find(
+      (b) => b.textContent?.includes("Read")
+    )!;
+    await act(async () => {
+      fireEvent.click(playBtn);
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    expect(mockGetChunks).toHaveBeenCalled();
+  });
+
+  it("seekTo with no chunks while paused does NOT trigger loadAndPlay", async () => {
+    // Seeking while paused should not start loading — seek is a no-op until playing
     let seekFn: ((t: number) => void) | null = null;
     mockGetChunks.mockResolvedValue(["Seek text."]);
     mockSynthesize.mockResolvedValue({ url: "blob:audio", wordBoundaries: [] });
@@ -581,7 +610,8 @@ describe("seekTo — seek logic with loaded chunks (lines 300-356)", () => {
       await new Promise((r) => setTimeout(r, 100));
     });
 
-    expect(mockGetChunks).toHaveBeenCalled();
+    // loadAndPlay should NOT be triggered since status is "paused"
+    expect(mockGetChunks).not.toHaveBeenCalled();
   });
 
   it("pause saves audio position via saveAudioPosition", async () => {

--- a/frontend/src/__tests__/TTSControls.extra.test.tsx
+++ b/frontend/src/__tests__/TTSControls.extra.test.tsx
@@ -805,3 +805,66 @@ describe("saveAudioPosition on chapter unmount (line 96)", () => {
     expect(true).toBe(true);
   });
 });
+
+// ── onControlsRegister: pause and play callbacks exposed to parent ────────────
+
+describe("onControlsRegister exposes pause and play to parent", () => {
+  it("registers pause and play on mount", async () => {
+    const onControlsRegister = jest.fn();
+    render(<TTSControls {...DEFAULT_PROPS} onControlsRegister={onControlsRegister} />);
+    await waitFor(() => expect(onControlsRegister).toHaveBeenCalledTimes(1));
+    const controls = onControlsRegister.mock.calls[0][0];
+    expect(typeof controls.pause).toBe("function");
+    expect(typeof controls.play).toBe("function");
+  });
+
+  it("calling registered pause while playing halts audio", async () => {
+    let controls: { pause: () => void; play: () => void } | null = null;
+    mockGetChunks.mockResolvedValue(["Chunk."]);
+    mockSynthesize.mockResolvedValue({ url: "blob:audio", wordBoundaries: [] });
+
+    render(
+      <TTSControls
+        {...DEFAULT_PROPS}
+        onControlsRegister={(c) => { controls = c; }}
+      />
+    );
+
+    const playBtn = screen.getAllByRole("button").find((b) => b.textContent?.includes("Read"))!;
+    await act(async () => {
+      fireEvent.click(playBtn);
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    await waitFor(() => expect(controls).not.toBeNull());
+
+    await act(async () => {
+      controls!.pause();
+      await flushPromises();
+    });
+
+    await waitFor(() => expect(screen.getByText(/Read/)).toBeInTheDocument());
+  });
+
+  it("calling registered play while paused starts playback", async () => {
+    let controls: { pause: () => void; play: () => void } | null = null;
+    mockGetChunks.mockResolvedValue(["Chunk."]);
+    mockSynthesize.mockResolvedValue({ url: "blob:audio", wordBoundaries: [] });
+
+    render(
+      <TTSControls
+        {...DEFAULT_PROPS}
+        onControlsRegister={(c) => { controls = c; }}
+      />
+    );
+
+    await waitFor(() => expect(controls).not.toBeNull());
+
+    await act(async () => {
+      controls!.play();
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    expect(mockGetChunks).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/UndoToast.test.tsx
+++ b/frontend/src/__tests__/UndoToast.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { render, screen, act, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UndoToast from "@/components/UndoToast";
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.clearAllMocks();
+});
+
+describe("UndoToast", () => {
+  it("renders the message and Undo button", () => {
+    render(<UndoToast message="Highlight deleted" onUndo={jest.fn()} onDone={jest.fn()} />);
+    expect(screen.getByText("Highlight deleted")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Undo" })).toBeInTheDocument();
+  });
+
+  it("calls onUndo and onDone when Undo is clicked", async () => {
+    const onUndo = jest.fn();
+    const onDone = jest.fn();
+    render(<UndoToast message="Highlight deleted" onUndo={onUndo} onDone={onDone} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Undo" }));
+
+    expect(onUndo).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(onDone).toHaveBeenCalledTimes(1), { timeout: 500 });
+  });
+
+  it("auto-dismisses after 3 seconds by calling onDone", async () => {
+    jest.useFakeTimers();
+    const onDone = jest.fn();
+    render(<UndoToast message="Highlight deleted" onUndo={jest.fn()} onDone={onDone} />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(3300);
+    });
+
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call onUndo when auto-dismissed", async () => {
+    jest.useFakeTimers();
+    const onUndo = jest.fn();
+    const onDone = jest.fn();
+    render(<UndoToast message="Highlight deleted" onUndo={onUndo} onDone={onDone} />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(3300);
+    });
+
+    expect(onUndo).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -12,6 +12,7 @@ import TranslationView from "@/components/TranslationView";
 import SentenceReader from "@/components/SentenceReader";
 import SelectionToolbar from "@/components/SelectionToolbar";
 import AnnotationToolbar from "@/components/AnnotationToolbar";
+import QuickHighlightPanel from "@/components/QuickHighlightPanel";
 import VocabularyToast from "@/components/VocabularyToast";
 import VocabWordTooltip from "@/components/VocabWordTooltip";
 import ChapterSummary from "@/components/ChapterSummary";
@@ -53,6 +54,13 @@ export default function ReaderPage() {
     chapterIndex: number;
     position: { x: number; y: number };
   } | null>(null);
+  const [quickHighlightPanel, setQuickHighlightPanel] = useState<{
+    sentenceText: string;
+    chapterIndex: number;
+    position: { x: number; y: number };
+    existingAnnotation?: Annotation;
+  } | null>(null);
+  const [typographyAnchorPos, setTypographyAnchorPos] = useState<{ x: number; y: number } | null>(null);
   const [scrollTargetSentence, setScrollTargetSentence] = useState<string | undefined>();
   const didUrlScrollRef = useRef(false);
 
@@ -910,7 +918,11 @@ export default function ReaderPage() {
           {/* Typography panel — desktop only */}
           <div className="relative hidden md:block">
             <button
-              onClick={() => setShowTypographyPanel((v) => !v)}
+              onClick={(e) => {
+                const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                setTypographyAnchorPos({ x: rect.right, y: rect.bottom });
+                setShowTypographyPanel((v) => !v);
+              }}
               title="Typography settings"
               className={`flex shrink-0 items-center gap-1 px-2 py-1 rounded-lg border text-xs font-bold transition-colors ${
                 showTypographyPanel || paragraphFocus
@@ -933,6 +945,7 @@ export default function ReaderPage() {
                 onFontFamily={setFontFamily}
                 onParagraphFocus={setParagraphFocus}
                 onClose={() => setShowTypographyPanel(false)}
+                anchorPos={typographyAnchorPos ?? undefined}
               />
             )}
           </div>
@@ -1251,6 +1264,14 @@ export default function ReaderPage() {
                   onAnnotate={session?.backendToken ? (sentenceText, ci, position) => {
                     setAnnotationPanel({ sentenceText, chapterIndex: ci, position });
                   } : undefined}
+                  onAnnotationClick={session?.backendToken ? (annotation, position) => {
+                    setQuickHighlightPanel({
+                      sentenceText: annotation.sentence_text,
+                      chapterIndex: annotation.chapter_index,
+                      position,
+                      existingAnnotation: annotation,
+                    });
+                  } : undefined}
                   showAnnotations={showAnnotations}
                   scrollTargetSentence={scrollTargetSentence}
                   scrollTargetWord={searchParams?.get("word") ? decodeURIComponent(searchParams.get("word")!) : undefined}
@@ -1301,11 +1322,15 @@ export default function ReaderPage() {
                 });
             }}
             onHighlight={session?.backendToken ? (text) => {
-              setAnnotationPanel({
-                sentenceText: text,
-                chapterIndex,
-                position: { x: window.innerWidth / 2, y: window.innerHeight / 2 },
-              });
+              let position = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+              try {
+                const sel = window.getSelection();
+                const rect = sel?.rangeCount ? sel.getRangeAt(0).getBoundingClientRect() : null;
+                if (rect && (rect.width > 0 || rect.height > 0)) {
+                  position = { x: rect.left + rect.width / 2, y: rect.bottom };
+                }
+              } catch { /* ignore — selection not available in test environments */ }
+              setQuickHighlightPanel({ sentenceText: text, chapterIndex, position });
             } : undefined}
             onNote={session?.backendToken ? (text) => {
               setAnnotationPanel({
@@ -1323,7 +1348,7 @@ export default function ReaderPage() {
             onVocab={session?.backendToken ? (word, context, rect) => setVocabTooltip({ word, context, rect }) : undefined}
           />
 
-          {/* Annotation toolbar */}
+          {/* Annotation toolbar (full note editor) */}
           {annotationPanel && (
             <AnnotationToolbar
               sentenceText={annotationPanel.sentenceText}
@@ -1349,6 +1374,40 @@ export default function ReaderPage() {
               }}
               onDeleted={(id) => {
                 setAnnotations((prev) => prev.filter((a) => a.id !== id));
+              }}
+            />
+          )}
+
+          {/* Quick highlight panel — color-only, instant save */}
+          {quickHighlightPanel && (
+            <QuickHighlightPanel
+              sentenceText={quickHighlightPanel.sentenceText}
+              chapterIndex={quickHighlightPanel.chapterIndex}
+              bookId={Number(bookId)}
+              position={quickHighlightPanel.position}
+              existingAnnotation={quickHighlightPanel.existingAnnotation}
+              onClose={() => setQuickHighlightPanel(null)}
+              onSaved={(annotation) => {
+                setAnnotations((prev) => {
+                  const idx = prev.findIndex((a) => a.id === annotation.id);
+                  if (idx >= 0) {
+                    const next = [...prev];
+                    next[idx] = annotation;
+                    return next;
+                  }
+                  return [...prev, annotation];
+                });
+              }}
+              onDeleted={(id) => {
+                setAnnotations((prev) => prev.filter((a) => a.id !== id));
+              }}
+              onOpenNote={() => {
+                setQuickHighlightPanel(null);
+                setAnnotationPanel({
+                  sentenceText: quickHighlightPanel.sentenceText,
+                  chapterIndex: quickHighlightPanel.chapterIndex,
+                  position: quickHighlightPanel.position,
+                });
               }}
             />
           )}

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -771,17 +771,20 @@ export default function ReaderPage() {
     ? current.text.split(/\n\n+/).filter((p) => p.trim())
     : [];
 
-  if (error)
-    return (
-      <div className="h-screen bg-parchment flex items-center justify-center">
-        <div className="text-center">
-          <p className="text-red-600 mb-4">{error}</p>
-          <button onClick={() => router.push("/")} className="text-amber-700 underline">
-            Back to library
-          </button>
-        </div>
-      </div>
-    );
+  function retryChapterLoad() {
+    setError("");
+    setLoading(true);
+    chaptersCache.delete(bookId);
+    getBookChapters(Number(bookId))
+      .then((data) => {
+        chaptersCache.set(bookId, data.chapters);
+        metaCache.set(bookId, data.meta);
+        setChapters(data.chapters);
+        setMeta(data.meta);
+      })
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }
 
   return (
     <div className="h-screen bg-parchment flex flex-col overflow-hidden">
@@ -1247,6 +1250,26 @@ export default function ReaderPage() {
                 {Array.from({ length: 14 }).map((_, i) => (
                   <div key={i} className={`h-4 bg-amber-200 rounded ${i % 5 === 4 ? "w-2/3" : "w-full"}`} />
                 ))}
+              </div>
+            ) : error ? (
+              <div className="max-w-prose mx-auto text-center py-16 px-4">
+                <BookOpenIcon className="w-10 h-10 text-amber-300 mx-auto mb-4" aria-hidden="true" />
+                <h2 className="font-serif text-lg text-ink mb-2">Failed to load chapter</h2>
+                <p className="text-sm text-stone-500 mb-6">{error}</p>
+                <div className="flex items-center justify-center gap-3">
+                  <button
+                    onClick={retryChapterLoad}
+                    className="px-4 py-2 rounded-lg bg-amber-700 text-white text-sm hover:bg-amber-800 transition-colors"
+                  >
+                    Retry
+                  </button>
+                  <button
+                    onClick={() => router.push("/")}
+                    className="px-4 py-2 rounded-lg border border-amber-300 text-amber-700 text-sm hover:bg-amber-50 transition-colors"
+                  >
+                    Back to library
+                  </button>
+                </div>
               </div>
             ) : (
               <>
@@ -1978,7 +2001,7 @@ export default function ReaderPage() {
 
 
       {/* ── Mobile floating bottom toolbar ─────────────────────────────── */}
-      {!loading && chapters.length > 0 && (
+      {!loading && (chapters.length > 0 || error) && (
         <div className="md:hidden fixed bottom-0 left-0 right-0 z-30 safe-bottom">
           {/* Translation options expand panel */}
           {translateExpanded && translationEnabled && (

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -77,6 +77,8 @@ export default function ReaderPage() {
   const [ttsIsLoading, setTtsIsLoading] = useState(false);
   const [ttsChunks, setTtsChunks] = useState<{ text: string; duration: number }[]>([]);
   const ttsSeekRef = useRef<(t: number) => void>(() => {});
+  const ttsControlsRef = useRef<{ pause: () => void; play: () => void } | null>(null);
+  const ttsIsPlayingRef = useRef(false);
 
   // Annotation display toggle (persisted)
   const [showAnnotations, setShowAnnotations] = useState(() => {
@@ -678,6 +680,13 @@ export default function ReaderPage() {
       } else if (e.key === "?") {
         e.preventDefault();
         setShowShortcuts((v) => !v);
+      } else if (e.key === " ") {
+        e.preventDefault();
+        if (ttsIsPlayingRef.current) {
+          ttsControlsRef.current?.pause();
+        } else {
+          ttsControlsRef.current?.play();
+        }
       } else if (e.key === "Escape") {
         if (focusMode) { e.preventDefault(); setFocusMode(false); }
         setShowTypographyPanel(false);
@@ -1115,6 +1124,7 @@ export default function ReaderPage() {
                 <p className="text-[10px] font-semibold uppercase tracking-widest text-stone-400 mb-2">Keyboard Shortcuts</p>
                 <div className="space-y-1.5">
                   {[
+                    { keys: ["Space"], label: "Play / Pause TTS" },
                     { keys: ["←", "→"], label: "Previous / Next chapter" },
                     { keys: ["F"], label: "Toggle focus mode" },
                     { keys: ["?"], label: "Show this panel" },
@@ -1308,16 +1318,24 @@ export default function ReaderPage() {
           {/* Selection toolbar — appears when user selects text */}
           <SelectionToolbar
             onRead={(text) => {
+              const wasPlaying = ttsIsPlayingRef.current;
+              if (wasPlaying) ttsControlsRef.current?.pause();
               synthesizeSpeech(text, bookLanguage, 1.0, getSettings().ttsGender)
                 .then(({ url }) => {
                   const audio = new Audio(url);
-                  audio.onended = () => URL.revokeObjectURL(url);
-                  audio.play().catch(() => URL.revokeObjectURL(url));
+                  const resume = () => {
+                    URL.revokeObjectURL(url);
+                    if (wasPlaying) ttsControlsRef.current?.play();
+                  };
+                  audio.onended = resume;
+                  audio.onerror = resume;
+                  audio.play().catch(resume);
                 })
                 .catch(() => {
                   window.speechSynthesis.cancel();
                   const utter = new SpeechSynthesisUtterance(text);
                   utter.lang = bookLanguage;
+                  utter.onend = () => { if (wasPlaying) ttsControlsRef.current?.play(); };
                   window.speechSynthesis.speak(utter);
                 });
             }}
@@ -1466,11 +1484,15 @@ export default function ReaderPage() {
                 setTtsCurrentTime(currentTime);
                 setTtsDuration(duration);
                 setTtsIsPlaying(isPlaying);
+                ttsIsPlayingRef.current = isPlaying;
               }}
               onLoadingChange={setTtsIsLoading}
               onChunksUpdate={setTtsChunks}
               onSeekRegister={(seekFn) => {
                 ttsSeekRef.current = seekFn;
+              }}
+              onControlsRegister={(controls) => {
+                ttsControlsRef.current = controls;
               }}
               stopAtTime={paragraphFocus ? ttsStopAt : undefined}
               onStopAtReached={() => setTtsStopAt(undefined)}

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { getBookChapters, deleteTranslationCache, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, getChapterTranslation, getChapterQueueStatus, retryChapterTranslation, enqueueBookTranslation, saveReadingProgress, getAnnotations, getVocabulary, saveVocabularyWord, exportVocabularyToObsidian, saveInsight, TranslationStatus, BookMeta, BookChapter, ApiError, Annotation, VocabularyWord } from "@/lib/api";
+import { getBookChapters, deleteTranslationCache, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, getChapterTranslation, getChapterQueueStatus, retryChapterTranslation, enqueueBookTranslation, saveReadingProgress, getAnnotations, createAnnotation, getVocabulary, saveVocabularyWord, exportVocabularyToObsidian, saveInsight, TranslationStatus, BookMeta, BookChapter, ApiError, Annotation, VocabularyWord } from "@/lib/api";
 import { recordRecentBook, saveLastChapter, getLastChapter } from "@/lib/recentBooks";
 import { getSettings, saveSettings, FontSize, Theme, LineHeight, ContentWidth, FontFamily } from "@/lib/settings";
 import TypographyPanel from "@/components/TypographyPanel";
@@ -14,6 +14,7 @@ import SelectionToolbar from "@/components/SelectionToolbar";
 import AnnotationToolbar from "@/components/AnnotationToolbar";
 import QuickHighlightPanel from "@/components/QuickHighlightPanel";
 import VocabularyToast from "@/components/VocabularyToast";
+import UndoToast from "@/components/UndoToast";
 import VocabWordTooltip from "@/components/VocabWordTooltip";
 import ChapterSummary from "@/components/ChapterSummary";
 import { SunIcon, MoonIcon, SepiaIcon, ChatIcon, GlobeIcon, NoteIcon, BookmarkIcon, BookOpenIcon, ExportIcon, SummaryIcon, PlayIcon, PauseIcon, CloseIcon, KeyboardIcon, FocusIcon, ArrowLeftIcon, ArrowRightIcon, ChevronDownIcon } from "@/components/Icons";
@@ -69,6 +70,9 @@ export default function ReaderPage() {
 
   // Obsidian export toast
   const [obsidianToast, setObsidianToast] = useState<string | null>(null);
+
+  // Annotation delete undo toast
+  const [deletedAnnotationToast, setDeletedAnnotationToast] = useState<Annotation | null>(null);
 
   // TTS Read-button playback state — fed by TTSControls via callback props.
   const [ttsCurrentTime, setTtsCurrentTime] = useState(0);
@@ -1391,7 +1395,9 @@ export default function ReaderPage() {
                 });
               }}
               onDeleted={(id) => {
+                const ann = annotations.find((a) => a.id === id);
                 setAnnotations((prev) => prev.filter((a) => a.id !== id));
+                if (ann) setDeletedAnnotationToast(ann);
               }}
             />
           )}
@@ -1417,7 +1423,9 @@ export default function ReaderPage() {
                 });
               }}
               onDeleted={(id) => {
+                const ann = annotations.find((a) => a.id === id);
                 setAnnotations((prev) => prev.filter((a) => a.id !== id));
+                if (ann) setDeletedAnnotationToast(ann);
               }}
               onOpenNote={() => {
                 setQuickHighlightPanel(null);
@@ -1441,6 +1449,29 @@ export default function ReaderPage() {
                 handleWordSave(vocabTooltip.word, vocabTooltip.context);
                 setVocabTooltip(null);
               }}
+            />
+          )}
+
+          {/* Annotation delete undo toast */}
+          {deletedAnnotationToast && (
+            <UndoToast
+              message="Highlight deleted"
+              onUndo={() => {
+                const ann = deletedAnnotationToast;
+                setDeletedAnnotationToast(null);
+                if (ann && session?.backendToken) {
+                  createAnnotation({
+                    book_id: ann.book_id,
+                    chapter_index: ann.chapter_index,
+                    sentence_text: ann.sentence_text,
+                    note_text: ann.note_text,
+                    color: ann.color,
+                  }).then((restored) => {
+                    setAnnotations((prev) => [...prev, restored]);
+                  }).catch(() => {});
+                }
+              }}
+              onDone={() => setDeletedAnnotationToast(null)}
             />
           )}
 

--- a/frontend/src/components/QuickHighlightPanel.tsx
+++ b/frontend/src/components/QuickHighlightPanel.tsx
@@ -1,0 +1,143 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import { createAnnotation, updateAnnotation, deleteAnnotation, Annotation } from "@/lib/api";
+import { TrashIcon, NoteIcon } from "@/components/Icons";
+
+const COLORS = [
+  { key: "yellow", bg: "bg-yellow-400", border: "border-yellow-500", label: "Yellow" },
+  { key: "blue", bg: "bg-blue-400", border: "border-blue-500", label: "Blue" },
+  { key: "green", bg: "bg-green-400", border: "border-green-500", label: "Green" },
+  { key: "pink", bg: "bg-pink-400", border: "border-pink-500", label: "Pink" },
+] as const;
+
+type ColorKey = (typeof COLORS)[number]["key"];
+
+interface Props {
+  sentenceText: string;
+  chapterIndex: number;
+  bookId: number;
+  position: { x: number; y: number };
+  existingAnnotation?: Annotation;
+  onClose: () => void;
+  onSaved: (annotation: Annotation) => void;
+  onDeleted: (id: number) => void;
+  onOpenNote?: () => void;
+}
+
+export default function QuickHighlightPanel({
+  sentenceText,
+  chapterIndex,
+  bookId,
+  position,
+  existingAnnotation,
+  onClose,
+  onSaved,
+  onDeleted,
+  onOpenNote,
+}: Props) {
+  const [busy, setBusy] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [onClose]);
+
+  const PANEL_W = 220;
+  const left = Math.max(8, Math.min(position.x - PANEL_W / 2, window.innerWidth - PANEL_W - 8));
+  const top = Math.min(position.y + 8, window.innerHeight - 72);
+
+  async function handleColor(colorKey: ColorKey) {
+    if (busy) return;
+    setBusy(true);
+    try {
+      let saved: Annotation;
+      if (existingAnnotation) {
+        saved = await updateAnnotation(existingAnnotation.id, {
+          color: colorKey,
+          note_text: existingAnnotation.note_text,
+        });
+      } else {
+        saved = await createAnnotation({
+          book_id: bookId,
+          chapter_index: chapterIndex,
+          sentence_text: sentenceText,
+          note_text: "",
+          color: colorKey,
+        });
+      }
+      onSaved(saved);
+      onClose();
+    } catch {
+      setBusy(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!existingAnnotation || busy) return;
+    setBusy(true);
+    try {
+      await deleteAnnotation(existingAnnotation.id);
+      onDeleted(existingAnnotation.id);
+      onClose();
+    } catch {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      ref={panelRef}
+      style={{ position: "fixed", top, left, zIndex: 1000 }}
+      className="flex items-center gap-2 bg-white border border-amber-200 rounded-xl shadow-xl px-3 py-2.5 animate-fade-in"
+      data-testid="quick-highlight-panel"
+    >
+      {COLORS.map((c) => (
+        <button
+          key={c.key}
+          title={c.label}
+          onClick={() => handleColor(c.key)}
+          disabled={busy}
+          className={`w-7 h-7 rounded-full ${c.bg} border-2 transition-all hover:scale-110 disabled:opacity-50 ${
+            existingAnnotation?.color === c.key ? `${c.border} scale-110` : "border-transparent"
+          }`}
+          aria-label={c.label}
+        />
+      ))}
+      {onOpenNote && (
+        <button
+          title="Add note"
+          onClick={onOpenNote}
+          disabled={busy}
+          className="w-7 h-7 rounded-full bg-stone-100 border border-stone-300 flex items-center justify-center text-stone-500 hover:bg-stone-200 transition-colors"
+          aria-label="Add note"
+        >
+          <NoteIcon className="w-3.5 h-3.5" />
+        </button>
+      )}
+      {existingAnnotation && (
+        <button
+          title="Delete highlight"
+          onClick={handleDelete}
+          disabled={busy}
+          className="w-7 h-7 rounded-full bg-red-50 border border-red-200 flex items-center justify-center text-red-500 hover:bg-red-100 transition-colors disabled:opacity-50"
+          aria-label="Delete highlight"
+        >
+          <TrashIcon className="w-3.5 h-3.5" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -268,6 +268,15 @@ interface Props {
     chapterIndex: number,
     position: { x: number; y: number },
   ) => void;
+  /**
+   * Called when the user clicks an already-annotated segment.
+   * Provides the annotation and the click position so the parent can open
+   * an inline color-picker / delete panel without navigating away.
+   */
+  onAnnotationClick?: (
+    annotation: Annotation,
+    position: { x: number; y: number },
+  ) => void;
   /** Chapter index — used with onAnnotate. */
   chapterIndex?: number;
   /** Existing annotations to highlight matching segments. */
@@ -397,6 +406,7 @@ export default function SentenceReader({
   translationDisplayMode = "parallel",
   translationLoading = false,
   onAnnotate,
+  onAnnotationClick,
   chapterIndex = 0,
   annotations,
   scrollTargetSentence,
@@ -679,6 +689,11 @@ export default function SentenceReader({
                 if (disabled || !isSegmentLoaded(seg)) return;
                 // Ignore clicks that are the tail of a text-selection drag
                 if (window.getSelection()?.toString().length) return;
+                const ann = showAnnotations ? getAnnotation(seg.text) : undefined;
+                if (ann && onAnnotationClick) {
+                  onAnnotationClick(ann, { x: e.clientX, y: e.clientY });
+                  return;
+                }
                 if (isPlaying || duration > 0) {
                   onSegmentClick(seg.startTime, seg.text);
                 }

--- a/frontend/src/components/TTSControls.tsx
+++ b/frontend/src/components/TTSControls.tsx
@@ -67,6 +67,7 @@ export default function TTSControls({
   const chunksRef = useRef<ChunkState[]>([]);
   const activeIndexRef = useRef<number>(0);
 
+  const statusRef = useRef<Status>("idle");
   const abortRef = useRef<AbortController | null>(null);
   const genRef = useRef(0);
 
@@ -86,6 +87,7 @@ export default function TTSControls({
   useEffect(() => { stopAtTimeRef.current = stopAtTime; }, [stopAtTime]);
 
   useEffect(() => {
+    statusRef.current = status;
     onLoadingChangeRef.current?.(status === "loading");
   }, [status]);
   useEffect(() => {
@@ -332,10 +334,14 @@ export default function TTSControls({
 
   async function seekTo(globalTime: number) {
     if (chunksRef.current.length === 0) {
-      await loadAndPlay(globalTime);
+      // Only start loading+playing if audio was already playing
+      if (statusRef.current === "playing") {
+        await loadAndPlay(globalTime);
+      }
       return;
     }
 
+    const wasPlaying = statusRef.current === "playing";
     let cumulative = 0;
     for (let i = 0; i < chunksRef.current.length; i++) {
       const chunk = chunksRef.current[i];
@@ -349,11 +355,15 @@ export default function TTSControls({
         chunk.audio.currentTime = Math.min(offset, chunk.duration);
         activeIndexRef.current = i;
         chunk.audio.playbackRate = rate;
-        try {
-          await chunk.audio.play();
-          setStatus("playing");
-        } catch {
-          // ignore — user-gesture rules etc.
+        if (wasPlaying) {
+          try {
+            await chunk.audio.play();
+            setStatus("playing");
+          } catch {
+            // ignore — user-gesture rules etc.
+          }
+        } else {
+          setStatus("paused");
         }
         setGlobalCurrentTime(globalTime);
         saveAudioPosition(bookId, chapterIndex, globalTime);

--- a/frontend/src/components/TTSControls.tsx
+++ b/frontend/src/components/TTSControls.tsx
@@ -20,6 +20,7 @@ interface Props {
   onLoadingChange?: (isLoading: boolean) => void;
   onChunksUpdate?: (chunks: ChunkSnapshot[]) => void;
   onSeekRegister?: (seekAndPlay: (time: number) => void) => void;
+  onControlsRegister?: (controls: { pause: () => void; play: () => void }) => void;
   /** Auto-pause when globalCurrentTime reaches this value. */
   stopAtTime?: number;
   /** Called when stopAtTime is reached and audio is auto-paused. */
@@ -51,6 +52,7 @@ export default function TTSControls({
   onLoadingChange,
   onChunksUpdate,
   onSeekRegister,
+  onControlsRegister,
   stopAtTime,
   onStopAtReached,
 }: Props) {
@@ -77,12 +79,14 @@ export default function TTSControls({
   const onLoadingChangeRef = useRef(onLoadingChange);
   const onChunksUpdateRef = useRef(onChunksUpdate);
   const onSeekRegisterRef = useRef(onSeekRegister);
+  const onControlsRegisterRef = useRef(onControlsRegister);
   const onStopAtReachedRef = useRef(onStopAtReached);
   const stopAtTimeRef = useRef(stopAtTime);
   useEffect(() => { onPlaybackUpdateRef.current = onPlaybackUpdate; }, [onPlaybackUpdate]);
   useEffect(() => { onLoadingChangeRef.current = onLoadingChange; }, [onLoadingChange]);
   useEffect(() => { onChunksUpdateRef.current = onChunksUpdate; }, [onChunksUpdate]);
   useEffect(() => { onSeekRegisterRef.current = onSeekRegister; }, [onSeekRegister]);
+  useEffect(() => { onControlsRegisterRef.current = onControlsRegister; }, [onControlsRegister]);
   useEffect(() => { onStopAtReachedRef.current = onStopAtReached; }, [onStopAtReached]);
   useEffect(() => { stopAtTimeRef.current = stopAtTime; }, [stopAtTime]);
 
@@ -388,6 +392,7 @@ export default function TTSControls({
 
   useEffect(() => {
     onSeekRegisterRef.current?.((time: number) => { seekTo(time); });
+    onControlsRegisterRef.current?.({ pause, play });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bookId, chapterIndex]);
 

--- a/frontend/src/components/TypographyPanel.tsx
+++ b/frontend/src/components/TypographyPanel.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { FontSize, LineHeight, ContentWidth, FontFamily, saveSettings } from "@/lib/settings";
 
 interface Props {
@@ -14,6 +14,8 @@ interface Props {
   onFontFamily: (v: FontFamily) => void;
   onParagraphFocus: (v: boolean) => void;
   onClose: () => void;
+  /** When provided, panel renders as position:fixed anchored to this point. */
+  anchorPos?: { x: number; y: number };
 }
 
 type Option<T> = { value: T; label: string };
@@ -82,6 +84,7 @@ export default function TypographyPanel({
   onFontFamily,
   onParagraphFocus,
   onClose,
+  anchorPos,
 }: Props) {
   const panelRef = useRef<HTMLDivElement>(null);
 
@@ -102,10 +105,20 @@ export default function TypographyPanel({
     };
   }
 
+  const fixedStyle: React.CSSProperties = anchorPos
+    ? {
+        position: "fixed",
+        top: anchorPos.y + 4,
+        left: Math.max(8, Math.min(anchorPos.x - 256, window.innerWidth - 264)),
+        zIndex: 1000,
+      }
+    : {};
+
   return (
     <div
       ref={panelRef}
-      className="absolute top-full right-0 mt-1 z-50 bg-white border border-amber-200 rounded-xl shadow-lg p-4 w-64 animate-fade-in"
+      style={fixedStyle}
+      className={`${anchorPos ? "" : "absolute top-full right-0 mt-1 z-50 "}bg-white border border-amber-200 rounded-xl shadow-lg p-4 w-64 animate-fade-in`}
       data-testid="typography-panel"
     >
       <div className="space-y-4">

--- a/frontend/src/components/UndoToast.tsx
+++ b/frontend/src/components/UndoToast.tsx
@@ -1,0 +1,47 @@
+"use client";
+import { useEffect, useState } from "react";
+
+const DURATION_MS = 3000;
+
+interface Props {
+  message: string;
+  onUndo: () => void;
+  onDone: () => void;
+}
+
+export default function UndoToast({ message, onUndo, onDone }: Props) {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setVisible(false);
+      setTimeout(onDone, 300);
+    }, DURATION_MS);
+    return () => clearTimeout(timer);
+  }, [onDone]);
+
+  function handleUndo() {
+    setVisible(false);
+    onUndo();
+    setTimeout(onDone, 300);
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className={`fixed bottom-6 left-1/2 -translate-x-1/2 z-50 bg-stone-800 text-white rounded-xl shadow-xl px-4 py-3 text-sm flex items-center gap-3 transition-all duration-300 ${
+        visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+      }`}
+    >
+      <span>{message}</span>
+      <button
+        onClick={handleUndo}
+        className="font-semibold text-amber-300 hover:text-amber-200 transition-colors shrink-0"
+      >
+        Undo
+      </button>
+    </div>
+  );
+}

--- a/scripts/pretranslate.py
+++ b/scripts/pretranslate.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""
+Pre-translate books offline and write results to the translations cache.
+
+Primary:  Helsinki-NLP/MarianMT  (free, CPU-friendly, ~300 MB/language pair)
+Fallback: Ollama local LLM       (free, needs GPU for speed, any language)
+
+Install extra dependencies first:
+    pip install torch --index-url https://download.pytorch.org/whl/cpu
+    pip install -r scripts/requirements-pretranslate.txt
+
+Usage:
+    # Translate one book into German (MarianMT default)
+    python scripts/pretranslate.py --book-id 1342 --lang de
+
+    # Translate all books into French using Ollama
+    python scripts/pretranslate.py --all --lang fr --provider ollama --model llama3:8b
+
+    # Preview only — no DB writes
+    python scripts/pretranslate.py --book-id 1342 --lang de --dry-run
+
+    # Re-translate even if cache exists
+    python scripts/pretranslate.py --book-id 1342 --lang de --force
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import sys
+import time
+
+# ── Bootstrap: add backend to sys.path so we can import services ─────────────
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+BACKEND_DIR = os.path.join(SCRIPT_DIR, "..", "backend")
+sys.path.insert(0, BACKEND_DIR)
+
+# ── Language pairs supported by MarianMT with good quality ───────────────────
+# Model name pattern: Helsinki-NLP/opus-mt-{src}-{tgt}
+# Priority order: zh > de > fr > it (future) > es (future)
+MARIAN_PAIRS: dict[str, str] = {
+    "zh": "Helsinki-NLP/opus-mt-en-zh",   # priority 1
+    "de": "Helsinki-NLP/opus-mt-en-de",   # priority 2
+    "fr": "Helsinki-NLP/opus-mt-en-fr",   # priority 3
+    "it": "Helsinki-NLP/opus-mt-en-it",   # priority 4 (optional, future)
+    "es": "Helsinki-NLP/opus-mt-en-es",   # priority 5 (optional, future)
+    "ru": "Helsinki-NLP/opus-mt-en-ru",
+    "nl": "Helsinki-NLP/opus-mt-en-nl",
+    "pt": "Helsinki-NLP/opus-mt-en-pt",
+    "pl": "Helsinki-NLP/opus-mt-en-pl",
+    "ja": "Helsinki-NLP/opus-mt-en-jap",
+}
+
+MARIAN_MAX_TOKENS = 480  # Leave headroom below the 512-token limit
+SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+(?=[A-ZÀ-ɏ一-鿿])")
+
+
+# ── Text chunking ─────────────────────────────────────────────────────────────
+
+def _split_sentences(text: str) -> list[str]:
+    parts = SENTENCE_SPLIT_RE.split(text.strip())
+    return [p.strip() for p in parts if p.strip()]
+
+
+def _chunk_for_marian(tokenizer, text: str) -> list[str]:
+    """Split text into chunks that fit within MARIAN_MAX_TOKENS tokens."""
+    sentences = _split_sentences(text)
+    if not sentences:
+        return [text] if text.strip() else []
+
+    chunks: list[str] = []
+    current: list[str] = []
+    current_len = 0
+
+    for sent in sentences:
+        sent_len = len(tokenizer.encode(sent))
+        if current and current_len + sent_len > MARIAN_MAX_TOKENS:
+            chunks.append(" ".join(current))
+            current = [sent]
+            current_len = sent_len
+        else:
+            current.append(sent)
+            current_len += sent_len
+
+    if current:
+        chunks.append(" ".join(current))
+
+    return chunks if chunks else [text]
+
+
+# ── MarianMT provider ─────────────────────────────────────────────────────────
+
+class MarianTranslator:
+    def __init__(self, lang: str):
+        model_name = MARIAN_PAIRS.get(lang)
+        if not model_name:
+            raise ValueError(
+                f"MarianMT does not have a quality model for '{lang}'. "
+                f"Supported: {', '.join(sorted(MARIAN_PAIRS))}. "
+                f"Use --provider ollama for other languages."
+            )
+        try:
+            from transformers import MarianMTModel, MarianTokenizer
+        except ImportError:
+            _missing_deps("transformers sentencepiece")
+
+        print(f"  Loading MarianMT model: {model_name}")
+        self.tokenizer = MarianTokenizer.from_pretrained(model_name)
+        self.model = MarianMTModel.from_pretrained(model_name)
+        self.model_name = model_name
+
+    def translate_paragraph(self, text: str) -> str:
+        if not text.strip():
+            return text
+        chunks = _chunk_for_marian(self.tokenizer, text)
+        translated_chunks: list[str] = []
+        for chunk in chunks:
+            inputs = self.tokenizer([chunk], return_tensors="pt", padding=True, truncation=True)
+            outputs = self.model.generate(**inputs)
+            translated = self.tokenizer.decode(outputs[0], skip_special_tokens=True)
+            translated_chunks.append(translated)
+        return " ".join(translated_chunks)
+
+    def provider_tag(self) -> str:
+        return "marian"
+
+    def model_tag(self) -> str:
+        return self.model_name
+
+
+# ── Ollama provider ───────────────────────────────────────────────────────────
+
+class OllamaTranslator:
+    def __init__(self, model: str, lang: str, base_url: str = "http://localhost:11434"):
+        self.model = model
+        self.lang = lang
+        self.base_url = base_url.rstrip("/")
+        self._check_connection()
+
+    def _check_connection(self) -> None:
+        try:
+            import requests
+            resp = requests.get(f"{self.base_url}/api/tags", timeout=5)
+            resp.raise_for_status()
+        except Exception as exc:
+            raise RuntimeError(
+                f"Cannot connect to Ollama at {self.base_url}. "
+                f"Start Ollama with: ollama serve\n  Error: {exc}"
+            )
+
+    def translate_paragraph(self, text: str) -> str:
+        if not text.strip():
+            return text
+        try:
+            import requests
+        except ImportError:
+            _missing_deps("requests")
+
+        lang_names = {
+            "de": "German", "fr": "French", "es": "Spanish", "it": "Italian",
+            "ru": "Russian", "nl": "Dutch", "pt": "Portuguese", "pl": "Polish",
+            "zh": "Chinese", "ja": "Japanese", "ko": "Korean", "ar": "Arabic",
+        }
+        target = lang_names.get(self.lang, self.lang)
+        prompt = (
+            f"Translate the following text to {target}. "
+            f"Return ONLY the translated text, no commentary, no explanation.\n\n"
+            f"{text}"
+        )
+        resp = requests.post(
+            f"{self.base_url}/api/generate",
+            json={"model": self.model, "prompt": prompt, "stream": False},
+            timeout=120,
+        )
+        resp.raise_for_status()
+        return resp.json().get("response", "").strip()
+
+    def provider_tag(self) -> str:
+        return "ollama"
+
+    def model_tag(self) -> str:
+        return self.model
+
+
+# ── DB helpers ────────────────────────────────────────────────────────────────
+
+async def _get_books(book_ids: list[int] | None) -> list[dict]:
+    """Return list of {id, meta, text_content} dicts."""
+    import aiosqlite
+    from services.db import DB_PATH
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        if book_ids:
+            placeholders = ",".join("?" * len(book_ids))
+            async with db.execute(
+                f"SELECT id, meta_json, text_content FROM books WHERE id IN ({placeholders})",
+                book_ids,
+            ) as cur:
+                return [dict(r) for r in await cur.fetchall()]
+        else:
+            async with db.execute(
+                "SELECT id, meta_json, text_content FROM books"
+            ) as cur:
+                return [dict(r) for r in await cur.fetchall()]
+
+
+async def _is_cached(book_id: int, chapter_index: int, lang: str) -> bool:
+    import aiosqlite
+    from services.db import DB_PATH
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "SELECT 1 FROM translations WHERE book_id=? AND chapter_index=? AND target_language=?",
+            (book_id, chapter_index, lang),
+        ) as cur:
+            return await cur.fetchone() is not None
+
+
+async def _save(book_id: int, chapter_index: int, lang: str,
+                paragraphs: list[str], provider: str, model: str) -> None:
+    from services.db import save_translation
+    await save_translation(
+        book_id, chapter_index, lang, paragraphs,
+        provider=provider, model=model,
+    )
+
+
+# ── Chapter extraction ────────────────────────────────────────────────────────
+
+def _get_chapters(book: dict) -> list[dict]:
+    """Return [{title, text}, ...] for a book row."""
+    text = book.get("text_content") or ""
+
+    # Uploaded book with confirmed chapters stored as JSON
+    if text.startswith("{"):
+        try:
+            data = json.loads(text)
+            if not data.get("draft", True):
+                return data.get("chapters", [])
+        except json.JSONDecodeError:
+            pass
+
+    # Gutenberg book — use splitter
+    from services.splitter import build_chapters
+    chapters = build_chapters(text)
+    return [{"title": ch.title, "text": ch.text} for ch in chapters]
+
+
+# ── Main translation loop ─────────────────────────────────────────────────────
+
+async def run(args: argparse.Namespace) -> None:
+    book_ids = [args.book_id] if args.book_id else None
+    books = await _get_books(book_ids)
+
+    if not books:
+        print("No books found.")
+        return
+
+    # Build translator
+    if args.provider == "marian":
+        translator = MarianTranslator(args.lang)
+    else:
+        translator = OllamaTranslator(args.model, args.lang,
+                                      base_url=args.ollama_url)
+
+    total_chapters = 0
+    translated_count = 0
+    skipped_count = 0
+
+    for book in books:
+        meta = json.loads(book.get("meta_json") or "{}")
+        title = meta.get("title", f"Book #{book['id']}")
+        chapters = _get_chapters(book)
+
+        print(f"\nBook {book['id']}: {title} — {len(chapters)} chapter(s)")
+
+        for idx, ch in enumerate(chapters):
+            already = not args.force and await _is_cached(book["id"], idx, args.lang)
+            total_chapters += 1
+
+            if already:
+                skipped_count += 1
+                print(f"  [{idx + 1}/{len(chapters)}] {ch['title'][:50]} — already cached, skipping")
+                continue
+
+            paragraphs = [p.strip() for p in ch["text"].split("\n\n") if p.strip()]
+            if not paragraphs:
+                print(f"  [{idx + 1}/{len(chapters)}] {ch['title'][:50]} — empty, skipping")
+                skipped_count += 1
+                continue
+
+            word_count = len(ch["text"].split())
+            print(f"  [{idx + 1}/{len(chapters)}] {ch['title'][:50]} ({word_count} words) ...", end="", flush=True)
+
+            if args.dry_run:
+                print(" [dry-run, skipped]")
+                skipped_count += 1
+                continue
+
+            t0 = time.time()
+            translated: list[str] = []
+            for para in paragraphs:
+                translated.append(translator.translate_paragraph(para))
+
+            elapsed = time.time() - t0
+            await _save(
+                book["id"], idx, args.lang, translated,
+                provider=translator.provider_tag(),
+                model=translator.model_tag(),
+            )
+            translated_count += 1
+            print(f" done ({elapsed:.1f}s)")
+
+    print(f"\nDone. {translated_count} translated, {skipped_count} skipped, {total_chapters} total.")
+
+
+# ── Error helpers ─────────────────────────────────────────────────────────────
+
+def _missing_deps(packages: str) -> None:
+    print(
+        f"\nMissing dependencies: {packages}\n"
+        f"Install with:\n"
+        f"  pip install torch --index-url https://download.pytorch.org/whl/cpu\n"
+        f"  pip install -r scripts/requirements-pretranslate.txt\n",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Pre-translate books offline and write results to the cache.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--book-id", type=int, metavar="N", help="Translate a single book by ID")
+    group.add_argument("--all", action="store_true", help="Translate all books in the DB")
+
+    parser.add_argument("--lang", required=True, metavar="LANG",
+                        help="Target language code (e.g. de, fr, es, zh)")
+    parser.add_argument("--provider", choices=["marian", "ollama"], default="marian",
+                        help="Translation provider (default: marian)")
+    parser.add_argument("--model", default="llama3:8b",
+                        help="Ollama model name (default: llama3:8b, ignored for marian)")
+    parser.add_argument("--ollama-url", default="http://localhost:11434",
+                        help="Ollama base URL (default: http://localhost:11434)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Preview what would be translated without writing to DB")
+    parser.add_argument("--force", action="store_true",
+                        help="Re-translate even if a cached translation exists")
+    parser.add_argument("--db", metavar="PATH",
+                        help="Override DB_PATH (defaults to backend/books.db or DB_PATH env)")
+
+    args = parser.parse_args()
+
+    if args.db:
+        os.environ["DB_PATH"] = args.db
+
+    if args.all:
+        args.book_id = None
+
+    if args.provider == "marian" and args.lang not in MARIAN_PAIRS:
+        print(
+            f"Warning: no MarianMT model for '{args.lang}'. "
+            f"Supported: {', '.join(sorted(MARIAN_PAIRS))}.\n"
+            f"Use --provider ollama for other languages.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/requirements-pretranslate.txt
+++ b/scripts/requirements-pretranslate.txt
@@ -1,0 +1,10 @@
+# Extra dependencies for scripts/pretranslate.py
+# Install with: pip install -r scripts/requirements-pretranslate.txt
+#
+# Note: torch CPU-only build is much smaller (~250 MB vs 2+ GB for GPU):
+#   pip install torch --index-url https://download.pytorch.org/whl/cpu
+#   pip install -r scripts/requirements-pretranslate.txt
+
+transformers>=4.40.0
+sentencepiece>=0.2.0
+requests>=2.28.0


### PR DESCRIPTION
## Summary

Closes #355

Uploaded books (`source='upload'`) are private to their owner, but the following endpoints served their content to any authenticated user:

- `GET /{book_id}/translation-status`
- `GET /{book_id}/chapters/{idx}/queue-status`
- `GET /{book_id}/chapters/{idx}/translation`
- `POST /{book_id}/chapters/{idx}/translation`
- `POST /{book_id}/translations/enqueue-all`
- `POST /{book_id}/chapters/{idx}/translation/retry`
- `POST /annotations`
- `POST /insights`
- `POST /ai/summary`
- `PUT /ai/translate/cache`

**Fix:** Add `check_book_access(book, user)` helper in `services/auth.py` that raises 403 for non-owner, non-admin access to uploaded books. Apply it to all affected endpoints. Replace the inline ownership checks in `book_meta` and `book_chapters` with the same helper.

The `request_chapter_translation` endpoint is restructured to load the book *before* checking the translation cache, so cached translations of private books cannot be served to non-owners.

## Tests

- 6 unit tests for `check_book_access` covering all access paths
- 10 integration tests for upload book access control across all book endpoints
- 1 integration test each for annotations, insights, and AI summary

All 975 backend tests pass.

⚠️ This PR depends on `feat/book-upload` (PR #347) for migration 021 (`source` and `owner_user_id` columns).
