### PR TITLE
fix: delete_user missing book_uploads cascade (closes #403)

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -285,6 +285,7 @@ async def delete_user(user_id: int) -> None:
         await db.execute("DELETE FROM book_insights WHERE user_id = ?", (user_id,))
         await db.execute("DELETE FROM user_reading_progress WHERE user_id = ?", (user_id,))
         await db.execute("DELETE FROM reading_history WHERE user_id = ?", (user_id,))
+        await db.execute("DELETE FROM book_uploads WHERE user_id = ?", (user_id,))
         await db.execute("DELETE FROM users WHERE id = ?", (user_id,))
         await db.commit()
 

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -218,6 +218,42 @@ async def test_delete_user_removes_reading_history(admin_client, admin_db, admin
     assert count == 0, "orphaned reading_history rows left after delete_user"
 
 
+async def test_delete_user_removes_book_uploads(admin_client, admin_db, admin_user):
+    """Regression #403: delete_user must also remove book_uploads rows.
+
+    PRAGMA foreign_keys is disabled so ON DELETE CASCADE on book_uploads.user_id
+    is never enforced; delete_user must include an explicit DELETE FROM book_uploads.
+    """
+    import json as _json
+    user2 = await get_or_create_user(
+        google_id="del-uploads-user", email="uploads@test.com", name="Uploads", picture=""
+    )
+    chapters = _json.dumps({"draft": False, "chapters": [{"title": "Ch1", "text": "text"}]})
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            """INSERT INTO books (id, title, authors, languages, subjects,
+               download_count, cover, text, images, source, owner_user_id)
+               VALUES (9901, 'Upload', '[]', '[]', '[]', 0, '', ?, '[]', 'upload', ?)""",
+            (chapters, user2["id"]),
+        )
+        await db.execute(
+            """INSERT INTO book_uploads (book_id, user_id, filename, file_size, format)
+               VALUES (9901, ?, 'test.epub', 1000, 'epub')""",
+            (user2["id"],),
+        )
+        await db.commit()
+
+    res = await admin_client.delete(f"/api/admin/users/{user2['id']}")
+    assert res.status_code == 200
+
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        async with conn.execute(
+            "SELECT COUNT(*) FROM book_uploads WHERE user_id = ?", (user2["id"],)
+        ) as cur:
+            (count,) = await cur.fetchone()
+    assert count == 0, "orphaned book_uploads rows left after delete_user"
+
+
 # ── Books ────────────────────────────────────────────────────────────────────
 
 async def test_get_books(admin_client, admin_db):


### PR DESCRIPTION
## Summary
- `delete_user()` in `services/db.py` did not delete from `book_uploads` when a user was removed
- SQLite FK enforcement is OFF so `ON DELETE CASCADE` on `book_uploads.user_id` never fires
- Orphaned `book_uploads` rows remained after user deletion, inflating upload quota counts

## Fix
Added `DELETE FROM book_uploads WHERE user_id = ?` to `delete_user()` before deleting from `users`.

## Test plan
- `test_delete_user_removes_book_uploads`: inserts a user with a `book_uploads` row, deletes the user via admin API, asserts zero `book_uploads` rows remain
- Full backend suite: 1013 passed
