### PR TITLE
fix: use BEGIN IMMEDIATE to prevent double-confirm race (closes #451)

### DIFF
--- a/backend/routers/uploads.py
+++ b/backend/routers/uploads.py
@@ -177,6 +177,10 @@ async def confirm_chapters(
 ):
     """Confirm chapter splits for an uploaded book. Writes chapters to DB and makes book readable."""
     async with aiosqlite.connect(_db.DB_PATH) as db:
+        # BEGIN IMMEDIATE acquires a write reservation immediately so a second
+        # concurrent confirm cannot read draft=True after this connection has
+        # written draft=False (#451).
+        await db.execute("BEGIN IMMEDIATE")
         async with db.execute(
             "SELECT text, owner_user_id, source FROM books WHERE id=?", (book_id,)
         ) as cur:

--- a/backend/tests/test_router_uploads.py
+++ b/backend/tests/test_router_uploads.py
@@ -520,3 +520,39 @@ async def test_request_translation_rejects_draft_book(client, test_user):
         f"Expected 400 for draft book translation request, got {resp.status_code} (#380)"
     )
     assert "draft" in resp.json()["detail"].lower() or "confirm" in resp.json()["detail"].lower()
+
+
+async def test_double_confirm_second_request_returns_400(client, test_user, tmp_db):
+    """Concurrent confirm requests: second confirm must return 400, not silently overwrite.
+
+    Regression for #451: the read-validate-write pattern was non-atomic; two concurrent
+    requests could both pass the draft==True check and both succeed. With BEGIN IMMEDIATE
+    the second request reads draft==False after the first commits and gets 400.
+    """
+    import asyncio
+
+    upload_resp = await client.post("/api/books/upload", files=_txt_upload())
+    assert upload_resp.status_code == 200
+    book_id = upload_resp.json()["book_id"]
+    detected = upload_resp.json()["detected_chapters"]
+    chapters_to_confirm = [
+        {"title": ch["title"], "original_index": ch["index"]}
+        for ch in detected
+    ]
+
+    # Fire two confirm requests concurrently
+    results = await asyncio.gather(
+        client.post(
+            f"/api/books/{book_id}/chapters/confirm",
+            json={"chapters": chapters_to_confirm},
+        ),
+        client.post(
+            f"/api/books/{book_id}/chapters/confirm",
+            json={"chapters": chapters_to_confirm},
+        ),
+        return_exceptions=True,
+    )
+    statuses = sorted(r.status_code for r in results if not isinstance(r, Exception))
+    assert statuses == [200, 400], (
+        f"Expected one 200 and one 400 from concurrent confirms, got statuses: {statuses}"
+    )


### PR DESCRIPTION
## Summary

- Wrap the `SELECT + UPDATE` in `confirm_chapters` with `BEGIN IMMEDIATE` so concurrent confirm requests serialize at the database lock level
- Without this, two concurrent POSTs could both read `draft=True` and both proceed to overwrite the confirmed state

## Why

Issue #451: the read-validate-write pattern was non-atomic. With `BEGIN DEFERRED` (default), two concurrent connections can both see `draft=True` before either commits. `BEGIN IMMEDIATE` acquires a write reservation immediately, forcing the second connection to wait for the first to commit — after which it reads `draft=False` and returns 400.

## Test plan

- [ ] `test_double_confirm_second_request_returns_400` — fires two confirms concurrently via `asyncio.gather`, asserts exactly one 200 and one 400
- [ ] `test_confirm_chapters_makes_book_readable` — normal confirm flow still works

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)
