### PR TITLE
fix: validate chapter_index bounds in POST /ai/summary (closes #448)

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -161,6 +161,14 @@ async def summary(req: SummaryRequest, _user: dict = Depends(get_current_user)):
         raise HTTPException(status_code=404, detail="Book not found")
     check_book_access(book, _user)
 
+    from services.book_chapters import split_with_html_preference as _split
+    _chapters = await _split(req.book_id, book.get("text") or "")
+    if req.chapter_index < 0 or req.chapter_index >= len(_chapters):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Chapter index out of range (book has {len(_chapters)} chapter(s)).",
+        )
+
     cached = await get_chapter_summary(req.book_id, req.chapter_index)
     if cached:
         return {"summary": cached["content"], "cached": True, "model": cached["model"]}

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -688,3 +688,27 @@ async def test_translate_post_cache_hit_blocked_for_non_owner(client, test_user,
         f"got {resp.status_code}: {resp.text}"
     )
 
+
+# ── chapter_index bounds checks on /ai/summary ───────────────────────────────
+
+async def test_ai_summary_out_of_bounds_chapter_returns_400(client, test_user, tmp_db):
+    """Regression #448: POST /ai/summary with chapter_index beyond chapter count
+    must return 400, not silently attempt to generate a summary for a non-existent chapter.
+    """
+    from services.book_chapters import clear_cache as _clear
+
+    text = "CHAPTER I\n\n" + "word " * 200 + "\n\nCHAPTER II\n\n" + "word " * 200
+    await save_book(9881, {"id": 9881, "title": "T", "authors": [], "languages": ["en"], "subjects": [], "download_count": 0, "cover": ""}, text)
+    _clear()
+
+    resp = await client.post("/api/ai/summary", json={
+        "book_id": 9881,
+        "chapter_index": 999,
+        "chapter_text": "some text",
+        "book_title": "T",
+        "author": "Unknown",
+    })
+    assert resp.status_code == 400, (
+        f"Expected 400 for out-of-bounds chapter_index=999, got {resp.status_code}: {resp.text}"
+    )
+

--- a/backend/tests/test_router_summary.py
+++ b/backend/tests/test_router_summary.py
@@ -28,6 +28,11 @@ _BOOK_META = {
 BOOK_ID = 9001
 CHAPTER_INDEX = 3
 CHAPTER_TEXT = "Mephistopheles erscheint im Studierzimmer des Faust."
+_CHAPTER = "word " * 200
+_BOOK_TEXT = (
+    f"CHAPTER I\n\n{_CHAPTER}\n\nCHAPTER II\n\n{_CHAPTER}"
+    f"\n\nCHAPTER III\n\n{_CHAPTER}\n\nCHAPTER IV\n\n{_CHAPTER}"
+)
 SUMMARY_CONTENT = "**Overview**\nFaust meets Mephistopheles.\n\n**Key Events**\n- The devil appears."
 
 _PAYLOAD = {
@@ -47,7 +52,7 @@ async def _set_queue_key(tmp_db):
 # ── Cache hit ─────────────────────────────────────────────────────────────────
 
 async def test_summary_cache_hit(client, tmp_db):
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     await save_chapter_summary(BOOK_ID, CHAPTER_INDEX, SUMMARY_CONTENT, model="test-model")
 
     with patch("routers.ai.gemini.generate_chapter_summary", new_callable=AsyncMock) as mock_gen:
@@ -64,7 +69,7 @@ async def test_summary_cache_hit(client, tmp_db):
 # ── Cache miss — queue key present ───────────────────────────────────────────
 
 async def test_summary_cache_miss_generates_and_caches(client, tmp_db):
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     await _set_queue_key(tmp_db)
 
     with patch("routers.ai.gemini.generate_chapter_summary", new_callable=AsyncMock, return_value=SUMMARY_CONTENT):
@@ -82,7 +87,7 @@ async def test_summary_cache_miss_generates_and_caches(client, tmp_db):
 
 
 async def test_summary_second_request_uses_cache(client, tmp_db):
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     await _set_queue_key(tmp_db)
 
     call_count = 0
@@ -103,7 +108,7 @@ async def test_summary_second_request_uses_cache(client, tmp_db):
 # ── No queue key ──────────────────────────────────────────────────────────────
 
 async def test_summary_no_queue_key_returns_503(client, tmp_db):
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
 
     resp = await client.post("/api/ai/summary", json=_PAYLOAD)
     assert resp.status_code == 503
@@ -119,7 +124,7 @@ async def test_summary_book_not_found_returns_404(client, tmp_db):
 # ── Gemini failure ────────────────────────────────────────────────────────────
 
 async def test_summary_gemini_error_returns_500(client, tmp_db):
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     await _set_queue_key(tmp_db)
 
     with patch(
@@ -135,7 +140,7 @@ async def test_summary_gemini_error_returns_500(client, tmp_db):
 # ── Admin delete ──────────────────────────────────────────────────────────────
 
 async def test_summary_admin_can_delete(client, test_user, tmp_db):
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     await save_chapter_summary(BOOK_ID, CHAPTER_INDEX, SUMMARY_CONTENT)
     await set_user_role(test_user["id"], "admin")
 
@@ -148,7 +153,7 @@ async def test_summary_admin_can_delete(client, test_user, tmp_db):
 
 
 async def test_summary_non_admin_delete_forbidden(client, test_user, tmp_db):
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     await save_chapter_summary(BOOK_ID, CHAPTER_INDEX, SUMMARY_CONTENT)
     # First user is auto-admin; explicitly demote them for this test.
     await set_user_role(test_user["id"], "user")


### PR DESCRIPTION
## Summary
- `POST /ai/summary` accepted any `chapter_index` value without bounds checking, allowing requests for chapters that don't exist
- This wasted Gemini API quota: the worker would receive either empty or stale text and produce a nonsense summary
- Applied the same `split_with_html_preference` guard introduced for translations in #429

## Test plan
- [x] Regression test: `test_ai_summary_out_of_bounds_chapter_returns_400` — creates a 2-chapter book, posts summary request for chapter 999, asserts 400
- [x] Full AI test module passes (43 tests)

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)
