### PR TITLE
feat: admin panel Uploads tab (closes #548)

### DIFF
--- a/frontend/src/__tests__/adminUploads.test.tsx
+++ b/frontend/src/__tests__/adminUploads.test.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UploadsPage from "@/app/admin/uploads/page";
+import AdminLayout from "@/app/admin/layout";
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+const mockAdminFetch = jest.fn();
+jest.mock("@/lib/adminFetch", () => ({
+  adminFetch: (...args: unknown[]) => mockAdminFetch(...args),
+}));
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => "/admin/uploads",
+}));
+jest.mock("@/lib/api", () => ({
+  getMe: () => Promise.resolve({ id: 1, role: "admin" }),
+  getAuthToken: () => "test-token",
+  awaitSession: () => Promise.resolve(),
+}));
+jest.mock("next/link", () => {
+  const MockLink = ({ href, children, ...rest }: React.ComponentProps<"a"> & { href: string }) => (
+    <a href={href} {...rest}>{children}</a>
+  );
+  MockLink.displayName = "MockLink";
+  return { __esModule: true, default: MockLink };
+});
+
+const SAMPLE_UPLOADS = [
+  {
+    book_id: 1001,
+    title: "My Uploaded Novel",
+    filename: "novel.epub",
+    file_size: 524288,
+    format: "epub",
+    uploaded_at: "2026-04-01T12:00:00",
+    uploader_email: "alice@example.com",
+    uploader_name: "Alice",
+  },
+  {
+    book_id: 1002,
+    title: "Another Book",
+    filename: "another.txt",
+    file_size: 102400,
+    format: "txt",
+    uploaded_at: "2026-04-02T08:30:00",
+    uploader_email: "bob@example.com",
+    uploader_name: "Bob",
+  },
+];
+
+beforeEach(() => {
+  mockAdminFetch.mockReset();
+  mockAdminFetch.mockResolvedValue(SAMPLE_UPLOADS);
+});
+
+async function renderPage() {
+  render(<UploadsPage />);
+  await flushPromises();
+  await waitFor(() => expect(screen.queryByText("Loading…")).not.toBeInTheDocument());
+}
+
+describe("Admin Uploads page", () => {
+  it("renders upload rows with title, uploader and format", async () => {
+    await renderPage();
+    expect(screen.getByText("My Uploaded Novel")).toBeInTheDocument();
+    expect(screen.getByText("novel.epub")).toBeInTheDocument();
+    expect(screen.getByText("alice@example.com")).toBeInTheDocument();
+    expect(screen.getByText("epub")).toBeInTheDocument();
+    expect(screen.getByText("Another Book")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no uploads exist", async () => {
+    mockAdminFetch.mockResolvedValue([]);
+    await renderPage();
+    expect(screen.getByText(/no uploads yet/i)).toBeInTheDocument();
+  });
+
+  it("shows error when fetch fails", async () => {
+    mockAdminFetch.mockRejectedValue(new Error("Server error"));
+    await renderPage();
+    expect(screen.getByText(/server error/i)).toBeInTheDocument();
+  });
+
+  it("filters uploads when user ID is entered and Filter is clicked", async () => {
+    mockAdminFetch.mockImplementation((path: string) => {
+      if (path.includes("user_id=99")) {
+        return Promise.resolve([SAMPLE_UPLOADS[0]]);
+      }
+      return Promise.resolve(SAMPLE_UPLOADS);
+    });
+
+    await renderPage();
+
+    const input = screen.getByPlaceholderText(/filter by user id/i);
+    await userEvent.type(input, "99");
+    const button = screen.getByRole("button", { name: /filter/i });
+    await userEvent.click(button);
+    await waitFor(() =>
+      expect(mockAdminFetch).toHaveBeenCalledWith(expect.stringContaining("user_id=99")),
+    );
+  });
+});
+
+describe("Admin layout includes Uploads tab", () => {
+  it("renders an Uploads tab link", async () => {
+    render(
+      <AdminLayout>
+        <div>child</div>
+      </AdminLayout>,
+    );
+    await waitFor(() => expect(screen.getByRole("link", { name: "Uploads" })).toBeInTheDocument());
+  });
+});

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -5,13 +5,14 @@ import Link from "next/link";
 import { getMe } from "@/lib/api";
 import { adminFetch, type Stats } from "@/lib/adminFetch";
 
-type TabKey = "users" | "books" | "audio" | "queue";
+type TabKey = "users" | "books" | "audio" | "queue" | "uploads";
 
 const TABS: { key: TabKey; label: string; href: string }[] = [
   { key: "users", label: "Users", href: "/admin/users" },
   { key: "books", label: "Books", href: "/admin/books" },
   { key: "audio", label: "Audio Cache", href: "/admin/audio" },
   { key: "queue", label: "Queue", href: "/admin/queue" },
+  { key: "uploads", label: "Uploads", href: "/admin/uploads" },
 ];
 
 function activeTab(pathname: string | null): TabKey | null {

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -1,0 +1,183 @@
+"use client";
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { adminFetch } from "@/lib/adminFetch";
+
+interface UploadEntry {
+  book_id: number;
+  title: string;
+  filename: string;
+  file_size: number;
+  format: string;
+  uploaded_at: string;
+  uploader_email: string;
+  uploader_name: string;
+}
+
+function fmt_size(bytes: number): string {
+  if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(1)} MB`;
+  return `${(bytes / 1024).toFixed(0)} KB`;
+}
+
+function fmt_date(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export default function UploadsPage() {
+  const router = useRouter();
+  const [uploads, setUploads] = useState<UploadEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [filterInput, setFilterInput] = useState("");
+  const [activeFilter, setActiveFilter] = useState<string>("");
+
+  const load = useCallback(
+    async (userId?: string) => {
+      setLoading(true);
+      setError("");
+      try {
+        const path = userId ? `/admin/uploads?user_id=${encodeURIComponent(userId)}` : "/admin/uploads";
+        const data = await adminFetch(path);
+        setUploads(data);
+      } catch (e: unknown) {
+        setError(e instanceof Error ? e.message : "Failed to load uploads");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  function handleFilter() {
+    const trimmed = filterInput.trim();
+    setActiveFilter(trimmed);
+    load(trimmed || undefined);
+  }
+
+  function clearFilter() {
+    setFilterInput("");
+    setActiveFilter("");
+    load();
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <div className="w-6 h-6 border-4 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+        <span className="sr-only">Loading…</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm">{error}</div>
+      )}
+
+      <div className="flex gap-2 items-center">
+        <input
+          type="number"
+          placeholder="Filter by user ID…"
+          value={filterInput}
+          onChange={(e) => setFilterInput(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleFilter()}
+          className="w-48 rounded-lg border border-amber-300 px-3 py-2 text-sm"
+          aria-label="User ID filter"
+          min={1}
+        />
+        <button
+          onClick={handleFilter}
+          className="rounded-lg bg-amber-700 text-white px-4 py-2 text-sm hover:bg-amber-800"
+          aria-label="Filter uploads"
+        >
+          Filter
+        </button>
+        {activeFilter && (
+          <button
+            onClick={clearFilter}
+            className="text-sm text-amber-600 hover:text-amber-900"
+          >
+            ✕ Clear filter (user {activeFilter})
+          </button>
+        )}
+        <span className="ml-auto text-xs text-stone-400">{uploads.length} upload{uploads.length !== 1 ? "s" : ""}</span>
+      </div>
+
+      {uploads.length === 0 ? (
+        <div className="bg-white rounded-xl border border-amber-200 px-4 py-12 text-center">
+          <svg
+            className="mx-auto mb-3 w-10 h-10 text-amber-200"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
+            />
+          </svg>
+          <p className="font-serif text-ink mb-1">No uploads yet</p>
+          <p className="text-sm text-stone-400">
+            {activeFilter ? `No uploads found for user ${activeFilter}.` : "No books have been uploaded by users."}
+          </p>
+        </div>
+      ) : (
+        <div className="bg-white rounded-xl border border-amber-200 overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-amber-200 bg-amber-50/60">
+                  <th className="px-4 py-2.5 text-left font-medium text-amber-800">Title</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-amber-800">File</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-amber-800">Format</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-amber-800">Size</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-amber-800">Uploader</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-amber-800">Date</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-amber-800"></th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-amber-100">
+                {uploads.map((u) => (
+                  <tr key={`${u.book_id}-${u.filename}`} className="hover:bg-amber-50/40">
+                    <td className="px-4 py-2.5 font-medium text-ink max-w-[200px] truncate">{u.title}</td>
+                    <td className="px-4 py-2.5 text-stone-500 max-w-[160px] truncate">{u.filename}</td>
+                    <td className="px-4 py-2.5">
+                      <span className="text-xs px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-200">
+                        {u.format}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2.5 text-stone-500 whitespace-nowrap">{fmt_size(u.file_size)}</td>
+                    <td className="px-4 py-2.5 text-stone-500 max-w-[160px] truncate" title={u.uploader_email}>
+                      {u.uploader_email}
+                    </td>
+                    <td className="px-4 py-2.5 text-stone-400 whitespace-nowrap">{fmt_date(u.uploaded_at)}</td>
+                    <td className="px-4 py-2.5">
+                      <button
+                        onClick={() => router.push(`/reader/${u.book_id}`)}
+                        className="text-xs text-amber-600 hover:text-amber-800"
+                      >
+                        Open
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `"uploads"` tab to the admin panel (`layout.tsx`), wired to `/admin/uploads`
- New `frontend/src/app/admin/uploads/page.tsx` fetches `GET /api/admin/uploads` and renders a table with: book title, filename, format, file size, uploader email, and upload date
- Optional filter by user ID (input + button; clears back to full list)
- Empty state with SVG illustration when no uploads exist
- 5 Jest tests covering: populated list, empty state, error handling, user-ID filter, and the "Uploads" tab link in the layout

Backend endpoint (`GET /api/admin/uploads`) was already shipped in PR #546.

Closes #548.

## Test plan

- [x] `npm --prefix frontend test -- --no-coverage --ci` — 1592 tests pass
- [ ] Navigate to `/admin/uploads` in the browser and confirm table renders
- [ ] Enter a user ID and click Filter — confirm filtered results appear
- [ ] Clear filter — confirm full list is restored
