### PR TITLE
fix: mobile bottom nav buttons 40→44px touch target

### DIFF
--- a/frontend/src/__tests__/ReaderMobileBottomNavTouchTargets.test.tsx
+++ b/frontend/src/__tests__/ReaderMobileBottomNavTouchTargets.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Regression test for #581: mobile bottom nav buttons must be at least 44×44px.
+ * The buttons (Translation, Play/Pause, Notes, Insight chat) were w-10 h-10 (40px),
+ * below the CLAUDE.md minimum of 44px for mobile touch targets.
+ */
+import React from "react";
+import { render, act } from "@testing-library/react";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: null, status: "unauthenticated" }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useParams: () => ({ bookId: "42" }),
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getBookChapters: jest.fn().mockResolvedValue({
+    meta: { id: 42, title: "Test Book", authors: [], languages: [], subjects: [], download_count: 0, cover: "" },
+    chapters: [{ title: "Chapter 1", content: "Hello world." }],
+  }),
+  getMe: jest.fn().mockRejectedValue(new Error("Not authed")),
+  getAnnotations: jest.fn().mockResolvedValue([]),
+  getVocabulary: jest.fn().mockResolvedValue([]),
+  getBookTranslationStatus: jest.fn().mockResolvedValue(null),
+  getChapterTranslation: jest.fn().mockResolvedValue(null),
+  getChapterQueueStatus: jest.fn().mockResolvedValue(null),
+  requestChapterTranslation: jest.fn(),
+  retryChapterTranslation: jest.fn(),
+  enqueueBookTranslation: jest.fn(),
+  deleteTranslationCache: jest.fn(),
+  saveReadingProgress: jest.fn(),
+  saveVocabularyWord: jest.fn(),
+  getWordDefinition: jest.fn(),
+  exportVocabularyToObsidian: jest.fn(),
+  saveInsight: jest.fn(),
+  synthesizeSpeech: jest.fn(),
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(msg: string, status: number) { super(msg); this.status = status; }
+  },
+}));
+
+jest.mock("@/lib/settings", () => ({
+  getSettings: jest.fn().mockReturnValue({
+    theme: "light", fontSize: "base", lineHeight: "normal",
+    translationLang: "zh", displayMode: "inline", insightLang: "en", chatFontSize: "xs",
+  }),
+  saveSettings: jest.fn(),
+}));
+
+jest.mock("@/lib/recentBooks", () => ({
+  recordRecentBook: jest.fn(),
+  saveLastChapter: jest.fn(),
+  getLastChapter: jest.fn().mockReturnValue(null),
+}));
+
+jest.mock("@/components/InsightChat", () => {
+  const InsightChat = () => <div data-testid="insight-chat" />;
+  const LANGUAGES = [
+    { code: "en", label: "English" }, { code: "zh", label: "Chinese" },
+    { code: "de", label: "German" }, { code: "fr", label: "French" },
+    { code: "es", label: "Spanish" },
+  ];
+  return { __esModule: true, default: InsightChat, LANGUAGES };
+});
+
+jest.mock("@/components/TTSControls", () => ({
+  __esModule: true,
+  default: () => <div data-testid="tts-controls" />,
+}));
+
+jest.mock("@/components/SentenceReader", () => ({
+  __esModule: true,
+  default: () => <div data-testid="sentence-reader" />,
+}));
+
+jest.mock("@/components/SelectionToolbar", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/components/AnnotationToolbar", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/components/AnnotationsSidebar", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/components/TranslationView", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import ReaderPage from "@/app/reader/[bookId]/page";
+
+const flushPromises = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe("Reader page — mobile bottom nav touch targets (#581)", () => {
+  it("mobile bottom nav Translation button is at least 44px (not h-10)", async () => {
+    render(<ReaderPage />);
+    await act(async () => await flushPromises());
+
+    const btn = document.querySelector('[aria-label="Translation"]');
+    expect(btn).not.toBeNull();
+    expect(btn!.className).not.toMatch(/\bh-10\b/);
+  });
+
+  it("mobile bottom nav Notes button is at least 44px (not h-10)", async () => {
+    render(<ReaderPage />);
+    await act(async () => await flushPromises());
+
+    const btn = document.querySelector('[aria-label="Notes"]');
+    expect(btn).not.toBeNull();
+    expect(btn!.className).not.toMatch(/\bh-10\b/);
+  });
+
+  it("mobile bottom nav Insight chat button is at least 44px (not h-10)", async () => {
+    render(<ReaderPage />);
+    await act(async () => await flushPromises());
+
+    const btn = document.querySelector('[aria-label="Insight chat"]');
+    expect(btn).not.toBeNull();
+    expect(btn!.className).not.toMatch(/\bh-10\b/);
+  });
+
+  it("mobile bottom nav Read aloud / Pause button is at least 44px (not h-10)", async () => {
+    render(<ReaderPage />);
+    await act(async () => await flushPromises());
+
+    const btn = document.querySelector('[aria-label="Read aloud"]') ?? document.querySelector('[aria-label="Pause"]');
+    expect(btn).not.toBeNull();
+    expect(btn!.className).not.toMatch(/\bh-10\b/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2146,7 +2146,7 @@ export default function ReaderPage() {
                   setTranslateExpanded(false);
                 }
               }}
-              className={`h-10 w-10 flex items-center justify-center rounded-lg border transition-colors ${
+              className={`h-11 w-11 flex items-center justify-center rounded-lg border transition-colors ${
                 translationEnabled
                   ? "bg-amber-700 text-white border-amber-700"
                   : "text-amber-700 bg-amber-50 border-amber-200"
@@ -2159,7 +2159,7 @@ export default function ReaderPage() {
                 const ttsEl = document.querySelector<HTMLButtonElement>("[data-tts-play]");
                 if (ttsEl) ttsEl.click();
               }}
-              className={`h-10 w-10 flex items-center justify-center rounded-lg border transition-colors ${
+              className={`h-11 w-11 flex items-center justify-center rounded-lg border transition-colors ${
                 ttsIsPlaying
                   ? "bg-amber-700 text-white border-amber-700"
                   : "text-amber-700 bg-amber-50 border-amber-200"
@@ -2169,7 +2169,7 @@ export default function ReaderPage() {
 
             <div className="relative flex-1 min-w-0 max-w-[110px]">
               <select
-                className="appearance-none h-10 w-full text-xs rounded-lg border border-amber-200 pl-2 pr-6 text-amber-700 bg-white truncate cursor-pointer focus:outline-none focus:ring-2 focus:ring-amber-300 transition-colors"
+                className="appearance-none h-11 w-full text-xs rounded-lg border border-amber-200 pl-2 pr-6 text-amber-700 bg-white truncate cursor-pointer focus:outline-none focus:ring-2 focus:ring-amber-300 transition-colors"
                 value={chapterIndex}
                 onChange={(e) => goToChapter(Number(e.target.value))}
               >
@@ -2187,7 +2187,7 @@ export default function ReaderPage() {
                 if (!session?.backendToken) { setAuthPrompt("save annotations and notes"); return; }
                 setNotesExpanded((v) => !v);
               }}
-              className={`relative h-10 w-10 flex items-center justify-center rounded-lg border transition-colors ${
+              className={`relative h-11 w-11 flex items-center justify-center rounded-lg border transition-colors ${
                 notesExpanded
                   ? "bg-amber-700 text-white border-amber-700"
                   : "text-amber-700 bg-amber-50 border-amber-200"
@@ -2204,7 +2204,7 @@ export default function ReaderPage() {
 
             <button
               onClick={() => setSidebarOpen((v) => !v)}
-              className={`h-10 w-10 flex items-center justify-center rounded-lg border transition-colors ${
+              className={`h-11 w-11 flex items-center justify-center rounded-lg border transition-colors ${
                 sidebarOpen
                   ? "bg-amber-700 text-white border-amber-700"
                   : "text-amber-700 bg-amber-50 border-amber-200"


### PR DESCRIPTION
## Summary

- All four mobile bottom nav buttons in the reader page (Translation, Play/Pause, Notes, Insight chat) were `h-10 w-10` (40×40px), 4px below the 44px CLAUDE.md minimum for mobile touch targets
- Changed to `h-11 w-11` (44px) on all four buttons; also bumped the chapter select to `h-11` for visual consistency
- Added regression test (`ReaderMobileBottomNavTouchTargets.test.tsx`) that fails if any of the four buttons revert to `h-10`

## Test plan
- [x] `ReaderMobileBottomNavTouchTargets.test.tsx` — 4 tests, all pass
- [x] Full frontend suite — 1612 tests, all pass

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)
