### PR TITLE
fix: add Path/Query max_length to admin translation path and queue delete params

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -6,7 +6,7 @@ Full CRUD where applicable.
 import json
 import aiosqlite
 from typing import Annotated
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from pydantic import BaseModel, Field
 from services.auth import get_current_user, decrypt_api_key, encrypt_api_key
 from services.db import (
@@ -422,7 +422,7 @@ async def delete_book_translations(book_id: int, _admin: dict = Depends(_require
 @router.delete("/translations/{book_id}/{target_language}")
 async def delete_language_translations(
     book_id: int,
-    target_language: str,
+    target_language: str = Path(..., max_length=20),
     _admin: dict = Depends(_require_admin),
 ):
     """Delete all cached translations for one language of a book."""
@@ -461,7 +461,7 @@ async def delete_language_translations(
 async def delete_translation(
     book_id: int,
     chapter_index: int,
-    target_language: str,
+    target_language: str = Path(..., max_length=20),
     _admin: dict = Depends(_require_admin),
 ):
     """Delete a specific cached translation."""
@@ -499,7 +499,7 @@ async def delete_translation(
 async def retranslate(
     book_id: int,
     chapter_index: int,
-    target_language: str,
+    target_language: str = Path(..., max_length=20),
     admin: dict = Depends(_require_admin),
 ):
     """Delete cached translation and re-translate the chapter."""
@@ -727,7 +727,7 @@ class MoveTranslationRequest(BaseModel):
 async def move_translation(
     book_id: int,
     chapter_index: int,
-    target_language: str,
+    target_language: Annotated[str, Path(max_length=20)],
     req: MoveTranslationRequest,
     _admin: dict = Depends(_require_admin),
 ):
@@ -1180,7 +1180,7 @@ async def queue_clear(
 @router.delete("/queue/book/{book_id}")
 async def queue_delete_book(
     book_id: int,
-    target_language: str | None = None,
+    target_language: str | None = Query(default=None, max_length=20),
     _admin: dict = Depends(_require_admin),
 ):
     norm = target_language.lower().split("-")[0] if target_language else None

--- a/backend/tests/test_router_admin_extended.py
+++ b/backend/tests/test_router_admin_extended.py
@@ -901,3 +901,50 @@ async def test_queue_retry_failed_oversized_language_returns_422(admin_client, a
     assert res.status_code == 422, (
         f"Expected 422 for oversized target_language in /queue/retry-failed, got {res.status_code}: {res.text}"
     )
+
+
+# ── Issue #583: admin translation path/query param bounds ────────────────────
+
+async def test_delete_language_translations_oversized_lang_returns_422(admin_client, admin_db):
+    """Regression #583: DELETE /admin/translations/{book_id}/{target_language} with >20 char lang must return 422."""
+    lang = "x" * 21
+    res = await admin_client.delete(f"/api/admin/translations/1/{lang}")
+    assert res.status_code == 422, (
+        f"Expected 422 for oversized target_language in DELETE /translations/{{book_id}}/{{lang}}, got {res.status_code}"
+    )
+
+
+async def test_delete_chapter_translation_oversized_lang_returns_422(admin_client, admin_db):
+    """Regression #583: DELETE /admin/translations/{book_id}/{chapter}/{target_language} with >20 char lang must return 422."""
+    lang = "x" * 21
+    res = await admin_client.delete(f"/api/admin/translations/1/0/{lang}")
+    assert res.status_code == 422, (
+        f"Expected 422 for oversized target_language in DELETE /translations/{{book}}/{{ch}}/{{lang}}, got {res.status_code}"
+    )
+
+
+async def test_retranslate_oversized_lang_returns_422(admin_client, admin_db):
+    """Regression #583: POST /admin/translations/{book_id}/{chapter}/{target_language}/retranslate with >20 char lang must return 422."""
+    lang = "x" * 21
+    res = await admin_client.post(f"/api/admin/translations/1/0/{lang}/retranslate")
+    assert res.status_code == 422, (
+        f"Expected 422 for oversized target_language in retranslate, got {res.status_code}"
+    )
+
+
+async def test_move_translation_oversized_lang_returns_422(admin_client, admin_db):
+    """Regression #583: POST /admin/translations/{book_id}/{chapter}/{target_language}/move with >20 char lang must return 422."""
+    lang = "x" * 21
+    res = await admin_client.post(f"/api/admin/translations/1/0/{lang}/move", json={"new_chapter_index": 1})
+    assert res.status_code == 422, (
+        f"Expected 422 for oversized target_language in move, got {res.status_code}"
+    )
+
+
+async def test_queue_delete_book_oversized_lang_query_returns_422(admin_client, admin_db):
+    """Regression #583: DELETE /admin/queue/book/{book_id}?target_language= with >20 char lang must return 422."""
+    lang = "x" * 21
+    res = await admin_client.delete(f"/api/admin/queue/book/1?target_language={lang}")
+    assert res.status_code == 422, (
+        f"Expected 422 for oversized target_language query param in DELETE /queue/book, got {res.status_code}"
+    )


### PR DESCRIPTION
## Summary
- Adds `Path(..., max_length=20)` to `{target_language}` in four admin-only DELETE/POST translation endpoints
- Adds `Query(default=None, max_length=20)` to `target_language` query param in `DELETE /admin/queue/book/{book_id}`
- Adds `Path` to the fastapi imports in `admin.py`
- Uses `Annotated[str, Path(max_length=20)]` for the endpoint that mixes a path param with a body param to avoid Python parameter ordering issues

## Test plan
- [x] 5 regression tests added: one per bounded param, each confirms 422 for a 21-char language string
- [x] Full backend suite passes (1184 tests)

Closes #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)
