### PR TITLE
fix: cap QueueSettingsRequest list item lengths

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1037,11 +1037,11 @@ async def queue_get_settings(_admin: dict = Depends(_require_admin)):
 class QueueSettingsRequest(BaseModel):
     enabled: bool | None = None
     api_key: str | None = Field(default=None, max_length=500)
-    auto_translate_languages: list[str] | None = None
+    auto_translate_languages: list[Annotated[str, Field(max_length=20)]] | None = Field(default=None, max_length=50)
     rpm: int | None = Field(default=None, ge=1)
     rpd: int | None = Field(default=None, ge=1)
     model: str | None = Field(default=None, max_length=200)
-    model_chain: list[str] | None = None
+    model_chain: list[Annotated[str, Field(max_length=200)]] | None = Field(default=None, max_length=20)
     max_output_tokens: int | None = Field(default=None, ge=1)
 
 

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -2143,3 +2143,42 @@ async def test_import_translations_oversized_paragraph_item_returns_422(admin_cl
     assert res.status_code == 422, (
         f"Expected 422 for oversized paragraph item in import, got {res.status_code}: {res.text}"
     )
+
+
+# ── Issue #531: QueueSettingsRequest list item bounds ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_queue_settings_oversized_language_item_returns_422(admin_client, admin_db):
+    """Regression #531: auto_translate_languages item > 20 chars must return 422."""
+    res = await admin_client.put(
+        "/api/admin/queue/settings",
+        json={"auto_translate_languages": ["x" * 21]},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for oversized language item, got {res.status_code}: {res.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_queue_settings_oversized_model_chain_item_returns_422(admin_client, admin_db):
+    """Regression #531: model_chain item > 200 chars must return 422."""
+    res = await admin_client.put(
+        "/api/admin/queue/settings",
+        json={"model_chain": ["m" * 201]},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for oversized model_chain item, got {res.status_code}: {res.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_queue_settings_too_many_languages_returns_422(admin_client, admin_db):
+    """Regression #531: auto_translate_languages list > 50 items must return 422."""
+    res = await admin_client.put(
+        "/api/admin/queue/settings",
+        json={"auto_translate_languages": ["en"] * 51},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for too many languages, got {res.status_code}: {res.text}"
+    )


### PR DESCRIPTION
## Summary
- `auto_translate_languages` items now capped at 20 chars; list size capped at 50
- `model_chain` items now capped at 200 chars; list size capped at 20

## Test plan
- [x] 3 regression tests: oversized language item → 422, oversized model_chain item → 422, too many languages → 422

Closes #531
