### PR TITLE
fix: bounds check on GET /books/{book_id}/chapters/{chapter_index}/queue-status (closes #457)

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -160,6 +160,13 @@ async def chapter_queue_status(
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
     check_book_access(book, user)
+    from services.book_chapters import split_with_html_preference as _split
+    _chapters = await _split(book_id, book.get("text") or "")
+    if chapter_index < 0 or chapter_index >= len(_chapters):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Chapter index out of range (book has {len(_chapters)} chapter(s)).",
+        )
     from services.translation_queue import queue_status_for_chapter
     return await queue_status_for_chapter(book_id, chapter_index, target_language)
 

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -1002,3 +1002,25 @@ async def test_retry_translation_out_of_bounds_chapter_returns_400(client, test_
         f"Expected 400 for out-of-bounds chapter_index=999 on 2-chapter book, "
         f"got {resp.status_code}: {resp.text}"
     )
+
+
+async def test_queue_status_out_of_bounds_chapter_returns_400(client, test_user):
+    """Regression #457: GET /books/{book_id}/chapters/{chapter_index}/queue-status
+    with chapter_index beyond the book's chapter count must return 400.
+
+    Without the bounds check any authenticated user gets a silent "not queued"
+    response for a chapter that does not exist."""
+    from services.book_chapters import clear_cache as _clear
+
+    text = "CHAPTER I\n\n" + "word " * 200 + "\n\nCHAPTER II\n\n" + "word " * 200
+    await save_book(9879, {**MOCK_META, "id": 9879}, text)
+    _clear()
+
+    resp = await client.get(
+        "/api/books/9879/chapters/999/queue-status?target_language=de"
+    )
+    assert resp.status_code == 400, (
+        f"Expected 400 for out-of-bounds chapter_index=999 on 2-chapter book, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    assert "out of range" in resp.json()["detail"].lower()


### PR DESCRIPTION
## Summary

- `GET /books/{book_id}/chapters/{chapter_index}/queue-status` accepted any `chapter_index` without bounds-checking against the book's actual chapter count
- Authenticated users querying e.g. `chapter_index=999` on a 2-chapter book received a misleading 200 `{"queued": false}` instead of a 400
- Same pattern as #453 (annotations, insights, vocabulary, reading-progress all fixed there)

## Fix

Added `split_with_html_preference` bounds check after `check_book_access` in `chapter_queue_status` (`books.py` line 162), returning `400 "Chapter index out of range"` for negative or out-of-bounds indices.

## Test plan

- [x] New regression test `test_queue_status_out_of_bounds_chapter_returns_400` confirms 400 for `chapter_index=999` on a 2-chapter book
- [x] All 65 `test_router_books.py` tests pass
- [x] Full backend suite: 1031 passed, 6 pre-existing stats failures (unrelated)

Closes #457
