### PR TITLE
fix: cap SaveTranslationRequest.paragraphs list size and per-item length

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections import defaultdict
-from typing import Literal
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import Response
@@ -270,7 +270,7 @@ class SaveTranslationRequest(BaseModel):
     book_id: int
     chapter_index: int
     target_language: str = Field(..., max_length=20)
-    paragraphs: list[str]
+    paragraphs: list[Annotated[str, Field(max_length=50000)]] = Field(..., max_length=2000)
     provider: str | None = Field(default=None, max_length=100)
     model: str | None = Field(default=None, max_length=200)
 

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -1076,3 +1076,36 @@ async def test_translate_cache_put_oversized_model_returns_422(client, test_user
         f"Expected 422 for oversized model in PUT /translate/cache, "
         f"got {resp.status_code}: {resp.text}"
     )
+
+
+# ── Issue #520: SaveTranslationRequest.paragraphs list bounds ─────────────────
+
+
+async def test_translate_cache_put_too_many_paragraphs_returns_422(client, test_user):
+    """Regression #520: PUT /ai/translate/cache with > 2000 paragraphs must return 422."""
+    await save_book(9824, {"title": "T", "authors": [], "languages": ["de"],
+                           "subjects": [], "download_count": 0, "cover": ""}, "text")
+    resp = await client.put(
+        "/api/ai/translate/cache",
+        json={"book_id": 9824, "chapter_index": 0, "target_language": "fr",
+              "paragraphs": ["p"] * 2001},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for too many paragraphs in PUT /translate/cache, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_translate_cache_put_oversized_paragraph_item_returns_422(client, test_user):
+    """Regression #520: PUT /ai/translate/cache with a paragraph > 50000 chars must return 422."""
+    await save_book(9825, {"title": "T", "authors": [], "languages": ["de"],
+                           "subjects": [], "download_count": 0, "cover": ""}, "text")
+    resp = await client.put(
+        "/api/ai/translate/cache",
+        json={"book_id": 9825, "chapter_index": 0, "target_language": "fr",
+              "paragraphs": ["x" * 50001]},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized paragraph item in PUT /translate/cache, "
+        f"got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## Summary

- Add `max_length=2000` to `SaveTranslationRequest.paragraphs` (list item count cap)
- Add `max_length=50000` per-item constraint via `Annotated[str, Field(max_length=50000)]`

## Why

`paragraphs: list[str]` was completely unbounded, allowing an attacker to POST a list with millions of items or a single multi-megabyte string, both of which get stored in the `translations` table. Closes #520.

## Test plan

- [ ] `test_translate_cache_put_too_many_paragraphs_returns_422` — list with 2001 items → 422
- [ ] `test_translate_cache_put_oversized_paragraph_item_returns_422` — item with 50001 chars → 422
- [ ] Full backend suite (545 tests) passes
