### PR TITLE
fix: clean up flashcard_reviews in admin delete_book before pruning vocabulary

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -255,6 +255,10 @@ async def delete_book(book_id: int, _admin: dict = Depends(_require_admin)):
         )
         await db.execute("DELETE FROM word_occurrences WHERE book_id = ?", (book_id,))
         await db.execute(
+            "DELETE FROM flashcard_reviews WHERE vocabulary_id NOT IN "
+            "(SELECT DISTINCT vocabulary_id FROM word_occurrences)"
+        )
+        await db.execute(
             "DELETE FROM vocabulary WHERE id NOT IN (SELECT DISTINCT vocabulary_id FROM word_occurrences)"
         )
         await db.execute("DELETE FROM annotations WHERE book_id = ?", (book_id,))

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -488,6 +488,42 @@ async def test_delete_book_removes_word_occurrences(admin_client, admin_db):
     assert count == 0
 
 
+async def test_delete_book_removes_flashcard_reviews(admin_client, admin_db):
+    """Regression #691: admin delete_book must clean up flashcard_reviews before pruning vocabulary.
+
+    SQLite FK enforcement is OFF so ON DELETE CASCADE never fires. Without an
+    explicit DELETE, orphaned flashcard_reviews rows inflate flashcard stats for
+    users who had saved words from the deleted book."""
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    async with aiosqlite.connect(admin_db) as db:
+        await db.execute("INSERT INTO vocabulary (user_id, word) VALUES (1, 'ephemeral')")
+        async with db.execute("SELECT id FROM vocabulary WHERE word='ephemeral'") as cur:
+            vocab_id = (await cur.fetchone())[0]
+        await db.execute(
+            "INSERT INTO word_occurrences (vocabulary_id, book_id, chapter_index, sentence_text)"
+            " VALUES (?, 100, 0, 'An ephemeral moment.')",
+            (vocab_id,),
+        )
+        await db.execute(
+            "INSERT INTO flashcard_reviews (user_id, vocabulary_id, due_date) VALUES (1, ?, date('now'))",
+            (vocab_id,),
+        )
+        await db.commit()
+
+    res = await admin_client.delete("/api/admin/books/100")
+    assert res.status_code == 200
+
+    async with aiosqlite.connect(admin_db) as db:
+        async with db.execute(
+            "SELECT COUNT(*) FROM flashcard_reviews WHERE vocabulary_id=?", (vocab_id,)
+        ) as cur:
+            count = (await cur.fetchone())[0]
+    assert count == 0, (
+        "flashcard_reviews rows must be deleted when admin deletes a book (#691); "
+        "orphaned rows inflate flashcard stats for affected users"
+    )
+
+
 async def test_delete_book_removes_annotations(admin_client, admin_db, admin_user):
     await save_book(100, BOOK_META, BOOK_TEXT)
     await create_annotation(admin_user["id"], 100, 0, "A great line.", "The full quote.", "yellow")


### PR DESCRIPTION
## Summary

- `DELETE /admin/books/{book_id}` was pruning `vocabulary` entries after removing `word_occurrences`, but did NOT clean up `flashcard_reviews` first
- SQLite FK enforcement is OFF so `ON DELETE CASCADE` on `flashcard_reviews.vocabulary_id` never fires — manual delete is required
- Added `DELETE FROM flashcard_reviews WHERE vocabulary_id NOT IN (SELECT DISTINCT vocabulary_id FROM word_occurrences)` immediately before the vocabulary prune, matching the pattern already used by `delete_uploaded_book` in `uploads.py`

## Test plan

- [ ] `test_delete_book_removes_flashcard_reviews`: seeds vocab + flashcard_reviews + word_occurrence for book 100, deletes the book, asserts flashcard_reviews count is 0 — fails before fix, passes after
- [ ] All related `test_delete_book_*` tests pass
- [ ] Full backend suite: 1221 tests pass

Closes #691
