### PR TITLE
fix: add max_length to target_language fields in books and vocabulary routers

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -6,7 +6,7 @@ from typing import AsyncIterator
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from services.gutenberg import search_books, get_book_meta, get_book_text, get_book_html
 from services.db import (
     get_cached_book,
@@ -205,7 +205,7 @@ async def get_chapter_translation(
 
 
 class RequestTranslationBody(BaseModel):
-    target_language: str
+    target_language: str = Field(..., max_length=20)
 
 
 @router.post("/{book_id}/chapters/{chapter_index}/translation")

--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -29,7 +29,7 @@ class WordSave(BaseModel):
 
 class ExportRequest(BaseModel):
     book_id: int | None = None
-    target_language: str = "zh"
+    target_language: str = Field(default="zh", max_length=20)
 
 
 @router.post("")

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -1050,3 +1050,45 @@ async def test_cached_books_hides_uploaded_books(client, test_user, tmp_db, inse
     assert 9891 not in returned_ids, (
         "Private uploaded book must NOT appear in cached list — its title is private"
     )
+
+
+# ── Issue #513: target_language max_length ────────────────────────────────────
+
+
+async def test_request_translation_oversized_target_language_returns_422(client, test_user):
+    """Regression #513: POST /books/{id}/chapters/0/translation with target_language > 20 chars
+    must return 422, not silently store a huge string in translation_queue."""
+    await save_book(9801, {**MOCK_META, "id": 9801}, "some text")
+    resp = await client.post(
+        "/api/books/9801/chapters/0/translation",
+        json={"target_language": "x" * 21},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized target_language, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_enqueue_all_oversized_target_language_returns_422(client, test_user):
+    """Regression #513: POST /books/{id}/translations/enqueue-all with target_language > 20 chars
+    must return 422."""
+    await save_book(9802, {**MOCK_META, "id": 9802}, "some text")
+    resp = await client.post(
+        "/api/books/9802/translations/enqueue-all",
+        json={"target_language": "y" * 21},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized target_language in enqueue-all, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_retry_translation_oversized_target_language_returns_422(client, test_user):
+    """Regression #513: POST /books/{id}/chapters/{idx}/translation/retry with target_language > 20 chars
+    must return 422."""
+    await save_book(9803, {**MOCK_META, "id": 9803}, "some text")
+    resp = await client.post(
+        "/api/books/9803/chapters/0/translation/retry",
+        json={"target_language": "z" * 21},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized target_language in retry, got {resp.status_code}: {resp.text}"
+    )

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -571,3 +571,17 @@ async def test_save_word_oversized_sentence_text_returns_422(client, test_user, 
         json={"word": "Wort", "book_id": 1, "chapter_index": 0, "sentence_text": "s" * 5001},
     )
     assert resp.status_code == 422, f"Expected 422 for oversized sentence_text, got {resp.status_code}"
+
+
+# ── Issue #513: ExportRequest.target_language max_length ─────────────────────
+
+async def test_export_obsidian_oversized_target_language_returns_422(client, test_user):
+    """Regression #513: POST /vocabulary/export/obsidian with target_language > 20 chars
+    must return 422, not pass to external translation API."""
+    resp = await client.post(
+        "/api/vocabulary/export/obsidian",
+        json={"target_language": "x" * 21},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized target_language in export/obsidian, got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## Summary
- Add `Field(max_length=20)` to `RequestTranslationBody.target_language` in `routers/books.py` — this field is stored in `translation_queue` and `translations` tables; an authenticated user could bloat the DB with huge language codes
- Add `Field(max_length=20)` to `ExportRequest.target_language` in `routers/vocabulary.py` — passed to external translation API without bounds

## Test plan
- `test_request_translation_oversized_target_language_returns_422` — 422 for 21-char target_language
- `test_enqueue_all_oversized_target_language_returns_422` — 422 on enqueue-all endpoint
- `test_retry_translation_oversized_target_language_returns_422` — 422 on retry endpoint
- `test_export_obsidian_oversized_target_language_returns_422` — 422 on Obsidian export
- Full backend suite: 1122 passed

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)
