### PR TITLE
fix: add max_length to QueuePlanRequest and RetryFailedRequest.target_language

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -920,7 +920,7 @@ async def queue_stop(_admin: dict = Depends(_require_admin)):
 
 
 class QueuePlanRequest(BaseModel):
-    target_language: str
+    target_language: str = Field(..., max_length=20)
     book_ids: list[int] | None = None
 
 
@@ -1225,7 +1225,7 @@ async def queue_retry_item(
 
 class RetryFailedRequest(BaseModel):
     book_id: int | None = None
-    target_language: str | None = None
+    target_language: str | None = Field(default=None, max_length=20)
 
 
 @router.post("/queue/retry-failed")

--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -44,7 +44,7 @@ async def cached_books():
 
 @router.get("/popular")
 async def popular_books(
-    language: str = "",
+    language: str = Query(default="", max_length=20),
     page: int = Query(1, ge=1),
     per_page: int = Query(50, ge=1, le=200),
 ):

--- a/backend/tests/test_router_admin_extended.py
+++ b/backend/tests/test_router_admin_extended.py
@@ -877,3 +877,27 @@ async def test_retranslate_all_preserves_old_translations_on_failure(admin_clien
     assert await get_cached_translation(200, 1, "fr") == ["original ch1"], (
         "Chapter 1 old translation was deleted before confirming new one succeeded"
     )
+
+
+# ── Issue #572: admin request body bounds ────────────────────────────────────
+
+async def test_queue_plan_oversized_language_returns_422(admin_client, admin_db):
+    """Regression #572: POST /admin/queue/plan with target_language > 20 chars must return 422."""
+    res = await admin_client.post(
+        "/api/admin/queue/plan",
+        json={"target_language": "x" * 21},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for oversized target_language in /queue/plan, got {res.status_code}: {res.text}"
+    )
+
+
+async def test_queue_retry_failed_oversized_language_returns_422(admin_client, admin_db):
+    """Regression #572: POST /admin/queue/retry-failed with target_language > 20 chars must return 422."""
+    res = await admin_client.post(
+        "/api/admin/queue/retry-failed",
+        json={"target_language": "x" * 21},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for oversized target_language in /queue/retry-failed, got {res.status_code}: {res.text}"
+    )

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -164,6 +164,14 @@ async def test_popular_books_unknown_language_falls_back_to_all(client, popular_
     assert data["total"] == 120  # falls back to "" collection
 
 
+async def test_popular_books_oversized_language_returns_422(client, popular_cache):
+    """Regression #568: GET /books/popular?language= must reject strings > 20 chars."""
+    resp = await client.get("/api/books/popular?language=" + "x" * 21)
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized language in /books/popular, got {resp.status_code}: {resp.text}"
+    )
+
+
 async def test_popular_books_empty_when_no_manifest(client):
     import routers.books as br
     original = br._popular_cache


### PR DESCRIPTION
## Summary

- `QueuePlanRequest.target_language` (admin.py:923) had no `max_length` — accepted arbitrarily long strings in `POST /admin/queue/plan`
- `RetryFailedRequest.target_language` (admin.py:1228) same issue — `POST /admin/queue/retry-failed`
- Added `Field(..., max_length=20)` / `Field(default=None, max_length=20)` to match every other `target_language` field in the codebase (e.g. `BulkRetranslateRequest`, `ImportTranslationEntry`)

## Tests

Two regression tests in `test_router_admin_extended.py` confirm 422 is returned for oversized `target_language` in both endpoints.

Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)
