### PR TITLE
fix: replace × with CloseIcon in reader Gemini reminder dismiss button (closes #604)

### DIFF
--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -822,10 +822,10 @@ export default function ReaderPage() {
           </span>
           <button
             onClick={() => setGeminiReminderVisible(false)}
-            className="shrink-0 text-amber-500 hover:text-amber-700 text-lg leading-none"
+            className="shrink-0 text-amber-500 hover:text-amber-700"
             aria-label="Dismiss"
           >
-            ×
+            <CloseIcon aria-hidden="true" className="w-4 h-4" />
           </button>
         </div>
       )}


### PR DESCRIPTION
## Summary

Fixes the Gemini API reminder banner's dismiss button in the reader page — it used a raw `×` character instead of `<CloseIcon />` from `Icons.tsx`, violating the project's icon system rules.

**Change:** `×` → `<CloseIcon aria-hidden="true" className="w-4 h-4" />`. `CloseIcon` was already imported at line 21 of the file.

The button already had `aria-label="Dismiss"` so screen-reader access was not affected — this is purely a visual icon system consistency fix.

## Tests

Regression test omitted: the Gemini reminder banner is only shown when `notifyAIUsed()` fires via InsightChat's `onAIUsed` prop, but InsightChat is mocked in all reader tests — the banner cannot be reached without major test infrastructure changes. An acknowledgment of this limitation exists in `ReaderPage.branches.test.tsx`.

Full frontend suite: 1621 passed (no regressions).

Closes #604
