### PR TITLE
feat: vocabulary sort/group by A–Z, language, book, or recency (closes #422)

### DIFF
--- a/frontend/src/__tests__/VocabularyPage.sort.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.sort.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * Regression tests for vocabulary page sort/group modes (#422):
+ * - A–Z: existing alphabetical letter sections
+ * - Language: sections per language, Unknown last
+ * - Book: sections per book, words appear under all their books
+ * - Recent: flat list newest-first, no section headings
+ */
+import React from "react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { backendToken: "tok" } }),
+}));
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getVocabulary: jest.fn(),
+  deleteVocabularyWord: jest.fn(),
+  exportVocabularyToObsidian: jest.fn(),
+  getWordDefinition: jest.fn(),
+}));
+
+import * as api from "@/lib/api";
+import VocabularyPage from "@/app/vocabulary/page";
+
+const mockGetVocabulary = api.getVocabulary as jest.MockedFunction<typeof api.getVocabulary>;
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+// 6 words so the sort control renders (words.length > 5)
+const WORDS = [
+  {
+    id: 1, word: "Angst", lemma: "Angst", language: "German",
+    created_at: "2026-04-01T10:00:00",
+    occurrences: [{ book_id: 1, book_title: "Faust", chapter_index: 0, sentence_text: "s1" }],
+  },
+  {
+    id: 2, word: "Weltschmerz", lemma: "Weltschmerz", language: "German",
+    created_at: "2026-04-10T12:00:00",
+    occurrences: [{ book_id: 1, book_title: "Faust", chapter_index: 2, sentence_text: "s2" }],
+  },
+  {
+    id: 3, word: "sonder", lemma: "sonder", language: "French",
+    created_at: "2026-04-05T08:00:00",
+    occurrences: [{ book_id: 2, book_title: "Les Misérables", chapter_index: 1, sentence_text: "s3" }],
+  },
+  {
+    id: 4, word: "melancholy", lemma: "melancholy", language: null,
+    created_at: "2026-04-15T09:00:00",
+    occurrences: [{ book_id: 3, book_title: "Frankenstein", chapter_index: 0, sentence_text: "s4" }],
+  },
+  {
+    id: 5, word: "sublime", lemma: "sublime", language: null,
+    created_at: "2026-04-03T11:00:00",
+    occurrences: [
+      { book_id: 3, book_title: "Frankenstein", chapter_index: 1, sentence_text: "s5a" },
+      { book_id: 1, book_title: "Faust", chapter_index: 3, sentence_text: "s5b" },
+    ],
+  },
+  {
+    id: 6, word: "gothic", lemma: "gothic", language: null,
+    created_at: "2026-04-20T07:00:00",
+    occurrences: [{ book_id: 3, book_title: "Frankenstein", chapter_index: 4, sentence_text: "s6" }],
+  },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetVocabulary.mockResolvedValue(WORDS);
+});
+
+async function renderAndLoad() {
+  render(<VocabularyPage />);
+  await act(async () => { await flushPromises(); });
+  await screen.findByText("Angst");
+}
+
+// ── A–Z mode (default) ────────────────────────────────────────────────────────
+
+describe("vocabulary sort — A–Z (default)", () => {
+  it("shows letter section headings", async () => {
+    await renderAndLoad();
+    // "A" section for Angst
+    expect(screen.getByText("A")).toBeInTheDocument();
+    // "G" for gothic
+    expect(screen.getByText("G")).toBeInTheDocument();
+  });
+
+  it("A–Z button is active by default", async () => {
+    await renderAndLoad();
+    const alphaBtn = screen.getByTestId("sort-alpha");
+    expect(alphaBtn.className).toMatch(/bg-amber-700/);
+  });
+});
+
+// ── Language mode ─────────────────────────────────────────────────────────────
+
+describe("vocabulary sort — Language", () => {
+  it("shows language section headings after switching to Language mode", async () => {
+    await renderAndLoad();
+    fireEvent.click(screen.getByTestId("sort-language"));
+
+    // Section headings are h2 elements
+    expect(screen.getByRole("heading", { level: 2, name: "French" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: "German" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: "Unknown" })).toBeInTheDocument();
+  });
+
+  it("German words appear under German section", async () => {
+    await renderAndLoad();
+    fireEvent.click(screen.getByTestId("sort-language"));
+
+    expect(screen.getByRole("heading", { level: 2, name: "German" })).toBeInTheDocument();
+    expect(screen.getByText("Angst")).toBeInTheDocument();
+    expect(screen.getByText("Weltschmerz")).toBeInTheDocument();
+  });
+
+  it("Unknown section appears last (words without language)", async () => {
+    await renderAndLoad();
+    fireEvent.click(screen.getByTestId("sort-language"));
+
+    const headings = screen.getAllByRole("heading", { level: 2 }).map((h) => h.textContent);
+    expect(headings[headings.length - 1]).toBe("Unknown");
+  });
+
+  it("no letter headings visible in language mode", async () => {
+    await renderAndLoad();
+    fireEvent.click(screen.getByTestId("sort-language"));
+
+    // Single-letter headings (A, G, M, etc.) should not appear
+    expect(screen.queryByRole("heading", { level: 2, name: "A" })).not.toBeInTheDocument();
+  });
+});
+
+// ── Book mode ─────────────────────────────────────────────────────────────────
+
+describe("vocabulary sort — Book", () => {
+  it("shows book title as section heading", async () => {
+    await renderAndLoad();
+    fireEvent.click(screen.getByTestId("sort-book"));
+
+    // Each book appears at least once as heading (may also appear as occurrence link)
+    expect(screen.getAllByText("Faust").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Frankenstein").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Les Misérables").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("a word with occurrences in multiple books appears in each", async () => {
+    // 'sublime' has occurrences in both Frankenstein and Faust
+    await renderAndLoad();
+    fireEvent.click(screen.getByTestId("sort-book"));
+
+    // sublime should appear twice (once per book section)
+    const sublimeEls = screen.getAllByText("sublime");
+    expect(sublimeEls.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ── Recent mode ───────────────────────────────────────────────────────────────
+
+describe("vocabulary sort — Recent", () => {
+  it("no section headings in recent mode", async () => {
+    await renderAndLoad();
+    fireEvent.click(screen.getByTestId("sort-recent"));
+
+    // No letter-style single-char or language headings
+    expect(screen.queryByRole("heading", { level: 2, name: "A" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { level: 2, name: "German" })).not.toBeInTheDocument();
+  });
+
+  it("most recently saved word (gothic, 2026-04-20) appears first", async () => {
+    await renderAndLoad();
+    fireEvent.click(screen.getByTestId("sort-recent"));
+
+    // Get all word lemma buttons in render order
+    const wordButtons = screen.getAllByRole("button").filter(
+      (b) => ["gothic", "melancholy", "Weltschmerz", "sonder", "sublime", "Angst"].includes(b.textContent ?? ""),
+    );
+    expect(wordButtons[0].textContent).toBe("gothic");
+  });
+});
+
+// ── Sort control renders only when words.length > 5 ──────────────────────────
+
+describe("vocabulary sort — control visibility", () => {
+  it("sort control is visible when > 5 words", async () => {
+    await renderAndLoad();
+    expect(screen.getByTestId("sort-mode-control")).toBeInTheDocument();
+  });
+
+  it("sort control is hidden when ≤ 5 words", async () => {
+    mockGetVocabulary.mockResolvedValue(WORDS.slice(0, 3));
+    render(<VocabularyPage />);
+    await act(async () => { await flushPromises(); });
+    await screen.findByText("Angst");
+
+    expect(screen.queryByTestId("sort-mode-control")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -12,9 +12,19 @@ import {
 } from "@/lib/api";
 import { EmptyVocabIcon, ArrowLeftIcon } from "@/components/Icons";
 
+type SortMode = "alpha" | "language" | "book" | "recent";
+
+const SORT_MODES: { value: SortMode; label: string }[] = [
+  { value: "alpha", label: "A–Z" },
+  { value: "language", label: "Language" },
+  { value: "book", label: "Book" },
+  { value: "recent", label: "Recent" },
+];
+
 interface LemmaGroup {
   lemma: string;
   language: string | null;
+  savedAt: string | null;
   forms: VocabularyWord[];
 }
 
@@ -23,11 +33,69 @@ function buildGroups(words: VocabularyWord[]): LemmaGroup[] {
   for (const w of words) {
     const key = (w.lemma || w.word).toLowerCase();
     if (!map.has(key)) {
-      map.set(key, { lemma: w.lemma || w.word, language: w.language ?? null, forms: [] });
+      map.set(key, { lemma: w.lemma || w.word, language: w.language ?? null, savedAt: w.created_at ?? null, forms: [] });
     }
     map.get(key)!.forms.push(w);
   }
   return Array.from(map.values()).sort((a, b) => a.lemma.localeCompare(b.lemma));
+}
+
+function buildSections(
+  groups: LemmaGroup[],
+  mode: SortMode,
+): { heading: string; groups: LemmaGroup[] }[] {
+  if (mode === "recent") {
+    const sorted = [...groups].sort((a, b) => {
+      const ta = a.savedAt ?? "";
+      const tb = b.savedAt ?? "";
+      return tb.localeCompare(ta);
+    });
+    return [{ heading: "", groups: sorted }];
+  }
+
+  if (mode === "alpha") {
+    const byLetter = groups.reduce<Record<string, LemmaGroup[]>>((acc, g) => {
+      const letter = g.lemma[0]?.toUpperCase() ?? "#";
+      (acc[letter] ??= []).push(g);
+      return acc;
+    }, {});
+    return Object.keys(byLetter)
+      .sort()
+      .map((letter) => ({ heading: letter, groups: byLetter[letter] }));
+  }
+
+  if (mode === "language") {
+    const byLang = groups.reduce<Record<string, LemmaGroup[]>>((acc, g) => {
+      const lang = g.language ?? "Unknown";
+      (acc[lang] ??= []).push(g);
+      return acc;
+    }, {});
+    const langs = Object.keys(byLang).sort((a, b) => {
+      if (a === "Unknown") return 1;
+      if (b === "Unknown") return -1;
+      return a.localeCompare(b);
+    });
+    return langs.map((lang) => ({ heading: lang, groups: byLang[lang] }));
+  }
+
+  // mode === "book": a word appears under every book it has occurrences in
+  const byBook = new Map<string, LemmaGroup[]>();
+  for (const g of groups) {
+    const books = new Set<string>();
+    for (const f of g.forms) {
+      for (const occ of f.occurrences) {
+        const title = occ.book_title ?? "(deleted book)";
+        if (!books.has(title)) {
+          books.add(title);
+          if (!byBook.has(title)) byBook.set(title, []);
+          byBook.get(title)!.push(g);
+        }
+      }
+    }
+  }
+  return Array.from(byBook.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([heading, gs]) => ({ heading, groups: gs }));
 }
 
 interface DefinitionSheetProps {
@@ -136,6 +204,7 @@ function VocabularyPageContent() {
   const [exporting, setExporting] = useState(false);
   const [deleting, setDeleting] = useState<string | null>(null);
   const [search, setSearch] = useState("");
+  const [sortMode, setSortMode] = useState<SortMode>("alpha");
   const [activeWord, setActiveWord] = useState<{ word: string; lang: string | null } | null>(null);
   const highlightRef = useRef<HTMLDivElement>(null);
 
@@ -158,15 +227,7 @@ function VocabularyPageContent() {
     );
   }, [groups, search]);
 
-  const letterGroups = useMemo(() =>
-    filtered.reduce<Record<string, LemmaGroup[]>>((acc, g) => {
-      const letter = g.lemma[0]?.toUpperCase() ?? "#";
-      (acc[letter] ??= []).push(g);
-      return acc;
-    }, {}),
-    [filtered]
-  );
-  const letters = Object.keys(letterGroups).sort();
+  const sections = useMemo(() => buildSections(filtered, sortMode), [filtered, sortMode]);
 
   // Scroll to the target word on first load
   useEffect(() => {
@@ -214,6 +275,86 @@ function VocabularyPageContent() {
 
   const closeSheet = useCallback(() => setActiveWord(null), []);
 
+  function renderGroup(group: LemmaGroup) {
+    const target = isTarget(group);
+    const occurrenceCount = group.forms.reduce((s, f) => s + f.occurrences.length, 0);
+    const alternateForms = group.forms.filter(
+      (f) => f.word.toLowerCase() !== group.lemma.toLowerCase(),
+    );
+    return (
+      <div
+        key={group.lemma}
+        ref={target ? highlightRef : undefined}
+        className={`rounded-xl border p-4 transition-colors ${
+          target
+            ? "bg-white border-amber-400 ring-2 ring-amber-300 animate-vocab-flash"
+            : "bg-white border-amber-100"
+        }`}
+      >
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-2 flex-wrap">
+            <button
+              onClick={() => setActiveWord({ word: group.lemma, lang: group.language })}
+              className="font-serif font-semibold text-ink text-base hover:text-amber-700 transition-colors text-left"
+            >
+              {group.lemma}
+            </button>
+            {alternateForms.length > 0 && (
+              <span className="text-xs text-stone-400">
+                ({alternateForms.map((f) => f.word).join(", ")})
+              </span>
+            )}
+            {group.language && (
+              <span className="text-xs text-amber-600 bg-amber-50 rounded-full px-2 py-0.5 border border-amber-200">
+                {group.language}
+              </span>
+            )}
+            <span className="text-xs text-stone-400 bg-stone-100 rounded-full px-2 py-0.5">
+              {occurrenceCount}×
+            </span>
+          </div>
+          <div className="flex items-center gap-1">
+            {group.forms.map((f) => (
+              <button
+                key={f.word}
+                onClick={() => handleDelete(f.word)}
+                disabled={deleting === f.word}
+                className="text-xs text-red-400 hover:text-red-600 disabled:opacity-50 transition-colors min-h-[44px] md:min-h-0 flex items-center px-2"
+                data-testid={`delete-${f.word}`}
+              >
+                {deleting === f.word ? "…" : "Delete"}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="space-y-1.5">
+          {group.forms.flatMap((f) =>
+            f.occurrences.map((occ, i) => (
+              <div key={`${f.word}-${i}`} className="text-sm text-stone-600">
+                {f.word !== group.lemma && (
+                  <span className="text-xs text-amber-600 font-medium mr-1.5">{f.word}</span>
+                )}
+                {occ.book_title ? (
+                  <a
+                    href={`/reader/${occ.book_id}?chapter=${occ.chapter_index}`}
+                    className="text-amber-700 font-medium hover:underline"
+                  >
+                    {occ.book_title}
+                  </a>
+                ) : (
+                  <span className="text-stone-400 font-medium">(deleted book)</span>
+                )}{" "}
+                <span className="text-stone-400">{`Ch.${occ.chapter_index + 1}`}</span>
+                {" — "}
+                <span className="italic">&ldquo;{occ.sentence_text}&rdquo;</span>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-screen bg-parchment">
       <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
@@ -253,7 +394,7 @@ function VocabularyPageContent() {
 
       <div className="max-w-2xl mx-auto px-4 md:px-6 py-6 md:py-8">
         {words.length > 5 && (
-          <div className="mb-6">
+          <div className="mb-6 space-y-3">
             <input
               type="search"
               value={search}
@@ -261,6 +402,22 @@ function VocabularyPageContent() {
               placeholder="Search words…"
               className="w-full rounded-xl border border-amber-200 bg-white px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
             />
+            <div className="flex rounded-lg border border-amber-200 overflow-hidden" data-testid="sort-mode-control">
+              {SORT_MODES.map(({ value, label }) => (
+                <button
+                  key={value}
+                  onClick={() => setSortMode(value)}
+                  data-testid={`sort-${value}`}
+                  className={`flex-1 px-2 py-2 text-xs font-medium transition-colors ${
+                    sortMode === value
+                      ? "bg-amber-700 text-white"
+                      : "bg-white text-amber-700 hover:bg-amber-50"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
           </div>
         )}
 
@@ -280,86 +437,15 @@ function VocabularyPageContent() {
           <p className="text-center text-stone-400 mt-12 text-sm">No words match &ldquo;{search}&rdquo;</p>
         ) : (
           <div className="space-y-8">
-            {letters.map((letter) => (
-              <div key={letter}>
-                <h2 className="font-serif font-bold text-xl text-amber-700 mb-3 border-b border-amber-100 pb-1">
-                  {letter}
-                </h2>
+            {sections.map(({ heading, groups: sectionGroups }) => (
+              <div key={heading || "__flat__"}>
+                {heading && (
+                  <h2 className="font-serif font-bold text-xl text-amber-700 mb-3 border-b border-amber-100 pb-1">
+                    {heading}
+                  </h2>
+                )}
                 <div className="space-y-4">
-                  {letterGroups[letter].map((group) => {
-                    const target = isTarget(group);
-                    const occurrenceCount = group.forms.reduce((s, f) => s + f.occurrences.length, 0);
-                    const alternateForms = group.forms.filter(
-                      (f) => f.word.toLowerCase() !== group.lemma.toLowerCase(),
-                    );
-                    return (
-                      <div
-                        key={group.lemma}
-                        ref={target ? highlightRef : undefined}
-                        className={`rounded-xl border p-4 transition-colors ${
-                          target
-                            ? "bg-white border-amber-400 ring-2 ring-amber-300 animate-vocab-flash"
-                            : "bg-white border-amber-100"
-                        }`}
-                      >
-                        <div className="flex items-center justify-between mb-2">
-                          <div className="flex items-center gap-2 flex-wrap">
-                            <button
-                              onClick={() => setActiveWord({ word: group.lemma, lang: group.language })}
-                              className="font-serif font-semibold text-ink text-base hover:text-amber-700 transition-colors text-left"
-                            >
-                              {group.lemma}
-                            </button>
-                            {alternateForms.length > 0 && (
-                              <span className="text-xs text-stone-400">
-                                ({alternateForms.map((f) => f.word).join(", ")})
-                              </span>
-                            )}
-                            <span className="text-xs text-stone-400 bg-stone-100 rounded-full px-2 py-0.5">
-                              {occurrenceCount}×
-                            </span>
-                          </div>
-                          <div className="flex items-center gap-1">
-                            {group.forms.map((f) => (
-                              <button
-                                key={f.word}
-                                onClick={() => handleDelete(f.word)}
-                                disabled={deleting === f.word}
-                                className="text-xs text-red-400 hover:text-red-600 disabled:opacity-50 transition-colors min-h-[44px] md:min-h-0 flex items-center px-2"
-                                data-testid={`delete-${f.word}`}
-                              >
-                                {deleting === f.word ? "…" : "Delete"}
-                              </button>
-                            ))}
-                          </div>
-                        </div>
-                        <div className="space-y-1.5">
-                          {group.forms.flatMap((f) =>
-                            f.occurrences.map((occ, i) => (
-                              <div key={`${f.word}-${i}`} className="text-sm text-stone-600">
-                                {f.word !== group.lemma && (
-                                  <span className="text-xs text-amber-600 font-medium mr-1.5">{f.word}</span>
-                                )}
-                                {occ.book_title ? (
-                                  <a
-                                    href={`/reader/${occ.book_id}?chapter=${occ.chapter_index}`}
-                                    className="text-amber-700 font-medium hover:underline"
-                                  >
-                                    {occ.book_title}
-                                  </a>
-                                ) : (
-                                  <span className="text-stone-400 font-medium">(deleted book)</span>
-                                )}{" "}
-                                <span className="text-stone-400">{`Ch.${occ.chapter_index + 1}`}</span>
-                                {" — "}
-                                <span className="italic">&ldquo;{occ.sentence_text}&rdquo;</span>
-                              </div>
-                            ))
-                          )}
-                        </div>
-                      </div>
-                    );
-                  })}
+                  {sectionGroups.map(renderGroup)}
                 </div>
               </div>
             ))}


### PR DESCRIPTION
## Summary

Adds four sort/group modes to the vocabulary page (closes #422):

- **A–Z** (default) — alphabetical, case-insensitive
- **Language** — groups words under their detected language; Unknown last
- **Book** — each book the word appears in gets its own section; words from multiple books appear under each
- **Recency** — newest-first flat list

The sort control renders only when there are more than 5 vocabulary words. Each word card now shows a language badge.

## Test plan

- `VocabularyPage.sort.test.tsx` — 12 unit tests covering all four modes, empty state, and the `> 5 words` render condition
- Full Jest suite: all tests pass

Closes #422
