### PR TITLE
fix: add LETTER/LETTRE/BRIEF to KEYWORD_RE for epistolary novels (closes #421)

### DIFF
--- a/backend/services/splitter.py
+++ b/backend/services/splitter.py
@@ -51,6 +51,7 @@ KEYWORD_RE = re.compile(
     r'|PART|PARTIE|TEIL|Teil'
     r'|ACT|ACTE|AKT|Akt'
     r'|SCENE|SCÈNE|SZENE|Szene'
+    r'|LETTER|LETTRE|BRIEF'
     r'|PROLOGUE?|EPILOGUE?|PRÉFACE|VORWORT|NACHWORT'
     r'|INTRODUCTION|EINLEITUNG)'
     r'[^\n]{0,80})'                # rest of the heading line

--- a/backend/tests/test_splitter.py
+++ b/backend/tests/test_splitter.py
@@ -73,6 +73,32 @@ def test_act_scene_headings():
     assert len(chs) == 3
 
 
+def test_letter_headings_english():
+    # Regression for #421: epistolary novels use "Letter I", "Letter II" headings.
+    text = "\n\nLetter I\n\n" + "Dear friend. " * 200
+    text += "\n\nLetter II\n\n" + "I write again. " * 200
+    text += "\n\nLetter III\n\n" + "Still writing. " * 200
+    chs = build_chapters(text)
+    assert len(chs) == 3
+    assert chs[0].title == "Letter I"
+
+
+def test_letter_headings_french():
+    text = "\n\nLETTRE I\n\n" + "Mon ami. " * 200
+    text += "\n\nLETTRE II\n\n" + "Je vous écris. " * 200
+    text += "\n\nLETTRE III\n\n" + "Encore une lettre. " * 200
+    chs = build_chapters(text)
+    assert len(chs) == 3
+
+
+def test_letter_headings_german():
+    text = "\n\nBrief I\n\n" + "Lieber Freund. " * 200
+    text += "\n\nBrief II\n\n" + "Ich schreibe. " * 200
+    text += "\n\nBrief III\n\n" + "Noch ein Brief. " * 200
+    chs = build_chapters(text)
+    assert len(chs) == 3
+
+
 def test_roman_numeral_chapters():
     text = ""
     for n in ["I", "II", "III", "IV", "V"]:


### PR DESCRIPTION
## Summary

- Added `LETTER|LETTRE|BRIEF` to `KEYWORD_RE` in `services/splitter.py`
- Epistolary novels (Frankenstein, Dracula) use "Letter I / II / III" headings that were not matched, collapsing all letters into one chapter when HTML fetch fails

## Why

`build_chapters()` falls back to plain-text splitting when Gutenberg HTML is unavailable. `KEYWORD_RE` already matched CHAPTER/PART/ACT/SCENE but not LETTER. Novels structured as letters (common in 18th–19th century literature) returned a single giant chapter.

## Test plan

- [x] `test_letter_headings_english` — "Letter I/II/III" → 3 chapters
- [x] `test_letter_headings_french` — "LETTRE I/II/III" → 3 chapters
- [x] `test_letter_headings_german` — "Brief I/II/III" → 3 chapters
- [x] Full backend suite: 1018 passed
- [x] Frontend suite: 1583 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
