### PR TITLE
fix: reject enqueue-book requests for unconfirmed draft uploads

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1108,8 +1108,23 @@ async def queue_enqueue_book(
     req: EnqueueBookRequest,
     admin: dict = Depends(_require_admin),
 ):
-    if not await get_cached_book(req.book_id):
+    book = await get_cached_book(req.book_id)
+    if not book:
         raise HTTPException(status_code=404, detail="Book not found")
+    text = book.get("text") or ""
+    if text.lstrip().startswith("{"):
+        try:
+            import json as _json
+            _data = _json.loads(text)
+            if _data.get("draft"):
+                raise HTTPException(
+                    status_code=400,
+                    detail="Book has not been confirmed yet. Confirm chapter splits before enqueueing for translation.",
+                )
+        except HTTPException:
+            raise
+        except (ValueError, TypeError):
+            pass
     added = await enqueue_for_book(
         req.book_id,
         target_languages=req.target_languages,

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -1081,6 +1081,35 @@ async def test_enqueue_book_nonexistent_returns_404(admin_client):
     assert res.status_code == 404
 
 
+async def test_enqueue_draft_book_returns_400(admin_client, admin_db):
+    """Regression #486: enqueuing an unconfirmed uploaded book must return 400.
+
+    Before the fix the endpoint returned 200 with enqueued=0, giving
+    the admin no indication that the book hadn't been confirmed yet.
+    """
+    import json as _json
+    import aiosqlite
+    draft_text = _json.dumps({"draft": True, "chapters": [{"title": "Ch 1", "text": "word " * 300}]})
+    async with aiosqlite.connect(admin_db) as db:
+        cur = await db.execute(
+            """INSERT INTO books (title, authors, languages, subjects, download_count,
+                                  cover, text, images, source, owner_user_id)
+               VALUES ('Draft', '[]', '[]', '[]', 0, '', ?, '[]', 'upload', 1)""",
+            (draft_text,),
+        )
+        book_id = cur.lastrowid
+        await db.commit()
+
+    res = await admin_client.post("/api/admin/queue/enqueue-book", json={
+        "book_id": book_id,
+        "target_languages": ["de"],
+    })
+    assert res.status_code == 400, (
+        f"Expected 400 for draft book, got {res.status_code}: {res.text}"
+    )
+    assert "draft" in res.json()["detail"].lower() or "confirm" in res.json()["detail"].lower()
+
+
 # ── Retry-failed bulk endpoint ───────────────────────────────────────────────
 
 async def _seed_failed(book_id: int, chapter_index: int, target_language: str):


### PR DESCRIPTION
## Summary
- `POST /admin/queue/enqueue-book` accepted draft (unconfirmed) uploaded books and returned `{"ok": true, "enqueued": 0}` with no error
- Admins had no way to distinguish this from "all chapters already translated" — a silent failure that required debugging to diagnose
- Fix: check for `"draft": true` in the book's text JSON before calling `enqueue_for_book`; raise 400 with a clear message if the book hasn't been confirmed yet

## Test plan
- [x] New regression test: enqueue a draft-state uploaded book → 400 with "confirm" in detail; was 200 before fix
- [x] Existing `test_enqueue_book_nonexistent_returns_404` still passes
- [x] Full backend suite: 1084 passed, 0 failed

Closes #486
