### PR TITLE
fix: enforce max length on upload filename, book title, and author (closes #638)

### DIFF
--- a/backend/routers/uploads.py
+++ b/backend/routers/uploads.py
@@ -86,6 +86,8 @@ async def upload_book(
 
     # Format check
     filename = file.filename or ""
+    if len(filename) > 255:
+        raise HTTPException(status_code=422, detail="Filename too long (max 255 characters).")
     if filename.endswith(".txt"):
         fmt = "txt"
         max_size = MAX_TXT_BYTES
@@ -116,10 +118,12 @@ async def upload_book(
             status_code=422,
             detail="No chapters could be detected. The file appears to be empty or contains no readable text.",
         )
+    title = (parsed["title"] or "Untitled")[:500]
+    author = (parsed["author"] or "Unknown")[:200]
     book_id = await _save_upload_book(
         user_id=user["id"],
-        title=parsed["title"],
-        author=parsed["author"],
+        title=title,
+        author=author,
         filename=filename,
         file_size=len(file_bytes),
         fmt=fmt,
@@ -129,8 +133,8 @@ async def upload_book(
 
     return {
         "book_id": book_id,
-        "title": parsed["title"],
-        "author": parsed["author"],
+        "title": title,
+        "author": author,
         "format": fmt,
         "detected_chapters": [
             {

--- a/backend/tests/test_router_uploads.py
+++ b/backend/tests/test_router_uploads.py
@@ -657,6 +657,44 @@ async def test_confirm_chapters_oversized_title_returns_422(client, test_user):
     )
 
 
+# ── Regression #638: upload metadata bounds ──────────────────────────────────
+
+
+async def test_upload_oversized_filename_returns_422(client, test_user):
+    """Regression #638: filename > 255 chars must return 422."""
+    long_name = "x" * 252 + ".txt"  # 256 chars total
+    resp = await client.post("/api/books/upload", files=_txt_upload(filename=long_name))
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized filename, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_upload_oversized_title_and_author_are_truncated(client, test_user, tmp_db):
+    """Regression #638: parser output with title > 500 or author > 200 chars must be
+    stored truncated (not rejected), since the user cannot easily control these values."""
+    with patch("services.book_parser.parse_txt") as mock_parse:
+        mock_parse.return_value = {
+            "title": "T" * 600,
+            "author": "A" * 300,
+            "chapters": [{"title": "Ch 1", "text": "Some content here."}],
+        }
+        resp = await client.post("/api/books/upload", files=_txt_upload())
+
+    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+    book_id = resp.json()["book_id"]
+    assert len(resp.json()["title"]) <= 500
+    assert len(resp.json()["author"]) <= 200
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute("SELECT title, authors FROM books WHERE id=?", (book_id,)) as cur:
+            row = await cur.fetchone()
+    assert row is not None
+    title_stored, authors_stored = row
+    assert len(title_stored) <= 500, f"Stored title length {len(title_stored)} exceeds 500"
+    authors_list = json.loads(authors_stored)
+    assert len(authors_list[0]) <= 200, f"Stored author length {len(authors_list[0])} exceeds 200"
+
+
 # ── Regression #630: flashcard_reviews cleanup on book delete ─────────────────
 
 


### PR DESCRIPTION
## Summary
- Reject `POST /books/upload` when the multipart `filename` exceeds 255 characters (returns 422)
- Truncate book `title` to 500 chars and `author` to 200 chars parsed from file content before the DB insert (epub DC metadata can be arbitrarily long in crafted files)

## Why
`file.filename` (HTTP header, user-controlled) and `parsed["title"]`/`parsed["author"]` (epub DC metadata) were inserted into the database without any length bounds, allowing an attacker to store megabytes of data per upload row.

## Test plan
- [x] `test_upload_oversized_filename_returns_422` — 256-char filename → 422
- [x] `test_upload_oversized_title_and_author_are_truncated` — 600-char title / 300-char author stored ≤ 500/200
- [x] Full backend suite: 1207 tests pass

Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)
