### PR TITLE
fix: add max_length to GeminiKeyRequest and ObsidianSettingsUpdate fields

### DIFF
--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -1,6 +1,6 @@
 from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from services.auth import get_current_user, encrypt_api_key, decrypt_api_key, check_book_access
 from services.db import (
     set_user_gemini_key, get_user_by_id, get_reading_progress,
@@ -26,7 +26,7 @@ async def me(user: dict = Depends(get_current_user)):
 
 
 class GeminiKeyRequest(BaseModel):
-    api_key: str
+    api_key: str = Field(..., max_length=500)
 
 
 @router.post("/gemini-key")
@@ -97,9 +97,9 @@ async def get_obsidian(user: dict = Depends(get_current_user)):
 
 
 class ObsidianSettingsUpdate(BaseModel):
-    github_token: Optional[str] = None
-    obsidian_repo: str = ""
-    obsidian_path: str = ""
+    github_token: Optional[str] = Field(default=None, max_length=500)
+    obsidian_repo: str = Field(default="", max_length=200)
+    obsidian_path: str = Field(default="", max_length=1000)
 
 
 @router.patch("/obsidian-settings")

--- a/backend/tests/test_router_user.py
+++ b/backend/tests/test_router_user.py
@@ -300,3 +300,37 @@ async def test_patch_obsidian_valid_path_accepted(client, test_user):
     assert resp.status_code == 200, (
         f"Expected 200 for valid obsidian_path, got {resp.status_code}: {resp.text}"
     )
+
+
+# ── Issue #508: user fields max_length ────────────────────────────────────────
+
+async def test_save_oversized_gemini_key_returns_422(client, test_user):
+    """POST /user/gemini-key rejects api_key longer than 500 chars (issue #508)."""
+    resp = await client.post("/api/user/gemini-key", json={"api_key": "x" * 501})
+    assert resp.status_code == 422, f"Expected 422 for oversized api_key, got {resp.status_code}"
+
+
+async def test_patch_obsidian_oversized_github_token_returns_422(client, test_user):
+    """PATCH /user/obsidian-settings rejects github_token longer than 500 chars (issue #508)."""
+    resp = await client.patch("/api/user/obsidian-settings", json={
+        "github_token": "x" * 501,
+        "obsidian_repo": "user/vault",
+    })
+    assert resp.status_code == 422, f"Expected 422 for oversized github_token, got {resp.status_code}"
+
+
+async def test_patch_obsidian_oversized_repo_returns_422(client, test_user):
+    """PATCH /user/obsidian-settings rejects obsidian_repo longer than 200 chars (issue #508)."""
+    resp = await client.patch("/api/user/obsidian-settings", json={
+        "obsidian_repo": "x" * 201,
+    })
+    assert resp.status_code == 422, f"Expected 422 for oversized obsidian_repo, got {resp.status_code}"
+
+
+async def test_patch_obsidian_oversized_path_returns_422(client, test_user):
+    """PATCH /user/obsidian-settings rejects obsidian_path longer than 1000 chars (issue #508)."""
+    resp = await client.patch("/api/user/obsidian-settings", json={
+        "obsidian_repo": "user/vault",
+        "obsidian_path": "a/" * 501,
+    })
+    assert resp.status_code == 422, f"Expected 422 for oversized obsidian_path, got {resp.status_code}"


### PR DESCRIPTION
## What changed
Add `Field(max_length=N)` to user-facing fields that are stored in the `users` table but had no upper bound:

- `GeminiKeyRequest.api_key`: max 500 chars (real Gemini keys are ~43 chars)
- `ObsidianSettingsUpdate.github_token`: max 500 chars (GitHub PATs are ~40-100 chars)
- `ObsidianSettingsUpdate.obsidian_repo`: max 200 chars (format: `owner/repo`)
- `ObsidianSettingsUpdate.obsidian_path`: max 1000 chars (file path)

Without bounds, a user could submit a multi-MB string that gets encrypted and stored, loading multi-MB data on every authenticated request.

## Test plan
- `test_save_oversized_gemini_key_returns_422` — 501-char api_key → 422
- `test_patch_obsidian_oversized_github_token_returns_422` — 501-char token → 422
- `test_patch_obsidian_oversized_repo_returns_422` — 201-char repo → 422
- `test_patch_obsidian_oversized_path_returns_422` — 1001-char path → 422
- Full backend suite: 1112 passed (pre-rebase onto main with PR #509)

Closes #508
