### PR TITLE
fix: clean up flashcard_reviews before vocabulary prune in delete_user

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -300,7 +300,12 @@ async def delete_user(user_id: int) -> None:
         await db.execute(f"DELETE FROM chapter_summaries WHERE book_id IN ({_owned})", (user_id,))
         await db.execute(f"DELETE FROM translation_queue WHERE book_id IN ({_owned})", (user_id,))
         await db.execute(f"DELETE FROM word_occurrences WHERE book_id IN ({_owned})", (user_id,))
-        # Prune vocabulary entries that now have no occurrences (owned books just deleted).
+        # Prune flashcard_reviews and vocabulary for entries left without any occurrence.
+        # FK enforcement is OFF so ON DELETE CASCADE never fires automatically.
+        await db.execute(
+            "DELETE FROM flashcard_reviews WHERE vocabulary_id NOT IN "
+            "(SELECT DISTINCT vocabulary_id FROM word_occurrences)"
+        )
         await db.execute(
             "DELETE FROM vocabulary WHERE id NOT IN (SELECT DISTINCT vocabulary_id FROM word_occurrences)"
         )

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -305,6 +305,70 @@ async def test_delete_user_prunes_orphaned_vocabulary_from_other_readers(admin_c
     assert count == 0, "orphaned vocabulary entry remains after owner deleted"
 
 
+async def test_delete_user_cleans_flashcard_reviews_for_other_readers(admin_client, admin_db):
+    """Regression #695: deleting a book owner must clean up flashcard_reviews for
+    other users whose vocabulary entries are pruned when the owned book is removed.
+
+    FK enforcement is OFF, so the cascade on flashcard_reviews(vocabulary_id) never
+    fires automatically. delete_user() must explicitly DELETE FROM flashcard_reviews
+    between the word_occurrences prune and the vocabulary prune.
+    """
+    import json as _json
+    from services.db import _ensure_flashcard_rows
+
+    owner = await get_or_create_user(
+        google_id="fr-owner-695", email="fr-owner@test.com", name="Owner", picture=""
+    )
+    reader = await get_or_create_user(
+        google_id="fr-reader-695", email="fr-reader@test.com", name="Reader", picture=""
+    )
+    chapters = _json.dumps({"draft": False, "chapters": [{"title": "Ch1", "text": "unique695"}]})
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            """INSERT INTO books (id, title, authors, languages, subjects,
+               download_count, cover, text, images, source, owner_user_id)
+               VALUES (9971, 'OwnedBook695', '[]', '[]', '[]', 0, '', ?, '[]', 'upload', ?)""",
+            (chapters, owner["id"]),
+        )
+        await db.execute(
+            "INSERT OR IGNORE INTO vocabulary (user_id, word) VALUES (?, ?)",
+            (reader["id"], "unique695"),
+        )
+        async with db.execute(
+            "SELECT id FROM vocabulary WHERE user_id = ? AND word = ?",
+            (reader["id"], "unique695"),
+        ) as cur:
+            (vocab_id,) = await cur.fetchone()
+        await db.execute(
+            "INSERT OR IGNORE INTO word_occurrences "
+            "(vocabulary_id, book_id, chapter_index, sentence_text) VALUES (?, ?, ?, ?)",
+            (vocab_id, 9971, 0, "unique695 sentence"),
+        )
+        await db.commit()
+
+    await _ensure_flashcard_rows(reader["id"])
+
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        async with db.execute(
+            "SELECT COUNT(*) FROM flashcard_reviews WHERE vocabulary_id = ?", (vocab_id,)
+        ) as cur:
+            (before,) = await cur.fetchone()
+    assert before > 0, "test setup: flashcard_reviews row not created for reader"
+
+    res = await admin_client.delete(f"/api/admin/users/{owner['id']}")
+    assert res.status_code == 200
+
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        async with db.execute(
+            "SELECT COUNT(*) FROM flashcard_reviews WHERE vocabulary_id = ?", (vocab_id,)
+        ) as cur:
+            (after,) = await cur.fetchone()
+    assert after == 0, (
+        "flashcard_reviews rows must be deleted when delete_user prunes orphaned vocabulary (#695); "
+        "orphaned rows inflate flashcard stats for affected readers"
+    )
+
+
 async def test_delete_user_removes_flashcard_reviews(admin_client, admin_db, admin_user):
     """Regression #630: delete_user must delete flashcard_reviews rows.
 


### PR DESCRIPTION
## Summary

- `delete_user()` in `services/db.py` deletes `word_occurrences` for books owned by the deleted user, then prunes `vocabulary` entries with no remaining occurrences — but never cleans up `flashcard_reviews` for those pruned vocabulary entries
- Since SQLite FK enforcement is OFF, `ON DELETE CASCADE` on `flashcard_reviews(vocabulary_id)` never fires, leaving orphaned rows that inflate flashcard stats for other users (e.g. an admin/reader who saved words from the deleted owner's book)
- Fix: adds `DELETE FROM flashcard_reviews WHERE vocabulary_id NOT IN (SELECT DISTINCT vocabulary_id FROM word_occurrences)` between the word_occurrences prune and the vocabulary prune — same pattern used in `delete_uploaded_book()` and admin `delete_book()` after PR #693

## Test plan

- [x] New regression test `test_delete_user_cleans_flashcard_reviews_for_other_readers` in `test_router_admin.py` — creates owner + reader, reader saves word from owner's book, flashcard row seeded, owner deleted → asserts flashcard_reviews count is 0
- [x] All 1220 backend tests pass

Closes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)
