### PR TITLE
fix: return empty url when definition source is AI (closes #551)

### DIFF
--- a/backend/services/gemini.py
+++ b/backend/services/gemini.py
@@ -186,13 +186,13 @@ async def define_word(api_key: str, word: str, lang: str = "en") -> dict:
                 for d in data.get("definitions", [])[:3]
                 if d.get("text")
             ],
-            "url": f"https://en.wiktionary.org/wiki/{word}",
+            "url": "",
             "source": "ai",
         }
     except Exception:
         return {
             "lemma": word, "language": lang, "definitions": [],
-            "url": f"https://en.wiktionary.org/wiki/{word}", "source": "ai",
+            "url": "", "source": "ai",
         }
 
 

--- a/backend/tests/test_gemini.py
+++ b/backend/tests/test_gemini.py
@@ -354,6 +354,25 @@ async def test_translate_chapters_batch_sends_permissive_safety_settings():
     assert all(isinstance(s, g_types.SafetySetting) for s in config.safety_settings)
 
 
+# ── define_word ───────────────────────────────────────────────────────────────
+
+async def test_define_word_returns_empty_url_for_ai_source():
+    """Regression #551: AI-sourced definitions must not return a wiktionary URL."""
+    valid_json = '{"lemma": "Aufmerksamkeit", "definitions": [{"pos": "noun", "text": "attention"}]}'
+    with mock_generate(valid_json):
+        result = await gemini.define_word("key", "Aufmerksamkeit", "de")
+    assert result["source"] == "ai"
+    assert result["url"] == "", f"Expected empty url for AI source, got: {result['url']!r}"
+
+
+async def test_define_word_returns_empty_url_on_parse_error():
+    """Regression #551: malformed AI response still returns empty url (not wiktionary)."""
+    with mock_generate("not valid json"):
+        result = await gemini.define_word("key", "xyz", "de")
+    assert result["source"] == "ai"
+    assert result["url"] == "", f"Expected empty url for AI source on error, got: {result['url']!r}"
+
+
 async def test_translate_chapters_batch_error_includes_raw_preview():
     """The error message must include a preview of what the model
     actually returned so admins can tell truncation apart from a

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -176,7 +176,7 @@ function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
             </div>
           )}
 
-          {def && (
+          {def && def.url && (
             <a
               href={def.url}
               target="_blank"


### PR DESCRIPTION
## Summary

- `define_word` in `services/gemini.py` was returning `url: "https://en.wiktionary.org/wiki/{word}"` even when the definition source is AI — meaning the word had no wiktionary entry (that's why AI was called in the first place)
- Returns `url: ""` now so the frontend correctly suppresses the "View on Wiktionary" link
- Guards `vocabulary/page.tsx` against rendering `<a href="">` when url is empty

## Tests

- 2 new regression tests in `test_gemini.py`: `test_define_word_returns_empty_url_for_ai_source` and `test_define_word_returns_empty_url_on_parse_error`
- Full backend suite: 1164 passed
- Full frontend suite: 1592 passed

Closes #551
