### PR TITLE
fix: reject out-of-bounds chapter_index with 400 (closes #429)

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -265,6 +265,15 @@ async def request_chapter_translation(
             detail="Cannot translate to the same language as the original.",
         )
 
+    # 0e. Guard: reject out-of-bounds chapter_index.
+    from services.book_chapters import split_with_html_preference
+    _chapters = await split_with_html_preference(book_id, book_meta.get("text") or "")
+    if chapter_index < 0 or chapter_index >= len(_chapters):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Chapter index out of range (book has {len(_chapters)} chapter(s)).",
+        )
+
     # 1. New translation requires login.
     if user is None:
         raise HTTPException(
@@ -375,8 +384,16 @@ async def retry_chapter_translation(
     check_book_access(book, user)
 
     from services.translation_queue import enqueue, queue_status_for_chapter, worker
+    from services.book_chapters import split_with_html_preference as _split
 
     target_language = req.target_language.lower().split("-")[0]
+
+    _ch = await _split(book_id, book.get("text") or "")
+    if chapter_index < 0 or chapter_index >= len(_ch):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Chapter index out of range (book has {len(_ch)} chapter(s)).",
+        )
 
     # Guard: reject retry of a running item. enqueue(reset_failed=True) resets
     # status='pending' in-place — same row ID. When the worker finishes it calls

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -952,3 +952,48 @@ async def test_owner_can_access_own_upload_book(client, test_user, tmp_db):
     await _insert_upload_book(9911, test_user["id"])
     resp = await client.get("/api/books/9911")
     assert resp.status_code == 200, resp.text
+
+
+# ── chapter_index bounds checks ───────────────────────────────────────────────
+
+async def test_request_translation_out_of_bounds_chapter_returns_400(client, test_user):
+    """Regression #429: POST /translation with chapter_index beyond chapter count must
+    return 400 instead of silently enqueuing impossible work.
+    """
+    from services.db import set_user_gemini_key
+    from services.auth import encrypt_api_key
+    from services.book_chapters import clear_cache as _clear
+
+    text = "CHAPTER I\n\n" + "word " * 200 + "\n\nCHAPTER II\n\n" + "word " * 200
+    await save_book(9877, {**MOCK_META, "id": 9877, "languages": ["de"]}, text)
+    _clear()
+    await set_user_gemini_key(test_user["id"], encrypt_api_key("test-key"))
+
+    resp = await client.post(
+        "/api/books/9877/chapters/999/translation",
+        json={"target_language": "en"},
+    )
+    assert resp.status_code == 400, (
+        f"Expected 400 for out-of-bounds chapter_index=999 on 2-chapter book, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_retry_translation_out_of_bounds_chapter_returns_400(client, test_user):
+    """Regression #429: POST /translation/retry with out-of-bounds chapter_index
+    must return 400 instead of silently enqueuing impossible work.
+    """
+    from services.book_chapters import clear_cache as _clear
+
+    text = "CHAPTER I\n\n" + "word " * 200 + "\n\nCHAPTER II\n\n" + "word " * 200
+    await save_book(9878, {**MOCK_META, "id": 9878, "languages": ["de"]}, text)
+    _clear()
+
+    resp = await client.post(
+        "/api/books/9878/chapters/999/translation/retry",
+        json={"target_language": "en"},
+    )
+    assert resp.status_code == 400, (
+        f"Expected 400 for out-of-bounds chapter_index=999 on 2-chapter book, "
+        f"got {resp.status_code}: {resp.text}"
+    )

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -345,8 +345,13 @@ async def test_retry_chapter_translation_inserts_if_no_row(client):
     still succeeds and creates a pending row."""
     import aiosqlite
     import services.db as db_module
+    from services.book_chapters import clear_cache as _clear
 
-    await save_book(1342, MOCK_META, "text")
+    text = "\n\n".join(
+        f"CHAPTER {i}\n\n" + "word " * 200 for i in range(1, 4)
+    )
+    await save_book(1342, MOCK_META, text)
+    _clear()
     resp = await client.post(
         "/api/books/1342/chapters/2/translation/retry",
         json={"target_language": "fr"},


### PR DESCRIPTION
## Root cause

`POST /books/{id}/chapters/{idx}/translation` and its `/retry` variant accepted any integer `chapter_index` without validating it against the actual chapter count. An out-of-bounds index was silently enqueued, the API returned `status=pending` (false success), and the queue worker later marked it `failed` with "chapter index out of range".

## Fix

Both endpoints now call `split_with_html_preference(book_id, text)` (result is cached so it's essentially free for a book the user is actively reading) and raise `HTTP 400` if `chapter_index < 0` or `chapter_index >= len(chapters)`.

## Test plan

- `test_request_translation_out_of_bounds_chapter_returns_400` — asserts POST with `chapter_index=999` on a 2-chapter book returns 400
- `test_retry_translation_out_of_bounds_chapter_returns_400` — same for the `/retry` variant
- Full backend suite: 1022 passed

Closes #429
