### PR TITLE
chore: add PM polling cadence rule (180s default) to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,12 @@ Always work highest priority first. Re-check priority each time you pick the nex
 - Approve design docs (Path B) before implementation begins
 - Keep `product/review-state.md` updated every cycle
 
+**Polling cadence (when running as a `/loop`):**
+- **Default: 180s (3 min) between cycles.** Tighter than CI (~2–3 min) so PRs are caught before auto-merge fires; under the 5-min prompt-cache TTL so context stays warm.
+- **Quiet periods** (nothing new for 2 cycles running): back off to 900s (15 min) to save tokens. Resume 180s as soon as new activity appears.
+- **Bursts** (≥3 new PRs in the last cycle): stay at 180s or drop to 120s until the queue is reviewed.
+- Sized for a team of 3 active code roles (Dev + UI/UX + Architect). If `dev2` is running, treat as 4 roles and keep 180s as the floor.
+
 **Startup sequence:**
 1. Read all memory files in `MEMORY.md`
 2. Run `git worktree list` — warn user if `in-progress` issues exist but no worktrees are set up


### PR DESCRIPTION
## Summary

Adds a **Polling cadence** section to the PM role in `CLAUDE.md` so future PM sessions start at the right frequency without guessing.

- **Default: 180s (3 min)** — tighter than CI (~2–3 min), under the 5-min prompt-cache TTL.
- **Quiet**: back off to 900s after 2 idle cycles.
- **Burst**: drop to 120s if ≥3 new PRs arrived last cycle.
- Sized for 3 active code roles (Dev + UI/UX + Architect), with a floor at 180s if `dev2` is running.

## Why

Without this rule, each new PM session has to re-derive the right cadence from first principles, which produces inconsistent behavior and sometimes misses PRs before auto-merge fires.

## Test plan

- [ ] No code changes — docs-only PR.
- [ ] Next PM session reads the new rule and applies it at startup.
