### PR TITLE
fix: replace 📒 emoji with SVG icon in notes empty state

### DIFF
--- a/frontend/src/__tests__/NotesPageEmptyStateIcon.test.ts
+++ b/frontend/src/__tests__/NotesPageEmptyStateIcon.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Verifies notes page empty state uses SVG icon not emoji.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf-8"
+);
+
+describe("Notes page empty state", () => {
+  it("does not use 📒 emoji", () => {
+    expect(src).not.toContain("📒");
+  });
+
+  it("imports EmptyNotesIcon from Icons", () => {
+    expect(src).toMatch(/EmptyNotesIcon/);
+  });
+
+  it("uses EmptyNotesIcon in empty state", () => {
+    expect(src).toMatch(/<EmptyNotesIcon/);
+  });
+
+  it("uses ArrowRightIcon instead of raw → arrow in CTA button", () => {
+    expect(src).toMatch(/Open reader[\s\S]{0,50}<ArrowRightIcon/);
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/lib/api";
 
 import { chapterLabel, truncate } from "@/lib/notesMarkdown";
-import { ArrowLeftIcon, TrashIcon, EditIcon, ChevronRightIcon, ChevronDownIcon, ArrowRightIcon, RetryIcon } from "@/components/Icons";
+import { ArrowLeftIcon, TrashIcon, EditIcon, ChevronRightIcon, ChevronDownIcon, ArrowRightIcon, RetryIcon, EmptyNotesIcon } from "@/components/Icons";
 
 type ViewMode = "section" | "chapter";
 
@@ -682,14 +682,14 @@ export default function BookNotesPage() {
           </div>
         ) : annCount + insCount + vocCount === 0 ? (
           <div className="text-center py-24 text-stone-400">
-            <p className="text-4xl mb-3">📒</p>
+            <EmptyNotesIcon className="w-16 h-16 mx-auto mb-3 text-amber-300" aria-hidden="true" />
             <p className="font-serif text-lg text-ink mb-1">No notes yet</p>
             <p className="text-sm">Annotate sentences, save AI insights, or add words to vocabulary while reading.</p>
             <button
               onClick={() => router.push(`/reader/${bookId}`)}
-              className="mt-4 px-5 py-2 rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800"
+              className="mt-4 px-5 py-2 rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 inline-flex items-center gap-1"
             >
-              Open reader →
+              Open reader <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
             </button>
           </div>
         ) : (


### PR DESCRIPTION
## What changed
Replaced the `📒` emoji in the notes page empty state with `<EmptyNotesIcon />` (SVG from `Icons.tsx`). Also replaced the raw `→` arrow in the "Open reader" CTA button with `<ArrowRightIcon />`.

## Why
CLAUDE.md design rules:
- "Never use emoji as UI icons. Emoji render inconsistently across OS/browser and fail accessibility."
- "Every empty state needs: a subtle illustration or icon (SVG, not emoji)"

## Test plan
- New `NotesPageEmptyStateIcon.test.ts` with 4 assertions:
  - No `📒` emoji in source
  - `EmptyNotesIcon` imported and used
  - `ArrowRightIcon` used in CTA
- Full frontend suite: 1656 tests pass

Closes #671
