### PR TITLE
fix: implement admin audio cache GET and DELETE endpoints (closes #455)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -326,17 +326,36 @@ async def seed_popular_status(_admin: dict = Depends(_require_admin)):
 
 @router.get("/audio")
 async def get_audio_cache(_admin: dict = Depends(_require_admin)):
-    return []
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT book_id, chapter_index, chunk_index, provider, voice, "
+            "content_type, LENGTH(audio) AS audio_bytes, created_at FROM audio_cache "
+            "ORDER BY book_id, chapter_index, chunk_index"
+        ) as cur:
+            rows = await cur.fetchall()
+    return [dict(r) for r in rows]
 
 
 @router.delete("/audio/{book_id}")
 async def delete_book_audio(book_id: int, _admin: dict = Depends(_require_admin)):
-    return {"ok": True, "deleted": 0}
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("DELETE FROM audio_cache WHERE book_id=?", (book_id,))
+        deleted = db.total_changes
+        await db.commit()
+    return {"ok": True, "deleted": deleted}
 
 
 @router.delete("/audio/{book_id}/{chapter_index}")
 async def delete_chapter_audio(book_id: int, chapter_index: int, _admin: dict = Depends(_require_admin)):
-    return {"ok": True, "deleted": 0}
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "DELETE FROM audio_cache WHERE book_id=? AND chapter_index=?",
+            (book_id, chapter_index),
+        )
+        deleted = db.total_changes
+        await db.commit()
+    return {"ok": True, "deleted": deleted}
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -704,16 +704,74 @@ async def test_delete_book_translations_rejects_409_when_running(admin_client, a
 
 # ── Audio ────────────────────────────────────────────────────────────────────
 
+async def _insert_audio(db_path: str, book_id: int, chapter_index: int, chunk_index: int = 0):
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT OR REPLACE INTO audio_cache "
+            "(book_id, chapter_index, chunk_index, provider, voice, content_type, audio) "
+            "VALUES (?, ?, ?, 'tts', 'en-US', 'audio/mpeg', ?)",
+            (book_id, chapter_index, chunk_index, b"audio-data"),
+        )
+        await db.commit()
+
+
 async def test_get_audio_empty(admin_client, admin_db):
     res = await admin_client.get("/api/admin/audio")
     assert res.status_code == 200
     assert res.json() == []
 
 
+async def test_get_audio_returns_cached_entries(admin_client, admin_db):
+    """GET /admin/audio must return rows from audio_cache, not a hard-coded empty list (#455)."""
+    await _insert_audio(admin_db, book_id=10, chapter_index=0)
+    await _insert_audio(admin_db, book_id=10, chapter_index=1)
+    await _insert_audio(admin_db, book_id=20, chapter_index=0)
+    res = await admin_client.get("/api/admin/audio")
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data) >= 3, f"Expected at least 3 audio rows, got {len(data)}: {data}"
+
+
 async def test_delete_book_audio(admin_client, admin_db):
     res = await admin_client.delete("/api/admin/audio/999")
     assert res.status_code == 200
     assert res.json()["deleted"] == 0
+
+
+async def test_delete_book_audio_removes_rows(admin_client, admin_db):
+    """DELETE /admin/audio/{book_id} must actually delete rows from audio_cache (#455)."""
+    await _insert_audio(admin_db, book_id=77, chapter_index=0)
+    await _insert_audio(admin_db, book_id=77, chapter_index=1)
+    await _insert_audio(admin_db, book_id=99, chapter_index=0)
+
+    res = await admin_client.delete("/api/admin/audio/77")
+    assert res.status_code == 200
+    assert res.json()["deleted"] == 2, f"Expected 2 deleted, got: {res.json()}"
+
+    # Book 99 audio must be unaffected
+    async with aiosqlite.connect(admin_db) as db:
+        async with db.execute("SELECT COUNT(*) FROM audio_cache WHERE book_id=99") as cur:
+            count = (await cur.fetchone())[0]
+    assert count == 1, "audio for book 99 was incorrectly deleted"
+
+
+async def test_delete_chapter_audio_removes_rows(admin_client, admin_db):
+    """DELETE /admin/audio/{book_id}/{chapter_index} must delete only that chapter's rows (#455)."""
+    await _insert_audio(admin_db, book_id=55, chapter_index=0, chunk_index=0)
+    await _insert_audio(admin_db, book_id=55, chapter_index=0, chunk_index=1)
+    await _insert_audio(admin_db, book_id=55, chapter_index=1, chunk_index=0)
+
+    res = await admin_client.delete("/api/admin/audio/55/0")
+    assert res.status_code == 200
+    assert res.json()["deleted"] == 2, f"Expected 2 deleted, got: {res.json()}"
+
+    # Chapter 1 must be unaffected
+    async with aiosqlite.connect(admin_db) as db:
+        async with db.execute(
+            "SELECT COUNT(*) FROM audio_cache WHERE book_id=55 AND chapter_index=1"
+        ) as cur:
+            count = (await cur.fetchone())[0]
+    assert count == 1, "audio for chapter 1 was incorrectly deleted"
 
 
 # ── Stats ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `GET /admin/audio` was returning a hard-coded `[]` without querying the database — now queries `audio_cache` and returns all rows with size info
- `DELETE /admin/audio/{book_id}` was returning `{"ok": true, "deleted": 0}` without deleting — now issues `DELETE WHERE book_id=?` and returns actual rowcount
- `DELETE /admin/audio/{book_id}/{chapter_index}` same stub issue — now deletes by book_id + chapter_index

## Test plan

- [ ] `test_get_audio_returns_cached_entries` — insert rows, verify GET returns them
- [ ] `test_delete_book_audio_removes_rows` — insert 2 rows for book 77, delete, verify 2 deleted and book 99 untouched
- [ ] `test_delete_chapter_audio_removes_rows` — insert 3 rows for book 55, delete chapter 0, verify 2 deleted and chapter 1 untouched
- [ ] `test_get_audio_empty` and `test_delete_book_audio` still pass (no-data path unchanged)

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)
