### PR TITLE
fix: add min-h-[44px] to VocabWordTooltip save button for touch target compliance (closes #600)

### DIFF
--- a/frontend/src/__tests__/VocabWordTooltipTouchTarget.test.tsx
+++ b/frontend/src/__tests__/VocabWordTooltipTouchTarget.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * Regression test for #600: VocabWordTooltip "Save to vocab" button must
+ * meet the 44px minimum touch target height requirement.
+ */
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+
+jest.mock("@/lib/api", () => ({
+  getWordDefinition: jest.fn().mockResolvedValue({
+    lemma: "beistehen",
+    language: "de",
+    definitions: [{ pos: "Verb", text: "to assist" }],
+    url: "https://en.wiktionary.org/wiki/beistehen",
+  }),
+}));
+
+import VocabWordTooltip from "@/components/VocabWordTooltip";
+
+const RECT = {
+  left: 100, top: 200, right: 200, bottom: 220, width: 100, height: 20, x: 100, y: 200,
+  toJSON: () => ({}),
+} as DOMRect;
+
+const BASE = { word: "beistehen", lang: "de", rect: RECT, onClose: jest.fn(), onSave: jest.fn() };
+const flushPromises = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe("VocabWordTooltip — save button touch target (#600)", () => {
+  it("save button has min-h-[44px] class", async () => {
+    render(<VocabWordTooltip {...BASE} />);
+    await act(async () => await flushPromises());
+
+    const saveBtn = screen.getByRole("button", { name: /save to vocab/i });
+    expect(saveBtn.className).toContain("min-h-[44px]");
+  });
+});

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -117,7 +117,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
         <button
           onClick={handleSave}
           disabled={saved}
-          className={`text-xs font-medium px-3 py-1 rounded-lg transition-colors ${
+          className={`text-xs font-medium px-3 py-1 min-h-[44px] rounded-lg transition-colors flex items-center justify-center ${
             saved
               ? "bg-stone-100 text-stone-400 cursor-default"
               : "bg-amber-600 text-white hover:bg-amber-700"


### PR DESCRIPTION
## Summary

Fixes the "Save to vocab" button in `VocabWordTooltip.tsx` — it used `py-1` padding, yielding ~26px total height, below the 44px minimum touch target required on mobile.

**Change:** Added `min-h-[44px] flex items-center justify-center` to the save button. This is the primary vocabulary save action, frequently used from the reader on mobile.

## Tests

1 new regression test in `VocabWordTooltipTouchTarget.test.tsx`:
- Save button has `min-h-[44px]` class

All 19 existing VocabWordTooltip tests still pass (20 total).
Full frontend suite: 1618 passed.

Closes #600
