### PR TITLE
fix: replace Unicode symbols with SVG icons in upload and admin uploads pages

### DIFF
--- a/frontend/src/__tests__/UploadPagesUnicodeIcons.test.ts
+++ b/frontend/src/__tests__/UploadPagesUnicodeIcons.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Verifies upload and admin uploads pages use SVG icons not Unicode symbols.
+ */
+import fs from "fs";
+import path from "path";
+
+const uploadSrc = fs.readFileSync(
+  path.join(__dirname, "../app/upload/page.tsx"),
+  "utf-8"
+);
+const chaptersSrc = fs.readFileSync(
+  path.join(__dirname, "../app/upload/[bookId]/chapters/page.tsx"),
+  "utf-8"
+);
+const adminUploadsSrc = fs.readFileSync(
+  path.join(__dirname, "../app/admin/uploads/page.tsx"),
+  "utf-8"
+);
+
+describe("Upload page Unicode icon replacements", () => {
+  it("upload page Back button does not use raw ← arrow", () => {
+    expect(uploadSrc).not.toMatch(/>\s*←\s*Back/);
+  });
+
+  it("upload page imports ArrowLeftIcon", () => {
+    expect(uploadSrc).toMatch(/ArrowLeftIcon/);
+  });
+
+  it("upload page Back button uses ArrowLeftIcon", () => {
+    expect(uploadSrc).toMatch(/ArrowLeftIcon[\s\S]{0,50}Back/);
+  });
+});
+
+describe("Upload chapters page Unicode icon replacements", () => {
+  it("chapters page Back button does not use raw ← arrow", () => {
+    expect(chaptersSrc).not.toMatch(/>\s*←\s*Back/);
+  });
+
+  it("chapters page imports ArrowLeftIcon", () => {
+    expect(chaptersSrc).toMatch(/ArrowLeftIcon/);
+  });
+
+  it("chapters page Back button uses ArrowLeftIcon", () => {
+    expect(chaptersSrc).toMatch(/ArrowLeftIcon[\s\S]{0,50}Back/);
+  });
+});
+
+describe("Admin uploads page Unicode icon replacements", () => {
+  it("admin uploads Clear filter button does not use raw ✕", () => {
+    expect(adminUploadsSrc).not.toMatch(/>\s*✕\s*Clear/);
+  });
+
+  it("admin uploads imports CloseIcon", () => {
+    expect(adminUploadsSrc).toMatch(/CloseIcon/);
+  });
+
+  it("admin uploads Clear filter button uses CloseIcon", () => {
+    expect(adminUploadsSrc).toMatch(/CloseIcon[\s\S]{0,100}Clear filter/);
+  });
+});

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -2,6 +2,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { adminFetch } from "@/lib/adminFetch";
+import { CloseIcon } from "@/components/Icons";
 
 interface UploadEntry {
   book_id: number;
@@ -106,7 +107,7 @@ export default function UploadsPage() {
             onClick={clearFilter}
             className="text-sm text-amber-600 hover:text-amber-900"
           >
-            ✕ Clear filter (user {activeFilter})
+            <CloseIcon className="w-3.5 h-3.5 inline" aria-hidden="true" /> Clear filter (user {activeFilter})
           </button>
         )}
         <span className="ml-auto text-xs text-stone-400">{uploads.length} upload{uploads.length !== 1 ? "s" : ""}</span>

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { getDraftChapters, confirmChapters, DraftChapter, ApiError } from "@/lib/api";
-import { TrashIcon } from "@/components/Icons";
+import { TrashIcon, ArrowLeftIcon } from "@/components/Icons";
 
 interface ChapterSpec {
   title: string;
@@ -104,7 +104,7 @@ export default function ChapterEditorPage() {
               onClick={() => router.push("/upload")}
               className="text-sm text-amber-600 hover:text-amber-800 transition-colors"
             >
-              ← Back
+              <ArrowLeftIcon className="w-4 h-4 inline" aria-hidden="true" /> Back
             </button>
             <h1 className="font-serif text-lg font-semibold text-ink">
               Review Chapters

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { uploadBook, getUploadQuota, UploadQuota, ApiError } from "@/lib/api";
-import { UploadIcon } from "@/components/Icons";
+import { UploadIcon, ArrowLeftIcon } from "@/components/Icons";
 
 export default function UploadPage() {
   const router = useRouter();
@@ -100,7 +100,7 @@ export default function UploadPage() {
             onClick={() => router.push("/")}
             className="text-sm text-amber-600 hover:text-amber-800 transition-colors"
           >
-            ← Back
+            <ArrowLeftIcon className="w-4 h-4 inline" aria-hidden="true" /> Back
           </button>
           <h1 className="font-serif text-lg font-semibold text-ink">Upload a Book</h1>
         </div>


### PR DESCRIPTION
## What changed

Replaced raw Unicode symbols with SVG icons from `@/components/Icons.tsx` in upload and admin uploads pages:

- `upload/page.tsx`: Added `ArrowLeftIcon` import; `← Back` → `<ArrowLeftIcon> Back`
- `upload/[bookId]/chapters/page.tsx`: Added `ArrowLeftIcon` import; `← Back` → `<ArrowLeftIcon> Back`  
- `admin/uploads/page.tsx`: Added `CloseIcon` import; `✕ Clear filter` → `<CloseIcon> Clear filter`

## Why

Raw Unicode characters render inconsistently across OS/browser and violate the CLAUDE.md icon system rules.

## Tests

Test file `UploadPagesUnicodeIcons.test.ts` with 9 assertions verifying all three replacements.

All 1638 tests pass.

Closes #677
