### PR TITLE
fix: split_with_html_preference handles uploaded book JSON text

### DIFF
--- a/backend/services/book_chapters.py
+++ b/backend/services/book_chapters.py
@@ -16,6 +16,7 @@ Chapter list for a book.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from collections import defaultdict
 
@@ -57,6 +58,22 @@ async def split_with_html_preference(book_id: int, text: str) -> list[Chapter]:
         cached = _chapter_cache.get(book_id)
         if cached is not None:
             return cached
+
+        # Uploaded books store chapters as JSON, not raw text.
+        # Detect and return pre-split chapters directly to avoid feeding
+        # JSON to the Gutenberg HTML / regex splitter.
+        if text and text.lstrip().startswith("{"):
+            try:
+                data = json.loads(text)
+                if not data.get("draft") and "chapters" in data:
+                    chapters: list[Chapter] = [
+                        Chapter(title=ch["title"], text=ch["text"])
+                        for ch in data["chapters"]
+                    ]
+                    _chapter_cache[book_id] = chapters
+                    return chapters
+            except (ValueError, KeyError, TypeError):
+                pass  # not a valid uploaded-book JSON — fall through to normal split
 
         try:
             html = await get_book_html(book_id)

--- a/backend/tests/test_router_uploads.py
+++ b/backend/tests/test_router_uploads.py
@@ -437,3 +437,50 @@ async def test_delete_uploaded_book_sql_guard_preserves_running_queue_row(
         "SQL guard (AND status != 'running') must preserve running queue rows "
         "even when Python 409 check is bypassed (#372)"
     )
+
+
+# ── Uploaded book chapter-split fix (#380) ────────────────────────────────────
+
+async def test_translation_status_uploaded_book_reports_correct_chapter_count(
+    client, test_user, tmp_db
+):
+    """Regression #380: translation-status must report the correct chapter count
+    for uploaded books. Previously, split_with_html_preference received JSON text
+    and produced wrong chapter counts."""
+    book_id = await _upload_and_confirm(client)
+
+    resp = await client.get(f"/api/books/{book_id}/translation-status?target_language=zh")
+    assert resp.status_code == 200
+    data = resp.json()
+    # The sample TXT has 2 chapters (Chapter 1 and Chapter 2); must not be 1 or garbage
+    assert data["total_chapters"] >= 2, (
+        f"total_chapters={data['total_chapters']} — split_with_html_preference "
+        "must return the uploaded book's pre-split chapters, not split JSON text (#380)"
+    )
+
+
+async def test_split_with_html_preference_handles_uploaded_book_json():
+    """Regression #380: split_with_html_preference must return correct chapters
+    when passed uploaded-book JSON text instead of raw book text."""
+    import json
+    from services.book_chapters import split_with_html_preference, clear_cache
+
+    uploaded_json = json.dumps({
+        "draft": False,
+        "chapters": [
+            {"title": "Chapter One", "text": "The first chapter content here."},
+            {"title": "Chapter Two", "text": "The second chapter content here."},
+            {"title": "Chapter Three", "text": "The third chapter content here."},
+        ]
+    })
+
+    clear_cache(99999)
+    chapters = await split_with_html_preference(99999, uploaded_json)
+    clear_cache(99999)
+
+    assert len(chapters) == 3, (
+        f"Expected 3 chapters from uploaded JSON, got {len(chapters)} (#380)"
+    )
+    assert chapters[0].title == "Chapter One"
+    assert "first chapter" in chapters[0].text
+    assert chapters[2].title == "Chapter Three"


### PR DESCRIPTION
## Summary

- Uploaded books store chapters as JSON (`{"draft": false, "chapters": [...]}`), not raw text
- `split_with_html_preference` received this JSON, passed it to the Gutenberg HTML fetcher (fails for non-Gutenberg IDs), then to `build_chapters(json_text)` which produced 1 chapter containing the entire JSON blob
- Two places were broken: `translation_status` reported `total_chapters=1` instead of the real count; the queue worker translated the raw JSON string instead of actual chapter text — any chapter at index > 0 failed with "chapter index out of range"

## Fix

In `split_with_html_preference`: detect if `text` is a confirmed-upload JSON blob (starts with `{`, parses with `draft: false` and `chapters` key) and return `Chapter` objects from the stored chapters directly, bypassing the Gutenberg/text-split path.

## Test plan

- `test_translation_status_uploaded_book_reports_correct_chapter_count`: verifies `total_chapters` >= 2 for a confirmed uploaded book
- `test_split_with_html_preference_handles_uploaded_book_json`: directly verifies the function returns 3 chapters with correct titles/text from uploaded JSON

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)
