### PR TITLE
fix: homepage filter pills and view toggle buttons touch targets

### DIFF
--- a/frontend/src/__tests__/HomePageFilterTouchTargets.test.tsx
+++ b/frontend/src/__tests__/HomePageFilterTouchTargets.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Regression tests for issue #618 — homepage filter pills and view toggle
+ * buttons below 44px touch target and missing aria-labels.
+ */
+import React from "react";
+import { render, act } from "@testing-library/react";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: null, status: "unauthenticated" }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getPopularBooks: jest.fn().mockResolvedValue({ books: [], total: 0 }),
+  getMe: jest.fn().mockRejectedValue(new Error("not authed")),
+  searchBooks: jest.fn().mockResolvedValue([]),
+  getReadingProgress: jest.fn().mockResolvedValue([]),
+  getUserStats: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock("@/lib/recentBooks", () => ({
+  getRecentBooks: jest.fn().mockReturnValue([]),
+  removeRecentBook: jest.fn(),
+}));
+
+jest.mock("@/components/BookCard", () => ({
+  __esModule: true,
+  default: ({ book }: { book: { title: string } }) => <div>{book.title}</div>,
+}));
+
+jest.mock("@/components/BookDetailModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import HomePage from "@/app/page";
+
+const flushPromises = () => new Promise<void>((r) => setTimeout(r, 0));
+
+afterEach(() => jest.clearAllMocks());
+
+async function renderHomePage() {
+  render(<HomePage />);
+  await act(async () => await flushPromises());
+}
+
+test("Quick search pill buttons have min-h-[44px]", async () => {
+  await renderHomePage();
+
+  // Quick search pills: rounded-full border border-amber-300 px-3 — they trigger searches
+  const pillButtons = Array.from(document.querySelectorAll("button")).filter(
+    (b) => b.className.includes("rounded-full") && b.className.includes("px-3") && b.className.includes("border-amber-300")
+  );
+  expect(pillButtons.length).toBeGreaterThan(0);
+  for (const btn of pillButtons) {
+    expect(btn.className).toContain("min-h-[44px]");
+  }
+});
+
+test("Grid view toggle button has aria-label", async () => {
+  await renderHomePage();
+
+  const gridBtn = document.querySelector('[title="Grid view"]') as HTMLElement | null;
+  expect(gridBtn).not.toBeNull();
+  expect(gridBtn!.getAttribute("aria-label")).toBe("Grid view");
+});
+
+test("List view toggle button has aria-label", async () => {
+  await renderHomePage();
+
+  const listBtn = document.querySelector('[title="List view"]') as HTMLElement | null;
+  expect(listBtn).not.toBeNull();
+  expect(listBtn!.getAttribute("aria-label")).toBe("List view");
+});
+
+test("Grid view toggle button has min-h-[44px]", async () => {
+  await renderHomePage();
+
+  const gridBtn = document.querySelector('[title="Grid view"]') as HTMLElement | null;
+  expect(gridBtn).not.toBeNull();
+  expect(gridBtn!.className).toContain("min-h-[44px]");
+});
+
+test("List view toggle button has min-h-[44px]", async () => {
+  await renderHomePage();
+
+  const listBtn = document.querySelector('[title="List view"]') as HTMLElement | null;
+  expect(listBtn).not.toBeNull();
+  expect(listBtn!.className).toContain("min-h-[44px]");
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,7 +5,7 @@ import { getRecentBooks, removeRecentBook, RecentBook } from "@/lib/recentBooks"
 import BookCard from "@/components/BookCard";
 import BookDetailModal from "@/components/BookDetailModal";
 import ReadingStats from "@/components/ReadingStats";
-import { FireIcon, ArrowRightIcon, BookOpenIcon, NoteIcon, InsightIcon, VocabIcon, BookCoverPlaceholderIcon, GlobeIcon, SummaryIcon, SpeakerIcon } from "@/components/Icons";
+import { FireIcon, ArrowRightIcon, BookOpenIcon, NoteIcon, InsightIcon, VocabIcon, BookCoverPlaceholderIcon, GlobeIcon, SummaryIcon, SpeakerIcon, GridViewIcon, ListViewIcon } from "@/components/Icons";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 
@@ -573,7 +573,7 @@ export default function Home() {
                 {FEATURED.map((f) => (
                   <button
                     key={f.query}
-                    className="text-xs rounded-full border border-amber-300 px-3 py-1 text-amber-800 hover:bg-amber-100 transition-colors"
+                    className="text-xs rounded-full border border-amber-300 px-3 py-1 min-h-[44px] text-amber-800 hover:bg-amber-100 transition-colors"
                     onClick={() => { setQuery(f.query); setLang(f.lang); handleSearch(f.query, f.lang); }}
                     disabled={searching}
                   >
@@ -626,7 +626,7 @@ export default function Home() {
                       <button
                         key={l.code}
                         onClick={() => handlePopularLangChange(l.code)}
-                        className={`text-xs rounded-full px-3 py-1 border transition-colors ${
+                        className={`text-xs rounded-full px-3 py-1 min-h-[44px] border transition-colors ${
                           popularLang === l.code
                             ? "bg-amber-700 text-white border-amber-700"
                             : "border-amber-300 text-amber-700 hover:bg-amber-50"
@@ -641,21 +641,18 @@ export default function Home() {
                   <button
                     onClick={() => setPopularView("grid")}
                     title="Grid view"
-                    className={`p-1.5 rounded transition-colors ${popularView === "grid" ? "bg-amber-100 text-amber-800" : "text-amber-500 hover:text-amber-700"}`}
+                    aria-label="Grid view"
+                    className={`p-1.5 min-h-[44px] min-w-[44px] flex items-center justify-center rounded transition-colors ${popularView === "grid" ? "bg-amber-100 text-amber-800" : "text-amber-500 hover:text-amber-700"}`}
                   >
-                    <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 16 16">
-                      <rect x="1" y="1" width="6" height="6" rx="1"/><rect x="9" y="1" width="6" height="6" rx="1"/>
-                      <rect x="1" y="9" width="6" height="6" rx="1"/><rect x="9" y="9" width="6" height="6" rx="1"/>
-                    </svg>
+                    <GridViewIcon className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => setPopularView("list")}
                     title="List view"
-                    className={`p-1.5 rounded transition-colors ${popularView === "list" ? "bg-amber-100 text-amber-800" : "text-amber-500 hover:text-amber-700"}`}
+                    aria-label="List view"
+                    className={`p-1.5 min-h-[44px] min-w-[44px] flex items-center justify-center rounded transition-colors ${popularView === "list" ? "bg-amber-100 text-amber-800" : "text-amber-500 hover:text-amber-700"}`}
                   >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 16 16">
-                      <line x1="3" y1="4" x2="13" y2="4"/><line x1="3" y1="8" x2="13" y2="8"/><line x1="3" y1="12" x2="13" y2="12"/>
-                    </svg>
+                    <ListViewIcon className="w-4 h-4" />
                   </button>
                 </div>
               </div>

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -396,3 +396,20 @@ export function FlashcardIcon({ className = "w-4 h-4" }: IconProps) {
     </svg>
   );
 }
+
+export function GridViewIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+      <rect x="1" y="1" width="6" height="6" rx="1"/><rect x="9" y="1" width="6" height="6" rx="1"/>
+      <rect x="1" y="9" width="6" height="6" rx="1"/><rect x="9" y="9" width="6" height="6" rx="1"/>
+    </svg>
+  );
+}
+
+export function ListViewIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+      <line x1="3" y1="4" x2="13" y2="4"/><line x1="3" y1="8" x2="13" y2="8"/><line x1="3" y1="12" x2="13" y2="12"/>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

- Quick search pills: added `min-h-[44px]` (were `py-1` ~26 px)
- Language filter pills: added `min-h-[44px]` (were `py-1` ~26 px)
- Grid/list view toggle buttons: replaced inline SVGs with `GridViewIcon`/`ListViewIcon` from `Icons.tsx`; added `aria-label`; added `min-h-[44px] min-w-[44px]`
- Added `GridViewIcon` and `ListViewIcon` to `Icons.tsx`
- 5 regression tests in `HomePageFilterTouchTargets.test.tsx`

Closes #618

## Test plan

- [x] All 5 new regression tests pass
- [x] Full frontend suite passes (1626 tests)
