### PR TITLE
chore: user-approval gate for Path B + architecture issue template + needs-revision loop

### DIFF
--- a/.claude/skills/submit-pr/SKILL.md
+++ b/.claude/skills/submit-pr/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: submit-pr
+description: Full PR submission workflow for book-reader-ai — rebase, commit staged changes, push, create PR with auto-merge, watch until merged. Use when the user says "submit", "open a PR", "push this", or "ship it".
+---
+
+Follow this exact sequence. Never skip steps.
+
+## 1. Verify branch state
+```
+git -C /Users/alfmunny/Projects/AI/book-reader-ai status
+git -C /Users/alfmunny/Projects/AI/book-reader-ai log --oneline -3
+```
+Confirm the branch is NOT `main` and there are staged/committed changes to push.
+
+## 2. Check if a PR already exists for this branch
+```
+gh pr list --head $(git -C /Users/alfmunny/Projects/AI/book-reader-ai branch --show-current) --json number,state -q '.[0]'
+```
+- If state is `MERGED` or `CLOSED`: stop, tell the user, create a new branch instead.
+- If state is `OPEN`: skip PR creation, go to step 7 (auto-merge).
+
+## 3. Check in-flight PR cap (3 per session)
+```
+gh pr list --author @me --state open --json number -q '. | length'
+```
+If the count is ≥ 3, stop. Tell the user: "3 or more of your PRs are already open; per CLAUDE.md the per-session cap blocks new submits until one merges." Do not push, do not create.
+
+## 4. Rebase onto latest main
+```
+git -C /Users/alfmunny/Projects/AI/book-reader-ai fetch origin main
+git -C /Users/alfmunny/Projects/AI/book-reader-ai rebase origin/main
+```
+
+## 5. Run full test suite — must pass before pushing
+```
+npm --prefix /Users/alfmunny/Projects/AI/book-reader-ai/frontend test -- --no-coverage --ci
+/Users/alfmunny/Projects/AI/book-reader-ai/backend/venv/bin/pytest --tb=short -q --no-cov
+```
+If tests fail: stop, fix, re-run.
+
+## 6. Push
+```
+git -C /Users/alfmunny/Projects/AI/book-reader-ai push -u origin <branch>
+```
+Use `--force-with-lease` if already pushed and rebased.
+
+## 7. Create PR (write body to file first)
+Write a concise PR body to `/tmp/pr-body.md` covering: what changed, why, test plan.
+```
+gh pr create --title "<title>" --body-file /tmp/pr-body.md --base main
+```
+
+## 8. Enable auto-merge
+```
+gh pr merge <N> --auto --squash
+```
+
+## 9. Watch CI checks + merge state + review status (background)
+Launch in background with `run_in_background: true`. This loop catches CI failures, BEHIND branches, and review requests — not just merge events:
+```bash
+while true; do
+  STATE=$(gh pr view <N> --json state -q '.state')
+  MERGE=$(gh pr view <N> --json mergeStateStatus -q '.mergeStateStatus')
+  [ "$STATE" = "MERGED" ] && echo "PR #<N> merged" && break
+  [ "$STATE" = "CLOSED" ] && echo "PR #<N> closed without merge" && break
+
+  # Stop watching when PM/user requests changes — author needs to take over.
+  NEEDS_REV=$(gh pr view <N> --json labels -q '.labels[].name' | grep -c '^needs-revision$')
+  if [ "$NEEDS_REV" -gt 0 ]; then
+    echo "PR #<N>: needs-revision label applied — author must address review comments"
+    gh pr view <N> --comments | tail -40
+    break
+  fi
+
+  # Rebase when BEHIND so auto-merge can proceed.
+  if [ "$MERGE" = "BEHIND" ]; then
+    echo "PR #<N>: BEHIND — rebasing"
+    git -C /Users/alfmunny/Projects/AI/book-reader-ai fetch origin main --quiet
+    git -C /Users/alfmunny/Projects/AI/book-reader-ai rebase origin/main
+    git -C /Users/alfmunny/Projects/AI/book-reader-ai push --force-with-lease
+  fi
+
+  FAILED=$(gh pr checks <N> --json name,conclusion 2>/dev/null \
+    | python3 -c "import json,sys; d=json.load(sys.stdin); print(sum(1 for c in d if c['conclusion'] in ('FAILURE','ERROR','CANCELLED')))" 2>/dev/null)
+  if [ "$FAILED" != "" ] && [ "$FAILED" -gt 0 ]; then
+    echo "PR #<N>: $FAILED CI check(s) failed — investigate before merge"
+    gh pr checks <N>
+    break
+  fi
+
+  sleep 30
+done
+```
+
+The background watcher exits cleanly on: MERGED, CLOSED, `needs-revision` label applied, or a CI failure. The session receives a task-notification in each case and must act on it:
+- MERGED → continue (PR done).
+- CLOSED → report to user, investigate why.
+- `needs-revision` → read the review comments, revise on the branch, remove the label, re-run `/submit-pr` to restart the watcher.
+- CI failure → investigate the failing check, fix, push, re-run `/submit-pr`.
+
+Report the result to the user when the background task completes.

--- a/.github/ISSUE_TEMPLATE/architecture.md
+++ b/.github/ISSUE_TEMPLATE/architecture.md
@@ -1,0 +1,49 @@
+---
+name: Architecture proposal (Path B)
+about: Propose a complex or cross-cutting feature requiring user + PM approval before work begins
+title: "architecture: "
+labels: architecture
+assignees: ""
+---
+
+<!--
+Path B issues require COMPLETE design in the body below. Incomplete templates will be
+sent back for revision (`needs-revision` label). The user reviews and adds
+`user-approved`; PM reviews scope/technical fit and adds `pm-approved`. Architect may
+claim only when BOTH labels are present.
+-->
+
+## 1. Problem
+
+What breaks or is missing today. Who is affected and how.
+
+## 2. Proposed solution
+
+Architecture overview. How it works end-to-end. Include a short diagram or flow if helpful.
+
+## 3. Schema changes
+
+New tables, new columns, migrations. Write "None" if truly none.
+
+## 4. API changes
+
+New endpoints, changed contracts, breaking changes. Write "None" if truly none.
+
+## 5. Files touched
+
+Rough list with line estimates so reviewers can gauge scope.
+
+| Path | Why | ~Lines |
+|------|-----|--------|
+|      |     |        |
+
+## 6. Open questions
+
+Explicit list the user can answer **yes / no / defer**. Number them.
+
+1. ?
+2. ?
+
+## 7. Alternatives considered
+
+What was rejected and why.

--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,9 @@ frontend/e2e-results.json
 # Tauri
 src-tauri/target/
 
-# Claude Code local settings
-.claude/
+# Claude Code local settings (ignore everything EXCEPT the skills dir)
+.claude/*
+!.claude/skills/
 
 # General
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,10 @@ Anyone files issue (feat label)
 
 **Path B — Complex/cross-cutting feature (`architecture` label):**
 ```
-Anyone files issue (architecture label)
-  → Architect claims it
+Anyone files issue (architecture label) — MUST include complete design in body
+  → User reviews issue body → adds `user-approved` label         ← USER GATE
+  → PM reviews → adds `pm-approved` label (confirms scope/fit)
+  → Architect claims it (only after BOTH labels are present)
   → Design doc PR first (docs/design/<feature>.md)
   → PM reviews design doc → approves or requests changes
   → Design doc merged
@@ -81,6 +83,57 @@ Anyone files issue (architecture label)
 **When to use Path B:** new DB table, new service/router, schema migrations with existing-data impact, features touching 3+ files across different services, or anything the user/PM flags as needing a design review first.
 
 **Path B is NOT needed for:** bug fixes, small enhancements, adding a field to an existing model, adding a new endpoint that follows an established pattern.
+
+### User approval gate (Path B only)
+
+Every `architecture`-labeled issue requires **human user approval** before any role can claim it. This is the gate that decides whether a big feature is in scope for the product.
+
+**Signal:** the `user-approved` label, applied by the user directly on GitHub. PM does NOT apply this label. If it's missing, Architect must not claim.
+
+**Dependency order:**
+- `user-approved` (user) → `pm-approved` (PM confirms scope/technical fit) → Architect may claim.
+- Both labels required before claim. Either can arrive first.
+
+**User's filter URL** for pending approvals: `is:issue is:open label:architecture -label:user-approved -label:needs-revision`.
+
+**When user rejects:** user closes the issue or adds `needs-revision` with a comment.
+
+### Architecture issue template (mandatory)
+
+Every architecture issue must include **complete design content in the body** before it is eligible for user review. Missing design is a blocker; PM comments "design incomplete — please fill in the architecture issue template" and leaves `user-approved` off.
+
+Required sections:
+
+1. **Problem** — what breaks or is missing today; user impact.
+2. **Proposed solution** — architecture overview, how it works end-to-end.
+3. **Schema changes** — new tables, new columns, migrations. None is a valid answer.
+4. **API changes** — new endpoints, changed contracts. None is a valid answer.
+5. **Files touched** — rough list with line estimates so reviewers gauge scope.
+6. **Open questions** — explicit list user can answer yes/no/defer; each numbered.
+7. **Alternatives considered** — what was rejected and why.
+
+A GitHub issue template (`.github/ISSUE_TEMPLATE/architecture.md`) pre-populates these sections when an architecture issue is filed via the web UI.
+
+**Who writes it:**
+- User or PM filing: fill out the template.
+- Architect in idle mode (during FEATURES.md gap analysis): fill it out before filing. "Write a short proposal, file, and wait for a formal design review" is no longer acceptable — the proposal *is* the design review.
+- Dev: still forbidden from filing architecture issues.
+
+### Revision feedback loop (all roles, all items)
+
+A single label — `needs-revision` — carries change requests from reviewer back to author, for both issues and PRs.
+
+**Semantics:** *"Author, come back and revise this."*
+
+**Triggers (reviewer side):**
+- PM or user reads an issue body → finds the design incomplete, wrong, or wants a change → adds `needs-revision` + comment explaining what.
+- PM reviews a PR → wants changes before merge → adds `needs-revision` + review comment.
+
+**Response (author side), checked every cycle:**
+- Architect: scan `gh issue list --author @me --label architecture,needs-revision`. For each, open the issue, read the new comments, revise the issue body (or the design doc if that phase), remove `needs-revision`, comment "design updated — please re-review."
+- Dev / UI/UX / Architect on their own PRs: scan `gh pr list --author @me --label needs-revision`. For each, address the comments, push the fix, remove the label.
+
+The label is the ONLY sanctioned way to send something back for revision in this workflow. A bare comment is advisory; `needs-revision` is the action signal.
 
 ### Priority tiers (Dev + Architect use when picking issues)
 
@@ -97,14 +150,19 @@ Always work highest priority first. Re-check priority each time you pick the nex
 
 At the top of every cycle — before claiming, implementing, or submitting anything — every code role (Dev / UI/UX / Architect) executes this check in order. Never skip steps.
 
-1. **Check your own open PRs first:** `gh pr list --author @me --state open --json number,title,mergeStateStatus`.
+1. **Check your own open PRs first:** `gh pr list --author @me --state open --json number,title,mergeStateStatus,labels`.
    - For each PR with `mergeStateStatus = BEHIND`: rebase + force-push. `/submit-pr` handles this if you re-run it on the branch; otherwise run `git -C <worktree> fetch origin main && git -C <worktree> rebase origin/main && git -C <worktree> push origin <branch> --force-with-lease`.
    - For each PR with failing CI: investigate. Fix or mark `blocked` and comment.
+   - **For each PR with the `needs-revision` label:** read the review comments (`gh pr view <N> --comments`), address them on the branch, push, remove the label, and re-run `/submit-pr` to restart the watcher. This is the reviewer's signal that the author must come back.
    - For each PR MERGED since last cycle: remove `in-progress` label from the corresponding issue.
-2. **In-flight PR limit: 3 per session.** If you already have 3 or more open PRs authored by you, **do not submit a new PR this cycle.** You can still claim an issue and work it locally (branch, commits, tests), but hold off on `/submit-pr` until the count drops below 3. Prevents the backlog rot and CI-queue jam observed on 2026-04-23.
-3. **If open PR count < 3**, pick the highest-priority unclaimed issue that matches your role label. Claim it. Work it. Submit via `/submit-pr`.
-4. **If there are no unclaimed issues AND your PR count < 3**, enter your role's idle mode (bug hunt / UX audit / architecture gap analysis). File one issue, claim it, work it, submit.
-5. **If there are no unclaimed issues AND your PR count ≥ 3**, wait. Re-check PRs every few minutes; as soon as one merges, the slot frees up and you resume step 3.
+2. **Architect only — check your own open `architecture` issues:** `gh issue list --author @me --label architecture --state open --json number,title,labels`.
+   - For each with `needs-revision`: open the issue, read the new comments, revise the issue body, remove the label, post "design updated — please re-review." This is the only way user/PM feedback reaches the design.
+   - For each with `user-approved` + `pm-approved` (no `needs-revision`): ready to claim and proceed with the design doc PR.
+   - For each awaiting one of those labels: leave alone; the reviewer will act.
+3. **In-flight PR limit: 3 per session.** If you already have 3 or more open PRs authored by you, **do not submit a new PR this cycle.** You can still claim an issue and work it locally (branch, commits, tests), but hold off on `/submit-pr` until the count drops below 3. Prevents the backlog rot and CI-queue jam observed on 2026-04-23.
+4. **If open PR count < 3**, pick the highest-priority unclaimed issue that matches your role label. Architect: must check for both `user-approved` + `pm-approved` before claiming. Claim it. Work it. Submit via `/submit-pr`.
+5. **If there are no unclaimed issues AND your PR count < 3**, enter your role's idle mode (bug hunt / UX audit / architecture gap analysis). File one issue, (claim only if role rules permit — Architect must wait for `user-approved`), work it, submit.
+6. **If there are no unclaimed issues AND your PR count ≥ 3**, wait. Re-check PRs every few minutes; as soon as one merges, the slot frees up and you resume step 4.
 
 ---
 
@@ -115,13 +173,14 @@ At the top of every cycle — before claiming, implementing, or submitting anyth
 **File scope:** `product/`, `docs/`, `CLAUDE.md` only. Never edits source code, never creates fix branches.
 
 **Responsibilities:**
-- Triage new issues: apply role labels, set priority, update `product/backlog.md`
-- Review every merged PR: read the diff, file follow-up issues for anything incomplete
-- Review open PRs: comment with concerns or approval; apply `blocked` label if a hard concern exists
-- Watch deployments: run `/loop` for smoke-test and deploy monitoring
-- Approve design docs (Path B) before implementation begins
-- Keep `product/review-state.md` updated every cycle
-- **Submit every PR via the `/submit-pr` skill.** Never run `gh pr create` + `gh pr merge` directly — the skill rebases, tests, pushes, creates, enables auto-merge, and launches a background watcher that catches BEHIND/check-failures until MERGED. Once the skill returns, the watcher runs async; you are free to pick up new work.
+- Triage new issues: apply role labels, set priority, update `product/backlog.md`.
+- **For `architecture`-labeled issues:** verify the issue body follows the architecture template (all 7 sections filled). If not, comment "design incomplete — please fill in the architecture issue template" and leave labels off. If complete, review scope/technical fit and add `pm-approved`. Do NOT add `user-approved` — only the user adds that. Surface the issue to the user via a brief summary comment.
+- Review every merged PR: read the diff, file follow-up issues for anything incomplete.
+- Review open PRs: comment with concerns or approval. For PRs needing changes, add `needs-revision` (the canonical signal to the author). For hard blockers, add `blocked`.
+- Watch deployments: run `/loop` for smoke-test and deploy monitoring.
+- Approve design docs (Path B) before implementation begins.
+- Keep `product/review-state.md` updated every cycle.
+- **Submit every PR via the `/submit-pr` skill.** Never run `gh pr create` + `gh pr merge` directly — the skill rebases, tests, pushes, creates, enables auto-merge, and launches a background watcher. Once the skill returns, the watcher runs async; you are free to pick up new work.
 
 **Polling cadence (fixed-interval cron via `/loop Nm`):**
 - PM runs as `/loop ${PM_POLL_MINUTES}m <prompt>`, launched by `scripts/start-roles.sh`. The harness fires the cron every N minutes regardless of whether the prior turn re-armed a wakeup — this guarantees the loop cannot die silently between turns.
@@ -204,18 +263,20 @@ At the top of every cycle — before claiming, implementing, or submitting anyth
 - Update `docs/FEATURES.md` when a new feature ships
 
 **Workflow (Path B — design-first):**
-1. Read all memory files in `MEMORY.md`
-2. Claim the issue
-3. Write `docs/design/<feature>.md` — cover: problem, solution, schema changes, API changes, open questions
-4. **Submit the design doc via `/submit-pr` skill.** Comment on the issue linking to the PR. Background watcher picks up BEHIND/failures; session can pick up new work once the skill returns, subject to the 3-PR limit (see "Per-cycle priority" above).
-5. After PM approves and design doc merges: begin implementation in a new branch
-6. **Submit the implementation via `/submit-pr` skill** with `Closes #N` in the body. Same watcher semantics as step 4.
-7. After merge: remove `in-progress` label
+1. Read all memory files in `MEMORY.md`.
+2. **Only claim issues with BOTH `user-approved` AND `pm-approved` labels.** Issues missing either are not ready. If your own filed issue is missing `user-approved`, skip — don't claim your own work before the user has signed off.
+3. Check for `needs-revision` on your architecture issues first (see per-cycle priority). Revise the issue body, remove the label, re-request review — **before** claiming new work.
+4. Once claimed, write `docs/design/<feature>.md` — most of this content can be copied from the approved issue body since it already contains the complete design.
+5. **Submit the design doc via `/submit-pr` skill.** Comment on the issue linking to the PR. Background watcher picks up BEHIND/failures; session can pick up new work once the skill returns, subject to the 3-PR limit.
+6. If PM adds `needs-revision` on the design doc PR: address the comments, push, re-run `/submit-pr`.
+7. After PM approves and design doc merges: begin implementation in a new branch.
+8. **Submit the implementation via `/submit-pr` skill** with `Closes #N` in the body. Same watcher semantics.
+9. After merge: remove `in-progress` label.
 
 **Workflow (Path A — direct implementation):**
-Same as Dev workflow, but may include a design note in the PR body instead of a separate doc.
+Same as Dev workflow, but may include a design note in the PR body instead of a separate doc. Path A does NOT require `user-approved` — it's for small-scope enhancements.
 
-**Idle mode (no unclaimed issues):** Identify the highest-value unimplemented feature or most impactful refactor. Review `docs/FEATURES.md` and the open issue list for gaps. Open a GitHub issue with the `architecture` label describing the proposal, claim it, and begin a design doc following Path B. Never implement without PM sign-off on the design doc.
+**Idle mode (no unclaimed issues):** Identify the highest-value unimplemented feature or most impactful refactor. Review `docs/FEATURES.md` and the open issue list for gaps. **File a GitHub issue using the `.github/ISSUE_TEMPLATE/architecture.md` template with all 7 sections filled in — bare proposals are no longer acceptable.** Do NOT claim your own issue; wait for `user-approved` + `pm-approved`. Never implement without PM sign-off on the design doc.
 
 **Continuous operation:** After every PR merges, immediately pick the next issue without waiting.
 


### PR DESCRIPTION
## Summary

Adds the user-approval gate and feedback loop for Path B features (big / architecture-level changes):

1. **`user-approved` label** — human user approval is required before any role can claim a Path B issue. PM's `pm-approved` is separate (confirms scope/technical fit).
2. **Design must be in the issue body** — architecture issues require 7 filled-out sections (problem, solution, schema changes, API changes, files touched, open questions, alternatives). Enforced at triage by PM; GitHub issue template pre-populates the structure.
3. **`needs-revision` label** — universal signal "author, come back and revise." Works on both architecture issues (revise design in issue body) and PRs (address review comments). `/submit-pr`'s background watcher now exits when it sees this label so the author session picks up the revision.
4. **Architect per-cycle priority gains a step** — check own architecture issues for `needs-revision` and round-trip them before anything else.

Stacks on top of PR #710 (per-cycle priority / 3-PR cap / startup walkthrough).

## Why

Without this:
- Any role could spontaneously implement a "complete new feature" without the user being asked.
- The user had no canonical place to approve or reject big features — just PR reviews after design was done.
- If the user/PM requested design changes via a comment, nothing pinged the Architect to revise. The issue just sat.

## Changes

### CLAUDE.md

- New subsection **"User approval gate (Path B only)"** — documents the `user-approved` label semantics, dependency order, filter URL, and rejection path.
- New subsection **"Architecture issue template (mandatory)"** — lists the 7 required sections. References the new issue template file.
- New subsection **"Revision feedback loop (all roles, all items)"** — documents `needs-revision` for issues and PRs.
- **Path B workflow** updated: new step ordering with both labels required before claim; `needs-revision` round-trip as step 3.
- **Per-cycle priority** gains step 2 (Architect-only) for own `architecture` issues: pick up `needs-revision`, proceed when `user-approved` + `pm-approved`.
- **PM Responsibilities** updated to reflect the new label flow (never add `user-approved`, always check template completeness, use `needs-revision` for change requests).
- **Architect idle mode** updated: filed issues must use the template; never claim your own issue; wait for both approval labels.

### `/submit-pr` skill (project-level override)

Copied the user-level skill to `.claude/skills/submit-pr/SKILL.md` and extended it:
- New **Step 3** — checks the 3-PR in-flight cap before pushing.
- **Step 9 watch loop** — exits when `needs-revision` label is applied, in addition to MERGED/CLOSED/CI-failure. Caller is expected to address comments, remove the label, and re-run `/submit-pr`.

Project-level skill takes precedence over user-level, so the new behavior ships with the repo and every role session automatically gets it.

### `.github/ISSUE_TEMPLATE/architecture.md`

Pre-populates the 7 required sections when someone files an architecture issue via the GitHub web UI. Reduces incomplete submissions.

### `.gitignore`

Un-ignores `.claude/skills/` so future project-level skills can be checked in.

## Bootstrap note

I'm submitting this while 3 of my other PRs (#702, #703, #710) are still open — which violates the 3-PR cap this change (and #710) codifies. Called out because it's worth knowing:
- The 3 existing PRs are stuck on a CI queue backup, not the cap.
- The rules aren't in effect until #710 merges.
- One-time exception per your explicit request to ship this urgently.

## Known gap (follow-up)

`@me` in `gh pr list --author @me` returns ALL PRs authored by the shared GitHub user, not just this session's. Needs a session-identifier convention (e.g., branch prefix) for the per-session cap to actually distinguish. Follow-up PR.

## Test plan

- [x] Backend pytest: passing
- [x] Frontend Jest: passing
- [ ] Post-merge: next Architect session reads the updated Path B workflow, leaves non-approved issues alone, and picks up `needs-revision` on its own architecture issues.
- [ ] Post-merge: next PM session verifies architecture-issue template completeness before surfacing to user.
- [ ] GitHub issue template renders correctly when filing a new issue.
