### PR TITLE
fix: replace raw ↗ Unicode with SVG icons in BookDetailModal and VocabWordTooltip

### DIFF
--- a/frontend/src/__tests__/ModalTooltipUnicodeIcons.test.ts
+++ b/frontend/src/__tests__/ModalTooltipUnicodeIcons.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Verifies BookDetailModal and VocabWordTooltip use SVG icons not raw Unicode.
+ */
+import fs from "fs";
+import path from "path";
+
+const modal = fs.readFileSync(
+  path.join(__dirname, "../components/BookDetailModal.tsx"),
+  "utf-8"
+);
+
+const tooltip = fs.readFileSync(
+  path.join(__dirname, "../components/VocabWordTooltip.tsx"),
+  "utf-8"
+);
+
+const icons = fs.readFileSync(
+  path.join(__dirname, "../components/Icons.tsx"),
+  "utf-8"
+);
+
+describe("BookDetailModal Unicode icon replacement", () => {
+  it("Gutenberg link does not use raw ↗ Unicode", () => {
+    expect(modal).not.toMatch(/Gutenberg\s*↗/);
+  });
+
+  it("imports ArrowUpRightIcon", () => {
+    expect(modal).toMatch(/ArrowUpRightIcon/);
+  });
+
+  it("Gutenberg link uses ArrowUpRightIcon", () => {
+    expect(modal).toMatch(/Gutenberg.*ArrowUpRightIcon/s);
+  });
+});
+
+describe("VocabWordTooltip Unicode icon replacement", () => {
+  it("Wiktionary link does not use raw ↗ Unicode", () => {
+    expect(tooltip).not.toMatch(/Wiktionary\s*↗/);
+  });
+
+  it("imports ArrowUpRightIcon", () => {
+    expect(tooltip).toMatch(/ArrowUpRightIcon/);
+  });
+
+  it("Wiktionary link uses ArrowUpRightIcon", () => {
+    expect(tooltip).toMatch(/Wiktionary.*ArrowUpRightIcon/s);
+  });
+});
+
+describe("Icons.tsx exports ArrowUpRightIcon", () => {
+  it("ArrowUpRightIcon is defined in Icons.tsx", () => {
+    expect(icons).toMatch(/ArrowUpRightIcon/);
+  });
+});

--- a/frontend/src/components/BookDetailModal.tsx
+++ b/frontend/src/components/BookDetailModal.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { BookMeta, getBookTranslationStatus, TranslationStatus } from "@/lib/api";
 import { RecentBook } from "@/lib/recentBooks";
 import { getSettings } from "@/lib/settings";
-import { BookCoverPlaceholderIcon, CloseIcon, CheckIcon } from "@/components/Icons";
+import { BookCoverPlaceholderIcon, CloseIcon, CheckIcon, ArrowUpRightIcon } from "@/components/Icons";
 
 const LANG_NAMES: Record<string, string> = {
   en: "English", de: "German", fr: "French", es: "Spanish",
@@ -138,7 +138,7 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
             rel="noopener noreferrer"
             className="text-xs text-amber-600 hover:text-amber-800 hover:underline ml-auto"
           >
-            View on Project Gutenberg ↗
+            View on Project Gutenberg <ArrowUpRightIcon className="w-3 h-3 inline" aria-hidden="true" />
           </a>
         </div>
       </div>

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -422,3 +422,11 @@ export function SearchIcon({ className = "w-4 h-4" }: IconProps) {
     </svg>
   );
 }
+
+export function ArrowUpRightIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <line x1="7" y1="17" x2="17" y2="7"/><polyline points="7 7 17 7 17 17"/>
+    </svg>
+  );
+}

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
 import { getWordDefinition, WordDefinition } from "@/lib/api";
-import { CloseIcon, CheckCircleIcon } from "@/components/Icons";
+import { CloseIcon, CheckCircleIcon, ArrowUpRightIcon } from "@/components/Icons";
 
 interface Props {
   word: string;
@@ -111,7 +111,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
             rel="noopener noreferrer"
             className="text-[11px] text-amber-600 hover:text-amber-800"
           >
-            Wiktionary ↗
+            Wiktionary <ArrowUpRightIcon className="w-3 h-3 inline" aria-hidden="true" />
           </a>
         ) : <span />}
         <button


### PR DESCRIPTION
## What changed
- `BookDetailModal.tsx`: Gutenberg link replaces raw `↗` with `<ArrowUpRightIcon>` SVG
- `VocabWordTooltip.tsx`: Wiktionary link replaces raw `↗` with `<ArrowUpRightIcon>` SVG
- `Icons.tsx`: Add `ArrowUpRightIcon` (diagonal external-link arrow)
- `ModalTooltipUnicodeIcons.test.ts`: 7 source-string assertions

## Why
Raw Unicode arrows render inconsistently across OS/browser. CLAUDE.md requires all UI icons to come from `@/components/Icons.tsx`.

## Test plan
- [x] `ModalTooltipUnicodeIcons.test.ts` — no raw `↗` in Gutenberg/Wiktionary links; ArrowUpRightIcon imported and used in both components; defined in Icons.tsx
- [x] Full frontend suite passes (1653 tests)

Closes #696
Closes #697
