### PR TITLE
fix: cap ImportTranslationEntry.paragraphs list size and per-item length

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -581,7 +581,7 @@ class ImportTranslationEntry(BaseModel):
     book_id: int
     chapter_index: int
     target_language: str = Field(..., max_length=20)
-    paragraphs: list[str]
+    paragraphs: list[Annotated[str, Field(max_length=50000)]] = Field(..., max_length=2000)
     provider: str | None = Field(default=None, max_length=100)
     model: str | None = Field(default=None, max_length=200)
     title_translation: str | None = Field(default=None, max_length=500)

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -2112,3 +2112,34 @@ async def test_enqueue_book_oversized_target_language_returns_422(admin_client, 
     assert res.status_code == 422, (
         f"Expected 422 for oversized target_language in enqueue-book, got {res.status_code}"
     )
+
+
+# ── Issue #524: ImportTranslationEntry.paragraphs bounds ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_import_translations_too_many_paragraphs_returns_422(admin_client, admin_db):
+    """Regression #524: POST /admin/translations/import with > 2000 paragraphs
+    in an entry must return 422."""
+    res = await admin_client.post(
+        "/api/admin/translations/import",
+        json={"entries": [{"book_id": 1, "chapter_index": 0,
+                           "target_language": "en", "paragraphs": ["p"] * 2001}]},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for too many paragraphs in import, got {res.status_code}: {res.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_import_translations_oversized_paragraph_item_returns_422(admin_client, admin_db):
+    """Regression #524: POST /admin/translations/import with a paragraph item > 50000 chars
+    must return 422."""
+    res = await admin_client.post(
+        "/api/admin/translations/import",
+        json={"entries": [{"book_id": 1, "chapter_index": 0,
+                           "target_language": "en", "paragraphs": ["x" * 50001]}]},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for oversized paragraph item in import, got {res.status_code}: {res.text}"
+    )


### PR DESCRIPTION
## Summary

Add `max_length=2000` list-size cap and `max_length=50000` per-item cap to `ImportTranslationEntry.paragraphs` in the admin import endpoint.

## Why

`paragraphs: list[str]` in `ImportTranslationEntry` was fully unbounded, identical to the risk fixed in PR #523 for `SaveTranslationRequest`. An admin POST to `/admin/translations/import` with thousands of large paragraphs could write a ~500MB JSON blob into the `translations` table. Closes #524.

## Test plan

- [ ] `test_import_translations_too_many_paragraphs_returns_422` — 2001 items → 422
- [ ] `test_import_translations_oversized_paragraph_item_returns_422` — item with 50001 chars → 422
- [ ] Full backend suite (553 tests) passes
