### PR TITLE
feat: store Gutenberg EPUBs in DB for reliable chapter splitting

### DIFF
--- a/backend/migrations/023_book_epubs.sql
+++ b/backend/migrations/023_book_epubs.sql
@@ -1,7 +1,7 @@
 -- Stores the downloaded EPUB binary for each Gutenberg book.
 -- Used by split_with_html_preference as the primary chapter source
 -- (preferred over on-demand HTML fetch and plain-text regex splitting).
--- Populated at book-add time for new books; backfill script available
+-- Populated at book-add time for new books. Backfill script available
 -- for books already in the DB.
 CREATE TABLE IF NOT EXISTS book_epubs (
     book_id    INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE,

--- a/backend/migrations/023_book_epubs.sql
+++ b/backend/migrations/023_book_epubs.sql
@@ -1,0 +1,11 @@
+-- Stores the downloaded EPUB binary for each Gutenberg book.
+-- Used by split_with_html_preference as the primary chapter source
+-- (preferred over on-demand HTML fetch and plain-text regex splitting).
+-- Populated at book-add time for new books; backfill script available
+-- for books already in the DB.
+CREATE TABLE IF NOT EXISTS book_epubs (
+    book_id    INTEGER PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE,
+    epub_url   TEXT    NOT NULL DEFAULT '',
+    epub_bytes BLOB    NOT NULL,
+    cached_at  TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);

--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -7,13 +7,14 @@ from typing import AsyncIterator
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
-from services.gutenberg import search_books, get_book_meta, get_book_text, get_book_html
+from services.gutenberg import search_books, get_book_meta, get_book_text, get_book_epub
 from services.db import (
     get_cached_book,
     save_book,
+    save_book_epub,
     list_cached_books,
 )
-from services.splitter import build_chapters, build_chapters_from_html
+from services.splitter import build_chapters
 from services.auth import get_current_user, get_optional_user, decrypt_api_key, check_book_access
 
 logger = logging.getLogger(__name__)
@@ -505,7 +506,20 @@ async def _fetch_and_cache(book_id: int) -> tuple[dict, str]:
     meta = await get_book_meta(book_id)
     text = await get_book_text(book_id)
     await save_book(book_id, meta, text)
+    # Fetch EPUB in background so book-add stays snappy.
+    asyncio.create_task(_fetch_and_store_epub(book_id))
     return meta, text
+
+
+async def _fetch_and_store_epub(book_id: int) -> None:
+    try:
+        result = await get_book_epub(book_id)
+        if result:
+            epub_bytes, epub_url = result
+            await save_book_epub(book_id, epub_bytes, epub_url)
+            logger.info("EPUB cached for book %d (%d KB)", book_id, len(epub_bytes) // 1024)
+    except Exception:
+        logger.debug("EPUB fetch failed for book %d (no EPUB edition available)", book_id)
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/backend/services/book_chapters.py
+++ b/backend/services/book_chapters.py
@@ -1,16 +1,15 @@
 """Shared chapter-list resolver used by BOTH the reader endpoint and the
 translation queue worker.
 
-Previously the reader used a (cached) HTML-preferring splitter, while the
-queue worker called `build_chapters(text)` directly. For books where the
-two splitters produced different chapter lists (plays / drama like Faust,
-or any book where `<div class="chapter">` markup differs from what
-heading-regex finds in plain text), the worker would translate chapter
-indices that DON'T correspond to what the reader is displaying — off-by-
-one visible to users from the first divergent chapter onward.
+Priority (all DB-only, no external fetches at chapter-load time):
+  1. Pre-split JSON  — uploaded books that store chapters as structured JSON.
+  2. Stored EPUB     — preferred for Gutenberg books: explicit spine/TOC gives
+                       clean paragraph boundaries and reliable titles.
+  3. Plain-text regex fallback — for Gutenberg books with no EPUB available.
 
-This module is the one place both call sites share to get the canonical
-Chapter list for a book.
+New Gutenberg books have their EPUB fetched and stored at add-time.
+Existing books (pre-EPUB feature) get their EPUB fetched in a background
+task on first chapter access, becoming available on the next cold start.
 """
 
 from __future__ import annotations
@@ -20,55 +19,38 @@ import json
 import logging
 from collections import defaultdict
 
-from services.gutenberg import get_book_html
-from services.splitter import Chapter, build_chapters, build_chapters_from_html
+from services.splitter import Chapter, build_chapters, build_chapters_from_epub
 
 logger = logging.getLogger(__name__)
 
-# In-memory cache keyed by book_id. Populated on first split after each
-# process restart; every subsequent call returns the cached list. The
-# reader previously had its own cache in routers/books.py — merged here
-# so reader + worker share the same result.
 _chapter_cache: dict[int, list[Chapter]] = {}
-
-# One lock per book_id: serializes concurrent cache-miss requests so the
-# second waiter reuses the result written by the first instead of running
-# a different split path and returning a divergent chapter list.
 _split_locks: dict[int, asyncio.Lock] = defaultdict(asyncio.Lock)
+
+# Track books for which a background EPUB fetch has already been fired this
+# process lifetime so we don't hammer Gutenberg on every chapter request.
+_epub_fetch_attempted: set[int] = set()
 
 
 async def split_with_html_preference(book_id: int, text: str) -> list[Chapter]:
-    """Return the canonical chapter list for a book.
+    """Return the canonical chapter list for a book (DB-only, no external calls).
 
-    Strategy:
-      1. Try Gutenberg's HTML edition — much cleaner on books with nested
-         structure (War and Peace, Faust drama, etc.).
-      2. Fall back to the plain-text splitter if HTML isn't available,
-         fails, or produces fewer than 2 chapters.
-
-    CPU-heavy work runs on a thread so the event loop stays responsive.
+    The name is kept for backwards compatibility with call sites.
     """
     cached = _chapter_cache.get(book_id)
     if cached is not None:
         return cached
 
     async with _split_locks[book_id]:
-        # Double-check: a concurrent request may have populated the cache
-        # while we were waiting for the lock.
         cached = _chapter_cache.get(book_id)
         if cached is not None:
             return cached
 
-        # Uploaded books store chapters as JSON, not raw text.
-        # Detect and return pre-split chapters directly to avoid feeding
-        # JSON to the Gutenberg HTML / regex splitter.
+        # ── 1. Uploaded books: pre-split JSON ─────────────────────────────────
         if text and text.lstrip().startswith("{"):
             try:
                 data = json.loads(text)
                 if "chapters" in data:
                     if data.get("draft"):
-                        # Draft: not yet confirmed — no translatable chapters.
-                        # Do NOT cache; the caller should reject draft books explicitly.
                         return []
                     chapters: list[Chapter] = [
                         Chapter(title=ch["title"], text=ch["text"])
@@ -77,28 +59,53 @@ async def split_with_html_preference(book_id: int, text: str) -> list[Chapter]:
                     _chapter_cache[book_id] = chapters
                     return chapters
             except (ValueError, KeyError, TypeError):
-                pass  # not a valid uploaded-book JSON — fall through to normal split
+                pass
 
+        # ── 2. Stored EPUB (Gutenberg books) ──────────────────────────────────
         try:
-            html = await get_book_html(book_id)
-            if html:
-                chapters = await asyncio.to_thread(build_chapters_from_html, html)
+            from services.db import get_book_epub_bytes
+            epub_bytes = await get_book_epub_bytes(book_id)
+            if epub_bytes:
+                chapters = await asyncio.to_thread(build_chapters_from_epub, epub_bytes)
                 if len(chapters) >= 2:
                     _chapter_cache[book_id] = chapters
                     return chapters
+            elif book_id not in _epub_fetch_attempted:
+                # Existing book with no EPUB yet — fetch silently in background.
+                # Current request falls through to plain-text; EPUB available next restart.
+                _epub_fetch_attempted.add(book_id)
+                asyncio.create_task(_background_fetch_epub(book_id))
         except Exception:
-            logger.exception(
-                "HTML split failed for book %s, falling back to text", book_id,
-            )
+            logger.exception("EPUB split failed for book %s, falling back to text", book_id)
 
+        # ── 3. Plain-text regex fallback ──────────────────────────────────────
         chapters = await asyncio.to_thread(build_chapters, text)
         _chapter_cache[book_id] = chapters
         return chapters
 
 
+async def _background_fetch_epub(book_id: int) -> None:
+    """Fetch and store EPUB for a pre-existing Gutenberg book (fire-and-forget).
+
+    Does not update the in-memory chapter cache — stored EPUB becomes
+    available on the next cold start.
+    """
+    try:
+        from services.gutenberg import get_book_epub
+        from services.db import save_book_epub
+        result = await get_book_epub(book_id)
+        if result:
+            epub_bytes, epub_url = result
+            await save_book_epub(book_id, epub_bytes, epub_url)
+            logger.info(
+                "Background EPUB cached for book %d (%d KB)", book_id, len(epub_bytes) // 1024
+            )
+    except Exception:
+        logger.debug("Background EPUB fetch failed for book %d", book_id, exc_info=True)
+
+
 def clear_cache(book_id: int | None = None) -> None:
-    """Invalidate cached chapter list. Called from admin book-delete
-    and retranslate paths so stale chapter indices don't linger."""
+    """Invalidate cached chapter list."""
     if book_id is None:
         _chapter_cache.clear()
     else:

--- a/backend/services/book_parser.py
+++ b/backend/services/book_parser.py
@@ -106,51 +106,23 @@ def parse_txt(content: str) -> dict[str, Any]:
 
 
 def parse_epub(file_bytes: bytes) -> dict[str, Any]:
-    """Parse epub file. Returns {title, author, chapters: [{title, text}]}."""
+    """Parse epub file. Returns {title, author, chapters: [{title, text}]}.
+
+    Delegates to build_chapters_from_epub() for consistent spine-ordered,
+    NCX-titled extraction shared with the Gutenberg ingestion path.
+    """
     try:
-        import ebooklib
+        from services.splitter import build_chapters_from_epub
         from ebooklib import epub
-        from html.parser import HTMLParser
 
-        class _TextExtractor(HTMLParser):
-            def __init__(self):
-                super().__init__()
-                self.text_parts: list[str] = []
-                self._skip = False
-
-            def handle_starttag(self, tag, attrs):
-                if tag in ('script', 'style'):
-                    self._skip = True
-
-            def handle_endtag(self, tag):
-                if tag in ('script', 'style'):
-                    self._skip = False
-                if tag in ('p', 'div', 'br', 'h1', 'h2', 'h3', 'h4'):
-                    self.text_parts.append('\n')
-
-            def handle_data(self, data):
-                if not self._skip:
-                    self.text_parts.append(data)
-
-            def get_text(self) -> str:
-                return ''.join(self.text_parts)
-
-        book = epub.read_epub(io.BytesIO(file_bytes))
-
-        title = book.get_metadata('DC', 'title')
-        title = title[0][0] if title else "Untitled"
-        author_meta = book.get_metadata('DC', 'creator')
+        book_epub = epub.read_epub(io.BytesIO(file_bytes), options={"ignore_ncx": False})
+        dc_title = book_epub.get_metadata("DC", "title")
+        title = dc_title[0][0] if dc_title else "Untitled"
+        author_meta = book_epub.get_metadata("DC", "creator")
         author = author_meta[0][0] if author_meta else "Unknown"
 
-        chapters = []
-        for item in book.get_items_of_type(ebooklib.ITEM_DOCUMENT):
-            extractor = _TextExtractor()
-            extractor.feed(item.get_content().decode('utf-8', errors='replace'))
-            text = extractor.get_text().strip()
-            if len(text) < 50:  # skip very short items (nav, cover pages)
-                continue
-            ch_title = item.get_name().split('/')[-1].replace('.xhtml', '').replace('.html', '')
-            chapters.append({"title": ch_title, "text": text})
+        chapters_obj = build_chapters_from_epub(file_bytes)
+        chapters = [{"title": c.title, "text": c.text} for c in chapters_obj]
 
         return {"title": title, "author": author, "chapters": chapters[:MAX_CHAPTERS]}
 

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -487,6 +487,32 @@ async def save_book(book_id: int, meta: dict, text: str, images: list | None = N
 
 
 
+
+# ── EPUB cache ────────────────────────────────────────────────────────────────
+
+async def save_book_epub(book_id: int, epub_bytes: bytes, epub_url: str = "") -> None:
+    """Persist downloaded EPUB bytes for a Gutenberg book."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            """
+            INSERT OR REPLACE INTO book_epubs (book_id, epub_url, epub_bytes)
+            VALUES (?, ?, ?)
+            """,
+            (book_id, epub_url, epub_bytes),
+        )
+        await db.commit()
+
+
+async def get_book_epub_bytes(book_id: int) -> bytes | None:
+    """Return stored EPUB bytes for a book, or None if not cached."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "SELECT epub_bytes FROM book_epubs WHERE book_id = ?", (book_id,)
+        ) as cur:
+            row = await cur.fetchone()
+    return row[0] if row else None
+
+
 # ── App settings (key/value config used by the always-on queue, etc.) ────────
 
 async def get_setting(key: str) -> str | None:

--- a/backend/services/gutenberg.py
+++ b/backend/services/gutenberg.py
@@ -94,6 +94,43 @@ async def get_book_html(book_id: int) -> str | None:
     return None
 
 
+
+async def get_book_epub(book_id: int) -> tuple[bytes, str] | None:
+    """Download the no-images EPUB from Gutenberg, if available.
+
+    Returns (epub_bytes, epub_url) or None when no EPUB edition exists.
+    Prefers the no-images variant to minimise download size (~80-300 KB).
+    """
+    try:
+        async with httpx.AsyncClient(timeout=15, follow_redirects=True) as client:
+            resp = await client.get(f"{GUTENBERG_SEARCH}/{book_id}")
+            resp.raise_for_status()
+            formats = resp.json().get("formats", {})
+    except Exception:
+        return None
+
+    epub_url = ""
+    for key, url in formats.items():
+        if "epub" in key.lower():
+            if "noimages" in url:
+                epub_url = url
+                break
+            elif not epub_url:
+                epub_url = url
+
+    if not epub_url:
+        return None
+
+    try:
+        async with httpx.AsyncClient(timeout=60, follow_redirects=True) as client:
+            resp = await client.get(epub_url)
+            if resp.status_code == 200:
+                return resp.content, epub_url
+    except Exception:
+        return None
+    return None
+
+
 async def get_book_text(book_id: int) -> str:
     """Download the plain-text version of a Gutenberg book.
 

--- a/backend/services/splitter.py
+++ b/backend/services/splitter.py
@@ -595,7 +595,9 @@ def build_chapters_from_epub(epub_bytes: bytes) -> list[Chapter]:
         )
         chapters.append(Chapter(title=_clean_title(title), text=text))
 
-    return _validate(chapters) or []
+    # EPUB spine is authoritative structure, not a heuristic guess.
+    # Skip the regex-oriented _validate() and just require >= 2 chapters.
+    return chapters if len(chapters) >= 2 else []
 
 
 def _epub_nav_titles(book) -> dict[str, str]:

--- a/backend/services/splitter.py
+++ b/backend/services/splitter.py
@@ -532,6 +532,126 @@ def _html_body_text(
     return "\n\n".join(parts)
 
 
+
+# ── EPUB-based splitter ──────────────────────────────────────────────────────
+
+def build_chapters_from_epub(epub_bytes: bytes) -> list[Chapter]:
+    """Extract chapters from a Gutenberg EPUB using spine order and NCX/nav titles.
+
+    Returns [] on any failure so callers fall through gracefully.
+    """
+    try:
+        import io
+        import ebooklib
+        from ebooklib import epub as epublib
+        from lxml import html as lxmlhtml
+    except ImportError:
+        return []
+
+    try:
+        book = epublib.read_epub(io.BytesIO(epub_bytes), options={"ignore_ncx": False})
+    except Exception:
+        return []
+
+    nav_titles = _epub_nav_titles(book)
+    id_to_item = {
+        item.get_id(): item
+        for item in book.get_items_of_type(ebooklib.ITEM_DOCUMENT)
+    }
+
+    _SKIP_SUFFIXES = {
+        "nav.xhtml", "nav.html", "cover.xhtml", "cover.html",
+        "toc.xhtml", "toc.html", "title.xhtml", "titlepage.xhtml",
+        "halftitle.xhtml", "copyright.xhtml", "dedication.xhtml",
+        "colophon.xhtml", "index.xhtml",
+    }
+
+    chapters: list[Chapter] = []
+    for item_id, _ in book.spine:
+        item = id_to_item.get(item_id)
+        if item is None:
+            continue
+        basename = item.get_name().split("/")[-1].lower()
+        if basename in _SKIP_SUFFIXES:
+            continue
+
+        raw = item.get_content()
+        try:
+            doc = lxmlhtml.fromstring(raw)
+            body = doc.find(".//body")
+            if body is None:
+                body = doc
+            text = _html_body_text(body, skip_first_heading=True)
+        except Exception:
+            continue
+
+        if not text.strip() or len(text.split()) < 30:
+            continue
+
+        title = (
+            nav_titles.get(item_id)
+            or _epub_heading_title(raw)
+            or f"Section {len(chapters) + 1}"
+        )
+        chapters.append(Chapter(title=_clean_title(title), text=text))
+
+    return _validate(chapters) or []
+
+
+def _epub_nav_titles(book) -> dict[str, str]:
+    """Return {item_id: chapter_title} from the EPUB TOC (NCX or EPUB3 nav)."""
+    import ebooklib
+
+    name_to_id: dict[str, str] = {
+        item.get_name(): item.get_id()
+        for item in book.get_items_of_type(ebooklib.ITEM_DOCUMENT)
+    }
+
+    titles: dict[str, str] = {}
+
+    def _resolve(href: str) -> str | None:
+        bare = href.split("#")[0].lstrip("/")
+        if bare in name_to_id:
+            return name_to_id[bare]
+        for name, item_id in name_to_id.items():
+            if name.endswith("/" + bare) or name == bare:
+                return item_id
+        return None
+
+    def _walk(toc_items) -> None:
+        for entry in toc_items:
+            if isinstance(entry, tuple):
+                section, children = entry
+                if getattr(section, "href", None):
+                    item_id = _resolve(section.href)
+                    if item_id and getattr(section, "title", None):
+                        titles.setdefault(item_id, section.title)
+                _walk(children)
+            elif getattr(entry, "href", None):
+                item_id = _resolve(entry.href)
+                if item_id and getattr(entry, "title", None):
+                    titles.setdefault(item_id, entry.title)
+
+    _walk(book.toc)
+    return titles
+
+
+def _epub_heading_title(raw_xhtml: bytes) -> str:
+    """Extract the first heading from XHTML as a fallback chapter title."""
+    try:
+        from lxml import html as lxmlhtml
+        doc = lxmlhtml.fromstring(raw_xhtml)
+        for tag in ("h1", "h2", "h3", "h4"):
+            elems = doc.findall(f".//{tag}")
+            if elems:
+                text = " ".join(elems[0].itertext()).strip()
+                if text:
+                    return text
+    except Exception:
+        pass
+    return ""
+
+
 # Dramatic speaker cue: an all-caps label that introduces a speaker's
 # lines in plays (BÜRGERMÄDCHEN., ZWEITER SCHÜLER (zum ersten).,
 # ANDRER BÜRGER., FAUST, MEPHISTOPHELES, IRRLICHT (im Wechselgesang).

--- a/backend/tests/test_book_chapters.py
+++ b/backend/tests/test_book_chapters.py
@@ -18,42 +18,45 @@ def _make_chapters(*titles: str) -> list[Chapter]:
 
 @pytest.fixture(autouse=True)
 def clear_chapter_cache():
-    """Start each test with an empty chapter cache."""
+    """Start each test with an empty chapter cache and fetch-attempted set."""
     clear_cache()
+    book_chapters_module._epub_fetch_attempted.clear()
     yield
     clear_cache()
+    book_chapters_module._epub_fetch_attempted.clear()
 
 
-# ── HTML path ─────────────────────────────────────────────────────────────────
+# ── EPUB path ─────────────────────────────────────────────────────────────────
 
-async def test_uses_html_when_available_and_has_two_or_more_chapters():
-    html_chapters = _make_chapters("Chapter 1", "Chapter 2", "Chapter 3")
+async def test_uses_epub_when_available_and_has_two_or_more_chapters():
+    epub_chapters = _make_chapters("Chapter 1", "Chapter 2", "Chapter 3")
     with (
-        patch("services.book_chapters.get_book_html", new_callable=AsyncMock, return_value="<html>...</html>"),
-        patch("services.book_chapters.build_chapters_from_html", return_value=html_chapters),
+        patch("services.db.get_book_epub_bytes", new_callable=AsyncMock, return_value=b"fake_epub"),
+        patch("services.book_chapters.build_chapters_from_epub", return_value=epub_chapters),
         patch("services.book_chapters.build_chapters") as mock_text,
     ):
         result = await split_with_html_preference(1, "plain text")
-    assert result == html_chapters
+    assert result == epub_chapters
     mock_text.assert_not_called()
 
 
-async def test_falls_back_to_text_when_html_produces_only_one_chapter():
-    html_chapters = _make_chapters("Only One")
+async def test_falls_back_to_text_when_epub_produces_only_one_chapter():
+    epub_chapters = _make_chapters("Only One")
     text_chapters = _make_chapters("Part 1", "Part 2")
     with (
-        patch("services.book_chapters.get_book_html", new_callable=AsyncMock, return_value="<html>...</html>"),
-        patch("services.book_chapters.build_chapters_from_html", return_value=html_chapters),
+        patch("services.db.get_book_epub_bytes", new_callable=AsyncMock, return_value=b"fake_epub"),
+        patch("services.book_chapters.build_chapters_from_epub", return_value=epub_chapters),
         patch("services.book_chapters.build_chapters", return_value=text_chapters),
     ):
         result = await split_with_html_preference(2, "plain text")
     assert result == text_chapters
 
 
-async def test_falls_back_when_html_fetch_returns_none():
+async def test_falls_back_when_epub_bytes_is_none():
     text_chapters = _make_chapters("Chapter A", "Chapter B")
     with (
-        patch("services.book_chapters.get_book_html", new_callable=AsyncMock, return_value=None),
+        patch("services.db.get_book_epub_bytes", new_callable=AsyncMock, return_value=None),
+        patch("services.book_chapters._background_fetch_epub", new_callable=AsyncMock),
         patch("services.book_chapters.build_chapters", return_value=text_chapters) as mock_text,
     ):
         result = await split_with_html_preference(3, "plain text")
@@ -61,21 +64,21 @@ async def test_falls_back_when_html_fetch_returns_none():
     mock_text.assert_called_once()
 
 
-async def test_falls_back_when_html_fetch_raises():
+async def test_falls_back_when_epub_raises():
     text_chapters = _make_chapters("Fallback 1", "Fallback 2")
     with (
-        patch("services.book_chapters.get_book_html", new_callable=AsyncMock, side_effect=Exception("network error")),
+        patch("services.db.get_book_epub_bytes", new_callable=AsyncMock, side_effect=Exception("db error")),
         patch("services.book_chapters.build_chapters", return_value=text_chapters),
     ):
         result = await split_with_html_preference(4, "plain text")
     assert result == text_chapters
 
 
-async def test_falls_back_when_html_parse_raises():
-    text_chapters = _make_chapters("Parse Fallback")
+async def test_falls_back_when_epub_parse_raises():
+    text_chapters = _make_chapters("Parse Fallback 1", "Parse Fallback 2")
     with (
-        patch("services.book_chapters.get_book_html", new_callable=AsyncMock, return_value="<bad html>"),
-        patch("services.book_chapters.build_chapters_from_html", side_effect=Exception("parse error")),
+        patch("services.db.get_book_epub_bytes", new_callable=AsyncMock, return_value=b"bad_epub"),
+        patch("services.book_chapters.build_chapters_from_epub", side_effect=Exception("parse error")),
         patch("services.book_chapters.build_chapters", return_value=text_chapters),
     ):
         result = await split_with_html_preference(5, "plain text")
@@ -87,22 +90,23 @@ async def test_falls_back_when_html_parse_raises():
 async def test_cache_hit_skips_subsequent_calls():
     chapters = _make_chapters("Ch 1", "Ch 2")
     with (
-        patch("services.book_chapters.get_book_html", new_callable=AsyncMock, return_value="<html>") as mock_html,
-        patch("services.book_chapters.build_chapters_from_html", return_value=chapters),
+        patch("services.db.get_book_epub_bytes", new_callable=AsyncMock, return_value=b"fake_epub") as mock_epub,
+        patch("services.book_chapters.build_chapters_from_epub", return_value=chapters),
     ):
         first = await split_with_html_preference(10, "text")
         second = await split_with_html_preference(10, "text")
 
     assert first is second
-    # HTML was only fetched once
-    assert mock_html.call_count == 1
+    # EPUB bytes only fetched once
+    assert mock_epub.call_count == 1
 
 
 async def test_different_books_are_cached_independently():
     c1 = _make_chapters("Book1 Ch1", "Book1 Ch2")
     c2 = _make_chapters("Book2 Ch1", "Book2 Ch2")
     with (
-        patch("services.book_chapters.get_book_html", new_callable=AsyncMock, return_value=None),
+        patch("services.db.get_book_epub_bytes", new_callable=AsyncMock, return_value=None),
+        patch("services.book_chapters._background_fetch_epub", new_callable=AsyncMock),
         patch("services.book_chapters.build_chapters", side_effect=[c1, c2]),
     ):
         r1 = await split_with_html_preference(11, "text1")
@@ -118,7 +122,8 @@ async def test_clear_cache_by_book_id_forces_re_split():
     chapters_v1 = _make_chapters("Original Ch")
     chapters_v2 = _make_chapters("Updated Ch 1", "Updated Ch 2")
     with (
-        patch("services.book_chapters.get_book_html", new_callable=AsyncMock, return_value=None),
+        patch("services.db.get_book_epub_bytes", new_callable=AsyncMock, return_value=None),
+        patch("services.book_chapters._background_fetch_epub", new_callable=AsyncMock),
         patch("services.book_chapters.build_chapters", side_effect=[chapters_v1, chapters_v2]),
     ):
         r1 = await split_with_html_preference(20, "original text")
@@ -132,14 +137,14 @@ async def test_clear_cache_by_book_id_forces_re_split():
 async def test_clear_cache_all_removes_all_books():
     chapters = _make_chapters("Ch1", "Ch2")
     with (
-        patch("services.book_chapters.get_book_html", new_callable=AsyncMock, return_value=None),
+        patch("services.db.get_book_epub_bytes", new_callable=AsyncMock, return_value=None),
+        patch("services.book_chapters._background_fetch_epub", new_callable=AsyncMock),
         patch("services.book_chapters.build_chapters", return_value=chapters),
     ):
         await split_with_html_preference(30, "text")
         await split_with_html_preference(31, "text")
 
     clear_cache()
-    # Both removed
     assert book_chapters_module._chapter_cache == {}
 
 
@@ -151,7 +156,8 @@ async def test_clear_cache_specific_does_not_affect_other_books():
     c1 = _make_chapters("Book A 1", "Book A 2")
     c2 = _make_chapters("Book B 1", "Book B 2")
     with (
-        patch("services.book_chapters.get_book_html", new_callable=AsyncMock, return_value=None),
+        patch("services.db.get_book_epub_bytes", new_callable=AsyncMock, return_value=None),
+        patch("services.book_chapters._background_fetch_epub", new_callable=AsyncMock),
         patch("services.book_chapters.build_chapters", side_effect=[c1, c2]),
     ):
         await split_with_html_preference(40, "text")
@@ -167,27 +173,28 @@ async def test_clear_cache_specific_does_not_affect_other_books():
 async def test_concurrent_calls_return_identical_chapter_list():
     """Two concurrent cache-miss calls must resolve to the same chapter list.
 
-    Without a lock, one call can take the HTML path (returning 3 chapters) and
-    the other can take the text-fallback path (returning 2 chapters), causing
+    Without a lock, one call could take the EPUB path (returning 3 chapters)
+    and the other the plain-text path (returning 2 chapters), causing
     translation index misalignment between the reader and the queue worker.
     """
-    html_chapters = _make_chapters("HTML Ch 1", "HTML Ch 2", "HTML Ch 3")
+    epub_chapters = _make_chapters("EPUB Ch 1", "EPUB Ch 2", "EPUB Ch 3")
     text_chapters = _make_chapters("Text Ch 1", "Text Ch 2")
 
     call_count = {"n": 0}
 
-    async def _slow_html_fetch(_book_id):
+    async def _slow_epub_fetch(_book_id):
         call_count["n"] += 1
         if call_count["n"] == 1:
-            # First caller: yield so the second caller enters before HTML arrives
+            # First caller: yield so the second caller enters before EPUB arrives
             await asyncio.sleep(0)
-            return "<html>...</html>"
-        # Second caller: HTML not available
+            return b"fake_epub"
+        # Second caller: no EPUB (would fall back to text)
         return None
 
     with (
-        patch("services.book_chapters.get_book_html", side_effect=_slow_html_fetch),
-        patch("services.book_chapters.build_chapters_from_html", return_value=html_chapters),
+        patch("services.db.get_book_epub_bytes", side_effect=_slow_epub_fetch),
+        patch("services.book_chapters.build_chapters_from_epub", return_value=epub_chapters),
+        patch("services.book_chapters._background_fetch_epub", new_callable=AsyncMock),
         patch("services.book_chapters.build_chapters", return_value=text_chapters),
     ):
         results = await asyncio.gather(

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -44,9 +44,9 @@ async def admin_db(monkeypatch, tmp_path):
     monkeypatch.setattr(db_module, "DB_PATH", path)
     monkeypatch.setattr(admin_module, "DB_PATH", path)
 
-    async def _no_html(_book_id):
-        return None
-    monkeypatch.setattr("services.book_chapters.get_book_html", _no_html)
+    from unittest.mock import AsyncMock as _AsyncMock
+    monkeypatch.setattr("services.db.get_book_epub_bytes", _AsyncMock(return_value=None))
+    monkeypatch.setattr("services.book_chapters._background_fetch_epub", _AsyncMock())
     from services.book_chapters import clear_cache as _clear_cache
     _clear_cache()
 

--- a/backend/tests/test_router_admin_extended.py
+++ b/backend/tests/test_router_admin_extended.py
@@ -65,9 +65,9 @@ async def admin_db(monkeypatch, tmp_path):
     monkeypatch.setattr(db_module, "DB_PATH", path)
     monkeypatch.setattr(admin_module, "DB_PATH", path)
 
-    async def _no_html(_book_id):
-        return None
-    monkeypatch.setattr("services.book_chapters.get_book_html", _no_html)
+    from unittest.mock import AsyncMock as _AsyncMock
+    monkeypatch.setattr("services.db.get_book_epub_bytes", _AsyncMock(return_value=None))
+    monkeypatch.setattr("services.book_chapters._background_fetch_epub", _AsyncMock())
     from services.book_chapters import clear_cache as _clear_cache
     _clear_cache()
 

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -740,13 +740,13 @@ async def test_chapter_queue_status_normalizes_language(client):
 
 # ── import-stream uses HTML splitter (issue #276) ─────────────────────────────
 
-async def test_import_stream_uses_html_splitter_chapter_count(client):
-    """import-stream must use split_with_html_preference, not build_chapters.
+async def test_import_stream_uses_epub_splitter_chapter_count(client):
+    """import-stream must use split_with_html_preference (EPUB path), not build_chapters.
 
-    When the HTML edition produces a different chapter count than the plain-text
+    When the EPUB edition produces a different chapter count than the plain-text
     splitter, the import dialog chapter count must match the reader (issue #276).
     Before the fix the stream called build_chapters(text) and returned 2;
-    after the fix it calls split_with_html_preference and returns 3.
+    after the fix it calls split_with_html_preference with EPUB and returns 3.
     """
     from unittest.mock import AsyncMock, patch
     from services.book_chapters import clear_cache
@@ -762,20 +762,16 @@ async def test_import_stream_uses_html_splitter_chapter_count(client):
     clear_cache(book_id)
     await save_book(book_id, meta, text)
 
-    # HTML that produces 3 chapters — different from the plain-text count.
-    # Each chapter body needs >= 50 words (tiny skip) and >= 100 words
-    # (tiny-first-merge avoidance) to be kept as its own chapter.
-    body = " ".join(["word"] * 110)
-    html_3ch = f"""<!DOCTYPE html><html><body>
-<div class="chapter" id="link2HCH0001"><h2>Chapter I</h2><p>{body}</p></div>
-<div class="chapter" id="link2HCH0002"><h2>Chapter II</h2><p>{body}</p></div>
-<div class="chapter" id="link2HCH0003"><h2>Chapter III</h2><p>{body}</p></div>
-</body></html>"""
+    # EPUB path returns 3 chapters — different from the plain-text count.
+    epub_3ch = [
+        Chapter(title="Chapter I", text="word " * 110),
+        Chapter(title="Chapter II", text="word " * 110),
+        Chapter(title="Chapter III", text="word " * 110),
+    ]
 
-    with patch(
-        "services.book_chapters.get_book_html",
-        new_callable=AsyncMock,
-        return_value=html_3ch,
+    with (
+        patch("services.db.get_book_epub_bytes", new_callable=AsyncMock, return_value=b"fake_epub"),
+        patch("services.book_chapters.build_chapters_from_epub", return_value=epub_3ch),
     ):
         resp = await client.get(f"/api/books/{book_id}/import-stream")
 
@@ -785,7 +781,7 @@ async def test_import_stream_uses_html_splitter_chapter_count(client):
     assert chapters_ev is not None, "chapters event missing from import stream"
     assert chapters_ev["total"] == 3, (
         f"import-stream reported {chapters_ev['total']} chapters but expected 3 "
-        "(HTML splitter); build_chapters on the plain text would return 2"
+        "(EPUB splitter); build_chapters on the plain text would return 2"
     )
     clear_cache(book_id)
 

--- a/backend/tests/test_splitter.py
+++ b/backend/tests/test_splitter.py
@@ -1290,24 +1290,29 @@ def test_build_chapters_from_epub_skips_short_items():
     cover.content = b'<html><body><p>Cover page.</p></body></html>'
     book.add_item(cover)
 
-    ch = epub.EpubHtml(title="Chapter I", file_name="chapter01.xhtml", lang="en")
-    ch.content = (
-        b'<html><body><h2>Chapter I</h2>'
-        + b'<p>Alice content sentence one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty more words here.</p>' * 3
-        + b'</body></html>'
-    )
-    book.add_item(ch)
+    body = b'<p>Alice content sentence one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty more words here.</p>' * 3
+
+    ch1 = epub.EpubHtml(title="Chapter I", file_name="chapter01.xhtml", lang="en")
+    ch1.content = b'<html><body><h2>Chapter I</h2>' + body + b'</body></html>'
+    book.add_item(ch1)
+
+    ch2 = epub.EpubHtml(title="Chapter II", file_name="chapter02.xhtml", lang="en")
+    ch2.content = b'<html><body><h2>Chapter II</h2>' + body + b'</body></html>'
+    book.add_item(ch2)
 
     nav = epub.EpubNav()
     book.add_item(epub.EpubNcx())
     book.add_item(nav)
-    book.toc = [epub.Link("chapter01.xhtml", "Chapter I", "ch1")]
-    book.spine = ["nav", cover, ch]
+    book.toc = [
+        epub.Link("chapter01.xhtml", "Chapter I", "ch1"),
+        epub.Link("chapter02.xhtml", "Chapter II", "ch2"),
+    ]
+    book.spine = ["nav", cover, ch1, ch2]
 
     buf = io.BytesIO()
     epub.write_epub(buf, book)
 
     chapters = build_chapters_from_epub(buf.getvalue())
-    # cover.xhtml is in SKIP_SUFFIXES and also < 30 words — must not appear
+    # cover.xhtml is in SKIP_SUFFIXES — must not appear
     assert all("Cover" not in c.title for c in chapters)
-    assert len(chapters) >= 1
+    assert len(chapters) == 2

--- a/backend/tests/test_splitter.py
+++ b/backend/tests/test_splitter.py
@@ -1178,3 +1178,136 @@ def test_html_inline_text_empty_inner_child_not_appended():
     # "leading text" and "trailing" should be present; no crash
     assert "leading" in text
     assert "trailing" in text
+
+
+# ── EPUB splitter ─────────────────────────────────────────────────────────────
+
+def _make_test_epub(chapters: list[tuple[str, str]]) -> bytes:
+    """Build a minimal but valid EPUB for testing."""
+    import io
+    from ebooklib import epub
+
+    book = epub.EpubBook()
+    book.set_title("Test Book")
+    book.set_language("en")
+    book.add_author("Test Author")
+
+    spine = ["nav"]
+    toc = []
+    for i, (title, body) in enumerate(chapters):
+        uid = f"chapter{i+1:02d}"
+        fname = f"{uid}.xhtml"
+        content = (
+            f'<?xml version="1.0" encoding="utf-8"?>'
+            f'<html xmlns="http://www.w3.org/1999/xhtml">'
+            f"<head><title>{title}</title></head>"
+            f"<body><h2>{title}</h2>"
+            + "".join(f"<p>{body} sentence {j}.</p>" for j in range(8))
+            + "</body></html>"
+        )
+        item = epub.EpubHtml(title=title, file_name=fname, lang="en")
+        item.content = content.encode("utf-8")
+        book.add_item(item)
+        spine.append(item)
+        toc.append(epub.Link(fname, title, uid))
+
+    book.toc = toc
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = spine
+
+    buf = io.BytesIO()
+    epub.write_epub(buf, book)
+    return buf.getvalue()
+
+
+from services.splitter import build_chapters_from_epub, _epub_nav_titles
+
+
+def test_build_chapters_from_epub_basic():
+    epub_bytes = _make_test_epub([
+        ("Chapter I", "Alice was beginning to be very tired"),
+        ("Chapter II", "Curiouser and curiouser cried Alice"),
+        ("Chapter III", "They were indeed a queer looking party"),
+    ])
+    chapters = build_chapters_from_epub(epub_bytes)
+    assert len(chapters) == 3
+    assert chapters[0].title == "Chapter I"
+    assert chapters[1].title == "Chapter II"
+    assert chapters[2].title == "Chapter III"
+
+
+def test_build_chapters_from_epub_uses_toc_titles():
+    epub_bytes = _make_test_epub([
+        ("Chapter I — Down the Rabbit-Hole", "Alice was beginning to be very tired"),
+        ("Chapter II — The Pool of Tears", "Curiouser and curiouser"),
+        ("Chapter III — A Caucus-Race", "They were indeed a queer looking party"),
+    ])
+    chapters = build_chapters_from_epub(epub_bytes)
+    assert "Down the Rabbit-Hole" in chapters[0].title
+    assert "Pool of Tears" in chapters[1].title
+
+
+def test_build_chapters_from_epub_preserves_paragraph_breaks():
+    epub_bytes = _make_test_epub([
+        ("Chapter I", "First paragraph of text"),
+        ("Chapter II", "Second chapter content here"),
+        ("Chapter III", "Third chapter more words"),
+    ])
+    chapters = build_chapters_from_epub(epub_bytes)
+    # Each <p> should become a paragraph separated by \n\n
+    assert "\n\n" in chapters[0].text
+
+
+def test_build_chapters_from_epub_spine_order():
+    """Chapters must come out in spine reading order, not arbitrary order."""
+    epub_bytes = _make_test_epub([
+        ("First", "Alpha content words here yes"),
+        ("Second", "Beta content words here yes"),
+        ("Third", "Gamma content words here yes"),
+    ])
+    chapters = build_chapters_from_epub(epub_bytes)
+    assert chapters[0].title == "First"
+    assert chapters[1].title == "Second"
+    assert chapters[2].title == "Third"
+
+
+def test_build_chapters_from_epub_returns_empty_on_invalid_bytes():
+    assert build_chapters_from_epub(b"not an epub") == []
+    assert build_chapters_from_epub(b"") == []
+
+
+def test_build_chapters_from_epub_skips_short_items():
+    """Items with fewer than 30 words should be skipped (nav/cover pages)."""
+    import io
+    from ebooklib import epub
+
+    book = epub.EpubBook()
+    book.set_title("Test")
+    book.set_language("en")
+
+    cover = epub.EpubHtml(title="Cover", file_name="cover.xhtml", lang="en")
+    cover.content = b'<html><body><p>Cover page.</p></body></html>'
+    book.add_item(cover)
+
+    ch = epub.EpubHtml(title="Chapter I", file_name="chapter01.xhtml", lang="en")
+    ch.content = (
+        b'<html><body><h2>Chapter I</h2>'
+        + b'<p>Alice content sentence one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty more words here.</p>' * 3
+        + b'</body></html>'
+    )
+    book.add_item(ch)
+
+    nav = epub.EpubNav()
+    book.add_item(epub.EpubNcx())
+    book.add_item(nav)
+    book.toc = [epub.Link("chapter01.xhtml", "Chapter I", "ch1")]
+    book.spine = ["nav", cover, ch]
+
+    buf = io.BytesIO()
+    epub.write_epub(buf, book)
+
+    chapters = build_chapters_from_epub(buf.getvalue())
+    # cover.xhtml is in SKIP_SUFFIXES and also < 30 words — must not appear
+    assert all("Cover" not in c.title for c in chapters)
+    assert len(chapters) >= 1

--- a/backend/tests/test_translation_queue.py
+++ b/backend/tests/test_translation_queue.py
@@ -42,14 +42,11 @@ BOOK_TEXT = (
 async def tmp_db(monkeypatch, tmp_path):
     path = str(tmp_path / "queue-test.db")
     monkeypatch.setattr(db_module, "DB_PATH", path)
-    # Tests use book_ids that happen to be real Gutenberg IDs. Without
-    # this patch, split_with_html_preference would hit the network and
-    # use real Gutenberg HTML — producing a different chapter count
-    # than the 2-chapter BOOK_TEXT fixture. Force the plain-text
-    # fallback for all queue tests.
-    async def _no_html(_book_id):
-        return None
-    monkeypatch.setattr("services.book_chapters.get_book_html", _no_html)
+    # Prevent any EPUB DB/network calls so split_with_html_preference falls
+    # back to plain-text, producing the expected 2-chapter count from BOOK_TEXT.
+    from unittest.mock import AsyncMock as _AsyncMock
+    monkeypatch.setattr("services.db.get_book_epub_bytes", _AsyncMock(return_value=None))
+    monkeypatch.setattr("services.book_chapters._background_fetch_epub", _AsyncMock())
     from services.book_chapters import clear_cache as _clear_cache
     _clear_cache()
     await init_db()

--- a/backend/tests/test_translation_queue_branches.py
+++ b/backend/tests/test_translation_queue_branches.py
@@ -52,10 +52,10 @@ async def tmp_db(monkeypatch, tmp_path):
     monkeypatch.setattr(db_module, "DB_PATH", path)
     import services.translation_queue as tq_module
     monkeypatch.setattr(tq_module.db_module, "DB_PATH", path)
-    # Prevent network calls in split_with_html_preference
-    async def _no_html(_book_id):
-        return None
-    monkeypatch.setattr("services.book_chapters.get_book_html", _no_html)
+    # Prevent any EPUB DB/network calls in split_with_html_preference
+    from unittest.mock import AsyncMock as _AsyncMock
+    monkeypatch.setattr("services.db.get_book_epub_bytes", _AsyncMock(return_value=None))
+    monkeypatch.setattr("services.book_chapters._background_fetch_epub", _AsyncMock())
     from services.book_chapters import clear_cache
     clear_cache()
     await init_db()

--- a/docs/design-epub-ingestion.md
+++ b/docs/design-epub-ingestion.md
@@ -1,0 +1,339 @@
+# Design: EPUB Ingestion for Gutenberg Books
+
+**Status:** Proposed  
+**Author:** Investigation 2026-04-23  
+**Relates to:** `services/splitter.py`, `services/book_chapters.py`, `services/gutenberg.py`
+
+---
+
+## 1. Background: Current Ingestion Pipeline
+
+When a user adds a Gutenberg book the system does the following:
+
+```
+User adds book ID
+      │
+      ▼
+get_book_meta()        ← Gutendex API: title, authors, format URLs
+      │
+      ▼
+get_book_text()        ← downloads plain text (.txt) and stores in books.text
+      │
+      ▼
+[On first chapter request]
+split_with_html_preference()
+      │
+      ├─ Try get_book_html()    → build_chapters_from_html()   ✅ semantic <div class="chapter">
+      │   (re-fetched each cold start, cached in-memory)
+      │
+      └─ Fall back to text      → build_chapters()              ⚠️ regex heuristics
+              │
+              ├─ KEYWORD_RE (CHAPTER, ACT, LETTER, ...)
+              ├─ Roman numerals (I, II, III...)
+              ├─ Table of Contents scraping
+              └─ Word-count chunking (2000-word blocks, last resort)
+```
+
+**What is stored in the DB:** only the raw plain text (`books.text`). The HTML edition is fetched on-demand when chapters are first requested and cached in process memory — never persisted.
+
+---
+
+## 2. Problem Statement
+
+### Where plain-text splitting breaks down
+
+| Failure case | Example | Symptom |
+|---|---|---|
+| No keyword headings | Poetry collections, essays | Falls to roman-numeral or word-count fallback |
+| Non-English keywords | Finnish "Luku", Arabic books | KEYWORD_RE misses → bad fallback |
+| Plays with scene numbering | Shakespeare | Over-splits into dozens of tiny scenes |
+| Epistolary novels | Frankenstein, Dracula | Recently fixed with LETTER keyword, but fragile |
+| Books with complex TOC | Multi-volume works | TOC scraper produces wrong chapter boundaries |
+| Prose without blank lines | Some 19th-century typesetting | Entire book becomes one chapter |
+
+The **word-count fallback** (2,000-word chunks) is semantically meaningless — it cuts mid-sentence, mid-scene, or mid-dialogue. Translation alignment suffers because paragraph boundaries are lost.
+
+### Why HTML edition partially solves it
+
+The `build_chapters_from_html()` path (lxml + `<div class="chapter">`) gives near-perfect results when available. But:
+
+- Only **~60% of Gutenberg books** have an HTML edition indexed by Gutendex.
+- HTML editions can themselves be poorly structured (flat `<p>` soup, or missing chapter divs).
+- HTML editions are fetched on-demand but **never stored**, so every cold-start re-downloads ~1–3 MB.
+
+---
+
+## 3. Why EPUB is the Right Middle Tier
+
+Gutenberg publishes EPUBs for **~90% of books** (vs ~60% for HTML). The EPUB format provides:
+
+| Property | Plain text | Gutenberg HTML | EPUB |
+|---|---|---|---|
+| Chapter boundaries | Heuristic regex | `<div class="chapter">` | Explicit spine/TOC |
+| Chapter titles | Matched from text | `<h1>/<h2>` in div | NCX/nav `<navPoint>` |
+| Paragraph structure | `\n\n` split | `<p>` tags | `<p>` tags in XHTML |
+| Reading order | Implicit | Implicit | Explicit spine |
+| Format availability | ~100% | ~60% | ~90% |
+| File size | ~200–800 KB | ~200–600 KB | ~80–300 KB (no-images) |
+| Already a dependency | — | lxml | **ebooklib** ✅ |
+
+### EPUB structure (Gutenberg)
+
+A Gutenberg EPUB is a ZIP archive containing:
+- **`content.opf`** — manifest + spine (ordered list of document items)
+- **`toc.ncx`** or **`nav.xhtml`** — TOC with human-readable chapter titles
+- **`chapter_001.xhtml`, `chapter_002.xhtml`, ...** — one XHTML file per chapter
+
+The spine gives guaranteed reading order; the NCX/nav gives guaranteed chapter titles. No regex needed.
+
+```
+book.epub
+├── OEBPS/
+│   ├── content.opf          ← spine: [ch01, ch02, ch03, ...]
+│   ├── toc.ncx              ← "Chapter I — Down the Rabbit-Hole"
+│   ├── chapter001.xhtml     ← <html><body><h2>Chapter I</h2><p>...</p></body></html>
+│   ├── chapter002.xhtml
+│   └── ...
+└── META-INF/container.xml
+```
+
+---
+
+## 4. Proposed Architecture
+
+Add EPUB as a **second fallback** between HTML and plain text. No DB schema change is required — this mirrors how HTML is currently handled (fetched on-demand, cached in memory).
+
+```
+split_with_html_preference()
+      │
+      ├─ 1. Pre-split JSON?      → return directly            (uploaded books, EPUB pre-parsed)
+      │
+      ├─ 2. get_book_html()      → build_chapters_from_html() ← EXISTING (keep, priority 1)
+      │      lxml + <div class="chapter">
+      │      Accept if ≥ 2 chapters
+      │
+      ├─ 3. get_book_epub()      → build_chapters_from_epub() ← NEW (priority 2)
+      │      ebooklib spine + NCX titles + lxml body extract
+      │      Accept if ≥ 2 chapters
+      │
+      └─ 4. build_chapters(text) → regex splitter             ← EXISTING (last resort)
+```
+
+**Why keep HTML as priority 1:** The existing `<div class="chapter">` parsing is excellent and already battle-tested. EPUB is only needed when HTML is unavailable or malformed.
+
+**Why EPUB before plain text:** EPUB provides explicit TOC and spine — structural information that the regex splitter has to guess. Even a mediocre EPUB parser will beat the plain-text fallback for most books.
+
+---
+
+## 5. New Components
+
+### 5.1 `gutenberg.py` — `get_book_epub(book_id: int) -> bytes | None`
+
+```python
+async def get_book_epub(book_id: int) -> bytes | None:
+    """Download the no-images EPUB from Gutenberg, if available.
+
+    Prefers 'application/epub+zip' (no-images variant) from Gutendex formats
+    to minimise download size (~80–300 KB vs 2–5 MB with images).
+    Returns raw bytes or None.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=15, follow_redirects=True) as client:
+            resp = await client.get(f"{GUTENBERG_SEARCH}/{book_id}")
+            resp.raise_for_status()
+            formats = resp.json().get("formats", {})
+    except Exception:
+        return None
+
+    # Prefer no-images variant (smaller download)
+    epub_url = ""
+    for key, url in formats.items():
+        if key == "application/epub+zip":
+            if "noimages" in url:
+                epub_url = url
+                break
+            elif not epub_url:
+                epub_url = url  # images variant as fallback
+
+    if not epub_url:
+        return None
+
+    try:
+        async with httpx.AsyncClient(timeout=60, follow_redirects=True) as client:
+            resp = await client.get(epub_url)
+            if resp.status_code == 200:
+                return resp.content
+    except Exception:
+        return None
+    return None
+```
+
+### 5.2 `splitter.py` — `build_chapters_from_epub(epub_bytes: bytes) -> list[Chapter]`
+
+Core logic:
+
+```python
+def build_chapters_from_epub(epub_bytes: bytes) -> list[Chapter]:
+    import io
+    import ebooklib
+    from ebooklib import epub as epublib
+
+    book = epublib.read_epub(io.BytesIO(epub_bytes), options={"ignore_ncx": False})
+
+    # Build ordered chapter list from spine
+    spine_ids = {item_id for item_id, _ in book.spine}
+    nav_titles = _extract_nav_titles(book)          # id → human title from NCX/nav
+    skip_names = {"nav.xhtml", "cover.xhtml", "toc.xhtml", "title.xhtml"}
+
+    chapters: list[Chapter] = []
+    for item in book.get_items_of_type(ebooklib.ITEM_DOCUMENT):
+        if item.get_name().lower() in skip_names:
+            continue
+        if item.get_id() not in spine_ids:
+            continue
+
+        html = item.get_content().decode("utf-8", errors="replace")
+        title = nav_titles.get(item.get_id()) or _extract_html_title(html)
+        text = _html_body_text(html)   # reuse existing helper from HTML splitter
+
+        if not text.strip() or len(text.split()) < 30:
+            continue  # skip nav pages, cover descriptions
+
+        chapters.append(Chapter(title=title or f"Section {len(chapters)+1}", text=text))
+
+    return chapters if len(chapters) >= 2 else []
+
+
+def _extract_nav_titles(book) -> dict[str, str]:
+    """Return {item_id: title} from NCX or EPUB3 nav document."""
+    titles: dict[str, str] = {}
+    # Try NCX (EPUB2)
+    ncx = book.toc
+    _walk_ncx(ncx, titles, book)
+    return titles
+```
+
+**Key decisions:**
+- Use `book.spine` for reading order (not `get_items_of_type` which is unordered).
+- Pull titles from NCX/nav — do not rely on `<h1>` in body (inconsistent across publishers).
+- Reuse `_html_body_text()` from the existing HTML splitter to extract clean paragraph text.
+- Skip items shorter than 30 words (nav pages, cover pages, colophon).
+- Return `[]` if fewer than 2 chapters — caller falls through to next strategy.
+
+### 5.3 `book_chapters.py` — Insert EPUB tier
+
+```python
+async def split_with_html_preference(book_id: int, text: str) -> list[Chapter]:
+    ...
+    # 1. Pre-split JSON (existing)
+    # 2. HTML (existing)
+
+    # 3. EPUB — new tier
+    epub_bytes = await asyncio.get_event_loop().run_in_executor(
+        None, lambda: asyncio.run(get_book_epub(book_id))
+    )
+    # (or just: epub_bytes = await get_book_epub(book_id))
+    if epub_bytes:
+        epub_chapters = await asyncio.get_event_loop().run_in_executor(
+            None, build_chapters_from_epub, epub_bytes
+        )
+        if len(epub_chapters) >= 2:
+            _chapter_cache[book_id] = epub_chapters
+            return epub_chapters
+
+    # 4. Plain text regex fallback (existing)
+    ...
+```
+
+---
+
+## 6. Storage Strategy
+
+**Decision: keep fetching on-demand (no DB change required).**
+
+Rationale:
+- The HTML edition is already fetched on-demand and only cached in memory. EPUB follows the same pattern.
+- Storing EPUB bytes in the DB would require a new `BLOB` column (~300 KB per book) and a migration.
+- The in-memory `_chapter_cache` survives the lifetime of a request and is reused for all subsequent chapter accesses within the same process.
+
+**Optional future improvement:** Store `epub_url` in the books table so we can avoid the double Gutendex API hit. Defer until this proves to be a bottleneck.
+
+### What happens to existing books?
+
+No action required. On the next cold-start chapter request for an existing Gutenberg book, `split_with_html_preference` will run the full cascade:
+
+1. Check in-memory cache (miss — process restarted)
+2. Try HTML (same as today)
+3. **Try EPUB** ← new — may now succeed where HTML was absent before
+4. Fall back to stored plain text
+
+---
+
+## 7. Impact on Translation Alignment
+
+The translation pipeline consumes `chapter.text` split by `\n\n` (paragraph boundaries). EPUB improves alignment in two ways:
+
+**Before (plain-text fallback):**
+```
+chapter.text = "Alice was beginning to be very tired...  [2000 words of merged paragraphs]"
+# \n\n boundaries are wherever the regex split ended — often mid-scene
+```
+
+**After (EPUB):**
+```
+chapter.text = "Alice was beginning to be very tired...\n\n"
+              "So she was considering in her own mind...\n\n"
+              "There was nothing so very remarkable..."
+# \n\n boundaries come from <p> tags in the EPUB XHTML — paragraph-perfect
+```
+
+Each `<p>` in the EPUB body becomes one paragraph in `chapter.text`. The translator sees clean paragraph boundaries, which means:
+- Sentence-level context is preserved within each batch.
+- Paragraph count matches between source and translated output (no boundary drift).
+- The reader's paragraph-by-paragraph display aligns 1:1 with translated paragraphs.
+
+---
+
+## 8. Improving User-Upload EPUB Parsing (book_parser.py)
+
+The existing `parse_epub()` in `book_parser.py` uses item filename as the chapter title (a rough heuristic). It should be upgraded to use the same NCX title extraction as the new Gutenberg path. This is a secondary improvement — same implementation, same `_extract_nav_titles()` helper.
+
+---
+
+## 9. Trade-offs
+
+| Trade-off | Decision |
+|---|---|
+| HTML vs EPUB as tier 2 | EPUB — covers more books (~90% vs ~60%), and structural info (TOC) is explicitly provided rather than inferred from `<div>` class names |
+| Store EPUB bytes vs fetch-on-demand | Fetch-on-demand — avoids DB migration, consistent with existing HTML handling |
+| EPUB over HTML | No — keep HTML as tier 1. It's already proven and `<div class="chapter">` is more semantically specific than EPUB spine items |
+| Parse NCX vs `<h1>` in body for titles | NCX — body headings are unreliable (sometimes missing, sometimes duplicated inside paragraphs) |
+| Spine order vs document order | Spine — EPUB spec guarantees spine order reflects intended reading order |
+| Minimum chapter threshold | 2 (same as HTML path) — lets the caller fall through gracefully if EPUB yields only 1 section |
+
+---
+
+## 10. Implementation Plan
+
+All changes stay within three existing files. No DB migration, no new tables, no frontend changes.
+
+| Step | File | Change | Size |
+|------|------|--------|------|
+| 1 | `services/gutenberg.py` | Add `get_book_epub()` | ~35 lines |
+| 2 | `services/splitter.py` | Add `build_chapters_from_epub()` + `_extract_nav_titles()` | ~80 lines |
+| 3 | `services/book_chapters.py` | Insert EPUB tier into `split_with_html_preference()` | ~12 lines |
+| 4 | `services/book_parser.py` | Upgrade `parse_epub()` to use NCX titles | ~20 lines |
+| 5 | `tests/test_splitter.py` | Unit tests for EPUB parsing with fixture `.epub` bytes | ~60 lines |
+| 6 | `tests/test_book_chapters.py` | Integration test: EPUB tier is preferred over plain text | ~30 lines |
+
+**Estimated effort:** 1 session (~3–4 hours with tests).
+
+---
+
+## 11. Out of Scope
+
+- **Storing EPUB files in the DB** — deferred; fetch-on-demand is sufficient.
+- **Re-ingesting existing books** — not needed; the cascade runs automatically on cold start.
+- **Displaying EPUB-native formatting** (bold, italic, images) in the reader — the reader consumes plain text; formatting is stripped at ingestion time. A separate "rich reader" feature would be needed for this.
+- **EPUB DRM** — all Gutenberg EPUBs are DRM-free. Not applicable.
+- **User upload: EPUB 3 nav vs EPUB 2 NCX** — `ebooklib` handles both; no special case needed.

--- a/reports/pretranslate_benchmark_2229.md
+++ b/reports/pretranslate_benchmark_2229.md
@@ -1,0 +1,174 @@
+# Pre-Translation Benchmark Report
+
+**Book:** #2229 — Faust: Der Tragödie erster Teil (English translation by Bayard Taylor)  
+**Date:** 2026-04-23 00:36  
+**Provider:** MarianMT (Helsinki-NLP, CPU-only PyTorch)  
+**Machine:** Apple Silicon Mac, CPU inference  
+
+---
+
+## Summary
+
+| Language | Chapters | Total Words | Kernel Time | Wall Time | Words/sec | Sec/chapter (avg) |
+|----------|----------|-------------|-------------|-----------|-----------|-------------------|
+| **German** (`de`) | 26 of 27¹ | 30,315 | 19m 59s | 20m 11s | **25.3** | 46.1s |
+| **French** (`fr`) | 26 of 27¹ | 30,315 | 33m 58s | 34m 28s | **14.9** | 78.4s |
+
+> ¹ Chapter 1 (*Zueignung*, 221 words) timing not captured — model load overlapped with first chapter output.  
+> Kernel time = sum of per-chapter translation times (excludes DB write overhead).
+
+**French is ~41% slower than German** on this text. See Observations for likely cause.
+
+---
+
+## Comparison: Alice in Wonderland (#11, de)
+
+Run immediately before Faust on the same machine (model already cached):
+
+| Book | Chapters | Total Words | Kernel Time | Words/sec |
+|------|----------|-------------|-------------|-----------|
+| Alice (#11) | 11 | 24,233 | 18m 32s | 21.8 |
+| Faust (#2229) | 26 | 30,315 | 19m 59s | 25.3 |
+
+Faust runs faster per-word despite being longer — likely because Faust has many short
+dialogue scenes (< 500 words) that fit in a single MarianMT chunk, whereas Alice has
+denser prose paragraphs that require more chunking overhead.
+
+---
+
+## German (`de`)
+
+**Model:** `Helsinki-NLP/opus-mt-en-de` (~298 MB)  
+**Total:** 30,315 words · 19m 59s kernel · **25.3 words/sec**
+
+| # | Chapter | Words | Time | Words/sec |
+|---|---------|-------|------|-----------|
+| 1 | Zueignung | 221 | — | — (model load) |
+| 2 | Vorspiel auf dem Theater | 1,361 | 37.2s | 36.6 |
+| 3 | Prolog im Himmel | 793 | 27.2s | 29.2 |
+| 4 | Nacht | 2,868 | 99.9s | 28.7 |
+| 5 | Vor dem Tor | 2,341 | 76.5s | 30.6 |
+| 6 | Studierzimmer | 5,332 | 203.2s | 26.2 |
+| 7 | Auerbachs Keller in Leipzig | 1,992 | 93.8s | 21.2 |
+| 8 | Hexenküche | 2,058 | 84.5s | 24.4 |
+| 9 | Straße (I) | 474 | 24.1s | 19.7 |
+| 10 | Abend | 847 | 32.9s | 25.7 |
+| 11 | Spaziergang | 401 | 13.2s | 30.4 |
+| 12 | Der Nachbarin Haus | 1,191 | 50.3s | 23.7 |
+| 13 | Straße (II) | 342 | 14.8s | 23.1 |
+| 14 | Garten | 1,048 | 45.7s | 22.9 |
+| 15 | Ein Gartenhäuschen | 147 | 7.3s | 20.1 |
+| 16 | Wald und Höhle | 1,038 | 34.5s | 30.1 |
+| 17 | Gretchens Stube | 138 | 5.2s | 26.5 |
+| 18 | Marthens Garten | 851 | 34.1s | 25.0 |
+| 19 | Am Brunnen | 293 | 12.3s | 23.8 |
+| 20 | Zwinger | 164 | 6.3s | 26.0 |
+| 21 | Nacht. Straße vor Gretchens Türe | 949 | 50.2s | 18.9 |
+| 22 | Dom | 239 | 10.6s | 22.5 |
+| 23 | Walpurgisnacht | 2,636 | 115.8s | 22.8 |
+| 24 | Walpurgisnachtstraum | 953 | 40.0s | 23.8 |
+| 25 | Trüber Tag. Feld | 488 | 21.9s | 22.3 |
+| 26 | Nacht, offen Feld | 42 | 2.8s | 15.0 |
+| 27 | Kerker | 1,329 | 54.9s | 24.2 |
+
+> **Slowest:** Studierzimmer (203.2s — 5,332 words, the longest chapter by far)  
+> **Fastest:** Nacht, offen Feld (2.8s — only 42 words)  
+> **Best rate:** Vorspiel auf dem Theater (36.6 w/s — moderate length, dialogue-heavy)
+
+---
+
+## French (`fr`)
+
+**Model:** `Helsinki-NLP/opus-mt-en-fr` (~298 MB)  
+**Total:** 30,315 words · 33m 58s kernel · **14.9 words/sec**
+
+| # | Chapter | Words | Time | Words/sec |
+|---|---------|-------|------|-----------|
+| 1 | Zueignung | 221 | — | — (model load) |
+| 2 | Vorspiel auf dem Theater | 1,361 | 86.9s | 15.7 |
+| 3 | Prolog im Himmel | 793 | 53.6s | 14.8 |
+| 4 | Nacht | 2,868 | 200.0s | 14.3 |
+| 5 | Vor dem Tor | 2,341 | 156.5s | 15.0 |
+| 6 | Studierzimmer | 5,332 | 356.0s | 15.0 |
+| 7 | Auerbachs Keller in Leipzig | 1,992 | 145.2s | 13.7 |
+| 8 | Hexenküche | 2,058 | 132.6s | 15.5 |
+| 9 | Straße (I) | 474 | 33.5s | 14.1 |
+| 10 | Abend | 847 | 55.5s | 15.3 |
+| 11 | Spaziergang | 401 | 16.2s | 24.8 |
+| 12 | Der Nachbarin Haus | 1,191 | 79.2s | 15.0 |
+| 13 | Straße (II) | 342 | 22.8s | 15.0 |
+| 14 | Garten | 1,048 | 69.7s | 15.0 |
+| 15 | Ein Gartenhäuschen | 147 | 10.0s | 14.7 |
+| 16 | Wald und Höhle | 1,038 | 68.8s | 15.1 |
+| 17 | Gretchens Stube | 138 | 9.4s | 14.7 |
+| 18 | Marthens Garten | 851 | 55.9s | 15.2 |
+| 19 | Am Brunnen | 293 | 18.6s | 15.8 |
+| 20 | Zwinger | 164 | 9.8s | 16.7 |
+| 21 | Nacht. Straße vor Gretchens Türe | 949 | 59.4s | 16.0 |
+| 22 | Dom | 239 | 14.8s | 16.1 |
+| 23 | Walpurgisnacht | 2,636 | 182.9s | 14.4 |
+| 24 | Walpurgisnachtstraum | 953 | 61.6s | 15.5 |
+| 25 | Trüber Tag. Feld | 488 | 40.9s | 11.9 |
+| 26 | Nacht, offen Feld | 42 | 3.2s | 13.1 |
+| 27 | Kerker | 1,329 | 95.5s | 13.9 |
+
+> **Slowest:** Studierzimmer (356.0s — same chapter, nearly 2× slower than German)  
+> **Fastest:** Nacht, offen Feld (3.2s)  
+> **Most consistent:** nearly every chapter lands within 13–16 w/s, unlike German's wider 19–37 range
+
+---
+
+## Observations
+
+### 1. French is uniformly slower than German (~41%)
+
+German throughput varies widely (18–37 w/s); French is nearly flat at 13–16 w/s.
+The `opus-mt-en-fr` model likely uses a larger vocabulary or produces longer output
+tokens on average (French inflection and articles expand word count). Since MarianMT
+generates tokens one-by-one, a higher output token count directly increases wall time.
+
+### 2. Chapter size dominates total time
+
+The single longest chapter — *Studierzimmer* (5,332 words) — accounts for:
+- 17% of German kernel time (203s out of 1199s)
+- 17% of French kernel time (356s out of 2038s)
+
+Short scenes (< 200 words) finish in under 10 seconds. A seeding strategy that
+prioritises short chapters first would show visible DB progress faster.
+
+### 3. de throughput is higher for short/dialogue scenes
+
+Chapters with dense dialogue (many short lines, low average sentence length) run
+faster: *Straße I* (474 words, 19.7 w/s), *Spaziergang* (401 words, 30.4 w/s).
+The chunker splits at sentence boundaries, so short-sentence text produces smaller,
+faster-to-generate chunks.
+
+### 4. CPU is viable for seeding; GPU would be 10–20×
+
+Faust (~30k words) cost ~20 min (de) and ~34 min (fr) on CPU. A typical GPU
+(RTX 3080 or M2 Pro Neural Engine) would reduce this to 1–3 minutes per language.
+For a full library seed, GPU or Ollama with a faster model is recommended.
+
+---
+
+## Throughput Estimates for Other Books
+
+Based on observed 25.3 w/s (de) and 14.9 w/s (fr):
+
+| Book size | German (de) | French (fr) |
+|-----------|-------------|-------------|
+| 25k words (Alice) | ~17 min | ~28 min |
+| 30k words (Faust) | ~20 min | ~34 min |
+| 60k words (typical novel) | ~40 min | ~67 min |
+| 180k words (War & Peace) | ~2h | ~3h 22m |
+
+---
+
+## Notes
+
+- Timing is wall-clock time for the translation kernel only (excludes DB write ~0.5s/chapter).
+- `Words/sec` = source-side English word count ÷ translation time (kernel only).
+- Model downloads occur on first run only; cached on subsequent runs.
+- MarianMT chunk cap: 480 tokens — long paragraphs are split and translated in pieces, then rejoined with spaces.
+- CPU only; no GPU acceleration used.
+- Both translations are now cached in the local SQLite DB and served immediately by the reader.

--- a/scripts/backfill_epubs.py
+++ b/scripts/backfill_epubs.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Backfill EPUB files for all Gutenberg books already in the DB.
+
+Books added before the EPUB-ingestion feature (feat/epub-ingestion) only have
+plain-text cached. This script fetches and stores their EPUBs so that
+split_with_html_preference() uses the better EPUB-based chapter split on the
+next cold start.
+
+Usage:
+    # Dry-run (show what would be fetched, no writes)
+    python scripts/backfill_epubs.py --dry-run
+
+    # Backfill all books missing an EPUB
+    python scripts/backfill_epubs.py
+
+    # Re-fetch even if EPUB already cached
+    python scripts/backfill_epubs.py --force
+
+    # Limit to specific book IDs
+    python scripts/backfill_epubs.py --book-ids 11 84 2229
+
+    # Override DB path
+    python scripts/backfill_epubs.py --db /path/to/books.db
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+import time
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+BACKEND_DIR = os.path.join(SCRIPT_DIR, "..", "backend")
+sys.path.insert(0, BACKEND_DIR)
+
+
+async def run(args: argparse.Namespace) -> None:
+    import aiosqlite
+    from services.db import DB_PATH, save_book_epub
+    from services.gutenberg import get_book_epub
+
+    db_path = args.db or DB_PATH
+
+    async with aiosqlite.connect(db_path) as db:
+        db.row_factory = aiosqlite.Row
+
+        # Find candidate books: Gutenberg books (no owner / source != upload)
+        if args.book_ids:
+            placeholders = ",".join("?" * len(args.book_ids))
+            query = f"SELECT id, title FROM books WHERE id IN ({placeholders})"
+            params = list(args.book_ids)
+        else:
+            query = """
+                SELECT id, title FROM books
+                WHERE (source IS NULL OR source != 'upload')
+                ORDER BY id
+            """
+            params = []
+
+        async with db.execute(query, params) as cur:
+            all_books = [dict(r) for r in await cur.fetchall()]
+
+        if not args.force:
+            # Exclude books that already have an EPUB cached
+            async with db.execute("SELECT book_id FROM book_epubs") as cur:
+                already = {r[0] for r in await cur.fetchall()}
+            books = [b for b in all_books if b["id"] not in already]
+            skipped_cached = len(all_books) - len(books)
+        else:
+            books = all_books
+            skipped_cached = 0
+
+    total = len(books)
+    print(f"Books to process: {total}  (skipped already cached: {skipped_cached})")
+    if args.dry_run:
+        print("Dry-run — no writes.")
+        for b in books:
+            print(f"  Would fetch EPUB for #{b['id']} {b['title']}")
+        return
+
+    ok = skipped = failed = 0
+    t0 = time.time()
+
+    for i, book in enumerate(books, 1):
+        book_id = book["id"]
+        title = book["title"][:50]
+        print(f"  [{i}/{total}] #{book_id} {title} ...", end="", flush=True)
+        try:
+            result = await get_book_epub(book_id)
+            if result:
+                epub_bytes, epub_url = result
+                await save_book_epub(book_id, epub_bytes, epub_url)
+                print(f" ok ({len(epub_bytes)//1024} KB)")
+                ok += 1
+            else:
+                print(" no EPUB available")
+                skipped += 1
+        except Exception as exc:
+            print(f" ERROR: {exc}")
+            failed += 1
+
+    elapsed = time.time() - t0
+    print(f"\nDone in {elapsed:.0f}s: {ok} stored, {skipped} no EPUB, {failed} errors.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill EPUB cache for existing Gutenberg books.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("--book-ids", type=int, nargs="+", metavar="N",
+                        help="Backfill specific book IDs only")
+    parser.add_argument("--force", action="store_true",
+                        help="Re-fetch even if EPUB already cached")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show what would be fetched without writing")
+    parser.add_argument("--db", metavar="PATH",
+                        help="Override DB path (defaults to DB_PATH env or backend/books.db)")
+    args = parser.parse_args()
+    if args.db:
+        os.environ["DB_PATH"] = args.db
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_pretranslate.py
+++ b/scripts/benchmark_pretranslate.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""
+Benchmark pretranslate.py on a target book across multiple languages.
+
+Runs each language sequentially, captures per-chapter timing, and writes
+a markdown report to reports/pretranslate_benchmark_{book_id}.md.
+
+Usage:
+    python scripts/benchmark_pretranslate.py --book-id 2229 --langs de fr
+    python scripts/benchmark_pretranslate.py --book-id 2229 --langs de fr zh --force
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+REPO_DIR = SCRIPT_DIR.parent
+REPORTS_DIR = REPO_DIR / "reports"
+
+LANG_NAMES = {
+    "de": "German", "fr": "French", "es": "Spanish", "it": "Italian",
+    "ru": "Russian", "nl": "Dutch", "pt": "Portuguese", "pl": "Polish",
+    "zh": "Chinese", "ja": "Japanese",
+}
+
+# Matches lines like:  [3/27] Nacht (2868 words) ... done (42.3s)
+CHAPTER_RE = re.compile(
+    r'\[\s*(\d+)/(\d+)\]\s+(.+?)\s+\((\d+) words\).*?done \((\d+(?:\.\d+)?)s\)'
+)
+
+
+def run_language(book_id: int, lang: str, force: bool) -> tuple[list[dict], float, str]:
+    """Translate one language, return (chapters, wall_time_s, raw_output)."""
+    cmd = [
+        sys.executable, str(SCRIPT_DIR / "pretranslate.py"),
+        "--book-id", str(book_id),
+        "--lang", lang,
+    ]
+    if force:
+        cmd.append("--force")
+
+    print(f"\n{'='*60}")
+    print(f"  Starting: {LANG_NAMES.get(lang, lang)} ({lang})")
+    print(f"{'='*60}")
+
+    t0 = time.time()
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+    )
+
+    output_lines: list[str] = []
+    for line in proc.stdout:
+        sys.stdout.write(line)
+        sys.stdout.flush()
+        output_lines.append(line)
+
+    proc.wait()
+    wall = time.time() - t0
+    full_output = "".join(output_lines)
+
+    chapters: list[dict] = []
+    for m in CHAPTER_RE.finditer(full_output):
+        chapters.append({
+            "index": int(m.group(1)),
+            "total": int(m.group(2)),
+            "title": m.group(3).strip(),
+            "words": int(m.group(4)),
+            "seconds": float(m.group(5)),
+        })
+
+    return chapters, wall, full_output
+
+
+def words_per_sec(words: int, seconds: float) -> float:
+    return words / seconds if seconds > 0 else 0.0
+
+
+def format_duration(seconds: float) -> str:
+    m, s = divmod(int(seconds), 60)
+    return f"{m}m {s:02d}s" if m else f"{s}s"
+
+
+def build_report(book_id: int, book_title: str, lang_results: list[dict]) -> str:
+    now = datetime.now().strftime("%Y-%m-%d %H:%M")
+    lines: list[str] = []
+
+    lines += [
+        f"# Pre-Translation Benchmark Report",
+        f"",
+        f"**Book:** #{book_id} — {book_title}  ",
+        f"**Date:** {now}  ",
+        f"**Provider:** MarianMT (Helsinki-NLP, CPU)  ",
+        f"",
+        f"---",
+        f"",
+        f"## Summary",
+        f"",
+        f"| Language | Chapters | Total Words | Wall Time | Words/sec | Sec/chapter (avg) |",
+        f"|----------|----------|-------------|-----------|-----------|-------------------|",
+    ]
+
+    for r in lang_results:
+        lang = r["lang"]
+        lang_name = LANG_NAMES.get(lang, lang)
+        chapters = r["chapters"]
+        total_words = sum(c["words"] for c in chapters)
+        total_secs = sum(c["seconds"] for c in chapters)
+        wall = r["wall_time"]
+        wps = words_per_sec(total_words, total_secs)
+        avg_sec = total_secs / len(chapters) if chapters else 0
+        lines.append(
+            f"| **{lang_name}** (`{lang}`) "
+            f"| {len(chapters)} "
+            f"| {total_words:,} "
+            f"| {format_duration(wall)} "
+            f"| {wps:.1f} "
+            f"| {avg_sec:.1f}s |"
+        )
+
+    lines += ["", "---", ""]
+
+    for r in lang_results:
+        lang = r["lang"]
+        lang_name = LANG_NAMES.get(lang, lang)
+        chapters = r["chapters"]
+        total_words = sum(c["words"] for c in chapters)
+        total_secs = sum(c["seconds"] for c in chapters)
+
+        lines += [
+            f"## {lang_name} (`{lang}`)",
+            f"",
+            f"**Total:** {total_words:,} words in {format_duration(total_secs)} "
+            f"({words_per_sec(total_words, total_secs):.1f} words/sec wall-clock for translation kernel)",
+            f"",
+            f"| # | Chapter | Words | Time | Words/sec |",
+            f"|---|---------|-------|------|-----------|",
+        ]
+
+        for c in chapters:
+            wps = words_per_sec(c["words"], c["seconds"])
+            lines.append(
+                f"| {c['index']} | {c['title']} | {c['words']:,} | {c['seconds']:.1f}s | {wps:.1f} |"
+            )
+
+        lines += [
+            f"",
+            f"> **Slowest:** {max(chapters, key=lambda c: c['seconds'])['title']} "
+            f"({max(c['seconds'] for c in chapters):.1f}s)  ",
+            f"> **Fastest:** {min(chapters, key=lambda c: c['seconds'])['title']} "
+            f"({min(c['seconds'] for c in chapters):.1f}s)",
+            f"",
+        ]
+
+    lines += [
+        "---",
+        "",
+        "## Notes",
+        "",
+        "- Timing is wall-clock time for the translation kernel only (excludes DB write).",
+        "- `Words/sec` is source-side English word count divided by translation time.",
+        "- Model downloads (first run only) are excluded from per-chapter timings.",
+        "- MarianMT chunk size cap: 480 tokens — long paragraphs are split and re-joined.",
+        "- CPU only; no GPU acceleration.",
+        "",
+    ]
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark pretranslate across languages.")
+    parser.add_argument("--book-id", type=int, required=True)
+    parser.add_argument("--langs", nargs="+", required=True)
+    parser.add_argument("--force", action="store_true", help="Re-translate even if cached")
+    args = parser.parse_args()
+
+    # Resolve book title from DB
+    book_title = f"Book #{args.book_id}"
+    try:
+        import asyncio, aiosqlite, os
+        sys.path.insert(0, str(REPO_DIR / "backend"))
+        from services.db import DB_PATH
+        async def _get_title():
+            async with aiosqlite.connect(DB_PATH) as db:
+                async with db.execute("SELECT title FROM books WHERE id=?", (args.book_id,)) as cur:
+                    row = await cur.fetchone()
+                    return row[0] if row else book_title
+        book_title = asyncio.run(_get_title())
+    except Exception:
+        pass
+
+    print(f"\nBenchmark: '{book_title}' (#{args.book_id})")
+    print(f"Languages: {', '.join(args.langs)}")
+    print(f"Force: {args.force}")
+
+    lang_results: list[dict] = []
+    total_start = time.time()
+
+    for lang in args.langs:
+        chapters, wall, _ = run_language(args.book_id, lang, args.force)
+        lang_results.append({"lang": lang, "chapters": chapters, "wall_time": wall})
+        if chapters:
+            total_w = sum(c["words"] for c in chapters)
+            total_s = sum(c["seconds"] for c in chapters)
+            print(f"\n  {LANG_NAMES.get(lang, lang)}: {len(chapters)} chapters, "
+                  f"{total_w:,} words, {format_duration(int(total_s))}, "
+                  f"{words_per_sec(total_w, total_s):.1f} w/s")
+        else:
+            print(f"\n  {lang}: no chapters captured (all skipped or error)")
+
+    total_elapsed = time.time() - total_start
+    print(f"\nAll languages done in {format_duration(int(total_elapsed))}.")
+
+    REPORTS_DIR.mkdir(exist_ok=True)
+    report_path = REPORTS_DIR / f"pretranslate_benchmark_{args.book_id}.md"
+    report_path.write_text(build_report(args.book_id, book_title, lang_results))
+    print(f"\nReport written to: {report_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `book_epubs` table (migration 023) to store Gutenberg EPUB binaries per book
- New `build_chapters_from_epub()` in `splitter.py` uses EPUB spine + NCX/nav TOC for reliable chapter titles and order
- `split_with_html_preference()` in `book_chapters.py` now follows DB-only priority chain: pre-split JSON → stored EPUB → plain-text regex (no on-demand HTML fetch at chapter-load time)
- New Gutenberg books have their EPUB fetched and stored at add-time via background task; existing books trigger a silent background fetch on first chapter access
- `scripts/backfill_epubs.py` for bulk EPUB population of existing books
- Fixed migration 023 comment semicolon that caused the migration runner to produce invalid SQL
- Updated all tests: replaced mocks of removed `get_book_html`/`build_chapters_from_html` with `services.db.get_book_epub_bytes` and `services.book_chapters.build_chapters_from_epub`

## Why

Plain-text regex splitting and on-demand HTML fetching are unreliable: regex misses nested structure (plays, dramas like Faust), and HTML fetches add latency and Gutenberg network dependency at reader page load. EPUB binaries encode the authoritative reading order and chapter titles via spine and NCX/nav TOC, giving consistent results across all book types.

## Test plan

- [x] All 1152 backend tests pass (`pytest --tb=short -q --no-cov`)
- [x] 6 new EPUB splitter tests: basic parsing, TOC title extraction, paragraph breaks, spine order, invalid bytes fallback, short-item skipping
- [x] `test_book_chapters.py` updated to mock EPUB path and verify all 3 priority paths (EPUB, fallback, plain-text)
- [x] Migration 023 applies cleanly to fresh DB
- [x] `scripts/backfill_epubs.py --dry-run` script available for bulk population

🤖 Generated with [Claude Code](https://claude.com/claude-code)
