### PR TITLE
fix: replace → character with ArrowRightIcon SVG in notes book list

### DIFF
--- a/frontend/src/__tests__/NotesPageArrowIcon.test.tsx
+++ b/frontend/src/__tests__/NotesPageArrowIcon.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Regression test for #577: notes page book-list arrow must use SVG ArrowRightIcon,
+ * not the raw → character (which leaks into the button's accessible name).
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { act } from "@testing-library/react";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { backendToken: "token" }, status: "authenticated" }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getAllAnnotations: jest.fn(),
+  getAllInsights: jest.fn(),
+  getVocabulary: jest.fn(),
+}));
+
+import * as api from "@/lib/api";
+import NotesPage from "@/app/notes/page";
+
+const mockGetAllAnnotations = api.getAllAnnotations as jest.MockedFunction<typeof api.getAllAnnotations>;
+const mockGetAllInsights = api.getAllInsights as jest.MockedFunction<typeof api.getAllInsights>;
+const mockGetVocabulary = api.getVocabulary as jest.MockedFunction<typeof api.getVocabulary>;
+
+const flushPromises = () => new Promise<void>((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetAllInsights.mockResolvedValue([]);
+  mockGetVocabulary.mockResolvedValue([]);
+});
+
+describe("NotesPage — book list arrow icon (#577)", () => {
+  it("does not render the raw → character in book list buttons", async () => {
+    mockGetAllAnnotations.mockResolvedValue([
+      {
+        id: 1, book_id: 10, chapter_index: 0,
+        sentence_text: "A sentence.", note_text: "", color: "yellow",
+        book_title: "Pride and Prejudice", created_at: "2026-01-01T00:00:00",
+      },
+    ]);
+
+    render(<NotesPage />);
+    await act(async () => await flushPromises());
+
+    await waitFor(() =>
+      expect(screen.getByText("Pride and Prejudice")).toBeInTheDocument()
+    );
+
+    const btn = screen.getByText("Pride and Prejudice").closest("button");
+    expect(btn).not.toBeNull();
+    // Raw → character must not appear in button text content
+    expect(btn!.textContent).not.toContain("→");
+  });
+
+  it("renders an SVG icon in the book list button instead of → text", async () => {
+    mockGetAllAnnotations.mockResolvedValue([
+      {
+        id: 1, book_id: 10, chapter_index: 0,
+        sentence_text: "A sentence.", note_text: "", color: "yellow",
+        book_title: "Moby Dick", created_at: "2026-01-01T00:00:00",
+      },
+    ]);
+
+    render(<NotesPage />);
+    await act(async () => await flushPromises());
+
+    await waitFor(() =>
+      expect(screen.getByText("Moby Dick")).toBeInTheDocument()
+    );
+
+    const btn = screen.getByText("Moby Dick").closest("button");
+    expect(btn).not.toBeNull();
+    // An SVG should be present inside the button (from ArrowRightIcon)
+    const svg = btn!.querySelector("svg");
+    expect(svg).not.toBeNull();
+  });
+});

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { getAllAnnotations, getAllInsights, getVocabulary, AnnotationWithBook, BookInsightWithBook, VocabularyWord } from "@/lib/api";
-import { NoteIcon, InsightIcon, VocabIcon, EmptyNotesIcon, ArrowLeftIcon, WordIcon } from "@/components/Icons";
+import { NoteIcon, InsightIcon, VocabIcon, EmptyNotesIcon, ArrowLeftIcon, ArrowRightIcon, WordIcon } from "@/components/Icons";
 
 interface BookSummary {
   bookId: number;
@@ -186,7 +186,7 @@ export default function NotesOverviewPage() {
                   </div>
                   <div className="shrink-0 text-right">
                     <span className="text-xs text-stone-400">{timeAgo(book.lastActivity)}</span>
-                    <p className="text-amber-600 group-hover:text-amber-800 text-lg mt-0.5">→</p>
+                    <ArrowRightIcon aria-hidden="true" className="w-4 h-4 text-amber-600 group-hover:text-amber-800 mt-0.5" />
                   </div>
                 </div>
               </button>


### PR DESCRIPTION
## Summary

- Replaced raw `→` character in each book-list button on the Notes overview page with `<ArrowRightIcon aria-hidden="true" />` from `Icons.tsx`
- The raw `→` was included in the button's accessible name, causing screen readers to announce "Book Title … Right arrow" on every list item
- Added regression test (`NotesPageArrowIcon.test.tsx`) verifying no `→` character appears in button text content and an SVG is present instead

## Test plan
- [x] `NotesPageArrowIcon.test.tsx` — 2 tests, both pass
- [x] Full frontend suite — 1610 tests, all pass

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)
