### PR TITLE
fix: add max_length constraints to InsightCreate and WordSave fields

### DIFF
--- a/backend/routers/insights.py
+++ b/backend/routers/insights.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from services.auth import get_current_user, check_book_access
 from services.db import save_insight, get_insights, get_all_insights, delete_insight, get_cached_book
 
@@ -9,9 +9,9 @@ router = APIRouter(prefix="/insights", tags=["insights"])
 class InsightCreate(BaseModel):
     book_id: int
     chapter_index: int | None = None
-    question: str
-    answer: str
-    context_text: str | None = None
+    question: str = Field(..., max_length=2000)
+    answer: str = Field(..., max_length=20000)
+    context_text: str | None = Field(default=None, max_length=5000)
 
 
 @router.post("")

--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from services.auth import get_current_user, encrypt_api_key, decrypt_api_key, check_book_access
 from services.db import (
@@ -21,10 +21,10 @@ router = APIRouter(prefix="/vocabulary", tags=["vocabulary"])
 
 
 class WordSave(BaseModel):
-    word: str
+    word: str = Field(..., max_length=200)
     book_id: int
     chapter_index: int
-    sentence_text: str
+    sentence_text: str = Field(..., max_length=5000)
 
 
 class ExportRequest(BaseModel):

--- a/backend/tests/test_router_insights.py
+++ b/backend/tests/test_router_insights.py
@@ -320,3 +320,23 @@ async def test_create_insight_out_of_bounds_chapter_returns_400(client, test_use
     )
     assert resp.status_code == 400, f"Expected 400 for out-of-bounds chapter, got {resp.status_code}: {resp.text}"
     assert "out of range" in resp.json()["detail"].lower()
+
+
+async def test_post_insight_oversized_question_returns_422(client, test_user, tmp_db):
+    """POST /insights rejects question longer than max_length (issue #496)."""
+    await save_book(9884, {**_META, "id": 9884}, "text")
+    resp = await client.post(
+        "/api/insights",
+        json={"book_id": 9884, "question": "q" * 2001, "answer": "A."},
+    )
+    assert resp.status_code == 422, f"Expected 422 for oversized question, got {resp.status_code}"
+
+
+async def test_post_insight_oversized_answer_returns_422(client, test_user, tmp_db):
+    """POST /insights rejects answer longer than max_length (issue #496)."""
+    await save_book(9885, {**_META, "id": 9885}, "text")
+    resp = await client.post(
+        "/api/insights",
+        json={"book_id": 9885, "question": "Q?", "answer": "a" * 20001},
+    )
+    assert resp.status_code == 422, f"Expected 422 for oversized answer, got {resp.status_code}"

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -553,3 +553,21 @@ async def test_save_vocabulary_out_of_bounds_chapter_returns_400(client, test_us
     )
     assert resp.status_code == 400, f"Expected 400 for out-of-bounds chapter, got {resp.status_code}: {resp.text}"
     assert "out of range" in resp.json()["detail"].lower()
+
+
+async def test_save_word_oversized_word_returns_422(client, test_user, tmp_db):
+    """POST /vocabulary rejects word longer than max_length (issue #498)."""
+    resp = await client.post(
+        "/api/vocabulary",
+        json={"word": "w" * 201, "book_id": 1, "chapter_index": 0, "sentence_text": "A sentence."},
+    )
+    assert resp.status_code == 422, f"Expected 422 for oversized word, got {resp.status_code}"
+
+
+async def test_save_word_oversized_sentence_text_returns_422(client, test_user, tmp_db):
+    """POST /vocabulary rejects sentence_text longer than max_length (issue #498)."""
+    resp = await client.post(
+        "/api/vocabulary",
+        json={"word": "Wort", "book_id": 1, "chapter_index": 0, "sentence_text": "s" * 5001},
+    )
+    assert resp.status_code == 422, f"Expected 422 for oversized sentence_text, got {resp.status_code}"


### PR DESCRIPTION
## What changed
- `InsightCreate.question`: `Field(..., max_length=2000)`
- `InsightCreate.answer`: `Field(..., max_length=20000)`
- `InsightCreate.context_text`: `Field(default=None, max_length=5000)`
- `WordSave.word`: `Field(..., max_length=200)`
- `WordSave.sentence_text`: `Field(..., max_length=5000)`

## Why
Neither model had length limits. Clients could POST multi-MB strings directly into `book_insights` / `vocabulary` / `word_occurrences`, causing storage exhaustion and query performance degradation.

## Test plan
- `test_post_insight_oversized_question_returns_422` — 2001-char question → 422
- `test_post_insight_oversized_answer_returns_422` — 20001-char answer → 422
- `test_save_word_oversized_word_returns_422` — 201-char word → 422
- `test_save_word_oversized_sentence_text_returns_422` — 5001-char sentence_text → 422
- Full backend suite: 1097 passed

Closes #496
Closes #498
