### PR TITLE
fix: draft uploaded book guards for translation and chapter split

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -242,7 +242,22 @@ async def request_chapter_translation(
     if not book_meta:
         raise HTTPException(status_code=404, detail="Book not found")
 
-    # 0b. Guard: reject same-language translation.
+    # 0c. Guard: reject draft uploaded books — chapters not yet confirmed.
+    if book_meta.get("source") == "upload":
+        try:
+            import json as _json
+            _data = _json.loads(book_meta.get("text") or "{}")
+            if _data.get("draft"):
+                raise HTTPException(
+                    status_code=400,
+                    detail="Book chapters not yet confirmed. Confirm the chapter structure before translating.",
+                )
+        except HTTPException:
+            raise
+        except Exception:
+            pass
+
+    # 0d. Guard: reject same-language translation.
     source = (book_meta.get("languages") or [None])[0]
     if source and source.lower().split("-")[0] == target_language:
         raise HTTPException(

--- a/backend/routers/uploads.py
+++ b/backend/routers/uploads.py
@@ -216,6 +216,9 @@ async def confirm_chapters(
         )
         await db.commit()
 
+    # Invalidate any stale chapter-split cache from draft-state accesses.
+    from services.book_chapters import clear_cache as _clear_chapter_cache
+    _clear_chapter_cache(book_id)
     return {"ok": True, "chapter_count": len(final_chapters)}
 
 

--- a/backend/services/book_chapters.py
+++ b/backend/services/book_chapters.py
@@ -65,7 +65,11 @@ async def split_with_html_preference(book_id: int, text: str) -> list[Chapter]:
         if text and text.lstrip().startswith("{"):
             try:
                 data = json.loads(text)
-                if not data.get("draft") and "chapters" in data:
+                if "chapters" in data:
+                    if data.get("draft"):
+                        # Draft: not yet confirmed — no translatable chapters.
+                        # Do NOT cache; the caller should reject draft books explicitly.
+                        return []
                     chapters: list[Chapter] = [
                         Chapter(title=ch["title"], text=ch["text"])
                         for ch in data["chapters"]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -29,6 +29,22 @@ def no_wiktionary_http(monkeypatch):
     monkeypatch.setattr(db_module, "_update_lemma", AsyncMock(return_value=None))
 
 
+@pytest.fixture(autouse=True)
+def clear_chapter_cache():
+    """Reset the in-memory chapter-split cache between tests.
+
+    The cache is a process-level dict keyed by book_id. Without this,
+    a test that confirms an uploaded book (id=1) populates the cache,
+    and a later test that uploads a *draft* book (also id=1 in a fresh
+    temp DB) receives stale confirmed chapters — causing wrong
+    total_chapters counts.
+    """
+    from services.book_chapters import clear_cache
+    clear_cache()
+    yield
+    clear_cache()
+
+
 @pytest.fixture
 async def tmp_db(monkeypatch, tmp_path):
     path = str(tmp_path / "test.db")

--- a/backend/tests/test_router_uploads.py
+++ b/backend/tests/test_router_uploads.py
@@ -484,3 +484,35 @@ async def test_split_with_html_preference_handles_uploaded_book_json():
     assert chapters[0].title == "Chapter One"
     assert "first chapter" in chapters[0].text
     assert chapters[2].title == "Chapter Three"
+
+
+async def test_translation_status_draft_book_reports_zero_chapters(client, test_user):
+    """Regression #380: translation-status must report total_chapters=0 for a
+    draft uploaded book (not yet confirmed by the user)."""
+    # Upload but do NOT confirm → book stays in draft state
+    upload_resp = await client.post("/api/books/upload", files=_txt_upload())
+    assert upload_resp.status_code == 200
+    book_id = upload_resp.json()["book_id"]
+
+    resp = await client.get(f"/api/books/{book_id}/translation-status?target_language=zh")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_chapters"] == 0, (
+        f"Draft uploaded book must report total_chapters=0, got {data['total_chapters']} (#380)"
+    )
+
+
+async def test_request_translation_rejects_draft_book(client, test_user):
+    """Regression #380: POST /books/{id}/chapters/{ch}/translation must return
+    400 for a draft uploaded book — chapters not yet confirmed."""
+    upload_resp = await client.post("/api/books/upload", files=_txt_upload())
+    book_id = upload_resp.json()["book_id"]
+
+    resp = await client.post(
+        f"/api/books/{book_id}/chapters/0/translation",
+        json={"target_language": "zh"},
+    )
+    assert resp.status_code == 400, (
+        f"Expected 400 for draft book translation request, got {resp.status_code} (#380)"
+    )
+    assert "draft" in resp.json()["detail"].lower() or "confirm" in resp.json()["detail"].lower()


### PR DESCRIPTION
## Summary

Follow-up to #381 — three additional guards for draft uploaded books:

- `split_with_html_preference`: return `[]` for draft books (without caching) so callers get an empty chapter list rather than 1 garbage chapter from regex-splitting JSON
- `request_chapter_translation`: reject draft books with 400 before reaching the Gemini key check — chapter confirmation is a prerequisite for translation
- `confirm_chapters`: clear the in-memory chapter cache after confirmation so the newly-confirmed chapters are used on the next access

Also adds an autouse test fixture to clear the process-level chapter cache between tests, preventing cross-test contamination.

## Test plan

- `test_translation_status_draft_book_reports_zero_chapters`: verifies `total_chapters=0` for a draft uploaded book
- `test_request_translation_rejects_draft_book`: verifies 400 is returned before the Gemini key guard
- Full suite: 1004 tests pass

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)
