### PR TITLE
fix: add min-h-[44px] to SegmentedControl buttons in TypographyPanel (closes #598)

### DIFF
--- a/frontend/src/__tests__/TypographyPanelTouchTarget.test.tsx
+++ b/frontend/src/__tests__/TypographyPanelTouchTarget.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Regression test for #598: SegmentedControl buttons in TypographyPanel
+ * must meet the 44px minimum touch target requirement.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import TypographyPanel from "@/components/TypographyPanel";
+import type { FontSize, LineHeight, ContentWidth, FontFamily } from "@/lib/settings";
+
+jest.mock("@/lib/settings", () => ({
+  saveSettings: jest.fn(),
+}));
+
+const DEFAULT_PROPS = {
+  fontSize: "base" as FontSize,
+  lineHeight: "normal" as LineHeight,
+  contentWidth: "normal" as ContentWidth,
+  fontFamily: "serif" as FontFamily,
+  paragraphFocus: false,
+  onFontSize: jest.fn(),
+  onLineHeight: jest.fn(),
+  onContentWidth: jest.fn(),
+  onFontFamily: jest.fn(),
+  onParagraphFocus: jest.fn(),
+  onClose: jest.fn(),
+};
+
+describe("TypographyPanel — touch targets (#598)", () => {
+  it("SegmentedControl buttons have min-h-[44px] class for touch target compliance", () => {
+    const { container } = render(<TypographyPanel {...DEFAULT_PROPS} />);
+
+    // Find all segmented control buttons (S, M, L, XL, Serif, Sans, Tight, etc.)
+    const segmentBtns = Array.from(container.querySelectorAll("button")).filter(
+      (btn) =>
+        btn.classList.contains("flex-1") &&
+        !btn.hasAttribute("role") // exclude the toggle switch
+    );
+
+    expect(segmentBtns.length).toBeGreaterThan(0);
+    segmentBtns.forEach((btn) => {
+      expect(btn.className).toContain("min-h-[44px]");
+    });
+  });
+
+  it("all four control groups have accessible touch targets", () => {
+    render(<TypographyPanel {...DEFAULT_PROPS} />);
+
+    // All segmented buttons should be accessible
+    ["S", "M", "L", "XL", "Serif", "Sans", "Tight", "Relaxed", "Narrow", "Wide"].forEach(
+      (label) => {
+        const btn = screen.getByText(label);
+        expect(btn.className).toContain("min-h-[44px]");
+      }
+    );
+  });
+});

--- a/frontend/src/components/TypographyPanel.tsx
+++ b/frontend/src/components/TypographyPanel.tsx
@@ -59,7 +59,7 @@ function SegmentedControl<T extends string>({
         <button
           key={opt.value}
           onClick={() => onChange(opt.value)}
-          className={`flex-1 px-2 py-1.5 text-xs font-medium transition-colors ${
+          className={`flex-1 px-2 py-1.5 min-h-[44px] text-xs font-medium transition-colors flex items-center justify-center ${
             value === opt.value
               ? "bg-amber-700 text-white"
               : "bg-white text-amber-700 hover:bg-amber-50"


### PR DESCRIPTION
## Summary

Fixes touch target size violation in `TypographyPanel.tsx` — the `SegmentedControl` buttons had only `py-1.5` padding, yielding ~28px total height, below the required 44px minimum for mobile touch targets.

**Change:** Added `min-h-[44px] flex items-center justify-center` to the `SegmentedControl` button className. These buttons control font size, font family, line spacing, and content width in the immersive reading mode panel — frequently used on mobile.

## Tests

2 new regression tests in `TypographyPanelTouchTarget.test.tsx`:
- All flex-1 segment buttons have `min-h-[44px]` class
- All 10 labeled buttons (S, M, L, XL, Serif, Sans, Tight, Relaxed, Narrow, Wide) meet the requirement

All 9 existing TypographyPanel tests still pass (11 total).
Full frontend suite: 1619 passed.

Closes #598
