### PR TITLE
fix: POST /admin/translations/import missing running-job guard

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -593,6 +593,25 @@ async def import_translations(
         if not await get_cached_book(bid):
             raise HTTPException(status_code=404, detail=f"Book {bid} not found")
 
+    # Pre-check: reject if any chapter to be imported has a running queue job.
+    # The worker uses INSERT OR REPLACE and would overwrite the imported translation
+    # when it finishes — same race as retranslate (#334) and PUT /translate/cache (#341).
+    from services.translation_queue import queue_status_for_chapter
+    for entry in req.entries:
+        if not entry.paragraphs:
+            continue
+        lang = entry.target_language.lower().split("-")[0]
+        status = await queue_status_for_chapter(entry.book_id, entry.chapter_index, lang)
+        if status["status"] == "running":
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"A translation job is currently running for book {entry.book_id} "
+                    f"chapter {entry.chapter_index} ({lang}). "
+                    "Wait for it to finish before importing."
+                ),
+            )
+
     count = 0
     for entry in req.entries:
         if not entry.paragraphs:

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -1124,6 +1124,48 @@ async def test_import_translations_rejects_nonexistent_book(admin_client, admin_
     assert res.status_code == 404
 
 
+async def test_import_translations_rejects_409_when_chapter_is_running(admin_client, admin_db):
+    """Regression #395: POST /admin/translations/import must return 409 when
+    any of the imported chapters has a queue worker currently running.
+
+    Without this guard: admin imports a pre-translated chapter → save_translation
+    (INSERT OR REPLACE) writes the imported data → worker finishes → worker's
+    INSERT OR REPLACE silently overwrites the admin's import.
+
+    Same race as retranslate (#334) and PUT /ai/translate/cache (#341)."""
+    from services.translation_queue import enqueue
+    from services.db import get_cached_translation
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    await save_translation(100, 0, "de", ["old translation"])
+    await enqueue(100, 0, "de")
+    async with aiosqlite.connect(admin_db) as db:
+        await db.execute(
+            "UPDATE translation_queue SET status='running' "
+            "WHERE book_id=100 AND chapter_index=0 AND target_language='de'"
+        )
+        await db.commit()
+
+    res = await admin_client.post(
+        "/api/admin/translations/import",
+        json={
+            "entries": [{
+                "book_id": 100,
+                "chapter_index": 0,
+                "target_language": "de",
+                "paragraphs": ["imported translation"],
+            }],
+        },
+    )
+    assert res.status_code == 409, (
+        f"Expected 409 when worker is running, got {res.status_code}: {res.text}"
+    )
+
+    # The old translation must still be in place (import was rejected)
+    assert await get_cached_translation(100, 0, "de") == ["old translation"], (
+        "Existing translation must be untouched when 409 guard fires"
+    )
+
+
 async def test_move_translation_shifts_chapter_index(admin_client, admin_db):
     """POST /admin/translations/{id}/{idx}/{lang}/move reassigns an existing
     cached translation to a different chapter_index without retranslating.


### PR DESCRIPTION
## Summary
- `POST /admin/translations/import` was missing a running-job guard: if any of the entries being imported had a queue worker running for the same (book, chapter, language), the worker's `INSERT OR REPLACE` would silently overwrite the admin's imported translation when it finished — same race as retranslate (#334) and PUT /ai/translate/cache (#341)
- Added pre-check loop that rejects with 409 if any chapter has status='running'

## Test plan
- [x] `test_import_translations_rejects_409_when_chapter_is_running` — returns 409 and leaves existing translation untouched
- [x] Full suite: 1010 passed

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)
