### PR TITLE
fix: book-exists and chapter bounds check for DELETE /ai/summary

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -210,6 +210,16 @@ async def delete_summary(book_id: int, chapter_index: int, user: dict = Depends(
     """Admin-only: delete a cached summary so it will be regenerated on next request."""
     if user.get("role") != "admin":
         raise HTTPException(status_code=403, detail="Admin only")
+    book = await get_cached_book(book_id)
+    if book is None:
+        raise HTTPException(status_code=404, detail="Book not found")
+    from services.book_chapters import split_with_html_preference as _split
+    _chapters = await _split(book_id, book.get("text") or "")
+    if chapter_index < 0 or chapter_index >= len(_chapters):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Chapter index out of range (book has {len(_chapters)} chapter(s)).",
+        )
     from services.db import DB_PATH
     import aiosqlite
     async with aiosqlite.connect(DB_PATH) as db:

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -796,3 +796,27 @@ async def test_ai_summary_out_of_bounds_chapter_returns_400(client, test_user, t
         f"Expected 400 for out-of-bounds chapter_index=999, got {resp.status_code}: {resp.text}"
     )
 
+
+# ── DELETE /ai/summary bounds checks (Issue #464) ────────────────────────────
+
+async def test_delete_summary_nonexistent_book_returns_404(client, test_user, tmp_db):
+    """Regression #464: DELETE /ai/summary must return 404 when the book does not exist."""
+    resp = await client.delete("/api/ai/summary", params={"book_id": 99999, "chapter_index": 0})
+    assert resp.status_code == 404, (
+        f"Expected 404 for non-existent book, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_delete_summary_out_of_bounds_chapter_returns_400(client, test_user, tmp_db):
+    """Regression #464: DELETE /ai/summary must return 400 when chapter_index is out of range."""
+    from services.book_chapters import clear_cache as _clear
+
+    text = "CHAPTER I\n\n" + "word " * 200 + "\n\nCHAPTER II\n\n" + "word " * 200
+    await save_book(9882, {"id": 9882, "title": "T", "authors": [], "languages": ["en"], "subjects": [], "download_count": 0, "cover": ""}, text)
+    _clear()
+
+    resp = await client.delete("/api/ai/summary", params={"book_id": 9882, "chapter_index": 999})
+    assert resp.status_code == 400, (
+        f"Expected 400 for out-of-bounds chapter_index=999, got {resp.status_code}: {resp.text}"
+    )
+


### PR DESCRIPTION
## Summary
- `DELETE /ai/summary` returned `200 {"ok": true}` for non-existent books instead of 404
- `DELETE /ai/summary` silently deleted nothing when `chapter_index` was out of bounds instead of returning 400
- Added book-exists check (404) and chapter bounds check (400) consistent with all other summary/translation endpoints

## Test plan
- `test_delete_summary_nonexistent_book_returns_404`: confirms 404 when book_id=99999 (not in DB)
- `test_delete_summary_out_of_bounds_chapter_returns_400`: confirms 400 for chapter_index=999 on a 2-chapter book
- Full backend suite: 1065 passed

Closes #464
