### PR TITLE
fix: add ge=1 bounds to book_id params in uploads, user, vocabulary routers (closes #731)

### DIFF
--- a/backend/routers/uploads.py
+++ b/backend/routers/uploads.py
@@ -4,7 +4,7 @@ import logging
 
 import aiosqlite
 import services.db as _db
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, Path, UploadFile
 from pydantic import BaseModel, Field
 from services.auth import get_current_user
 from services.db import get_user_book_chapters, count_draft_user_book_chapters
@@ -168,7 +168,7 @@ async def upload_quota(user: dict = Depends(get_current_user)):
 
 
 @router.get("/{book_id}/chapters/draft")
-async def get_draft_chapters(book_id: int, user: dict = Depends(get_current_user)):
+async def get_draft_chapters(book_id: int = Path(..., ge=1), user: dict = Depends(get_current_user)):
     """Return the draft chapter list for an uploaded book pending confirmation."""
     async with aiosqlite.connect(_db.DB_PATH) as db:
         async with db.execute(
@@ -212,8 +212,8 @@ class ConfirmChaptersBody(BaseModel):
 
 @router.post("/{book_id}/chapters/confirm")
 async def confirm_chapters(
-    book_id: int,
     body: ConfirmChaptersBody,
+    book_id: int = Path(..., ge=1),
     user: dict = Depends(get_current_user),
 ):
     """Confirm chapter splits for an uploaded book. Replaces draft rows with confirmed rows."""
@@ -279,7 +279,7 @@ async def confirm_chapters(
 
 
 @router.delete("/upload/{book_id}")
-async def delete_uploaded_book(book_id: int, user: dict = Depends(get_current_user)):
+async def delete_uploaded_book(book_id: int = Path(..., ge=1), user: dict = Depends(get_current_user)):
     """Delete an uploaded book and all associated data."""
     async with aiosqlite.connect(_db.DB_PATH) as db:
         async with db.execute(

--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Path
 from pydantic import BaseModel, Field
 from services.auth import get_current_user, encrypt_api_key, decrypt_api_key, check_book_access
 from services.db import (
@@ -59,8 +59,8 @@ class ProgressUpdate(BaseModel):
 
 @router.put("/reading-progress/{book_id}")
 async def update_reading_progress(
-    book_id: int,
     req: ProgressUpdate,
+    book_id: int = Path(..., ge=1),
     user: dict = Depends(get_current_user),
 ):
     book = await get_cached_book(book_id)

--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -25,7 +25,7 @@ router = APIRouter(prefix="/vocabulary", tags=["vocabulary"])
 
 class WordSave(BaseModel):
     word: str = Field(..., max_length=200)
-    book_id: int
+    book_id: int = Field(..., ge=1)
     chapter_index: int = Field(..., ge=0)
     sentence_text: str = Field(..., max_length=5000)
 

--- a/backend/tests/test_router_uploads.py
+++ b/backend/tests/test_router_uploads.py
@@ -789,3 +789,27 @@ async def test_confirm_chapters_negative_original_index_returns_422(client, test
         json={"chapters": [{"title": "Ch 1", "original_index": -1}]},
     )
     assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+# ── Issue #731: ge=1 bounds on book_id path params in uploads router ──────────
+
+
+async def test_get_draft_chapters_negative_book_id_returns_422(client, test_user):
+    """Regression #731: GET /books/{id}/chapters/draft with negative id must return 422."""
+    resp = await client.get("/api/books/-1/chapters/draft")
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+async def test_confirm_chapters_negative_book_id_returns_422(client, test_user):
+    """Regression #731: POST /books/{id}/chapters/confirm with negative book_id must return 422."""
+    resp = await client.post(
+        "/api/books/-1/chapters/confirm",
+        json={"chapters": [{"title": "Ch 1", "original_index": 0}]},
+    )
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+async def test_delete_uploaded_book_negative_id_returns_422(client, test_user):
+    """Regression #731: DELETE /books/upload/{id} with negative id must return 422."""
+    resp = await client.delete("/api/books/upload/-1")
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"

--- a/backend/tests/test_router_user.py
+++ b/backend/tests/test_router_user.py
@@ -342,3 +342,12 @@ async def test_update_reading_progress_negative_chapter_index_returns_422(client
                            "subjects": [], "download_count": 0, "cover": ""}, "text")
     resp = await client.put("/api/user/reading-progress/9001", json={"chapter_index": -1})
     assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+# ── Issue #731: ge=1 bound on book_id path param in user router ───────────────
+
+
+async def test_update_reading_progress_negative_book_id_returns_422(client, test_user):
+    """Regression #731: PUT /user/reading-progress/{book_id} with negative id must return 422."""
+    resp = await client.put("/api/user/reading-progress/-1", json={"chapter_index": 0})
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -723,3 +723,15 @@ async def test_save_word_negative_chapter_index_returns_422(client, test_user, t
         "sentence_text": "Hello world.",
     })
     assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+# ── Issue #731: ge=1 bound on book_id body field in vocabulary router ─────────
+
+
+async def test_save_word_negative_book_id_returns_422(client, test_user):
+    """Regression #731: POST /vocabulary with book_id < 1 must return 422."""
+    resp = await client.post("/api/vocabulary", json={
+        "word": "hello", "book_id": -1, "chapter_index": 0,
+        "sentence_text": "Hello world.",
+    })
+    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"


### PR DESCRIPTION
## Summary

- Added `Path(..., ge=1)` to `book_id` path params in: `get_draft_chapters`, `confirm_chapters`, `delete_uploaded_book` (uploads router), `update_reading_progress` (user router)
- Added `Field(..., ge=1)` to `WordSave.book_id` body field (vocabulary router)
- Negative IDs previously silently hit the DB with `WHERE id=-N`, producing wrong results

## Test plan

- [ ] 5 new `test_*_negative_book_id_returns_422` tests pass
- [ ] Full suite: 1245 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
