### PR TITLE
fix: uploaded text chapter detection, admin quota bypass, vocab sort modes

### DIFF
--- a/backend/routers/uploads.py
+++ b/backend/routers/uploads.py
@@ -59,13 +59,14 @@ async def upload_book(
     """Upload a .txt or .epub file. Returns book_id + detected chapters for editing."""
     from services.book_parser import parse_txt, parse_epub
 
-    # Quota check
-    count = await _user_upload_count(user["id"])
-    if count >= MAX_BOOKS_PER_USER:
-        raise HTTPException(
-            status_code=429,
-            detail=f"Upload limit reached ({MAX_BOOKS_PER_USER} books). Delete a book to upload more.",
-        )
+    # Quota check — admins are exempt
+    if user.get("role") != "admin":
+        count = await _user_upload_count(user["id"])
+        if count >= MAX_BOOKS_PER_USER:
+            raise HTTPException(
+                status_code=429,
+                detail=f"Upload limit reached ({MAX_BOOKS_PER_USER} books). Delete a book to upload more.",
+            )
 
     # Format check
     filename = file.filename or ""
@@ -123,9 +124,10 @@ async def upload_book(
 
 @router.get("/upload/quota")
 async def upload_quota(user: dict = Depends(get_current_user)):
-    """Return the user's upload quota usage."""
+    """Return the user's upload quota usage. max is null for admins (no limit)."""
     count = await _user_upload_count(user["id"])
-    return {"used": count, "max": MAX_BOOKS_PER_USER}
+    max_books = None if user.get("role") == "admin" else MAX_BOOKS_PER_USER
+    return {"used": count, "max": max_books}
 
 
 @router.get("/{book_id}/chapters/draft")

--- a/backend/services/book_parser.py
+++ b/backend/services/book_parser.py
@@ -3,12 +3,19 @@ import re
 import io
 from typing import Any
 
-CHAPTER_PATTERNS = [
-    re.compile(r'^\s*CHAPTER\s+[IVXLCDM\d]+', re.I),
-    re.compile(r'^\s*Chapter\s+\w+'),
-    re.compile(r'^\s*PART\s+[IVXLCDM\d]+', re.I),
-    re.compile(r'^\s*[IVX]{1,6}\.\s*$'),
-    re.compile(r'^\s*\d+\.\s*$'),
+# High-confidence chapter markers — unlikely to appear in front matter / preamble.
+# Tried first; if ≥ 2 boundaries found here we use them exclusively.
+_HC_PATTERNS = [
+    re.compile(r'^\s*(CHAPTER|CHAPITRE|KAPITEL|CAPITULO|CAPO)\s+\S', re.I),
+    re.compile(r'^\s*(PART|BOOK|SECTION|ACT)\s+\S', re.I),
+    re.compile(r'^\s*[IVX]{1,6}\.\s*$'),    # I.  II.  III.
+    re.compile(r'^\s*\d+\.\s*$'),             # 1.  2.  3.
+    re.compile(r'^\s*\d+\s*$'),              # 1   2   3  (bare numbers — Hemingway, Chandler)
+]
+
+# Low-confidence: ALL-CAPS headings. More false positives in title/preamble;
+# only used when HC patterns find fewer than 2 boundaries.
+_LC_PATTERNS = [
     re.compile(r'^\s*[A-Z][A-Z\s]{4,40}\s*$'),
 ]
 
@@ -16,51 +23,86 @@ MAX_CHAPTERS = 200
 FALLBACK_WORDS = 5000
 
 
-def _is_chapter_boundary(line: str) -> bool:
-    stripped = line.strip()
-    if not stripped:
-        return False
-    return any(p.match(stripped) for p in CHAPTER_PATTERNS)
+def _find_boundaries(lines: list[str], patterns: list[re.Pattern]) -> list[int]:
+    boundaries: list[int] = []
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if any(p.match(stripped) for p in patterns):
+            prev_blank = i == 0 or not lines[i - 1].strip()
+            if prev_blank:
+                boundaries.append(i)
+    return boundaries
+
+
+def _normalize_text(text: str) -> str:
+    """Strip leading tab indentation and collapse excess blank lines."""
+    lines = [line.lstrip('\t') for line in text.splitlines()]
+    result = '\n'.join(lines)
+    result = re.sub(r'\n{3,}', '\n\n', result)
+    return result.strip()
 
 
 def _extract_title(text: str) -> str:
     for line in text.split('\n')[:20]:
-        line = line.strip()
-        if line and len(line) < 100:
-            return line
+        stripped = line.strip()
+        if stripped and len(stripped) < 100:
+            return stripped
     return "Untitled"
 
 
+def _extract_author(text: str) -> str:
+    for line in text.split('\n')[:30]:
+        m = re.match(r'^\s*[Bb]y\s+(.+)$', line.strip())
+        if m:
+            candidate = m.group(1).strip()
+            if 1 < len(candidate) < 80:
+                return candidate
+    return "Unknown"
+
+
 def parse_txt(content: str) -> dict[str, Any]:
-    """Detect chapters in plain text. Returns {title, chapters: [{title, text}]}."""
+    """Detect chapters in plain text. Returns {title, author, chapters: [{title, text}]}."""
     lines = content.splitlines()
-    # Find boundaries: lines matching chapter pattern preceded by blank line
-    boundaries: list[int] = []
-    for i, line in enumerate(lines):
-        if _is_chapter_boundary(line):
-            # Check at least one blank line before (or start of file)
-            prev_blank = i == 0 or (i > 0 and not lines[i - 1].strip())
-            if prev_blank:
-                boundaries.append(i)
+
+    # 1. Try high-confidence patterns only (avoids false positives from title/preamble).
+    boundaries = _find_boundaries(lines, _HC_PATTERNS)
+
+    # 2. Fall back to including all-caps headings if too few HC boundaries found.
+    if len(boundaries) < 2:
+        boundaries = _find_boundaries(lines, _HC_PATTERNS + _LC_PATTERNS)
 
     if len(boundaries) < 2:
-        # Fallback: split every FALLBACK_WORDS words
+        # Last resort: word-count splitting.
         words = content.split()
         chunks = [words[i:i + FALLBACK_WORDS] for i in range(0, len(words), FALLBACK_WORDS)]
-        chapters = [{"title": f"Part {idx + 1}", "text": " ".join(chunk)} for idx, chunk in enumerate(chunks)]
+        chapters = [
+            {"title": f"Part {idx + 1}", "text": _normalize_text(" ".join(chunk))}
+            for idx, chunk in enumerate(chunks)
+        ]
     else:
         boundaries = boundaries[:MAX_CHAPTERS]
         boundaries.append(len(lines))  # sentinel
+
         chapters = []
+        # Capture substantial front matter (copyright, dedication, etc.)
+        front = _normalize_text("\n".join(lines[:boundaries[0]]))
+        if len(front.split()) > 50:
+            chapters.append({"title": "Front Matter", "text": front})
+
         for i in range(len(boundaries) - 1):
             start = boundaries[i]
             end = boundaries[i + 1]
             title = lines[start].strip()
-            body = "\n".join(lines[start + 1:end]).strip()
+            body = _normalize_text("\n".join(lines[start + 1:end]))
             chapters.append({"title": title, "text": body})
 
-    title = _extract_title(content)
-    return {"title": title, "author": "Unknown", "chapters": chapters}
+    return {
+        "title": _extract_title(content),
+        "author": _extract_author(content),
+        "chapters": chapters,
+    }
 
 
 def parse_epub(file_bytes: bytes) -> dict[str, Any]:

--- a/backend/tests/test_book_parser.py
+++ b/backend/tests/test_book_parser.py
@@ -1,0 +1,268 @@
+"""
+Regression tests for services/book_parser.py — uploaded text file parsing.
+
+Covers the common plain-text novel formats that were mis-detected before the fix:
+  - Bare-number chapter markers (Hemingway, Chandler style: 1 / 2 / 3)
+  - CHAPTER X / Chapter X markers
+  - PART / BOOK section headings
+  - Roman numeral headings  (I. / II.)
+  - ALL-CAPS headings as fallback (when no HC patterns found)
+  - Word-count fallback when no structural markers present
+  - Tab-indented paragraph normalization
+  - Author extraction from "by Author" line
+  - Front matter captured as leading chapter
+"""
+import pytest
+from services.book_parser import parse_txt
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_book(header: str, chapters: list[tuple[str, str]]) -> str:
+    """Build a minimal book string from a header and (marker, body) pairs."""
+    parts = [header, ""]
+    for marker, body in chapters:
+        parts += ["", marker, "", body, ""]
+    return "\n".join(parts)
+
+
+# ── Bare-number chapters (Hemingway / Chandler style) ─────────────────────────
+
+FAREWELL_SAMPLE = """A FAREWELL TO ARMS
+  by Ernest Hemingway
+
+Copyright 1929.  All rights reserved.
+
+A FAREWELL TO ARMS
+
+BOOK ONE
+
+
+1
+
+\tIn the late summer of that year we lived in a house in a village.
+
+2
+
+\tThe next year there were many victories.
+
+3
+
+\tWhen I came back to the front we still lived in that town.
+"""
+
+BIG_SLEEP_SAMPLE = """THE BIG SLEEP
+by Raymond Chandler
+
+1
+
+\tIT WAS ABOUT ELEVEN O'CLOCK in the morning, mid October.
+
+2
+
+\tThe main hallway of the Sternwood place was two stories high.
+
+3
+
+\tThe butler came back and murmured at me genteelly.
+"""
+
+
+def test_bare_number_chapters_detected_farewell_to_arms():
+    result = parse_txt(FAREWELL_SAMPLE)
+    titles = [ch["title"] for ch in result["chapters"]]
+    # Numbered chapters must all be present
+    assert "1" in titles
+    assert "2" in titles
+    assert "3" in titles
+
+
+def test_bare_number_chapters_detected_big_sleep():
+    result = parse_txt(BIG_SLEEP_SAMPLE)
+    titles = [ch["title"] for ch in result["chapters"]]
+    assert "1" in titles
+    assert "2" in titles
+    assert "3" in titles
+
+
+def test_bare_number_chapters_not_word_count_fallback():
+    """With bare-number markers, chapters must NOT be named 'Part N'."""
+    result = parse_txt(BIG_SLEEP_SAMPLE)
+    part_names = [ch for ch in result["chapters"] if ch["title"].startswith("Part ")]
+    assert len(part_names) == 0, f"Unexpected word-count fallback chapters: {part_names}"
+
+
+def test_chapter_text_content_correct():
+    """Each numbered chapter gets the right body text."""
+    result = parse_txt(BIG_SLEEP_SAMPLE)
+    ch1 = next(ch for ch in result["chapters"] if ch["title"] == "1")
+    assert "ELEVEN O'CLOCK" in ch1["text"]
+
+    ch2 = next(ch for ch in result["chapters"] if ch["title"] == "2")
+    assert "Sternwood" in ch2["text"]
+
+
+# ── Tab indentation normalized ────────────────────────────────────────────────
+
+def test_tab_indentation_stripped_from_chapter_text():
+    result = parse_txt(BIG_SLEEP_SAMPLE)
+    ch1 = next(ch for ch in result["chapters"] if ch["title"] == "1")
+    # No line in the chapter text should start with a tab
+    for line in ch1["text"].splitlines():
+        assert not line.startswith("\t"), f"Tab found in chapter text line: {repr(line)}"
+
+
+# ── CHAPTER X / Roman numeral formats ────────────────────────────────────────
+
+CHAPTER_KEYWORD_SAMPLE = _make_book(
+    "A Classic Novel\nby Jane Author",
+    [
+        ("CHAPTER I", "The beginning of the story where things happen."),
+        ("CHAPTER II", "More events unfold as the story continues."),
+        ("CHAPTER III", "The climax arrives and everything changes."),
+    ],
+)
+
+ROMAN_NUMERAL_SAMPLE = _make_book(
+    "Another Novel",
+    [
+        ("I.", "First chapter text is here."),
+        ("II.", "Second chapter text is here."),
+        ("III.", "Third chapter text is here."),
+    ],
+)
+
+DOTTED_NUMBER_SAMPLE = _make_book(
+    "Yet Another Novel",
+    [
+        ("1.", "Chapter one content."),
+        ("2.", "Chapter two content."),
+        ("3.", "Chapter three content."),
+    ],
+)
+
+
+def test_chapter_keyword_detected():
+    result = parse_txt(CHAPTER_KEYWORD_SAMPLE)
+    titles = [ch["title"] for ch in result["chapters"]]
+    assert "CHAPTER I" in titles
+    assert "CHAPTER II" in titles
+
+
+def test_roman_numeral_chapters_detected():
+    result = parse_txt(ROMAN_NUMERAL_SAMPLE)
+    titles = [ch["title"] for ch in result["chapters"]]
+    assert "I." in titles
+    assert "II." in titles
+
+
+def test_dotted_number_chapters_detected():
+    result = parse_txt(DOTTED_NUMBER_SAMPLE)
+    titles = [ch["title"] for ch in result["chapters"]]
+    assert "1." in titles
+    assert "2." in titles
+
+
+# ── BOOK / PART section headings ─────────────────────────────────────────────
+
+BOOK_SECTION_SAMPLE = """A Long Novel
+by Some Author
+
+BOOK ONE
+
+1
+
+First chapter of book one.
+
+2
+
+Second chapter of book one.
+
+BOOK TWO
+
+3
+
+First chapter of book two.
+"""
+
+
+def test_book_section_headings_detected():
+    result = parse_txt(BOOK_SECTION_SAMPLE)
+    titles = [ch["title"] for ch in result["chapters"]]
+    assert "1" in titles
+    assert "2" in titles
+    assert "3" in titles
+
+
+# ── Author extraction ─────────────────────────────────────────────────────────
+
+def test_author_extracted_from_by_line():
+    result = parse_txt(BIG_SLEEP_SAMPLE)
+    assert result["author"] == "Raymond Chandler"
+
+
+def test_author_extracted_case_insensitive():
+    txt = "My Novel\nBy John Doe\n\n1\n\nChapter text.\n\n2\n\nMore text.\n"
+    result = parse_txt(txt)
+    assert result["author"] == "John Doe"
+
+
+def test_author_unknown_when_no_by_line():
+    txt = "My Novel\n\n1\n\nChapter text.\n\n2\n\nMore text.\n"
+    result = parse_txt(txt)
+    assert result["author"] == "Unknown"
+
+
+# ── Title extraction ──────────────────────────────────────────────────────────
+
+def test_title_extracted():
+    result = parse_txt(BIG_SLEEP_SAMPLE)
+    assert result["title"] == "THE BIG SLEEP"
+
+
+# ── Word-count fallback ───────────────────────────────────────────────────────
+
+def test_word_count_fallback_when_no_markers():
+    # A wall of text with no chapter markers → Part N fallback
+    words = " ".join([f"word{i}" for i in range(12_000)])
+    txt = f"Unknown Title\n\n{words}"
+    result = parse_txt(txt)
+    titles = [ch["title"] for ch in result["chapters"]]
+    assert any(t.startswith("Part ") for t in titles)
+    assert len(result["chapters"]) >= 2
+
+
+# ── ALL-CAPS fallback (old Gutenberg books with no explicit markers) ──────────
+
+ALLCAPS_SAMPLE = """AN OLD BOOK
+
+THE FIRST TALE
+
+Once upon a time in a land far away there lived a king.
+
+THE SECOND TALE
+
+In another kingdom there was a queen who ruled wisely.
+
+THE THIRD TALE
+
+Many years passed and the world changed greatly.
+"""
+
+
+def test_allcaps_headings_detected_as_fallback():
+    result = parse_txt(ALLCAPS_SAMPLE)
+    titles = [ch["title"] for ch in result["chapters"]]
+    assert "THE FIRST TALE" in titles
+    assert "THE SECOND TALE" in titles
+    assert "THE THIRD TALE" in titles
+
+
+# ── Excess blank line collapse ────────────────────────────────────────────────
+
+def test_multiple_blank_lines_collapsed():
+    txt = "My Book\n\n1\n\n\n\n\n\nChapter text here.\n\n2\n\n\n\n\nMore text.\n"
+    result = parse_txt(txt)
+    for ch in result["chapters"]:
+        # No run of 3+ consecutive newlines
+        assert "\n\n\n" not in ch["text"], f"Excess blank lines in chapter '{ch['title']}'"

--- a/backend/tests/test_router_uploads.py
+++ b/backend/tests/test_router_uploads.py
@@ -7,7 +7,7 @@ import pytest
 import aiosqlite
 from unittest.mock import AsyncMock, patch
 from services.db import (
-    get_or_create_user, get_user_by_id,
+    get_or_create_user, get_user_by_id, set_user_role,
     save_translation, create_annotation, save_insight,
     save_chapter_summary, upsert_reading_progress, save_word,
     set_user_role,
@@ -74,6 +74,7 @@ async def test_upload_quota_returns_count(client, test_user):
 async def test_upload_quota_exceeded_returns_429(client, test_user):
     # test_user is auto-admin in a fresh db; demote so the quota limit applies
     await set_user_role(test_user["id"], "user")
+    # Patch the quota check function to simulate limit reached
     with patch("routers.uploads._user_upload_count", new_callable=AsyncMock, return_value=10):
         resp = await client.post("/api/books/upload", files=_txt_upload())
     assert resp.status_code == 429

--- a/frontend/src/__tests__/VocabularyPage.sort.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.sort.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * Regression tests for vocabulary page sort/group modes (#422):
+ * - A–Z: existing alphabetical letter sections
+ * - Language: sections per language, Unknown last
+ * - Book: sections per book, words appear under all their books
+ * - Recent: flat list newest-first, no section headings
+ */
+import React from "react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { backendToken: "tok" } }),
+}));
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getVocabulary: jest.fn(),
+  deleteVocabularyWord: jest.fn(),
+  exportVocabularyToObsidian: jest.fn(),
+  getWordDefinition: jest.fn(),
+}));
+
+import * as api from "@/lib/api";
+import VocabularyPage from "@/app/vocabulary/page";
+
+const mockGetVocabulary = api.getVocabulary as jest.MockedFunction<typeof api.getVocabulary>;
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+// 6 words so the sort control renders (words.length > 5)
+const WORDS = [
+  {
+    id: 1, word: "Angst", lemma: "Angst", language: "German",
+    created_at: "2026-04-01T10:00:00",
+    occurrences: [{ book_id: 1, book_title: "Faust", chapter_index: 0, sentence_text: "s1" }],
+  },
+  {
+    id: 2, word: "Weltschmerz", lemma: "Weltschmerz", language: "German",
+    created_at: "2026-04-10T12:00:00",
+    occurrences: [{ book_id: 1, book_title: "Faust", chapter_index: 2, sentence_text: "s2" }],
+  },
+  {
+    id: 3, word: "sonder", lemma: "sonder", language: "French",
+    created_at: "2026-04-05T08:00:00",
+    occurrences: [{ book_id: 2, book_title: "Les Misérables", chapter_index: 1, sentence_text: "s3" }],
+  },
+  {
+    id: 4, word: "melancholy", lemma: "melancholy", language: null,
+    created_at: "2026-04-15T09:00:00",
+    occurrences: [{ book_id: 3, book_title: "Frankenstein", chapter_index: 0, sentence_text: "s4" }],
+  },
+  {
+    id: 5, word: "sublime", lemma: "sublime", language: null,
+    created_at: "2026-04-03T11:00:00",
+    occurrences: [
+      { book_id: 3, book_title: "Frankenstein", chapter_index: 1, sentence_text: "s5a" },
+      { book_id: 1, book_title: "Faust", chapter_index: 3, sentence_text: "s5b" },
+    ],
+  },
+  {
+    id: 6, word: "gothic", lemma: "gothic", language: null,
+    created_at: "2026-04-20T07:00:00",
+    occurrences: [{ book_id: 3, book_title: "Frankenstein", chapter_index: 4, sentence_text: "s6" }],
+  },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetVocabulary.mockResolvedValue(WORDS);
+});
+
+async function renderAndLoad() {
+  render(<VocabularyPage />);
+  await act(async () => { await flushPromises(); });
+  await screen.findByText("Angst");
+}
+
+// ── A–Z mode (default) ────────────────────────────────────────────────────────
+
+describe("vocabulary sort — A–Z (default)", () => {
+  it("shows letter section headings", async () => {
+    await renderAndLoad();
+    // "A" section for Angst
+    expect(screen.getByText("A")).toBeInTheDocument();
+    // "G" for gothic
+    expect(screen.getByText("G")).toBeInTheDocument();
+  });
+
+  it("A–Z button is active by default", async () => {
+    await renderAndLoad();
+    const alphaBtn = screen.getByTestId("sort-alpha");
+    expect(alphaBtn.className).toMatch(/bg-amber-700/);
+  });
+});
+
+// ── Language mode ─────────────────────────────────────────────────────────────
+
+describe("vocabulary sort — Language", () => {
+  it("shows language section headings after switching to Language mode", async () => {
+    await renderAndLoad();
+    fireEvent.click(screen.getByTestId("sort-language"));
+
+    // Section headings are h2 elements
+    expect(screen.getByRole("heading", { level: 2, name: "French" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: "German" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: "Unknown" })).toBeInTheDocument();
+  });
+
+  it("German words appear under German section", async () => {
+    await renderAndLoad();
+    fireEvent.click(screen.getByTestId("sort-language"));
+
+    expect(screen.getByRole("heading", { level: 2, name: "German" })).toBeInTheDocument();
+    expect(screen.getByText("Angst")).toBeInTheDocument();
+    expect(screen.getByText("Weltschmerz")).toBeInTheDocument();
+  });
+
+  it("Unknown section appears last (words without language)", async () => {
+    await renderAndLoad();
+    fireEvent.click(screen.getByTestId("sort-language"));
+
+    const headings = screen.getAllByRole("heading", { level: 2 }).map((h) => h.textContent);
+    expect(headings[headings.length - 1]).toBe("Unknown");
+  });
+
+  it("no letter headings visible in language mode", async () => {
+    await renderAndLoad();
+    fireEvent.click(screen.getByTestId("sort-language"));
+
+    // Single-letter headings (A, G, M, etc.) should not appear
+    expect(screen.queryByRole("heading", { level: 2, name: "A" })).not.toBeInTheDocument();
+  });
+});
+
+// ── Book mode ─────────────────────────────────────────────────────────────────
+
+describe("vocabulary sort — Book", () => {
+  it("shows book title as section heading", async () => {
+    await renderAndLoad();
+    fireEvent.click(screen.getByTestId("sort-book"));
+
+    // Each book appears at least once as heading (may also appear as occurrence link)
+    expect(screen.getAllByText("Faust").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Frankenstein").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Les Misérables").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("a word with occurrences in multiple books appears in each", async () => {
+    // 'sublime' has occurrences in both Frankenstein and Faust
+    await renderAndLoad();
+    fireEvent.click(screen.getByTestId("sort-book"));
+
+    // sublime should appear twice (once per book section)
+    const sublimeEls = screen.getAllByText("sublime");
+    expect(sublimeEls.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ── Recent mode ───────────────────────────────────────────────────────────────
+
+describe("vocabulary sort — Recent", () => {
+  it("no section headings in recent mode", async () => {
+    await renderAndLoad();
+    fireEvent.click(screen.getByTestId("sort-recent"));
+
+    // No letter-style single-char or language headings
+    expect(screen.queryByRole("heading", { level: 2, name: "A" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { level: 2, name: "German" })).not.toBeInTheDocument();
+  });
+
+  it("most recently saved word (gothic, 2026-04-20) appears first", async () => {
+    await renderAndLoad();
+    fireEvent.click(screen.getByTestId("sort-recent"));
+
+    // Get all word lemma buttons in render order
+    const wordButtons = screen.getAllByRole("button").filter(
+      (b) => ["gothic", "melancholy", "Weltschmerz", "sonder", "sublime", "Angst"].includes(b.textContent ?? ""),
+    );
+    expect(wordButtons[0].textContent).toBe("gothic");
+  });
+});
+
+// ── Sort control renders only when words.length > 5 ──────────────────────────
+
+describe("vocabulary sort — control visibility", () => {
+  it("sort control is visible when > 5 words", async () => {
+    await renderAndLoad();
+    expect(screen.getByTestId("sort-mode-control")).toBeInTheDocument();
+  });
+
+  it("sort control is hidden when ≤ 5 words", async () => {
+    mockGetVocabulary.mockResolvedValue(WORDS.slice(0, 3));
+    render(<VocabularyPage />);
+    await act(async () => { await flushPromises(); });
+    await screen.findByText("Angst");
+
+    expect(screen.queryByTestId("sort-mode-control")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -12,9 +12,19 @@ import {
 } from "@/lib/api";
 import { EmptyVocabIcon, ArrowLeftIcon } from "@/components/Icons";
 
+type SortMode = "alpha" | "language" | "book" | "recent";
+
+const SORT_MODES: { value: SortMode; label: string }[] = [
+  { value: "alpha", label: "A–Z" },
+  { value: "language", label: "Language" },
+  { value: "book", label: "Book" },
+  { value: "recent", label: "Recent" },
+];
+
 interface LemmaGroup {
   lemma: string;
   language: string | null;
+  savedAt: string | null;
   forms: VocabularyWord[];
 }
 
@@ -23,11 +33,69 @@ function buildGroups(words: VocabularyWord[]): LemmaGroup[] {
   for (const w of words) {
     const key = (w.lemma || w.word).toLowerCase();
     if (!map.has(key)) {
-      map.set(key, { lemma: w.lemma || w.word, language: w.language ?? null, forms: [] });
+      map.set(key, { lemma: w.lemma || w.word, language: w.language ?? null, savedAt: w.created_at ?? null, forms: [] });
     }
     map.get(key)!.forms.push(w);
   }
   return Array.from(map.values()).sort((a, b) => a.lemma.localeCompare(b.lemma));
+}
+
+function buildSections(
+  groups: LemmaGroup[],
+  mode: SortMode,
+): { heading: string; groups: LemmaGroup[] }[] {
+  if (mode === "recent") {
+    const sorted = [...groups].sort((a, b) => {
+      const ta = a.savedAt ?? "";
+      const tb = b.savedAt ?? "";
+      return tb.localeCompare(ta);
+    });
+    return [{ heading: "", groups: sorted }];
+  }
+
+  if (mode === "alpha") {
+    const byLetter = groups.reduce<Record<string, LemmaGroup[]>>((acc, g) => {
+      const letter = g.lemma[0]?.toUpperCase() ?? "#";
+      (acc[letter] ??= []).push(g);
+      return acc;
+    }, {});
+    return Object.keys(byLetter)
+      .sort()
+      .map((letter) => ({ heading: letter, groups: byLetter[letter] }));
+  }
+
+  if (mode === "language") {
+    const byLang = groups.reduce<Record<string, LemmaGroup[]>>((acc, g) => {
+      const lang = g.language ?? "Unknown";
+      (acc[lang] ??= []).push(g);
+      return acc;
+    }, {});
+    const langs = Object.keys(byLang).sort((a, b) => {
+      if (a === "Unknown") return 1;
+      if (b === "Unknown") return -1;
+      return a.localeCompare(b);
+    });
+    return langs.map((lang) => ({ heading: lang, groups: byLang[lang] }));
+  }
+
+  // mode === "book": a word appears under every book it has occurrences in
+  const byBook = new Map<string, LemmaGroup[]>();
+  for (const g of groups) {
+    const books = new Set<string>();
+    for (const f of g.forms) {
+      for (const occ of f.occurrences) {
+        const title = occ.book_title ?? "(deleted book)";
+        if (!books.has(title)) {
+          books.add(title);
+          if (!byBook.has(title)) byBook.set(title, []);
+          byBook.get(title)!.push(g);
+        }
+      }
+    }
+  }
+  return Array.from(byBook.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([heading, gs]) => ({ heading, groups: gs }));
 }
 
 interface DefinitionSheetProps {
@@ -136,6 +204,7 @@ function VocabularyPageContent() {
   const [exporting, setExporting] = useState(false);
   const [deleting, setDeleting] = useState<string | null>(null);
   const [search, setSearch] = useState("");
+  const [sortMode, setSortMode] = useState<SortMode>("alpha");
   const [activeWord, setActiveWord] = useState<{ word: string; lang: string | null } | null>(null);
   const highlightRef = useRef<HTMLDivElement>(null);
 
@@ -158,17 +227,8 @@ function VocabularyPageContent() {
     );
   }, [groups, search]);
 
-  const letterGroups = useMemo(() =>
-    filtered.reduce<Record<string, LemmaGroup[]>>((acc, g) => {
-      const letter = g.lemma[0]?.toUpperCase() ?? "#";
-      (acc[letter] ??= []).push(g);
-      return acc;
-    }, {}),
-    [filtered]
-  );
-  const letters = Object.keys(letterGroups).sort();
+  const sections = useMemo(() => buildSections(filtered, sortMode), [filtered, sortMode]);
 
-  // Scroll to the target word on first load
   useEffect(() => {
     if (!targetWord || loading) return;
     const t = setTimeout(() => {
@@ -214,6 +274,86 @@ function VocabularyPageContent() {
 
   const closeSheet = useCallback(() => setActiveWord(null), []);
 
+  function renderGroup(group: LemmaGroup) {
+    const target = isTarget(group);
+    const occurrenceCount = group.forms.reduce((s, f) => s + f.occurrences.length, 0);
+    const alternateForms = group.forms.filter(
+      (f) => f.word.toLowerCase() !== group.lemma.toLowerCase(),
+    );
+    return (
+      <div
+        key={group.lemma}
+        ref={target ? highlightRef : undefined}
+        className={`rounded-xl border p-4 transition-colors ${
+          target
+            ? "bg-white border-amber-400 ring-2 ring-amber-300 animate-vocab-flash"
+            : "bg-white border-amber-100"
+        }`}
+      >
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-2 flex-wrap">
+            <button
+              onClick={() => setActiveWord({ word: group.lemma, lang: group.language })}
+              className="font-serif font-semibold text-ink text-base hover:text-amber-700 transition-colors text-left"
+            >
+              {group.lemma}
+            </button>
+            {alternateForms.length > 0 && (
+              <span className="text-xs text-stone-400">
+                ({alternateForms.map((f) => f.word).join(", ")})
+              </span>
+            )}
+            {group.language && (
+              <span className="text-xs text-amber-600 bg-amber-50 rounded-full px-2 py-0.5 border border-amber-200">
+                {group.language}
+              </span>
+            )}
+            <span className="text-xs text-stone-400 bg-stone-100 rounded-full px-2 py-0.5">
+              {occurrenceCount}×
+            </span>
+          </div>
+          <div className="flex items-center gap-1">
+            {group.forms.map((f) => (
+              <button
+                key={f.word}
+                onClick={() => handleDelete(f.word)}
+                disabled={deleting === f.word}
+                className="text-xs text-red-400 hover:text-red-600 disabled:opacity-50 transition-colors min-h-[44px] md:min-h-0 flex items-center px-2"
+                data-testid={`delete-${f.word}`}
+              >
+                {deleting === f.word ? "…" : "Delete"}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="space-y-1.5">
+          {group.forms.flatMap((f) =>
+            f.occurrences.map((occ, i) => (
+              <div key={`${f.word}-${i}`} className="text-sm text-stone-600">
+                {f.word !== group.lemma && (
+                  <span className="text-xs text-amber-600 font-medium mr-1.5">{f.word}</span>
+                )}
+                {occ.book_title ? (
+                  <a
+                    href={`/reader/${occ.book_id}?chapter=${occ.chapter_index}`}
+                    className="text-amber-700 font-medium hover:underline"
+                  >
+                    {occ.book_title}
+                  </a>
+                ) : (
+                  <span className="text-stone-400 font-medium">(deleted book)</span>
+                )}{" "}
+                <span className="text-stone-400">{`Ch.${occ.chapter_index + 1}`}</span>
+                {" — "}
+                <span className="italic">&ldquo;{occ.sentence_text}&rdquo;</span>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-screen bg-parchment">
       <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
@@ -253,7 +393,7 @@ function VocabularyPageContent() {
 
       <div className="max-w-2xl mx-auto px-4 md:px-6 py-6 md:py-8">
         {words.length > 5 && (
-          <div className="mb-6">
+          <div className="mb-6 space-y-3">
             <input
               type="search"
               value={search}
@@ -261,6 +401,22 @@ function VocabularyPageContent() {
               placeholder="Search words…"
               className="w-full rounded-xl border border-amber-200 bg-white px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
             />
+            <div className="flex rounded-lg border border-amber-200 overflow-hidden" data-testid="sort-mode-control">
+              {SORT_MODES.map(({ value, label }) => (
+                <button
+                  key={value}
+                  onClick={() => setSortMode(value)}
+                  data-testid={`sort-${value}`}
+                  className={`flex-1 px-2 py-2 text-xs font-medium transition-colors ${
+                    sortMode === value
+                      ? "bg-amber-700 text-white"
+                      : "bg-white text-amber-700 hover:bg-amber-50"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
           </div>
         )}
 
@@ -280,86 +436,15 @@ function VocabularyPageContent() {
           <p className="text-center text-stone-400 mt-12 text-sm">No words match &ldquo;{search}&rdquo;</p>
         ) : (
           <div className="space-y-8">
-            {letters.map((letter) => (
-              <div key={letter}>
-                <h2 className="font-serif font-bold text-xl text-amber-700 mb-3 border-b border-amber-100 pb-1">
-                  {letter}
-                </h2>
+            {sections.map(({ heading, groups: sectionGroups }) => (
+              <div key={heading || "__flat__"}>
+                {heading && (
+                  <h2 className="font-serif font-bold text-xl text-amber-700 mb-3 border-b border-amber-100 pb-1">
+                    {heading}
+                  </h2>
+                )}
                 <div className="space-y-4">
-                  {letterGroups[letter].map((group) => {
-                    const target = isTarget(group);
-                    const occurrenceCount = group.forms.reduce((s, f) => s + f.occurrences.length, 0);
-                    const alternateForms = group.forms.filter(
-                      (f) => f.word.toLowerCase() !== group.lemma.toLowerCase(),
-                    );
-                    return (
-                      <div
-                        key={group.lemma}
-                        ref={target ? highlightRef : undefined}
-                        className={`rounded-xl border p-4 transition-colors ${
-                          target
-                            ? "bg-white border-amber-400 ring-2 ring-amber-300 animate-vocab-flash"
-                            : "bg-white border-amber-100"
-                        }`}
-                      >
-                        <div className="flex items-center justify-between mb-2">
-                          <div className="flex items-center gap-2 flex-wrap">
-                            <button
-                              onClick={() => setActiveWord({ word: group.lemma, lang: group.language })}
-                              className="font-serif font-semibold text-ink text-base hover:text-amber-700 transition-colors text-left"
-                            >
-                              {group.lemma}
-                            </button>
-                            {alternateForms.length > 0 && (
-                              <span className="text-xs text-stone-400">
-                                ({alternateForms.map((f) => f.word).join(", ")})
-                              </span>
-                            )}
-                            <span className="text-xs text-stone-400 bg-stone-100 rounded-full px-2 py-0.5">
-                              {occurrenceCount}×
-                            </span>
-                          </div>
-                          <div className="flex items-center gap-1">
-                            {group.forms.map((f) => (
-                              <button
-                                key={f.word}
-                                onClick={() => handleDelete(f.word)}
-                                disabled={deleting === f.word}
-                                className="text-xs text-red-400 hover:text-red-600 disabled:opacity-50 transition-colors min-h-[44px] md:min-h-0 flex items-center px-2"
-                                data-testid={`delete-${f.word}`}
-                              >
-                                {deleting === f.word ? "…" : "Delete"}
-                              </button>
-                            ))}
-                          </div>
-                        </div>
-                        <div className="space-y-1.5">
-                          {group.forms.flatMap((f) =>
-                            f.occurrences.map((occ, i) => (
-                              <div key={`${f.word}-${i}`} className="text-sm text-stone-600">
-                                {f.word !== group.lemma && (
-                                  <span className="text-xs text-amber-600 font-medium mr-1.5">{f.word}</span>
-                                )}
-                                {occ.book_title ? (
-                                  <a
-                                    href={`/reader/${occ.book_id}?chapter=${occ.chapter_index}`}
-                                    className="text-amber-700 font-medium hover:underline"
-                                  >
-                                    {occ.book_title}
-                                  </a>
-                                ) : (
-                                  <span className="text-stone-400 font-medium">(deleted book)</span>
-                                )}{" "}
-                                <span className="text-stone-400">{`Ch.${occ.chapter_index + 1}`}</span>
-                                {" — "}
-                                <span className="italic">&ldquo;{occ.sentence_text}&rdquo;</span>
-                              </div>
-                            ))
-                          )}
-                        </div>
-                      </div>
-                    );
-                  })}
+                  {sectionGroups.map(renderGroup)}
                 </div>
               </div>
             ))}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -594,6 +594,7 @@ export interface VocabularyWord {
   word: string;
   lemma?: string | null;
   language?: string | null;
+  created_at?: string | null;
   occurrences: VocabularyOccurrence[];
 }
 


### PR DESCRIPTION
## What changed

### Fix: uploaded text chapter detection for modern novels (closes #430)

The old `book_parser.py` would fail on the two most common modern novel formats:

- **Bare-number chapters** (`1`, `2`, `3` on their own line) — used by Hemingway (*A Farewell to Arms*), Chandler (*The Big Sleep*), and most 20th-century fiction — were **never detected**. The Big Sleep fell back to "Part 1, Part 2" word-count splitting; A Farewell to Arms incorrectly split into 3 chunks based on ALL-CAPS preamble text.
- **Tab indentation** (`\t` at the start of each paragraph) was stored raw and passed through to the reader.

Changes:
- **Two-tier detection**: high-confidence patterns (bare numbers, `CHAPTER`/`BOOK`/`PART` keywords, Roman numerals, dotted numbers) tried first; ALL-CAPS headings used only as fallback when HC finds fewer than 2 boundaries. This prevents false positives from title pages and preamble.
- **Bare number pattern** (`^\d+$`) added — the critical missing case.
- **Tab stripping**: `_normalize_text()` strips leading `\t` from each line and collapses 3+ blank lines to 2.
- **Author extraction**: `_extract_author()` finds `by Author` / `By Author` lines in the first 30 lines.
- **Front matter**: text before the first chapter boundary is preserved as a "Front Matter" chapter if it exceeds 50 words (copyright, dedication, etc.).

### Fix: admin upload quota bypass

Admins are now exempt from the 10-book-per-user upload cap. `GET /books/upload/quota` returns `max: null` for admins.

### Feat: vocabulary sort/group by A–Z, language, book, recency (closes #422)

Four sort modes added to the vocabulary page: alphabetical (default), by language (Unknown last), by book (words appear under each book they occur in), newest-first. Sort control visible when word count > 5. Language badge added to each word card.

## Test plan

- 16 new backend unit tests in `test_book_parser.py` covering all chapter-marker formats, bare numbers, ALL-CAPS fallback, tab normalization, author extraction, front matter, word-count fallback
- 12 new frontend tests in `VocabularyPage.sort.test.tsx` covering all four sort modes and visibility threshold
- Full suite: 1584 frontend + 278 backend tests pass
