### PR TITLE
fix: raise admin books action buttons to 44px touch target

### DIFF
--- a/frontend/src/__tests__/AdminBooksActionTouchTargets.test.ts
+++ b/frontend/src/__tests__/AdminBooksActionTouchTargets.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Verifies that admin/books book-level and language-level action buttons
+ * meet the 44px touch-target requirement.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/admin/books/page.tsx"),
+  "utf-8"
+);
+
+describe("Admin books action buttons touch targets", () => {
+  it("+ Translate button has min-h-[44px]", () => {
+    expect(src).toMatch(/\+ Translate[\s\S]{0,50}|queueLanguageForBook[\s\S]{0,300}min-h-\[44px\]/);
+  });
+
+  it("book Delete button has min-h-[44px]", () => {
+    expect(src).toMatch(/Delete.*and all its audio[\s\S]{0,300}min-h-\[44px\]/);
+  });
+
+  it("Retranslate all button has min-h-[44px]", () => {
+    expect(src).toMatch(/Retranslate all[\s\S]{0,50}|bulkRetranslating[\s\S]{0,500}min-h-\[44px\]/);
+  });
+
+  it("Delete all translations button has min-h-[44px]", () => {
+    expect(src).toMatch(/Delete all[\s\S]{0,50}|translations.*DELETE[\s\S]{0,400}min-h-\[44px\]/);
+  });
+});

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -386,7 +386,7 @@ export default function BooksPage() {
                 <button
                   onClick={() => queueLanguageForBook(b, newLangInput[b.id] ?? "zh")}
                   disabled={queueingLangFor?.startsWith(`${b.id}:`)}
-                  className="text-xs px-2 py-1 rounded border border-emerald-300 text-emerald-700 hover:bg-emerald-50 shrink-0 disabled:opacity-50"
+                  className="text-xs px-2 py-1 rounded border border-emerald-300 text-emerald-700 hover:bg-emerald-50 shrink-0 disabled:opacity-50 min-h-[44px]"
                   title="Queue this book for translation into the selected language"
                 >
                   {queueingLangFor?.startsWith(`${b.id}:`) ? "Queueing…" : "+ Translate"}
@@ -397,7 +397,7 @@ export default function BooksPage() {
                     if (confirm(`Delete "${b.title}" and all its audio/translations?`))
                       act(() => adminFetch(`/admin/books/${b.id}`, { method: "DELETE" }));
                   }}
-                  className="text-xs px-2 py-1 rounded border border-red-200 text-red-500 shrink-0"
+                  className="text-xs px-2 py-1 rounded border border-red-200 text-red-500 shrink-0 min-h-[44px]"
                 >
                   Delete
                 </button>
@@ -459,7 +459,7 @@ export default function BooksPage() {
                                     setBulkRetranslating(null);
                                   }
                                 }}
-                                className="ml-auto text-xs px-2 py-1 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-50"
+                                className="ml-auto text-xs px-2 py-1 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-50 min-h-[44px]"
                               >
                                 {bulkRetranslating === bulkKey ? "Retranslating…" : "Retranslate all"}
                               </button>
@@ -473,7 +473,7 @@ export default function BooksPage() {
                                     }),
                                   );
                                 }}
-                                className="text-xs px-2 py-1 rounded border border-red-200 text-red-500"
+                                className="text-xs px-2 py-1 rounded border border-red-200 text-red-500 min-h-[44px]"
                               >
                                 Delete all
                               </button>


### PR DESCRIPTION
## What changed
Added `min-h-[44px]` to four action buttons in `frontend/src/app/admin/books/page.tsx`:
- "+ Translate" (book-level, queues a language for translation)
- "Delete" (book-level, deletes book + all translations/audio)
- "Retranslate all" (language-level bulk retranslation)
- "Delete all" (language-level bulk deletion)

The translation-row Move/Retranslate/Delete buttons were already fixed in PR #658.

## Why
These buttons had only `py-1` with no `min-h-[44px]`, making them too small for reliable mobile taps per WCAG / design system rules (44×44px minimum touch target).

## Test plan
- New `AdminBooksActionTouchTargets.test.ts` with 4 assertions
- Full frontend suite: 1642 tests pass

Closes #665
