### PR TITLE
fix: cascade guard prevents all-grey sentences when one segment fails chunk matching

### DIFF
--- a/frontend/src/__tests__/SentenceReader.timing.test.tsx
+++ b/frontend/src/__tests__/SentenceReader.timing.test.tsx
@@ -183,4 +183,50 @@ describe("SentenceReader timing estimation", () => {
     const active = container.querySelector(".bg-amber-300");
     expect(active?.textContent).toContain("Quoiqu");
   });
+
+  it("cascade guard: sentence spanning chunk boundary does not grey out subsequent sentences", () => {
+    // Regression for issue #401: a short sentence that spans a chunk boundary
+    // (i.e. starts at the end of chunk 0 and ends in chunk 1) fails ALL matching
+    // attempts — exact, prefix (< 50 chars), and normalized. Previously chunkIdx
+    // advanced to chunks.length causing ALL subsequent segments to get chunkIdx=-1
+    // (greyed out). The cascade guard resets chunkIdx so later sentences are found.
+    //
+    // Simulate: chunk 0 ends mid-sentence; chunk 1 has the rest. The segment text
+    // is assembled from both halves (not present in either chunk alone).
+    const sentA = "You will rejoice to hear that no disaster has accompanied us."; // in chunk 0
+    const crossBoundarySent = "Go."; // short, starts end-of-chunk-0, ends chunk-1 → not in either
+    const sentC = "I arrived here yesterday with great relief."; // in chunk 1
+
+    // chunk 0 contains sentA and the very beginning of crossBoundarySent ("Go")
+    // chunk 1 contains the end of crossBoundarySent (".") and sentC
+    const chunk0 = `${sentA} Go`;              // "Go" not terminated → not findable as "Go."
+    const chunk1 = `.\n${sentC}`;             // ends with "." but "Go." spans the boundary
+
+    const chunks: ChunkInfo[] = [
+      { text: chunk0, duration: 5 },
+      { text: chunk1, duration: 5 },
+    ];
+
+    // Chapter text: all three sentences as one block
+    const text = `${sentA} ${crossBoundarySent} ${sentC}`;
+
+    const { container } = render(
+      <SentenceReader
+        text={text}
+        duration={10}
+        currentTime={8}  // well into chunk 1 where sentC should be active
+        isPlaying={true}
+        onSegmentClick={noop}
+        chunks={chunks}
+      />
+    );
+
+    // sentC must NOT be greyed out — the cascade guard should have kept chunkIdx
+    // in range so sentC is matched to chunk 1.
+    const allSegs = Array.from(container.querySelectorAll("[data-seg]"));
+    const sentCEl = allSegs.find((el) => el.textContent?.includes("arrived here yesterday"));
+    // Must be found and not have the grey class
+    expect(sentCEl).not.toBeNull();
+    expect(sentCEl?.className).not.toContain("text-stone-400");
+  });
 });

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -106,6 +106,13 @@ function parseIntoSegments(
     let cursor = 0;            // index into the current chunk's text
     for (let s = 0; s < allTexts.length; s++) {
       const seg = allTexts[s];
+      // Snapshot the search position before we try matching this segment.
+      // If all matching attempts fail (chunkIdx reaches chunks.length), we
+      // restore to the snapshot so subsequent segments are not blocked by the
+      // cascade (chunkIdx stuck at chunks.length → all remaining segs = -1).
+      const snapChunkIdx = chunkIdx;
+      const snapCursor = cursor;
+
       // Find this segment within the remaining chunk text
       while (chunkIdx < chunks.length) {
         const chunkText = chunks[chunkIdx].text.replace(/\r?\n/g, " ");
@@ -131,12 +138,14 @@ function parseIntoSegments(
           }
         }
         // Normalized whitespace fallback — handles mismatches from line-joining
-        // (e.g. \n → space in chunkText vs lines.join(" ") in segment).
+        // (e.g. trailing spaces before \n become extra spaces after replace).
         const normSeg = seg.replace(/\s+/g, " ").trim();
         const normChunkSlice = chunkText.slice(cursor).replace(/\s+/g, " ");
         const normPos = normChunkSlice.indexOf(normSeg);
         if (normPos >= 0) {
           segmentChunkIdx[s] = chunkIdx;
+          // cursor approximation: normPos is in the normalized string, so this
+          // slightly underestimates the real end, but never overshoots (safe).
           cursor = Math.min(cursor + normPos + normSeg.length, chunkText.length);
           break;
         }
@@ -144,7 +153,16 @@ function parseIntoSegments(
         chunkIdx++;
         cursor = 0;
       }
-      // Out of chunks → leave -1 (won't get a startTime, won't be coloured-as-loaded)
+
+      // Cascade guard: if we exhausted all chunks without a match, restore the
+      // snapshot so the next segment can continue searching from where we were.
+      // Assign this segment to the snapshot chunk (best-effort; likely the chunk
+      // where it starts or the immediately preceding chunk).
+      if (chunkIdx >= chunks.length && segmentChunkIdx[s] === -1) {
+        segmentChunkIdx[s] = snapChunkIdx;
+        chunkIdx = snapChunkIdx;
+        cursor = snapCursor;
+      }
     }
   }
 


### PR DESCRIPTION
## Root cause

The previous fix (PR #405) added a normalized-whitespace fallback but missed the **cascade failure** that is the actual trigger for the greying-out:

When any single sentence fails to match in all chunks — which happens with short sentences (< 50 chars) that **span a chunk boundary** — the `while` loop advances `chunkIdx` all the way to `chunks.length`. Every subsequent sentence then skips the matching loop entirely and gets `chunkIdx = -1`, turning all remaining text grey. This is why the failure point is variable (6th, 7th, 8th sentence): it depends on where the first short cross-boundary sentence lands in each chapter.

## Fix

Before each segment's matching loop, save a `(chunkIdx, cursor)` snapshot. If the loop exhausts all chunks without a match, restore the snapshot so the next segment searches from the same position — no cascade. The failed segment is assigned to the snapshot chunk (best-effort; typically the chunk where the sentence starts).

```
snapChunkIdx = chunkIdx;  snapCursor = cursor;
// ... matching loop (exact → prefix → normalized-whitespace) ...
if (chunkIdx >= chunks.length && segmentChunkIdx[s] === -1) {
  segmentChunkIdx[s] = snapChunkIdx;   // assign to best-estimate chunk
  chunkIdx = snapChunkIdx;             // restore for next segment
  cursor = snapCursor;
}
```

The normalized-whitespace fallback from PR #405 is retained for the secondary whitespace-mismatch case.

## Test plan

- [x] New regression test: `cascade guard: sentence spanning chunk boundary does not grey out subsequent sentences` — simulates a short sentence that fails all matching attempts, verifies sentences after it are still loaded (not grey)
- [x] All 1572 frontend tests pass

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)
