### PR TITLE
fix: validate rpm/rpd/max_output_tokens >= 1 in PUT /admin/queue/settings (closes #460)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -6,7 +6,7 @@ Full CRUD where applicable.
 import json
 import aiosqlite
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from services.auth import get_current_user, decrypt_api_key, encrypt_api_key
 from services.db import (
     DB_PATH,
@@ -1037,11 +1037,11 @@ class QueueSettingsRequest(BaseModel):
     enabled: bool | None = None
     api_key: str | None = None     # plaintext; empty string clears
     auto_translate_languages: list[str] | None = None
-    rpm: int | None = None
-    rpd: int | None = None
+    rpm: int | None = Field(default=None, ge=1)
+    rpd: int | None = Field(default=None, ge=1)
     model: str | None = None
     model_chain: list[str] | None = None
-    max_output_tokens: int | None = None
+    max_output_tokens: int | None = Field(default=None, ge=1)
 
 
 @router.put("/queue/settings")

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -1856,3 +1856,54 @@ async def test_delete_book_sql_guard_preserves_running_queue_row(admin_client, a
     assert row is not None and row[0] == "running", (
         "SQL guard (AND status != 'running') must preserve running queue row (#370)"
     )
+
+
+# ── Queue settings input validation ──────────────────────────────────────────
+
+
+async def test_queue_settings_rejects_zero_rpm(admin_client, admin_db):
+    """Regression #460: PUT /admin/queue/settings with rpm=0 must return 422.
+
+    Zero or negative RPM causes division-by-zero in the queue worker's
+    rate-limit sleep calculation."""
+    res = await admin_client.put(
+        "/api/admin/queue/settings",
+        json={"rpm": 0},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for rpm=0, got {res.status_code}: {res.text}"
+    )
+
+
+async def test_queue_settings_rejects_negative_rpd(admin_client, admin_db):
+    """Regression #460: PUT /admin/queue/settings with rpd=-1 must return 422."""
+    res = await admin_client.put(
+        "/api/admin/queue/settings",
+        json={"rpd": -1},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for rpd=-1, got {res.status_code}: {res.text}"
+    )
+
+
+async def test_queue_settings_rejects_zero_max_output_tokens(admin_client, admin_db):
+    """Regression #460: PUT /admin/queue/settings with max_output_tokens=0 must
+    return 422. Zero tokens passed to the AI API causes API errors."""
+    res = await admin_client.put(
+        "/api/admin/queue/settings",
+        json={"max_output_tokens": 0},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for max_output_tokens=0, got {res.status_code}: {res.text}"
+    )
+
+
+async def test_queue_settings_accepts_valid_positive_values(admin_client, admin_db):
+    """Regression #460: PUT /admin/queue/settings with valid positive values must succeed."""
+    res = await admin_client.put(
+        "/api/admin/queue/settings",
+        json={"rpm": 10, "rpd": 1000, "max_output_tokens": 8192},
+    )
+    assert res.status_code == 200, (
+        f"Expected 200 for valid positive values, got {res.status_code}: {res.text}"
+    )


### PR DESCRIPTION
## Summary

- `PUT /admin/queue/settings` accepted zero and negative values for `rpm`, `rpd`, and `max_output_tokens` without any validation
- `rpm=0` / `rpd=0` cause division-by-zero in the queue worker's rate-limit sleep (`60 / rpm`)
- `max_output_tokens <= 0` is passed directly to the AI provider API, causing API errors or empty responses

## Fix

Added `ge=1` constraint via Pydantic `Field` to `rpm`, `rpd`, and `max_output_tokens` in `QueueSettingsRequest`. Invalid values now return `422 Unprocessable Entity` before reaching the handler.

## Test plan

- [x] `test_queue_settings_rejects_zero_rpm` — 422 for `rpm=0`
- [x] `test_queue_settings_rejects_negative_rpd` — 422 for `rpd=-1`
- [x] `test_queue_settings_rejects_zero_max_output_tokens` — 422 for `max_output_tokens=0`
- [x] `test_queue_settings_accepts_valid_positive_values` — 200 for valid values
- [x] Full backend suite: 1036 passed, 6 pre-existing stats failures (unrelated)

Closes #460
