### PR TITLE
fix: add max_length=50,000 to TTS text field

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -88,7 +88,7 @@ class TranslateRequest(BaseModel):
 
 
 class TTSRequest(BaseModel):
-    text: str
+    text: str = Field(..., max_length=50_000)
     language: str = "en"
     rate: float = Field(default=1.0, ge=0.25, le=4.0)
     gender: Literal["female", "male"] = "female"

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -544,6 +544,31 @@ async def test_tts_rate_bounds(client, rate, expected):
     )
 
 
+# ── TTS text max_length validation (Issue #488) ───────────────────────────────
+
+async def test_tts_oversized_text_returns_422(client):
+    """Regression #488: TTS text over 50,000 characters must be rejected with 422.
+
+    Without a limit, a user could POST megabytes of text, causing Edge TTS
+    to exhaust server memory or run for minutes.
+    """
+    oversized_text = "x" * 50_001
+    resp = await client.post("/api/ai/tts", json={"text": oversized_text, "language": "en"})
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized text ({len(oversized_text)} chars), "
+        f"got {resp.status_code}: {resp.text[:200]}"
+    )
+
+
+async def test_tts_max_length_boundary_accepted(client):
+    """Exactly 50,000 characters must be accepted."""
+    with patch("routers.ai.synthesize", new_callable=AsyncMock, return_value=(b"\xff\xfb", "audio/mpeg", [])):
+        resp = await client.post("/api/ai/tts", json={"text": "x" * 50_000, "language": "en"})
+    assert resp.status_code == 200, (
+        f"Expected 200 for 50,000 char text, got {resp.status_code}: {resp.text[:200]}"
+    )
+
+
 # ── References ────────────────────────────────────────────────────────────────
 
 async def test_references_without_key_returns_400(client):


### PR DESCRIPTION
## Summary
- `TTSRequest.text` had no max_length — a 16 MB body was accepted by FastAPI's default, letting users submit megabytes of text to Edge TTS
- Edge TTS would attempt to synthesize all of it in memory, risking OOM errors or multi-minute delays
- Fix: `Field(..., max_length=50_000)` — covers the longest realistic chapter (~10,000 words)

## Test plan
- [x] New test: 50,001 chars → 422 (was 200 before fix)
- [x] Boundary test: exactly 50,000 chars → 200 (still accepted)
- [x] Full backend suite: 1084+ passed, 0 failed

Closes #488
