### PR TITLE
feat: user book upload with access control

### DIFF
--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -942,6 +942,7 @@ async def test_import_stream_blocked_for_non_owner_of_uploaded_book(anon_client,
     )
 
 
+
 async def test_gutenberg_book_still_accessible_to_any_user(client, test_user, tmp_db):
     await save_book(9910, MOCK_META, "some text")
     resp = await client.get("/api/books/9910")


### PR DESCRIPTION
## Summary

- Adds user book upload: `.txt` and `.epub` files, per-user quota (5 books / 10 MB), drag-and-drop UI
- Two-panel chapter editor to review and confirm extracted chapters before the book is readable
- Enforces ownership on all chapter-level endpoints (translation, summary, annotation, insights) so uploaded books can only be accessed by their owner

## Changes

**Backend**
- `backend/migrations/021_user_books.sql` — adds `source` + `owner_user_id` columns to `books`; new `book_uploads` table
- `backend/services/book_parser.py` — `parse_txt()` (regex heuristics) and `parse_epub()` (ebooklib) chapter extraction
- `backend/routers/uploads.py` — POST /books/upload, GET /books/upload/quota, GET /books/{id}/chapters/draft, POST /books/{id}/chapters/confirm, DELETE /books/upload/{id}
- `backend/routers/ai.py`, `annotations.py`, `insights.py` — ownership guard on chapter-level endpoints (Closes #355)
- `backend/services/auth.py` — `verify_book_owner()` helper

**Frontend**
- `frontend/src/app/upload/page.tsx` — drag-and-drop upload with quota bar and sign-in gate
- `frontend/src/app/upload/[bookId]/chapters/page.tsx` — chapter editor (split/merge/rename)
- `frontend/src/app/page.tsx` — "Upload a book" entry point on the home page
- `frontend/src/lib/api.ts` — upload and chapter API calls

## Test plan

- [x] `test_router_uploads.py` — 181-line upload router test suite
- [x] `test_auth_service.py` — `verify_book_owner` helper tests
- [x] `test_router_annotations.py`, `test_router_insights.py`, `test_router_summary.py`, `test_router_books.py` — ownership guard coverage
- [x] `UploadPage.test.tsx` — frontend upload page tests
- [x] Full backend suite: 995 passed
- [x] Full frontend suite: 1554 passed

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)
