### PR TITLE
fix: add max_length to AI metadata fields (book_title, author, language)

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -47,40 +47,40 @@ def _require_gemini_key(user: dict) -> str:
 
 class InsightRequest(BaseModel):
     chapter_text: str = Field(..., max_length=50_000)
-    book_title: str
-    author: str
-    response_language: str = "en"
+    book_title: str = Field(..., max_length=500)
+    author: str = Field(..., max_length=500)
+    response_language: str = Field(default="en", max_length=20)
 
 
 class QARequest(BaseModel):
     question: str = Field(..., max_length=2_000)
     passage: str = Field(..., max_length=50_000)
-    book_title: str
-    author: str
-    response_language: str = "en"
+    book_title: str = Field(..., max_length=500)
+    author: str = Field(..., max_length=500)
+    response_language: str = Field(default="en", max_length=20)
 
 
 class ReferencesRequest(BaseModel):
-    book_title: str
-    author: str
+    book_title: str = Field(..., max_length=500)
+    author: str = Field(..., max_length=500)
     chapter_title: str = Field(default="", max_length=500)
     chapter_excerpt: str = Field(default="", max_length=10_000)
-    response_language: str = "en"
+    response_language: str = Field(default="en", max_length=20)
 
 
 class SummaryRequest(BaseModel):
     book_id: int
     chapter_index: int
     chapter_text: str = Field(..., max_length=50_000)
-    book_title: str
-    author: str
-    chapter_title: str = ""
+    book_title: str = Field(..., max_length=500)
+    author: str = Field(..., max_length=500)
+    chapter_title: str = Field(default="", max_length=500)
 
 
 class TranslateRequest(BaseModel):
     text: str = Field(..., max_length=50_000)
-    source_language: str = "de"
-    target_language: str = "en"
+    source_language: str = Field(default="de", max_length=20)
+    target_language: str = Field(default="en", max_length=20)
     book_id: int | None = None
     chapter_index: int | None = None
     # "auto" → Gemini if user has a key, else Google Translate (free).
@@ -89,7 +89,7 @@ class TranslateRequest(BaseModel):
 
 class TTSRequest(BaseModel):
     text: str = Field(..., max_length=50_000)
-    language: str = "en"
+    language: str = Field(default="en", max_length=20)
     rate: float = Field(default=1.0, ge=0.25, le=4.0)
     gender: Literal["female", "male"] = "female"
 

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -970,3 +970,60 @@ async def test_references_oversized_chapter_excerpt_returns_422(client, test_use
         json={"book_title": "T", "author": "A", "chapter_excerpt": "x" * 10_001},
     )
     assert resp.status_code == 422, f"Expected 422 for oversized chapter_excerpt, got {resp.status_code}"
+
+
+# ── Issue #507: AI metadata field max_length ──────────────────────────────────
+
+async def test_summary_oversized_book_title_returns_422(client, test_user, tmp_db):
+    """POST /ai/summary rejects book_title longer than 500 chars (issue #507)."""
+    await save_book(9897, {"title": "T", "authors": [], "languages": ["en"], "subjects": [], "download_count": 0, "cover": ""}, "text")
+    resp = await client.post(
+        "/api/ai/summary",
+        json={"book_id": 9897, "chapter_index": 0, "chapter_text": "some text", "book_title": "t" * 501, "author": "A"},
+    )
+    assert resp.status_code == 422, f"Expected 422 for oversized book_title, got {resp.status_code}"
+
+
+async def test_insight_oversized_author_returns_422(client, test_user):
+    """POST /ai/insight rejects author longer than 500 chars (issue #507)."""
+    resp = await client.post(
+        "/api/ai/insight",
+        json={"chapter_text": "some text", "book_title": "T", "author": "a" * 501},
+    )
+    assert resp.status_code == 422, f"Expected 422 for oversized author, got {resp.status_code}"
+
+
+async def test_qa_oversized_book_title_returns_422(client, test_user):
+    """POST /ai/qa rejects book_title longer than 500 chars (issue #507)."""
+    resp = await client.post(
+        "/api/ai/qa",
+        json={"question": "Q?", "passage": "text", "book_title": "t" * 501, "author": "A"},
+    )
+    assert resp.status_code == 422, f"Expected 422 for oversized book_title in QA, got {resp.status_code}"
+
+
+async def test_references_oversized_author_returns_422(client, test_user):
+    """POST /ai/references rejects author longer than 500 chars (issue #507)."""
+    resp = await client.post(
+        "/api/ai/references",
+        json={"book_title": "T", "author": "a" * 501},
+    )
+    assert resp.status_code == 422, f"Expected 422 for oversized author in references, got {resp.status_code}"
+
+
+async def test_tts_oversized_language_returns_422(client):
+    """POST /ai/tts rejects language longer than 20 chars (issue #507)."""
+    resp = await client.post(
+        "/api/ai/tts",
+        json={"text": "hello", "language": "x" * 21},
+    )
+    assert resp.status_code == 422, f"Expected 422 for oversized language in TTS, got {resp.status_code}"
+
+
+async def test_translate_oversized_source_language_returns_422(client, test_user):
+    """POST /ai/translate rejects source_language longer than 20 chars (issue #507)."""
+    resp = await client.post(
+        "/api/ai/translate",
+        json={"text": "hello", "source_language": "x" * 21, "target_language": "en"},
+    )
+    assert resp.status_code == 422, f"Expected 422 for oversized source_language, got {resp.status_code}"


### PR DESCRIPTION
## What changed
Add `Field(max_length=N)` to AI prompt metadata fields that previously had no upper bound:

- `InsightRequest`: `book_title` (500), `author` (500), `response_language` (20)
- `QARequest`: `book_title` (500), `author` (500), `response_language` (20)
- `ReferencesRequest`: `book_title` (500), `author` (500), `response_language` (20)
- `SummaryRequest`: `book_title` (500), `author` (500), `chapter_title` (500)
- `TranslateRequest`: `source_language` (20), `target_language` (20)
- `TTSRequest`: `language` (20)

The summary endpoint is the critical case: it uses the **shared admin Gemini key**, so a client injecting a huge `book_title` or `author` into the prompt could drain shared quota.

## Test plan
- `test_summary_oversized_book_title_returns_422` — 501-char book_title → 422
- `test_insight_oversized_author_returns_422` — 501-char author → 422
- `test_qa_oversized_book_title_returns_422` — 501-char book_title → 422
- `test_references_oversized_author_returns_422` — 501-char author → 422
- `test_tts_oversized_language_returns_422` — 21-char language → 422
- `test_translate_oversized_source_language_returns_422` — 21-char source_language → 422
- Full backend suite: 1114 passed

Closes #507
