### PR TITLE
test: consolidate _insert_private_book into shared conftest fixture (closes #391)

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,9 +4,12 @@ Shared fixtures for router/integration tests.
 Provides:
   - `client`  — AsyncClient pointed at a fresh test app with a temp DB
   - `auth_headers` — Bearer token for a pre-created test user
+  - `insert_private_book` — factory that inserts an upload-sourced book owned by a given user
 """
 
+import json
 import pytest
+import aiosqlite
 from unittest.mock import AsyncMock, patch
 import services.db as db_module
 from services.db import init_db, get_or_create_user, get_user_by_id
@@ -84,3 +87,25 @@ async def anon_client(tmp_db):
 def auth_headers(test_user):
     token = create_jwt(test_user["id"], test_user["email"])
     return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def insert_private_book():
+    """Return a coroutine that inserts an upload-sourced private book owned by the given user.
+
+    Usage in tests::
+
+        await insert_private_book(book_id=8801, owner_user_id=owner["id"])
+    """
+    async def _impl(book_id: int, owner_user_id: int) -> None:
+        chapters = json.dumps({"draft": False, "chapters": [{"title": "Ch1", "text": "private"}]})
+        async with aiosqlite.connect(db_module.DB_PATH) as db:
+            await db.execute(
+                """INSERT OR REPLACE INTO books
+                   (id, title, authors, languages, subjects, download_count,
+                    cover, text, images, source, owner_user_id)
+                   VALUES (?, 'Private', '[]', '["en"]', '[]', 0, '', ?, '[]', 'upload', ?)""",
+                (book_id, chapters, owner_user_id),
+            )
+            await db.commit()
+    return _impl

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -16,7 +16,6 @@ import pytest
 import aiosqlite
 from unittest.mock import AsyncMock, patch
 from services.db import save_book, save_translation, get_cached_translation, set_user_gemini_key, set_setting, get_or_create_user
-import services.db as db_module
 from services.auth import encrypt_api_key
 
 
@@ -647,20 +646,8 @@ async def test_summary_concurrent_requests_call_gemini_once(client, test_user, t
 
 # ── Access control for private uploaded books ────────────────────────────────
 
-async def _insert_private_book_ai(book_id: int, owner_user_id: int) -> None:
-    chapters = json.dumps({"draft": False, "chapters": [{"title": "Ch1", "text": "private"}]})
-    async with aiosqlite.connect(db_module.DB_PATH) as db:
-        await db.execute(
-            """INSERT OR REPLACE INTO books
-               (id, title, authors, languages, subjects, download_count,
-                cover, text, images, source, owner_user_id)
-               VALUES (?, 'Private Book', '[]', '["de"]', '[]', 0, '', ?, '[]', 'upload', ?)""",
-            (book_id, chapters, owner_user_id),
-        )
-        await db.commit()
 
-
-async def test_translate_cache_get_blocked_for_non_owner(client, test_user, tmp_db):
+async def test_translate_cache_get_blocked_for_non_owner(client, test_user, tmp_db, insert_private_book):
     """GET /ai/translate/cache for a private uploaded book returns 403 for non-owners.
 
     Without check_book_access the endpoint returns cached translation paragraphs
@@ -668,7 +655,7 @@ async def test_translate_cache_get_blocked_for_non_owner(client, test_user, tmp_
     from services.db import set_user_role
     await set_user_role(test_user["id"], "user")
     owner = await get_or_create_user("ai-owner-gid1", "ai-owner1@ex.com", "AIOwner1", "")
-    await _insert_private_book_ai(8901, owner["id"])
+    await insert_private_book(8901, owner["id"])
     await save_translation(8901, 0, "en", ["Private translation content."])
     resp = await client.get(
         "/api/ai/translate/cache?book_id=8901&chapter_index=0&target_language=en"
@@ -679,7 +666,7 @@ async def test_translate_cache_get_blocked_for_non_owner(client, test_user, tmp_
     )
 
 
-async def test_translate_post_cache_hit_blocked_for_non_owner(client, test_user, tmp_db):
+async def test_translate_post_cache_hit_blocked_for_non_owner(client, test_user, tmp_db, insert_private_book):
     """POST /ai/translate with book_id of a private uploaded book returns 403 for non-owners.
 
     Without check_book_access the endpoint returns the cached translated chapter
@@ -687,7 +674,7 @@ async def test_translate_post_cache_hit_blocked_for_non_owner(client, test_user,
     from services.db import set_user_role
     await set_user_role(test_user["id"], "user")
     owner = await get_or_create_user("ai-owner-gid2", "ai-owner2@ex.com", "AIOwner2", "")
-    await _insert_private_book_ai(8902, owner["id"])
+    await insert_private_book(8902, owner["id"])
     await save_translation(8902, 0, "en", ["Private translated paragraph."])
     resp = await client.post("/api/ai/translate", json={
         "text": "Es war einmal.",

--- a/backend/tests/test_router_annotations.py
+++ b/backend/tests/test_router_annotations.py
@@ -383,30 +383,13 @@ async def test_update_annotation_select_runs_before_commit(tmp_db, test_user, mo
 
 # ── Upload book access control ─────────────────────────────────────────────
 
-import json as _json_ann
-import aiosqlite as _aio_ann
-import services.db as _db_ann
 
-
-async def _insert_private_book(book_id: int, owner_user_id: int) -> None:
-    chapters = _json_ann.dumps({"draft": False, "chapters": [{"title": "Ch1", "text": "private"}]})
-    async with _aio_ann.connect(_db_ann.DB_PATH) as db:
-        await db.execute(
-            """INSERT OR REPLACE INTO books
-               (id, title, authors, languages, subjects, download_count,
-                cover, text, images, source, owner_user_id)
-               VALUES (?, 'Private', '[]', '[]', '[]', 0, '', ?, '[]', 'upload', ?)""",
-            (book_id, chapters, owner_user_id),
-        )
-        await db.commit()
-
-
-async def test_create_annotation_blocked_for_non_owner_upload(client, test_user, tmp_db):
+async def test_create_annotation_blocked_for_non_owner_upload(client, test_user, tmp_db, insert_private_book):
     """Creating an annotation on someone else's uploaded book returns 403."""
     from services.db import get_or_create_user, set_user_role
     await set_user_role(test_user["id"], "user")
     owner = await get_or_create_user("ann-owner-gid", "ann-owner@ex.com", "AnnOwner", "")
-    await _insert_private_book(8801, owner["id"])
+    await insert_private_book(8801, owner["id"])
     resp = await client.post("/api/annotations", json={
         "book_id": 8801,
         "chapter_index": 0,
@@ -415,12 +398,12 @@ async def test_create_annotation_blocked_for_non_owner_upload(client, test_user,
     assert resp.status_code == 403, resp.text
 
 
-async def test_get_annotations_blocked_for_non_owner_upload(client, test_user, tmp_db):
+async def test_get_annotations_blocked_for_non_owner_upload(client, test_user, tmp_db, insert_private_book):
     """GET /annotations?book_id=N returns 403 for non-owner of a private uploaded book (#397)."""
     from services.db import get_or_create_user, set_user_role
     await set_user_role(test_user["id"], "user")
     owner = await get_or_create_user("ann-owner-get-gid", "ann-owner-get@ex.com", "AnnOwnerGet", "")
-    await _insert_private_book(8802, owner["id"])
+    await insert_private_book(8802, owner["id"])
     resp = await client.get(f"/api/annotations?book_id=8802")
     assert resp.status_code == 403, resp.text
 

--- a/backend/tests/test_router_insights.py
+++ b/backend/tests/test_router_insights.py
@@ -275,30 +275,13 @@ async def test_save_insight_select_runs_before_commit(tmp_db, test_user, monkeyp
 
 # ── Upload book access control ─────────────────────────────────────────────
 
-import json as _json_ins
-import aiosqlite as _aio_ins
-import services.db as _db_ins
 
-
-async def _insert_private_book_ins(book_id: int, owner_user_id: int) -> None:
-    chapters = _json_ins.dumps({"draft": False, "chapters": [{"title": "Ch1", "text": "private"}]})
-    async with _aio_ins.connect(_db_ins.DB_PATH) as db:
-        await db.execute(
-            """INSERT OR REPLACE INTO books
-               (id, title, authors, languages, subjects, download_count,
-                cover, text, images, source, owner_user_id)
-               VALUES (?, 'Private', '[]', '[]', '[]', 0, '', ?, '[]', 'upload', ?)""",
-            (book_id, chapters, owner_user_id),
-        )
-        await db.commit()
-
-
-async def test_create_insight_blocked_for_non_owner_upload(client, test_user, tmp_db):
+async def test_create_insight_blocked_for_non_owner_upload(client, test_user, tmp_db, insert_private_book):
     """Creating an insight on someone else's uploaded book returns 403."""
     from services.db import get_or_create_user, set_user_role
     await set_user_role(test_user["id"], "user")
     owner = await get_or_create_user("ins-owner-gid", "ins-owner@ex.com", "InsOwner", "")
-    await _insert_private_book_ins(8901, owner["id"])
+    await insert_private_book(8901, owner["id"])
     resp = await client.post("/api/insights", json={
         "book_id": 8901,
         "question": "What is it about?",
@@ -307,12 +290,12 @@ async def test_create_insight_blocked_for_non_owner_upload(client, test_user, tm
     assert resp.status_code == 403, resp.text
 
 
-async def test_get_insights_blocked_for_non_owner_upload(client, test_user, tmp_db):
+async def test_get_insights_blocked_for_non_owner_upload(client, test_user, tmp_db, insert_private_book):
     """GET /insights?book_id=N returns 403 for non-owner of a private uploaded book (#397)."""
     from services.db import get_or_create_user, set_user_role
     await set_user_role(test_user["id"], "user")
     owner = await get_or_create_user("ins-owner-get-gid", "ins-owner-get@ex.com", "InsOwnerGet", "")
-    await _insert_private_book_ins(8902, owner["id"])
+    await insert_private_book(8902, owner["id"])
     resp = await client.get("/api/insights?book_id=8902")
     assert resp.status_code == 403, resp.text
 

--- a/backend/tests/test_router_summary.py
+++ b/backend/tests/test_router_summary.py
@@ -159,30 +159,13 @@ async def test_summary_non_admin_delete_forbidden(client, test_user, tmp_db):
 
 # ── Upload book access control ─────────────────────────────────────────────
 
-import json as _json_sum
-import aiosqlite as _aio_sum
-import services.db as _db_sum
 
-
-async def _insert_private_book_sum(book_id: int, owner_user_id: int) -> None:
-    chapters = _json_sum.dumps({"draft": False, "chapters": [{"title": "Ch1", "text": "private"}]})
-    async with _aio_sum.connect(_db_sum.DB_PATH) as db:
-        await db.execute(
-            """INSERT OR REPLACE INTO books
-               (id, title, authors, languages, subjects, download_count,
-                cover, text, images, source, owner_user_id)
-               VALUES (?, 'Private', '[]', '[]', '[]', 0, '', ?, '[]', 'upload', ?)""",
-            (book_id, chapters, owner_user_id),
-        )
-        await db.commit()
-
-
-async def test_ai_summary_blocked_for_non_owner_upload(client, test_user, tmp_db):
+async def test_ai_summary_blocked_for_non_owner_upload(client, test_user, tmp_db, insert_private_book):
     """Requesting an AI summary for someone else's uploaded book returns 403."""
     from services.db import get_or_create_user
     await set_user_role(test_user["id"], "user")
     owner = await get_or_create_user("sum-owner-gid", "sum-owner@ex.com", "SumOwner", "")
-    await _insert_private_book_sum(8801, owner["id"])
+    await insert_private_book(8801, owner["id"])
     resp = await client.post("/api/ai/summary", json={
         "book_id": 8801,
         "chapter_index": 0,

--- a/backend/tests/test_router_user.py
+++ b/backend/tests/test_router_user.py
@@ -2,11 +2,8 @@
 Tests for routers/user.py — profile and Gemini key management.
 """
 
-import json
 import pytest
-import aiosqlite
 from services.db import get_user_by_id, set_user_gemini_key, save_book, get_or_create_user
-import services.db as db_module
 from services.auth import encrypt_api_key, decrypt_api_key
 
 _BOOK_META = {"title": "Test Book", "authors": ["Author"], "languages": ["en"], "subjects": [], "download_count": 0, "cover": ""}
@@ -238,20 +235,8 @@ async def test_patch_obsidian_settings_token_not_clobbered_by_stale_read(client,
 
 # ── Access control for private uploaded books ─────────────────────────────────
 
-async def _insert_private_book_user(book_id: int, owner_user_id: int) -> None:
-    chapters = json.dumps({"draft": False, "chapters": [{"title": "Ch1", "text": "private"}]})
-    async with aiosqlite.connect(db_module.DB_PATH) as db:
-        await db.execute(
-            """INSERT OR REPLACE INTO books
-               (id, title, authors, languages, subjects, download_count,
-                cover, text, images, source, owner_user_id)
-               VALUES (?, 'Private Book', '[]', '["en"]', '[]', 0, '', ?, '[]', 'upload', ?)""",
-            (book_id, chapters, owner_user_id),
-        )
-        await db.commit()
 
-
-async def test_update_reading_progress_blocked_for_non_owner(client, test_user, tmp_db):
+async def test_update_reading_progress_blocked_for_non_owner(client, test_user, tmp_db, insert_private_book):
     """PUT /user/reading-progress/{book_id} must return 403 for non-owners of private books.
 
     Without check_book_access the endpoint only checks existence; any authenticated
@@ -259,7 +244,7 @@ async def test_update_reading_progress_blocked_for_non_owner(client, test_user, 
     from services.db import set_user_role
     await set_user_role(test_user["id"], "user")
     owner = await get_or_create_user("rp-owner-gid", "rp-owner@ex.com", "RPOwner", "")
-    await _insert_private_book_user(8701, owner["id"])
+    await insert_private_book(8701, owner["id"])
     resp = await client.put("/api/user/reading-progress/8701", json={"chapter_index": 2})
     assert resp.status_code == 403, (
         f"Expected 403 for non-owner updating reading progress of private book, "

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -336,20 +336,8 @@ async def test_export_without_settings_returns_400(client, test_user):
 
 # ── Access control for private uploaded books ─────────────────────────────────
 
-async def _insert_private_book(book_id: int, owner_user_id: int) -> None:
-    chapters = json.dumps({"draft": False, "chapters": [{"title": "Ch1", "text": "private"}]})
-    async with aiosqlite.connect(db_module.DB_PATH) as db:
-        await db.execute(
-            """INSERT OR REPLACE INTO books
-               (id, title, authors, languages, subjects, download_count,
-                cover, text, images, source, owner_user_id)
-               VALUES (?, 'Private Book', '[]', '["en"]', '[]', 0, '', ?, '[]', 'upload', ?)""",
-            (book_id, chapters, owner_user_id),
-        )
-        await db.commit()
 
-
-async def test_save_word_blocked_for_non_owner_of_uploaded_book(client, test_user, tmp_db):
+async def test_save_word_blocked_for_non_owner_of_uploaded_book(client, test_user, tmp_db, insert_private_book):
     """POST /vocabulary for a private uploaded book must return 403 for non-owners.
 
     Without check_book_access the endpoint only checks existence (404 vs 200);
@@ -357,7 +345,7 @@ async def test_save_word_blocked_for_non_owner_of_uploaded_book(client, test_use
     from services.db import set_user_role
     await set_user_role(test_user["id"], "user")
     owner = await get_or_create_user("voc-owner-gid", "voc-owner@ex.com", "VocOwner", "")
-    await _insert_private_book(8801, owner["id"])
+    await insert_private_book(8801, owner["id"])
     resp = await client.post("/api/vocabulary", json={
         "word": "secret",
         "book_id": 8801,


### PR DESCRIPTION
## What changed

Six test files each defined a local `_insert_private_book_*` helper function — all identical (or near-identical) `INSERT OR REPLACE INTO books ... source='upload', owner_user_id=?` SQL. Removed all copies and replaced with a single shared `insert_private_book` fixture in `conftest.py`.

## Files

- `conftest.py` — new `insert_private_book` fixture (factory returning an async callable)
- `test_router_annotations.py` — uses `insert_private_book`, removed local `_insert_private_book`
- `test_router_insights.py` — uses `insert_private_book`, removed local `_insert_private_book_ins`
- `test_router_vocabulary.py` — uses `insert_private_book`, removed local `_insert_private_book`
- `test_router_ai.py` — uses `insert_private_book`, removed local `_insert_private_book_ai`
- `test_router_user.py` — uses `insert_private_book`, removed local `_insert_private_book_user`
- `test_router_summary.py` — uses `insert_private_book`, removed local `_insert_private_book_sum`

## Test plan

- [ ] `pytest backend/tests/` — all tests pass (no fixture-not-found errors)

Closes #391
