### PR TITLE
fix: raise AnnotationToolbar action button touch targets to 44px

### DIFF
--- a/frontend/src/__tests__/AnnotationToolbarTouchTarget.test.tsx
+++ b/frontend/src/__tests__/AnnotationToolbarTouchTarget.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * Regression tests for issue #613 — AnnotationToolbar action buttons below 44px touch target.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("@/lib/api", () => ({
+  createAnnotation: jest.fn(),
+  updateAnnotation: jest.fn(),
+  deleteAnnotation: jest.fn(),
+}));
+
+import AnnotationToolbar from "@/components/AnnotationToolbar";
+
+const baseProps = {
+  sentenceText: "Call me Ishmael.",
+  chapterIndex: 0,
+  bookId: 10,
+  position: { x: 100, y: 100 },
+  onClose: jest.fn(),
+  onSaved: jest.fn(),
+  onDeleted: jest.fn(),
+};
+
+afterEach(() => jest.clearAllMocks());
+
+test("Save button has min-h-[44px] touch target", () => {
+  render(<AnnotationToolbar {...baseProps} />);
+  const saveBtn = screen.getByRole("button", { name: /save/i });
+  expect(saveBtn.className).toContain("min-h-[44px]");
+});
+
+test("Close button has min-h-[44px] touch target", () => {
+  render(<AnnotationToolbar {...baseProps} />);
+  const closeBtn = screen.getByRole("button", { name: /close/i });
+  expect(closeBtn.className).toContain("min-h-[44px]");
+});
+
+test("Delete button has min-h-[44px] touch target when annotation exists", () => {
+  render(
+    <AnnotationToolbar
+      {...baseProps}
+      existingAnnotation={{ id: 1, note_text: "note", color: "yellow" }}
+    />
+  );
+  const deleteBtn = screen.getByRole("button", { name: /delete/i });
+  expect(deleteBtn.className).toContain("min-h-[44px]");
+});

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -151,7 +151,7 @@ export default function AnnotationToolbar({
         <button
           onClick={handleSave}
           disabled={saving}
-          className="flex-1 rounded-lg bg-amber-700 text-white text-sm py-1.5 hover:bg-amber-800 disabled:opacity-50 transition-colors"
+          className="flex-1 rounded-lg bg-amber-700 text-white text-sm py-1.5 min-h-[44px] hover:bg-amber-800 disabled:opacity-50 transition-colors"
         >
           {saving ? "Saving…" : "Save"}
         </button>
@@ -159,7 +159,7 @@ export default function AnnotationToolbar({
           <button
             onClick={handleDelete}
             disabled={deleting}
-            className="rounded-lg border border-red-300 text-red-600 text-sm px-3 py-1.5 hover:bg-red-50 disabled:opacity-50 transition-colors"
+            className="rounded-lg border border-red-300 text-red-600 text-sm px-3 py-1.5 min-h-[44px] hover:bg-red-50 disabled:opacity-50 transition-colors"
           >
             {deleting ? "…" : "Delete"}
           </button>
@@ -167,7 +167,7 @@ export default function AnnotationToolbar({
         <button
           onClick={onClose}
           aria-label="Close"
-          className="rounded-lg border border-stone-300 text-stone-500 px-2.5 py-1.5 hover:bg-stone-50 transition-colors flex items-center justify-center"
+          className="rounded-lg border border-stone-300 text-stone-500 px-2.5 py-1.5 min-h-[44px] hover:bg-stone-50 transition-colors flex items-center justify-center"
         >
           <CloseIcon className="w-4 h-4" />
         </button>


### PR DESCRIPTION
## Summary

- Save button: added `min-h-[44px]` (was `py-1.5` ~28 px)
- Delete button: added `min-h-[44px]` (was `py-1.5` ~28 px)
- Close button: added `min-h-[44px]` (was `py-1.5` ~28 px)
- 3 regression tests added in `AnnotationToolbarTouchTarget.test.tsx`

Closes #613

## Test plan

- [x] All 3 new regression tests pass
- [x] Full frontend suite passes (1624 tests)
