### PR TITLE
fix: add upper bound to GET /admin/queue/items limit parameter

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -5,7 +5,7 @@ Full CRUD where applicable.
 
 import json
 import aiosqlite
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from services.auth import get_current_user, decrypt_api_key, encrypt_api_key
 from services.db import (
@@ -1090,7 +1090,7 @@ async def queue_set_settings(
 async def queue_items(
     status: str | None = None,
     book_id: int | None = None,
-    limit: int = 200,
+    limit: int = Query(default=200, ge=1, le=1000),
     _admin: dict = Depends(_require_admin),
 ):
     return await list_queue(status=status, book_id=book_id, limit=limit)

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -1960,3 +1960,45 @@ async def test_queue_settings_accepts_valid_model_chain(admin_client, admin_db):
     assert res.status_code == 200, (
         f"Expected 200 for valid model_chain, got {res.status_code}: {res.text}"
     )
+
+
+# ── Queue items limit validation (Issue #484) ─────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_queue_items_over_limit_returns_422(admin_client, admin_db):
+    """Regression #484: GET /admin/queue/items?limit=9999999 must be rejected with 422.
+
+    Without an upper bound, the query runs with LIMIT 9999999 and can exhaust
+    server memory when the queue is large.
+    """
+    res = await admin_client.get("/api/admin/queue/items?limit=9999999")
+    assert res.status_code == 422, (
+        f"Expected 422 for over-limit value, got {res.status_code}: {res.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_queue_items_zero_limit_returns_422(admin_client, admin_db):
+    """Regression #484: limit=0 must be rejected."""
+    res = await admin_client.get("/api/admin/queue/items?limit=0")
+    assert res.status_code == 422, (
+        f"Expected 422 for zero limit, got {res.status_code}: {res.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_queue_items_default_limit_accepted(admin_client, admin_db):
+    """Default limit (200) must still be accepted."""
+    res = await admin_client.get("/api/admin/queue/items")
+    assert res.status_code == 200, (
+        f"Expected 200 for default limit, got {res.status_code}: {res.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_queue_items_max_limit_accepted(admin_client, admin_db):
+    """Upper boundary (1000) must be accepted."""
+    res = await admin_client.get("/api/admin/queue/items?limit=1000")
+    assert res.status_code == 200, (
+        f"Expected 200 for limit=1000, got {res.status_code}: {res.text}"
+    )


### PR DESCRIPTION
## Summary
- `GET /admin/queue/items?limit=2147483647` executed a SQLite query requesting 2+ billion rows, potentially exhausting server memory
- The `limit` parameter had no upper bound — only a default of 200
- Fix: `Query(default=200, ge=1, le=1000)` caps the maximum at 1000 items per request

## Test plan
- [x] New tests: `limit=9999999` → 422, `limit=0` → 422, `limit=200` (default) → 200, `limit=1000` (max) → 200
- [x] Full backend suite: 1080 passed, 0 failed

Closes #484
