### PR TITLE
fix: raise admin audio Delete button to 44px touch target

### DIFF
--- a/frontend/src/__tests__/AdminAudioDeleteTouchTarget.test.ts
+++ b/frontend/src/__tests__/AdminAudioDeleteTouchTarget.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Verifies the admin audio Delete button meets 44px touch-target requirement.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/admin/audio/page.tsx"),
+  "utf-8"
+);
+
+describe("Admin audio Delete button touch target", () => {
+  it("Delete button has min-h-[44px]", () => {
+    expect(src).toMatch(/DELETE[\s\S]{0,200}min-h-\[44px\]/);
+  });
+});

--- a/frontend/src/app/admin/audio/page.tsx
+++ b/frontend/src/app/admin/audio/page.tsx
@@ -67,7 +67,7 @@ export default function AudioPage() {
             onClick={() =>
               act(() => adminFetch(`/admin/audio/${a.book_id}/${a.chapter_index}`, { method: "DELETE" }))
             }
-            className="text-xs px-2 py-1 rounded border border-red-200 text-red-500"
+            className="text-xs px-2 py-1 rounded border border-red-200 text-red-500 min-h-[44px]"
           >
             Delete
           </button>


### PR DESCRIPTION
## What changed
Added `min-h-[44px]` to the Delete button in `frontend/src/app/admin/audio/page.tsx`.

## Why
The button only had `py-1` with no `min-h-[44px]`, making it too small for reliable mobile taps per WCAG / design system rules (44×44px minimum touch target).

## Test plan
- New `AdminAudioDeleteTouchTarget.test.ts` verifying `min-h-[44px]` in source
- Full frontend suite: 1638 tests pass

Closes #663
