### PR TITLE
feat: notes sidebar chapter filter with collapsable all-chapters view (closes #411)

### DIFF
--- a/frontend/e2e/annotation-translation.spec.ts
+++ b/frontend/e2e/annotation-translation.spec.ts
@@ -170,8 +170,8 @@ test("Notes sidebar shows empty state when no annotations", async ({ page }) => 
   await page.goto("/reader/1342");
   await page.getByRole("button", { name: /notes/i }).click();
 
-  // Empty state text should appear
-  await expect(page.getByText("No annotations yet.")).toBeVisible({ timeout: 3000 });
+  // Empty state text should appear (default "This chapter" filter view)
+  await expect(page.getByText("No annotations in this chapter yet.")).toBeVisible({ timeout: 3000 });
 });
 
 test("Notes sidebar shows existing annotations from API", async ({ page }) => {
@@ -210,6 +210,8 @@ test("Notes sidebar shows existing annotations from API", async ({ page }) => {
   await expect(page.getByText("Famous opening line")).toBeVisible({ timeout: 3000 });
   // Sentence text is shown in the notes panel (quoted/excerpted form)
   await expect(page.getByText(/truth universally acknowledged/).first()).toBeVisible({ timeout: 3000 });
+  // Mr. Bennet is chapter_index=1; switch to "All chapters" to see it
+  await page.getByRole("button", { name: "All chapters" }).click();
   await expect(page.getByText(/Mr\. Bennet was among/).first()).toBeVisible({ timeout: 3000 });
 });
 

--- a/frontend/src/__tests__/ReaderPage.branches2.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches2.test.tsx
@@ -599,7 +599,7 @@ describe("ReaderPage.branches2 — AnnotationToolbar onDeleted", () => {
       await userEvent.click(deleteBtn);
 
       await waitFor(() => {
-        expect(screen.queryByText("No annotations yet.")).toBeInTheDocument();
+        expect(screen.queryByText("No annotations in this chapter yet.")).toBeInTheDocument();
       });
     }
   });

--- a/frontend/src/__tests__/ReaderPage.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.test.tsx
@@ -493,7 +493,7 @@ describe("ReaderPage — sidebar tabs", () => {
     const notesBtn = await screen.findByTitle("Annotations & notes");
     await userEvent.click(notesBtn);
 
-    expect(await screen.findByText("No annotations yet.")).toBeInTheDocument();
+    expect(await screen.findByText("No annotations in this chapter yet.")).toBeInTheDocument();
   });
 
   it("opens vocab sidebar when 📚 Vocab button is clicked", async () => {
@@ -1100,6 +1100,10 @@ describe("ReaderPage — notes sidebar content", () => {
     const notesBtn = await screen.findByTitle("Annotations & notes");
     await userEvent.click(notesBtn);
 
+    // Switch to "All chapters" to see chapter group headings
+    const allChaptersBtn = await screen.findByRole("button", { name: "All chapters" });
+    await userEvent.click(allChaptersBtn);
+
     expect(await screen.findByText("Chapter 1")).toBeInTheDocument();
     expect(screen.getByText("Chapter 2")).toBeInTheDocument();
   });
@@ -1363,13 +1367,16 @@ describe("ReaderPage — mobile bottom bar interactions", () => {
     render(<ReaderPage />);
     await flushPromises();
 
-    // The mobile Notes button (aria-label="Notes") is in the mobile bottom bar
-    // Use getByRole with exact aria-label
-    const mobileNotesBtn = await screen.findByRole("button", { name: "Notes" });
-    expect(mobileNotesBtn).toBeInTheDocument();
+    // Find the mobile Notes button specifically by its aria-label="Notes"
+    let mobileNotesBtn: HTMLElement | undefined;
+    await waitFor(() => {
+      const allBtns = screen.queryAllByRole("button");
+      mobileNotesBtn = allBtns.find((b) => b.getAttribute("aria-label") === "Notes");
+      expect(mobileNotesBtn).toBeDefined();
+    });
 
-    await userEvent.click(mobileNotesBtn);
-    // Notes expanded panel should appear — "No annotations yet." in it
+    await userEvent.click(mobileNotesBtn!);
+    // Mobile expand panel appears — "No annotations yet." in it
     const noAnnotationsEls = await screen.findAllByText("No annotations yet.");
     expect(noAnnotationsEls.length).toBeGreaterThanOrEqual(1);
   });
@@ -1627,6 +1634,61 @@ describe("ReaderPage — vocab sidebar chapter filter", () => {
     // All chapters: 3 words
     await userEvent.click(screen.getByText("All chapters"));
     expect(await screen.findByText("3 words")).toBeInTheDocument();
+  });
+});
+
+// ── Notes sidebar chapter filter ──────────────────────────────────────────────
+
+describe("ReaderPage — notes sidebar chapter filter", () => {
+  it("shows 'This chapter' and 'All chapters' toggle buttons in notes sidebar", async () => {
+    mockGetAnnotations.mockResolvedValue([]);
+    mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
+    render(<ReaderPage />);
+    await flushPromises();
+
+    const notesBtn = await screen.findByTitle("Annotations & notes");
+    await userEvent.click(notesBtn);
+
+    expect(await screen.findByText("This chapter")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "All chapters" })).toBeInTheDocument();
+  });
+
+  it("defaults to 'This chapter' view and shows chapter-filtered empty state", async () => {
+    mockGetAnnotations.mockResolvedValue([]);
+    mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
+    render(<ReaderPage />);
+    await flushPromises();
+
+    const notesBtn = await screen.findByTitle("Annotations & notes");
+    await userEvent.click(notesBtn);
+
+    expect(await screen.findByText("No annotations in this chapter yet.")).toBeInTheDocument();
+  });
+
+  it("switching to 'All chapters' shows annotations from all chapters grouped by chapter", async () => {
+    const annotations = [
+      { id: 1, book_id: 42, chapter_index: 0, sentence_text: "First.", color: "yellow", note_text: "", created_at: "2024-01-01" },
+      { id: 2, book_id: 42, chapter_index: 1, sentence_text: "Second.", color: "blue", note_text: "", created_at: "2024-01-02" },
+    ];
+    mockGetAnnotations.mockResolvedValue(annotations);
+    mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
+    render(<ReaderPage />);
+    await flushPromises();
+
+    const notesBtn = await screen.findByTitle("Annotations & notes");
+    await userEvent.click(notesBtn);
+
+    // Default "This chapter" view shows only chapter 0 annotation
+    expect(await screen.findByText(/First\./)).toBeInTheDocument();
+    expect(screen.queryByText(/Second\./)).not.toBeInTheDocument();
+
+    // Switch to "All chapters" — both annotations appear with chapter headings
+    const allChaptersBtn = screen.getByRole("button", { name: "All chapters" });
+    await userEvent.click(allChaptersBtn);
+
+    expect(await screen.findByText("Chapter 1")).toBeInTheDocument();
+    expect(screen.getByText("Chapter 2")).toBeInTheDocument();
+    expect(screen.getByText(/Second\./)).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -100,6 +100,8 @@ export default function ReaderPage() {
     [vocabWords],
   );
   const [vocabView, setVocabView] = useState<"chapter" | "book">("chapter");
+  const [notesView, setNotesView] = useState<"chapter" | "all">("chapter");
+  const [collapsedNoteChapters, setCollapsedNoteChapters] = useState<Set<number>>(new Set());
   // Word definition tooltip (shown when "Word" is clicked in SelectionToolbar)
   const [vocabTooltip, setVocabTooltip] = useState<{ word: string; context: string; rect: DOMRect } | null>(null);
   const [sidebarWidth, setSidebarWidth] = useState(320);
@@ -1624,99 +1626,134 @@ export default function ReaderPage() {
               </div>
 
               {/* Notes tab */}
-              {sidebarTab === "notes" && (
-                <div className="flex-1 overflow-y-auto p-4 space-y-6">
-                  {annotationsLoading && annotations.length === 0 ? (
-                    <div className="flex justify-center mt-10">
-                      <span className="w-5 h-5 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+              {sidebarTab === "notes" && (() => {
+                const filteredNotes = notesView === "chapter"
+                  ? annotations.filter((a) => a.chapter_index === chapterIndex)
+                  : annotations;
+                const colorBadge: Record<string, string> = {
+                  yellow: "bg-yellow-100 border-yellow-300 text-yellow-800",
+                  blue: "bg-blue-100 border-blue-300 text-blue-800",
+                  green: "bg-green-100 border-green-300 text-green-800",
+                  pink: "bg-pink-100 border-pink-300 text-pink-800",
+                };
+                const renderCard = (ann: (typeof annotations)[0]) => (
+                  <div
+                    key={ann.id}
+                    className={`rounded-lg border px-3 py-2.5 cursor-pointer hover:opacity-80 transition-opacity ${colorBadge[ann.color] ?? colorBadge.yellow}`}
+                    onClick={() => {
+                      if (ann.chapter_index !== chapterIndex) {
+                        goToChapter(ann.chapter_index);
+                        setTimeout(() => setScrollTargetSentence(ann.sentence_text), 400);
+                      } else {
+                        setScrollTargetSentence(undefined);
+                        setTimeout(() => setScrollTargetSentence(ann.sentence_text), 10);
+                      }
+                      setSidebarOpen(false);
+                    }}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <p className="text-xs italic leading-relaxed line-clamp-3 flex-1">
+                        &ldquo;{ann.sentence_text}&rdquo;
+                      </p>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setAnnotationPanel({
+                            sentenceText: ann.sentence_text,
+                            chapterIndex: ann.chapter_index,
+                            position: { x: window.innerWidth / 2, y: window.innerHeight / 2 },
+                          });
+                        }}
+                        className="shrink-0 text-xs opacity-60 hover:opacity-100 mt-0.5"
+                        title="Edit annotation"
+                      >
+                        ✏️
+                      </button>
                     </div>
-                  ) : annotations.length === 0 ? (
-                    <div className="text-center text-stone-400 mt-10 text-sm">
-                      <p className="text-3xl mb-2">📝</p>
-                      <p>No annotations yet.</p>
-                      <p className="mt-1 text-xs">Long-press a sentence to add one.</p>
-                    </div>
-                  ) : (
-                    <>
-                      {Object.keys(
-                        annotations.reduce<Record<number, true>>((acc, a) => { acc[a.chapter_index] = true; return acc; }, {})
-                      ).map(Number).sort((a, b) => a - b).map((ch) => (
-                        <div key={ch}>
-                          <h3 className="text-xs font-semibold text-stone-400 uppercase tracking-wide mb-2">
-                            Chapter {ch + 1}
-                          </h3>
-                          <div className="space-y-2">
-                            {annotations.filter((a) => a.chapter_index === ch).map((ann) => {
-                              const colorBadge: Record<string, string> = {
-                                yellow: "bg-yellow-100 border-yellow-300 text-yellow-800",
-                                blue: "bg-blue-100 border-blue-300 text-blue-800",
-                                green: "bg-green-100 border-green-300 text-green-800",
-                                pink: "bg-pink-100 border-pink-300 text-pink-800",
-                              };
-                              return (
-                                <div
-                                  key={ann.id}
-                                  className={`rounded-lg border px-3 py-2.5 cursor-pointer hover:opacity-80 transition-opacity ${colorBadge[ann.color] ?? colorBadge.yellow}`}
-                                  onClick={() => {
-                                    if (ann.chapter_index !== chapterIndex) {
-                                      goToChapter(ann.chapter_index);
-                                      setTimeout(() => setScrollTargetSentence(ann.sentence_text), 400);
-                                    } else {
-                                      setScrollTargetSentence(undefined);
-                                      setTimeout(() => setScrollTargetSentence(ann.sentence_text), 10);
-                                    }
-                                    setSidebarOpen(false);
-                                  }}
-                                >
-                                  <div className="flex items-start justify-between gap-2">
-                                    <p className="text-xs italic leading-relaxed line-clamp-3 flex-1">
-                                      &ldquo;{ann.sentence_text}&rdquo;
-                                    </p>
-                                    <button
-                                      onClick={(e) => {
-                                        e.stopPropagation();
-                                        setAnnotationPanel({
-                                          sentenceText: ann.sentence_text,
-                                          chapterIndex: ann.chapter_index,
-                                          position: { x: window.innerWidth / 2, y: window.innerHeight / 2 },
-                                        });
-                                      }}
-                                      className="shrink-0 text-xs opacity-60 hover:opacity-100 mt-0.5"
-                                      title="Edit annotation"
-                                    >
-                                      ✏️
-                                    </button>
-                                  </div>
-                                  {ann.note_text && (
-                                    <p className="mt-1.5 text-xs font-medium border-t border-current/20 pt-1.5">
-                                      {ann.note_text}
-                                    </p>
-                                  )}
-                                </div>
-                              );
-                            })}
-                          </div>
-                        </div>
-                      ))}
-                    </>
-                  )}
-                  {/* Footer link */}
-                  <div className="border-t border-amber-100 pb-2 pt-3 flex gap-3 justify-between shrink-0">
-                    <a
-                      href={`/notes/${bookId}`}
-                      className="text-xs text-amber-700 hover:text-amber-900 font-medium transition-colors"
-                    >
-                      Book notes →
-                    </a>
-                    <a
-                      href="/notes"
-                      className="text-xs text-stone-400 hover:text-stone-600 transition-colors"
-                    >
-                      All books
-                    </a>
+                    {ann.note_text && (
+                      <p className="mt-1.5 text-xs font-medium border-t border-current/20 pt-1.5">
+                        {ann.note_text}
+                      </p>
+                    )}
                   </div>
-                </div>
-              )}
+                );
+                return (
+                  <div className="flex-1 overflow-y-auto p-4 space-y-3">
+                    {/* Filter toggle */}
+                    <div className="flex items-center gap-1 bg-stone-100 rounded-lg p-0.5">
+                      {(["chapter", "all"] as const).map((v) => (
+                        <button
+                          key={v}
+                          onClick={() => setNotesView(v)}
+                          className={`flex-1 text-xs py-1 rounded-md font-medium transition-colors ${
+                            notesView === v ? "bg-white text-amber-700 shadow-sm" : "text-stone-400 hover:text-stone-600"
+                          }`}
+                        >
+                          {v === "chapter" ? "This chapter" : "All chapters"}
+                        </button>
+                      ))}
+                    </div>
+                    {annotationsLoading && annotations.length === 0 ? (
+                      <div className="flex justify-center mt-10">
+                        <span className="w-5 h-5 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+                      </div>
+                    ) : filteredNotes.length === 0 ? (
+                      <div className="text-center text-stone-400 mt-10 text-sm">
+                        <p className="text-3xl mb-2">📝</p>
+                        <p>{notesView === "chapter" ? "No annotations in this chapter yet." : "No annotations yet."}</p>
+                        <p className="mt-1 text-xs">Long-press a sentence to add one.</p>
+                      </div>
+                    ) : notesView === "chapter" ? (
+                      <div className="space-y-2">
+                        {filteredNotes.map(renderCard)}
+                      </div>
+                    ) : (
+                      <>
+                        {Object.keys(
+                          annotations.reduce<Record<number, true>>((acc, a) => { acc[a.chapter_index] = true; return acc; }, {})
+                        ).map(Number).sort((a, b) => a - b).map((ch) => {
+                          const isCollapsed = collapsedNoteChapters.has(ch);
+                          return (
+                            <div key={ch}>
+                              <button
+                                className="flex items-center gap-1 w-full text-left text-xs font-semibold text-stone-400 uppercase tracking-wide mb-2"
+                                onClick={() => setCollapsedNoteChapters((prev) => {
+                                  const next = new Set(prev);
+                                  if (next.has(ch)) next.delete(ch); else next.add(ch);
+                                  return next;
+                                })}
+                              >
+                                <span>{isCollapsed ? "▶" : "▼"}</span>
+                                <span>Chapter {ch + 1}</span>
+                              </button>
+                              {!isCollapsed && (
+                                <div className="space-y-2">
+                                  {annotations.filter((a) => a.chapter_index === ch).map(renderCard)}
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </>
+                    )}
+                    {/* Footer link */}
+                    <div className="border-t border-amber-100 pb-2 pt-3 flex gap-3 justify-between shrink-0">
+                      <a
+                        href={`/notes/${bookId}`}
+                        className="text-xs text-amber-700 hover:text-amber-900 font-medium transition-colors"
+                      >
+                        Book notes →
+                      </a>
+                      <a
+                        href="/notes"
+                        className="text-xs text-stone-400 hover:text-stone-600 transition-colors"
+                      >
+                        All books
+                      </a>
+                    </div>
+                  </div>
+                );
+              })()}
 
               {/* Vocab tab */}
               {sidebarTab === "vocab" && (() => {


### PR DESCRIPTION
## Summary

- Adds "This chapter" / "All chapters" filter toggle to the reader notes sidebar, matching the existing vocab sidebar UX pattern
- Default view ("This chapter") shows only annotations for the currently active chapter
- "All chapters" view shows all annotations grouped by chapter, with ▶/▼ collapse toggles per chapter
- Empty state text reflects the active filter: "No annotations in this chapter yet." vs "No annotations yet."

## Test plan

- [x] New `describe("ReaderPage — notes sidebar chapter filter")` with 3 tests: toggle buttons visible, default chapter-filtered empty state, "All chapters" shows annotations from all chapters grouped by heading
- [x] Updated existing tests that previously expected "No annotations yet." in the desktop notes sidebar to use the new chapter-filtered text
- [x] Full test suite passes: 1575/1575

🤖 Generated with [Claude Code](https://claude.com/claude-code)
