### PR TITLE
fix: add max_length to SaveTranslationRequest fields

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -269,10 +269,10 @@ async def translate_cache(
 class SaveTranslationRequest(BaseModel):
     book_id: int
     chapter_index: int
-    target_language: str
+    target_language: str = Field(..., max_length=20)
     paragraphs: list[str]
-    provider: str | None = None
-    model: str | None = None
+    provider: str | None = Field(default=None, max_length=100)
+    model: str | None = Field(default=None, max_length=200)
 
 
 @router.put("/translate/cache")

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -1027,3 +1027,52 @@ async def test_translate_oversized_source_language_returns_422(client, test_user
         json={"text": "hello", "source_language": "x" * 21, "target_language": "en"},
     )
     assert resp.status_code == 422, f"Expected 422 for oversized source_language, got {resp.status_code}"
+
+
+# ── Issue #516: SaveTranslationRequest max_length ────────────────────────────
+
+
+async def test_translate_cache_put_oversized_target_language_returns_422(client, test_user):
+    """Regression #516: PUT /ai/translate/cache with target_language > 20 chars
+    must return 422, not store a huge string in translations table."""
+    await save_book(9821, {"title": "T", "authors": [], "languages": ["de"],
+                           "subjects": [], "download_count": 0, "cover": ""}, "text")
+    resp = await client.put(
+        "/api/ai/translate/cache",
+        json={"book_id": 9821, "chapter_index": 0, "target_language": "x" * 21,
+              "paragraphs": ["hello"]},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized target_language in PUT /translate/cache, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_translate_cache_put_oversized_provider_returns_422(client, test_user):
+    """Regression #516: PUT /ai/translate/cache with provider > 100 chars must return 422."""
+    await save_book(9822, {"title": "T", "authors": [], "languages": ["de"],
+                           "subjects": [], "download_count": 0, "cover": ""}, "text")
+    resp = await client.put(
+        "/api/ai/translate/cache",
+        json={"book_id": 9822, "chapter_index": 0, "target_language": "fr",
+              "paragraphs": ["hello"], "provider": "x" * 101},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized provider in PUT /translate/cache, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_translate_cache_put_oversized_model_returns_422(client, test_user):
+    """Regression #516: PUT /ai/translate/cache with model > 200 chars must return 422."""
+    await save_book(9823, {"title": "T", "authors": [], "languages": ["de"],
+                           "subjects": [], "download_count": 0, "cover": ""}, "text")
+    resp = await client.put(
+        "/api/ai/translate/cache",
+        json={"book_id": 9823, "chapter_index": 0, "target_language": "fr",
+              "paragraphs": ["hello"], "model": "m" * 201},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized model in PUT /translate/cache, "
+        f"got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## Summary
- Add `Field(max_length=20)` to `SaveTranslationRequest.target_language` — stored in `translations.target_language`
- Add `Field(max_length=100)` to `SaveTranslationRequest.provider` — stored in `translations.provider`
- Add `Field(max_length=200)` to `SaveTranslationRequest.model` — stored in `translations.model`

All three fields were unbounded; an authenticated user calling `PUT /ai/translate/cache` could bloat the translations table with large strings.

## Test plan
- `test_translate_cache_put_oversized_target_language_returns_422`
- `test_translate_cache_put_oversized_provider_returns_422`
- `test_translate_cache_put_oversized_model_returns_422`
- Full AI test suite: 77 passed

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)
