### PR TITLE
design: user_book_chapters table to replace JSON-in-books.text (#357)

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -368,3 +368,74 @@ python scripts/pretranslate.py --book-id 1342 --lang de --force   # overwrite ca
 **Dependencies:** `transformers`, `sentencepiece`, `torch` (CPU), `requests` (for Ollama).  
 **Chunking:** split at sentence boundaries to stay under MarianMT's 512-token limit.  
 **Estimated effort:** ~6 hours.
+
+---
+
+## Session 5 — 2026-04-23
+
+### Shipped this session
+
+- [x] Feature 9: EPUB DB Storage for Gutenberg books (PR #547)
+- [x] Feature 10: Admin Uploads Tab (PRs #546, #553)
+
+### Filed / awaiting approval
+
+- [ ] Feature 11: user_book_chapters table — replace JSON-in-books.text (design PR #555, issue #357)
+- [ ] Feature 2: Vocabulary Flashcards / SRS (design in FEATURES.md Feature 2, issue #556)
+- [ ] Feature 12: Chapter Comprehension Quiz (issue #557)
+
+---
+
+## Feature 9: EPUB DB Storage for Gutenberg Books ✅ (merged — PR #547)
+
+### Overview
+Gutenberg EPUBs are now downloaded once and stored in the database (`book_epubs` table), giving reliable chapter splitting with correct spine order and NCX/nav titles. Eliminates on-demand HTML re-fetching at chapter-load time.
+
+### What shipped
+- Migration 023: `book_epubs` table (`book_id PK`, `epub_bytes BLOB`, `epub_url`, `cached_at`)
+- `gutenberg.py`: `get_book_epub()` — fetches no-images EPUB via Gutendex formats list
+- `db.py`: `save_book_epub()` + `get_book_epub_bytes()`
+- `splitter.py`: `build_chapters_from_epub()` using spine order + NCX/nav titles
+- `book_chapters.py`: DB-only split path — EPUB → plain-text regex fallback; background lazy fetch for existing books
+- `routers/books.py`: fires EPUB download in background at book-add time
+- `book_parser.py`: `parse_epub()` now uses same `build_chapters_from_epub()` as Gutenberg path
+- `scripts/backfill_epubs.py`: one-time backfill for books already in DB
+
+---
+
+## Feature 10: Admin Uploads Tab ✅ (merged — PRs #546, #553)
+
+### Overview
+New "Uploads" tab in the admin panel showing all user-uploaded books with metadata.
+
+### What shipped
+- `GET /api/admin/uploads` endpoint (PR #546)
+- Frontend: `/admin/uploads` page — table of uploaded books with title, filename, format, file size, uploader email, upload date
+- Supports optional filtering by user ID
+- 115 frontend tests
+
+---
+
+## Feature 11: user_book_chapters Table (Issue #357 — awaiting PM approval)
+
+### Overview
+Replace the JSON blob in `books.text` for uploaded books with a proper `user_book_chapters` table. Unblocks full-text search and removes all `source=='upload'` branching from route handlers and the chapter-splitting service.
+
+### Design doc
+`docs/design/user-book-chapters.md` (PR #555 — awaiting PM review)
+
+### Estimated effort
+~4 hours after approval.
+
+---
+
+## Feature 12: Chapter Comprehension Quiz (Issue #557 — future)
+
+### Overview
+After reading a chapter, users get 3–5 AI-generated multiple-choice questions. Results stored per user/chapter. New tables: `quiz_questions`, `quiz_attempts`. New "Quiz" tab in reader sidebar.
+
+### Status
+Needs design doc. See issue #557.
+
+### Estimated effort
+~5 hours after design approval.

--- a/docs/design-epub-ingestion.md
+++ b/docs/design-epub-ingestion.md
@@ -1,8 +1,8 @@
 # Design: EPUB Ingestion for Gutenberg Books
 
-**Status:** Proposed  
+**Status:** Shipped (PR #547, 2026-04-23) — see [Shipped Implementation](#shipped-implementation) below for what changed from the proposal.  
 **Author:** Investigation 2026-04-23  
-**Relates to:** `services/splitter.py`, `services/book_chapters.py`, `services/gutenberg.py`
+**Relates to:** `services/splitter.py`, `services/book_chapters.py`, `services/gutenberg.py`, `backend/migrations/023_book_epubs.sql`
 
 ---
 
@@ -249,23 +249,13 @@ async def split_with_html_preference(book_id: int, text: str) -> list[Chapter]:
 
 ## 6. Storage Strategy
 
-**Decision: keep fetching on-demand (no DB change required).**
+**Proposed:** Keep fetching on-demand (no DB change).
 
-Rationale:
-- The HTML edition is already fetched on-demand and only cached in memory. EPUB follows the same pattern.
-- Storing EPUB bytes in the DB would require a new `BLOB` column (~300 KB per book) and a migration.
-- The in-memory `_chapter_cache` survives the lifetime of a request and is reused for all subsequent chapter accesses within the same process.
-
-**Optional future improvement:** Store `epub_url` in the books table so we can avoid the double Gutendex API hit. Defer until this proves to be a bottleneck.
+**Shipped (PR #547):** EPUBs are stored in the DB in a new `book_epubs` table. See [Shipped Implementation](#shipped-implementation) for why the decision changed.
 
 ### What happens to existing books?
 
-No action required. On the next cold-start chapter request for an existing Gutenberg book, `split_with_html_preference` will run the full cascade:
-
-1. Check in-memory cache (miss — process restarted)
-2. Try HTML (same as today)
-3. **Try EPUB** ← new — may now succeed where HTML was absent before
-4. Fall back to stored plain text
+A backfill script (`scripts/backfill_epubs.py`) fetches and stores EPUBs for all books already in the DB. New books have their EPUB fetched and stored in a background task at add-time.
 
 ---
 
@@ -337,3 +327,35 @@ All changes stay within three existing files. No DB migration, no new tables, no
 - **Displaying EPUB-native formatting** (bold, italic, images) in the reader — the reader consumes plain text; formatting is stripped at ingestion time. A separate "rich reader" feature would be needed for this.
 - **EPUB DRM** — all Gutenberg EPUBs are DRM-free. Not applicable.
 - **User upload: EPUB 3 nav vs EPUB 2 NCX** — `ebooklib` handles both; no special case needed.
+
+---
+
+## Shipped Implementation
+
+**PR #547 merged 2026-04-23.** The shipped version differs from the proposal in one key area: **EPUB bytes are stored in the DB**, not fetched on-demand.
+
+### What changed
+
+| Section | Proposed | Shipped |
+|---|---|---|
+| Storage | Fetch on-demand, cache in memory | New `book_epubs` table (migration 023) with `epub_bytes BLOB` |
+| Existing books | Automatic on cold-start | `scripts/backfill_epubs.py` one-time backfill |
+| New books | Fetch on first chapter request | Fetch in background task at book-add time |
+| HTML tier | Kept as tier 1 | **Removed** — EPUB is now tier 1 for Gutenberg books; plain-text regex is the only fallback |
+
+### Why DB storage was chosen over on-demand
+
+Railway's ephemeral filesystem means the process restarts frequently. An in-memory cache survives only for the lifetime of the process. Storing EPUBs in SQLite ensures chapter splitting is reliable and consistent across restarts without re-fetching from Gutenberg.
+
+### New files shipped
+
+| File | Purpose |
+|---|---|
+| `backend/migrations/023_book_epubs.sql` | `book_epubs` table: `book_id PK`, `epub_bytes BLOB`, `epub_url TEXT`, `cached_at TIMESTAMP` |
+| `backend/services/gutenberg.py` | `get_book_epub()` — fetches no-images EPUB via Gutendex formats |
+| `backend/services/db.py` | `save_book_epub()`, `get_book_epub_bytes()` |
+| `backend/services/splitter.py` | `build_chapters_from_epub()` with spine order + NCX/nav titles |
+| `backend/services/book_chapters.py` | DB-only split: EPUB (from DB) → plain-text regex. No on-demand HTML fetch. Background lazy fetch for existing books. |
+| `backend/routers/books.py` | Fires EPUB download in background at `POST /books/{id}` (book-add) |
+| `backend/services/book_parser.py` | `parse_epub()` delegates to `build_chapters_from_epub()` — user-upload uses same logic |
+| `backend/scripts/backfill_epubs.py` | One-time backfill for books already in DB |

--- a/docs/design/user-book-chapters.md
+++ b/docs/design/user-book-chapters.md
@@ -1,0 +1,183 @@
+# Design: user_book_chapters Table (Issue #357)
+
+**Status:** Awaiting PM approval  
+**Author:** Architect  
+**Date:** 2026-04-23
+
+---
+
+## Problem
+
+Uploaded book chapters are stored as a JSON blob inside `books.text`:
+
+```json
+{"draft": true, "chapters": [{"title": "...", "text": "..."}, ...]}
+```
+
+Gutenberg books use the same column for raw plain text. This creates three problems:
+
+1. **No full-text search** — SQL `LIKE '%query%'` on `books.text` matches JSON structure for uploaded books, not content.
+2. **Silent branching** — every code path that reads `books.text` must branch on `source='upload'` and parse JSON; this is not enforced by the schema and is easy to forget.
+3. **Schema contract violation** — `books.text` was designed for plain text. Using it for JSON breaks that invariant silently.
+
+Affected code paths today (all require a `source=='upload'` branch):
+- `routers/books.py:261` — draft guard before enqueue
+- `routers/books.py:468–484` — `GET /books/{id}/chapters`
+- `routers/uploads.py:171` — `GET /books/{id}/chapters/draft`
+- `routers/uploads.py:226` — `POST /books/{id}/chapters/confirm`
+- `routers/admin.py:1119` — draft guard before admin bulk enqueue
+
+---
+
+## Solution
+
+Add a `user_book_chapters` table. Store uploaded chapters there instead of JSON-in-`books.text`. Clear `books.text` for uploaded books (set to `''`).
+
+This eliminates every `source=='upload'` branch that touches `books.text`; code either reads from `user_book_chapters` (uploads) or splits `books.text` (Gutenberg) — the two paths are now governed by the schema, not runtime string inspection.
+
+---
+
+## Database Schema
+
+### New table (migration 024)
+
+```sql
+CREATE TABLE IF NOT EXISTS user_book_chapters (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    book_id       INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    chapter_index INTEGER NOT NULL,
+    title         TEXT    NOT NULL DEFAULT '',
+    text          TEXT    NOT NULL DEFAULT '',
+    is_draft      INTEGER NOT NULL DEFAULT 1,  -- 1=draft, 0=confirmed
+    UNIQUE(book_id, chapter_index)
+);
+CREATE INDEX IF NOT EXISTS ubc_book_draft ON user_book_chapters(book_id, is_draft);
+```
+
+### Data migration (same migration file)
+
+Move any existing JSON blobs to the new table and clear `books.text`:
+
+```sql
+-- For each uploaded book, parse existing JSON and insert rows.
+-- SQLite does not support JSON_EACH natively on all versions, so we use
+-- a Python migration helper (see below) instead of pure SQL.
+```
+
+Because SQLite's `json_each` support varies, the data migration runs as a Python script called from the migration runner (or as a one-time admin script). See [Migration Script](#migration-script) below.
+
+---
+
+## API Surface Changes
+
+All public endpoints remain **unchanged** in shape. Only internal implementation changes.
+
+| Endpoint | Current | After |
+|---|---|---|
+| `GET /books/{id}/chapters` | Parses JSON from `books.text` for uploads | Reads from `user_book_chapters` |
+| `GET /books/{id}/chapters/draft` | Parses JSON from `books.text` | Reads from `user_book_chapters WHERE is_draft=1` |
+| `POST /books/{id}/chapters/confirm` | Writes confirmed JSON back to `books.text` | Sets `is_draft=0` and updates rows in `user_book_chapters` |
+| `POST /books/upload` | Writes draft JSON to `books.text` | Inserts draft rows into `user_book_chapters`; sets `books.text=''` |
+| `DELETE /books/upload/{id}` | Cascades via `books.id` FK | Same (FK cascade covers `user_book_chapters`) |
+
+The draft guard in enqueue endpoints (`books.py:261`, `admin.py:1119`) becomes:
+
+```python
+# Before (fragile JSON parse)
+_data = json.loads(book_meta.get("text") or "{}")
+if _data.get("draft"): raise ...
+
+# After (schema-enforced)
+draft_count = await db.fetchone(
+    "SELECT COUNT(*) FROM user_book_chapters WHERE book_id=? AND is_draft=1", (book_id,)
+)
+if draft_count[0] > 0: raise ...
+```
+
+---
+
+## Migration Script
+
+The data migration is a Python helper, not pure SQL, because we need to parse arbitrary-length JSON. It runs once and is idempotent:
+
+```python
+# backend/scripts/migrate_upload_chapters.py
+"""One-time migration: move JSON chapters from books.text to user_book_chapters."""
+import json, asyncio
+from db import get_db
+
+async def run():
+    async with get_db() as db:
+        rows = await db.fetchall(
+            "SELECT id, text FROM books WHERE source='upload' AND text LIKE '{%'"
+        )
+        for book_id, text in rows:
+            try:
+                data = json.loads(text)
+            except (ValueError, TypeError):
+                continue
+            chapters = data.get("chapters", [])
+            is_draft = 1 if data.get("draft") else 0
+            for i, ch in enumerate(chapters):
+                await db.execute(
+                    """INSERT OR IGNORE INTO user_book_chapters
+                       (book_id, chapter_index, title, text, is_draft)
+                       VALUES (?, ?, ?, ?, ?)""",
+                    (book_id, i, ch.get("title", ""), ch.get("text", ""), is_draft)
+                )
+            await db.execute("UPDATE books SET text='' WHERE id=?", (book_id,))
+        await db.commit()
+
+asyncio.run(run())
+```
+
+The migration is idempotent: `INSERT OR IGNORE` skips already-migrated rows; the `text LIKE '{%'` filter skips already-cleared rows.
+
+---
+
+## Migration Policy Compliance
+
+This migration adds a new table and performs a data move — no constraints are added to existing rows. However, the migration policy requires a test for any migration that modifies existing data:
+
+- **Test required:** `test_migrations.py` — seed an uploaded book with JSON in `books.text`, run the migration script, verify rows appear in `user_book_chapters` and `books.text` is cleared.
+
+---
+
+## File Scope
+
+Files changed:
+
+| File | Change |
+|---|---|
+| `backend/migrations/024_user_book_chapters.sql` | New table DDL |
+| `backend/scripts/migrate_upload_chapters.py` | One-time data migration |
+| `backend/routers/uploads.py` | Write to / read from `user_book_chapters` instead of `books.text` |
+| `backend/routers/books.py` | Remove JSON-parse branch; read from `user_book_chapters` for uploads |
+| `backend/routers/admin.py` | Remove JSON-parse draft guard |
+| `backend/tests/test_router_uploads.py` | Update fixtures; add migration test |
+| `backend/tests/test_router_books.py` | Update upload chapter tests |
+| `backend/tests/test_migrations.py` | New test: data migration correctness |
+
+Total: 8 files, 3 services. No frontend changes needed.
+
+---
+
+## Open Questions
+
+1. **`books.text` for uploads** — Should we set it to `''` (empty string) or `NULL`? Empty string is safer (avoids nullable column change); NULL would require a schema migration to allow NULLs. **Proposed:** empty string for now.
+
+2. **Gutenberg chapter caching** — Gutenberg uses `services/book_chapters.py` (in-memory + EPUB cache) rather than `user_book_chapters`. Should we unify chapter storage for all sources? **Proposed:** No — scope creep. Keep Gutenberg caching separate; this design only fixes uploaded books.
+
+3. **Search** — Issue mentions full-text search as a motivation. Should this design include a FTS5 virtual table on `user_book_chapters.text`? **Proposed:** No — defer to a separate search issue. This design unblocks search; it doesn't implement it.
+
+---
+
+## Estimated Effort
+
+~4 hours: migration (1h), router updates (1.5h), test updates (1.5h).
+
+---
+
+## Decision
+
+**Awaiting PM approval.** Once the design doc is merged, implementation can begin on a `feat/user-book-chapters` branch.

--- a/docs/design/user-book-chapters.md
+++ b/docs/design/user-book-chapters.md
@@ -40,7 +40,9 @@ This eliminates every `source=='upload'` branch that touches `books.text`; code 
 
 ## Database Schema
 
-### New table (migration 024)
+### New table (migration 025)
+
+> **Note:** Migration `024_flashcard_reviews.sql` is already merged. This migration uses `025`.
 
 ```sql
 CREATE TABLE IF NOT EXISTS user_book_chapters (
@@ -150,7 +152,7 @@ Files changed:
 
 | File | Change |
 |---|---|
-| `backend/migrations/024_user_book_chapters.sql` | New table DDL |
+| `backend/migrations/025_user_book_chapters.sql` | New table DDL |
 | `backend/scripts/migrate_upload_chapters.py` | One-time data migration |
 | `backend/services/book_chapters.py` | Remove JSON-detect branch; query `user_book_chapters` for uploads |
 | `backend/routers/uploads.py` | Write to / read from `user_book_chapters` instead of `books.text` |

--- a/docs/design/user-book-chapters.md
+++ b/docs/design/user-book-chapters.md
@@ -1,6 +1,6 @@
 # Design: user_book_chapters Table (Issue #357)
 
-**Status:** Awaiting PM approval  
+**Status:** PM approved 2026-04-23 ✅ — revised to resolve migration-runner question  
 **Author:** Architect  
 **Date:** 2026-04-23
 
@@ -67,7 +67,25 @@ Move any existing JSON blobs to the new table and clear `books.text`:
 -- a Python migration helper (see below) instead of pure SQL.
 ```
 
-Because SQLite's `json_each` support varies, the data migration runs as a Python script called from the migration runner (or as a one-time admin script). See [Migration Script](#migration-script) below.
+Because SQLite's `json_each` support varies, the data migration is a Python helper (not pure SQL). The existing migration runner processes `.sql` files only and has no hook for Python; teaching it to run Python would be a separate, larger change and risks running arbitrary code during startup.
+
+**Decision: option (b) — manual ops step.**
+
+- Migration `025_user_book_chapters.sql` creates the table and indexes (pure SQL, runs automatically via the existing runner).
+- `backend/scripts/migrate_upload_chapters.py` is run **once, manually by ops**, after the `025` migration applies and before the router code that reads from `user_book_chapters` is deployed. The script is idempotent (see [Migration Script](#migration-script)), so re-running it is safe.
+
+Rationale:
+- Simpler and lower-risk — no migration-runner change.
+- The script runs under full application config (ENV, DB URL, encryption keys) with a normal Python import path — easier to debug than a migration-runner-invoked script.
+- It runs exactly once in the project's lifetime; paying the ergonomics cost for a permanent runner hook is not justified by a single-use script.
+
+**Deployment checklist (documented in the implementation PR):**
+1. Deploy backend with migration `025` + new services but **old router code** still reading from `books.text`. The `025` SQL runs on startup; the new table exists but is empty.
+2. Operator runs `python -m backend.scripts.migrate_upload_chapters` against the production DB. Idempotent; prints a count of rows migrated.
+3. Deploy router code that reads from `user_book_chapters`. The old code path keeps working until this deploy because step 2 did not clear `books.text` yet — see script note below.
+4. After step 3 is stable, the operator runs the same script with `--finalize` to UPDATE `books.text=''` on migrated rows (a separate idempotent phase).
+
+The two-phase design keeps the rollback path clean: if step 3 fails, the old router still reads `books.text` intact. The script's UPDATE step is gated behind `--finalize` so a premature first run cannot strand the old code path.
 
 ---
 
@@ -101,40 +119,65 @@ if draft_count[0] > 0: raise ...
 
 ## Migration Script
 
-The data migration is a Python helper, not pure SQL, because we need to parse arbitrary-length JSON. It runs once and is idempotent:
+The data migration is a Python helper, not pure SQL, because we need to parse arbitrary-length JSON. It runs manually and is idempotent. The script has two phases controlled by a `--finalize` flag so the old router code path stays intact during the router deploy (see Deployment checklist above):
 
 ```python
 # backend/scripts/migrate_upload_chapters.py
 """One-time migration: move JSON chapters from books.text to user_book_chapters."""
-import json, asyncio
+import argparse, json, asyncio
 from db import get_db
 
-async def run():
+async def copy_phase(db):
+    rows = await db.fetchall(
+        "SELECT id, text FROM books WHERE source='upload' AND text LIKE '{%'"
+    )
+    copied = 0
+    for book_id, text in rows:
+        try:
+            data = json.loads(text)
+        except (ValueError, TypeError):
+            continue
+        chapters = data.get("chapters", [])
+        is_draft = 1 if data.get("draft") else 0
+        for i, ch in enumerate(chapters):
+            await db.execute(
+                """INSERT OR IGNORE INTO user_book_chapters
+                   (book_id, chapter_index, title, text, is_draft)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (book_id, i, ch.get("title", ""), ch.get("text", ""), is_draft)
+            )
+        copied += 1
+    return copied
+
+async def finalize_phase(db):
+    # Only clear books.text for uploads that already have rows in user_book_chapters.
+    await db.execute("""
+        UPDATE books SET text = ''
+        WHERE source = 'upload'
+          AND text LIKE '{%'
+          AND EXISTS (SELECT 1 FROM user_book_chapters WHERE book_id = books.id)
+    """)
+
+async def run(finalize: bool):
     async with get_db() as db:
-        rows = await db.fetchall(
-            "SELECT id, text FROM books WHERE source='upload' AND text LIKE '{%'"
-        )
-        for book_id, text in rows:
-            try:
-                data = json.loads(text)
-            except (ValueError, TypeError):
-                continue
-            chapters = data.get("chapters", [])
-            is_draft = 1 if data.get("draft") else 0
-            for i, ch in enumerate(chapters):
-                await db.execute(
-                    """INSERT OR IGNORE INTO user_book_chapters
-                       (book_id, chapter_index, title, text, is_draft)
-                       VALUES (?, ?, ?, ?, ?)""",
-                    (book_id, i, ch.get("title", ""), ch.get("text", ""), is_draft)
-                )
-            await db.execute("UPDATE books SET text='' WHERE id=?", (book_id,))
+        copied = await copy_phase(db)
+        print(f"copy phase: {copied} upload book(s) processed")
+        if finalize:
+            await finalize_phase(db)
+            print("finalize phase: books.text cleared for migrated uploads")
         await db.commit()
 
-asyncio.run(run())
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--finalize", action="store_true",
+                        help="Clear books.text for uploads after router deploy is stable.")
+    args = parser.parse_args()
+    asyncio.run(run(args.finalize))
 ```
 
-The migration is idempotent: `INSERT OR IGNORE` skips already-migrated rows; the `text LIKE '{%'` filter skips already-cleared rows.
+The migration is idempotent in both phases:
+- Copy phase: `INSERT OR IGNORE` skips already-migrated rows; rows whose `books.text` is `''` are skipped by `text LIKE '{%'`.
+- Finalize phase: guarded by `EXISTS (SELECT 1 FROM user_book_chapters …)`; running it twice on an already-cleared row is a no-op.
 
 ---
 
@@ -142,7 +185,8 @@ The migration is idempotent: `INSERT OR IGNORE` skips already-migrated rows; the
 
 This migration adds a new table and performs a data move — no constraints are added to existing rows. However, the migration policy requires a test for any migration that modifies existing data:
 
-- **Test required:** `test_migrations.py` — seed an uploaded book with JSON in `books.text`, run the migration script, verify rows appear in `user_book_chapters` and `books.text` is cleared.
+- **Test required (SQL runner):** `test_migrations.py` — apply `025_user_book_chapters.sql` on a DB that seeds an uploaded book with JSON in `books.text`. Verify: the table + index exist, the FK cascade is active, and `books.text` is still intact (the SQL alone does not touch `books.text`).
+- **Test required (Python helper):** `test_migrate_upload_chapters.py` — seed one book with JSON + one book already cleared + one legacy (non-upload) book. Run `copy_phase`: upload JSON copied; pre-cleared row skipped; legacy row untouched. Run `copy_phase` again (idempotency): no duplicate rows inserted. Run `finalize_phase`: `books.text` cleared only for the copied upload; legacy row untouched. Run `finalize_phase` again (idempotency): no rows changed.
 
 ---
 
@@ -184,4 +228,8 @@ Total: 9 files, 4 services. No frontend changes needed.
 
 ## Decision
 
-**Awaiting PM approval.** Once the design doc is merged, implementation can begin on a `feat/user-book-chapters` branch.
+**PM approved 2026-04-23 ✅** with one clarification item, now resolved:
+
+- **Migration-runner question (resolved):** chose option (b). The existing SQL-only migration runner is not extended to execute Python. Instead, ops runs `backend/scripts/migrate_upload_chapters.py` manually in two phases (`copy` and `--finalize`). Rationale and deployment checklist are documented in the Data migration + Migration Script sections above.
+
+Implementation begins on `feat/user-book-chapters` once this design doc merges.

--- a/docs/design/user-book-chapters.md
+++ b/docs/design/user-book-chapters.md
@@ -26,6 +26,7 @@ Affected code paths today (all require a `source=='upload'` branch):
 - `routers/uploads.py:171` — `GET /books/{id}/chapters/draft`
 - `routers/uploads.py:226` — `POST /books/{id}/chapters/confirm`
 - `routers/admin.py:1119` — draft guard before admin bulk enqueue
+- `services/book_chapters.py:52–60` — in-memory chapter cache resolves uploads by detecting `text.startswith("{")`
 
 ---
 
@@ -151,6 +152,7 @@ Files changed:
 |---|---|
 | `backend/migrations/024_user_book_chapters.sql` | New table DDL |
 | `backend/scripts/migrate_upload_chapters.py` | One-time data migration |
+| `backend/services/book_chapters.py` | Remove JSON-detect branch; query `user_book_chapters` for uploads |
 | `backend/routers/uploads.py` | Write to / read from `user_book_chapters` instead of `books.text` |
 | `backend/routers/books.py` | Remove JSON-parse branch; read from `user_book_chapters` for uploads |
 | `backend/routers/admin.py` | Remove JSON-parse draft guard |
@@ -158,7 +160,7 @@ Files changed:
 | `backend/tests/test_router_books.py` | Update upload chapter tests |
 | `backend/tests/test_migrations.py` | New test: data migration correctness |
 
-Total: 8 files, 3 services. No frontend changes needed.
+Total: 9 files, 4 services. No frontend changes needed.
 
 ---
 


### PR DESCRIPTION
## Summary

Design doc for migrating uploaded book chapters out of the `books.text` JSON blob and into a proper `user_book_chapters` table (Path B — schema change, 3+ files, requires PM approval).

**Problem:** Uploaded books store chapters as `{"draft":true,"chapters":[...]}` in `books.text`. This breaks full-text search, requires silent branching in 5 code paths, and violates the column's plain-text contract.

**Proposed solution:**
- New `user_book_chapters` table (migration 024)
- One-time Python data migration script (idempotent, safe for prod)
- Replace all `json.loads(books.text)` branches in `uploads.py`, `books.py`, `admin.py`
- No API shape changes — all endpoints keep the same request/response

**Files in scope:** 8 files, backend only, no frontend changes.

**Estimated effort:** ~4 hours once approved.

## Review checklist

- [ ] Schema design looks correct (table, index, FK)
- [ ] Migration script is safe for production data
- [ ] Open questions answered (empty string vs NULL, Gutenberg unification, FTS defer)
- [ ] Effort estimate accepted

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)
