### PR TITLE
fix: add ge=1 bounds to book_id path params in books router (closes #727)

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -90,7 +90,7 @@ async def popular_books(
 
 
 @router.get("/{book_id}/translation-status")
-async def translation_status(book_id: int, target_language: str = Query(..., max_length=20), user: dict | None = Depends(get_optional_user)):
+async def translation_status(book_id: int = Path(..., ge=1), target_language: str = Query(..., max_length=20), user: dict | None = Depends(get_optional_user)):
     """Return book-level translation progress for the reader banner.
 
     Includes:
@@ -336,8 +336,8 @@ async def request_chapter_translation(
 
 @router.post("/{book_id}/translations/enqueue-all")
 async def enqueue_all_chapters(
-    book_id: int,
     req: RequestTranslationBody,
+    book_id: int = Path(..., ge=1),
     user: dict = Depends(get_current_user),
 ):
     """Queue every not-yet-translated chapter of a book for one language.
@@ -435,7 +435,7 @@ async def retry_chapter_translation(
 
 
 @router.get("/{book_id}")
-async def book_meta(book_id: int, user: dict | None = Depends(get_optional_user)):
+async def book_meta(book_id: int = Path(..., ge=1), user: dict | None = Depends(get_optional_user)):
     cached = await get_cached_book(book_id)
     if cached:
         check_book_access(cached, user)
@@ -447,7 +447,7 @@ async def book_meta(book_id: int, user: dict | None = Depends(get_optional_user)
 
 
 @router.get("/{book_id}/chapters")
-async def book_chapters(book_id: int, user: dict | None = Depends(get_optional_user)):
+async def book_chapters(book_id: int = Path(..., ge=1), user: dict | None = Depends(get_optional_user)):
     """
     Return book split into chapters.
     Serves from local DB if cached, otherwise fetches from Gutenberg and caches.
@@ -523,7 +523,7 @@ def _sse(event: str, data: dict) -> str:
 
 @router.get("/{book_id}/import-stream")
 async def import_stream(
-    book_id: int,
+    book_id: int = Path(..., ge=1),
     user: dict | None = Depends(get_optional_user),
 ):
     """Stream import progress for a book via Server-Sent Events.

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -1152,3 +1152,36 @@ async def test_chapter_translation_negative_chapter_index_returns_422(client, te
 
     resp = await client.get("/api/books/1/chapters/-1/queue-status?target_language=en")
     assert resp.status_code == 422, f"queue-status: expected 422, got {resp.status_code}: {resp.text}"
+
+
+# ── Issue #727: ge=1 bounds on remaining book_id path params ─────────────────
+
+
+async def test_translation_status_negative_book_id_returns_422(client):
+    """Regression #727: GET /books/{book_id}/translation-status with negative book_id must return 422."""
+    resp = await client.get("/api/books/-1/translation-status?target_language=en")
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+async def test_enqueue_all_negative_book_id_returns_422(client, test_user):
+    """Regression #727: POST /books/{book_id}/translations/enqueue-all with negative book_id must return 422."""
+    resp = await client.post("/api/books/-1/translations/enqueue-all", json={"target_language": "en"})
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+async def test_book_meta_negative_book_id_returns_422(client):
+    """Regression #727: GET /books/{book_id} with negative book_id must return 422."""
+    resp = await client.get("/api/books/-1")
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+async def test_book_chapters_negative_book_id_returns_422(client):
+    """Regression #727: GET /books/{book_id}/chapters with negative book_id must return 422."""
+    resp = await client.get("/api/books/-1/chapters")
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+async def test_import_stream_negative_book_id_returns_422(client):
+    """Regression #727: GET /books/{book_id}/import-stream with negative book_id must return 422."""
+    resp = await client.get("/api/books/-1/import-stream")
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"


### PR DESCRIPTION
## Summary

- Added `Path(..., ge=1)` to `book_id` in 5 endpoints that previously accepted negative integers
- Negative book IDs silently hit the DB with `WHERE id=-N`, always returning 0 rows and a misleading 404 — they should return 422 validation errors
- Affected: `translation_status`, `enqueue_all_chapters`, `book_meta`, `book_chapters`, `import_stream`

## Test plan

- [ ] 5 new `test_*_negative_book_id_returns_422` tests all pass
- [ ] Full suite: 1245 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
