### PR TITLE
fix: add max_length to vocabulary word/lang path and query params

### DIFF
--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -3,7 +3,7 @@ import base64
 from datetime import datetime, timezone
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from pydantic import BaseModel, Field
 
 from services.auth import get_current_user, encrypt_api_key, decrypt_api_key, check_book_access
@@ -64,13 +64,17 @@ async def list_vocabulary(user: dict = Depends(get_current_user)):
 
 
 @router.get("/definition/{word}")
-async def get_definition(word: str, lang: str = "en", user: dict = Depends(get_current_user)):
+async def get_definition(
+    word: str = Path(..., max_length=200),
+    lang: str = Query(default="en", max_length=20),
+    user: dict = Depends(get_current_user),
+):
     from services import wiktionary
     return await wiktionary.lookup(word, lang)
 
 
 @router.delete("/{word}")
-async def remove_word(word: str, user: dict = Depends(get_current_user)):
+async def remove_word(word: str = Path(..., max_length=200), user: dict = Depends(get_current_user)):
     deleted = await delete_word(user["id"], word)
     if not deleted:
         raise HTTPException(status_code=404, detail="Word not found")

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -585,3 +585,30 @@ async def test_export_obsidian_oversized_target_language_returns_422(client, tes
     assert resp.status_code == 422, (
         f"Expected 422 for oversized target_language in export/obsidian, got {resp.status_code}: {resp.text}"
     )
+
+
+# ── Issue #529: vocabulary word/lang path+query param bounds ─────────────────
+
+
+async def test_definition_oversized_word_returns_422(client, test_user):
+    """Regression #529: GET /vocabulary/definition/{word>200chars} must return 422."""
+    resp = await client.get("/api/vocabulary/definition/" + "w" * 201)
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized word in /definition, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_definition_oversized_lang_returns_422(client, test_user):
+    """Regression #529: GET /vocabulary/definition/word?lang=<21 chars> must return 422."""
+    resp = await client.get("/api/vocabulary/definition/test?lang=" + "x" * 21)
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized lang in /definition, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_remove_word_oversized_word_returns_422(client, test_user):
+    """Regression #529: DELETE /vocabulary/{word>200chars} must return 422."""
+    resp = await client.delete("/api/vocabulary/" + "w" * 201)
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized word in DELETE /vocabulary, got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## Summary

Add `max_length` bounds to vocabulary path/query parameters:

- `word: str = Path(..., max_length=200)` on `GET /vocabulary/definition/{word}` and `DELETE /vocabulary/{word}`
- `lang: str = Query(default="en", max_length=20)` on `GET /vocabulary/definition/{word}?lang=`

## Why

Unbounded path/query params allowed arbitrarily long strings to reach the wiktionary external API and the DB DELETE query. Closes #529.

## Test plan

- [ ] `test_definition_oversized_word_returns_422` — word with 201 chars → 422
- [ ] `test_definition_oversized_lang_returns_422` — lang with 21 chars → 422
- [ ] `test_remove_word_oversized_word_returns_422` — word with 201 chars → 422
- [ ] Full backend suite (556 tests) passes
