### PR TITLE
fix: replace raw Unicode arrows with SVG icons in homepage pagination

### DIFF
--- a/frontend/src/__tests__/HomePage.branches.test.tsx
+++ b/frontend/src/__tests__/HomePage.branches.test.tsx
@@ -533,9 +533,9 @@ describe("HomePage — popular books pagination", () => {
     await renderHome();
 
     await waitFor(() =>
-      expect(screen.getByText(/← Prev/i)).toBeInTheDocument(),
+      expect(screen.getByRole("button", { name: /Prev/i })).toBeInTheDocument(),
     );
-    expect(screen.getByText(/Next →/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Next/i })).toBeInTheDocument();
     expect(screen.getByText(/Page 1 of 2/i)).toBeInTheDocument();
   });
 
@@ -550,9 +550,9 @@ describe("HomePage — popular books pagination", () => {
     const user = userEvent.setup();
     await renderHome();
 
-    await waitFor(() => expect(screen.getByText(/Next →/i)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole("button", { name: /Next/i })).toBeInTheDocument());
 
-    await user.click(screen.getByText(/Next →/i));
+    await user.click(screen.getByRole("button", { name: /Next/i }));
 
     await waitFor(() =>
       expect(mockGetPopularBooks).toHaveBeenCalledTimes(2),
@@ -570,10 +570,10 @@ describe("HomePage — popular books pagination", () => {
     await renderHome();
 
     await waitFor(() =>
-      expect(screen.getByText(/← Prev/i)).toBeInTheDocument(),
+      expect(screen.getByRole("button", { name: /Prev/i })).toBeInTheDocument(),
     );
 
-    const prevBtn = screen.getByText(/← Prev/i).closest("button");
+    const prevBtn = screen.getByRole("button", { name: /Prev/i });
     expect(prevBtn).toBeDisabled();
   });
 });

--- a/frontend/src/__tests__/HomepagePaginationUnicodeIcons.test.ts
+++ b/frontend/src/__tests__/HomepagePaginationUnicodeIcons.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Verifies homepage pagination buttons use SVG icons not raw Unicode arrows.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/page.tsx"),
+  "utf-8"
+);
+
+describe("Homepage pagination Unicode icon replacements", () => {
+  it("Prev button does not use raw ← Unicode", () => {
+    expect(src).not.toMatch(/>\s*←\s*Prev/);
+  });
+
+  it("Next button does not use raw → Unicode", () => {
+    expect(src).not.toMatch(/Next\s*→\s*</);
+  });
+
+  it("imports ArrowLeftIcon", () => {
+    expect(src).toMatch(/ArrowLeftIcon/);
+  });
+
+  it("Prev button uses ArrowLeftIcon", () => {
+    const prevIdx = src.indexOf("Prev");
+    const snippet = src.slice(Math.max(0, prevIdx - 100), prevIdx + 10);
+    expect(snippet).toMatch(/ArrowLeftIcon/);
+  });
+
+  it("Next button uses ArrowRightIcon", () => {
+    const nextIdx = src.indexOf("Next <ArrowRightIcon");
+    expect(nextIdx).toBeGreaterThan(-1);
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,7 +5,7 @@ import { getRecentBooks, removeRecentBook, RecentBook } from "@/lib/recentBooks"
 import BookCard from "@/components/BookCard";
 import BookDetailModal from "@/components/BookDetailModal";
 import ReadingStats from "@/components/ReadingStats";
-import { FireIcon, ArrowRightIcon, BookOpenIcon, NoteIcon, InsightIcon, VocabIcon, BookCoverPlaceholderIcon, GlobeIcon, SummaryIcon, SpeakerIcon, GridViewIcon, ListViewIcon } from "@/components/Icons";
+import { FireIcon, ArrowLeftIcon, ArrowRightIcon, BookOpenIcon, NoteIcon, InsightIcon, VocabIcon, BookCoverPlaceholderIcon, GlobeIcon, SummaryIcon, SpeakerIcon, GridViewIcon, ListViewIcon } from "@/components/Icons";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 
@@ -733,7 +733,7 @@ export default function Home() {
                         disabled={popularPage === 1}
                         className="px-4 py-2.5 md:py-1.5 text-sm rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors min-h-[44px] md:min-h-0"
                       >
-                        ← Prev
+                        <ArrowLeftIcon className="w-4 h-4 inline" aria-hidden="true" /> Prev
                       </button>
                       <span className="text-sm text-amber-700">
                         Page {popularPage} of {Math.ceil(popularTotal / PER_PAGE)}
@@ -743,7 +743,7 @@ export default function Home() {
                         disabled={popularPage >= Math.ceil(popularTotal / PER_PAGE)}
                         className="px-4 py-2.5 md:py-1.5 text-sm rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors min-h-[44px] md:min-h-0"
                       >
-                        Next →
+                        Next <ArrowRightIcon className="w-4 h-4 inline" aria-hidden="true" />
                       </button>
                     </div>
                   )}


### PR DESCRIPTION
## What changed
- Replaced raw `←` Unicode arrow with `<ArrowLeftIcon>` SVG in homepage Prev pagination button
- Replaced raw `→` Unicode arrow with `<ArrowRightIcon>` SVG in homepage Next pagination button
- Updated `HomePage.branches.test.tsx` to query buttons by role/name (not by Unicode text)
- Added `HomepagePaginationUnicodeIcons.test.ts` with 5 source-string assertions

## Why
Raw Unicode arrows render inconsistently across OS/browser and fail accessibility audits. The project icon system requires all UI icons to come from `@/components/Icons.tsx`.

## Test plan
- [x] `HomepagePaginationUnicodeIcons.test.ts` — no raw `←`/`→` in pagination; ArrowLeftIcon imported and used; ArrowRightIcon used
- [x] `HomePage.branches.test.tsx` — pagination button tests updated to use `getByRole`
- [x] Full frontend suite passes

Closes #675
