### PR TITLE
fix: raise notes page header buttons to 44px touch target

### DIFF
--- a/frontend/src/__tests__/NotesPageHeaderTouchTargets.test.tsx
+++ b/frontend/src/__tests__/NotesPageHeaderTouchTargets.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Regression tests for issue #621 — notes page header buttons below 44px touch target.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { backendToken: "tok" }, status: "authenticated" }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  useParams: () => ({ bookId: "10" }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getBookChapters: jest.fn().mockResolvedValue({
+    book_id: 10,
+    meta: { id: 10, title: "Moby Dick", authors: [], languages: [], subjects: [], download_count: 0, cover: null },
+    chapters: [{ title: "Chapter 1", text: "" }],
+  }),
+  getAnnotations: jest.fn().mockResolvedValue([
+    { id: 1, book_id: 10, chapter_index: 0, sentence_text: "Hello", note_text: "Note", color: "yellow" },
+  ]),
+  getInsights: jest.fn().mockResolvedValue([]),
+  getVocabulary: jest.fn().mockResolvedValue([]),
+  updateAnnotation: jest.fn(),
+  deleteAnnotation: jest.fn(),
+  deleteInsight: jest.fn(),
+  exportVocabularyToObsidian: jest.fn(),
+}));
+
+import BookNotesPage from "@/app/notes/[bookId]/page";
+
+afterEach(() => jest.clearAllMocks());
+
+test("'Collapse all' button has min-h-[44px]", async () => {
+  render(<BookNotesPage />);
+  await waitFor(() => screen.getByText("Collapse all"));
+  const btn = screen.getByRole("button", { name: "Collapse all" });
+  expect(btn.className).toContain("min-h-[44px]");
+});
+
+test("'By section' view toggle button has min-h-[44px]", async () => {
+  render(<BookNotesPage />);
+  await waitFor(() => screen.getByText("By section"));
+  const btn = screen.getByRole("button", { name: "By section" });
+  expect(btn.className).toContain("min-h-[44px]");
+});
+
+test("'By chapter' view toggle button has min-h-[44px]", async () => {
+  render(<BookNotesPage />);
+  await waitFor(() => screen.getByText("By chapter"));
+  const btn = screen.getByRole("button", { name: "By chapter" });
+  expect(btn.className).toContain("min-h-[44px]");
+});
+
+test("Export button has min-h-[44px]", async () => {
+  render(<BookNotesPage />);
+  await waitFor(() => screen.getByText(/Export/));
+  // The export button has an arrow arrow character followed by Export
+  const btn = Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent?.includes("Export") && !b.getAttribute("aria-label")?.includes("edit") && !b.getAttribute("aria-label")?.includes("delete")
+  );
+  expect(btn).not.toBeUndefined();
+  expect(btn!.className).toContain("min-h-[44px]");
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -632,7 +632,7 @@ export default function BookNotesPage() {
           {(annCount + insCount + vocCount) > 0 && !loading && (
             <button
               onClick={toggleCollapseAll}
-              className="text-xs text-stone-400 hover:text-stone-600 shrink-0 transition-colors"
+              className="text-xs text-stone-400 hover:text-stone-600 shrink-0 transition-colors min-h-[44px]"
             >
               {isAllCollapsed ? "Expand all" : "Collapse all"}
             </button>
@@ -644,7 +644,7 @@ export default function BookNotesPage() {
               <button
                 key={m}
                 onClick={() => setViewMode(m)}
-                className={`px-3 py-1.5 transition-colors ${
+                className={`px-3 py-1.5 min-h-[44px] transition-colors ${
                   viewMode === m
                     ? "bg-amber-700 text-white"
                     : "text-amber-700 hover:bg-amber-50"
@@ -659,7 +659,7 @@ export default function BookNotesPage() {
           <button
             onClick={handleExport}
             disabled={exporting}
-            className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-amber-700 text-white text-xs font-medium hover:bg-amber-800 disabled:opacity-50 transition-colors"
+            className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 min-h-[44px] rounded-lg bg-amber-700 text-white text-xs font-medium hover:bg-amber-800 disabled:opacity-50 transition-colors"
           >
             {exporting ? "Exporting…" : "↗ Export"}
           </button>


### PR DESCRIPTION
## Summary

- Collapse all / Expand all button: added `min-h-[44px]` (was bare text, ~18 px)
- View toggle (By section / By chapter): added `min-h-[44px]` (was `py-1.5` ~28 px)
- Export button: added `min-h-[44px]` (was `py-1.5` ~28 px)
- 4 regression tests in `NotesPageHeaderTouchTargets.test.tsx`

Closes #621

## Test plan

- [x] All 4 new regression tests pass
- [x] Full frontend suite passes (1625 tests)
