### PR TITLE
fix: URL-encode word in wiktionary lookup (closes #612)

### DIFF
--- a/backend/services/wiktionary.py
+++ b/backend/services/wiktionary.py
@@ -1,5 +1,6 @@
 """Wiktionary REST API integration for word definitions and lemma extraction."""
 import re
+from urllib.parse import quote
 
 import httpx
 
@@ -63,8 +64,8 @@ async def lookup(word: str, lang: str = "en") -> dict:
             "url": str,             # canonical Wiktionary URL
         }
     """
-    url = f"{_BASE}/{word.lower()}"
-    wikt_url = f"https://en.wiktionary.org/wiki/{word}"
+    url = f"{_BASE}/{quote(word.lower(), safe='')}"
+    wikt_url = f"https://en.wiktionary.org/wiki/{quote(word, safe='')}"
 
     empty = {"lemma": word, "language": lang, "definitions": [], "url": wikt_url}
 

--- a/backend/tests/test_wiktionary.py
+++ b/backend/tests/test_wiktionary.py
@@ -268,3 +268,70 @@ async def test_lookup_lemma_only_extracted_from_first_definition():
         assert result["lemma"] == "go"
         # Second definition body still present
         assert len(result["definitions"]) == 2
+
+
+# ── URL encoding (regression for #612) ────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_lookup_word_with_hash_uses_encoded_url():
+    """A word containing '#' must have it percent-encoded in the API URL so the
+    fragment is not stripped by httpx before reaching the server."""
+    captured_urls: list[str] = []
+
+    async def fake_get(url, **kwargs):
+        captured_urls.append(url)
+        resp = MagicMock()
+        resp.status_code = 404
+        return resp
+
+    with patch("services.wiktionary.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = fake_get
+        await lookup("foo#bar", "en")
+
+    assert len(captured_urls) == 1
+    assert "#" not in captured_urls[0], (
+        "URL must not contain a raw '#' — it should be percent-encoded as %23"
+    )
+    assert "%23" in captured_urls[0]
+
+
+@pytest.mark.anyio
+async def test_lookup_word_with_question_mark_uses_encoded_url():
+    """A word containing '?' must have it percent-encoded so it is not treated
+    as the start of a query string."""
+    captured_urls: list[str] = []
+
+    async def fake_get(url, **kwargs):
+        captured_urls.append(url)
+        resp = MagicMock()
+        resp.status_code = 404
+        return resp
+
+    with patch("services.wiktionary.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = fake_get
+        await lookup("foo?bar", "en")
+
+    assert len(captured_urls) == 1
+    assert "?" not in captured_urls[0], (
+        "URL must not contain a raw '?' — it should be percent-encoded as %3F"
+    )
+    assert "%3F" in captured_urls[0]
+
+
+@pytest.mark.anyio
+async def test_lookup_word_with_special_chars_wikt_url_is_encoded():
+    """The display URL returned in the result must also be percent-encoded."""
+    with patch("services.wiktionary.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=MagicMock(status_code=404))
+        result = await lookup("foo#bar", "en")
+    assert "#" not in result["url"]
+    assert "%23" in result["url"]


### PR DESCRIPTION
## Summary

URL-encode the word in `wiktionary.lookup` so characters like `#` and `?` don't corrupt the Wiktionary API URL or the display URL returned in the response.

Before: `f"{_BASE}/{word.lower()}"` — a word containing `#` would be treated as a URL fragment and stripped before the request reaches the server.

After: `f"{_BASE}/{quote(word.lower(), safe='')}"` — all URL-special characters are percent-encoded.

Closes #612

## Test plan
- [x] 3 regression tests: words with `#` and `?` produce encoded URLs
- [x] Full backend suite: 1191 passed
