### PR TITLE
fix: replace raw → Unicode with ArrowRightIcon in notes overview book-list button

### DIFF
--- a/frontend/src/__tests__/NotesOverviewUnicodeArrow.test.ts
+++ b/frontend/src/__tests__/NotesOverviewUnicodeArrow.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Verifies notes overview page book-list button uses ArrowRightIcon not raw → Unicode.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/notes/page.tsx"),
+  "utf-8"
+);
+
+describe("Notes overview page Unicode arrow replacement", () => {
+  it("does not use raw → Unicode in book-list button", () => {
+    expect(src).not.toMatch(/>\s*→\s*<\/p>/);
+  });
+
+  it("imports ArrowRightIcon from Icons", () => {
+    expect(src).toMatch(/ArrowRightIcon/);
+  });
+
+  it("book-list button chevron uses ArrowRightIcon", () => {
+    expect(src).toMatch(/ArrowRightIcon[\s\S]{0,80}aria-hidden/);
+  });
+});

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { getAllAnnotations, getAllInsights, getVocabulary, AnnotationWithBook, BookInsightWithBook, VocabularyWord } from "@/lib/api";
-import { NoteIcon, InsightIcon, VocabIcon, EmptyNotesIcon, ArrowLeftIcon, WordIcon } from "@/components/Icons";
+import { NoteIcon, InsightIcon, VocabIcon, EmptyNotesIcon, ArrowLeftIcon, ArrowRightIcon, WordIcon } from "@/components/Icons";
 
 interface BookSummary {
   bookId: number;
@@ -186,7 +186,7 @@ export default function NotesOverviewPage() {
                   </div>
                   <div className="shrink-0 text-right">
                     <span className="text-xs text-stone-400">{timeAgo(book.lastActivity)}</span>
-                    <p className="text-amber-600 group-hover:text-amber-800 text-lg mt-0.5">→</p>
+                    <p className="text-amber-600 group-hover:text-amber-800 mt-0.5"><ArrowRightIcon className="w-5 h-5" aria-hidden="true" /></p>
                   </div>
                 </div>
               </button>


### PR DESCRIPTION
## What changed

Replaced raw `→` Unicode arrow with `<ArrowRightIcon>` SVG icon in the notes overview page book-list button chevron.

- Added `ArrowRightIcon` to the import from `@/components/Icons`
- `<p>→</p>` → `<p><ArrowRightIcon className="w-5 h-5" aria-hidden="true" /></p>`

## Why

Raw Unicode characters render inconsistently across OS/browser and violate the CLAUDE.md icon system rules. The `→` was inside a `<button>` element used as a visual affordance for navigation.

## Tests

New test `NotesOverviewUnicodeArrow.test.ts` with 3 assertions:
- No raw `→` in the button chevron
- `ArrowRightIcon` imported
- `ArrowRightIcon` used with `aria-hidden`

All 1638 tests pass.

Closes #680
