### PR TITLE
fix: cap GET /vocabulary/flashcards/due at 100 cards per session

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -1076,6 +1076,7 @@ async def get_flashcards_due(user_id: int) -> list[dict]:
             JOIN vocabulary v ON v.id = fr.vocabulary_id
             WHERE fr.user_id = ? AND fr.due_date <= date('now')
             ORDER BY fr.due_date ASC, v.word ASC
+            LIMIT 100
             """,
             (user_id,),
         ) as cur:

--- a/backend/tests/test_router_flashcards.py
+++ b/backend/tests/test_router_flashcards.py
@@ -181,6 +181,19 @@ async def test_stats_reviewed_today_after_review(client, test_user):
     assert data["reviewed_today"] == 1
 
 
+# ── Session cap (issue #564) ──────────────────────────────────────────────────
+
+async def test_due_flashcards_capped_at_100(client, test_user):
+    """GET /flashcards/due must return at most 100 cards even when more are due."""
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    for i in range(110):
+        await save_word(test_user["id"], f"word_{i:03d}", BOOK_ID, 0, f"Context {i}.")
+
+    resp = await client.get("/api/vocabulary/flashcards/due")
+    assert resp.status_code == 200
+    assert len(resp.json()) <= 100
+
+
 # ── Auth requirements ─────────────────────────────────────────────────────────
 
 async def test_flashcards_require_auth(anon_client):


### PR DESCRIPTION
## Summary
- Adds `LIMIT 100` to the `GET /vocabulary/flashcards/due` SQL query
- Prevents unbounded response payloads for power users with many saved words
- SM-2 is designed for short daily sessions; 100 cards per session is a generous cap

## Test plan
- [x] Added `test_due_flashcards_capped_at_100`: seeds 110 words, confirms response ≤ 100 cards
- [x] Full backend suite passes (1179 tests)

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)
