### PR TITLE
fix: raise QueueTab Stop/Start Worker buttons to 44px touch target

### DIFF
--- a/frontend/src/__tests__/QueueTabWorkerToggleTouchTargets.test.tsx
+++ b/frontend/src/__tests__/QueueTabWorkerToggleTouchTargets.test.tsx
@@ -1,0 +1,21 @@
+/**
+ * Verifies QueueTab Stop/Start Worker buttons meet 44px touch target minimum.
+ * Issue #655: py-1 gives ~24px height — below the 44px requirement.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../../src/components/QueueTab.tsx"),
+  "utf-8"
+);
+
+describe("QueueTab Stop/Start Worker buttons — 44px touch target (issue #655)", () => {
+  it("Stop Worker button has min-h-[44px]", () => {
+    expect(src).toMatch(/stopWorker[\s\S]{0,300}min-h-\[44px\]/);
+  });
+
+  it("Start Worker button has min-h-[44px]", () => {
+    expect(src).toMatch(/startWorker[\s\S]{0,300}min-h-\[44px\]/);
+  });
+});

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -508,7 +508,7 @@ export default function QueueTab({ adminFetch }: Props) {
             <button
               onClick={stopWorker}
               disabled={togglingWorker !== null}
-              className="text-xs px-3 py-1 rounded border border-red-200 text-red-600 hover:bg-red-50 disabled:opacity-50 inline-flex items-center gap-1.5"
+              className="text-xs px-3 py-1 rounded border border-red-200 text-red-600 hover:bg-red-50 disabled:opacity-50 inline-flex items-center gap-1.5 min-h-[44px]"
             >
               {togglingWorker === "stop" && (
                 <span
@@ -523,7 +523,7 @@ export default function QueueTab({ adminFetch }: Props) {
             <button
               onClick={startWorker}
               disabled={togglingWorker !== null}
-              className="text-xs px-3 py-1 rounded border border-emerald-300 text-emerald-700 hover:bg-emerald-50 disabled:opacity-50 inline-flex items-center gap-1.5"
+              className="text-xs px-3 py-1 rounded border border-emerald-300 text-emerald-700 hover:bg-emerald-50 disabled:opacity-50 inline-flex items-center gap-1.5 min-h-[44px]"
             >
               {togglingWorker === "start" && (
                 <span


### PR DESCRIPTION
## Summary

Raise QueueTab worker control buttons to meet the 44px minimum touch target.

- Stop Worker button (`py-1`): add `min-h-[44px]`
- Start Worker button (`py-1`): add `min-h-[44px]`

Buttons retain visual size via existing `py-1` padding; only the minimum height is enforced via `min-h-[44px]`.

## Test Plan

- [x] New test (`QueueTabWorkerToggleTouchTargets.test.tsx`) verifies both buttons have `min-h-[44px]`
- [x] All 1629 frontend tests pass

Closes #655
