### PR TITLE
feat: add GET /admin/uploads endpoint for uploaded books panel (closes #432)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1289,3 +1289,43 @@ async def queue_enqueue_all(admin: dict = Depends(_require_admin)):
         total += await enqueue_for_book(b["id"], target_languages=langs, queued_by=by)
     queue_worker().wake()
     return {"ok": True, "enqueued": total, "books_scanned": len(books)}
+
+
+@router.get("/uploads")
+async def get_uploads(
+    user_id: int | None = Query(default=None),
+    _admin: dict = Depends(_require_admin),
+):
+    """Return all user-uploaded books with uploader information.
+
+    Optionally filter by user_id.
+    """
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        if user_id is not None:
+            async with db.execute(
+                """
+                SELECT bu.book_id, b.title, bu.filename, bu.file_size, bu.format,
+                       bu.uploaded_at, u.email AS uploader_email, u.name AS uploader_name
+                FROM book_uploads bu
+                JOIN books b ON b.id = bu.book_id
+                JOIN users u ON u.id = bu.user_id
+                WHERE bu.user_id = ?
+                ORDER BY bu.uploaded_at DESC
+                """,
+                (user_id,),
+            ) as cursor:
+                rows = await cursor.fetchall()
+        else:
+            async with db.execute(
+                """
+                SELECT bu.book_id, b.title, bu.filename, bu.file_size, bu.format,
+                       bu.uploaded_at, u.email AS uploader_email, u.name AS uploader_name
+                FROM book_uploads bu
+                JOIN books b ON b.id = bu.book_id
+                JOIN users u ON u.id = bu.user_id
+                ORDER BY bu.uploaded_at DESC
+                """,
+            ) as cursor:
+                rows = await cursor.fetchall()
+    return [dict(row) for row in rows]

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -2182,3 +2182,73 @@ async def test_queue_settings_too_many_languages_returns_422(admin_client, admin
     assert res.status_code == 422, (
         f"Expected 422 for too many languages, got {res.status_code}: {res.text}"
     )
+
+
+# ── Admin uploads panel (issue #432) ─────────────────────────────────────────
+
+async def test_get_uploads_returns_empty_list(admin_client, admin_db):
+    """GET /admin/uploads returns [] when no books have been uploaded."""
+    res = await admin_client.get("/api/admin/uploads")
+    assert res.status_code == 200
+    assert res.json() == []
+
+
+async def test_get_uploads_returns_uploaded_books(admin_client, admin_db, admin_user):
+    """GET /admin/uploads returns upload records with book and uploader info."""
+    async with aiosqlite.connect(admin_db) as db:
+        await db.execute(
+            "INSERT INTO books (id, title, source, owner_user_id) VALUES (200, 'Uploaded Novel', 'upload', ?)",
+            (admin_user["id"],),
+        )
+        await db.execute(
+            "INSERT INTO book_uploads (book_id, user_id, filename, file_size, format) "
+            "VALUES (200, ?, 'novel.epub', 102400, 'epub')",
+            (admin_user["id"],),
+        )
+        await db.commit()
+
+    res = await admin_client.get("/api/admin/uploads")
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data) == 1
+    row = data[0]
+    assert row["book_id"] == 200
+    assert row["title"] == "Uploaded Novel"
+    assert row["filename"] == "novel.epub"
+    assert row["file_size"] == 102400
+    assert row["uploader_email"] == admin_user["email"]
+
+
+async def test_get_uploads_filter_by_user(admin_client, admin_db, admin_user):
+    """GET /admin/uploads?user_id=N returns only that user's uploads."""
+    async with aiosqlite.connect(admin_db) as db:
+        await db.execute(
+            "INSERT INTO users (google_id, email, name, picture) VALUES ('other-g', 'other@test.com', 'Other', '')"
+        )
+        async with db.execute("SELECT id FROM users WHERE google_id='other-g'") as cur:
+            other_id = (await cur.fetchone())[0]
+        await db.execute(
+            "INSERT INTO books (id, title, source, owner_user_id) VALUES (201, 'Admin Book', 'upload', ?)",
+            (admin_user["id"],),
+        )
+        await db.execute(
+            "INSERT INTO book_uploads (book_id, user_id, filename, file_size, format) "
+            "VALUES (201, ?, 'admin.epub', 1024, 'epub')",
+            (admin_user["id"],),
+        )
+        await db.execute(
+            "INSERT INTO books (id, title, source, owner_user_id) VALUES (202, 'Other Book', 'upload', ?)",
+            (other_id,),
+        )
+        await db.execute(
+            "INSERT INTO book_uploads (book_id, user_id, filename, file_size, format) "
+            "VALUES (202, ?, 'other.epub', 2048, 'epub')",
+            (other_id,),
+        )
+        await db.commit()
+
+    res = await admin_client.get(f"/api/admin/uploads?user_id={admin_user['id']}")
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data) == 1
+    assert data[0]["book_id"] == 201


### PR DESCRIPTION
## What

Adds `GET /api/admin/uploads` — a new admin endpoint that lists all user-uploaded books together with uploader name and email. Supports an optional `?user_id=N` query param for per-user filtering.

## Response shape

```json
[
  {
    "book_id": 200,
    "title": "Uploaded Novel",
    "filename": "novel.epub",
    "file_size": 102400,
    "format": "epub",
    "uploaded_at": "2026-04-23T10:00:00",
    "uploader_email": "user@example.com",
    "uploader_name": "User Name"
  }
]
```

## Why

Admin panel had no way to view or manage user-uploaded books. This endpoint provides the data foundation for the uploads tab.

## Test plan

- [x] `test_get_uploads_returns_empty_list` — 200 + `[]` when no uploads
- [x] `test_get_uploads_returns_uploaded_books` — correct book_id, title, filename, file_size, uploader_email
- [x] `test_get_uploads_filter_by_user` — `?user_id=N` returns only that user's uploads
- [x] Full backend suite: 913 passed

Closes #432
