### PR TITLE
feat: user_book_chapters table replaces JSON-in-books.text for uploads (#357)

### DIFF
--- a/backend/migrations/025_user_book_chapters.sql
+++ b/backend/migrations/025_user_book_chapters.sql
@@ -1,0 +1,20 @@
+-- Dedicated table for uploaded-book chapter content. Replaces the previous
+-- JSON-in-books.text encoding (issue #357, design doc docs/design/user-book-chapters.md).
+--
+-- Ops step: after this migration applies, run
+--   python -m backend.scripts.migrate_upload_chapters
+-- once to copy existing JSON content into this table, then
+--   python -m backend.scripts.migrate_upload_chapters --finalize
+-- once the new router code is deployed and stable to clear books.text.
+
+CREATE TABLE IF NOT EXISTS user_book_chapters (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    book_id       INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    chapter_index INTEGER NOT NULL,
+    title         TEXT    NOT NULL DEFAULT '',
+    text          TEXT    NOT NULL DEFAULT '',
+    is_draft      INTEGER NOT NULL DEFAULT 1,
+    UNIQUE(book_id, chapter_index)
+);
+
+CREATE INDEX IF NOT EXISTS ubc_book_draft ON user_book_chapters(book_id, is_draft);

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -242,6 +242,7 @@ async def delete_book(book_id: int, _admin: dict = Depends(_require_admin)):
                     "Wait for it to finish before deleting."
                 ),
             )
+        await db.execute("DELETE FROM user_book_chapters WHERE book_id = ?", (book_id,))
         await db.execute("DELETE FROM book_uploads WHERE book_id = ?", (book_id,))
         await db.execute("DELETE FROM books WHERE id = ?", (book_id,))
         await db.execute("DELETE FROM translations WHERE book_id = ?", (book_id,))
@@ -1112,20 +1113,13 @@ async def queue_enqueue_book(
     book = await get_cached_book(req.book_id)
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
-    text = book.get("text") or ""
-    if text.lstrip().startswith("{"):
-        try:
-            import json as _json
-            _data = _json.loads(text)
-            if _data.get("draft"):
-                raise HTTPException(
-                    status_code=400,
-                    detail="Book has not been confirmed yet. Confirm chapter splits before enqueueing for translation.",
-                )
-        except HTTPException:
-            raise
-        except (ValueError, TypeError):
-            pass
+    if book.get("source") == "upload":
+        from services.db import count_draft_user_book_chapters
+        if await count_draft_user_book_chapters(req.book_id) > 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Book has not been confirmed yet. Confirm chapter splits before enqueueing for translation.",
+            )
     added = await enqueue_for_book(
         req.book_id,
         target_languages=req.target_languages,

--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -110,11 +110,12 @@ async def translation_status(book_id: int, target_language: str = Query(..., max
         raise HTTPException(status_code=404, detail="Book not found")
     check_book_access(cached, user)
     total_chapters = 0
-    if cached.get("text"):
+    if cached.get("text") or cached.get("source") == "upload":
         # Use the shared resolver so total_chapters matches what the reader
-        # displays (and what the queue worker processes).
+        # displays (and what the queue worker processes). Uploaded books now
+        # store chapters in the user_book_chapters table (books.text is empty).
         from services.book_chapters import split_with_html_preference
-        chapters = await split_with_html_preference(book_id, cached["text"])
+        chapters = await split_with_html_preference(book_id, cached.get("text") or "")
         total_chapters = len(chapters)
 
     cached_translations = await count_translations_for_book(book_id, target_language)
@@ -259,18 +260,12 @@ async def request_chapter_translation(
 
     # 0c. Guard: reject draft uploaded books — chapters not yet confirmed.
     if book_meta.get("source") == "upload":
-        try:
-            import json as _json
-            _data = _json.loads(book_meta.get("text") or "{}")
-            if _data.get("draft"):
-                raise HTTPException(
-                    status_code=400,
-                    detail="Book chapters not yet confirmed. Confirm the chapter structure before translating.",
-                )
-        except HTTPException:
-            raise
-        except Exception:
-            pass
+        from services.db import count_draft_user_book_chapters
+        if await count_draft_user_book_chapters(book_id) > 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Book chapters not yet confirmed. Confirm the chapter structure before translating.",
+            )
 
     # 0d. Guard: reject same-language translation.
     source = (book_meta.get("languages") or [None])[0]
@@ -464,23 +459,18 @@ async def book_chapters(book_id: int, user: dict | None = Depends(get_optional_u
     """
     cached = await get_cached_book(book_id)
 
-    # Handle uploaded books (chapters stored as JSON in text field)
+    # Handle uploaded books (chapters in the user_book_chapters table).
     if cached and cached.get("source") == "upload":
         check_book_access(cached, user)
-        text = cached.get("text", "")
-        try:
-            import json as _json
-            data = _json.loads(text)
-        except Exception:
-            raise HTTPException(status_code=422, detail="Book data corrupted")
-        if data.get("draft"):
+        from services.db import count_draft_user_book_chapters, get_user_book_chapters
+        if await count_draft_user_book_chapters(book_id) > 0:
             raise HTTPException(status_code=400, detail="Book not yet confirmed. Visit /upload/{book_id}/chapters to confirm.")
-        raw_chapters = data.get("chapters", [])
+        chapters_rows = await get_user_book_chapters(book_id, include_drafts=False)
         meta = {k: v for k, v in cached.items() if k not in ("text", "cached_at", "images")}
         return {
             "book_id": book_id,
             "meta": meta,
-            "chapters": [{"title": ch["title"], "text": ch["text"]} for ch in raw_chapters],
+            "chapters": [{"title": r["title"], "text": r["text"]} for r in chapters_rows],
         }
 
     if cached and cached.get("text"):

--- a/backend/routers/uploads.py
+++ b/backend/routers/uploads.py
@@ -7,6 +7,7 @@ import services.db as _db
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from pydantic import BaseModel, Field
 from services.auth import get_current_user
+from services.db import get_user_book_chapters, count_draft_user_book_chapters
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/books", tags=["uploads"])
@@ -30,10 +31,12 @@ async def _save_upload_book(user_id: int, title: str, author: str, filename: str
                             max_books: int | None = None) -> int:
     """Insert a new uploaded book row (source='upload') and book_uploads row.
 
+    Chapters are persisted in the user_book_chapters table with is_draft=1.
+    The books.text column stays empty for uploads.
+
     If max_books is provided, the quota is re-checked inside the BEGIN IMMEDIATE
     transaction to prevent TOCTOU races between concurrent uploads.
     """
-    draft_json = json.dumps({"draft": True, "chapters": draft_chapters})
     async with aiosqlite.connect(_db.DB_PATH) as db:
         # BEGIN IMMEDIATE acquires a write lock immediately so that a second
         # concurrent upload cannot pass the quota check after this connection
@@ -53,14 +56,22 @@ async def _save_upload_book(user_id: int, title: str, author: str, filename: str
             cur = await db.execute(
                 """INSERT INTO books (title, authors, languages, subjects, download_count,
                                      cover, text, images, source, owner_user_id)
-                   VALUES (?, ?, '[]', '[]', 0, '', ?, '[]', 'upload', ?)""",
-                (title, json.dumps([author]), draft_json, user_id),
+                   VALUES (?, ?, '[]', '[]', 0, '', '', '[]', 'upload', ?)""",
+                (title, json.dumps([author]), user_id),
             )
             book_id = cur.lastrowid
             await db.execute(
                 """INSERT INTO book_uploads (book_id, user_id, filename, file_size, format)
                    VALUES (?, ?, ?, ?, ?)""",
                 (book_id, user_id, filename, file_size, fmt),
+            )
+            await db.executemany(
+                """INSERT INTO user_book_chapters (book_id, chapter_index, title, text, is_draft)
+                   VALUES (?, ?, ?, ?, 1)""",
+                [
+                    (book_id, i, ch.get("title", "") or "", ch.get("text", "") or "")
+                    for i, ch in enumerate(draft_chapters)
+                ],
             )
             await db.execute("COMMIT")
             return book_id
@@ -161,34 +172,30 @@ async def get_draft_chapters(book_id: int, user: dict = Depends(get_current_user
     """Return the draft chapter list for an uploaded book pending confirmation."""
     async with aiosqlite.connect(_db.DB_PATH) as db:
         async with db.execute(
-            "SELECT text, owner_user_id, source FROM books WHERE id=?", (book_id,)
+            "SELECT owner_user_id, source FROM books WHERE id=?", (book_id,)
         ) as cur:
             row = await cur.fetchone()
     if not row:
         raise HTTPException(status_code=404, detail="Book not found")
-    if row[2] != "upload":
+    if row[1] != "upload":
         raise HTTPException(status_code=400, detail="Not an uploaded book")
-    if row[1] != user["id"] and user.get("role") != "admin":
+    if row[0] != user["id"] and user.get("role") != "admin":
         raise HTTPException(status_code=403, detail="Not your book")
 
-    try:
-        data = json.loads(row[0])
-    except Exception:
-        raise HTTPException(status_code=500, detail="Draft data corrupted")
-
-    if not data.get("draft"):
+    draft_rows = await get_user_book_chapters(book_id, include_drafts=True)
+    if not draft_rows or all(r["is_draft"] == 0 for r in draft_rows):
         raise HTTPException(status_code=400, detail="Book already confirmed")
 
-    chapters = data.get("chapters", [])
     return {
         "chapters": [
             {
                 "index": i,
-                "title": ch["title"],
-                "preview": ch["text"][:300].strip(),
-                "word_count": len(ch["text"].split()),
+                "title": r["title"],
+                "preview": (r["text"] or "")[:300].strip(),
+                "word_count": len((r["text"] or "").split()),
             }
-            for i, ch in enumerate(chapters)
+            for i, r in enumerate(draft_rows)
+            if r["is_draft"] == 1
         ]
     }
 
@@ -209,53 +216,61 @@ async def confirm_chapters(
     body: ConfirmChaptersBody,
     user: dict = Depends(get_current_user),
 ):
-    """Confirm chapter splits for an uploaded book. Writes chapters to DB and makes book readable."""
+    """Confirm chapter splits for an uploaded book. Replaces draft rows with confirmed rows."""
+    if not body.chapters:
+        raise HTTPException(status_code=400, detail="chapters list cannot be empty")
+
     async with aiosqlite.connect(_db.DB_PATH) as db:
         # BEGIN IMMEDIATE acquires a write reservation immediately so a second
-        # concurrent confirm cannot read draft=True after this connection has
-        # written draft=False (#451).
+        # concurrent confirm cannot read is_draft=1 after this connection has
+        # written is_draft=0 (#451).
         await db.execute("BEGIN IMMEDIATE")
         async with db.execute(
-            "SELECT text, owner_user_id, source FROM books WHERE id=?", (book_id,)
+            "SELECT owner_user_id, source FROM books WHERE id=?", (book_id,)
         ) as cur:
             row = await cur.fetchone()
         if not row:
+            await db.execute("ROLLBACK")
             raise HTTPException(status_code=404, detail="Book not found")
-        if row[2] != "upload":
+        if row[1] != "upload":
+            await db.execute("ROLLBACK")
             raise HTTPException(status_code=400, detail="Not an uploaded book")
-        if row[1] != user["id"] and user.get("role") != "admin":
+        if row[0] != user["id"] and user.get("role") != "admin":
+            await db.execute("ROLLBACK")
             raise HTTPException(status_code=403, detail="Not your book")
 
-        try:
-            data = json.loads(row[0])
-        except Exception:
-            raise HTTPException(status_code=500, detail="Draft data corrupted")
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT chapter_index, title, text, is_draft FROM user_book_chapters "
+            "WHERE book_id=? ORDER BY chapter_index",
+            (book_id,),
+        ) as cur:
+            orig_rows = [dict(r) for r in await cur.fetchall()]
 
-        if not data.get("draft"):
+        if not any(r["is_draft"] == 1 for r in orig_rows):
+            await db.execute("ROLLBACK")
             raise HTTPException(status_code=400, detail="Book already confirmed")
 
-        if not body.chapters:
-            raise HTTPException(status_code=400, detail="chapters list cannot be empty")
+        orig_by_idx = {r["chapter_index"]: r for r in orig_rows}
 
-        orig_chapters = data.get("chapters", [])
-
-        # Build final chapters: body.chapters provides the ordering/titles;
-        # original text comes from orig_chapters by matching original index
-        final_chapters = []
+        final_chapters: list[dict] = []
         for ch_spec in body.chapters:
             orig_idx = ch_spec.original_index if ch_spec.original_index is not None else ch_spec.index
             title = ch_spec.title or f"Chapter {len(final_chapters) + 1}"
-            if orig_idx is not None and 0 <= orig_idx < len(orig_chapters):
-                text = orig_chapters[orig_idx]["text"]
+            if orig_idx is not None and orig_idx in orig_by_idx:
+                text = orig_by_idx[orig_idx]["text"] or ""
             else:
                 text = ""
             final_chapters.append({"title": title, "text": text})
 
-        confirmed_json = json.dumps({"draft": False, "chapters": final_chapters})
-        await db.execute(
-            "UPDATE books SET text=? WHERE id=?", (confirmed_json, book_id)
+        # Replace the draft rows atomically: delete + reinsert as confirmed.
+        await db.execute("DELETE FROM user_book_chapters WHERE book_id=?", (book_id,))
+        await db.executemany(
+            """INSERT INTO user_book_chapters (book_id, chapter_index, title, text, is_draft)
+               VALUES (?, ?, ?, ?, 0)""",
+            [(book_id, i, ch["title"], ch["text"]) for i, ch in enumerate(final_chapters)],
         )
-        await db.commit()
+        await db.execute("COMMIT")
 
     # Invalidate any stale chapter-split cache from draft-state accesses.
     from services.book_chapters import clear_cache as _clear_chapter_cache
@@ -316,6 +331,7 @@ async def delete_uploaded_book(book_id: int, user: dict = Depends(get_current_us
         await db.execute("DELETE FROM chapter_summaries WHERE book_id=?", (book_id,))
         await db.execute("DELETE FROM reading_history WHERE book_id=?", (book_id,))
         await db.execute("DELETE FROM user_reading_progress WHERE book_id=?", (book_id,))
+        await db.execute("DELETE FROM user_book_chapters WHERE book_id=?", (book_id,))
         await db.execute("DELETE FROM book_uploads WHERE book_id=?", (book_id,))
         await db.execute("DELETE FROM books WHERE id=?", (book_id,))
         await db.commit()

--- a/backend/scripts/migrate_upload_chapters.py
+++ b/backend/scripts/migrate_upload_chapters.py
@@ -1,0 +1,110 @@
+"""One-time migration: move JSON chapters from books.text to user_book_chapters.
+
+Run in two phases (both idempotent):
+
+    # Phase 1 — copy rows into the new table (books.text untouched)
+    python -m backend.scripts.migrate_upload_chapters
+
+    # Phase 2 — clear books.text after the new router code is stable
+    python -m backend.scripts.migrate_upload_chapters --finalize
+
+The two-phase split keeps the rollback path safe: if the router deploy that
+reads from user_book_chapters fails, books.text is still intact and the old
+code path keeps working.
+
+See docs/design/user-book-chapters.md for the full deployment checklist.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+
+import aiosqlite
+
+
+def _resolve_db_path() -> str:
+    """Resolve the DB path the same way services.db does."""
+    return os.environ.get(
+        "DB_PATH",
+        os.path.join(os.path.dirname(__file__), "..", "books.db"),
+    )
+
+
+async def copy_phase(db: aiosqlite.Connection) -> int:
+    """Copy upload-book JSON into user_book_chapters. Returns count of books processed."""
+    async with db.execute(
+        "SELECT id, text FROM books WHERE source='upload' AND text LIKE '{%'"
+    ) as cur:
+        rows = await cur.fetchall()
+
+    copied = 0
+    for book_id, text in rows:
+        try:
+            data = json.loads(text)
+        except (ValueError, TypeError):
+            continue
+        chapters = data.get("chapters") or []
+        is_draft = 1 if data.get("draft") else 0
+        for i, ch in enumerate(chapters):
+            if not isinstance(ch, dict):
+                continue
+            await db.execute(
+                """INSERT OR IGNORE INTO user_book_chapters
+                   (book_id, chapter_index, title, text, is_draft)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (book_id, i, ch.get("title", "") or "", ch.get("text", "") or "", is_draft),
+            )
+        copied += 1
+    return copied
+
+
+async def finalize_phase(db: aiosqlite.Connection) -> int:
+    """Clear books.text for uploads that already have rows in user_book_chapters."""
+    async with db.execute(
+        """UPDATE books
+           SET text = ''
+           WHERE source = 'upload'
+             AND text LIKE '{%'
+             AND EXISTS (
+                 SELECT 1 FROM user_book_chapters WHERE book_id = books.id
+             )"""
+    ) as cur:
+        return cur.rowcount or 0
+
+
+async def run(db_path: str, finalize: bool) -> None:
+    async with aiosqlite.connect(db_path) as db:
+        copied = await copy_phase(db)
+        print(f"copy phase: {copied} upload book(s) processed")
+        if finalize:
+            cleared = await finalize_phase(db)
+            print(f"finalize phase: books.text cleared for {cleared} book(s)")
+        await db.commit()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--finalize",
+        action="store_true",
+        help="After the new router deploy is stable, clear books.text for migrated uploads.",
+    )
+    parser.add_argument(
+        "--db-path",
+        default=None,
+        help="SQLite file (defaults to $DB_PATH or backend/books.db)",
+    )
+    args = parser.parse_args()
+    db_path = args.db_path or _resolve_db_path()
+    if not os.path.exists(db_path):
+        print(f"error: database not found at {db_path}", file=sys.stderr)
+        sys.exit(1)
+    asyncio.run(run(db_path, args.finalize))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/services/book_chapters.py
+++ b/backend/services/book_chapters.py
@@ -2,9 +2,10 @@
 translation queue worker.
 
 Priority (all DB-only, no external fetches at chapter-load time):
-  1. Pre-split JSON  — uploaded books that store chapters as structured JSON.
-  2. Stored EPUB     — preferred for Gutenberg books: explicit spine/TOC gives
-                       clean paragraph boundaries and reliable titles.
+  1. user_book_chapters — uploaded books store their chapters in a dedicated
+                          table (issue #357); draft rows are filtered out.
+  2. Stored EPUB        — preferred for Gutenberg books: explicit spine/TOC
+                          gives clean paragraph boundaries and reliable titles.
   3. Plain-text regex fallback — for Gutenberg books with no EPUB available.
 
 New Gutenberg books have their EPUB fetched and stored at add-time.
@@ -15,7 +16,6 @@ task on first chapter access, becoming available on the next cold start.
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from collections import defaultdict
 
@@ -34,7 +34,8 @@ _epub_fetch_attempted: set[int] = set()
 async def split_with_html_preference(book_id: int, text: str) -> list[Chapter]:
     """Return the canonical chapter list for a book (DB-only, no external calls).
 
-    The name is kept for backwards compatibility with call sites.
+    The `text` argument is used only for the plain-text regex fallback (Gutenberg).
+    Uploaded books are resolved from the user_book_chapters table.
     """
     cached = _chapter_cache.get(book_id)
     if cached is not None:
@@ -45,21 +46,16 @@ async def split_with_html_preference(book_id: int, text: str) -> list[Chapter]:
         if cached is not None:
             return cached
 
-        # ── 1. Uploaded books: pre-split JSON ─────────────────────────────────
-        if text and text.lstrip().startswith("{"):
-            try:
-                data = json.loads(text)
-                if "chapters" in data:
-                    if data.get("draft"):
-                        return []
-                    chapters: list[Chapter] = [
-                        Chapter(title=ch["title"], text=ch["text"])
-                        for ch in data["chapters"]
-                    ]
-                    _chapter_cache[book_id] = chapters
-                    return chapters
-            except (ValueError, KeyError, TypeError):
-                pass
+        # ── 1. Uploaded books: dedicated chapters table (issue #357) ──────────
+        from services.db import get_book_source, get_user_book_chapters
+        source = await get_book_source(book_id)
+        if source == "upload":
+            rows = await get_user_book_chapters(book_id, include_drafts=False)
+            chapters: list[Chapter] = [
+                Chapter(title=r["title"], text=r["text"]) for r in rows
+            ]
+            _chapter_cache[book_id] = chapters
+            return chapters
 
         # ── 2. Stored EPUB (Gutenberg books) ──────────────────────────────────
         try:

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -308,6 +308,7 @@ async def delete_user(user_id: int) -> None:
         await db.execute(f"DELETE FROM book_insights WHERE book_id IN ({_owned})", (user_id,))
         await db.execute(f"DELETE FROM user_reading_progress WHERE book_id IN ({_owned})", (user_id,))
         await db.execute(f"DELETE FROM reading_history WHERE book_id IN ({_owned})", (user_id,))
+        await db.execute(f"DELETE FROM user_book_chapters WHERE book_id IN ({_owned})", (user_id,))
         await db.execute(f"DELETE FROM book_uploads WHERE book_id IN ({_owned})", (user_id,))
         await db.execute("DELETE FROM books WHERE owner_user_id = ?", (user_id,))
         await db.execute("DELETE FROM users WHERE id = ?", (user_id,))
@@ -492,6 +493,61 @@ async def save_book(book_id: int, meta: dict, text: str, images: list | None = N
         )
 
 
+
+
+# ── Uploaded-book chapters (issue #357) ──────────────────────────────────────
+
+async def get_book_source(book_id: int) -> str | None:
+    """Return the 'source' column of a book (e.g. 'gutenberg', 'upload') or None if missing."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "SELECT source FROM books WHERE id = ?", (book_id,)
+        ) as cur:
+            row = await cur.fetchone()
+    return row[0] if row else None
+
+
+async def get_user_book_chapters(
+    book_id: int, include_drafts: bool = False,
+) -> list[dict]:
+    """Return rows from user_book_chapters for an uploaded book, ordered by chapter_index."""
+    query = "SELECT id, chapter_index, title, text, is_draft FROM user_book_chapters WHERE book_id = ?"
+    if not include_drafts:
+        query += " AND is_draft = 0"
+    query += " ORDER BY chapter_index"
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(query, (book_id,)) as cur:
+            rows = await cur.fetchall()
+    return [dict(r) for r in rows]
+
+
+async def count_draft_user_book_chapters(book_id: int) -> int:
+    """Return count of draft rows for an uploaded book (0 means fully confirmed or empty)."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "SELECT COUNT(*) FROM user_book_chapters WHERE book_id = ? AND is_draft = 1",
+            (book_id,),
+        ) as cur:
+            row = await cur.fetchone()
+    return row[0] if row else 0
+
+
+async def insert_user_book_chapters_draft(book_id: int, chapters: list[dict]) -> None:
+    """Insert a fresh set of draft chapters for a newly uploaded book.
+
+    Caller provides chapters in final index order with 'title' and 'text'.
+    """
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.executemany(
+            """INSERT INTO user_book_chapters (book_id, chapter_index, title, text, is_draft)
+               VALUES (?, ?, ?, ?, 1)""",
+            [
+                (book_id, i, ch.get("title", "") or "", ch.get("text", "") or "")
+                for i, ch in enumerate(chapters)
+            ],
+        )
+        await db.commit()
 
 
 # ── EPUB cache ────────────────────────────────────────────────────────────────

--- a/backend/tests/test_book_chapters.py
+++ b/backend/tests/test_book_chapters.py
@@ -18,10 +18,16 @@ def _make_chapters(*titles: str) -> list[Chapter]:
 
 @pytest.fixture(autouse=True)
 def clear_chapter_cache():
-    """Start each test with an empty chapter cache and fetch-attempted set."""
+    """Start each test with an empty chapter cache and fetch-attempted set.
+
+    Also stubs `services.db.get_book_source` by default so these tests can
+    exercise the resolver without a fully-initialized DB. Individual tests
+    may override via their own patch stack.
+    """
     clear_cache()
     book_chapters_module._epub_fetch_attempted.clear()
-    yield
+    with patch("services.db.get_book_source", new_callable=AsyncMock, return_value=None):
+        yield
     clear_cache()
     book_chapters_module._epub_fetch_attempted.clear()
 

--- a/backend/tests/test_migrate_upload_chapters.py
+++ b/backend/tests/test_migrate_upload_chapters.py
@@ -1,0 +1,188 @@
+"""Tests for the two-phase migrate_upload_chapters.py helper (issue #357)."""
+from __future__ import annotations
+
+import json
+
+import aiosqlite
+import pytest
+
+from scripts.migrate_upload_chapters import copy_phase, finalize_phase
+from services.migrations import run as run_migrations
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test.db")
+
+
+async def _seed_upload(db: aiosqlite.Connection, book_id: int, payload: dict) -> None:
+    """Insert an uploaded book with JSON-in-text (legacy encoding)."""
+    await db.execute(
+        "INSERT INTO books (id, title, source, text) VALUES (?, ?, 'upload', ?)",
+        (book_id, f"book-{book_id}", json.dumps(payload)),
+    )
+
+
+async def test_copy_phase_copies_chapters_and_leaves_books_text_intact(tmp_db):
+    await run_migrations(tmp_db)
+    async with aiosqlite.connect(tmp_db) as db:
+        await _seed_upload(db, 1, {
+            "draft": False,
+            "chapters": [
+                {"title": "C1", "text": "text1"},
+                {"title": "C2", "text": "text2"},
+            ],
+        })
+        await db.commit()
+
+        processed = await copy_phase(db)
+        await db.commit()
+
+        assert processed == 1
+        async with db.execute(
+            "SELECT chapter_index, title, text, is_draft FROM user_book_chapters "
+            "WHERE book_id=1 ORDER BY chapter_index"
+        ) as cur:
+            rows = await cur.fetchall()
+        assert rows == [(0, "C1", "text1", 0), (1, "C2", "text2", 0)]
+
+        # books.text is NOT cleared in the copy phase — rollback safety.
+        async with db.execute("SELECT text FROM books WHERE id=1") as cur:
+            text = (await cur.fetchone())[0]
+        assert text.startswith("{")
+
+
+async def test_copy_phase_marks_draft_correctly(tmp_db):
+    await run_migrations(tmp_db)
+    async with aiosqlite.connect(tmp_db) as db:
+        await _seed_upload(db, 2, {
+            "draft": True,
+            "chapters": [{"title": "C1", "text": "t"}],
+        })
+        await db.commit()
+        await copy_phase(db)
+        await db.commit()
+        async with db.execute(
+            "SELECT is_draft FROM user_book_chapters WHERE book_id=2"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 1
+
+
+async def test_copy_phase_is_idempotent(tmp_db):
+    await run_migrations(tmp_db)
+    async with aiosqlite.connect(tmp_db) as db:
+        await _seed_upload(db, 3, {
+            "draft": False,
+            "chapters": [{"title": "C1", "text": "t"}],
+        })
+        await db.commit()
+        await copy_phase(db)
+        await db.commit()
+        await copy_phase(db)
+        await db.commit()
+        async with db.execute(
+            "SELECT COUNT(*) FROM user_book_chapters WHERE book_id=3"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 1
+
+
+async def test_copy_phase_skips_non_upload_books(tmp_db):
+    await run_migrations(tmp_db)
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute(
+            "INSERT INTO books (id, title, source, text) VALUES (4, 'gute', 'gutenberg', 'plain text')"
+        )
+        await db.commit()
+        processed = await copy_phase(db)
+        await db.commit()
+        assert processed == 0
+        async with db.execute(
+            "SELECT COUNT(*) FROM user_book_chapters WHERE book_id=4"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 0
+
+
+async def test_copy_phase_skips_books_already_cleared(tmp_db):
+    """A second deploy wave must not re-copy data into already-cleared books."""
+    await run_migrations(tmp_db)
+    async with aiosqlite.connect(tmp_db) as db:
+        # Upload row with books.text=''. copy_phase should not touch it (filter LIKE '{%').
+        await db.execute(
+            "INSERT INTO books (id, title, source, text) VALUES (5, 'x', 'upload', '')"
+        )
+        await db.commit()
+        processed = await copy_phase(db)
+        await db.commit()
+        assert processed == 0
+
+
+async def test_copy_phase_handles_corrupt_json_gracefully(tmp_db):
+    await run_migrations(tmp_db)
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute(
+            "INSERT INTO books (id, title, source, text) VALUES (6, 'x', 'upload', '{garbage')"
+        )
+        await db.commit()
+        processed = await copy_phase(db)
+        await db.commit()
+        # Corrupt JSON is skipped silently — returned count reflects books with chapters processed.
+        assert processed == 0
+        async with db.execute(
+            "SELECT COUNT(*) FROM user_book_chapters WHERE book_id=6"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 0
+
+
+async def test_finalize_phase_clears_only_migrated_books(tmp_db):
+    await run_migrations(tmp_db)
+    async with aiosqlite.connect(tmp_db) as db:
+        # Migrated upload (has rows in user_book_chapters)
+        await _seed_upload(db, 7, {
+            "draft": False,
+            "chapters": [{"title": "C1", "text": "t"}],
+        })
+        # Upload that has NOT been through copy_phase (no rows in user_book_chapters)
+        await _seed_upload(db, 8, {
+            "draft": False,
+            "chapters": [{"title": "C1", "text": "t"}],
+        })
+        # Gutenberg book with plain text — must never be touched
+        await db.execute(
+            "INSERT INTO books (id, title, source, text) VALUES (9, 'g', 'gutenberg', 'plain')"
+        )
+        await db.commit()
+
+        await copy_phase(db)
+        # Simulate: only book 8's data got copied via some other path, but book 7 was NOT.
+        # We overwrite: actually simpler — remove book 8's user_book_chapters rows to
+        # simulate the "not yet copied" state.
+        await db.execute("DELETE FROM user_book_chapters WHERE book_id=8")
+        await db.commit()
+
+        cleared = await finalize_phase(db)
+        await db.commit()
+
+        # Only book 7 should be cleared.
+        assert cleared == 1
+        async with db.execute("SELECT id, text FROM books ORDER BY id") as cur:
+            rows = await cur.fetchall()
+        texts = {row[0]: row[1] for row in rows}
+        assert texts[7] == ""
+        assert texts[8].startswith("{")
+        assert texts[9] == "plain"
+
+
+async def test_finalize_phase_is_idempotent(tmp_db):
+    await run_migrations(tmp_db)
+    async with aiosqlite.connect(tmp_db) as db:
+        await _seed_upload(db, 10, {
+            "draft": False,
+            "chapters": [{"title": "C1", "text": "t"}],
+        })
+        await db.commit()
+        await copy_phase(db)
+        await finalize_phase(db)
+        await db.commit()
+        cleared_second = await finalize_phase(db)
+        await db.commit()
+        assert cleared_second == 0

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -823,3 +823,43 @@ async def test_semicolon_in_sql_comment_does_not_break_migration(tmp_db, tmp_mig
             row = await cursor.fetchone()
     assert row is not None
     assert row[0] == "hello"
+
+
+# ── 025_user_book_chapters (issue #357) ──────────────────────────────────────
+
+async def test_migration_025_user_book_chapters_table_created(tmp_db):
+    """Migration 025 creates user_book_chapters table + index."""
+    await run_migrations(tmp_db)
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='user_book_chapters'"
+        ) as cur:
+            assert await cur.fetchone() is not None
+        async with db.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='ubc_book_draft'"
+        ) as cur:
+            assert await cur.fetchone() is not None
+        async with db.execute(
+            "SELECT name FROM pragma_table_info('user_book_chapters')"
+        ) as cur:
+            cols = {r[0] for r in await cur.fetchall()}
+    assert cols == {"id", "book_id", "chapter_index", "title", "text", "is_draft"}
+
+
+async def test_migration_025_unique_constraint_enforced(tmp_db):
+    """user_book_chapters (book_id, chapter_index) UNIQUE must reject duplicates."""
+    await run_migrations(tmp_db)
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute(
+            "INSERT INTO books (id, title, source) VALUES (1, 'x', 'upload')"
+        )
+        await db.execute(
+            "INSERT INTO user_book_chapters (book_id, chapter_index, title, text, is_draft) "
+            "VALUES (1, 0, 'Ch1', 't', 1)"
+        )
+        with pytest.raises(aiosqlite.IntegrityError):
+            await db.execute(
+                "INSERT INTO user_book_chapters (book_id, chapter_index, title, text, is_draft) "
+                "VALUES (1, 0, 'dup', 't', 1)"
+            )
+        await db.rollback()

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -1128,17 +1128,19 @@ async def test_enqueue_draft_book_returns_400(admin_client, admin_db):
     Before the fix the endpoint returned 200 with enqueued=0, giving
     the admin no indication that the book hadn't been confirmed yet.
     """
-    import json as _json
     import aiosqlite
-    draft_text = _json.dumps({"draft": True, "chapters": [{"title": "Ch 1", "text": "word " * 300}]})
     async with aiosqlite.connect(admin_db) as db:
         cur = await db.execute(
             """INSERT INTO books (title, authors, languages, subjects, download_count,
                                   cover, text, images, source, owner_user_id)
-               VALUES ('Draft', '[]', '[]', '[]', 0, '', ?, '[]', 'upload', 1)""",
-            (draft_text,),
+               VALUES ('Draft', '[]', '[]', '[]', 0, '', '', '[]', 'upload', 1)"""
         )
         book_id = cur.lastrowid
+        await db.execute(
+            "INSERT INTO user_book_chapters (book_id, chapter_index, title, text, is_draft) "
+            "VALUES (?, 0, 'Ch 1', ?, 1)",
+            (book_id, "word " * 300),
+        )
         await db.commit()
 
     res = await admin_client.post("/api/admin/queue/enqueue-book", json={

--- a/backend/tests/test_router_uploads.py
+++ b/backend/tests/test_router_uploads.py
@@ -482,31 +482,57 @@ async def test_translation_status_uploaded_book_reports_correct_chapter_count(
     )
 
 
-async def test_split_with_html_preference_handles_uploaded_book_json():
-    """Regression #380: split_with_html_preference must return correct chapters
-    when passed uploaded-book JSON text instead of raw book text."""
-    import json
+async def test_split_with_html_preference_reads_user_book_chapters(tmp_db):
+    """split_with_html_preference resolves uploaded books from user_book_chapters
+    (issue #357, replaces JSON-in-books.text path)."""
     from services.book_chapters import split_with_html_preference, clear_cache
 
-    uploaded_json = json.dumps({
-        "draft": False,
-        "chapters": [
-            {"title": "Chapter One", "text": "The first chapter content here."},
-            {"title": "Chapter Two", "text": "The second chapter content here."},
-            {"title": "Chapter Three", "text": "The third chapter content here."},
-        ]
-    })
+    async with aiosqlite.connect(tmp_db) as db:
+        cur = await db.execute(
+            "INSERT INTO books (title, source, text) VALUES ('T', 'upload', '')"
+        )
+        book_id = cur.lastrowid
+        await db.executemany(
+            "INSERT INTO user_book_chapters (book_id, chapter_index, title, text, is_draft) "
+            "VALUES (?, ?, ?, ?, 0)",
+            [
+                (book_id, 0, "Chapter One", "The first chapter content here."),
+                (book_id, 1, "Chapter Two", "The second chapter content here."),
+                (book_id, 2, "Chapter Three", "The third chapter content here."),
+            ],
+        )
+        await db.commit()
 
-    clear_cache(99999)
-    chapters = await split_with_html_preference(99999, uploaded_json)
-    clear_cache(99999)
+    clear_cache(book_id)
+    chapters = await split_with_html_preference(book_id, "")
+    clear_cache(book_id)
 
-    assert len(chapters) == 3, (
-        f"Expected 3 chapters from uploaded JSON, got {len(chapters)} (#380)"
-    )
+    assert len(chapters) == 3
     assert chapters[0].title == "Chapter One"
     assert "first chapter" in chapters[0].text
     assert chapters[2].title == "Chapter Three"
+
+
+async def test_split_with_html_preference_skips_draft_rows(tmp_db):
+    """Draft rows are hidden from the reader/queue until confirmed."""
+    from services.book_chapters import split_with_html_preference, clear_cache
+
+    async with aiosqlite.connect(tmp_db) as db:
+        cur = await db.execute(
+            "INSERT INTO books (title, source, text) VALUES ('T', 'upload', '')"
+        )
+        book_id = cur.lastrowid
+        await db.execute(
+            "INSERT INTO user_book_chapters (book_id, chapter_index, title, text, is_draft) "
+            "VALUES (?, 0, 'D', 't', 1)",
+            (book_id,),
+        )
+        await db.commit()
+
+    clear_cache(book_id)
+    chapters = await split_with_html_preference(book_id, "")
+    clear_cache(book_id)
+    assert chapters == []
 
 
 async def test_translation_status_draft_book_reports_zero_chapters(client, test_user):


### PR DESCRIPTION
## Summary

Implements the `user_book_chapters` table design (PR #555, merged). Replaces the JSON-in-`books.text` encoding for uploaded books with a dedicated relational table.

Closes #357.

## What changed

**Schema**
- New migration `025_user_book_chapters.sql`: `user_book_chapters(id, book_id, chapter_index, title, text, is_draft)` + `UNIQUE(book_id, chapter_index)` + `ubc_book_draft` index.
- `books.text` is now `''` for uploaded books. Chapter content lives in the new table.

**Ops script (two-phase, idempotent)**
- `backend/scripts/migrate_upload_chapters.py` — run once by ops after 025 applies. Phase 1 (default) copies JSON chapters into `user_book_chapters`; Phase 2 (`--finalize`) clears `books.text`. Split keeps rollback safe if the router deploy is reverted.
- Deployment checklist is in the design doc.

**Code refactors**
- `services/book_chapters.py::split_with_html_preference` — removed the JSON-detect branch; now queries `books.source` and reads confirmed rows from `user_book_chapters` for uploads.
- `routers/uploads.py` — `upload`, `get_draft_chapters`, `confirm_chapters`, `delete_uploaded_book` all read/write the new table. `books.text` never receives JSON.
- `routers/books.py` — translation request draft guard, `GET /books/{id}/chapters`, `translation-status` all use the new helpers.
- `routers/admin.py` — `enqueue-book` draft guard + `delete_book` cascade.
- `services/db.py` — adds `get_book_source`, `get_user_book_chapters`, `count_draft_user_book_chapters`, `insert_user_book_chapters_draft`; extends `delete_user` with `user_book_chapters` cascade.

**Tests**
- `test_migrations.py` — 2 new tests: table/index DDL + UNIQUE constraint.
- `test_migrate_upload_chapters.py` (new file) — 7 tests: copy idempotency, draft flag preservation, skip non-upload, skip already-cleared, corrupt-JSON graceful skip, finalize correctness, finalize idempotency.
- `test_router_uploads.py` — legacy JSON test replaced with two tests that exercise the new table path (confirmed rows + draft skip).
- `test_router_admin.py` — `test_enqueue_draft_book_returns_400` updated to seed a draft row in `user_book_chapters`.

## Deployment

Per the design doc checklist:
1. Deploy backend with 025 applied + this code. `user_book_chapters` is created but empty.
2. Ops: `python -m backend.scripts.migrate_upload_chapters` (copy phase; `books.text` still intact).
3. Verify new router path works for existing uploads.
4. Ops: `python -m backend.scripts.migrate_upload_chapters --finalize` once stable.

If step 3 rolls back, `books.text` is still intact and the previous router keeps working.

## Test plan

- [ ] Full backend suite passes
- [ ] Migration 025 applies cleanly on a DB that has existing uploaded books
- [ ] `copy_phase` runs idempotent; second run inserts 0 rows
- [ ] `finalize_phase` is gated behind `--finalize` and the `EXISTS` guard
- [ ] Cascade deletes: admin `delete_book`, upload `delete_uploaded_book`, and `delete_user` all remove `user_book_chapters` rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
