### PR TITLE
fix: import-stream enforces access control for private uploaded books

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -503,8 +503,14 @@ async def import_stream(
     /books/{id}/translations/enqueue-all.
 
     Idempotent: skips already-cached work.
-    All books are publicly accessible without login.
+    Gutenberg books are publicly accessible; uploaded books require ownership.
     """
+    # Access guard runs before the stream starts so the HTTP status is 403,
+    # not a mid-stream error. Uploaded books are private; Gutenberg books are
+    # not yet in the DB at this point so no check is needed for them.
+    _pre_cached = await get_cached_book(book_id)
+    if _pre_cached:
+        check_book_access(_pre_cached, user)
 
     async def generator() -> AsyncIterator[str]:
         try:

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -927,6 +927,21 @@ async def test_upload_book_retry_translation_blocked_for_non_owner(client, test_
     assert resp.status_code == 403, resp.text
 
 
+async def test_import_stream_blocked_for_non_owner_of_uploaded_book(anon_client, tmp_db):
+    """Regression #383: import-stream must return 403 for an uploaded (private)
+    book when the requester is not the owner. Previously the access check was
+    missing and chapter titles / word counts were leaked."""
+    import services.db as _db
+    from services.db import get_or_create_user
+    owner = await get_or_create_user("owner-gid-is", "owner-is@ex.com", "OwnerIS", "")
+    await _insert_upload_book(9909, owner["id"])
+    resp = await anon_client.get("/api/books/9909/import-stream")
+    assert resp.status_code == 403, (
+        f"Expected 403 for unauthenticated access to private uploaded book import-stream, "
+        f"got {resp.status_code} (#383)"
+    )
+
+
 async def test_gutenberg_book_still_accessible_to_any_user(client, test_user, tmp_db):
     await save_book(9910, MOCK_META, "some text")
     resp = await client.get("/api/books/9910")


### PR DESCRIPTION
## Summary

`GET /books/{book_id}/import-stream` was missing a `check_book_access()` call for uploaded (private) books. Any unauthenticated or unauthorized user could stream the chapter titles and word counts of a private book — the same data blocked by every other book endpoint (`/books/{id}`, `/books/{id}/chapters`, etc.).

Fix: call `get_cached_book` + `check_book_access` in the endpoint function body before starting the `StreamingResponse` generator, so FastAPI returns a proper 403 before any data is sent.

Gutenberg books that haven't been fetched yet (not in DB) are unaffected — no access check is needed since they're public.

## Test plan

- `test_import_stream_blocked_for_non_owner_of_uploaded_book`: inserts a private uploaded book, calls import-stream as anonymous user, expects 403
- `test_import_stream_public_without_login`: existing test confirms Gutenberg books still stream without auth

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)
