### PR TITLE
fix: add ge=1/ge=0 bounds to admin router path and body params (closes #725)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -79,7 +79,7 @@ class ApproveRequest(BaseModel):
 
 
 @router.put("/users/{user_id}/approve")
-async def approve_user(user_id: int, req: ApproveRequest, _admin: dict = Depends(_require_admin)):
+async def approve_user(user_id: int = Path(..., ge=1), req: ApproveRequest = Body(...), _admin: dict = Depends(_require_admin)):
     if not await get_user_by_id(user_id):
         raise HTTPException(status_code=404, detail="User not found")
     await set_user_approved(user_id, req.approved)
@@ -91,7 +91,7 @@ class RoleRequest(BaseModel):
 
 
 @router.put("/users/{user_id}/role")
-async def change_role(user_id: int, req: RoleRequest, admin: dict = Depends(_require_admin)):
+async def change_role(req: RoleRequest, user_id: int = Path(..., ge=1), admin: dict = Depends(_require_admin)):
     if req.role not in ("admin", "user"):
         raise HTTPException(status_code=400, detail="Role must be 'admin' or 'user'")
     if user_id == admin["id"] and req.role != "admin":
@@ -103,7 +103,7 @@ async def change_role(user_id: int, req: RoleRequest, admin: dict = Depends(_req
 
 
 @router.delete("/users/{user_id}")
-async def remove_user(user_id: int, admin: dict = Depends(_require_admin)):
+async def remove_user(user_id: int = Path(..., ge=1), admin: dict = Depends(_require_admin)):
     if user_id == admin["id"]:
         raise HTTPException(status_code=400, detail="Cannot delete yourself")
     if not await get_user_by_id(user_id):
@@ -199,7 +199,7 @@ async def get_books(_admin: dict = Depends(_require_admin)):
 
 
 class ImportBookRequest(BaseModel):
-    book_id: int
+    book_id: int = Field(..., ge=1)
 
 
 @router.post("/books/import")
@@ -220,7 +220,7 @@ async def import_book(req: ImportBookRequest, _admin: dict = Depends(_require_ad
 
 
 @router.delete("/books/{book_id}")
-async def delete_book(book_id: int, _admin: dict = Depends(_require_admin)):
+async def delete_book(book_id: int = Path(..., ge=1), _admin: dict = Depends(_require_admin)):
     """Delete a cached book and all its associated audio + translation cache."""
     if not await get_cached_book(book_id):
         raise HTTPException(status_code=404, detail="Book not found")
@@ -344,7 +344,7 @@ async def get_audio_cache(_admin: dict = Depends(_require_admin)):
 
 
 @router.delete("/audio/{book_id}")
-async def delete_book_audio(book_id: int, _admin: dict = Depends(_require_admin)):
+async def delete_book_audio(book_id: int = Path(..., ge=1), _admin: dict = Depends(_require_admin)):
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute("DELETE FROM audio_cache WHERE book_id=?", (book_id,))
         deleted = db.total_changes
@@ -353,7 +353,7 @@ async def delete_book_audio(book_id: int, _admin: dict = Depends(_require_admin)
 
 
 @router.delete("/audio/{book_id}/{chapter_index}")
-async def delete_chapter_audio(book_id: int, chapter_index: int, _admin: dict = Depends(_require_admin)):
+async def delete_chapter_audio(book_id: int = Path(..., ge=1), chapter_index: int = Path(..., ge=0), _admin: dict = Depends(_require_admin)):
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute(
             "DELETE FROM audio_cache WHERE book_id=? AND chapter_index=?",
@@ -392,7 +392,7 @@ async def get_translations(_admin: dict = Depends(_require_admin)):
 
 
 @router.delete("/translations/{book_id}")
-async def delete_book_translations(book_id: int, _admin: dict = Depends(_require_admin)):
+async def delete_book_translations(book_id: int = Path(..., ge=1), _admin: dict = Depends(_require_admin)):
     """Delete all translations for a book."""
     async with aiosqlite.connect(DB_PATH) as db:
         # Reject if any worker is running — it would re-insert via INSERT OR REPLACE. (#338)
@@ -426,7 +426,7 @@ async def delete_book_translations(book_id: int, _admin: dict = Depends(_require
 
 @router.delete("/translations/{book_id}/{target_language}")
 async def delete_language_translations(
-    book_id: int,
+    book_id: int = Path(..., ge=1),
     target_language: str = Path(..., max_length=20),
     _admin: dict = Depends(_require_admin),
 ):
@@ -464,8 +464,8 @@ async def delete_language_translations(
 
 @router.delete("/translations/{book_id}/{chapter_index}/{target_language}")
 async def delete_translation(
-    book_id: int,
-    chapter_index: int,
+    book_id: int = Path(..., ge=1),
+    chapter_index: int = Path(..., ge=0),
     target_language: str = Path(..., max_length=20),
     _admin: dict = Depends(_require_admin),
 ):
@@ -502,8 +502,8 @@ async def delete_translation(
 
 @router.post("/translations/{book_id}/{chapter_index}/{target_language}/retranslate")
 async def retranslate(
-    book_id: int,
-    chapter_index: int,
+    book_id: int = Path(..., ge=1),
+    chapter_index: int = Path(..., ge=0),
     target_language: str = Path(..., max_length=20),
     admin: dict = Depends(_require_admin),
 ):
@@ -583,8 +583,8 @@ class BulkRetranslateRequest(BaseModel):
 
 
 class ImportTranslationEntry(BaseModel):
-    book_id: int
-    chapter_index: int
+    book_id: int = Field(..., ge=1)
+    chapter_index: int = Field(..., ge=0)
     target_language: str = Field(..., max_length=20)
     paragraphs: list[Annotated[str, Field(max_length=50000)]] = Field(..., max_length=2000)
     provider: str | None = Field(default=None, max_length=100)
@@ -656,8 +656,8 @@ async def import_translations(
 
 @router.post("/translations/{book_id}/retranslate-all")
 async def retranslate_all(
-    book_id: int,
     req: BulkRetranslateRequest,
+    book_id: int = Path(..., ge=1),
     admin: dict = Depends(_require_admin),
 ):
     """Retranslate ALL chapters of a book for a target language.
@@ -725,13 +725,13 @@ async def retranslate_all(
 
 
 class MoveTranslationRequest(BaseModel):
-    new_chapter_index: int
+    new_chapter_index: int = Field(..., ge=0)
 
 
 @router.post("/translations/{book_id}/{chapter_index}/{target_language}/move")
 async def move_translation(
-    book_id: int,
-    chapter_index: int,
+    book_id: int = Path(..., ge=1),
+    chapter_index: int = Path(..., ge=0),
     target_language: str = Path(..., max_length=20),
     req: MoveTranslationRequest = Body(...),
     _admin: dict = Depends(_require_admin),
@@ -1103,7 +1103,7 @@ async def queue_items(
 
 
 class EnqueueBookRequest(BaseModel):
-    book_id: int
+    book_id: int = Field(..., ge=1)
     target_languages: list[Annotated[str, Field(max_length=20)]] | None = Field(default=None, max_length=100)
     priority: int = 50   # lower than default so admin enqueues jump the line
     reset_failed: bool = False
@@ -1137,7 +1137,7 @@ async def queue_enqueue_book(
 
 @router.delete("/queue/items/{item_id}")
 async def queue_delete_item(
-    item_id: int, _admin: dict = Depends(_require_admin),
+    item_id: int = Path(..., ge=1), _admin: dict = Depends(_require_admin),
 ):
     # Reject deletion of running items: the worker will still save its result,
     # so silently "succeeding" here gives the admin a false sense of cancellation (#296).
@@ -1177,7 +1177,7 @@ async def queue_clear(
 
 @router.delete("/queue/book/{book_id}")
 async def queue_delete_book(
-    book_id: int,
+    book_id: int = Path(..., ge=1),
     target_language: str | None = Query(default=None, max_length=20),
     _admin: dict = Depends(_require_admin),
 ):
@@ -1188,7 +1188,7 @@ async def queue_delete_book(
 
 @router.post("/queue/items/{item_id}/retry")
 async def queue_retry_item(
-    item_id: int, _admin: dict = Depends(_require_admin),
+    item_id: int = Path(..., ge=1), _admin: dict = Depends(_require_admin),
 ):
     # Reset priority too — without this, a row that was bumped to the back
     # on failure would be retried but still sit behind everything else.
@@ -1222,7 +1222,7 @@ async def queue_retry_item(
 
 
 class RetryFailedRequest(BaseModel):
-    book_id: int | None = None
+    book_id: int | None = Field(default=None, ge=1)
     target_language: str | None = Field(default=None, max_length=20)
 
 

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -2569,3 +2569,132 @@ async def test_retranslate_all_uploaded_book_returns_200(admin_client, admin_db,
     body = res.json()
     assert body["ok"] is True
     assert body["chapters"] == 2
+
+
+# ── Issue #725: ge bounds on admin path and body params ───────────────────────
+
+
+async def test_approve_user_negative_id_returns_422(admin_client):
+    res = await admin_client.put("/api/admin/users/-1/approve", json={"approved": True})
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_change_role_negative_user_id_returns_422(admin_client):
+    res = await admin_client.put("/api/admin/users/-1/role", json={"role": "user"})
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_remove_user_negative_id_returns_422(admin_client):
+    res = await admin_client.delete("/api/admin/users/-1")
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_delete_book_negative_id_returns_422(admin_client):
+    res = await admin_client.delete("/api/admin/books/-1")
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_delete_book_audio_negative_id_returns_422(admin_client):
+    res = await admin_client.delete("/api/admin/audio/-1")
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_delete_chapter_audio_negative_chapter_returns_422(admin_client):
+    res = await admin_client.delete("/api/admin/audio/1/-1")
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_delete_book_translations_negative_id_returns_422(admin_client):
+    res = await admin_client.delete("/api/admin/translations/-1")
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_delete_language_translations_negative_book_id_returns_422(admin_client):
+    res = await admin_client.delete("/api/admin/translations/-1/zh")
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_delete_translation_negative_chapter_returns_422(admin_client):
+    res = await admin_client.delete("/api/admin/translations/1/-1/zh")
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_retranslate_negative_chapter_returns_422(admin_client):
+    res = await admin_client.post("/api/admin/translations/1/-1/zh/retranslate")
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_retranslate_all_negative_book_id_returns_422(admin_client):
+    res = await admin_client.post(
+        "/api/admin/translations/-1/retranslate-all",
+        json={"target_language": "zh"},
+    )
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_move_translation_negative_chapter_returns_422(admin_client):
+    res = await admin_client.post(
+        "/api/admin/translations/1/-1/zh/move",
+        json={"new_chapter_index": 0},
+    )
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_move_translation_negative_new_chapter_returns_422(admin_client):
+    res = await admin_client.post(
+        "/api/admin/translations/1/0/zh/move",
+        json={"new_chapter_index": -1},
+    )
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_import_book_negative_id_returns_422(admin_client):
+    res = await admin_client.post("/api/admin/books/import", json={"book_id": -1})
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_import_translation_entry_negative_book_id_returns_422(admin_client):
+    res = await admin_client.post(
+        "/api/admin/translations/import",
+        json={"entries": [{"book_id": -1, "chapter_index": 0, "target_language": "zh", "paragraphs": ["p"]}]},
+    )
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_import_translation_entry_negative_chapter_index_returns_422(admin_client):
+    res = await admin_client.post(
+        "/api/admin/translations/import",
+        json={"entries": [{"book_id": 1, "chapter_index": -1, "target_language": "zh", "paragraphs": ["p"]}]},
+    )
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_enqueue_book_negative_book_id_returns_422(admin_client):
+    res = await admin_client.post(
+        "/api/admin/queue/enqueue-book",
+        json={"book_id": -1},
+    )
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_queue_delete_item_negative_id_returns_422(admin_client):
+    res = await admin_client.delete("/api/admin/queue/items/-1")
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_queue_retry_item_negative_id_returns_422(admin_client):
+    res = await admin_client.post("/api/admin/queue/items/-1/retry")
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_queue_delete_book_negative_id_returns_422(admin_client):
+    res = await admin_client.delete("/api/admin/queue/book/-1")
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+async def test_retry_failed_negative_book_id_returns_422(admin_client):
+    res = await admin_client.post(
+        "/api/admin/queue/retry-failed",
+        json={"book_id": -1},
+    )
+    assert res.status_code == 422, f"Expected 422, got {res.status_code}"


### PR DESCRIPTION
## Summary

- Added `Path(..., ge=1)` to `user_id`, `book_id`, `item_id` path parameters across all admin endpoints
- Added `Path(..., ge=0)` to `chapter_index` path parameters
- Added `Field(..., ge=N)` to body model fields: `ImportBookRequest.book_id`, `ImportTranslationEntry.book_id`/`chapter_index`, `MoveTranslationRequest.new_chapter_index`, `EnqueueBookRequest.book_id`, `RetryFailedRequest.book_id`
- Negative integers previously silently produced wrong SQL results (e.g. `WHERE book_id=-1` returning 0 rows and bubbling up as a misleading 404)
- 21 new regression tests, all passing

## Test plan

- [ ] All 21 `test_*_negative_*_returns_422` tests pass
- [ ] Full suite: 1247 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
