### PR TITLE
fix: replace raw ↻ Unicode with RetryIcon in ChapterSummary Refresh button

### DIFF
--- a/frontend/src/__tests__/ChapterSummaryUnicodeIcon.test.ts
+++ b/frontend/src/__tests__/ChapterSummaryUnicodeIcon.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Verifies ChapterSummary Refresh button does not use raw Unicode ↻ symbol.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/ChapterSummary.tsx"),
+  "utf-8"
+);
+
+describe("ChapterSummary Unicode icon replacement", () => {
+  it("does not use raw ↻ Unicode in button text", () => {
+    expect(src).not.toMatch(/↻\s*Refresh/);
+  });
+
+  it("imports RetryIcon from Icons", () => {
+    expect(src).toMatch(/RetryIcon/);
+  });
+
+  it("Refresh button uses RetryIcon", () => {
+    expect(src).toMatch(/RetryIcon[\s\S]{0,80}Refresh/);
+  });
+});

--- a/frontend/src/components/ChapterSummary.tsx
+++ b/frontend/src/components/ChapterSummary.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState, useCallback } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { generateChapterSummary } from "@/lib/api";
-import { SummaryIcon } from "@/components/Icons";
+import { SummaryIcon, RetryIcon } from "@/components/Icons";
 
 interface Props {
   bookId: string;
@@ -91,7 +91,7 @@ export default function ChapterSummary({
             title="Regenerate summary"
             className="text-xs text-amber-600 hover:text-amber-800 hover:underline transition-colors"
           >
-            {summary ? "↻ Refresh" : "Generate"}
+            {summary ? <><RetryIcon className="w-3 h-3 inline" aria-hidden="true" /> Refresh</> : "Generate"}
           </button>
         )}
       </div>


### PR DESCRIPTION
## What changed

Replaced raw `↻` Unicode symbol with `<RetryIcon>` SVG icon in the `ChapterSummary` component's Refresh button.

- Added `RetryIcon` to import from `@/components/Icons`
- `{summary ? "↻ Refresh" : "Generate"}` → `{summary ? <><RetryIcon … /> Refresh</> : "Generate"}`

## Why

Raw Unicode symbols render inconsistently across OS/browser and violate the icon system rules in CLAUDE.md.

## Tests

New test `ChapterSummaryUnicodeIcon.test.ts` with 3 assertions:
- No raw `↻` in ChapterSummary source
- `RetryIcon` imported
- `RetryIcon` used in the Refresh button

All 1638 tests pass.

Closes #679
