### PR TITLE
fix: reject out-of-bounds chapter_index on annotations, insights, vocabulary, reading-progress (closes #450)

### DIFF
--- a/backend/routers/annotations.py
+++ b/backend/routers/annotations.py
@@ -33,6 +33,13 @@ async def create(req: AnnotationCreate, user: dict = Depends(get_current_user)):
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
     check_book_access(book, user)
+    from services.book_chapters import split_with_html_preference as _split
+    _chapters = await _split(req.book_id, book.get("text") or "")
+    if req.chapter_index >= len(_chapters):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Chapter index out of range (book has {len(_chapters)} chapter(s)).",
+        )
     return await create_annotation(
         user["id"],
         req.book_id,

--- a/backend/routers/insights.py
+++ b/backend/routers/insights.py
@@ -26,6 +26,14 @@ async def create(req: InsightCreate, user: dict = Depends(get_current_user)):
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
     check_book_access(book, user)
+    if req.chapter_index is not None:
+        from services.book_chapters import split_with_html_preference as _split
+        _chapters = await _split(req.book_id, book.get("text") or "")
+        if req.chapter_index >= len(_chapters):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Chapter index out of range (book has {len(_chapters)} chapter(s)).",
+            )
     return await save_insight(
         user["id"],
         req.book_id,

--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -69,6 +69,13 @@ async def update_reading_progress(
     check_book_access(book, user)
     if req.chapter_index < 0:
         raise HTTPException(status_code=400, detail="chapter_index must be >= 0")
+    from services.book_chapters import split_with_html_preference as _split
+    _chapters = await _split(book_id, book.get("text") or "")
+    if req.chapter_index >= len(_chapters):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Chapter index out of range (book has {len(_chapters)} chapter(s)).",
+        )
     await upsert_progress_and_log_event(user["id"], book_id, req.chapter_index)
     return {"ok": True}
 

--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -42,6 +42,13 @@ async def save(req: WordSave, user: dict = Depends(get_current_user)):
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
     check_book_access(book, user)
+    from services.book_chapters import split_with_html_preference as _split
+    _chapters = await _split(req.book_id, book.get("text") or "")
+    if req.chapter_index < 0 or req.chapter_index >= len(_chapters):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Chapter index out of range (book has {len(_chapters)} chapter(s)).",
+        )
     return await save_word(
         user["id"],
         req.word,

--- a/backend/tests/test_router_annotations.py
+++ b/backend/tests/test_router_annotations.py
@@ -20,7 +20,7 @@ async def test_create_annotation(client, test_user):
     await save_book(BOOK_ID, _BOOK_META, "text")
     resp = await client.post("/api/annotations", json={
         "book_id": BOOK_ID,
-        "chapter_index": 2,
+        "chapter_index": 0,
         "sentence_text": "It was the best of times.",
         "note_text": "Famous opener",
         "color": "yellow",
@@ -28,7 +28,7 @@ async def test_create_annotation(client, test_user):
     assert resp.status_code == 200
     data = resp.json()
     assert data["book_id"] == BOOK_ID
-    assert data["chapter_index"] == 2
+    assert data["chapter_index"] == 0
     assert data["sentence_text"] == "It was the best of times."
     assert data["note_text"] == "Famous opener"
     assert data["color"] == "yellow"
@@ -412,3 +412,17 @@ async def test_get_annotations_returns_404_for_missing_book(client, test_user, t
     """GET /annotations?book_id=N returns 404 when book doesn't exist (#397)."""
     resp = await client.get("/api/annotations?book_id=999998")
     assert resp.status_code == 404, resp.text
+
+
+async def test_create_annotation_out_of_bounds_chapter_returns_400(client, test_user, tmp_db):
+    """POST /annotations rejects chapter_index beyond the book's chapter count (issue #450)."""
+    from services.book_chapters import clear_cache as _clear
+    text = "CHAPTER I\n\n" + "word " * 200 + "\n\nCHAPTER II\n\n" + "word " * 200
+    await save_book(9882, {**_BOOK_META, "id": 9882}, text)
+    _clear()
+    resp = await client.post(
+        "/api/annotations",
+        json={"book_id": 9882, "chapter_index": 999, "sentence_text": "some sentence"},
+    )
+    assert resp.status_code == 400, f"Expected 400 for out-of-bounds chapter, got {resp.status_code}: {resp.text}"
+    assert "out of range" in resp.json()["detail"].lower()

--- a/backend/tests/test_router_insights.py
+++ b/backend/tests/test_router_insights.py
@@ -11,7 +11,7 @@ async def test_post_creates_insight_and_returns_it(client: AsyncClient):
     await save_book(1, _META, "text")
     payload = {
         "book_id": 1,
-        "chapter_index": 2,
+        "chapter_index": 0,
         "question": "What is the theme?",
         "answer": "The theme is love.",
     }
@@ -19,7 +19,7 @@ async def test_post_creates_insight_and_returns_it(client: AsyncClient):
     assert resp.status_code == 200
     data = resp.json()
     assert data["book_id"] == 1
-    assert data["chapter_index"] == 2
+    assert data["chapter_index"] == 0
     assert data["question"] == "What is the theme?"
     assert data["answer"] == "The theme is love."
     assert "id" in data
@@ -304,3 +304,19 @@ async def test_get_insights_returns_404_for_missing_book(client, test_user, tmp_
     """GET /insights?book_id=N returns 404 when book doesn't exist (#397)."""
     resp = await client.get("/api/insights?book_id=999999")
     assert resp.status_code == 404, resp.text
+
+
+async def test_create_insight_out_of_bounds_chapter_returns_400(client, test_user, tmp_db):
+    """POST /insights rejects chapter_index beyond the book's chapter count (issue #450)."""
+    from services.db import save_book
+    from services.book_chapters import clear_cache as _clear
+    _META2 = {"title": "T2", "authors": [], "languages": ["en"], "subjects": [], "download_count": 0, "cover": ""}
+    text = "CHAPTER I\n\n" + "word " * 200 + "\n\nCHAPTER II\n\n" + "word " * 200
+    await save_book(9883, {**_META2, "id": 9883}, text)
+    _clear()
+    resp = await client.post(
+        "/api/insights",
+        json={"book_id": 9883, "chapter_index": 999, "question": "Q?", "answer": "A."},
+    )
+    assert resp.status_code == 400, f"Expected 400 for out-of-bounds chapter, got {resp.status_code}: {resp.text}"
+    assert "out of range" in resp.json()["detail"].lower()

--- a/backend/tests/test_router_user.py
+++ b/backend/tests/test_router_user.py
@@ -63,8 +63,8 @@ async def test_reading_progress_empty_initially(client, test_user):
 
 
 async def test_reading_progress_save_and_retrieve(client, test_user):
-    await save_book(BOOK_ID, _BOOK_META, "Chapter text")
-    resp = await client.put(f"/api/user/reading-progress/{BOOK_ID}", json={"chapter_index": 3})
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    resp = await client.put(f"/api/user/reading-progress/{BOOK_ID}", json={"chapter_index": 0})
     assert resp.status_code == 200
     assert resp.json()["ok"] is True
 
@@ -72,11 +72,14 @@ async def test_reading_progress_save_and_retrieve(client, test_user):
     entries = resp.json()["entries"]
     assert len(entries) == 1
     assert entries[0]["book_id"] == BOOK_ID
-    assert entries[0]["chapter_index"] == 3
+    assert entries[0]["chapter_index"] == 0
 
 
 async def test_reading_progress_upserts(client, test_user):
-    await save_book(BOOK_ID, _BOOK_META, "Chapter text")
+    from services.book_chapters import clear_cache as _clear
+    _multi = "\n\n".join(f"CHAPTER {i}\n\n" + "word " * 200 for i in range(1, 7))
+    await save_book(BOOK_ID, _BOOK_META, _multi)
+    _clear()
     await client.put(f"/api/user/reading-progress/{BOOK_ID}", json={"chapter_index": 1})
     await client.put(f"/api/user/reading-progress/{BOOK_ID}", json={"chapter_index": 5})
 
@@ -250,3 +253,15 @@ async def test_update_reading_progress_blocked_for_non_owner(client, test_user, 
         f"Expected 403 for non-owner updating reading progress of private book, "
         f"got {resp.status_code}: {resp.text}"
     )
+
+
+async def test_reading_progress_out_of_bounds_chapter_returns_400(client, test_user, tmp_db):
+    """PUT /user/reading-progress/{book_id} rejects chapter_index beyond book's chapter count (issue #450)."""
+    from services.book_chapters import clear_cache as _clear
+    _META3 = {"title": "T3", "authors": [], "languages": ["en"], "subjects": [], "download_count": 0, "cover": ""}
+    text = "CHAPTER I\n\n" + "word " * 200 + "\n\nCHAPTER II\n\n" + "word " * 200
+    await save_book(9884, {**_META3, "id": 9884}, text)
+    _clear()
+    resp = await client.put("/api/user/reading-progress/9884", json={"chapter_index": 999})
+    assert resp.status_code == 400, f"Expected 400 for out-of-bounds chapter, got {resp.status_code}: {resp.text}"
+    assert "out of range" in resp.json()["detail"].lower()

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -26,7 +26,7 @@ async def test_save_word(client, test_user):
     resp = await client.post("/api/vocabulary", json={
         "word": "leviathan",
         "book_id": BOOK_ID,
-        "chapter_index": 3,
+        "chapter_index": 0,
         "sentence_text": "The great leviathan swam past.",
     })
     assert resp.status_code == 200
@@ -41,7 +41,7 @@ async def test_save_word_deduplicates_occurrence(client, test_user):
     payload = {
         "word": "whale",
         "book_id": BOOK_ID,
-        "chapter_index": 1,
+        "chapter_index": 0,
         "sentence_text": "Call me Ishmael.",
     }
     await client.post("/api/vocabulary", json=payload)
@@ -539,3 +539,17 @@ async def test_save_word_select_runs_before_commit(tmp_db, test_user, monkeypatc
         "SELECT must run before COMMIT in save_word to avoid returning data "
         "from a concurrent _update_lemma write (#351)"
     )
+
+
+async def test_save_vocabulary_out_of_bounds_chapter_returns_400(client, test_user, tmp_db):
+    """POST /vocabulary rejects chapter_index beyond the book's chapter count (issue #450)."""
+    from services.book_chapters import clear_cache as _clear
+    text = "CHAPTER I\n\n" + "word " * 200 + "\n\nCHAPTER II\n\n" + "word " * 200
+    await save_book(9885, {**_BOOK_META, "id": 9885}, text)
+    _clear()
+    resp = await client.post(
+        "/api/vocabulary",
+        json={"word": "Wort", "book_id": 9885, "chapter_index": 999, "sentence_text": "Ein Satz."},
+    )
+    assert resp.status_code == 400, f"Expected 400 for out-of-bounds chapter, got {resp.status_code}: {resp.text}"
+    assert "out of range" in resp.json()["detail"].lower()

--- a/backend/tests/test_router_vocabulary_extended.py
+++ b/backend/tests/test_router_vocabulary_extended.py
@@ -548,13 +548,13 @@ async def test_save_word_different_sentence_same_chapter_creates_second_occurren
     await client.post("/api/vocabulary", json={
         "word": "tempest",
         "book_id": BOOK_ID,
-        "chapter_index": 2,
+        "chapter_index": 0,
         "sentence_text": "The tempest raged.",
     })
     await client.post("/api/vocabulary", json={
         "word": "tempest",
         "book_id": BOOK_ID,
-        "chapter_index": 2,
+        "chapter_index": 0,
         "sentence_text": "A tempest approached.",
     })
 
@@ -566,7 +566,10 @@ async def test_save_word_different_sentence_same_chapter_creates_second_occurren
 
 async def test_save_word_same_sentence_different_chapter_creates_separate_occurrences(client, test_user):
     """Same word in different chapters creates separate occurrences."""
-    await save_book(BOOK_ID, _BOOK_META, "text")
+    from services.book_chapters import clear_cache as _clear
+    _two_ch = "CHAPTER I\n\n" + "word " * 200 + "\n\nCHAPTER II\n\n" + "word " * 200
+    await save_book(BOOK_ID, _BOOK_META, _two_ch)
+    _clear()
 
     await client.post("/api/vocabulary", json={
         "word": "horizon",
@@ -577,7 +580,7 @@ async def test_save_word_same_sentence_different_chapter_creates_separate_occurr
     await client.post("/api/vocabulary", json={
         "word": "horizon",
         "book_id": BOOK_ID,
-        "chapter_index": 5,
+        "chapter_index": 1,
         "sentence_text": "The horizon stretched far.",
     })
 
@@ -587,7 +590,7 @@ async def test_save_word_same_sentence_different_chapter_creates_separate_occurr
     assert len(entry["occurrences"]) == 2
     chapters = {occ["chapter_index"] for occ in entry["occurrences"]}
     assert 0 in chapters
-    assert 5 in chapters
+    assert 1 in chapters
 
 
 # ── GET /vocabulary/definition/{word} ────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add upper-bounds validation to `POST /annotations`, `POST /insights`, `POST /vocabulary`, and `PUT /user/reading-progress/{book_id}`: reject any `chapter_index >= len(chapters)` with HTTP 400
- Fix pre-existing tests that used arbitrary chapter indices on single-chapter test books (chapter_index 1–5 → valid values, multi-chapter books where needed)

## Why

Issue #450: four write endpoints accepted any non-negative `chapter_index`, allowing clients to store data associated with chapters that don't exist in the book. This is consistent with the bounds check already added to `POST /ai/summary` (#448) and translation endpoints.

## Test plan

- [ ] `test_create_annotation_out_of_bounds_chapter_returns_400` — regression for POST /annotations
- [ ] `test_create_insight_out_of_bounds_chapter_returns_400` — regression for POST /insights
- [ ] `test_reading_progress_out_of_bounds_chapter_returns_400` — regression for PUT /user/reading-progress/{id}
- [ ] `test_save_vocabulary_out_of_bounds_chapter_returns_400` — regression for POST /vocabulary
- [ ] All previously-passing tests in the 5 affected files still pass

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)
