### PR TITLE
fix: add max_length to ImportTranslationsRequest.entries and EnqueueBookRequest.target_languages (#626)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -588,7 +588,7 @@ class ImportTranslationEntry(BaseModel):
 
 
 class ImportTranslationsRequest(BaseModel):
-    entries: list[ImportTranslationEntry]
+    entries: list[ImportTranslationEntry] = Field(..., max_length=5000)
 
 
 @router.post("/translations/import")
@@ -1099,7 +1099,7 @@ async def queue_items(
 
 class EnqueueBookRequest(BaseModel):
     book_id: int
-    target_languages: list[Annotated[str, Field(max_length=20)]] | None = None
+    target_languages: list[Annotated[str, Field(max_length=20)]] | None = Field(default=None, max_length=100)
     priority: int = 50   # lower than default so admin enqueues jump the line
     reset_failed: bool = False
 

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -2301,3 +2301,22 @@ async def test_move_translation_oversized_target_language_returns_422(admin_clie
         json={"new_chapter_index": 1},
     )
     assert res.status_code == 422
+
+
+# ── Unbounded list params (regression for #626) ───────────────────────────────
+
+async def test_import_translations_oversized_entries_returns_422(admin_client):
+    oversized = [
+        {"book_id": 1, "chapter_index": i, "target_language": "en", "paragraphs": ["text"]}
+        for i in range(5001)
+    ]
+    res = await admin_client.post("/api/admin/translations/import", json={"entries": oversized})
+    assert res.status_code == 422
+
+
+async def test_enqueue_book_oversized_target_languages_returns_422(admin_client):
+    res = await admin_client.post(
+        "/api/admin/queue/enqueue-book",
+        json={"book_id": 1, "target_languages": ["en"] * 101},
+    )
+    assert res.status_code == 422


### PR DESCRIPTION
## Summary

- Adds `Field(..., max_length=5000)` to `ImportTranslationsRequest.entries` — the list was unbounded, allowing arbitrarily large import payloads on the admin `POST /translations/import` endpoint
- Adds `Field(default=None, max_length=100)` to `EnqueueBookRequest.target_languages` — list length was unbounded on `POST /queue/enqueue-book`

Both endpoints are admin-only so blast radius is low, but the inputs should still be bounded for consistency and to prevent resource exhaustion.

## Test plan

- [x] `test_import_translations_oversized_entries_returns_422` — 5001 entries → 422
- [x] `test_enqueue_book_oversized_target_languages_returns_422` — 101 languages → 422
- [x] Full 1203-test suite passes

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)
