### PR TITLE
fix: bump SentenceActionPopup buttons from min-h-[36px] to min-h-[44px] (closes #607)

### DIFF
--- a/frontend/src/__tests__/SentenceActionPopupTouchTarget.test.tsx
+++ b/frontend/src/__tests__/SentenceActionPopupTouchTarget.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * Regression test for #607: SentenceActionPopup buttons must have
+ * min-h-[44px] touch targets.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import SentenceActionPopup from "@/components/SentenceActionPopup";
+
+const BASE_PROPS = {
+  sentenceText: "It is a truth universally acknowledged.",
+  position: { x: 200, y: 300 },
+  onRead: jest.fn(),
+  onClose: jest.fn(),
+  onNote: jest.fn(),
+  onChat: jest.fn(),
+};
+
+describe("SentenceActionPopup — touch targets (#607)", () => {
+  it("Read button meets 44px minimum touch target", () => {
+    render(<SentenceActionPopup {...BASE_PROPS} />);
+    const btn = screen.getByRole("button", { name: /read/i });
+    expect(btn.className).toContain("min-h-[44px]");
+  });
+
+  it("Note button meets 44px minimum touch target", () => {
+    render(<SentenceActionPopup {...BASE_PROPS} />);
+    const btn = screen.getByRole("button", { name: /note/i });
+    expect(btn.className).toContain("min-h-[44px]");
+  });
+
+  it("Chat button meets 44px minimum touch target", () => {
+    render(<SentenceActionPopup {...BASE_PROPS} />);
+    const btn = screen.getByRole("button", { name: /chat/i });
+    expect(btn.className).toContain("min-h-[44px]");
+  });
+});

--- a/frontend/src/components/SentenceActionPopup.tsx
+++ b/frontend/src/components/SentenceActionPopup.tsx
@@ -49,14 +49,14 @@ export default function SentenceActionPopup({ sentenceText: _sentenceText, posit
     >
       <button
         onClick={() => { onRead(); onClose(); }}
-        className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[36px]"
+        className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px]"
       >
         <SpeakerIcon className="w-3.5 h-3.5 shrink-0" /> Read
       </button>
       {onNote && (
         <button
           onClick={() => { onNote(); onClose(); }}
-          className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[36px]"
+          className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px]"
         >
           <NoteIcon className="w-3.5 h-3.5 shrink-0" /> Note
         </button>
@@ -64,7 +64,7 @@ export default function SentenceActionPopup({ sentenceText: _sentenceText, posit
       {onChat && (
         <button
           onClick={() => { onChat(); onClose(); }}
-          className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[36px]"
+          className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px]"
         >
           <ChatIcon className="w-3.5 h-3.5 shrink-0" /> Chat
         </button>


### PR DESCRIPTION
## Summary

Fixes touch target size in `SentenceActionPopup.tsx` — the Read/Note/Chat buttons had `min-h-[36px]`, which is 8px below the 44px minimum for touch targets. This popup appears when users tap on sentences in the reader — a primary mobile interaction.

**Change:** `min-h-[36px]` → `min-h-[44px]` on all three action buttons.

## Tests

3 new regression tests in `SentenceActionPopupTouchTarget.test.tsx`:
- Read button has `min-h-[44px]`
- Note button has `min-h-[44px]`
- Chat button has `min-h-[44px]`

All 15 existing SentenceActionPopup tests still pass (18 total).
Full frontend suite: 1624 passed.

Closes #607
