### PR TITLE
fix: TypographyPanel invisible in focus mode + Highlight uses full sentence (#398, #400)

### DIFF
--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -958,22 +958,8 @@ export default function ReaderPage() {
             >
               <span className="font-serif">Aa</span>
             </button>
-            {showTypographyPanel && (
-              <TypographyPanel
-                fontSize={fontSize}
-                lineHeight={lineHeight}
-                contentWidth={contentWidth}
-                fontFamily={fontFamily}
-                paragraphFocus={paragraphFocus}
-                onFontSize={setFontSize}
-                onLineHeight={setLineHeight}
-                onContentWidth={setContentWidth}
-                onFontFamily={setFontFamily}
-                onParagraphFocus={setParagraphFocus}
-                onClose={() => setShowTypographyPanel(false)}
-                anchorPos={typographyAnchorPos ?? undefined}
-              />
-            )}
+{/* TypographyPanel rendered at page root — NOT inside the header,
+              so it is unaffected by the header's opacity-0 in focus/immersive mode. */}
           </div>
 
           {/* Theme — desktop only */}
@@ -1189,6 +1175,24 @@ export default function ReaderPage() {
           )}
         </div>
       </header>
+
+      {/* TypographyPanel is outside the header so focus-mode opacity-0 doesn't hide it (#398) */}
+      {showTypographyPanel && (
+        <TypographyPanel
+          fontSize={fontSize}
+          lineHeight={lineHeight}
+          contentWidth={contentWidth}
+          fontFamily={fontFamily}
+          paragraphFocus={paragraphFocus}
+          onFontSize={setFontSize}
+          onLineHeight={setLineHeight}
+          onContentWidth={setContentWidth}
+          onFontFamily={setFontFamily}
+          onParagraphFocus={setParagraphFocus}
+          onClose={() => setShowTypographyPanel(false)}
+          anchorPos={typographyAnchorPos ?? undefined}
+        />
+      )}
 
       {/* ── Banners (hidden in immersive mode on mobile) ──────────────── */}
       <div className={`shrink-0 transition-all duration-300 ${

--- a/frontend/src/components/SelectionToolbar.tsx
+++ b/frontend/src/components/SelectionToolbar.tsx
@@ -104,6 +104,15 @@ export default function SelectionToolbar({ onRead, onHighlight, onNote, onChat, 
     setSelection(null);
   }
 
+  function handleHighlight(fn?: (text: string) => void) {
+    if (!fn || !selection) return;
+    // Annotations are sentence-granularity — store the full sentence (context)
+    // so the highlight colors exactly one sentence, not a partial substring match (#400).
+    fn(selection.context || selection.text);
+    window.getSelection()?.removeAllRanges();
+    setSelection(null);
+  }
+
   function handleVocabAction() {
     if (!onVocab || !selection) return;
     onVocab(selection.text, selection.context || selection.text, selection.rect);
@@ -126,7 +135,7 @@ export default function SelectionToolbar({ onRead, onHighlight, onNote, onChat, 
         </button>
       )}
       {onHighlight && (
-        <button onClick={() => handleAction(onHighlight)} className={btnClass}>
+        <button onClick={() => handleHighlight(onHighlight)} className={btnClass}>
           <HighlightIcon className="w-3.5 h-3.5 shrink-0" />
           Highlight
         </button>


### PR DESCRIPTION
## What changed

**Fix #398 — TypographyPanel invisible in focus mode**

The TypographyPanel was rendered inside the `<header>` element. Focus mode applies `opacity-0` to the header, which creates a CSS compositing layer that propagates zero opacity to all descendants — including fixed-position children like the panel. Moving the panel outside the header entirely fixes this.

**Fix #400 — Highlight stores full sentence, not raw selection**

When a user highlights a word or phrase, the toolbar was passing the raw selected text to `onHighlight`. Annotations are matched sentence-by-sentence at render time, so storing a partial string caused mismatches (no sentence highlighted, or wrong sentence colored). Now `handleHighlight` passes `selection.context` (the full surrounding sentence extracted by `extractContext`) so the stored text always matches exactly one sentence span.

## Files changed

- `frontend/src/app/reader/[bookId]/page.tsx` — moved `<TypographyPanel>` render from inside `<header>` to page root level
- `frontend/src/components/SelectionToolbar.tsx` — new `handleHighlight()` that passes `context` instead of raw selection text

## Test plan

- [ ] Open reader → enable focus mode → click Typography button → panel appears (was invisible before)
- [ ] Select a partial word/phrase → click Highlight → full sentence is highlighted (not partial match)
- [ ] Select full sentence → click Highlight → sentence highlighted correctly
- [ ] Existing annotation tests pass: `pytest backend/tests/test_router_annotations.py`

Closes #398
Closes #400
