### PR TITLE
fix: add max_length to AnnotationUpdate, SummaryRequest, and ReferencesRequest fields

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -63,15 +63,15 @@ class QARequest(BaseModel):
 class ReferencesRequest(BaseModel):
     book_title: str
     author: str
-    chapter_title: str = ""
-    chapter_excerpt: str = ""
+    chapter_title: str = Field(default="", max_length=500)
+    chapter_excerpt: str = Field(default="", max_length=10_000)
     response_language: str = "en"
 
 
 class SummaryRequest(BaseModel):
     book_id: int
     chapter_index: int
-    chapter_text: str
+    chapter_text: str = Field(..., max_length=50_000)
     book_title: str
     author: str
     chapter_title: str = ""

--- a/backend/routers/annotations.py
+++ b/backend/routers/annotations.py
@@ -19,7 +19,7 @@ class AnnotationCreate(BaseModel):
 
 
 class AnnotationUpdate(BaseModel):
-    note_text: Optional[str] = None
+    note_text: Optional[str] = Field(default=None, max_length=10000)
     color: Optional[AnnotationColor] = None
 
 

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -946,3 +946,27 @@ async def test_tts_chunks_oversized_text_returns_422(client, test_user):
         json={"text": "x" * 50_001},
     )
     assert resp.status_code == 422, f"Expected 422 for oversized text, got {resp.status_code}"
+
+
+async def test_summary_oversized_chapter_text_returns_422(client, test_user, tmp_db):
+    """POST /ai/summary rejects chapter_text longer than 50,000 chars (issue #505)."""
+    from services.db import save_book
+    from services.book_chapters import clear_cache as _clear
+    _BOOK_META = {"id": 9896, "title": "T", "authors": [], "languages": ["en"], "subjects": [], "download_count": 0, "cover": ""}
+    text = "CHAPTER I\n\n" + "word " * 200
+    await save_book(9896, _BOOK_META, text)
+    _clear()
+    resp = await client.post(
+        "/api/ai/summary",
+        json={"book_id": 9896, "chapter_index": 0, "chapter_text": "x" * 50_001, "book_title": "T", "author": "A"},
+    )
+    assert resp.status_code == 422, f"Expected 422 for oversized chapter_text, got {resp.status_code}"
+
+
+async def test_references_oversized_chapter_excerpt_returns_422(client, test_user):
+    """POST /ai/references rejects chapter_excerpt longer than max_length (issue #505)."""
+    resp = await client.post(
+        "/api/ai/references",
+        json={"book_title": "T", "author": "A", "chapter_excerpt": "x" * 10_001},
+    )
+    assert resp.status_code == 422, f"Expected 422 for oversized chapter_excerpt, got {resp.status_code}"

--- a/backend/tests/test_router_annotations.py
+++ b/backend/tests/test_router_annotations.py
@@ -473,3 +473,18 @@ async def test_create_annotation_oversized_sentence_text_returns_422(client, tes
     assert resp.status_code == 422, (
         f"Expected 422 for oversized sentence_text, got {resp.status_code}: {resp.text[:200]}"
     )
+
+
+async def test_patch_annotation_oversized_note_text_returns_422(client, test_user, tmp_db):
+    """PATCH /annotations/{id} rejects note_text longer than max_length (issue #504)."""
+    from services.db import save_book
+    text = "CHAPTER I\n\n" + "word " * 300
+    await save_book(9895, {**_BOOK_META, "id": 9895}, text)
+    from services.book_chapters import clear_cache as _clear
+    _clear()
+    ann = await create_annotation(test_user["id"], 9895, 0, "Some sentence.", "", "yellow")
+    resp = await client.patch(
+        f"/api/annotations/{ann['id']}",
+        json={"note_text": "x" * 10_001},
+    )
+    assert resp.status_code == 422, f"Expected 422 for oversized note_text in PATCH, got {resp.status_code}"


### PR DESCRIPTION
## What changed
- `AnnotationUpdate.note_text`: `Field(default=None, max_length=10000)` — closes bypass where PATCH could exceed AnnotationCreate's 10000-char limit
- `SummaryRequest.chapter_text`: `Field(..., max_length=50_000)` — uses shared admin Gemini key; unbounded input wasted shared quota
- `ReferencesRequest.chapter_title`: `Field(default="", max_length=500)`
- `ReferencesRequest.chapter_excerpt`: `Field(default="", max_length=10_000)`

## Test plan
- `test_patch_annotation_oversized_note_text_returns_422` — 10,001-char PATCH note_text → 422
- `test_summary_oversized_chapter_text_returns_422` — 50,001-char chapter_text → 422
- `test_references_oversized_chapter_excerpt_returns_422` — 10,001-char chapter_excerpt → 422
- Full backend suite: 1107 passed

Closes #504
Closes #505
