### PR TITLE
fix: add bounds validation for TTS rate parameter

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import Response
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from services.auth import get_current_user, decrypt_api_key, check_book_access
 from services.db import (
     get_cached_translation,
@@ -90,7 +90,7 @@ class TranslateRequest(BaseModel):
 class TTSRequest(BaseModel):
     text: str
     language: str = "en"
-    rate: float = 1.0
+    rate: float = Field(default=1.0, ge=0.25, le=4.0)
     gender: Literal["female", "male"] = "female"
 
 

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -524,6 +524,26 @@ async def test_tts_error_returns_500(client):
     assert resp.status_code == 500
 
 
+# ── TTS rate bounds validation (Issue #482) ───────────────────────────────────
+
+@pytest.mark.parametrize("rate,expected", [
+    (9999, 422),    # absurdly fast → malformed Edge TTS percentage string
+    (-100, 422),    # negative → malformed string
+    (0.1, 422),     # below 0.25 minimum → invalid
+    (5.0, 422),     # above 4.0 maximum → invalid
+    (0.25, 200),    # lower boundary → valid
+    (4.0, 200),     # upper boundary → valid
+    (1.5, 200),     # normal value → valid
+])
+async def test_tts_rate_bounds(client, rate, expected):
+    """Regression #482: TTS rate must be validated to prevent malformed Edge TTS strings."""
+    with patch("routers.ai.synthesize", new_callable=AsyncMock, return_value=(b"\xff\xfb", "audio/mpeg", [])):
+        resp = await client.post("/api/ai/tts", json={"text": "hi", "language": "en", "rate": rate})
+    assert resp.status_code == expected, (
+        f"rate={rate}: expected {expected}, got {resp.status_code}: {resp.text}"
+    )
+
+
 # ── References ────────────────────────────────────────────────────────────────
 
 async def test_references_without_key_returns_400(client):


### PR DESCRIPTION
## Summary
- `TTSRequest.rate` had no min/max bounds — any float was accepted
- `rate=9999` would produce `"+999800%"` as the Edge TTS rate string, an invalid value that causes synthesis to fail unpredictably
- Fix: add `Field(ge=0.25, le=4.0)` — covers all realistic playback speeds (-75% … +300% in Edge TTS terms)

## Test plan
- [x] 4 new parametrized test cases for out-of-range values (9999, -100, 0.1, 5.0) → 422; all were FAIL before fix
- [x] 3 boundary/normal value cases (0.25, 4.0, 1.5) → 200; were already passing
- [x] Full backend suite: 1078 passed, 0 failed

Closes #482
