### PR TITLE
fix: check_book_access for vocabulary POST and ai translate cache endpoints

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -221,6 +221,10 @@ async def translate_cache(
     _user: dict = Depends(get_current_user),
 ):
     """Check if a translation is cached. Returns paragraphs + provider/model if yes, 404 if not."""
+    book = await get_cached_book(book_id)
+    if not book:
+        raise HTTPException(status_code=404, detail="Book not found")
+    check_book_access(book, _user)
     target_language = target_language.lower().split("-")[0]
     from services.db import get_cached_translation_with_meta
     cached = await get_cached_translation_with_meta(book_id, chapter_index, target_language)
@@ -281,19 +285,23 @@ async def translate(req: TranslateRequest, user: dict = Depends(get_current_user
     if src == tgt:
         raise HTTPException(status_code=400, detail="Source and target language are the same.")
     try:
+        # Validate book existence and access BEFORE cache lookup — checking the
+        # cache first would leak cached translation content of private uploaded
+        # books to any authenticated user who knows the book_id.
+        if req.book_id is not None:
+            _book = await get_cached_book(req.book_id)
+            if not _book:
+                raise HTTPException(status_code=404, detail="Book not found")
+            check_book_access(_book, user)
+        if req.chapter_index is not None and req.chapter_index < 0:
+            raise HTTPException(status_code=400, detail="chapter_index must be >= 0")
+
         # Check shared DB cache first — cache hits don't need any key.
         # Use normalized codes so "ZH" and "zh-CN" both hit a "zh" cache entry.
         if req.book_id is not None and req.chapter_index is not None:
             cached = await get_cached_translation(req.book_id, req.chapter_index, tgt)
             if cached:
                 return {"paragraphs": cached, "cached": True}
-
-        # Validate book/chapter before spending API quota on translation.
-        if req.book_id is not None:
-            if not await get_cached_book(req.book_id):
-                raise HTTPException(status_code=404, detail="Book not found")
-        if req.chapter_index is not None and req.chapter_index < 0:
-            raise HTTPException(status_code=400, detail="chapter_index must be >= 0")
 
         # Resolve "auto" to a concrete provider
         raw_key = user.get("gemini_key")

--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -6,7 +6,7 @@ import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from services.auth import get_current_user, encrypt_api_key, decrypt_api_key
+from services.auth import get_current_user, encrypt_api_key, decrypt_api_key, check_book_access
 from services.db import (
     save_word,
     get_vocabulary,
@@ -38,8 +38,10 @@ async def save(req: WordSave, user: dict = Depends(get_current_user)):
         raise HTTPException(status_code=400, detail="Word cannot be empty")
     if not req.sentence_text or not req.sentence_text.strip():
         raise HTTPException(status_code=400, detail="sentence_text cannot be empty")
-    if not await get_cached_book(req.book_id):
+    book = await get_cached_book(req.book_id)
+    if not book:
         raise HTTPException(status_code=404, detail="Book not found")
+    check_book_access(book, user)
     return await save_word(
         user["id"],
         req.word,

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -11,9 +11,12 @@ Focuses on:
 """
 
 import asyncio
+import json
 import pytest
+import aiosqlite
 from unittest.mock import AsyncMock, patch
-from services.db import save_book, save_translation, get_cached_translation, set_user_gemini_key, set_setting
+from services.db import save_book, save_translation, get_cached_translation, set_user_gemini_key, set_setting, get_or_create_user
+import services.db as db_module
 from services.auth import encrypt_api_key
 
 
@@ -35,6 +38,7 @@ async def test_translate_normalizes_language_codes(client):
     Translation stored under 'zh' must be a cache hit when the client
     sends 'ZH' or 'zh-CN'.  Without normalization, 'tgt' is computed but
     discarded — the raw req.target_language hits the DB and misses."""
+    await save_book(1342, _BOOK_META, "text")
     await save_translation(1342, 0, "zh", TRANSLATED)
 
     with patch("routers.ai.gemini") as mock_gemini:
@@ -54,6 +58,7 @@ async def test_translate_normalizes_language_codes(client):
 
 async def test_translate_cache_hit_works_without_key(client):
     """Cache hits return the stored result without hitting Gemini at all."""
+    await save_book(1342, _BOOK_META, "text")
     await save_translation(1342, 0, "en", TRANSLATED)
 
     with patch("routers.ai.gemini") as mock_gemini:
@@ -149,6 +154,8 @@ async def test_translate_same_language_base_code_returns_400(client, test_user):
 
 async def test_translate_cache_get_returns_cached(client):
     """GET /translate/cache returns cached translation."""
+    _m = {"title": "T", "authors": [], "languages": ["de"], "subjects": [], "download_count": 0, "cover": ""}
+    await save_book(1, _m, "text")
     await save_translation(1, 0, "en", TRANSLATED)
     resp = await client.get("/api/ai/translate/cache?book_id=1&chapter_index=0&target_language=en")
     assert resp.status_code == 200
@@ -165,6 +172,8 @@ async def test_translate_cache_get_normalizes_language(client):
     """GET /translate/cache?target_language=ZH must hit a 'zh' row.
 
     Without normalization the lookup uses 'ZH' as-is and misses 'zh'."""
+    _m = {"title": "T", "authors": [], "languages": ["de"], "subjects": [], "download_count": 0, "cover": ""}
+    await save_book(5, _m, "text")
     await save_translation(5, 0, "zh", ["翻译"])
     resp = await client.get("/api/ai/translate/cache?book_id=5&chapter_index=0&target_language=ZH")
     assert resp.status_code == 200
@@ -590,5 +599,62 @@ async def test_summary_concurrent_requests_call_gemini_once(client, test_user, t
     assert call_count == 1, (
         f"Expected 1 Gemini call for concurrent requests to the same chapter, "
         f"got {call_count}. Missing per-key asyncio.Lock in the summary endpoint."
+    )
+
+
+# ── Access control for private uploaded books ────────────────────────────────
+
+async def _insert_private_book_ai(book_id: int, owner_user_id: int) -> None:
+    chapters = json.dumps({"draft": False, "chapters": [{"title": "Ch1", "text": "private"}]})
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            """INSERT OR REPLACE INTO books
+               (id, title, authors, languages, subjects, download_count,
+                cover, text, images, source, owner_user_id)
+               VALUES (?, 'Private Book', '[]', '["de"]', '[]', 0, '', ?, '[]', 'upload', ?)""",
+            (book_id, chapters, owner_user_id),
+        )
+        await db.commit()
+
+
+async def test_translate_cache_get_blocked_for_non_owner(client, test_user, tmp_db):
+    """GET /ai/translate/cache for a private uploaded book returns 403 for non-owners.
+
+    Without check_book_access the endpoint returns cached translation paragraphs
+    to any authenticated user who knows the book_id (sequential integer)."""
+    from services.db import set_user_role
+    await set_user_role(test_user["id"], "user")
+    owner = await get_or_create_user("ai-owner-gid1", "ai-owner1@ex.com", "AIOwner1", "")
+    await _insert_private_book_ai(8901, owner["id"])
+    await save_translation(8901, 0, "en", ["Private translation content."])
+    resp = await client.get(
+        "/api/ai/translate/cache?book_id=8901&chapter_index=0&target_language=en"
+    )
+    assert resp.status_code == 403, (
+        f"Expected 403 for non-owner reading cached translation of private book, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_translate_post_cache_hit_blocked_for_non_owner(client, test_user, tmp_db):
+    """POST /ai/translate with book_id of a private uploaded book returns 403 for non-owners.
+
+    Without check_book_access the endpoint returns the cached translated chapter
+    content to any authenticated user — the access check must precede the cache lookup."""
+    from services.db import set_user_role
+    await set_user_role(test_user["id"], "user")
+    owner = await get_or_create_user("ai-owner-gid2", "ai-owner2@ex.com", "AIOwner2", "")
+    await _insert_private_book_ai(8902, owner["id"])
+    await save_translation(8902, 0, "en", ["Private translated paragraph."])
+    resp = await client.post("/api/ai/translate", json={
+        "text": "Es war einmal.",
+        "source_language": "de",
+        "target_language": "en",
+        "book_id": 8902,
+        "chapter_index": 0,
+    })
+    assert resp.status_code == 403, (
+        f"Expected 403 for non-owner accessing cached translation of private book via POST /ai/translate, "
+        f"got {resp.status_code}: {resp.text}"
     )
 

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -2,9 +2,12 @@
 Tests for routers/vocabulary.py — save/get/delete words and Obsidian export.
 """
 
+import json
 import pytest
+import aiosqlite
 from unittest.mock import AsyncMock, patch
-from services.db import save_book, save_word, update_obsidian_settings
+from services.db import save_book, save_word, update_obsidian_settings, get_or_create_user
+import services.db as db_module
 from services.auth import encrypt_api_key
 
 _BOOK_META = {
@@ -329,6 +332,41 @@ async def test_export_without_settings_returns_400(client, test_user):
     resp = await client.post("/api/vocabulary/export/obsidian", json={"book_id": BOOK_ID})
     assert resp.status_code == 400
     assert "not configured" in resp.json()["detail"]
+
+
+# ── Access control for private uploaded books ─────────────────────────────────
+
+async def _insert_private_book(book_id: int, owner_user_id: int) -> None:
+    chapters = json.dumps({"draft": False, "chapters": [{"title": "Ch1", "text": "private"}]})
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            """INSERT OR REPLACE INTO books
+               (id, title, authors, languages, subjects, download_count,
+                cover, text, images, source, owner_user_id)
+               VALUES (?, 'Private Book', '[]', '["en"]', '[]', 0, '', ?, '[]', 'upload', ?)""",
+            (book_id, chapters, owner_user_id),
+        )
+        await db.commit()
+
+
+async def test_save_word_blocked_for_non_owner_of_uploaded_book(client, test_user, tmp_db):
+    """POST /vocabulary for a private uploaded book must return 403 for non-owners.
+
+    Without check_book_access the endpoint only checks existence (404 vs 200);
+    any authenticated user can save vocabulary entries for another user's private book."""
+    from services.db import set_user_role
+    await set_user_role(test_user["id"], "user")
+    owner = await get_or_create_user("voc-owner-gid", "voc-owner@ex.com", "VocOwner", "")
+    await _insert_private_book(8801, owner["id"])
+    resp = await client.post("/api/vocabulary", json={
+        "word": "secret",
+        "book_id": 8801,
+        "chapter_index": 0,
+        "sentence_text": "A secret sentence.",
+    })
+    assert resp.status_code == 403, (
+        f"Expected 403 for non-owner saving vocab for private book, got {resp.status_code}: {resp.text}"
+    )
 
 
 async def test_export_github_api_error_returns_502(client, test_user):


### PR DESCRIPTION
## Summary
- `POST /vocabulary` was missing `check_book_access` — any authenticated user could save vocabulary entries for another user's private uploaded book
- `GET /ai/translate/cache` was missing `check_book_access` — any authenticated user could read cached chapter translations of private books
- `POST /ai/translate` had the book access check AFTER the cache lookup — cache hits leaked translation content of private books before the check fired

## Test plan
- [x] `test_save_word_blocked_for_non_owner_of_uploaded_book` — POST /vocabulary returns 403 for non-owner
- [x] `test_translate_cache_get_blocked_for_non_owner` — GET /ai/translate/cache returns 403 for non-owner
- [x] `test_translate_post_cache_hit_blocked_for_non_owner` — POST /ai/translate returns 403 for non-owner even when translation is cached
- [x] Full suite: 1007 passed

Closes #386, #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)
