### PR TITLE
fix: replace emoji icons with SVG and add aria-labels in AnnotationsSidebar (closes #561)

### DIFF
--- a/frontend/src/__tests__/AnnotationsSidebar.test.tsx
+++ b/frontend/src/__tests__/AnnotationsSidebar.test.tsx
@@ -146,3 +146,29 @@ test("sidebar footer shows 'Book notes' link when bookId provided", async () => 
   const bookLink = screen.getByRole("link", { name: /book notes/i });
   expect(bookLink).toHaveAttribute("href", "/notes/42");
 });
+
+// ── Regression #561: emoji icons and missing aria-labels ──────────────────────
+
+test("edit button has aria-label so screen readers announce it correctly", async () => {
+  const ann = makeAnnotation({ sentence_text: "Some sentence." });
+  render(<AnnotationsSidebar {...BASE_PROPS} annotations={[ann]} totalCount={1} />);
+  await userEvent.click(screen.getByTestId("annotations-toggle"));
+  // getByRole with name relies on aria-label (not just title)
+  expect(screen.getByRole("button", { name: "Edit annotation" })).toBeInTheDocument();
+});
+
+test("annotation link button has aria-label when bookId is provided", async () => {
+  const ann = makeAnnotation({ sentence_text: "Some sentence." });
+  render(<AnnotationsSidebar {...BASE_PROPS} annotations={[ann]} totalCount={1} bookId={42} />);
+  await userEvent.click(screen.getByTestId("annotations-toggle"));
+  expect(screen.getByRole("link", { name: /view in notes/i })).toBeInTheDocument();
+});
+
+test("toggle button does not contain emoji characters in its text content", () => {
+  render(<AnnotationsSidebar {...BASE_PROPS} />);
+  const btn = screen.getByTestId("annotations-toggle");
+  // Text content should be "Notes" (with count badge), not an emoji like 📝
+  const emojiRegex = /\p{Emoji_Presentation}/u;
+  expect(btn.textContent).not.toMatch(emojiRegex);
+  expect(btn.textContent).toMatch(/Notes/);
+});

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState } from "react";
 import type { Annotation } from "@/lib/api";
-import { ArrowRightIcon } from "@/components/Icons";
+import { ArrowRightIcon, NoteIcon, EditIcon, CloseIcon, EmptyNotesIcon } from "@/components/Icons";
 
 const COLOR_BADGE: Record<string, string> = {
   yellow: "bg-yellow-100 border-yellow-300 text-yellow-800",
@@ -48,7 +48,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
         className="relative shrink-0 flex items-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-xs font-medium transition-colors min-h-[44px] md:min-h-0"
         data-testid="annotations-toggle"
       >
-        📝 Notes
+        <NoteIcon className="w-3.5 h-3.5" /> Notes
         {totalCount > 0 && (
           <span className="absolute -top-1.5 -right-1.5 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-amber-600 text-white text-[10px] font-bold px-1">
             {totalCount}
@@ -66,10 +66,10 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
             <h2 className="font-serif font-semibold text-ink text-sm">Annotations</h2>
             <button
               onClick={() => setOpen(false)}
-              className="text-stone-400 hover:text-stone-600 text-lg leading-none"
+              className="text-stone-400 hover:text-stone-600"
               aria-label="Close"
             >
-              ✕
+              <CloseIcon className="w-4 h-4" />
             </button>
           </div>
 
@@ -80,7 +80,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
               </div>
             ) : annotations.length === 0 ? (
               <div className="text-center text-stone-400 mt-10 text-sm">
-                <p className="text-3xl mb-2">📝</p>
+                <EmptyNotesIcon className="w-10 h-10 text-stone-300 mx-auto mb-2" />
                 <p>No annotations yet.</p>
                 <p className="mt-1 text-xs">Click a sentence and choose Note to add one.</p>
               </div>
@@ -112,18 +112,20 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
                               <a
                                 href={`/notes/${bookId}#annotation-${ann.id}`}
                                 onClick={(e) => { e.stopPropagation(); setOpen(false); }}
-                                className="text-xs opacity-60 hover:opacity-100"
+                                className="opacity-60 hover:opacity-100"
                                 title="View in notes page"
+                                aria-label="View in notes page"
                               >
-                                📄
+                                <ArrowRightIcon className="w-3.5 h-3.5" />
                               </a>
                             )}
                             <button
                               onClick={(e) => { e.stopPropagation(); onEdit(ann); setOpen(false); }}
-                              className="text-xs opacity-60 hover:opacity-100"
+                              className="opacity-60 hover:opacity-100"
                               title="Edit annotation"
+                              aria-label="Edit annotation"
                             >
-                              ✏️
+                              <EditIcon className="w-3.5 h-3.5" />
                             </button>
                           </div>
                         </div>


### PR DESCRIPTION
## Summary

Fixes emoji-as-icon violations and missing `aria-label` attributes in `AnnotationsSidebar.tsx` found during UX audit.

**Changes:**
- Toggle button: `📝 Notes` → `<NoteIcon /> Notes` (SVG from Icons.tsx)
- Empty state: `📝` emoji `<p>` → `<EmptyNotesIcon />` (SVG)
- Annotation link button: `📄` emoji → `<ArrowRightIcon />` + `aria-label="View in notes page"`
- Edit button: `✏️` emoji → `<EditIcon />` + `aria-label="Edit annotation"`
- Close button: `✕` text → `<CloseIcon />` (kept existing `aria-label="Close"`)

## Tests

- 3 new regression tests in `AnnotationsSidebar.test.tsx`:
  - Edit button has `aria-label` (screen reader accessible name)
  - Annotation link has `aria-label`
  - Toggle button text has no emoji characters
- Full frontend suite: 1599 passed

Closes #561
