### PR TITLE
fix: move upload quota check inside BEGIN IMMEDIATE transaction

### DIFF
--- a/backend/routers/uploads.py
+++ b/backend/routers/uploads.py
@@ -26,12 +26,30 @@ async def _user_upload_count(user_id: int) -> int:
 
 
 async def _save_upload_book(user_id: int, title: str, author: str, filename: str,
-                            file_size: int, fmt: str, draft_chapters: list[dict]) -> int:
-    """Insert a new uploaded book row (source='upload') and book_uploads row."""
+                            file_size: int, fmt: str, draft_chapters: list[dict],
+                            max_books: int | None = None) -> int:
+    """Insert a new uploaded book row (source='upload') and book_uploads row.
+
+    If max_books is provided, the quota is re-checked inside the BEGIN IMMEDIATE
+    transaction to prevent TOCTOU races between concurrent uploads.
+    """
     draft_json = json.dumps({"draft": True, "chapters": draft_chapters})
     async with aiosqlite.connect(_db.DB_PATH) as db:
-        await db.execute("BEGIN")
+        # BEGIN IMMEDIATE acquires a write lock immediately so that a second
+        # concurrent upload cannot pass the quota check after this connection
+        # has already started its insert (#489).
+        await db.execute("BEGIN IMMEDIATE")
         try:
+            if max_books is not None:
+                async with db.execute(
+                    "SELECT COUNT(*) FROM book_uploads WHERE user_id=?", (user_id,)
+                ) as cur:
+                    count = (await cur.fetchone())[0]
+                if count >= max_books:
+                    raise HTTPException(
+                        status_code=429,
+                        detail=f"Upload limit reached ({max_books} books). Delete a book to upload more.",
+                    )
             cur = await db.execute(
                 """INSERT INTO books (title, authors, languages, subjects, download_count,
                                      cover, text, images, source, owner_user_id)
@@ -46,6 +64,9 @@ async def _save_upload_book(user_id: int, title: str, author: str, filename: str
             )
             await db.execute("COMMIT")
             return book_id
+        except HTTPException:
+            await db.execute("ROLLBACK")
+            raise
         except Exception:
             await db.execute("ROLLBACK")
             raise
@@ -59,14 +80,9 @@ async def upload_book(
     """Upload a .txt or .epub file. Returns book_id + detected chapters for editing."""
     from services.book_parser import parse_txt, parse_epub
 
-    # Quota check — admins are exempt
-    if user.get("role") != "admin":
-        count = await _user_upload_count(user["id"])
-        if count >= MAX_BOOKS_PER_USER:
-            raise HTTPException(
-                status_code=429,
-                detail=f"Upload limit reached ({MAX_BOOKS_PER_USER} books). Delete a book to upload more.",
-            )
+    # Admins are exempt; non-admins have the quota re-checked atomically inside
+    # _save_upload_book to prevent TOCTOU races between concurrent uploads (#489).
+    max_books = None if user.get("role") == "admin" else MAX_BOOKS_PER_USER
 
     # Format check
     filename = file.filename or ""
@@ -108,6 +124,7 @@ async def upload_book(
         file_size=len(file_bytes),
         fmt=fmt,
         draft_chapters=chapters,
+        max_books=max_books,
     )
 
     return {

--- a/backend/tests/test_router_uploads.py
+++ b/backend/tests/test_router_uploads.py
@@ -71,13 +71,31 @@ async def test_upload_quota_returns_count(client, test_user):
     assert resp2.json()["used"] == 1
 
 
-async def test_upload_quota_exceeded_returns_429(client, test_user):
-    # test_user is auto-admin in a fresh db; demote so the quota limit applies
+async def test_upload_quota_exceeded_returns_429(client, test_user, tmp_db):
+    """Quota enforcement is now checked atomically inside the DB transaction.
+
+    We fill the quota via real DB inserts (not a mock) to ensure the
+    in-transaction re-check fires correctly (#489 TOCTOU fix).
+    """
     await set_user_role(test_user["id"], "user")
-    # Patch the quota check function to simulate limit reached
-    with patch("routers.uploads._user_upload_count", new_callable=AsyncMock, return_value=10):
-        resp = await client.post("/api/books/upload", files=_txt_upload())
-    assert resp.status_code == 429
+    # Insert 10 fake book_uploads rows directly so we don't have to upload 10 files
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        for i in range(10):
+            cur = await db.execute(
+                """INSERT INTO books (title, authors, languages, subjects, download_count,
+                                     cover, text, images, source, owner_user_id)
+                   VALUES (?, '[]', '[]', '[]', 0, '', '{}', '[]', 'upload', ?)""",
+                (f"Filler book {i}", test_user["id"]),
+            )
+            book_id = cur.lastrowid
+            await db.execute(
+                "INSERT INTO book_uploads (book_id, user_id, filename, file_size, format) VALUES (?, ?, ?, 0, 'txt')",
+                (book_id, test_user["id"], f"filler{i}.txt"),
+            )
+        await db.commit()
+
+    resp = await client.post("/api/books/upload", files=_txt_upload())
+    assert resp.status_code == 429, f"Expected 429 for over-quota upload, got {resp.status_code}: {resp.text}"
     assert "limit" in resp.json()["detail"].lower()
 
 


### PR DESCRIPTION
## Summary
- The upload quota check (`_user_upload_count`) and book insertion (`_save_upload_book`) ran in separate transactions — a classic TOCTOU race
- Two concurrent uploads by the same user could both read count=9, both pass the check, and both insert, leaving 11 books when the limit is 10
- Fix: move the quota re-check inside the `BEGIN IMMEDIATE` transaction in `_save_upload_book`; the write lock prevents any other writer from interleaving between check and insert

## Test plan
- [x] Updated `test_upload_quota_exceeded_returns_429` to fill quota via real DB inserts instead of mocking `_user_upload_count` (which is no longer on the critical path)
- [x] Full affected tests: 78 passed, 0 failed

Closes #489
