### PR TITLE
fix: add max_length constraints to AnnotationCreate fields

### DIFF
--- a/backend/routers/annotations.py
+++ b/backend/routers/annotations.py
@@ -1,6 +1,6 @@
 from typing import Literal, Optional
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from services.auth import get_current_user, check_book_access
 from services.db import create_annotation, get_annotations, get_all_annotations, update_annotation, delete_annotation, get_cached_book
 
@@ -13,8 +13,8 @@ AnnotationColor = Literal["yellow", "blue", "green", "pink"]
 class AnnotationCreate(BaseModel):
     book_id: int
     chapter_index: int
-    sentence_text: str
-    note_text: str = ""
+    sentence_text: str = Field(..., max_length=5000)
+    note_text: str = Field(default="", max_length=10000)
     color: AnnotationColor = "yellow"
 
 

--- a/backend/tests/test_router_annotations.py
+++ b/backend/tests/test_router_annotations.py
@@ -426,3 +426,50 @@ async def test_create_annotation_out_of_bounds_chapter_returns_400(client, test_
     )
     assert resp.status_code == 400, f"Expected 400 for out-of-bounds chapter, got {resp.status_code}: {resp.text}"
     assert "out of range" in resp.json()["detail"].lower()
+
+
+# ── Text field max_length validation (Issue #494) ─────────────────────────────
+
+@pytest.mark.asyncio
+async def test_create_annotation_oversized_note_text_returns_422(client, test_user, tmp_db):
+    """Regression #494: note_text over 10,000 chars must be rejected with 422.
+
+    Without a limit a user could store multi-MB notes, causing DB bloat
+    and degrading annotation query performance.
+    """
+    text = "CHAPTER I\n\n" + "word " * 300
+    await save_book(9890, {**_BOOK_META, "id": 9890}, text)
+    from services.book_chapters import clear_cache as _clear
+    _clear()
+    resp = await client.post(
+        "/api/annotations",
+        json={
+            "book_id": 9890,
+            "chapter_index": 0,
+            "sentence_text": "A sentence.",
+            "note_text": "x" * 10_001,
+        },
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized note_text, got {resp.status_code}: {resp.text[:200]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_annotation_oversized_sentence_text_returns_422(client, test_user, tmp_db):
+    """Regression #494: sentence_text over 5,000 chars must be rejected with 422."""
+    text = "CHAPTER I\n\n" + "word " * 300
+    await save_book(9893, {**_BOOK_META, "id": 9893}, text)
+    from services.book_chapters import clear_cache as _clear
+    _clear()
+    resp = await client.post(
+        "/api/annotations",
+        json={
+            "book_id": 9893,
+            "chapter_index": 0,
+            "sentence_text": "y" * 5_001,
+        },
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized sentence_text, got {resp.status_code}: {resp.text[:200]}"
+    )


### PR DESCRIPTION
## What changed
- Added `Field(max_length=5000)` to `AnnotationCreate.sentence_text`
- Added `Field(max_length=10000)` to `AnnotationCreate.note_text`

## Why
Without bounds, a client could POST arbitrarily large strings, wasting storage and risking DB performance degradation.

## Test plan
- `test_create_annotation_oversized_note_text_returns_422` — 10,001-char note_text → 422
- `test_create_annotation_oversized_sentence_text_returns_422` — 5,001-char sentence_text → 422
- Full backend suite: 1092 passed

Closes #494
