### PR TITLE
fix: homepage icon-only buttons aria-label + extract SVGs to Icons.tsx

### DIFF
--- a/frontend/src/__tests__/HomePageIconA11y.test.tsx
+++ b/frontend/src/__tests__/HomePageIconA11y.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Regression tests for #585: homepage icon-only buttons must have aria-label.
+ * - Profile/avatar button: icon-only, needs explicit aria-label (not just title)
+ * - Grid/List view toggles: icon-only SVG buttons, need explicit aria-label
+ * - Profile button touch target: must be ≥44px on mobile (not w-10 h-10)
+ */
+import React from "react";
+import { render, act, waitFor } from "@testing-library/react";
+
+const mockUseSession = jest.fn();
+jest.mock("next-auth/react", () => ({
+  useSession: (...args: unknown[]) => mockUseSession(...args),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getPopularBooks: jest.fn().mockResolvedValue({ books: [], total: 0 }),
+  getMe: jest.fn().mockRejectedValue(new Error("Not authed")),
+  searchBooks: jest.fn().mockResolvedValue({ books: [], total: 0 }),
+  getReadingProgress: jest.fn().mockResolvedValue([]),
+  getUserStats: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock("@/lib/recentBooks", () => ({
+  getRecentBooks: jest.fn().mockReturnValue([]),
+  removeRecentBook: jest.fn(),
+}));
+
+jest.mock("@/components/BookCard", () => ({
+  __esModule: true,
+  default: ({ book }: { book: { id: number; title: string } }) => (
+    <div data-testid={`book-card-${book.id}`}>{book.title}</div>
+  ),
+}));
+
+jest.mock("@/components/BookDetailModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/components/ReadingStats", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import HomePage from "@/app/page";
+
+const flushPromises = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe("HomePage — icon a11y (#585)", () => {
+  beforeEach(() => {
+    mockUseSession.mockReturnValue({
+      data: {
+        backendToken: "tok",
+        backendUser: { id: 1, name: "Alice", email: "a@b.com", picture: null, is_admin: false },
+      },
+      status: "authenticated",
+    });
+  });
+
+  it("profile button has an explicit aria-label attribute (not just title)", async () => {
+    render(<HomePage />);
+    await act(async () => await flushPromises());
+
+    // Find the profile button by its rounded-full class (avatar button)
+    const profileBtn = document.querySelector("button.rounded-full");
+    expect(profileBtn).not.toBeNull();
+    expect(profileBtn).toHaveAttribute("aria-label");
+  });
+
+  it("profile button is at least 44px wide on mobile (not w-10)", async () => {
+    render(<HomePage />);
+    await act(async () => await flushPromises());
+
+    const profileBtn = document.querySelector("button.rounded-full");
+    expect(profileBtn).not.toBeNull();
+    // Must not have the 40px classes without a 44px override
+    expect(profileBtn!.className).not.toMatch(/\bw-10\b/);
+  });
+
+  it("Grid view button has an explicit aria-label", async () => {
+    render(<HomePage />);
+    await act(async () => await flushPromises());
+
+    const gridBtn = document.querySelector('[title="Grid view"]');
+    expect(gridBtn).not.toBeNull();
+    expect(gridBtn).toHaveAttribute("aria-label", "Grid view");
+  });
+
+  it("List view button has an explicit aria-label", async () => {
+    render(<HomePage />);
+    await act(async () => await flushPromises());
+
+    const listBtn = document.querySelector('[title="List view"]');
+    expect(listBtn).not.toBeNull();
+    expect(listBtn).toHaveAttribute("aria-label", "List view");
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,7 +5,7 @@ import { getRecentBooks, removeRecentBook, RecentBook } from "@/lib/recentBooks"
 import BookCard from "@/components/BookCard";
 import BookDetailModal from "@/components/BookDetailModal";
 import ReadingStats from "@/components/ReadingStats";
-import { FireIcon, ArrowRightIcon, BookOpenIcon, NoteIcon, InsightIcon, VocabIcon, BookCoverPlaceholderIcon, GlobeIcon, SummaryIcon, SpeakerIcon } from "@/components/Icons";
+import { FireIcon, ArrowRightIcon, BookOpenIcon, NoteIcon, InsightIcon, VocabIcon, BookCoverPlaceholderIcon, GlobeIcon, SummaryIcon, SpeakerIcon, GridIcon, ListIcon } from "@/components/Icons";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 
@@ -183,7 +183,8 @@ export default function Home() {
             <button
               onClick={() => router.push("/profile")}
               title={session?.backendUser?.name ?? "Profile & Settings"}
-              className="w-10 h-10 md:w-9 md:h-9 rounded-full overflow-hidden border border-amber-200 hover:border-amber-400 transition-colors"
+              aria-label={session?.backendUser?.name ?? "Profile & Settings"}
+              className="w-11 h-11 md:w-9 md:h-9 rounded-full overflow-hidden border border-amber-200 hover:border-amber-400 transition-colors"
             >
               {session?.backendUser?.picture ? (
                 // eslint-disable-next-line @next/next/no-img-element
@@ -641,21 +642,18 @@ export default function Home() {
                   <button
                     onClick={() => setPopularView("grid")}
                     title="Grid view"
+                    aria-label="Grid view"
                     className={`p-1.5 rounded transition-colors ${popularView === "grid" ? "bg-amber-100 text-amber-800" : "text-amber-500 hover:text-amber-700"}`}
                   >
-                    <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 16 16">
-                      <rect x="1" y="1" width="6" height="6" rx="1"/><rect x="9" y="1" width="6" height="6" rx="1"/>
-                      <rect x="1" y="9" width="6" height="6" rx="1"/><rect x="9" y="9" width="6" height="6" rx="1"/>
-                    </svg>
+                    <GridIcon className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => setPopularView("list")}
                     title="List view"
+                    aria-label="List view"
                     className={`p-1.5 rounded transition-colors ${popularView === "list" ? "bg-amber-100 text-amber-800" : "text-amber-500 hover:text-amber-700"}`}
                   >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 16 16">
-                      <line x1="3" y1="4" x2="13" y2="4"/><line x1="3" y1="8" x2="13" y2="8"/><line x1="3" y1="12" x2="13" y2="12"/>
-                    </svg>
+                    <ListIcon className="w-4 h-4" />
                   </button>
                 </div>
               </div>

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -396,3 +396,20 @@ export function FlashcardIcon({ className = "w-4 h-4" }: IconProps) {
     </svg>
   );
 }
+
+export function GridIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+      <rect x="1" y="1" width="6" height="6" rx="1"/><rect x="9" y="1" width="6" height="6" rx="1"/>
+      <rect x="1" y="9" width="6" height="6" rx="1"/><rect x="9" y="9" width="6" height="6" rx="1"/>
+    </svg>
+  );
+}
+
+export function ListIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+      <line x1="3" y1="4" x2="13" y2="4"/><line x1="3" y1="8" x2="13" y2="8"/><line x1="3" y1="12" x2="13" y2="12"/>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

- **Profile button**: added `aria-label` (was only `title`) and bumped mobile touch target from `w-10 h-10` (40px) to `w-11 h-11` (44px; desktop stays `md:w-9 md:h-9`)
- **Grid/List view toggles**: added `aria-label` to both; extracted inline `<svg>` blocks to `GridIcon` and `ListIcon` in `Icons.tsx` so they follow the project icon system
- Added regression test (`HomePageIconA11y.test.tsx`) checking all three buttons for explicit `aria-label` and the profile button for correct size class

## Test plan
- [x] `HomePageIconA11y.test.tsx` — 4 tests, all pass
- [x] Full frontend suite — 1612 tests, all pass

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)
