### PR TITLE
fix: prevent duplicate book_insights rows with UNIQUE INDEX and INSERT OR IGNORE

### DIFF
--- a/backend/migrations/022_book_insights_unique.sql
+++ b/backend/migrations/022_book_insights_unique.sql
@@ -1,0 +1,3 @@
+-- Prevent duplicate insights for the same question in the same chapter
+CREATE UNIQUE INDEX IF NOT EXISTS uq_book_insights_question
+    ON book_insights (user_id, book_id, COALESCE(chapter_index, -1), question);

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -953,14 +953,25 @@ async def save_insight(
 ) -> dict:
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
-        cursor = await db.execute(
-            """INSERT INTO book_insights (user_id, book_id, chapter_index, question, answer, context_text)
+        await db.execute(
+            """INSERT OR IGNORE INTO book_insights (user_id, book_id, chapter_index, question, answer, context_text)
                VALUES (?, ?, ?, ?, ?, ?)""",
             (user_id, book_id, chapter_index, question, answer, context_text),
         )
-        row_id = cursor.lastrowid
-        async with db.execute("SELECT * FROM book_insights WHERE id = ?", (row_id,)) as c:
-            row = await c.fetchone()
+        # SELECT before COMMIT — prevents dict(None) crash if a concurrent
+        # delete_book removes the row between our COMMIT and a later SELECT.
+        if chapter_index is None:
+            async with db.execute(
+                "SELECT * FROM book_insights WHERE user_id=? AND book_id=? AND chapter_index IS NULL AND question=?",
+                (user_id, book_id, question),
+            ) as c:
+                row = await c.fetchone()
+        else:
+            async with db.execute(
+                "SELECT * FROM book_insights WHERE user_id=? AND book_id=? AND chapter_index=? AND question=?",
+                (user_id, book_id, chapter_index, question),
+            ) as c:
+                row = await c.fetchone()
         await db.commit()
     return dict(row)
 

--- a/backend/services/migrations.py
+++ b/backend/services/migrations.py
@@ -99,6 +99,16 @@ async def run(db_path: str) -> list[str]:
              "SELECT name FROM sqlite_master WHERE type='table' AND name='reading_history'"),
             ("021_user_books",
              "SELECT 1 FROM pragma_table_info('books') WHERE name='source'"),
+            # 022: skip if index already exists OR if the table exists but 'question'
+            # column is absent (legacy DBs that pre-date migration 015 use 'insight'
+            # instead of 'question'/'answer' and cannot receive this index).
+            # The table-existence guard prevents a false positive on fresh databases
+            # where book_insights has not been created yet.
+            ("022_book_insights_unique",
+             "SELECT 1 FROM sqlite_master WHERE type='index' AND name='uq_book_insights_question' "
+             "UNION ALL "
+             "SELECT 1 WHERE EXISTS (SELECT 1 FROM sqlite_master WHERE type='table' AND name='book_insights') "
+             "AND NOT EXISTS (SELECT 1 FROM pragma_table_info('book_insights') WHERE name='question')"),
         ]
         bootstrapped: list[str] = []
         for version, check_sql in bootstrap_checks:

--- a/backend/tests/test_router_insights.py
+++ b/backend/tests/test_router_insights.py
@@ -340,3 +340,16 @@ async def test_post_insight_oversized_answer_returns_422(client, test_user, tmp_
         json={"book_id": 9885, "question": "Q?", "answer": "a" * 20001},
     )
     assert resp.status_code == 422, f"Expected 422 for oversized answer, got {resp.status_code}"
+
+
+async def test_duplicate_insight_returns_existing_row(client, test_user, tmp_db):
+    """POST /insights with identical question deduplicates — returns existing row, GET returns 1 entry (issue #497)."""
+    await save_book(9887, {**_META, "id": 9887}, "text")
+    payload = {"book_id": 9887, "chapter_index": 0, "question": "Q?", "answer": "A."}
+    r1 = await client.post("/api/insights", json=payload)
+    assert r1.status_code == 200
+    r2 = await client.post("/api/insights", json=payload)
+    assert r2.status_code == 200
+    assert r1.json()["id"] == r2.json()["id"], "Duplicate POST should return the same insight id"
+    resp = await client.get("/api/insights?book_id=9887")
+    assert len(resp.json()) == 1, f"Expected 1 insight, got {len(resp.json())}"


### PR DESCRIPTION
## What changed
- New migration `022_book_insights_unique.sql`: adds `UNIQUE INDEX uq_book_insights_question` on `(user_id, book_id, COALESCE(chapter_index, -1), question)`
- `save_insight` in `services/db.py`: switched from plain `INSERT` to `INSERT OR IGNORE`, returns existing row on duplicate (SELECT before COMMIT to preserve delete-race safety from #351)
- `services/migrations.py`: adds bootstrap entry for migration 022 — marks it as applied for legacy DBs that pre-date migration 015 (use old `insight` column instead of `question`/`answer`) to prevent startup failure

## Why
`book_insights` had no UNIQUE constraint. Rapid or retried duplicate POSTs created multiple identical rows, inflating `GET /insights` results and wasting storage — unlike annotations and vocabulary_occurrences which already deduplicate.

## Test plan
- `test_duplicate_insight_returns_existing_row` — POSTing identical insight twice returns same `id`, `GET /insights` returns exactly 1 row
- `test_save_insight_select_runs_before_commit` — SELECT order invariant preserved
- `test_schema_migrations_table_records_versions` — migration 022 appears in schema_migrations on fresh DB
- `test_bootstrap_marks_016_when_context_text_exists` — legacy schema (no `question` col) still bootstraps cleanly
- Full backend suite: 1096 passed

Closes #497
