### PR TITLE
fix: raise VocabWordTooltip close button to 44px touch target

### DIFF
--- a/frontend/src/__tests__/VocabWordTooltipCloseTouchTarget.test.tsx
+++ b/frontend/src/__tests__/VocabWordTooltipCloseTouchTarget.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * Regression test for issue #627 — VocabWordTooltip close button below 44px.
+ */
+import React from "react";
+import { render } from "@testing-library/react";
+
+jest.mock("@/lib/api", () => ({
+  getWordDefinition: jest.fn().mockResolvedValue({ definitions: [] }),
+  saveVocabWord: jest.fn().mockResolvedValue({}),
+}));
+
+import VocabWordTooltip from "@/components/VocabWordTooltip";
+
+const mockRect = {
+  top: 100, left: 100, bottom: 120, right: 200, width: 100, height: 20,
+  x: 100, y: 100, toJSON: () => {},
+} as DOMRect;
+
+const BASE = {
+  word: "serendipity",
+  lang: "en",
+  rect: mockRect,
+  onClose: jest.fn(),
+  onSave: jest.fn(),
+};
+
+test("close button has min-h-[44px] and min-w-[44px]", () => {
+  render(<VocabWordTooltip {...BASE} />);
+
+  const closeBtn = document.querySelector("button[aria-label='Close']") as HTMLButtonElement | null;
+  expect(closeBtn).not.toBeNull();
+  expect(closeBtn!.className).toContain("min-h-[44px]");
+  expect(closeBtn!.className).toContain("min-w-[44px]");
+});

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -69,7 +69,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
       {/* Header */}
       <div className="flex items-center justify-between px-3 pt-2.5 pb-1.5 border-b border-amber-100">
         <span className="font-semibold text-ink text-sm">{word}</span>
-        <button onClick={onClose} aria-label="Close" className="text-stone-400 hover:text-stone-600 p-0.5 rounded transition-colors"><CloseIcon className="w-3.5 h-3.5" /></button>
+        <button onClick={onClose} aria-label="Close" className="text-stone-400 hover:text-stone-600 p-0.5 rounded transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"><CloseIcon className="w-3.5 h-3.5" /></button>
       </div>
 
       {/* Body */}


### PR DESCRIPTION
## Summary
- VocabWordTooltip close (×) button: added `min-h-[44px] min-w-[44px] flex items-center justify-center` (was `p-0.5` only, ~16px target)
- 1 regression test in `VocabWordTooltipCloseTouchTarget.test.tsx`

Closes #627

## Test plan
- [x] Regression test: close button has `min-h-[44px]` and `min-w-[44px]`
- [x] Full frontend suite passes (1622 tests)
