### PR TITLE
fix: chapter_index bounds checks on translation cache and GET translation endpoints (closes #462)

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -234,6 +234,13 @@ async def translate_cache(
         raise HTTPException(status_code=404, detail="Book not found")
     check_book_access(book, _user)
     target_language = target_language.lower().split("-")[0]
+    from services.book_chapters import split_with_html_preference as _split
+    _chapters = await _split(book_id, book.get("text") or "")
+    if chapter_index < 0 or chapter_index >= len(_chapters):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Chapter index out of range (book has {len(_chapters)} chapter(s)).",
+        )
     from services.db import get_cached_translation_with_meta
     cached = await get_cached_translation_with_meta(book_id, chapter_index, target_language)
     if cached:
@@ -265,6 +272,13 @@ async def save_translate_cache(req: SaveTranslationRequest, _user: dict = Depend
         raise HTTPException(status_code=404, detail="Book not found")
     check_book_access(book, _user)
     target_language = req.target_language.lower().split("-")[0]
+    from services.book_chapters import split_with_html_preference as _split
+    _chapters = await _split(req.book_id, book.get("text") or "")
+    if req.chapter_index < 0 or req.chapter_index >= len(_chapters):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Chapter index out of range (book has {len(_chapters)} chapter(s)).",
+        )
     # Reject if a queue worker is actively translating this chapter — the
     # worker's save_translation (INSERT OR REPLACE) would overwrite whatever
     # we write here when it finishes. (#341)
@@ -303,6 +317,14 @@ async def translate(req: TranslateRequest, user: dict = Depends(get_current_user
             check_book_access(_book, user)
         if req.chapter_index is not None and req.chapter_index < 0:
             raise HTTPException(status_code=400, detail="chapter_index must be >= 0")
+        if req.book_id is not None and req.chapter_index is not None and _book is not None:
+            from services.book_chapters import split_with_html_preference as _split
+            _chapters = await _split(req.book_id, _book.get("text") or "")
+            if req.chapter_index >= len(_chapters):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Chapter index out of range (book has {len(_chapters)} chapter(s)).",
+                )
 
         # Check shared DB cache first — cache hits don't need any key.
         # Use normalized codes so "ZH" and "zh-CN" both hit a "zh" cache entry.

--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -184,6 +184,13 @@ async def get_chapter_translation(
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
     check_book_access(book, user)
+    from services.book_chapters import split_with_html_preference as _split
+    _chapters = await _split(book_id, book.get("text") or "")
+    if chapter_index < 0 or chapter_index >= len(_chapters):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Chapter index out of range (book has {len(_chapters)} chapter(s)).",
+        )
     from services.db import get_cached_translation_with_meta
     cached = await get_cached_translation_with_meta(book_id, chapter_index, target_language)
     if not cached:

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -238,13 +238,15 @@ async def test_translate_cache_put_saves(client, test_user):
     from services.db import save_book
     _BOOK_META = {"title": "Faust", "authors": ["Goethe"], "languages": ["de"],
                   "subjects": [], "download_count": 0, "cover": ""}
+    from services.book_chapters import clear_cache as _clear
     await save_book(2, _BOOK_META, "text")
+    _clear()
     resp = await client.put("/api/ai/translate/cache", json={
-        "book_id": 2, "chapter_index": 1, "target_language": "fr",
+        "book_id": 2, "chapter_index": 0, "target_language": "fr",
         "paragraphs": ["Bonjour"],
     })
     assert resp.status_code == 200
-    cached = await get_cached_translation(2, 1, "fr")
+    cached = await get_cached_translation(2, 0, "fr")
     assert cached == ["Bonjour"]
 
 
@@ -687,6 +689,88 @@ async def test_translate_post_cache_hit_blocked_for_non_owner(client, test_user,
         f"Expected 403 for non-owner accessing cached translation of private book via POST /ai/translate, "
         f"got {resp.status_code}: {resp.text}"
     )
+
+
+# ── chapter_index bounds checks on translation endpoints ─────────────────────
+
+_BOUNDS_META = {"title": "Bounds Test", "authors": [], "languages": ["de"],
+                "subjects": [], "download_count": 0, "cover": ""}
+_BOUNDS_TEXT = "CHAPTER I\n\n" + "word " * 200 + "\n\nCHAPTER II\n\n" + "word " * 200
+
+
+async def test_put_translate_cache_out_of_bounds_chapter_returns_400(client, test_user, tmp_db):
+    """Regression #462: PUT /ai/translate/cache with chapter_index beyond chapter count
+    must return 400 instead of storing a translation at a non-existent chapter."""
+    from services.book_chapters import clear_cache as _clear
+    await save_book(9886, {**_BOUNDS_META, "id": 9886}, _BOUNDS_TEXT)
+    _clear()
+
+    resp = await client.put("/api/ai/translate/cache", json={
+        "book_id": 9886,
+        "chapter_index": 999,
+        "target_language": "en",
+        "paragraphs": ["test"],
+    })
+    assert resp.status_code == 400, (
+        f"Expected 400 for out-of-bounds chapter_index=999 on PUT /ai/translate/cache, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    assert "out of range" in resp.json()["detail"].lower()
+
+
+async def test_get_translate_cache_out_of_bounds_chapter_returns_400(client, test_user, tmp_db):
+    """Regression #462: GET /ai/translate/cache with chapter_index beyond chapter count
+    must return 400 instead of a misleading 404."""
+    from services.book_chapters import clear_cache as _clear
+    await save_book(9887, {**_BOUNDS_META, "id": 9887}, _BOUNDS_TEXT)
+    _clear()
+
+    resp = await client.get(
+        "/api/ai/translate/cache?book_id=9887&chapter_index=999&target_language=en"
+    )
+    assert resp.status_code == 400, (
+        f"Expected 400 for out-of-bounds chapter_index=999 on GET /ai/translate/cache, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    assert "out of range" in resp.json()["detail"].lower()
+
+
+async def test_post_ai_translate_out_of_bounds_chapter_returns_400(client, test_user, tmp_db):
+    """Regression #462: POST /ai/translate with chapter_index beyond chapter count
+    must return 400 (only lower bound was checked before this fix)."""
+    from services.book_chapters import clear_cache as _clear
+    await save_book(9888, {**_BOUNDS_META, "id": 9888}, _BOUNDS_TEXT)
+    _clear()
+
+    resp = await client.post("/api/ai/translate", json={
+        "book_id": 9888,
+        "chapter_index": 999,
+        "text": "Some text.",
+        "source_language": "de",
+        "target_language": "en",
+    })
+    assert resp.status_code == 400, (
+        f"Expected 400 for out-of-bounds chapter_index=999 on POST /ai/translate, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    assert "out of range" in resp.json()["detail"].lower()
+
+
+async def test_get_chapter_translation_out_of_bounds_returns_400(client, test_user, tmp_db):
+    """Regression #462: GET /books/{id}/chapters/{idx}/translation with out-of-bounds
+    chapter_index must return 400 instead of a misleading 404."""
+    from services.book_chapters import clear_cache as _clear
+    await save_book(9889, {**_BOUNDS_META, "id": 9889}, _BOUNDS_TEXT)
+    _clear()
+
+    resp = await client.get(
+        "/api/books/9889/chapters/999/translation?target_language=en"
+    )
+    assert resp.status_code == 400, (
+        f"Expected 400 for out-of-bounds chapter_index=999 on GET /books/{{}}/chapters/999/translation, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    assert "out of range" in resp.json()["detail"].lower()
 
 
 # ── chapter_index bounds checks on /ai/summary ───────────────────────────────


### PR DESCRIPTION
## Summary

Four translation endpoints accepted any `chapter_index` value without validating it against the book's actual chapter count. Same pattern as #450 (annotations, insights, vocabulary, reading-progress) and #457 (queue-status).

| Endpoint | Impact before fix |
|---|---|
| `PUT /ai/translate/cache` | Any user could write translations at non-existent chapter indices, creating orphaned DB records |
| `GET /ai/translate/cache` | Returned misleading 404 ("Not cached") instead of 400 for invalid indices |
| `POST /ai/translate` | Only checked `< 0`, missing upper bound — could trigger work on non-existent chapters |
| `GET /books/{id}/chapters/{idx}/translation` | Returned misleading 404 instead of 400 for invalid indices |

## Fix

Added `split_with_html_preference` bounds check after `check_book_access` in each endpoint, returning `400 "Chapter index out of range"` for `chapter_index < 0 or chapter_index >= len(chapters)`.

## Test plan

- [x] `test_put_translate_cache_out_of_bounds_chapter_returns_400`
- [x] `test_get_translate_cache_out_of_bounds_chapter_returns_400`
- [x] `test_post_ai_translate_out_of_bounds_chapter_returns_400`
- [x] `test_get_chapter_translation_out_of_bounds_returns_400`
- [x] Fixed `test_translate_cache_put_saves` (used `chapter_index=1` on single-chapter book)
- [x] All 47 `test_router_ai.py` tests pass
- [x] Full suite: 1051 passed + 6 pre-existing stats failures (unrelated)

Closes #462
