### PR TITLE
fix: add max_length bounds to GET query params in books.py

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -28,8 +28,8 @@ router = APIRouter(prefix="/books", tags=["books"])
 
 @router.get("/search")
 async def search(
-    q: str = Query(..., description="Search query"),
-    language: str = Query("", description="Language code e.g. en, de, fr"),
+    q: str = Query(..., max_length=200, description="Search query"),
+    language: str = Query("", max_length=20, description="Language code e.g. en, de, fr"),
     page: int = Query(1, ge=1),
 ):
     return await search_books(q, language, page)
@@ -89,7 +89,7 @@ async def popular_books(
 
 
 @router.get("/{book_id}/translation-status")
-async def translation_status(book_id: int, target_language: str, user: dict | None = Depends(get_optional_user)):
+async def translation_status(book_id: int, target_language: str = Query(..., max_length=20), user: dict | None = Depends(get_optional_user)):
     """Return book-level translation progress for the reader banner.
 
     Includes:
@@ -146,7 +146,7 @@ async def translation_status(book_id: int, target_language: str, user: dict | No
 async def chapter_queue_status(
     book_id: int,
     chapter_index: int,
-    target_language: str,
+    target_language: str = Query(..., max_length=20),
     user: dict = Depends(get_current_user),
 ):
     """Per-chapter queue lookup for the reader page.
@@ -175,7 +175,7 @@ async def chapter_queue_status(
 async def get_chapter_translation(
     book_id: int,
     chapter_index: int,
-    target_language: str,
+    target_language: str = Query(..., max_length=20),
     user: dict | None = Depends(get_optional_user),
 ):
     """Return the cached translation if available, 404 otherwise. Never enqueues."""

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -1092,3 +1092,46 @@ async def test_retry_translation_oversized_target_language_returns_422(client, t
     assert resp.status_code == 422, (
         f"Expected 422 for oversized target_language in retry, got {resp.status_code}: {resp.text}"
     )
+
+
+# ── Issue #517: Unbounded GET query params ────────────────────────────────────
+
+
+async def test_search_oversized_q_returns_422(client):
+    """Regression #517: GET /books/search?q=<201 chars> must return 422."""
+    resp = await client.get(f"/api/books/search?q={'x' * 201}")
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized q in /books/search, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_search_oversized_language_returns_422(client):
+    """Regression #517: GET /books/search?language=<21 chars> must return 422."""
+    resp = await client.get(f"/api/books/search?q=test&language={'x' * 21}")
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized language in /books/search, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_translation_status_oversized_target_language_returns_422(client):
+    """Regression #517: GET /books/{id}/translation-status?target_language=<21 chars> must return 422."""
+    resp = await client.get(f"/api/books/1/translation-status?target_language={'x' * 21}")
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized target_language in translation-status, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_chapter_queue_status_oversized_target_language_returns_422(client, test_user):
+    """Regression #517: GET /books/{id}/chapters/{idx}/queue-status?target_language=<21 chars> must return 422."""
+    resp = await client.get(f"/api/books/1/chapters/0/queue-status?target_language={'x' * 21}")
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized target_language in chapter queue-status, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_chapter_translation_oversized_target_language_returns_422(client):
+    """Regression #517: GET /books/{id}/chapters/{idx}/translation?target_language=<21 chars> must return 422."""
+    resp = await client.get(f"/api/books/1/chapters/0/translation?target_language={'x' * 21}")
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized target_language in chapter translation, got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## Summary

- `GET /books/search?q=` — added `Query(max_length=200)`
- `GET /books/search?language=` — added `Query(max_length=20)`
- `GET /books/{id}/translation-status?target_language=` — added `Query(max_length=20)`
- `GET /books/{id}/chapters/{idx}/queue-status?target_language=` — added `Query(max_length=20)`
- `GET /books/{id}/chapters/{idx}/translation?target_language=` — added `Query(max_length=20)`

## Why

Follow-up to #513/PR #515. POST body fields were bounded but GET query params were not — an oversized `q` or `target_language` would reach the Gutenberg API or the DB query unchanged. Closes #517.

## Test plan

- [ ] 5 new regression tests (`test_*_oversized_*_returns_422`) all return 422
- [ ] Full backend suite (551 tests) passes
