### PR TITLE
fix: raise SelectionToolbar touch target from 40px to 44px (closes #563)

### DIFF
--- a/frontend/src/__tests__/SelectionToolbar.test.tsx
+++ b/frontend/src/__tests__/SelectionToolbar.test.tsx
@@ -153,6 +153,18 @@ describe("SelectionToolbar", () => {
     expect(screen.queryByRole("button", { name: /Chat/i })).not.toBeInTheDocument();
   });
 
+  it("toolbar buttons meet 44px minimum touch target height (regression #563)", () => {
+    render(<SelectionToolbar onRead={jest.fn()} />);
+    simulateSelection("tap target check", readerEl);
+    act(() => { document.dispatchEvent(new Event("selectionchange")); });
+
+    const btn = screen.getByRole("button", { name: /Read/i });
+    const classList = btn.className;
+    // min-h-[40px] is below 44px — must be min-h-[44px] or larger
+    expect(classList).not.toMatch(/min-h-\[4[0-3]px\]/);
+    expect(classList).toMatch(/min-h-\[44px\]/);
+  });
+
   it("hides toolbar on reader scroll", () => {
     render(<SelectionToolbar onRead={jest.fn()} />);
     simulateSelection("scroll away", readerEl);

--- a/frontend/src/components/SelectionToolbar.tsx
+++ b/frontend/src/components/SelectionToolbar.tsx
@@ -111,7 +111,7 @@ export default function SelectionToolbar({ onRead, onHighlight, onNote, onChat, 
     setSelection(null);
   }
 
-  const btnClass = "flex items-center gap-1.5 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-white/10 active:bg-white/20 transition-colors min-h-[40px]";
+  const btnClass = "flex items-center gap-1.5 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-white/10 active:bg-white/20 transition-colors min-h-[44px]";
 
   return (
     <div


### PR DESCRIPTION
## Summary

`SelectionToolbar` buttons had `min-h-[40px]` — 4px below the WCAG 2.5.5 and CLAUDE.md required 44×44px minimum touch target on mobile. Changed to `min-h-[44px]`.

## Tests

- 1 new regression test: verifies the button class matches `min-h-[44px]` and does NOT match any `min-h-[40–43px]` variant
- Full frontend suite: 1604 passed

Closes #563
