### PR TITLE
fix: reject out-of-bounds chapter_index on annotations, vocabulary, reading-progress, insights (closes #450)

### DIFF
--- a/backend/routers/annotations.py
+++ b/backend/routers/annotations.py
@@ -27,12 +27,17 @@ class AnnotationUpdate(BaseModel):
 async def create(req: AnnotationCreate, user: dict = Depends(get_current_user)):
     if not req.sentence_text or not req.sentence_text.strip():
         raise HTTPException(status_code=400, detail="sentence_text cannot be empty")
-    if req.chapter_index < 0:
-        raise HTTPException(status_code=400, detail="chapter_index must be >= 0")
     book = await get_cached_book(req.book_id)
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
     check_book_access(book, user)
+    from services.book_chapters import split_with_html_preference
+    _chapters = await split_with_html_preference(req.book_id, book.get("text") or "")
+    if req.chapter_index < 0 or req.chapter_index >= len(_chapters):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Chapter index out of range (book has {len(_chapters)} chapter(s)).",
+        )
     return await create_annotation(
         user["id"],
         req.book_id,

--- a/backend/routers/insights.py
+++ b/backend/routers/insights.py
@@ -20,12 +20,18 @@ async def create(req: InsightCreate, user: dict = Depends(get_current_user)):
         raise HTTPException(status_code=400, detail="question cannot be empty")
     if not req.answer or not req.answer.strip():
         raise HTTPException(status_code=400, detail="answer cannot be empty")
-    if req.chapter_index is not None and req.chapter_index < 0:
-        raise HTTPException(status_code=400, detail="chapter_index must be >= 0")
     book = await get_cached_book(req.book_id)
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
     check_book_access(book, user)
+    if req.chapter_index is not None:
+        from services.book_chapters import split_with_html_preference
+        _chapters = await split_with_html_preference(req.book_id, book.get("text") or "")
+        if req.chapter_index < 0 or req.chapter_index >= len(_chapters):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Chapter index out of range (book has {len(_chapters)} chapter(s)).",
+            )
     return await save_insight(
         user["id"],
         req.book_id,

--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -67,8 +67,13 @@ async def update_reading_progress(
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
     check_book_access(book, user)
-    if req.chapter_index < 0:
-        raise HTTPException(status_code=400, detail="chapter_index must be >= 0")
+    from services.book_chapters import split_with_html_preference
+    _chapters = await split_with_html_preference(book_id, book.get("text") or "")
+    if req.chapter_index < 0 or req.chapter_index >= len(_chapters):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Chapter index out of range (book has {len(_chapters)} chapter(s)).",
+        )
     await upsert_progress_and_log_event(user["id"], book_id, req.chapter_index)
     return {"ok": True}
 

--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -42,6 +42,13 @@ async def save(req: WordSave, user: dict = Depends(get_current_user)):
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
     check_book_access(book, user)
+    from services.book_chapters import split_with_html_preference
+    _chapters = await split_with_html_preference(req.book_id, book.get("text") or "")
+    if req.chapter_index < 0 or req.chapter_index >= len(_chapters):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Chapter index out of range (book has {len(_chapters)} chapter(s)).",
+        )
     return await save_word(
         user["id"],
         req.word,

--- a/backend/tests/test_router_annotations.py
+++ b/backend/tests/test_router_annotations.py
@@ -14,10 +14,15 @@ _BOOK_META = {
     "cover": "",
 }
 BOOK_ID = 8001
+_CH = "word " * 200
+_BOOK_TEXT = (
+    f"CHAPTER I\n\n{_CH}\n\nCHAPTER II\n\n{_CH}\n\nCHAPTER III\n\n{_CH}"
+    f"\n\nCHAPTER IV\n\n{_CH}\n\nCHAPTER V\n\n{_CH}\n\nCHAPTER VI\n\n{_CH}"
+)
 
 
 async def test_create_annotation(client, test_user):
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     resp = await client.post("/api/annotations", json={
         "book_id": BOOK_ID,
         "chapter_index": 2,
@@ -36,7 +41,7 @@ async def test_create_annotation(client, test_user):
 
 
 async def test_create_annotation_defaults(client, test_user):
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     resp = await client.post("/api/annotations", json={
         "book_id": BOOK_ID,
         "chapter_index": 0,
@@ -49,7 +54,7 @@ async def test_create_annotation_defaults(client, test_user):
 
 
 async def test_get_annotations_for_book(client, test_user):
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     await create_annotation(test_user["id"], BOOK_ID, 0, "Sentence 1", "note1", "blue")
     await create_annotation(test_user["id"], BOOK_ID, 1, "Sentence 2", "note2", "red")
 
@@ -68,7 +73,7 @@ async def test_get_annotations_returns_own_only(client, test_user):
     other = await get_or_create_user(
         google_id="other-g", email="other@example.com", name="Other", picture=""
     )
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     await create_annotation(test_user["id"], BOOK_ID, 0, "My sentence", "mine", "yellow")
     await create_annotation(other["id"], BOOK_ID, 0, "Other sentence", "theirs", "green")
 
@@ -80,7 +85,7 @@ async def test_get_annotations_returns_own_only(client, test_user):
 
 
 async def test_update_annotation(client, test_user):
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     ann = await create_annotation(test_user["id"], BOOK_ID, 0, "Text", "old note", "yellow")
 
     resp = await client.patch(f"/api/annotations/{ann['id']}", json={
@@ -99,7 +104,7 @@ async def test_update_annotation_note_text_only(client, test_user):
     Regression: AnnotationUpdate previously required both fields, so the
     notes-page save (which only sends note_text) always returned 422.
     """
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     ann = await create_annotation(test_user["id"], BOOK_ID, 0, "Text", "old", "blue")
 
     resp = await client.patch(f"/api/annotations/{ann['id']}", json={"note_text": "new note"})
@@ -123,7 +128,7 @@ async def test_update_annotation_own_only(client, test_user):
     other = await get_or_create_user(
         google_id="other-g2", email="other2@example.com", name="Other2", picture=""
     )
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     ann = await create_annotation(other["id"], BOOK_ID, 0, "Their text", "", "yellow")
 
     resp = await client.patch(f"/api/annotations/{ann['id']}", json={
@@ -134,7 +139,7 @@ async def test_update_annotation_own_only(client, test_user):
 
 
 async def test_delete_annotation(client, test_user):
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     ann = await create_annotation(test_user["id"], BOOK_ID, 0, "To delete", "", "yellow")
 
     resp = await client.delete(f"/api/annotations/{ann['id']}")
@@ -156,7 +161,7 @@ async def test_delete_annotation_own_only(client, test_user):
     other = await get_or_create_user(
         google_id="other-g3", email="other3@example.com", name="Other3", picture=""
     )
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     ann = await create_annotation(other["id"], BOOK_ID, 0, "Theirs", "", "yellow")
 
     resp = await client.delete(f"/api/annotations/{ann['id']}")
@@ -179,8 +184,8 @@ async def test_get_all_returns_annotations_across_books(client, test_user):
     """GET /api/annotations/all returns all of the user's annotations with book_title."""
     from services.db import save_book
 
-    await save_book(8101, {**_BOOK_META, "title": "Book A"}, "text")
-    await save_book(8102, {**_BOOK_META, "title": "Book B"}, "text")
+    await save_book(8101, {**_BOOK_META, "title": "Book A"}, _BOOK_TEXT)
+    await save_book(8102, {**_BOOK_META, "title": "Book B"}, _BOOK_TEXT)
     await create_annotation(test_user["id"], 8101, 0, "Sentence A", "note A", "yellow")
     await create_annotation(test_user["id"], 8102, 1, "Sentence B", "note B", "blue")
 
@@ -200,7 +205,7 @@ async def test_get_all_returns_own_annotations_only(client, test_user):
     other = await get_or_create_user(
         google_id="other-all-ann-g", email="other-all-ann@example.com", name="Other", picture=""
     )
-    await save_book(8103, _BOOK_META, "text")
+    await save_book(8103, _BOOK_META, _BOOK_TEXT)
     await create_annotation(test_user["id"], 8103, 0, "My sentence", "mine", "yellow")
     await create_annotation(other["id"], 8103, 0, "Their sentence", "theirs", "green")
 
@@ -234,7 +239,7 @@ async def test_create_annotation_rejects_empty_sentence(client, test_user):
 
     An annotation with no text context is meaningless and represents a
     client error."""
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     resp = await client.post("/api/annotations", json={
         "book_id": BOOK_ID,
         "chapter_index": 0,
@@ -247,13 +252,33 @@ async def test_create_annotation_rejects_negative_chapter_index(client, test_use
     """POST /annotations with chapter_index < 0 must return 400.
     Negative indices are not valid book positions and would produce
     invisible orphan rows (no reader query matches chapter -1)."""
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     resp = await client.post("/api/annotations", json={
         "book_id": BOOK_ID,
         "chapter_index": -1,
         "sentence_text": "Some highlighted text.",
     })
     assert resp.status_code == 400
+
+
+async def test_create_annotation_rejects_out_of_range_chapter_index(client, test_user):
+    """POST /annotations with chapter_index >= book chapter count must return 400.
+
+    Without the upper bound guard, out-of-range indices produce orphaned rows
+    that are never retrieved (no reader ever shows a chapter beyond the last one).
+
+    Uses book_id=99001 (above Gutenberg range) so get_book_html returns None."""
+    from services.db import save_book as _sb
+    from unittest.mock import AsyncMock, patch
+    await _sb(99001, {**_BOOK_META}, "Only one chapter here, no chapter markers.")
+    with patch("services.book_chapters.get_book_html", new_callable=AsyncMock, return_value=None):
+        resp = await client.post("/api/annotations", json={
+            "book_id": 99001,
+            "chapter_index": 1,
+            "sentence_text": "A sentence.",
+        })
+    assert resp.status_code == 400, resp.text
+    assert "out of range" in resp.json()["detail"].lower()
 
 
 async def test_create_annotation_select_runs_before_commit(tmp_db, test_user, monkeypatch):
@@ -268,7 +293,7 @@ async def test_create_annotation_select_runs_before_commit(tmp_db, test_user, mo
     import services.db as db_module
     from services.db import save_book, create_annotation
 
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
 
     events: list[str] = []
     orig_connect = _real_aiosqlite.connect
@@ -327,7 +352,7 @@ async def test_update_annotation_select_runs_before_commit(tmp_db, test_user, mo
     import services.db as db_module
     from services.db import save_book, create_annotation, update_annotation
 
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     ann = await create_annotation(test_user["id"], BOOK_ID, 0, "Sentence", "v1", "yellow")
 
     events: list[str] = []

--- a/backend/tests/test_router_insights.py
+++ b/backend/tests/test_router_insights.py
@@ -5,10 +5,15 @@ from httpx import AsyncClient
 from services.db import save_book, save_insight
 
 _META = {"title": "Test", "authors": [], "languages": ["en"], "subjects": [], "download_count": 0, "cover": ""}
+_CH = "word " * 200
+_BOOK_TEXT = (
+    f"CHAPTER I\n\n{_CH}\n\nCHAPTER II\n\n{_CH}\n\nCHAPTER III\n\n{_CH}"
+    f"\n\nCHAPTER IV\n\n{_CH}\n\nCHAPTER V\n\n{_CH}\n\nCHAPTER VI\n\n{_CH}"
+)
 
 
 async def test_post_creates_insight_and_returns_it(client: AsyncClient):
-    await save_book(1, _META, "text")
+    await save_book(1, _META, _BOOK_TEXT)
     payload = {
         "book_id": 1,
         "chapter_index": 2,
@@ -26,7 +31,7 @@ async def test_post_creates_insight_and_returns_it(client: AsyncClient):
 
 
 async def test_post_with_null_chapter_index(client: AsyncClient):
-    await save_book(5, _META, "text")
+    await save_book(5, _META, _BOOK_TEXT)
     payload = {
         "book_id": 5,
         "chapter_index": None,
@@ -41,8 +46,8 @@ async def test_post_with_null_chapter_index(client: AsyncClient):
 
 
 async def test_get_returns_insights_for_book_id(client: AsyncClient):
-    await save_book(10, _META, "text")
-    await save_book(99, _META, "text")
+    await save_book(10, _META, _BOOK_TEXT)
+    await save_book(99, _META, _BOOK_TEXT)
     for i in range(2):
         await client.post(
             "/api/insights",
@@ -62,7 +67,7 @@ async def test_get_returns_insights_for_book_id(client: AsyncClient):
 
 async def test_get_returns_only_current_users_insights(client: AsyncClient, test_user):
     """A second authenticated client should not see the first user's insights."""
-    await save_book(7, _META, "text")
+    await save_book(7, _META, _BOOK_TEXT)
 
     await client.post(
         "/api/insights",
@@ -86,7 +91,7 @@ async def test_get_returns_only_current_users_insights(client: AsyncClient, test
 
 
 async def test_delete_returns_ok(client: AsyncClient):
-    await save_book(3, _META, "text")
+    await save_book(3, _META, _BOOK_TEXT)
     resp = await client.post(
         "/api/insights",
         json={"book_id": 3, "question": "Delete me", "answer": "Yes"},
@@ -122,8 +127,8 @@ async def test_delete_returns_404_if_wrong_user(client: AsyncClient, test_user):
 
 async def test_get_all_returns_insights_across_books(client: AsyncClient, test_user):
     """GET /api/insights/all returns all of the user's insights with book_title."""
-    await save_book(20, _META, "text")
-    await save_book(21, _META, "text")
+    await save_book(20, _META, _BOOK_TEXT)
+    await save_book(21, _META, _BOOK_TEXT)
     await client.post("/api/insights", json={"book_id": 20, "question": "Q-A", "answer": "A-A"})
     await client.post("/api/insights", json={"book_id": 21, "question": "Q-B", "answer": "A-B"})
 
@@ -138,7 +143,7 @@ async def test_get_all_returns_insights_across_books(client: AsyncClient, test_u
 
 async def test_get_all_returns_own_insights_only(client: AsyncClient, test_user):
     """GET /api/insights/all must not return other users' insights."""
-    await save_book(30, _META, "text")
+    await save_book(30, _META, _BOOK_TEXT)
     from services.db import get_or_create_user
 
     other = await get_or_create_user(
@@ -179,7 +184,7 @@ async def test_post_insight_rejects_nonexistent_book(client: AsyncClient):
 
 async def test_post_insight_rejects_empty_question(client: AsyncClient):
     """POST /insights with empty question must return 400."""
-    await save_book(1, _META, "text")
+    await save_book(1, _META, _BOOK_TEXT)
     resp = await client.post(
         "/api/insights",
         json={"book_id": 1, "question": "", "answer": "Some answer."},
@@ -189,7 +194,7 @@ async def test_post_insight_rejects_empty_question(client: AsyncClient):
 
 async def test_post_insight_rejects_empty_answer(client: AsyncClient):
     """POST /insights with empty answer must return 400."""
-    await save_book(1, _META, "text")
+    await save_book(1, _META, _BOOK_TEXT)
     resp = await client.post(
         "/api/insights",
         json={"book_id": 1, "question": "What is the theme?", "answer": ""},
@@ -201,12 +206,31 @@ async def test_post_insight_rejects_negative_chapter_index(client: AsyncClient):
     """POST /insights with chapter_index < 0 must return 400.
     A negative chapter_index is not a valid position and produces an
     invisible orphan row (no reader query matches chapter -1)."""
-    await save_book(1, _META, "text")
+    await save_book(1, _META, _BOOK_TEXT)
     resp = await client.post(
         "/api/insights",
         json={"book_id": 1, "question": "Q?", "answer": "A.", "chapter_index": -5},
     )
     assert resp.status_code == 400
+
+
+async def test_post_insight_rejects_out_of_range_chapter_index(client: AsyncClient):
+    """POST /insights with chapter_index >= book chapter count must return 400.
+
+    Out-of-range indices produce orphaned insight rows that never appear in
+    the reader — the chapter tab is hidden for chapters beyond the last one.
+
+    Uses book_id=99004 (above Gutenberg range) so get_book_html returns None,
+    ensuring the text splitter runs and the single-chunk text yields 1 chapter."""
+    from unittest.mock import AsyncMock, patch
+    await save_book(99004, _META, "No chapter markers — single chunk.")
+    with patch("services.book_chapters.get_book_html", new_callable=AsyncMock, return_value=None):
+        resp = await client.post(
+            "/api/insights",
+            json={"book_id": 99004, "question": "Q?", "answer": "A.", "chapter_index": 1},
+        )
+    assert resp.status_code == 400, resp.text
+    assert "out of range" in resp.json()["detail"].lower()
 
 
 async def test_save_insight_select_runs_before_commit(tmp_db, test_user, monkeypatch):
@@ -220,7 +244,7 @@ async def test_save_insight_select_runs_before_commit(tmp_db, test_user, monkeyp
     import services.db as db_module
     from services.db import save_book, save_insight
 
-    await save_book(1, _META, "text")
+    await save_book(1, _META, _BOOK_TEXT)
 
     events: list[str] = []
     orig_connect = _real_aiosqlite.connect

--- a/backend/tests/test_router_user.py
+++ b/backend/tests/test_router_user.py
@@ -8,6 +8,11 @@ from services.auth import encrypt_api_key, decrypt_api_key
 
 _BOOK_META = {"title": "Test Book", "authors": ["Author"], "languages": ["en"], "subjects": [], "download_count": 0, "cover": ""}
 BOOK_ID = 9999
+_CH = "word " * 200
+_BOOK_TEXT = (
+    f"CHAPTER I\n\n{_CH}\n\nCHAPTER II\n\n{_CH}\n\nCHAPTER III\n\n{_CH}"
+    f"\n\nCHAPTER IV\n\n{_CH}\n\nCHAPTER V\n\n{_CH}\n\nCHAPTER VI\n\n{_CH}"
+)
 
 
 async def test_get_me_returns_profile(client, test_user):
@@ -63,7 +68,7 @@ async def test_reading_progress_empty_initially(client, test_user):
 
 
 async def test_reading_progress_save_and_retrieve(client, test_user):
-    await save_book(BOOK_ID, _BOOK_META, "Chapter text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     resp = await client.put(f"/api/user/reading-progress/{BOOK_ID}", json={"chapter_index": 3})
     assert resp.status_code == 200
     assert resp.json()["ok"] is True
@@ -76,7 +81,7 @@ async def test_reading_progress_save_and_retrieve(client, test_user):
 
 
 async def test_reading_progress_upserts(client, test_user):
-    await save_book(BOOK_ID, _BOOK_META, "Chapter text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     await client.put(f"/api/user/reading-progress/{BOOK_ID}", json={"chapter_index": 1})
     await client.put(f"/api/user/reading-progress/{BOOK_ID}", json={"chapter_index": 5})
 
@@ -104,6 +109,21 @@ async def test_reading_progress_rejects_negative_chapter_index(client, test_user
     await save_book(BOOK_ID, _META, "text")
     resp = await client.put(f"/api/user/reading-progress/{BOOK_ID}", json={"chapter_index": -1})
     assert resp.status_code == 400
+
+
+async def test_reading_progress_rejects_out_of_range_chapter_index(client, test_user):
+    """PUT reading-progress with chapter_index >= book chapter count must return 400.
+
+    Storing an out-of-range index corrupts the user's resume position (the reader
+    never shows a chapter beyond the last one).
+
+    Uses book_id=99003 (above Gutenberg range) so get_book_html returns None."""
+    from unittest.mock import AsyncMock, patch
+    await save_book(99003, _BOOK_META, "No chapter markers — single chunk.")
+    with patch("services.book_chapters.get_book_html", new_callable=AsyncMock, return_value=None):
+        resp = await client.put("/api/user/reading-progress/99003", json={"chapter_index": 1})
+    assert resp.status_code == 400, resp.text
+    assert "out of range" in resp.json()["detail"].lower()
 
 
 async def test_get_obsidian_settings_returns_defaults_initially(client, test_user):

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -19,10 +19,15 @@ _BOOK_META = {
     "cover": "",
 }
 BOOK_ID = 9001
+_CH = "word " * 200
+_BOOK_TEXT = (
+    f"CHAPTER I\n\n{_CH}\n\nCHAPTER II\n\n{_CH}\n\nCHAPTER III\n\n{_CH}"
+    f"\n\nCHAPTER IV\n\n{_CH}\n\nCHAPTER V\n\n{_CH}\n\nCHAPTER VI\n\n{_CH}"
+)
 
 
 async def test_save_word(client, test_user):
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     resp = await client.post("/api/vocabulary", json={
         "word": "leviathan",
         "book_id": BOOK_ID,
@@ -37,7 +42,7 @@ async def test_save_word(client, test_user):
 
 async def test_save_word_deduplicates_occurrence(client, test_user):
     """Saving the same word+book+sentence twice should not create duplicate occurrences."""
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     payload = {
         "word": "whale",
         "book_id": BOOK_ID,
@@ -60,7 +65,7 @@ async def test_get_vocabulary_empty(client, test_user):
 
 
 async def test_get_vocabulary_with_occurrences(client, test_user):
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     await save_word(test_user["id"], "ahab", BOOK_ID, 5, "Captain Ahab spoke.")
 
     resp = await client.get("/api/vocabulary")
@@ -82,7 +87,7 @@ async def test_get_vocabulary_own_only(client, test_user):
     other = await get_or_create_user(
         google_id="voc-other", email="vocother@example.com", name="Other", picture=""
     )
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     await save_word(other["id"], "secret", BOOK_ID, 0, "A secret word.")
 
     resp = await client.get("/api/vocabulary")
@@ -90,7 +95,7 @@ async def test_get_vocabulary_own_only(client, test_user):
 
 
 async def test_delete_word(client, test_user):
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     await save_word(test_user["id"], "cetacean", BOOK_ID, 0, "A cetacean species.")
 
     resp = await client.delete("/api/vocabulary/cetacean")
@@ -112,7 +117,7 @@ async def test_delete_word_own_only(client, test_user):
     other = await get_or_create_user(
         google_id="voc-other2", email="vocother2@example.com", name="Other2", picture=""
     )
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     await save_word(other["id"], "pirate", BOOK_ID, 0, "A pirate's life.")
 
     resp = await client.delete("/api/vocabulary/pirate")
@@ -134,7 +139,7 @@ async def test_save_word_normalizes_case(client, test_user):
 
     SQLite UNIQUE(user_id, word) is case-sensitive, so without explicit
     lowercasing they produce two separate rows."""
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     await client.post("/api/vocabulary", json={
         "word": "Apple", "book_id": BOOK_ID, "chapter_index": 0, "sentence_text": "Apple pie."
     })
@@ -148,7 +153,7 @@ async def test_save_word_normalizes_case(client, test_user):
 
 async def test_delete_word_case_insensitive(client, test_user):
     """DELETE /vocabulary/Apple must remove 'apple' saved as lowercase."""
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     await save_word(test_user["id"], "apple", BOOK_ID, 0, "An apple.")
     resp = await client.delete("/api/vocabulary/Apple")
     assert resp.status_code == 200
@@ -163,7 +168,7 @@ async def test_save_word_rejects_empty_word(client, test_user):
     can never delete it via DELETE /vocabulary/ (no path segment) and
     the UNIQUE(user_id, word) constraint allows exactly one empty entry
     per user, polluting the vocabulary silently."""
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     resp = await client.post("/api/vocabulary", json={
         "word": "", "book_id": BOOK_ID, "chapter_index": 0, "sentence_text": "Some text."
     })
@@ -172,7 +177,7 @@ async def test_save_word_rejects_empty_word(client, test_user):
 
 async def test_save_word_strips_and_rejects_whitespace_only_word(client, test_user):
     """POST /vocabulary with whitespace-only word must return 400."""
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     resp = await client.post("/api/vocabulary", json={
         "word": "   ", "book_id": BOOK_ID, "chapter_index": 0, "sentence_text": "Some text."
     })
@@ -198,7 +203,7 @@ async def test_save_word_rejects_empty_sentence(client, test_user):
 
     An occurrence with no sentence context cannot be displayed and
     represents a client error."""
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     resp = await client.post("/api/vocabulary", json={
         "word": "spectre",
         "book_id": BOOK_ID,
@@ -210,7 +215,7 @@ async def test_save_word_rejects_empty_sentence(client, test_user):
 
 async def test_save_word_rejects_whitespace_only_sentence(client, test_user):
     """POST /vocabulary with whitespace-only sentence_text must return 400."""
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
     resp = await client.post("/api/vocabulary", json={
         "word": "spectre",
         "book_id": BOOK_ID,
@@ -218,6 +223,27 @@ async def test_save_word_rejects_whitespace_only_sentence(client, test_user):
         "sentence_text": "   ",
     })
     assert resp.status_code == 400
+
+
+async def test_save_word_rejects_out_of_range_chapter_index(client, test_user):
+    """POST /vocabulary with chapter_index >= book chapter count must return 400.
+
+    Out-of-range indices produce orphaned word_occurrences that break vocab
+    dedup and cleanup logic which relies on valid chapter positions.
+
+    Uses book_id=99002 (above Gutenberg range) so get_book_html returns None."""
+    from services.db import save_book as _sb
+    from unittest.mock import AsyncMock, patch
+    await _sb(99002, {**_BOOK_META}, "No chapter markers — single chunk.")
+    with patch("services.book_chapters.get_book_html", new_callable=AsyncMock, return_value=None):
+        resp = await client.post("/api/vocabulary", json={
+            "word": "leviathan",
+            "book_id": 99002,
+            "chapter_index": 1,
+            "sentence_text": "The great leviathan swam past.",
+        })
+    assert resp.status_code == 400, resp.text
+    assert "out of range" in resp.json()["detail"].lower()
 
 
 # ── Atomicity regression ─────────────────────────────────────────────────────
@@ -237,7 +263,7 @@ async def test_save_word_is_atomic(test_user, tmp_db):
     """
     import aiosqlite
 
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_book(BOOK_ID, _BOOK_META, _BOOK_TEXT)
 
     original_connect = aiosqlite.connect
 
@@ -291,7 +317,7 @@ async def test_save_word_is_atomic(test_user, tmp_db):
 # ── Export endpoint ───────────────────────────────────────────────────────────
 
 async def _setup_export(test_user, book_id=BOOK_ID):
-    await save_book(book_id, _BOOK_META, "text")
+    await save_book(book_id, _BOOK_META, _BOOK_TEXT)
     await save_word(test_user["id"], "leviathan", book_id, 3, "The great leviathan.")
     enc_token = encrypt_api_key("ghp_test_token")
     await update_obsidian_settings(


### PR DESCRIPTION
## Summary
- Adds upper-bound validation for `chapter_index` on 4 endpoints that only had a lower-bound guard or no guard at all:
  - `POST /annotations/` — was `>= 0` only; now rejects indices >= chapter count
  - `POST /vocabulary/` — had no chapter_index validation; now validates fully
  - `PUT /user/reading-progress/{book_id}` — was `>= 0` only; now rejects out-of-range
  - `POST /insights/` — had `>= 0` only for optional field; now validates when not None
- Uses the same `split_with_html_preference` bounds check pattern as `#429` (translate) and `#448` (summary)
- 4 new regression tests (one per endpoint) added with patched `get_book_html` to work reliably in CI without network access
- All existing tests updated to use 6-chapter `_BOOK_TEXT` so valid chapter indices remain in-range after the new guard

## Test plan
- [x] All 4 new regression tests: confirm endpoints return 400 for out-of-bounds `chapter_index`
- [x] All existing tests for the 4 affected files pass (90/90)

Closes #450
