### PR TITLE
fix: replace Unicode arrows/symbols with SVG icons in reader page

### DIFF
--- a/frontend/e2e/ux-reading.spec.ts
+++ b/frontend/e2e/ux-reading.spec.ts
@@ -118,7 +118,7 @@ test.describe("Bottom-of-chapter navigation", () => {
   });
 
   test("bottom prev chapter is disabled on first chapter", async ({ page }) => {
-    await expect(page.getByTestId("bottom-prev-chapter")).toHaveAttribute("disabled", "");
+    await expect(page.getByTestId("bottom-prev-chapter")).toBeDisabled();
   });
 
   test("bottom next chapter navigates forward", async ({ page }) => {
@@ -130,7 +130,7 @@ test.describe("Bottom-of-chapter navigation", () => {
     await page.keyboard.press("ArrowRight");
     await page.keyboard.press("ArrowRight");
     await expect(page.getByText(MOCK_CHAPTERS[2].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 5000 });
-    await expect(page.getByTestId("bottom-next-chapter")).toHaveAttribute("disabled", "");
+    await expect(page.getByTestId("bottom-next-chapter")).toBeDisabled();
   });
 });
 

--- a/frontend/e2e/ux-reading.spec.ts
+++ b/frontend/e2e/ux-reading.spec.ts
@@ -110,20 +110,19 @@ test.describe("Bottom-of-chapter navigation", () => {
   });
 
   test("bottom prev chapter link is present", async ({ page }) => {
-    await expect(page.getByText("← Previous chapter")).toBeVisible();
+    await expect(page.getByTestId("bottom-prev-chapter")).toBeVisible();
   });
 
   test("bottom next chapter link is present", async ({ page }) => {
-    await expect(page.getByText("Next chapter →")).toBeVisible();
+    await expect(page.getByTestId("bottom-next-chapter")).toBeVisible();
   });
 
   test("bottom prev chapter is disabled on first chapter", async ({ page }) => {
-    const prevBtn = page.getByText("← Previous chapter");
-    await expect(prevBtn).toHaveAttribute("disabled", "");
+    await expect(page.getByTestId("bottom-prev-chapter")).toHaveAttribute("disabled", "");
   });
 
   test("bottom next chapter navigates forward", async ({ page }) => {
-    await page.getByText("Next chapter →").click();
+    await page.getByTestId("bottom-next-chapter").click();
     await expect(page.getByText(MOCK_CHAPTERS[1].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 5000 });
   });
 
@@ -131,8 +130,7 @@ test.describe("Bottom-of-chapter navigation", () => {
     await page.keyboard.press("ArrowRight");
     await page.keyboard.press("ArrowRight");
     await expect(page.getByText(MOCK_CHAPTERS[2].text.slice(0, 20), { exact: false })).toBeVisible({ timeout: 5000 });
-    const nextBtn = page.getByText("Next chapter →");
-    await expect(nextBtn).toHaveAttribute("disabled", "");
+    await expect(page.getByTestId("bottom-next-chapter")).toHaveAttribute("disabled", "");
   });
 });
 

--- a/frontend/src/__tests__/ReaderPage.branches.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches.test.tsx
@@ -1435,7 +1435,7 @@ describe("ReaderPage.branches — in-memory translation cache hit", () => {
     await flushPromises();
 
     // Navigate to next chapter and back (to trigger cache hit on second visit)
-    const nextBtn = await screen.findByText("Next chapter →");
+    const nextBtn = await screen.findByText(/Next chapter/);
     await userEvent.click(nextBtn);
     await flushPromises();
 

--- a/frontend/src/__tests__/ReaderPage.branches2.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches2.test.tsx
@@ -1563,7 +1563,7 @@ describe("ReaderPage.branches2 — translation loaded from in-memory cache", () 
     const countAfterFirstRender = fetchCount;
 
     // Navigate to next chapter and back to trigger cache hit
-    const nextBtn = await screen.findByText("Next chapter →");
+    const nextBtn = await screen.findByText(/Next chapter/);
     await userEvent.click(nextBtn);
     await flushPromises();
 
@@ -1662,12 +1662,12 @@ describe("ReaderPage.branches2 — in-memory translation cache hit", () => {
     const beforeNavigate = fetchCount;
 
     // Navigate to chapter 2
-    const nextBtn = await screen.findByText("Next chapter →");
+    const nextBtn = await screen.findByText(/Next chapter/);
     await userEvent.click(nextBtn);
     await flushPromises();
 
     // Navigate back to chapter 1
-    const prevBtns = await screen.findAllByText("← Previous chapter");
+    const prevBtns = await screen.findAllByText(/Previous chapter/);
     await userEvent.click(prevBtns[0]);
     await flushPromises();
 

--- a/frontend/src/__tests__/ReaderPage.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.test.tsx
@@ -303,8 +303,8 @@ describe("ReaderPage — after chapters load", () => {
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
     render(<ReaderPage />);
     await flushPromises();
-    expect(await screen.findByText("← Previous chapter")).toBeInTheDocument();
-    expect(screen.getByText("Next chapter →")).toBeInTheDocument();
+    expect(await screen.findByText(/Previous chapter/)).toBeInTheDocument();
+    expect(screen.getByText(/Next chapter/)).toBeInTheDocument();
   });
 
   it("shows chapter progress fraction", async () => {
@@ -378,7 +378,7 @@ describe("ReaderPage — chapter navigation", () => {
     render(<ReaderPage />);
     await flushPromises();
 
-    const nextBtn = await screen.findByText("Next chapter →");
+    const nextBtn = await screen.findByText(/Next chapter/);
     await userEvent.click(nextBtn);
 
     await waitFor(() => {
@@ -394,7 +394,7 @@ describe("ReaderPage — chapter navigation", () => {
     render(<ReaderPage />);
     await flushPromises();
 
-    const prevBtn = await screen.findByText("← Previous chapter");
+    const prevBtn = await screen.findByText(/Previous chapter/);
     expect(prevBtn).toBeDisabled();
   });
 
@@ -406,7 +406,7 @@ describe("ReaderPage — chapter navigation", () => {
     await flushPromises();
 
     // Navigate to last chapter first
-    const nextBtns = await screen.findAllByText("Next chapter →");
+    const nextBtns = await screen.findAllByText(/Next chapter/);
     expect(nextBtns[0]).toBeDisabled();
   });
 
@@ -416,7 +416,7 @@ describe("ReaderPage — chapter navigation", () => {
     render(<ReaderPage />);
     await flushPromises();
 
-    const nextBtn = await screen.findByText("Next chapter →");
+    const nextBtn = await screen.findByText(/Next chapter/);
     await userEvent.click(nextBtn);
 
     await waitFor(() => {
@@ -430,7 +430,7 @@ describe("ReaderPage — chapter navigation", () => {
     render(<ReaderPage />);
     await flushPromises();
 
-    const nextBtn = await screen.findByText("Next chapter →");
+    const nextBtn = await screen.findByText(/Next chapter/);
     await userEvent.click(nextBtn);
 
     await waitFor(() => {
@@ -716,7 +716,7 @@ describe("ReaderPage — unauthenticated session", () => {
     render(<ReaderPage />);
     await flushPromises();
 
-    const nextBtn = await screen.findByText("Next chapter →");
+    const nextBtn = await screen.findByText(/Next chapter/);
     await userEvent.click(nextBtn);
 
     expect(mockSaveReadingProgress).not.toHaveBeenCalled();
@@ -1131,7 +1131,7 @@ describe("ReaderPage — notes sidebar content", () => {
 });
 
 describe("ReaderPage — vocab sidebar content", () => {
-  it("shows 'View all →' button when vocab tab is open", async () => {
+  it("shows 'View all' button when vocab tab is open", async () => {
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
     render(<ReaderPage />);
     await flushPromises();
@@ -1139,10 +1139,10 @@ describe("ReaderPage — vocab sidebar content", () => {
     const vocabBtn = await screen.findByTitle("Vocabulary");
     await userEvent.click(vocabBtn);
 
-    expect(await screen.findByText("View all →")).toBeInTheDocument();
+    expect(await screen.findByText(/View all/)).toBeInTheDocument();
   });
 
-  it("'View all →' navigates to /vocabulary", async () => {
+  it("'View all' navigates to /vocabulary", async () => {
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
     render(<ReaderPage />);
     await flushPromises();
@@ -1150,7 +1150,7 @@ describe("ReaderPage — vocab sidebar content", () => {
     const vocabBtn = await screen.findByTitle("Vocabulary");
     await userEvent.click(vocabBtn);
 
-    const viewAllBtn = await screen.findByText("View all →");
+    const viewAllBtn = await screen.findByText(/View all/);
     await userEvent.click(viewAllBtn);
 
     expect(mockPush).toHaveBeenCalledWith("/vocabulary");

--- a/frontend/src/__tests__/ReaderPageUnicodeIcons.test.ts
+++ b/frontend/src/__tests__/ReaderPageUnicodeIcons.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Verifies reader page does not use raw Unicode arrows/symbols as interactive icons.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf-8"
+);
+
+describe("Reader page Unicode icon replacements", () => {
+  it("no raw ← character in button text (should use ArrowLeftIcon)", () => {
+    // Keyboard shortcut labels like ["←", "→"] in the help dialog are fine
+    // We only check that it's not used as visible button content
+    const buttonLeftMatches = src.match(/>←\s/g);
+    expect(buttonLeftMatches).toBeNull();
+  });
+
+  it("no raw → character as button/link label (should use ArrowRightIcon)", () => {
+    // Inline arrows in button text like "Next →" or "View all →"
+    const arrowMatches = src.match(/→\s*<\/button>|→\s*\n\s*<\/a>/g);
+    expect(arrowMatches).toBeNull();
+  });
+
+  it("no raw ✕ character as button content (should use CloseIcon)", () => {
+    const closeMatches = src.match(/>✕</g);
+    expect(closeMatches).toBeNull();
+  });
+
+  it("focus mode uses ArrowLeftIcon for Prev", () => {
+    expect(src).toMatch(/goToChapter\(chapterIndex - 1\)[\s\S]{0,400}<ArrowLeftIcon/);
+  });
+
+  it("focus mode uses ArrowRightIcon for Next", () => {
+    expect(src).toMatch(/goToChapter\(chapterIndex \+ 1\)[\s\S]{0,400}<ArrowRightIcon/);
+  });
+
+  it("focus mode uses CloseIcon for exit", () => {
+    expect(src).toMatch(/setFocusMode\(false\)[\s\S]{0,400}<CloseIcon/);
+  });
+
+  it("Library back button uses ArrowLeftIcon", () => {
+    expect(src).toMatch(/router\.push\("\/"\)[\s\S]{0,200}<ArrowLeftIcon/);
+  });
+
+  it("chapter navigation uses ArrowLeftIcon", () => {
+    expect(src).toMatch(/Previous chapter[\s\S]{0,50}|<ArrowLeftIcon[\s\S]{0,100}Previous chapter/);
+  });
+
+  it("Book notes link uses ArrowRightIcon", () => {
+    expect(src).toMatch(/Book notes[\s\S]{0,50}<ArrowRightIcon/);
+  });
+
+  it("View all button uses ArrowRightIcon", () => {
+    expect(src).toMatch(/View all[\s\S]{0,50}<ArrowRightIcon/);
+  });
+
+  it("chat close button uses CloseIcon not raw ✕", () => {
+    expect(src).toMatch(/Close chat[\s\S]{0,200}<CloseIcon/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1354,6 +1354,7 @@ export default function ReaderPage() {
                 />
                 <div className={`mt-10 flex justify-between ${translationEnabled && displayMode === "parallel" ? "max-w-7xl mx-auto" : "prose-reader mx-auto"}`}>
                   <button
+                    data-testid="bottom-prev-chapter"
                     onClick={() => goToChapter(Math.max(0, chapterIndex - 1))}
                     disabled={chapterIndex === 0}
                     className="inline-flex items-center gap-1 text-sm text-amber-700 hover:text-amber-900 disabled:opacity-30"
@@ -1362,6 +1363,7 @@ export default function ReaderPage() {
                     {chapterIndex + 1} / {chapters.length} · {Math.round(((chapterIndex + 1) / chapters.length) * 100)}%
                   </span>
                   <button
+                    data-testid="bottom-next-chapter"
                     onClick={() => goToChapter(Math.min(chapters.length - 1, chapterIndex + 1))}
                     disabled={chapterIndex === chapters.length - 1}
                     className="inline-flex items-center gap-1 text-sm text-amber-700 hover:text-amber-900 disabled:opacity-30"

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -837,8 +837,8 @@ export default function ReaderPage() {
             <button
               onClick={() => chapterIndex > 0 && goToChapter(chapterIndex - 1)}
               disabled={chapterIndex === 0}
-              className="px-2 py-1 rounded-full hover:bg-amber-50 disabled:opacity-30 transition-colors min-h-[44px]"
-            >← Prev</button>
+              className="inline-flex items-center gap-1 px-2 py-1 rounded-full hover:bg-amber-50 disabled:opacity-30 transition-colors min-h-[44px]"
+            ><ArrowLeftIcon className="w-3 h-3" aria-hidden="true" /> Prev</button>
             <span className="text-stone-400 mx-0.5">|</span>
             <span className="text-stone-600 max-w-[180px] truncate font-medium">
               {chapters[chapterIndex]?.title || `Ch. ${chapterIndex + 1}`}
@@ -847,8 +847,8 @@ export default function ReaderPage() {
             <button
               onClick={() => chapterIndex < chapters.length - 1 && goToChapter(chapterIndex + 1)}
               disabled={chapterIndex === chapters.length - 1}
-              className="px-2 py-1 rounded-full hover:bg-amber-50 disabled:opacity-30 transition-colors min-h-[44px]"
-            >Next →</button>
+              className="inline-flex items-center gap-1 px-2 py-1 rounded-full hover:bg-amber-50 disabled:opacity-30 transition-colors min-h-[44px]"
+            >Next <ArrowRightIcon className="w-3 h-3" aria-hidden="true" /></button>
             {paragraphFocus && (
               <>
                 <span className="text-stone-400 mx-0.5">|</span>
@@ -874,9 +874,9 @@ export default function ReaderPage() {
             <span className="text-stone-400 mx-0.5">|</span>
             <button
               onClick={() => setFocusMode(false)}
-              className="px-2 py-1 rounded-full hover:bg-red-50 text-stone-500 hover:text-red-600 transition-colors min-h-[44px]"
+              className="inline-flex items-center gap-1 px-2 py-1 rounded-full hover:bg-red-50 text-stone-500 hover:text-red-600 transition-colors min-h-[44px]"
               title="Exit focus mode (F)"
-            >✕ Focus</button>
+            ><CloseIcon className="w-3 h-3" aria-hidden="true" /> Focus</button>
           </div>
         </div>
       )}
@@ -891,7 +891,7 @@ export default function ReaderPage() {
             onClick={() => router.push("/")}
             className="text-amber-700 hover:text-amber-900 text-sm shrink-0 min-h-[44px] flex items-center"
           >
-            ← <span className="hidden sm:inline ml-1">Library</span>
+            <ArrowLeftIcon className="w-4 h-4 shrink-0" aria-hidden="true" /><span className="hidden sm:inline ml-1">Library</span>
           </button>
 
           <div className="min-w-0 flex-1">
@@ -1356,16 +1356,16 @@ export default function ReaderPage() {
                   <button
                     onClick={() => goToChapter(Math.max(0, chapterIndex - 1))}
                     disabled={chapterIndex === 0}
-                    className="text-sm text-amber-700 hover:text-amber-900 disabled:opacity-30"
-                  >← Previous chapter</button>
+                    className="inline-flex items-center gap-1 text-sm text-amber-700 hover:text-amber-900 disabled:opacity-30"
+                  ><ArrowLeftIcon className="w-4 h-4" aria-hidden="true" /> Previous chapter</button>
                   <span className="text-xs text-amber-500 self-center">
                     {chapterIndex + 1} / {chapters.length} · {Math.round(((chapterIndex + 1) / chapters.length) * 100)}%
                   </span>
                   <button
                     onClick={() => goToChapter(Math.min(chapters.length - 1, chapterIndex + 1))}
                     disabled={chapterIndex === chapters.length - 1}
-                    className="text-sm text-amber-700 hover:text-amber-900 disabled:opacity-30"
-                  >Next chapter →</button>
+                    className="inline-flex items-center gap-1 text-sm text-amber-700 hover:text-amber-900 disabled:opacity-30"
+                  >Next chapter <ArrowRightIcon className="w-4 h-4" aria-hidden="true" /></button>
                 </div>
               </>
             )}
@@ -1748,7 +1748,7 @@ export default function ReaderPage() {
                         href={`/notes/${bookId}`}
                         className="text-xs text-amber-700 hover:text-amber-900 font-medium transition-colors"
                       >
-                        Book notes →
+                        Book notes <ArrowRightIcon className="w-3 h-3 inline" aria-hidden="true" />
                       </a>
                       <a
                         href="/notes"
@@ -1787,7 +1787,7 @@ export default function ReaderPage() {
                         {filteredVocab.length} word{filteredVocab.length !== 1 ? "s" : ""}
                       </span>
                       <button onClick={() => router.push("/vocabulary")} className="text-xs text-amber-600 hover:text-amber-800 font-medium">
-                        View all →
+                        View all <ArrowRightIcon className="w-3 h-3 inline" aria-hidden="true" />
                       </button>
                     </div>
                     {filteredVocab.length === 0 ? (
@@ -2036,9 +2036,9 @@ export default function ReaderPage() {
               <span className="font-serif font-semibold text-ink text-sm">Chat</span>
               <button
                 onClick={() => { setSidebarOpen(false); setChatSheetText(null); }}
-                className="min-w-[44px] min-h-[44px] flex items-center justify-center text-amber-700 text-lg"
+                className="min-w-[44px] min-h-[44px] flex items-center justify-center text-amber-700"
                 aria-label="Close chat"
-              >✕</button>
+              ><CloseIcon className="w-4 h-4" aria-hidden="true" /></button>
             </div>
             <InsightChat
               bookId={bookId}

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -18,7 +18,7 @@ import UndoToast from "@/components/UndoToast";
 import VocabWordTooltip from "@/components/VocabWordTooltip";
 import ChapterSummary from "@/components/ChapterSummary";
 import AuthPromptModal from "@/components/AuthPromptModal";
-import { SunIcon, MoonIcon, SepiaIcon, ChatIcon, GlobeIcon, NoteIcon, EditIcon, BookmarkIcon, BookOpenIcon, ExportIcon, SummaryIcon, PlayIcon, PauseIcon, CloseIcon, KeyboardIcon, FocusIcon, ArrowLeftIcon, ArrowRightIcon, ChevronDownIcon, EmptyVocabIcon } from "@/components/Icons";
+import { SunIcon, MoonIcon, SepiaIcon, ChatIcon, GlobeIcon, NoteIcon, EditIcon, BookmarkIcon, BookOpenIcon, ExportIcon, SummaryIcon, PlayIcon, PauseIcon, CloseIcon, KeyboardIcon, FocusIcon, ArrowLeftIcon, ArrowRightIcon, ChevronDownIcon, EmptyVocabIcon, ArrowUpRightIcon } from "@/components/Icons";
 
 // In-memory cache: bookId → chapters (survives client-side navigation)
 const chaptersCache = new Map<string, BookChapter[]>();
@@ -910,7 +910,7 @@ export default function ReaderPage() {
                       rel="noopener noreferrer"
                       className="shrink-0 text-xs text-amber-500 hover:text-amber-700"
                       title="View on Project Gutenberg"
-                    >↗</a>
+                    ><ArrowUpRightIcon className="w-3 h-3" aria-hidden="true" /></a>
                   )}
                 </div>
                 <p className="text-xs text-amber-700 truncate">{meta.authors.join(", ")}</p>


### PR DESCRIPTION
## What changed
Replaced 9 raw Unicode characters used as interactive UI icons in `frontend/src/app/reader/[bookId]/page.tsx`:

| Location | Before | After |
|---|---|---|
| Focus mode Prev button | `← Prev` | `<ArrowLeftIcon /> Prev` |
| Focus mode Next button | `Next →` | `Next <ArrowRightIcon />` |
| Focus mode Exit button | `✕ Focus` | `<CloseIcon /> Focus` |
| Header Library button | `← Library` | `<ArrowLeftIcon /> Library` |
| Chapter nav Prev | `← Previous chapter` | `<ArrowLeftIcon /> Previous chapter` |
| Chapter nav Next | `Next chapter →` | `Next chapter <ArrowRightIcon />` |
| Notes sidebar link | `Book notes →` | `Book notes <ArrowRightIcon />` |
| Vocab sidebar button | `View all →` | `View all <ArrowRightIcon />` |
| Chat close button | `✕` | `<CloseIcon />` |

Updated 3 existing test files (`ReaderPage.test.tsx`, `ReaderPage.branches.test.tsx`, `ReaderPage.branches2.test.tsx`) to use regex matchers for button text instead of exact Unicode string matches.

## Why
CLAUDE.md design rule: "All interactive icons must come from `@/components/Icons.tsx` (SVG, `currentColor`, `aria-hidden="true"`)." Raw Unicode characters render inconsistently across platforms and fail accessibility.

## Test plan
- New `ReaderPageUnicodeIcons.test.ts` with 11 assertions
- 3 existing test files updated to match new button text
- Full frontend suite: 1667 tests pass

Closes #673
