### PR TITLE
chore: add --help to start-roles.sh and refresh workflow-startup.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,8 @@ Always work highest priority first. Re-check priority each time you pick the nex
 7. Run the full test suite; all tests must pass before committing
 8. Commit, push, create PR with `Closes #N` in the body and `--label bug` or `--label feat`
 9. Enable auto-merge and launch the background poll loop
-10. After merge: remove `in-progress` label; update `project_bug_hunt_2026_04.md` memory
+10. **Before picking a new issue:** check `gh pr list --state open --author @me` — if any of your own PRs is BEHIND or BLOCKED, rebase/fix it first. Only open a new PR once your existing PRs are either MERGED or have CI running without problems.
+11. After merge: remove `in-progress` label; update `project_bug_hunt_2026_04.md` memory
 
 **Idle mode (no unclaimed issues):** Enter bug-hunt mode. Systematically read `backend/routers/` for: missing input bounds checks on path/query/body params, missing book/user `.exists()` guards before DB operations, exception paths that could leak sensitive data, routes with no test coverage. File each finding as a `bug` issue with an appropriate priority label, then immediately claim and fix it. Do not accumulate a backlog — file one, fix one, repeat.
 
@@ -164,7 +165,8 @@ Always work highest priority first. Re-check priority each time you pick the nex
 4. Write frontend test first (Jest/RTL or E2E), then implement
 5. Run full frontend test suite before pushing
 6. PR with `Closes #N`, `--label ux` or `--label ui`
-7. After merge: remove `in-progress` label
+7. **Before picking a new issue:** check `gh pr list --state open --author @me` — if any of your own PRs is BEHIND or BLOCKED, rebase/fix it first. Only open a new PR once existing PRs are merged or have CI running cleanly.
+8. After merge: remove `in-progress` label
 
 **Idle mode (no unclaimed issues):** Run a UX audit. Check frontend components for: emoji used as UI icons instead of SVG from `Icons.tsx`, icon-only buttons missing `aria-label`, interactive elements with touch targets under 44px, hardcoded hex colors instead of CSS token variables. File each violation as a `ux` issue, then immediately claim and fix it. File one, fix one, repeat.
 
@@ -191,7 +193,8 @@ Always work highest priority first. Re-check priority each time you pick the nex
 4. Open design doc PR; comment on the issue linking to the PR; wait for PM approval
 5. After PM approves and design doc merges: begin implementation in a new branch
 6. Implementation PR with `Closes #N`; PM reviews; merged
-7. After merge: remove `in-progress` label
+7. **Before picking a new issue:** check `gh pr list --state open --author @me` — if any of your own PRs is BEHIND or BLOCKED, rebase/fix it first. Only open a new PR once existing PRs are merged or have CI running cleanly.
+8. After merge: remove `in-progress` label
 
 **Workflow (Path A — direct implementation):**
 Same as Dev workflow, but may include a design note in the PR body instead of a separate doc.

--- a/docs/workflow-startup.md
+++ b/docs/workflow-startup.md
@@ -8,12 +8,12 @@ loops — without waiting for you.
 
 ## Roles at a glance
 
-| Role | What it does when active | What it does when idle |
-|---|---|---|
-| **PM** | Reviews PRs, triages issues, watches deploys | Runs the review loop continuously |
-| **Dev** | Fixes bugs and implements features | Bug-hunts: scans routes for missing bounds/guards |
-| **UI/UX Dev** | Fixes UX/UI issues | UX-audits: scans components for design rule violations |
-| **Architect** | Designs and implements complex features | Proposes new features; writes design docs |
+| Role | Model | What it does when active | What it does when idle |
+|---|---|---|---|
+| **PM** | claude-sonnet-4-6 | Reviews PRs, triages issues, watches deploys | Runs the review loop continuously |
+| **Dev** | claude-sonnet-4-6 | Fixes bugs and implements features | Bug-hunts: scans routes for missing bounds/guards |
+| **UI/UX Dev** | claude-haiku-4-5-20251001 | Fixes UX/UI issues | UX-audits: scans components for design rule violations |
+| **Architect** | claude-opus-4-7 | Designs and implements complex features | Proposes new features; writes design docs |
 
 Full rules for each role are in `CLAUDE.md`.
 
@@ -43,25 +43,52 @@ bash /Users/alfmunny/Projects/AI/book-reader-ai/scripts/start-roles.sh
 
 This opens a tmux session named `book-ai` with four windows and starts each role immediately.
 
+To bypass permission prompts (fully autonomous mode):
+```bash
+bash /Users/alfmunny/Projects/AI/book-reader-ai/scripts/start-roles.sh --bypass
+```
+
 Attach to the session:
 ```bash
 tmux attach -t book-ai
 ```
 
-Navigate between roles:
+Navigate between role windows (prefix key is `C-a`):
 ```
-Ctrl+b  0   PM
-Ctrl+b  1   Dev
-Ctrl+b  2   UI/UX Dev
-Ctrl+b  3   Architect
+C-a p   previous window
+C-a n   next window
+C-a w   visual window picker
 ```
+Or switch by name: `C-a '` then type the window name (`pm`, `dev`, `uiux`, `arch`).
 
-To add a second Dev session (for parallel bug fixing):
+### Tmux keybindings for this project
+
+| Key | Action |
+|---|---|
+| `C-a O` | Collapse all roles into a 2×2 overview pane |
+| `C-a o` | Restore overview back to separate windows |
+
+### Subcommands
+
+| Subcommand | Description |
+|---|---|
+| *(none)* | Start all 4 roles in separate tmux windows |
+| `overview` | Collapse roles into a 2×2 pane (session must be running) |
+| `restore` | Spread overview panes back to separate windows |
+| `stop` | Gracefully stop the `book-ai` session |
+| `restart [--bypass]` | Stop then start fresh |
+| `dev2 [--bypass]` | Add a second Dev window to a running session |
+| `--help` / `-h` | Show usage summary |
+
+Examples:
 ```bash
-tmux new-window -t book-ai: -n dev2
-tmux send-keys -t book-ai:dev2 "$(cat /tmp/book-ai-dev-prompt.txt | head -1 | xargs -I{} echo 'claude \"{}\"')" Enter
-# Or simpler:
-bash /Users/alfmunny/Projects/AI/book-reader-ai/scripts/start-dev.sh book-ai dev2
+bash scripts/start-roles.sh --bypass        # start with bypass
+bash scripts/start-roles.sh overview        # collapse to 2×2
+bash scripts/start-roles.sh restore         # back to separate windows
+bash scripts/start-roles.sh stop            # graceful shutdown
+bash scripts/start-roles.sh restart         # stop + fresh start
+bash scripts/start-roles.sh dev2            # add second Dev window
+bash scripts/start-roles.sh --help          # show help
 ```
 
 ---
@@ -73,25 +100,25 @@ Open four terminal windows/tabs. In each, run the command for that role:
 ### PM
 ```bash
 cd /Users/alfmunny/Projects/AI/book-reader-ai
-claude "/loop Act as product manager for book-reader-ai. Every cycle: (1) check for new open PRs and recently merged PRs since the last review state saved in product/review-state.md, (2) check for new or updated files in docs/, (3) review anything new — read the diff/doc, comment on open PRs if there are concerns or questions, create GitHub issues for follow-ups after merges, update product/backlog.md with findings. Save the latest reviewed PR number and latest main commit SHA to product/review-state.md after each cycle so the next cycle knows where to pick up. If nothing is new, say so briefly and wait."
+claude --model claude-sonnet-4-6 "/loop Act as product manager for book-reader-ai. Every cycle: (1) check for new open PRs and recently merged PRs since the last review state saved in product/review-state.md, (2) check for new or updated files in docs/, (3) review anything new — read the diff/doc, comment on open PRs if there are concerns or questions, create GitHub issues for follow-ups after merges, update product/backlog.md with findings. Save the latest reviewed PR number and latest main commit SHA to product/review-state.md after each cycle so the next cycle knows where to pick up. If nothing is new, say so briefly and wait."
 ```
 
 ### Dev
 ```bash
 cd /Users/alfmunny/Projects/AI/book-reader-ai
-claude "You are a Dev session for book-reader-ai. Read CLAUDE.md at /Users/alfmunny/Projects/AI/book-reader-ai/CLAUDE.md and follow the Dev role rules exactly. Read all memory files listed in /Users/alfmunny/.claude/projects/-Users-alfmunny-Projects-AI/memory/MEMORY.md. Then start immediately: verify your worktree exists, pick the highest-priority unclaimed bug or feat issue (no in-progress label), claim it, and work it to completion (regression test first, fix, full test suite, PR with auto-merge). After each PR merges, pick the next issue without waiting. If no unclaimed issues exist, enter bug-hunt mode as defined in CLAUDE.md: scan backend/routers/ for missing bounds checks and missing .exists() guards, file and fix one bug at a time."
+claude --model claude-sonnet-4-6 "You are a Dev session for book-reader-ai. Read CLAUDE.md at /Users/alfmunny/Projects/AI/book-reader-ai/CLAUDE.md and follow the Dev role rules exactly. Read all memory files listed in /Users/alfmunny/.claude/projects/-Users-alfmunny-Projects-AI/memory/MEMORY.md. Then start immediately: verify your worktree exists, pick the highest-priority unclaimed bug or feat issue (no in-progress label), claim it, and work it to completion (regression test first, fix, full test suite, PR with auto-merge). After each PR merges, pick the next issue without waiting. If no unclaimed issues exist, enter bug-hunt mode as defined in CLAUDE.md: scan backend/routers/ for missing bounds checks and missing .exists() guards, file and fix one bug at a time."
 ```
 
 ### UI/UX Dev
 ```bash
 cd /Users/alfmunny/Projects/AI/book-reader-ai
-claude "You are the UI/UX Dev for book-reader-ai. Read CLAUDE.md at /Users/alfmunny/Projects/AI/book-reader-ai/CLAUDE.md and follow the UI/UX Dev role rules. Read all memory files listed in /Users/alfmunny/.claude/projects/-Users-alfmunny-Projects-AI/memory/MEMORY.md. Then start immediately: verify your worktree exists, pick the highest-priority unclaimed ux or ui issue (no in-progress label), claim it, and work it to completion (test first, implement, PR). After each PR merges, pick the next issue without waiting. If no unclaimed ux/ui issues exist, run a UX audit as defined in CLAUDE.md: scan frontend components for emoji icons, missing aria-labels, touch targets under 44px, hardcoded hex colors — file and fix one violation at a time."
+claude --model claude-haiku-4-5-20251001 "You are the UI/UX Dev for book-reader-ai. Read CLAUDE.md at /Users/alfmunny/Projects/AI/book-reader-ai/CLAUDE.md and follow the UI/UX Dev role rules. Read all memory files listed in /Users/alfmunny/.claude/projects/-Users-alfmunny-Projects-AI/memory/MEMORY.md. Then start immediately: verify your worktree exists, pick the highest-priority unclaimed ux or ui issue (no in-progress label), claim it, and work it to completion (test first, implement, PR). After each PR merges, pick the next issue without waiting. If no unclaimed ux/ui issues exist, run a UX audit as defined in CLAUDE.md: scan frontend components for emoji icons, missing aria-labels, touch targets under 44px, hardcoded hex colors — file and fix one violation at a time."
 ```
 
 ### Architect
 ```bash
 cd /Users/alfmunny/Projects/AI/book-reader-ai
-claude "You are the Architect for book-reader-ai. Read CLAUDE.md at /Users/alfmunny/Projects/AI/book-reader-ai/CLAUDE.md and follow the Architect role rules. Read all memory files listed in /Users/alfmunny/.claude/projects/-Users-alfmunny-Projects-AI/memory/MEMORY.md. Then start immediately: verify your worktree exists, pick the highest-priority unclaimed architecture issue (no in-progress label), claim it, and work it following the appropriate path (design doc PR first for Path B). After each task completes, pick the next without waiting. If no architecture issues exist, identify the highest-value unimplemented feature, file an architecture issue for it, claim it, and begin a design doc — but do not implement without PM sign-off."
+claude --model claude-opus-4-7 "You are the Architect for book-reader-ai. Read CLAUDE.md at /Users/alfmunny/Projects/AI/book-reader-ai/CLAUDE.md and follow the Architect role rules. Read all memory files listed in /Users/alfmunny/.claude/projects/-Users-alfmunny-Projects-AI/memory/MEMORY.md. Then start immediately: verify your worktree exists, pick the highest-priority unclaimed architecture issue (no in-progress label), claim it, and work it following the appropriate path (design doc PR first for Path B). After each task completes, pick the next without waiting. If no architecture issues exist, identify the highest-value unimplemented feature, file an architecture issue for it, claim it, and begin a design doc — but do not implement without PM sign-off."
 ```
 
 ---
@@ -99,12 +126,12 @@ claude "You are the Architect for book-reader-ai. Read CLAUDE.md at /Users/alfmu
 ## Adding a second Dev session
 
 Two Dev sessions can run simultaneously — each in its own branch, each claiming different
-issues via the `in-progress` label. To start a second Dev session:
+issues via the `in-progress` label. To add a second Dev window to a running session:
 
 ```bash
-# In a new terminal tab or tmux window:
-cd /Users/alfmunny/Projects/AI/book-reader-ai
-claude "You are a second Dev session for book-reader-ai. Same role rules as Dev in CLAUDE.md. Read /Users/alfmunny/Projects/AI/book-reader-ai/CLAUDE.md and all memory files. Your worktree is book-reader-ai-dev (shared with the first Dev session — always branch off the worktree's main, never commit to another session's branch). Pick the highest-priority unclaimed issue, work it, loop."
+bash /Users/alfmunny/Projects/AI/book-reader-ai/scripts/start-roles.sh dev2
+# with bypass:
+bash /Users/alfmunny/Projects/AI/book-reader-ai/scripts/start-roles.sh dev2 --bypass
 ```
 
 PM will naturally assign issues from different subsystems to avoid file-level conflicts.
@@ -159,12 +186,17 @@ Once started, you should not need to intervene. Here is what each role does:
 
 ## Stopping
 
-To stop all roles gracefully:
+Graceful stop (sends Ctrl+C / Ctrl+D to all panes, then kills session):
 ```bash
-tmux kill-session -t book-ai
+bash /Users/alfmunny/Projects/AI/book-reader-ai/scripts/start-roles.sh stop
 ```
 
-Or stop individual windows:
+Or stop and restart fresh:
+```bash
+bash /Users/alfmunny/Projects/AI/book-reader-ai/scripts/start-roles.sh restart
+```
+
+Or kill individual windows:
 ```bash
 tmux kill-window -t book-ai:dev2
 ```

--- a/scripts/start-roles.sh
+++ b/scripts/start-roles.sh
@@ -34,6 +34,7 @@ SUBCOMMAND=""
 for arg in "$@"; do
   case "$arg" in
     --bypass)  BYPASS="--dangerously-skip-permissions" ;;
+    --help|-h|help) SUBCOMMAND="help" ;;
     overview|restore|stop|restart|dev2) SUBCOMMAND="$arg" ;;
   esac
 done
@@ -153,6 +154,38 @@ cmd_restore() {
 # ── Route subcommands ─────────────────────────────────────────────────────────
 
 case "$SUBCOMMAND" in
+  help)
+    cat <<'EOF'
+Usage: bash scripts/start-roles.sh [subcommand] [--bypass]
+
+Subcommands:
+  (none)              Start all 4 roles in separate tmux windows
+  overview            Collapse roles into a 2×2 overview pane
+  restore             Spread overview panes back to separate windows
+  stop                Gracefully stop the book-ai tmux session
+  restart [--bypass]  Stop then start fresh
+  dev2    [--bypass]  Add a second Dev window to a running session
+  --help | -h | help  Show this help
+
+Flags:
+  --bypass  Pass --dangerously-skip-permissions to every claude invocation
+
+Models:
+  PM      claude-sonnet-4-6
+  Dev     claude-sonnet-4-6
+  UI/UX   claude-haiku-4-5-20251001
+  Arch    claude-opus-4-7
+
+Tmux keybindings (prefix = C-a):
+  C-a O   overview   (collapse to 2×2)
+  C-a o   restore    (back to separate windows)
+
+Session: book-ai
+  Attach:   tmux attach -t book-ai
+  Windows:  pm | dev | uiux | arch
+EOF
+    exit 0
+    ;;
   stop)
     cmd_stop
     exit 0

--- a/scripts/start-roles.sh
+++ b/scripts/start-roles.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
-# start-roles.sh — launch all book-reader-ai roles in a single tmux session
+# start-roles.sh — launch and manage book-reader-ai role sessions in tmux
 #
 # Usage:
-#   bash scripts/start-roles.sh          # start all 4 roles
-#   bash scripts/start-roles.sh dev2     # add a second Dev window to an existing session
+#   bash scripts/start-roles.sh [--bypass]          # start all 4 roles in separate windows
+#   bash scripts/start-roles.sh overview [--bypass] # collapse into a 2×2 overview pane
+#   bash scripts/start-roles.sh restore             # spread overview panes back to windows
+#   bash scripts/start-roles.sh stop                # gracefully stop the session
+#   bash scripts/start-roles.sh restart [--bypass]  # stop then start fresh
+#   bash scripts/start-roles.sh dev2 [--bypass]     # add a second Dev window
 #
 # Requires: tmux, claude (Claude Code CLI), gh (GitHub CLI)
 
@@ -11,20 +15,33 @@ set -euo pipefail
 
 REPO="/Users/alfmunny/Projects/AI/book-reader-ai"
 SESSION="book-ai"
-MEMORY_DIR="/Users/alfmunny/.claude/projects/-Users-alfmunny-Projects-AI/memory/MEMORY.md"
 
-# ── helpers ──────────────────────────────────────────────────────────────────
+# ── Parse args ────────────────────────────────────────────────────────────────
 
-die() { echo "ERROR: $*" >&2; exit 1; }
+BYPASS=""
+SUBCOMMAND=""
+for arg in "$@"; do
+  case "$arg" in
+    --bypass)  BYPASS="--dangerously-skip-permissions" ;;
+    overview|restore|stop|restart|dev2) SUBCOMMAND="$arg" ;;
+  esac
+done
+
+CLAUDE="claude${BYPASS:+ $BYPASS}"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+die()      { echo "ERROR: $*" >&2; exit 1; }
+running()  { tmux has-session -t "$SESSION" 2>/dev/null; }
 
 check_deps() {
-  command -v tmux  >/dev/null 2>&1 || die "tmux not found — brew install tmux"
+  command -v tmux   >/dev/null 2>&1 || die "tmux not found — brew install tmux"
   command -v claude >/dev/null 2>&1 || die "claude CLI not found — install Claude Code"
-  command -v gh    >/dev/null 2>&1 || die "gh not found — brew install gh"
-  gh auth status   >/dev/null 2>&1 || die "gh not authenticated — run: gh auth login"
+  command -v gh     >/dev/null 2>&1 || die "gh not found — brew install gh"
+  gh auth status    >/dev/null 2>&1 || die "gh not authenticated — run: gh auth login"
 }
 
-# Write prompt files to /tmp so tmux send-keys avoids quoting issues
+# Write role prompts to /tmp to avoid shell-quoting nightmares in send-keys
 write_prompts() {
   cat > /tmp/book-ai-pm.txt << 'PROMPT'
 /loop Act as product manager for book-reader-ai. Every cycle: (1) check for new open PRs and recently merged PRs since the last review state saved in product/review-state.md, (2) check for new or updated files in docs/, (3) review anything new — read the diff/doc, comment on open PRs if there are concerns or questions, create GitHub issues for follow-ups after merges, update product/backlog.md with findings. Save the latest reviewed PR number and latest main commit SHA to product/review-state.md after each cycle so the next cycle knows where to pick up. If nothing is new, say so briefly and wait.
@@ -43,65 +60,147 @@ You are the Architect for book-reader-ai. Read CLAUDE.md at /Users/alfmunny/Proj
 PROMPT
 }
 
-# Launch a named window and start claude with the given prompt file
+# Launch a single-window role (used for all 4 roles and dev2)
 start_window() {
-  local window="$1"
+  local name="$1"
   local prompt_file="$2"
-  tmux new-window -t "${SESSION}:" -n "$window"
-  # Use a wrapper so the prompt file is read at launch time, not at script write time
-  tmux send-keys -t "${SESSION}:${window}" \
-    "cd '$REPO' && claude \"\$(cat '$prompt_file')\"" Enter
+  tmux new-window -t "${SESSION}:" -n "$name"
+  tmux send-keys -t "${SESSION}:${name}" \
+    "cd '$REPO' && $CLAUDE \"\$(cat '$prompt_file')\"" Enter
 }
 
-# ── add-dev2 mode ─────────────────────────────────────────────────────────────
+# ── stop: send graceful exit signals then kill ────────────────────────────────
 
-if [[ "${1:-}" == "dev2" ]]; then
-  tmux has-session -t "$SESSION" 2>/dev/null || die "Session '$SESSION' not running — start it first without arguments"
-  write_prompts
-  start_window "dev2" "/tmp/book-ai-dev.txt"
-  echo "Added dev2 window to session '$SESSION'"
-  echo "Switch to it: tmux select-window -t ${SESSION}:dev2"
-  exit 0
-fi
+cmd_stop() {
+  running || { echo "Session '$SESSION' is not running."; exit 0; }
+  echo "Sending Ctrl+C then Ctrl+D to all panes..."
+  while IFS= read -r pane_id; do
+    tmux send-keys -t "$pane_id" C-c 2>/dev/null || true
+  done < <(tmux list-panes -a -t "$SESSION" -F "#{pane_id}" 2>/dev/null)
+  sleep 1
+  while IFS= read -r pane_id; do
+    tmux send-keys -t "$pane_id" C-d 2>/dev/null || true
+  done < <(tmux list-panes -a -t "$SESSION" -F "#{pane_id}" 2>/dev/null)
+  sleep 2
+  if running; then
+    echo "Force-killing session..."
+    tmux kill-session -t "$SESSION"
+  fi
+  echo "Session '$SESSION' stopped."
+}
 
-# ── full startup ──────────────────────────────────────────────────────────────
+# ── overview: join all 4 role panes into a 2×2 window ────────────────────────
+
+cmd_overview() {
+  running || die "Session '$SESSION' is not running — start it first."
+  if tmux list-windows -t "$SESSION" -F "#{window_name}" 2>/dev/null | grep -q "^overview$"; then
+    tmux select-window -t "${SESSION}:overview"
+    echo "Switched to existing overview window."
+    exit 0
+  fi
+  echo "Creating overview window..."
+  # Use the pm window as the base (rename it) — no empty extra pane
+  tmux rename-window -t "${SESSION}:pm" "overview"
+  for role in dev uiux arch; do
+    if tmux list-windows -t "$SESSION" -F "#{window_name}" 2>/dev/null | grep -q "^${role}$"; then
+      tmux join-pane -s "${SESSION}:${role}.0" -t "${SESSION}:overview"
+    fi
+  done
+  tmux select-layout -t "${SESSION}:overview" tiled
+  # Pane labels: index 0=PM, 1=Dev, 2=UI/UX, 3=Arch
+  tmux set-option -t "${SESSION}" pane-border-status top
+  tmux set-option -t "${SESSION}" pane-border-format \
+    " #{?#{==:#{pane_index},0},PM,#{?#{==:#{pane_index},1},Dev,#{?#{==:#{pane_index},2},UI/UX,Arch}}} "
+  tmux select-pane -t "${SESSION}:overview.0"
+  echo "Overview ready — all roles in 2×2 grid."
+  echo "  Run: bash scripts/start-roles.sh restore   ← spread back to separate windows"
+}
+
+# ── restore: break overview panes back into separate windows ──────────────────
+
+cmd_restore() {
+  running || die "Session '$SESSION' is not running."
+  if ! tmux list-windows -t "$SESSION" -F "#{window_name}" 2>/dev/null | grep -q "^overview$"; then
+    echo "No overview window found — roles are already in separate windows."
+    exit 0
+  fi
+  echo "Restoring roles to separate windows..."
+  # break-pane always acts on pane 0 (the remaining panes shift down after each break)
+  tmux break-pane -t "${SESSION}:overview.0" -d -n "pm"
+  tmux break-pane -t "${SESSION}:overview.0" -d -n "dev"
+  tmux break-pane -t "${SESSION}:overview.0" -d -n "uiux"
+  # Last pane stays in what was the overview window — rename it
+  tmux rename-window -t "${SESSION}:overview" "arch"
+  tmux set-option -t "${SESSION}" pane-border-status off
+  tmux select-window -t "${SESSION}:pm"
+  echo "Roles restored: pm / dev / uiux / arch"
+}
+
+# ── Route subcommands ─────────────────────────────────────────────────────────
+
+case "$SUBCOMMAND" in
+  stop)
+    cmd_stop
+    exit 0
+    ;;
+  restart)
+    cmd_stop
+    # fall through to full startup below
+    ;;
+  overview)
+    cmd_overview
+    exit 0
+    ;;
+  restore)
+    cmd_restore
+    exit 0
+    ;;
+  dev2)
+    running || die "Session '$SESSION' not running — start it first."
+    write_prompts
+    start_window "dev2" "/tmp/book-ai-dev.txt"
+    echo "Added dev2 window to session '$SESSION'."
+    echo "Switch to it:  tmux select-window -t ${SESSION}:dev2"
+    exit 0
+    ;;
+esac
+
+# ── Full startup ──────────────────────────────────────────────────────────────
 
 check_deps
 
-# Warn about missing worktrees (roles create their own branches, but base dirs help)
 echo "Checking worktrees..."
 git -C "$REPO" worktree list
 
 echo ""
 echo "Starting tmux session '$SESSION'..."
 
-# Kill stale session if it exists
-tmux kill-session -t "$SESSION" 2>/dev/null && echo "(killed existing session)"
+if running; then
+  tmux kill-session -t "$SESSION"
+  echo "(killed existing session)"
+fi
 
 write_prompts
 
-# Create session — first window is PM
-tmux new-session -d -s "$SESSION" -n "pm" -x 220 -y 50
+# Four separate windows — one per role
+tmux new-session -d -s "$SESSION" -n "pm"   -x 220 -y 50
 tmux send-keys -t "${SESSION}:pm" \
-  "cd '$REPO' && claude \"\$(cat /tmp/book-ai-pm.txt)\"" Enter
+  "cd '$REPO' && $CLAUDE \"\$(cat /tmp/book-ai-pm.txt)\"" Enter
 
-# Add remaining role windows
 start_window "dev"  "/tmp/book-ai-dev.txt"
 start_window "uiux" "/tmp/book-ai-uiux.txt"
 start_window "arch" "/tmp/book-ai-arch.txt"
 
-# Focus PM window
 tmux select-window -t "${SESSION}:pm"
 
 echo ""
-echo "All roles started in tmux session '$SESSION'."
+echo "All 4 roles started in session '$SESSION'."
 echo ""
-echo "Attach:              tmux attach -t $SESSION"
-echo "Switch windows:      Ctrl+b then window name or number"
-echo "  Ctrl+b 0  →  pm"
-echo "  Ctrl+b 1  →  dev"
-echo "  Ctrl+b 2  →  uiux"
-echo "  Ctrl+b 3  →  arch"
+echo "  Windows:  pm | dev | uiux | arch"
 echo ""
-echo "Add a second Dev:    bash scripts/start-roles.sh dev2"
-echo "Stop everything:     tmux kill-session -t $SESSION"
+echo "  Attach:          tmux attach -t $SESSION"
+echo "  Switch windows:  Ctrl+b + window name  (or Ctrl+b w for visual picker)"
+echo "  Overview pane:   bash scripts/start-roles.sh overview"
+echo "  Stop:            bash scripts/start-roles.sh stop"
+echo "  Restart:         bash scripts/start-roles.sh restart"
+echo "  Add Dev2:        bash scripts/start-roles.sh dev2"

--- a/scripts/start-roles.sh
+++ b/scripts/start-roles.sh
@@ -16,6 +16,17 @@ set -euo pipefail
 REPO="/Users/alfmunny/Projects/AI/book-reader-ai"
 SESSION="book-ai"
 
+# ── Model assignments per role ─────────────────────────────────────────────────
+# PM:    Sonnet — nuanced design reviews, PR comments, issue triage
+# Dev:   Sonnet — code generation and test writing
+# UX:    Haiku  — formulaic audit work (emoji→SVG, aria-label, touch targets)
+# Arch:  Opus   — deep reasoning for design docs and cross-cutting decisions
+
+MODEL_PM="claude-sonnet-4-6"
+MODEL_DEV="claude-sonnet-4-6"
+MODEL_UIUX="claude-haiku-4-5-20251001"
+MODEL_ARCH="claude-opus-4-7"
+
 # ── Parse args ────────────────────────────────────────────────────────────────
 
 BYPASS=""
@@ -27,7 +38,8 @@ for arg in "$@"; do
   esac
 done
 
-CLAUDE="claude${BYPASS:+ $BYPASS}"
+# Base claude command (bypass flag only — model is passed per-role)
+CLAUDE_BASE="claude${BYPASS:+ $BYPASS}"
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -61,12 +73,14 @@ PROMPT
 }
 
 # Launch a single-window role (used for all 4 roles and dev2)
+# Usage: start_window <name> <prompt_file> <model>
 start_window() {
   local name="$1"
   local prompt_file="$2"
+  local model="$3"
   tmux new-window -t "${SESSION}:" -n "$name"
   tmux send-keys -t "${SESSION}:${name}" \
-    "cd '$REPO' && $CLAUDE \"\$(cat '$prompt_file')\"" Enter
+    "cd '$REPO' && $CLAUDE_BASE --model '$model' \"\$(cat '$prompt_file')\"" Enter
 }
 
 # ── stop: send graceful exit signals then kill ────────────────────────────────
@@ -158,7 +172,7 @@ case "$SUBCOMMAND" in
   dev2)
     running || die "Session '$SESSION' not running — start it first."
     write_prompts
-    start_window "dev2" "/tmp/book-ai-dev.txt"
+    start_window "dev2" "/tmp/book-ai-dev.txt" "$MODEL_DEV"
     echo "Added dev2 window to session '$SESSION'."
     echo "Switch to it:  tmux select-window -t ${SESSION}:dev2"
     exit 0
@@ -185,11 +199,11 @@ write_prompts
 # Four separate windows — one per role
 tmux new-session -d -s "$SESSION" -n "pm"   -x 220 -y 50
 tmux send-keys -t "${SESSION}:pm" \
-  "cd '$REPO' && $CLAUDE \"\$(cat /tmp/book-ai-pm.txt)\"" Enter
+  "cd '$REPO' && $CLAUDE_BASE --model '$MODEL_PM' \"\$(cat /tmp/book-ai-pm.txt)\"" Enter
 
-start_window "dev"  "/tmp/book-ai-dev.txt"
-start_window "uiux" "/tmp/book-ai-uiux.txt"
-start_window "arch" "/tmp/book-ai-arch.txt"
+start_window "dev"  "/tmp/book-ai-dev.txt"  "$MODEL_DEV"
+start_window "uiux" "/tmp/book-ai-uiux.txt" "$MODEL_UIUX"
+start_window "arch" "/tmp/book-ai-arch.txt" "$MODEL_ARCH"
 
 tmux select-window -t "${SESSION}:pm"
 
@@ -197,6 +211,11 @@ echo ""
 echo "All 4 roles started in session '$SESSION'."
 echo ""
 echo "  Windows:  pm | dev | uiux | arch"
+echo ""
+echo "  Models:   pm=$MODEL_PM"
+echo "            dev=$MODEL_DEV"
+echo "            uiux=$MODEL_UIUX"
+echo "            arch=$MODEL_ARCH"
 echo ""
 echo "  Attach:          tmux attach -t $SESSION"
 echo "  Switch windows:  Ctrl+b + window name  (or Ctrl+b w for visual picker)"


### PR DESCRIPTION
## Summary

- `scripts/start-roles.sh`: add `--help` / `-h` / `help` flag that prints subcommands, per-role model assignments, and tmux keybindings
- `docs/workflow-startup.md`: fix prefix key (`C-a` not `C-b`), add model column to roles table, document all subcommands with examples, add tmux keybinding table (`C-a O` / `C-a o`), replace raw tmux commands with script commands for stop/restart/dev2

## Test plan

- [ ] `bash scripts/start-roles.sh --help` prints full usage table and exits 0
- [ ] `bash scripts/start-roles.sh -h` same
- [ ] `bash scripts/start-roles.sh help` same
- [ ] Existing subcommands (overview, restore, stop, restart, dev2) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)