### PR TITLE
fix: GET /insights and GET /annotations missing check_book_access

### DIFF
--- a/backend/routers/annotations.py
+++ b/backend/routers/annotations.py
@@ -50,6 +50,10 @@ async def list_all_annotations(user: dict = Depends(get_current_user)):
 
 @router.get("")
 async def list_annotations(book_id: int, user: dict = Depends(get_current_user)):
+    book = await get_cached_book(book_id)
+    if not book:
+        raise HTTPException(status_code=404, detail="Book not found")
+    check_book_access(book, user)
     return await get_annotations(user["id"], book_id)
 
 

--- a/backend/routers/insights.py
+++ b/backend/routers/insights.py
@@ -43,6 +43,10 @@ async def list_all_insights(user: dict = Depends(get_current_user)):
 
 @router.get("")
 async def list_insights(book_id: int, user: dict = Depends(get_current_user)):
+    book = await get_cached_book(book_id)
+    if not book:
+        raise HTTPException(status_code=404, detail="Book not found")
+    check_book_access(book, user)
     return await get_insights(user["id"], book_id)
 
 

--- a/backend/tests/test_router_annotations.py
+++ b/backend/tests/test_router_annotations.py
@@ -413,3 +413,19 @@ async def test_create_annotation_blocked_for_non_owner_upload(client, test_user,
         "sentence_text": "some text",
     })
     assert resp.status_code == 403, resp.text
+
+
+async def test_get_annotations_blocked_for_non_owner_upload(client, test_user, tmp_db):
+    """GET /annotations?book_id=N returns 403 for non-owner of a private uploaded book (#397)."""
+    from services.db import get_or_create_user, set_user_role
+    await set_user_role(test_user["id"], "user")
+    owner = await get_or_create_user("ann-owner-get-gid", "ann-owner-get@ex.com", "AnnOwnerGet", "")
+    await _insert_private_book(8802, owner["id"])
+    resp = await client.get(f"/api/annotations?book_id=8802")
+    assert resp.status_code == 403, resp.text
+
+
+async def test_get_annotations_returns_404_for_missing_book(client, test_user, tmp_db):
+    """GET /annotations?book_id=N returns 404 when book doesn't exist (#397)."""
+    resp = await client.get("/api/annotations?book_id=999998")
+    assert resp.status_code == 404, resp.text

--- a/backend/tests/test_router_insights.py
+++ b/backend/tests/test_router_insights.py
@@ -305,3 +305,19 @@ async def test_create_insight_blocked_for_non_owner_upload(client, test_user, tm
         "answer": "Private stuff.",
     })
     assert resp.status_code == 403, resp.text
+
+
+async def test_get_insights_blocked_for_non_owner_upload(client, test_user, tmp_db):
+    """GET /insights?book_id=N returns 403 for non-owner of a private uploaded book (#397)."""
+    from services.db import get_or_create_user, set_user_role
+    await set_user_role(test_user["id"], "user")
+    owner = await get_or_create_user("ins-owner-get-gid", "ins-owner-get@ex.com", "InsOwnerGet", "")
+    await _insert_private_book_ins(8902, owner["id"])
+    resp = await client.get("/api/insights?book_id=8902")
+    assert resp.status_code == 403, resp.text
+
+
+async def test_get_insights_returns_404_for_missing_book(client, test_user, tmp_db):
+    """GET /insights?book_id=N returns 404 when book doesn't exist (#397)."""
+    resp = await client.get("/api/insights?book_id=999999")
+    assert resp.status_code == 404, resp.text


### PR DESCRIPTION
## Summary

Both `GET /insights?book_id=N` and `GET /annotations?book_id=N` accepted a `book_id` query parameter but did not call `check_book_access`, allowing any authenticated user to enumerate insights and annotations on private uploaded books they do not own.

The corresponding POST endpoints already had the guard — this makes GET consistent.

## Changes

- `routers/insights.py`: added `get_cached_book` + `check_book_access` to `list_insights`
- `routers/annotations.py`: added `get_cached_book` + `check_book_access` to `list_annotations`
- Tests: two new 403 regression tests and two new 404 tests for missing books

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)
