### PR TITLE
fix: pretranslate script wrong DB column names + lazy translator init

### DIFF
--- a/backend/tests/test_pretranslate.py
+++ b/backend/tests/test_pretranslate.py
@@ -82,7 +82,7 @@ def test_get_chapters_from_confirmed_json():
         {"title": "Chapter I", "text": "First chapter text."},
         {"title": "Chapter II", "text": "Second chapter text."},
     ]
-    book = {"text_content": json.dumps({"draft": False, "chapters": chapters})}
+    book = {"text": json.dumps({"draft": False, "chapters": chapters})}
     result = pt._get_chapters(book)
     assert len(result) == 2
     assert result[0]["title"] == "Chapter I"
@@ -90,7 +90,7 @@ def test_get_chapters_from_confirmed_json():
 
 
 def test_get_chapters_skips_draft_json():
-    book = {"text_content": json.dumps({"draft": True, "chapters": []})}
+    book = {"text": json.dumps({"draft": True, "chapters": []})}
     # Draft books fall back to splitter — patch at source module
     with patch("services.splitter.build_chapters", return_value=[]) as mock_split:
         result = pt._get_chapters(book)
@@ -98,7 +98,7 @@ def test_get_chapters_skips_draft_json():
 
 
 def test_get_chapters_from_gutenberg_text():
-    book = {"text_content": "Chapter I\n\nSome text here.\n\nChapter II\n\nMore text."}
+    book = {"text": "Chapter I\n\nSome text here.\n\nChapter II\n\nMore text."}
     with patch("services.splitter.build_chapters") as mock_split:
         mock_split.return_value = [
             MagicMock(title="Chapter I", text="Some text here."),
@@ -110,7 +110,7 @@ def test_get_chapters_from_gutenberg_text():
 
 
 def test_get_chapters_empty_text():
-    book = {"text_content": ""}
+    book = {"text": ""}
     with patch("services.splitter.build_chapters", return_value=[]):
         result = pt._get_chapters(book)
     assert result == []

--- a/scripts/pretranslate.py
+++ b/scripts/pretranslate.py
@@ -186,7 +186,7 @@ class OllamaTranslator:
 # ── DB helpers ────────────────────────────────────────────────────────────────
 
 async def _get_books(book_ids: list[int] | None) -> list[dict]:
-    """Return list of {id, meta, text_content} dicts."""
+    """Return list of {id, title, text} dicts."""
     import aiosqlite
     from services.db import DB_PATH
     async with aiosqlite.connect(DB_PATH) as db:
@@ -194,13 +194,13 @@ async def _get_books(book_ids: list[int] | None) -> list[dict]:
         if book_ids:
             placeholders = ",".join("?" * len(book_ids))
             async with db.execute(
-                f"SELECT id, meta_json, text_content FROM books WHERE id IN ({placeholders})",
+                f"SELECT id, title, text FROM books WHERE id IN ({placeholders})",
                 book_ids,
             ) as cur:
                 return [dict(r) for r in await cur.fetchall()]
         else:
             async with db.execute(
-                "SELECT id, meta_json, text_content FROM books"
+                "SELECT id, title, text FROM books"
             ) as cur:
                 return [dict(r) for r in await cur.fetchall()]
 
@@ -229,7 +229,7 @@ async def _save(book_id: int, chapter_index: int, lang: str,
 
 def _get_chapters(book: dict) -> list[dict]:
     """Return [{title, text}, ...] for a book row."""
-    text = book.get("text_content") or ""
+    text = book.get("text") or ""
 
     # Uploaded book with confirmed chapters stored as JSON
     if text.startswith("{"):
@@ -256,20 +256,25 @@ async def run(args: argparse.Namespace) -> None:
         print("No books found.")
         return
 
-    # Build translator
-    if args.provider == "marian":
-        translator = MarianTranslator(args.lang)
-    else:
-        translator = OllamaTranslator(args.model, args.lang,
-                                      base_url=args.ollama_url)
+    # Translator is loaded lazily on first real translation (skipped for --dry-run)
+    translator = None
+
+    def _get_translator():
+        nonlocal translator
+        if translator is None:
+            if args.provider == "marian":
+                translator = MarianTranslator(args.lang)
+            else:
+                translator = OllamaTranslator(args.model, args.lang,
+                                              base_url=args.ollama_url)
+        return translator
 
     total_chapters = 0
     translated_count = 0
     skipped_count = 0
 
     for book in books:
-        meta = json.loads(book.get("meta_json") or "{}")
-        title = meta.get("title", f"Book #{book['id']}")
+        title = book.get("title") or f"Book #{book['id']}"
         chapters = _get_chapters(book)
 
         print(f"\nBook {book['id']}: {title} — {len(chapters)} chapter(s)")
@@ -297,16 +302,17 @@ async def run(args: argparse.Namespace) -> None:
                 skipped_count += 1
                 continue
 
+            t = _get_translator()
             t0 = time.time()
             translated: list[str] = []
             for para in paragraphs:
-                translated.append(translator.translate_paragraph(para))
+                translated.append(t.translate_paragraph(para))
 
             elapsed = time.time() - t0
             await _save(
                 book["id"], idx, args.lang, translated,
-                provider=translator.provider_tag(),
-                model=translator.model_tag(),
+                provider=t.provider_tag(),
+                model=t.model_tag(),
             )
             translated_count += 1
             print(f" done ({elapsed:.1f}s)")


### PR DESCRIPTION
## Summary

- Fixes `scripts/pretranslate.py` querying non-existent columns `meta_json` and `text_content` — the `books` table uses `title` and `text`
- Makes translator lazy-initialized so `--dry-run` works without installing torch/transformers
- Updates test fixtures to use the correct `text` key

## Root cause

The script was written assuming a different schema, but the actual DB schema (from migration 001) uses `title` and `text`. This caused an `OperationalError: no such column: meta_json` crash on any real invocation.

## Test plan

- [x] 17 pretranslate unit tests pass
- [x] `--dry-run` on book 1952 (The Yellow Wallpaper) runs without requiring torch installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
