### PR TITLE
fix: replace ← and ↻ Unicode characters with SVG icons in admin layout

### DIFF
--- a/frontend/src/__tests__/AdminLayout.redirect.test.tsx
+++ b/frontend/src/__tests__/AdminLayout.redirect.test.tsx
@@ -56,15 +56,15 @@ test("renders authenticated layout with tabs when user is admin", async () => {
   mockGetMe.mockResolvedValue({ id: 1, email: "admin@x.com", role: "admin" });
   render(<AdminLayout><div>child content</div></AdminLayout>);
   await waitFor(() => screen.getByText("child content"));
-  expect(screen.getByText("← Library")).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /Library/i })).toBeInTheDocument();
   expect(screen.getByText("Users")).toBeInTheDocument();
 });
 
-test("clicking ← Library navigates to / (line 76)", async () => {
+test("clicking Library button navigates to /", async () => {
   mockGetMe.mockResolvedValue({ id: 1, email: "admin@x.com", role: "admin" });
   render(<AdminLayout><div>child</div></AdminLayout>);
-  await waitFor(() => screen.getByText("← Library"));
-  fireEvent.click(screen.getByText("← Library"));
+  await waitFor(() => screen.getByRole("button", { name: /Library/i }));
+  fireEvent.click(screen.getByRole("button", { name: /Library/i }));
   expect(mockPush).toHaveBeenCalledWith("/");
 });
 

--- a/frontend/src/__tests__/AdminLayoutUnicodeIcons.test.tsx
+++ b/frontend/src/__tests__/AdminLayoutUnicodeIcons.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * Verifies admin layout header buttons use SVG icons instead of Unicode characters.
+ * Issue #650: ← and ↻ characters used as UI icons.
+ */
+import fs from "fs";
+import path from "path";
+
+const layoutPath = path.join(
+  __dirname,
+  "../../src/app/admin/layout.tsx"
+);
+
+const source = fs.readFileSync(layoutPath, "utf-8");
+
+describe("admin/layout.tsx icon system compliance", () => {
+  it("does not use ← Unicode arrow character as a UI icon", () => {
+    expect(source).not.toContain("← Library");
+    expect(source).not.toContain("←");
+  });
+
+  it("does not use ↻ Unicode refresh character as a UI icon", () => {
+    expect(source).not.toContain("↻ Refresh");
+    expect(source).not.toContain("↻");
+  });
+
+  it("imports ArrowLeftIcon from Icons", () => {
+    expect(source).toMatch(/ArrowLeftIcon/);
+  });
+
+  it("imports RetryIcon from Icons", () => {
+    expect(source).toMatch(/RetryIcon/);
+  });
+});

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -4,6 +4,7 @@ import { useRouter, usePathname } from "next/navigation";
 import Link from "next/link";
 import { getMe } from "@/lib/api";
 import { adminFetch, type Stats } from "@/lib/adminFetch";
+import { ArrowLeftIcon, RetryIcon } from "@/components/Icons";
 
 type TabKey = "users" | "books" | "audio" | "queue" | "uploads";
 
@@ -73,12 +74,12 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   return (
     <main className="min-h-screen bg-parchment">
       <header className="border-b border-amber-200 bg-white/60 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
-        <button onClick={() => router.push("/")} className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] flex items-center">
-          ← Library
+        <button onClick={() => router.push("/")} className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] flex items-center gap-1">
+          <ArrowLeftIcon className="w-4 h-4" aria-hidden="true" /> Library
         </button>
         <h1 className="font-serif font-bold text-ink text-lg md:text-xl">Admin Panel</h1>
-        <button onClick={loadStats} className="ml-auto text-sm text-amber-600 hover:text-amber-900 min-h-[44px] flex items-center">
-          ↻ Refresh
+        <button onClick={loadStats} className="ml-auto text-sm text-amber-600 hover:text-amber-900 min-h-[44px] flex items-center gap-1">
+          <RetryIcon className="w-4 h-4" aria-hidden="true" /> Refresh
         </button>
       </header>
 


### PR DESCRIPTION
## Summary

Replace Unicode arrow characters used as UI icons in the admin layout header with SVG icons from `Icons.tsx`.

- `← Library` button: `←` (U+2190) → `ArrowLeftIcon`
- `↻ Refresh` button: `↻` (U+21BB) → `RetryIcon`

Both icons already existed in `Icons.tsx`. The buttons retain their visible text labels.

## Test Plan

- [x] New test (`AdminLayoutUnicodeIcons.test.tsx`) verifies Unicode characters absent, SVG icon imports present
- [x] Updated `AdminLayout.redirect.test.tsx` to use `getByRole("button", { name: /Library/i })` instead of text-content query
- [x] All 1631 frontend tests pass

Closes #650
