### PR TITLE
fix: add max_length to auth request token and name fields

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from services.auth import verify_google_id_token, verify_apple_id_token, verify_github_access_token, create_jwt
 from services.db import get_or_create_user, get_or_create_user_github, get_or_create_user_apple
 
@@ -22,7 +22,7 @@ def _user_response(user: dict) -> dict:
 
 
 class GoogleAuthRequest(BaseModel):
-    id_token: str
+    id_token: str = Field(..., max_length=2000)
 
 
 @router.post("/google")
@@ -43,7 +43,7 @@ async def google_login(req: GoogleAuthRequest):
 
 
 class GitHubAuthRequest(BaseModel):
-    access_token: str
+    access_token: str = Field(..., max_length=500)
 
 
 @router.post("/github")
@@ -69,8 +69,8 @@ async def github_login(req: GitHubAuthRequest):
 
 
 class AppleAuthRequest(BaseModel):
-    id_token: str
-    name: str = ""
+    id_token: str = Field(..., max_length=2000)
+    name: str = Field(default="", max_length=500)
 
 
 @router.post("/apple")

--- a/backend/tests/test_router_auth.py
+++ b/backend/tests/test_router_auth.py
@@ -107,3 +107,42 @@ async def test_github_login_idempotent(client, tmp_db):
     assert resp1.status_code == 200
     assert resp2.status_code == 200
     assert resp1.json()["user"]["id"] == resp2.json()["user"]["id"]
+
+
+# ── Issue #537: auth token field bounds ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_google_login_oversized_id_token_returns_422(client):
+    """Regression #537: POST /auth/google with id_token > 2000 chars must return 422."""
+    resp = await client.post("/api/auth/google", json={"id_token": "x" * 2001})
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized Google id_token, got {resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_github_login_oversized_access_token_returns_422(client):
+    """Regression #537: POST /auth/github with access_token > 500 chars must return 422."""
+    resp = await client.post("/api/auth/github", json={"access_token": "g" * 501})
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized GitHub access_token, got {resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_apple_login_oversized_id_token_returns_422(client):
+    """Regression #537: POST /auth/apple with id_token > 2000 chars must return 422."""
+    resp = await client.post("/api/auth/apple", json={"id_token": "a" * 2001, "name": "Alice"})
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized Apple id_token, got {resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_apple_login_oversized_name_returns_422(client):
+    """Regression #537: POST /auth/apple with name > 500 chars must return 422."""
+    resp = await client.post("/api/auth/apple", json={"id_token": "valid-tok", "name": "N" * 501})
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized Apple name, got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## Summary
- Added `Field(max_length=2000)` to `GoogleAuthRequest.id_token`
- Added `Field(max_length=500)` to `GitHubAuthRequest.access_token`
- Added `Field(max_length=2000)` to `AppleAuthRequest.id_token`
- Added `Field(max_length=500)` to `AppleAuthRequest.name`

Oversized tokens are now rejected at the Pydantic layer before hitting external OAuth APIs.

## Test plan
- [x] 4 regression tests: oversized Google/GitHub/Apple tokens and Apple name → 422

Closes #537
