### PR TITLE
fix: raise vocabulary page lemma word button to 44px touch target

### DIFF
--- a/frontend/src/__tests__/VocabLemmaTouchTarget.test.ts
+++ b/frontend/src/__tests__/VocabLemmaTouchTarget.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Verifies vocabulary page lemma word button meets 44px minimum touch target.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/page.tsx"),
+  "utf-8"
+);
+
+describe("Vocabulary page lemma word button touch target", () => {
+  it("lemma button has min-h-[44px]", () => {
+    expect(src).toMatch(/setActiveWord[\s\S]{0,200}min-h-\[44px\]/);
+  });
+
+  it("lemma button uses flex items-center for vertical alignment", () => {
+    expect(src).toMatch(/setActiveWord[\s\S]{0,200}flex items-center/);
+  });
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -294,7 +294,7 @@ function VocabularyPageContent() {
           <div className="flex items-center gap-2 flex-wrap">
             <button
               onClick={() => setActiveWord({ word: group.lemma, lang: group.language })}
-              className="font-serif font-semibold text-ink text-base hover:text-amber-700 transition-colors text-left"
+              className="font-serif font-semibold text-ink text-base hover:text-amber-700 transition-colors text-left min-h-[44px] flex items-center"
             >
               {group.lemma}
             </button>


### PR DESCRIPTION
## What changed

Added `min-h-[44px] flex items-center` to the vocabulary page lemma word button.

The button displayed the word/lemma heading with only `text-base` styling — at ~24px height, it fell well below the 44px minimum touch target required by the design system.

## Tests

New test `VocabLemmaTouchTarget.test.ts` with 2 assertions:
- Lemma button has `min-h-[44px]`
- Lemma button uses `flex items-center` for proper vertical centering

All 1640 tests pass.

Closes #686
