### PR TITLE
fix: admin delete_book book_uploads cascade and POST /ai/translate running-job guard

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -241,6 +241,7 @@ async def delete_book(book_id: int, _admin: dict = Depends(_require_admin)):
                     "Wait for it to finish before deleting."
                 ),
             )
+        await db.execute("DELETE FROM book_uploads WHERE book_id = ?", (book_id,))
         await db.execute("DELETE FROM books WHERE id = ?", (book_id,))
         await db.execute("DELETE FROM translations WHERE book_id = ?", (book_id,))
         await db.execute("DELETE FROM audio_cache WHERE book_id = ?", (book_id,))

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -349,7 +349,20 @@ async def translate(req: TranslateRequest, user: dict = Depends(get_current_user
                 raise
 
         # Save to shared cache with normalized language codes so any casing variant hits it.
+        # Guard: reject if the queue worker is currently translating this chapter (#393).
+        # The worker uses INSERT OR REPLACE — it would overwrite whatever we save here.
+        # Same pattern as save_translate_cache (PUT /translate/cache, PR #341).
         if req.book_id is not None and req.chapter_index is not None:
+            from services.translation_queue import queue_status_for_chapter
+            _qstatus = await queue_status_for_chapter(req.book_id, req.chapter_index, tgt)
+            if _qstatus["status"] == "running":
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"A translation job is currently running for chapter {req.chapter_index}. "
+                        "Wait for it to finish before saving."
+                    ),
+                )
             await save_translation(
                 req.book_id, req.chapter_index, tgt, paragraphs,
                 provider=chosen,

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -377,6 +377,41 @@ async def test_delete_book_removes_reading_history(admin_client, admin_db, admin
     assert count == 0, "reading_history rows must be removed when the book is deleted"
 
 
+async def test_delete_book_removes_book_uploads_row(admin_client, admin_db, admin_user):
+    """Regression #392: admin delete_book must remove book_uploads rows.
+
+    SQLite FK enforcement is OFF so ON DELETE CASCADE never fires. Without an
+    explicit DELETE, the orphaned book_uploads row keeps counting against the
+    user's upload quota — preventing them from uploading a replacement book."""
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    async with aiosqlite.connect(admin_db) as db:
+        await db.execute(
+            """INSERT INTO book_uploads (book_id, user_id, filename, file_size, format)
+               VALUES (100, ?, 'test.txt', 1024, 'txt')""",
+            (admin_user["id"],),
+        )
+        await db.commit()
+
+    async with aiosqlite.connect(admin_db) as db:
+        async with db.execute(
+            "SELECT COUNT(*) FROM book_uploads WHERE book_id=100"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 1
+
+    res = await admin_client.delete("/api/admin/books/100")
+    assert res.status_code == 200
+
+    async with aiosqlite.connect(admin_db) as db:
+        async with db.execute(
+            "SELECT COUNT(*) FROM book_uploads WHERE book_id=100"
+        ) as cur:
+            count = (await cur.fetchone())[0]
+    assert count == 0, (
+        "book_uploads row must be deleted when admin deletes a book (#392); "
+        "orphaned row inflates upload quota and blocks user from re-uploading"
+    )
+
+
 # ── Translations ─────────────────────────────────────────────────────────────
 
 async def test_get_translations(admin_client, admin_db):

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -278,6 +278,49 @@ async def test_translate_cache_put_rejects_409_when_running(client, test_user, t
     assert cached == ["existing paragraph"]
 
 
+async def test_translate_post_rejects_409_when_running(client, test_user, tmp_db):
+    """Regression #393: POST /ai/translate must return 409 when a queue worker is
+    actively translating the same chapter and we're about to save a new result.
+
+    The guard must fire BEFORE save_translation, not before the cache lookup:
+    a cache HIT returns early without saving (no race), but a cache MISS where
+    we just finished translating must be blocked so the worker's INSERT OR REPLACE
+    doesn't silently overwrite the freshly-saved result."""
+    from services.db import save_book, get_cached_translation, set_user_gemini_key
+    from services.translation_queue import enqueue
+    from services.auth import encrypt_api_key as _enc
+    _BM = {"title": "Faust", "authors": ["Goethe"], "languages": ["de"],
+            "subjects": [], "download_count": 0, "cover": ""}
+    await save_book(61, _BM, "text")
+    await set_user_gemini_key(test_user["id"], _enc("my-key"))
+    # No pre-seeded cached translation — we need the AI call path to reach the save
+    await enqueue(61, 0, "zh")
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute(
+            "UPDATE translation_queue SET status='running' "
+            "WHERE book_id=61 AND chapter_index=0 AND target_language='zh'"
+        )
+        await db.commit()
+
+    with patch("services.translate._gemini_translate", new_callable=AsyncMock, return_value=["new paragraph"]):
+        resp = await client.post("/api/ai/translate", json={
+            "text": "Es war einmal.",
+            "source_language": "de",
+            "target_language": "zh",
+            "book_id": 61,
+            "chapter_index": 0,
+        })
+    assert resp.status_code == 409, (
+        f"Expected 409 when worker is running and about to save, got {resp.status_code}: {resp.text}"
+    )
+
+    # Nothing must have been written to the translation cache
+    cached = await get_cached_translation(61, 0, "zh")
+    assert cached is None, (
+        "No translation must be saved when 409 guard fires for running worker"
+    )
+
+
 # ── Insight ───────────────────────────────────────────────────────────────────
 
 async def test_insight_without_key_returns_400(client):


### PR DESCRIPTION
## Summary
- `admin DELETE /books/{book_id}` was missing `DELETE FROM book_uploads` — orphaned rows kept counting against the user's upload quota after an admin deleted their book
- `POST /ai/translate` was missing a running-job guard before `save_translation` — same race as PR #341: a worker translating the same chapter would overwrite the user's freshly-saved result via `INSERT OR REPLACE`

## Test plan
- [x] `test_delete_book_removes_book_uploads_row` — admin delete cleans up book_uploads row
- [x] `test_translate_post_rejects_409_when_running` — POST /ai/translate returns 409 when worker is running and about to save
- [x] Full suite: 1011 passed

Closes #392, #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)
