### PR TITLE
fix: validate model_chain entries and filter whitespace auto_translate_languages

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1060,9 +1060,9 @@ async def queue_set_settings(
         await set_setting(
             SETTING_AUTO_LANGS,
             json.dumps([
-                lang.lower().split("-")[0]
+                lang.strip().lower().split("-")[0]
                 for lang in req.auto_translate_languages
-                if lang
+                if lang and lang.strip()
             ]),
         )
     if req.rpm is not None:
@@ -1072,11 +1072,14 @@ async def queue_set_settings(
     if req.model is not None:
         await set_setting(SETTING_MODEL, req.model)
     if req.model_chain is not None:
+        if not req.model_chain:
+            raise HTTPException(status_code=400, detail="model_chain cannot be empty")
+        if any(not m.strip() for m in req.model_chain):
+            raise HTTPException(status_code=400, detail="model_chain entries cannot be empty strings")
         # Keep the legacy single-model setting in sync with the chain head
         # so any code path still reading SETTING_MODEL stays consistent.
         await set_setting(SETTING_MODEL_CHAIN, json.dumps(req.model_chain))
-        if req.model_chain:
-            await set_setting(SETTING_MODEL, req.model_chain[0])
+        await set_setting(SETTING_MODEL, req.model_chain[0])
     if req.max_output_tokens is not None:
         await set_setting(SETTING_MAX_OUTPUT_TOKENS, str(req.max_output_tokens))
     queue_worker().wake()

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -1907,3 +1907,56 @@ async def test_queue_settings_accepts_valid_positive_values(admin_client, admin_
     assert res.status_code == 200, (
         f"Expected 200 for valid positive values, got {res.status_code}: {res.text}"
     )
+
+
+# ── model_chain validation (Issue #474) ──────────────────────────────────────
+
+async def test_queue_settings_rejects_empty_model_chain(admin_client, admin_db):
+    """Regression #474: empty model_chain list must return 400 (would leave SETTING_MODEL stale)."""
+    res = await admin_client.put(
+        "/api/admin/queue/settings",
+        json={"model_chain": []},
+    )
+    assert res.status_code == 400, (
+        f"Expected 400 for empty model_chain, got {res.status_code}: {res.text}"
+    )
+
+
+async def test_queue_settings_rejects_model_chain_with_empty_entry(admin_client, admin_db):
+    """Regression #474: model_chain with empty-string entry must return 400
+    (would set SETTING_MODEL to '' causing AI calls to fail)."""
+    res = await admin_client.put(
+        "/api/admin/queue/settings",
+        json={"model_chain": ["", "gemini-1.5-flash"]},
+    )
+    assert res.status_code == 400, (
+        f"Expected 400 for model_chain with empty entry, got {res.status_code}: {res.text}"
+    )
+
+
+async def test_queue_settings_rejects_auto_translate_languages_with_whitespace_entry(admin_client, admin_db):
+    """Regression #474: whitespace-only language codes in auto_translate_languages
+    must be stripped, resulting in valid stored codes only."""
+    res = await admin_client.put(
+        "/api/admin/queue/settings",
+        json={"auto_translate_languages": ["  ", "en", " "]},
+    )
+    # Should succeed but store only ["en"] — whitespace entries are silently filtered
+    assert res.status_code == 200, (
+        f"Expected 200 (whitespace filtered), got {res.status_code}: {res.text}"
+    )
+    from services.db import get_setting
+    import json as _json
+    stored = _json.loads(await get_setting("auto_translate_languages") or "[]")
+    assert stored == ["en"], f"Expected only ['en'] after whitespace filtering, got {stored}"
+
+
+async def test_queue_settings_accepts_valid_model_chain(admin_client, admin_db):
+    """Regression #474: a non-empty model_chain with valid entries must be accepted."""
+    res = await admin_client.put(
+        "/api/admin/queue/settings",
+        json={"model_chain": ["gemini-2.0-flash", "gemini-1.5-flash"]},
+    )
+    assert res.status_code == 200, (
+        f"Expected 200 for valid model_chain, got {res.status_code}: {res.text}"
+    )

--- a/backend/tests/test_router_admin_extended.py
+++ b/backend/tests/test_router_admin_extended.py
@@ -378,19 +378,13 @@ async def test_queue_put_settings_model_chain_updates_model_too(admin_client, ad
     assert model == "gemini-2.5-pro"
 
 
-async def test_queue_put_settings_empty_model_chain_does_not_update_model(admin_client, admin_db):
-    """An empty model_chain list doesn't update the model setting."""
-    from services.translation_queue import SETTING_MODEL
-    from services.db import set_setting
-    await set_setting(SETTING_MODEL, "original-model")
-
+async def test_queue_put_settings_empty_model_chain_returns_400(admin_client, admin_db):
+    """Regression #474: empty model_chain must be rejected (would leave SETTING_MODEL stale)."""
     res = await admin_client.put(
         "/api/admin/queue/settings",
         json={"model_chain": []},
     )
-    assert res.status_code == 200
-    # Model should remain unchanged
-    assert await get_setting(SETTING_MODEL) == "original-model"
+    assert res.status_code == 400, f"Expected 400 for empty model_chain, got {res.status_code}"
 
 
 async def test_queue_put_settings_max_output_tokens(admin_client, admin_db):


### PR DESCRIPTION
## Summary
- `PUT /admin/queue/settings` accepted `model_chain: []` (empty list), storing it in DB while leaving `SETTING_MODEL` stale — the primary model setting would no longer reflect the chain head
- `model_chain` also accepted entries like `["", "gemini-1.5-flash"]` — would set `SETTING_MODEL = ""`, causing all subsequent AI calls to fail with model-not-specified errors
- `auto_translate_languages` used `if lang` which passes whitespace-only strings like `"  "`, storing invalid empty language codes after normalization
- Fixed by validating `model_chain` before storage and filtering with `lang.strip()` for auto_translate_languages

## Test plan
- `test_queue_settings_rejects_empty_model_chain`: `model_chain: []` → 400
- `test_queue_settings_rejects_model_chain_with_empty_entry`: `model_chain: ["", "gemini-1.5-flash"]` → 400
- `test_queue_settings_rejects_auto_translate_languages_with_whitespace_entry`: `["  ", "en", " "]` → 200, stored as `["en"]`
- `test_queue_settings_accepts_valid_model_chain`: `["gemini-2.0-flash", "gemini-1.5-flash"]` → 200

Closes #474
