### PR TITLE
fix: hide private uploaded books from GET /books/cached

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -675,11 +675,17 @@ async def get_user_stats(user_id: int) -> dict:
 
 
 async def list_cached_books() -> list[dict]:
-    """Return all cached books (without text field)."""
+    """Return publicly available cached books (Gutenberg only, without text field).
+
+    Uploaded books are excluded — their titles are private to the owner.
+    """
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         async with db.execute(
-            "SELECT id, title, authors, languages, subjects, download_count, cover, cached_at FROM books ORDER BY cached_at DESC"
+            "SELECT id, title, authors, languages, subjects, download_count, cover, cached_at"
+            " FROM books"
+            " WHERE (source IS NULL OR source != 'upload')"
+            " ORDER BY cached_at DESC"
         ) as cursor:
             rows = await cursor.fetchall()
     result = []

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -1024,3 +1024,29 @@ async def test_queue_status_out_of_bounds_chapter_returns_400(client, test_user)
         f"got {resp.status_code}: {resp.text}"
     )
     assert "out of range" in resp.json()["detail"].lower()
+
+
+# ── GET /books/cached hides private uploads (Issue #478) ─────────────────────
+
+async def test_cached_books_hides_uploaded_books(client, test_user, tmp_db, insert_private_book):
+    """Regression #478: GET /books/cached must not return private uploaded books.
+
+    Any unauthenticated user calling /books/cached should only see publicly
+    available Gutenberg books, not titles of other users' private uploads.
+    """
+    import aiosqlite
+    import services.db as db_module
+
+    # Insert a confirmed uploaded book (source='upload') owned by test_user
+    await insert_private_book(book_id=9891, owner_user_id=test_user["id"])
+
+    # Also insert a public Gutenberg book
+    await save_book(9892, {**MOCK_META, "id": 9892}, "some text")
+
+    resp = await client.get("/api/books/cached")
+    assert resp.status_code == 200
+    returned_ids = {b["id"] for b in resp.json()}
+    assert 9892 in returned_ids, "Public Gutenberg book must appear in cached list"
+    assert 9891 not in returned_ids, (
+        "Private uploaded book must NOT appear in cached list — its title is private"
+    )


### PR DESCRIPTION
## Summary
- `GET /books/cached` returned ALL books including private user uploads (source='upload'), without any authentication
- Any unauthenticated request could enumerate the titles of other users' private books
- Fixed by adding `WHERE (source IS NULL OR source != 'upload')` to `list_cached_books()` so only public Gutenberg books appear in the public library

## Test plan
- `test_cached_books_hides_uploaded_books`: inserts a private uploaded book (source='upload') and a public Gutenberg book; verifies only the Gutenberg book appears in the cached list
- All 12 `cached` tests pass

Closes #478
