### PR TITLE
test(e2e): landing hero visibility and highlight sentence context (closes #406, #407)

### DIFF
--- a/frontend/e2e/landing.spec.ts
+++ b/frontend/e2e/landing.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * E2E: Landing page hero visibility (#406)
+ *
+ * - Unauthenticated visitor: hero section is visible on the Discover tab
+ * - Authenticated user: hero section is hidden
+ */
+import { test, expect } from "./base";
+import { mockBackend } from "./fixtures";
+
+async function mockUnauthenticated(page: import("@playwright/test").Page) {
+  // Do NOT mock the auth session — let the E2E dev server handle it. Since no
+  // auth cookie is present, NextAuth's /api/auth/session returns null and
+  // useSession() reports status="unauthenticated".
+  //
+  // Stub backend routes that would otherwise fail (no real backend in E2E).
+  await page.route("**/api/user/me", (route) =>
+    route.fulfill({ status: 401, json: { detail: "Not authenticated" } })
+  );
+  await page.route("**/api/books/cached", (route) =>
+    route.fulfill({ json: [] })
+  );
+  await page.route(/\/api\/books\/search\?/, (route) =>
+    route.fulfill({ json: { count: 0, books: [] } })
+  );
+  await page.route("**/api/user/reading-progress*", (route) =>
+    route.fulfill({ json: { entries: [] } })
+  );
+}
+
+test("unauthenticated visitor sees landing hero on discover tab", async ({ page }) => {
+  await mockUnauthenticated(page);
+  await page.goto("/");
+
+  // The page should show the landing hero headline
+  // JSX uses &rsquo; (U+2019) so we use .s wildcard to avoid ASCII vs curly-quote mismatch
+  await expect(
+    page.getByText(/Read the world.s greatest books/i)
+  ).toBeVisible({ timeout: 5000 });
+
+  // Sign-in CTA should be present
+  await expect(page.getByRole("button", { name: /Sign in free/i })).toBeVisible();
+});
+
+test("authenticated user does not see landing hero", async ({ page }) => {
+  await mockBackend(page);
+  await page.goto("/");
+
+  // The page should NOT show the hero headline
+  await expect(
+    page.getByText(/Read the world.s greatest books/i)
+  ).not.toBeVisible({ timeout: 3000 });
+});

--- a/frontend/e2e/reader-highlight.spec.ts
+++ b/frontend/e2e/reader-highlight.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * E2E: SelectionToolbar Highlight passes full sentence context (#407)
+ *
+ * When a user selects a word and clicks Highlight, the annotation POST
+ * must send the **full sentence** (from the nearest [data-seg] element)
+ * as sentence_text — not just the selected substring.
+ */
+import { test, expect } from "./base";
+import { mockBackend, MOCK_CHAPTERS } from "./fixtures";
+
+test.beforeEach(async ({ page }) => {
+  await mockBackend(page);
+});
+
+test("highlight sends full sentence text, not raw selection substring", async ({ page }) => {
+  // Capture the annotation POST body for assertion
+  let annotationBody: Record<string, unknown> | null = null;
+  await page.route("**/api/annotations", (route) => {
+    if (route.request().method() === "POST") {
+      annotationBody = route.request().postDataJSON() as Record<string, unknown>;
+      route.fulfill({
+        json: { id: 99, book_id: 1342, chapter_index: 0, sentence_text: annotationBody?.sentence_text, note_text: "", color: "yellow" },
+      });
+    } else {
+      route.fulfill({ json: [] });
+    }
+  });
+
+  await page.goto("/reader/1342");
+
+  // Wait for the first chapter sentence to appear
+  const fullSentence = MOCK_CHAPTERS[0].text;
+  await expect(page.getByText(fullSentence.slice(0, 30), { exact: false })).toBeVisible({ timeout: 5000 });
+
+  // Use evaluate to select just the first word ("It") inside the first [data-seg] span,
+  // then dispatch selectionchange so SelectionToolbar picks it up.
+  const segText = await page.evaluate(() => {
+    const seg = document.querySelector("[data-seg]");
+    if (!seg || !seg.firstChild) return null;
+    const range = document.createRange();
+    // Select just the first two characters ("It") of the segment's text node
+    range.setStart(seg.firstChild, 0);
+    range.setEnd(seg.firstChild, Math.min(2, seg.firstChild.textContent?.length ?? 2));
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+    document.dispatchEvent(new Event("selectionchange"));
+    return seg.textContent?.trim() ?? null;
+  });
+
+  // The segment must exist and contain text
+  expect(segText).toBeTruthy();
+
+  // SelectionToolbar should appear with Highlight button
+  const highlightBtn = page.getByRole("button", { name: /highlight/i });
+  await expect(highlightBtn).toBeVisible({ timeout: 3000 });
+
+  // Click Highlight — this opens the QuickHighlightPanel with color choices
+  await highlightBtn.click();
+
+  // QuickHighlightPanel shows color buttons; click Yellow to trigger the annotation POST
+  const yellowBtn = page.getByRole("button", { name: /yellow/i });
+  await expect(yellowBtn).toBeVisible({ timeout: 3000 });
+  await yellowBtn.click();
+
+  // Verify the POST was made with the full sentence, not just "It"
+  expect(annotationBody).not.toBeNull();
+  const sentenceText = (annotationBody as Record<string, unknown>)?.sentence_text as string;
+  expect(sentenceText).not.toBe("It");
+  expect(sentenceText).toBe(segText);
+  // Confirm it contains the full sentence text
+  expect(sentenceText.length).toBeGreaterThan(5);
+});


### PR DESCRIPTION
## Summary

- Adds E2E test for landing hero visibility (#406): unauthenticated visitors see the hero on the Discover tab; authenticated users do not
- Adds E2E test for SelectionToolbar highlight full-sentence context (#407): selecting a word and highlighting sends the full `[data-seg]` sentence as `sentence_text`, not just the raw selection substring

## Key details

- **Landing hero test**: The hero uses `&rsquo;` (U+2019 curly quote) in JSX, so the locator uses `.s` wildcard (`/Read the world.s greatest books/i`) to avoid ASCII-vs-Unicode apostrophe mismatch
- **Highlight test**: Clicking "Highlight" in `SelectionToolbar` opens `QuickHighlightPanel` with color choices; the test clicks "Yellow" to trigger the annotation POST and then asserts `sentence_text` equals the full segment text
- Both tests pass locally against the Playwright dev server with `mockBackend`

## Test plan

- [x] `landing.spec.ts` — unauthenticated hero visible / authenticated hero hidden: both pass
- [x] `reader-highlight.spec.ts` — full sentence in annotation POST: passes

Closes #406, #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)
