### PR TITLE
fix: add check_book_access to GET /insights and GET /annotations (#397)

### DIFF
--- a/backend/routers/annotations.py
+++ b/backend/routers/annotations.py
@@ -50,6 +50,10 @@ async def list_all_annotations(user: dict = Depends(get_current_user)):
 
 @router.get("")
 async def list_annotations(book_id: int, user: dict = Depends(get_current_user)):
+    book = await get_cached_book(book_id)
+    if not book:
+        raise HTTPException(status_code=404, detail="Book not found")
+    check_book_access(book, user)
     return await get_annotations(user["id"], book_id)
 
 

--- a/backend/routers/insights.py
+++ b/backend/routers/insights.py
@@ -43,6 +43,10 @@ async def list_all_insights(user: dict = Depends(get_current_user)):
 
 @router.get("")
 async def list_insights(book_id: int, user: dict = Depends(get_current_user)):
+    book = await get_cached_book(book_id)
+    if not book:
+        raise HTTPException(status_code=404, detail="Book not found")
+    check_book_access(book, user)
     return await get_insights(user["id"], book_id)
 
 

--- a/backend/tests/test_router_annotations.py
+++ b/backend/tests/test_router_annotations.py
@@ -413,3 +413,19 @@ async def test_create_annotation_blocked_for_non_owner_upload(client, test_user,
         "sentence_text": "some text",
     })
     assert resp.status_code == 403, resp.text
+
+
+async def test_get_annotations_blocked_for_non_owner_upload(client, test_user, tmp_db):
+    """GET /annotations on someone else's uploaded book must return 403 (#397)."""
+    from services.db import get_or_create_user, set_user_role
+    await set_user_role(test_user["id"], "user")
+    owner = await get_or_create_user("ann-get-owner-gid", "ann-get-owner@ex.com", "AnnGetOwner", "")
+    await _insert_private_book(8802, owner["id"])
+    resp = await client.get("/api/annotations", params={"book_id": 8802})
+    assert resp.status_code == 403, resp.text
+
+
+async def test_get_annotations_returns_404_for_nonexistent_book(client, test_user, tmp_db):
+    """GET /annotations for a book that doesn't exist must return 404 (#397)."""
+    resp = await client.get("/api/annotations", params={"book_id": 999888})
+    assert resp.status_code == 404, resp.text

--- a/backend/tests/test_router_insights.py
+++ b/backend/tests/test_router_insights.py
@@ -305,3 +305,19 @@ async def test_create_insight_blocked_for_non_owner_upload(client, test_user, tm
         "answer": "Private stuff.",
     })
     assert resp.status_code == 403, resp.text
+
+
+async def test_get_insights_blocked_for_non_owner_upload(client, test_user, tmp_db):
+    """GET /insights on someone else's uploaded book must return 403 (#397)."""
+    from services.db import get_or_create_user, set_user_role
+    await set_user_role(test_user["id"], "user")
+    owner = await get_or_create_user("ins-get-owner-gid", "ins-get-owner@ex.com", "InsGetOwner", "")
+    await _insert_private_book_ins(8902, owner["id"])
+    resp = await client.get("/api/insights", params={"book_id": 8902})
+    assert resp.status_code == 403, resp.text
+
+
+async def test_get_insights_returns_404_for_nonexistent_book(client, test_user, tmp_db):
+    """GET /insights for a book that doesn't exist must return 404 (#397)."""
+    resp = await client.get("/api/insights", params={"book_id": 999888})
+    assert resp.status_code == 404, resp.text


### PR DESCRIPTION
## Summary

- `GET /api/insights?book_id=N` and `GET /api/annotations?book_id=N` lacked the `get_cached_book` + `check_book_access` guard that the corresponding POST endpoints already had
- Any authenticated user could query insights/annotations on private uploaded books they don't own; they'd only see their own entries (filtered by `user_id`) but the endpoint should 404 on unknown books and 403 on inaccessible ones
- Now consistent with all other endpoints that accept `book_id`

## Test plan

- [ ] `test_get_insights_blocked_for_non_owner_upload` — GET returns 403 for private upload not owned by caller
- [ ] `test_get_insights_returns_404_for_nonexistent_book` — GET returns 404 for missing book
- [ ] `test_get_annotations_blocked_for_non_owner_upload` — same for annotations
- [ ] `test_get_annotations_returns_404_for_nonexistent_book` — same for annotations
- [ ] Full backend suite: 1016 tests pass

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)
