### PR TITLE
fix: add max_length constraints to AI endpoint input fields

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -46,15 +46,15 @@ def _require_gemini_key(user: dict) -> str:
 # ── Request models ────────────────────────────────────────────────────────────
 
 class InsightRequest(BaseModel):
-    chapter_text: str
+    chapter_text: str = Field(..., max_length=50_000)
     book_title: str
     author: str
     response_language: str = "en"
 
 
 class QARequest(BaseModel):
-    question: str
-    passage: str
+    question: str = Field(..., max_length=2_000)
+    passage: str = Field(..., max_length=50_000)
     book_title: str
     author: str
     response_language: str = "en"
@@ -78,7 +78,7 @@ class SummaryRequest(BaseModel):
 
 
 class TranslateRequest(BaseModel):
-    text: str
+    text: str = Field(..., max_length=50_000)
     source_language: str = "de"
     target_language: str = "en"
     book_id: int | None = None
@@ -95,7 +95,7 @@ class TTSRequest(BaseModel):
 
 
 class ChunkTextRequest(BaseModel):
-    text: str
+    text: str = Field(..., max_length=50_000)
 
 
 # ── Endpoints ─────────────────────────────────────────────────────────────────

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -899,3 +899,50 @@ async def test_delete_summary_out_of_bounds_chapter_returns_400(client, test_use
         f"Expected 400 for out-of-bounds chapter_index=999, got {resp.status_code}: {resp.text}"
     )
 
+
+
+# ── Issue #500: AI endpoint input bounds ──────────────────────────────────────
+
+async def test_translate_oversized_text_returns_422(client, test_user):
+    """POST /ai/translate rejects text longer than 50,000 chars (issue #500)."""
+    resp = await client.post(
+        "/api/ai/translate",
+        json={"text": "x" * 50_001, "source_language": "de", "target_language": "en"},
+    )
+    assert resp.status_code == 422, f"Expected 422 for oversized text, got {resp.status_code}"
+
+
+async def test_insight_oversized_chapter_text_returns_422(client, test_user, monkeypatch):
+    """POST /ai/insight rejects chapter_text longer than 50,000 chars (issue #500)."""
+    resp = await client.post(
+        "/api/ai/insight",
+        json={"chapter_text": "x" * 50_001, "book_title": "T", "author": "A"},
+    )
+    assert resp.status_code == 422, f"Expected 422 for oversized chapter_text, got {resp.status_code}"
+
+
+async def test_qa_oversized_question_returns_422(client, test_user, monkeypatch):
+    """POST /ai/qa rejects question longer than 2,000 chars (issue #500)."""
+    resp = await client.post(
+        "/api/ai/qa",
+        json={"question": "q" * 2001, "passage": "Some passage.", "book_title": "T", "author": "A"},
+    )
+    assert resp.status_code == 422, f"Expected 422 for oversized question, got {resp.status_code}"
+
+
+async def test_qa_oversized_passage_returns_422(client, test_user, monkeypatch):
+    """POST /ai/qa rejects passage longer than 50,000 chars (issue #500)."""
+    resp = await client.post(
+        "/api/ai/qa",
+        json={"question": "Q?", "passage": "p" * 50_001, "book_title": "T", "author": "A"},
+    )
+    assert resp.status_code == 422, f"Expected 422 for oversized passage, got {resp.status_code}"
+
+
+async def test_tts_chunks_oversized_text_returns_422(client, test_user):
+    """POST /ai/tts/chunks rejects text longer than 50,000 chars (issue #500)."""
+    resp = await client.post(
+        "/api/ai/tts/chunks",
+        json={"text": "x" * 50_001},
+    )
+    assert resp.status_code == 422, f"Expected 422 for oversized text, got {resp.status_code}"


### PR DESCRIPTION
## What changed
- `InsightRequest.chapter_text`: `Field(..., max_length=50_000)`
- `QARequest.question`: `Field(..., max_length=2_000)`
- `QARequest.passage`: `Field(..., max_length=50_000)`
- `TranslateRequest.text`: `Field(..., max_length=50_000)`
- `ChunkTextRequest.text`: `Field(..., max_length=50_000)`

## Why
No upper bounds on primary text inputs. `TranslateRequest` can use free Google Translate without a user key; `ChunkTextRequest` is purely local O(n) processing — both are DoS vectors. All AI-keyed endpoints accept unbounded payloads that pass costs to the user's Gemini quota.

## Test plan
- `test_translate_oversized_text_returns_422` — 50,001-char text → 422
- `test_insight_oversized_chapter_text_returns_422` — 50,001-char chapter_text → 422
- `test_qa_oversized_question_returns_422` — 2,001-char question → 422
- `test_qa_oversized_passage_returns_422` — 50,001-char passage → 422
- `test_tts_chunks_oversized_text_returns_422` — 50,001-char text → 422
- Full backend suite: 1104 passed

Closes #500
