### PR TITLE
fix: strip SQL line comments before splitting on semicolons (closes #544)

### DIFF
--- a/backend/services/migrations.py
+++ b/backend/services/migrations.py
@@ -18,6 +18,7 @@ This module has no external dependencies beyond `aiosqlite`.
 """
 
 import os
+import re
 import aiosqlite
 
 
@@ -147,10 +148,12 @@ async def run(db_path: str) -> list[str]:
                 continue
 
             # Apply each statement in the migration file inside one transaction.
-            # We split on `;` (with a trailing strip) because aiosqlite's
-            # execute() only runs one statement at a time.
+            # We split on `;` because aiosqlite's execute() only runs one
+            # statement at a time. Strip -- line comments first so semicolons
+            # inside comments don't produce spurious empty/invalid fragments.
             try:
-                for statement in sql.split(";"):
+                sql_no_comments = re.sub(r"--[^\n]*", "", sql)
+                for statement in sql_no_comments.split(";"):
                     stmt = statement.strip()
                     if stmt:
                         await db.execute(stmt)

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -778,3 +778,33 @@ async def test_missing_migrations_dir_returns_empty(tmp_db, monkeypatch):
             "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations'"
         ) as cursor:
             assert await cursor.fetchone() is not None
+
+
+# ── Semicolon inside SQL comment (issue #544) ────────────────────────────────
+
+async def test_semicolon_in_sql_comment_does_not_break_migration(tmp_db, tmp_migrations, monkeypatch):
+    """Regression #544: sql.split(';') naively splits on semicolons inside
+    -- line comments, producing invalid SQL fragments that crash the runner.
+
+    Example: a comment like '-- backfill script available; run manually' causes
+    the runner to try to execute ' run manually' as a statement."""
+    sql = (
+        "-- Creates the test table; run this before adding rows.\n"
+        "CREATE TABLE semicolon_test (\n"
+        "    id INTEGER PRIMARY KEY,\n"
+        "    name TEXT NOT NULL\n"
+        ");\n"
+        "-- Also insert a default row; ensures schema is populated.\n"
+        "INSERT INTO semicolon_test (id, name) VALUES (1, 'hello');\n"
+    )
+    (open(os.path.join(tmp_migrations, "001_semicolon_comment.sql"), "w")).write(sql)
+
+    monkeypatch.setattr("services.migrations._MIGRATIONS_DIR", tmp_migrations)
+    applied = await run_migrations(tmp_db)
+    assert "001_semicolon_comment" in applied
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute("SELECT name FROM semicolon_test WHERE id=1") as cursor:
+            row = await cursor.fetchone()
+    assert row is not None
+    assert row[0] == "hello"


### PR DESCRIPTION
## What

`services/migrations.py` split migration SQL on `;` without first stripping `--` line comments. A comment like `-- backfill script available; run manually` produced the fragment `run manually` as a standalone SQL statement, crashing with a syntax error.

## Why it matters

Migration 023 (EPUB feature, pending merge) contains a `;` inside a `--` comment. Any migration file with such a comment will fail to apply, breaking backend startup.

## Fix

Strip all `--` line comments with `re.sub(r"--[^\n]*", "", sql)` before splitting on `;`.

## Test plan

- [x] New regression test `test_semicolon_in_sql_comment_does_not_break_migration` creates a migration with `;` in two comment lines and verifies it applies cleanly (was failing before fix)
- [x] All 22 migration tests pass
- [x] Full backend suite: 910 passed

Closes #544
