### PR TITLE
fix: reject uploads that parse to zero chapters

### DIFF
--- a/backend/routers/uploads.py
+++ b/backend/routers/uploads.py
@@ -95,6 +95,11 @@ async def upload_book(
         raise HTTPException(status_code=422, detail=f"Could not parse file: {exc}")
 
     chapters = parsed["chapters"]
+    if not chapters:
+        raise HTTPException(
+            status_code=422,
+            detail="No chapters could be detected. The file appears to be empty or contains no readable text.",
+        )
     book_id = await _save_upload_book(
         user_id=user["id"],
         title=parsed["title"],

--- a/backend/tests/test_router_uploads.py
+++ b/backend/tests/test_router_uploads.py
@@ -578,3 +578,21 @@ async def test_confirm_chapters_empty_list_returns_400(client, test_user):
     assert resp.status_code == 400, (
         f"Expected 400 for empty chapters list, got {resp.status_code}: {resp.text}"
     )
+
+
+# ── Empty/whitespace file upload validation (Issue #480) ──────────────────────
+
+@pytest.mark.asyncio
+async def test_upload_whitespace_only_txt_returns_422(client, test_user):
+    """Regression #480: uploading a whitespace-only .txt file must return 422.
+
+    parse_txt() returns zero chapters for whitespace-only content; the endpoint
+    previously saved this as a draft with 0 chapters, making it unconfirmable
+    and consuming quota permanently.
+    """
+    whitespace_file = _txt_upload(content=b"   \n\n\t  \n   ", filename="empty.txt")
+    resp = await client.post("/api/books/upload", files=whitespace_file)
+    assert resp.status_code == 422, (
+        f"Expected 422 for whitespace-only file, got {resp.status_code}: {resp.text}"
+    )
+    assert "chapter" in resp.json()["detail"].lower()


### PR DESCRIPTION
## Summary
- `POST /books/upload` accepted whitespace-only (or otherwise empty) `.txt` files, saved a draft book with 0 chapters, and returned 200
- After PR #477 blocked confirming an empty chapters list, these drafts became permanently unconfirmable and consumed the user's upload quota forever
- Fix: after parsing, if `chapters` is empty, raise 422 immediately — no draft is written to the database

## Test plan
- [x] New regression test `test_upload_whitespace_only_txt_returns_422` — was FAIL before fix, PASS after
- [x] Full backend suite: 1072 passed, 0 failed

Closes #480
