### PR TITLE
fix: add ConfirmChapterSpec with max_length for chapter titles

### DIFF
--- a/backend/routers/uploads.py
+++ b/backend/routers/uploads.py
@@ -5,7 +5,7 @@ import logging
 import aiosqlite
 import services.db as _db
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from services.auth import get_current_user
 
 logger = logging.getLogger(__name__)
@@ -189,8 +189,14 @@ async def get_draft_chapters(book_id: int, user: dict = Depends(get_current_user
     }
 
 
+class ConfirmChapterSpec(BaseModel):
+    title: str = Field(default="", max_length=500)
+    original_index: int | None = None
+    index: int | None = None
+
+
 class ConfirmChaptersBody(BaseModel):
-    chapters: list[dict]  # [{title: str, index: int}] — reordered/renamed list
+    chapters: list[ConfirmChapterSpec]
 
 
 @router.post("/{book_id}/chapters/confirm")
@@ -233,9 +239,9 @@ async def confirm_chapters(
         # original text comes from orig_chapters by matching original index
         final_chapters = []
         for ch_spec in body.chapters:
-            orig_idx = ch_spec.get("original_index", ch_spec.get("index"))
-            title = ch_spec.get("title", f"Chapter {len(final_chapters) + 1}")
-            if orig_idx is not None and isinstance(orig_idx, int) and 0 <= orig_idx < len(orig_chapters):
+            orig_idx = ch_spec.original_index if ch_spec.original_index is not None else ch_spec.index
+            title = ch_spec.title or f"Chapter {len(final_chapters) + 1}"
+            if orig_idx is not None and 0 <= orig_idx < len(orig_chapters):
                 text = orig_chapters[orig_idx]["text"]
             else:
                 text = ""

--- a/backend/tests/test_router_uploads.py
+++ b/backend/tests/test_router_uploads.py
@@ -632,7 +632,26 @@ async def test_confirm_chapters_non_integer_original_index_returns_400(client, t
         f"/api/books/{book_id}/chapters/confirm",
         json={"chapters": [{"title": "Chapter 1", "original_index": "not_an_int"}]},
     )
-    assert resp.status_code in (200, 400), (
-        f"Expected 200 (graceful empty-text) or 400, got {resp.status_code} (likely 500 crash): {resp.text}"
+    assert resp.status_code in (200, 400, 422), (
+        f"Expected 200/400/422, got {resp.status_code} (likely 500 crash): {resp.text}"
     )
     assert resp.status_code != 500, "Non-integer original_index must not crash the server with 500"
+
+
+# ── Issue #519: ConfirmChapterSpec title max_length ───────────────────────────
+
+
+async def test_confirm_chapters_oversized_title_returns_422(client, test_user):
+    """Regression #519: chapter title > 500 chars must return 422, not store a
+    huge string in the books table."""
+    upload_resp = await client.post("/api/books/upload", files=_txt_upload())
+    assert upload_resp.status_code == 200
+    book_id = upload_resp.json()["book_id"]
+
+    resp = await client.post(
+        f"/api/books/{book_id}/chapters/confirm",
+        json={"chapters": [{"title": "x" * 501, "original_index": 0}]},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized chapter title, got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## Summary

- Add `ConfirmChapterSpec(BaseModel)` with `title: str = Field(default="", max_length=500)`, `original_index: int | None`, `index: int | None`
- Change `ConfirmChaptersBody.chapters` from `list[dict]` to `list[ConfirmChapterSpec]`
- Update handler to use typed attribute access instead of `.get()`

## Why

`chapters: list[dict]` was completely untyped — Pydantic v2 does not validate dict values, so arbitrarily long chapter titles could be stored in the `books` table JSON. Closes #519.

## Test plan

- [ ] `test_confirm_chapters_oversized_title_returns_422` — title with 501 chars → 422
- [ ] All 24 existing uploads tests still pass
- [ ] Full backend suite (546 tests) passes
