### PR TITLE
fix: clean up flashcard_reviews when deleting a vocabulary word

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -985,6 +985,11 @@ async def delete_word(user_id: int, word: str) -> bool:
                SELECT id FROM vocabulary WHERE user_id = ? AND word = ?)""",
             (user_id, word),
         )
+        await db.execute(
+            """DELETE FROM flashcard_reviews WHERE vocabulary_id IN (
+               SELECT id FROM vocabulary WHERE user_id = ? AND word = ?)""",
+            (user_id, word),
+        )
         cursor = await db.execute(
             "DELETE FROM vocabulary WHERE user_id = ? AND word = ?",
             (user_id, word),

--- a/backend/tests/test_router_flashcards.py
+++ b/backend/tests/test_router_flashcards.py
@@ -194,6 +194,27 @@ async def test_due_flashcards_capped_at_100(client, test_user):
     assert len(resp.json()) <= 100
 
 
+# ── Regression #685: orphaned flashcard_reviews after word deletion ───────────
+
+async def test_stats_reset_after_word_deletion(client, test_user):
+    """Deleting a word must clean up its flashcard_reviews row so stats don't inflate."""
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_word(test_user["id"], "ephemeron", BOOK_ID, 0, "An ephemeron.")
+
+    # Trigger lazy flashcard_reviews creation
+    stats_before = (await client.get("/api/vocabulary/flashcards/stats")).json()
+    assert stats_before["total"] == 1
+
+    # Delete the word
+    del_resp = await client.delete("/api/vocabulary/ephemeron")
+    assert del_resp.status_code == 200
+
+    # Stats must reflect zero words — no orphaned rows
+    stats_after = (await client.get("/api/vocabulary/flashcards/stats")).json()
+    assert stats_after["total"] == 0
+    assert stats_after["due_today"] == 0
+
+
 # ── Auth requirements ─────────────────────────────────────────────────────────
 
 async def test_flashcards_require_auth(anon_client):


### PR DESCRIPTION
## Summary

- `delete_word()` in `services/db.py` was removing rows from `word_occurrences` and `vocabulary` but leaving the corresponding `flashcard_reviews` row as an orphan
- `get_flashcard_stats()` counts directly from `flashcard_reviews WHERE user_id = ?` without joining `vocabulary`, so orphaned rows inflated `total` and `due_today` after word deletion
- Added `DELETE FROM flashcard_reviews WHERE vocabulary_id IN (SELECT id FROM vocabulary WHERE ...)` before the vocabulary delete

## Test plan

- [ ] `test_stats_reset_after_word_deletion`: saves a word, triggers lazy flashcard_reviews creation, deletes the word, verifies stats return zero — fails before fix, passes after
- [ ] Full backend suite: 1220 tests pass

Closes #685
