### PR TITLE
fix: add ge=1 bounds to book_id/id params in annotations, insights, ai routers (closes #729)

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -69,7 +69,7 @@ class ReferencesRequest(BaseModel):
 
 
 class SummaryRequest(BaseModel):
-    book_id: int
+    book_id: int = Field(..., ge=1)
     chapter_index: int = Field(..., ge=0)
     chapter_text: str = Field(..., max_length=50_000)
     book_title: str = Field(..., max_length=500)
@@ -81,7 +81,7 @@ class TranslateRequest(BaseModel):
     text: str = Field(..., max_length=50_000)
     source_language: str = Field(default="de", max_length=20)
     target_language: str = Field(default="en", max_length=20)
-    book_id: int | None = None
+    book_id: int | None = Field(default=None, ge=1)
     chapter_index: int | None = Field(default=None, ge=0)
     # "auto" → Gemini if user has a key, else Google Translate (free).
     provider: Literal["auto", "gemini", "google"] = "auto"
@@ -267,7 +267,7 @@ async def translate_cache(
 
 
 class SaveTranslationRequest(BaseModel):
-    book_id: int
+    book_id: int = Field(..., ge=1)
     chapter_index: int = Field(..., ge=0)
     target_language: str = Field(..., max_length=20)
     paragraphs: list[Annotated[str, Field(max_length=50000)]] = Field(..., max_length=2000)

--- a/backend/routers/annotations.py
+++ b/backend/routers/annotations.py
@@ -1,5 +1,5 @@
 from typing import Literal, Optional
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from pydantic import BaseModel, Field
 from services.auth import get_current_user, check_book_access
 from services.db import create_annotation, get_annotations, get_all_annotations, update_annotation, delete_annotation, get_cached_book
@@ -11,7 +11,7 @@ AnnotationColor = Literal["yellow", "blue", "green", "pink"]
 
 
 class AnnotationCreate(BaseModel):
-    book_id: int
+    book_id: int = Field(..., ge=1)
     chapter_index: int = Field(..., ge=0)
     sentence_text: str = Field(..., max_length=5000)
     note_text: str = Field(default="", max_length=10000)
@@ -56,7 +56,7 @@ async def list_all_annotations(user: dict = Depends(get_current_user)):
 
 
 @router.get("")
-async def list_annotations(book_id: int, user: dict = Depends(get_current_user)):
+async def list_annotations(book_id: int = Query(..., ge=1), user: dict = Depends(get_current_user)):
     book = await get_cached_book(book_id)
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
@@ -66,8 +66,8 @@ async def list_annotations(book_id: int, user: dict = Depends(get_current_user))
 
 @router.patch("/{annotation_id}")
 async def update(
-    annotation_id: int,
     req: AnnotationUpdate,
+    annotation_id: int = Path(..., ge=1),
     user: dict = Depends(get_current_user),
 ):
     result = await update_annotation(
@@ -80,7 +80,7 @@ async def update(
 
 
 @router.delete("/{annotation_id}")
-async def delete(annotation_id: int, user: dict = Depends(get_current_user)):
+async def delete(annotation_id: int = Path(..., ge=1), user: dict = Depends(get_current_user)):
     deleted = await delete_annotation(annotation_id, user["id"])
     if not deleted:
         raise HTTPException(status_code=404, detail="Annotation not found")

--- a/backend/routers/insights.py
+++ b/backend/routers/insights.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from pydantic import BaseModel, Field
 from services.auth import get_current_user, check_book_access
 from services.db import save_insight, get_insights, get_all_insights, delete_insight, get_cached_book
@@ -7,7 +7,7 @@ router = APIRouter(prefix="/insights", tags=["insights"])
 
 
 class InsightCreate(BaseModel):
-    book_id: int
+    book_id: int = Field(..., ge=1)
     chapter_index: int | None = Field(default=None, ge=0)
     question: str = Field(..., max_length=2000)
     answer: str = Field(..., max_length=20000)
@@ -50,7 +50,7 @@ async def list_all_insights(user: dict = Depends(get_current_user)):
 
 
 @router.get("")
-async def list_insights(book_id: int, user: dict = Depends(get_current_user)):
+async def list_insights(book_id: int = Query(..., ge=1), user: dict = Depends(get_current_user)):
     book = await get_cached_book(book_id)
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
@@ -59,7 +59,7 @@ async def list_insights(book_id: int, user: dict = Depends(get_current_user)):
 
 
 @router.delete("/{insight_id}")
-async def delete(insight_id: int, user: dict = Depends(get_current_user)):
+async def delete(insight_id: int = Path(..., ge=1), user: dict = Depends(get_current_user)):
     deleted = await delete_insight(insight_id, user["id"])
     if not deleted:
         raise HTTPException(status_code=404, detail="Insight not found")

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -1161,3 +1161,24 @@ async def test_save_translation_negative_chapter_index_returns_422(client, test_
         "paragraphs": ["Hello."],
     })
     assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+# ── Issue #729: ge=1 bounds on book_id in ai body models ─────────────────────
+
+
+async def test_summary_negative_book_id_returns_422(client, test_user):
+    """Regression #729: POST /ai/summary with book_id < 1 must return 422."""
+    resp = await client.post("/api/ai/summary", json={
+        "book_id": -1, "chapter_index": 0,
+        "chapter_text": "text", "book_title": "T", "author": "A",
+    })
+    assert resp.status_code == 422, f"Expected 422 for book_id=-1 in summary, got {resp.status_code}: {resp.text}"
+
+
+async def test_save_translation_negative_book_id_returns_422(client, test_user):
+    """Regression #729: PUT /ai/translate/cache with book_id < 1 must return 422."""
+    resp = await client.put("/api/ai/translate/cache", json={
+        "book_id": -1, "chapter_index": 0, "target_language": "en",
+        "paragraphs": ["Hello."],
+    })
+    assert resp.status_code == 422, f"Expected 422 for book_id=-1 in save_translation, got {resp.status_code}: {resp.text}"

--- a/backend/tests/test_router_annotations.py
+++ b/backend/tests/test_router_annotations.py
@@ -496,3 +496,33 @@ async def test_create_annotation_negative_chapter_index_returns_422(client, test
         "sentence_text": "some text", "note_text": "", "color": "yellow",
     })
     assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+# ── Issue #729: ge=1 bounds on book_id, annotation_id ────────────────────────
+
+
+async def test_create_annotation_negative_book_id_returns_422(client, test_user):
+    """Regression #729: POST /annotations with book_id < 1 must return 422."""
+    resp = await client.post("/api/annotations", json={
+        "book_id": -1, "chapter_index": 0,
+        "sentence_text": "text", "note_text": "", "color": "yellow",
+    })
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+async def test_list_annotations_negative_book_id_returns_422(client, test_user):
+    """Regression #729: GET /annotations?book_id=-1 must return 422."""
+    resp = await client.get("/api/annotations?book_id=-1")
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+async def test_update_annotation_negative_id_returns_422(client, test_user):
+    """Regression #729: PATCH /annotations/{id} with negative id must return 422."""
+    resp = await client.patch("/api/annotations/-1", json={"note_text": "note"})
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+async def test_delete_annotation_negative_id_returns_422(client, test_user):
+    """Regression #729: DELETE /annotations/{id} with negative id must return 422."""
+    resp = await client.delete("/api/annotations/-1")
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"

--- a/backend/tests/test_router_insights.py
+++ b/backend/tests/test_router_insights.py
@@ -361,3 +361,26 @@ async def test_create_insight_negative_chapter_index_returns_422(client, test_us
         "question": "Q?", "answer": "A.",
     })
     assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+# ── Issue #729: ge=1 bounds on book_id, insight_id ───────────────────────────
+
+
+async def test_create_insight_negative_book_id_returns_422(client, test_user):
+    """Regression #729: POST /insights with book_id < 1 must return 422."""
+    resp = await client.post("/api/insights", json={
+        "book_id": -1, "chapter_index": 0, "question": "Q?", "answer": "A.",
+    })
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+async def test_list_insights_negative_book_id_returns_422(client, test_user):
+    """Regression #729: GET /insights?book_id=-1 must return 422."""
+    resp = await client.get("/api/insights?book_id=-1")
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+async def test_delete_insight_negative_id_returns_422(client, test_user):
+    """Regression #729: DELETE /insights/{id} with negative id must return 422."""
+    resp = await client.delete("/api/insights/-1")
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"


### PR DESCRIPTION
## Summary

- Added `Field(..., ge=1)` to body fields: `AnnotationCreate.book_id`, `InsightCreate.book_id`, `SummaryRequest.book_id`, `TranslateRequest.book_id`, `SaveTranslationRequest.book_id`
- Added `Path(..., ge=1)` / `Query(..., ge=1)` to path/query params: `list_annotations(book_id)`, `update(annotation_id)`, `delete(annotation_id)`, `list_insights(book_id)`, `delete(insight_id)`
- Negative IDs previously silently produced empty SQL results and misleading 404/500 errors

## Test plan

- [ ] 9 new `test_*_negative_*_returns_422` tests all pass
- [ ] Full suite: 1249 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
