### PR TITLE
feat: FTS5 in-app search across annotations, vocabulary, and uploaded chapters (#648)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -14,6 +14,7 @@ from routers.annotations import router as annotations_router
 from routers.vocabulary import router as vocabulary_router
 from routers.insights import router as insights_router
 from routers.uploads import router as uploads_router
+from routers.search import router as search_router
 from services.db import init_db
 
 
@@ -94,6 +95,7 @@ app.include_router(annotations_router, prefix="/api")
 app.include_router(vocabulary_router, prefix="/api")
 app.include_router(insights_router, prefix="/api")
 app.include_router(uploads_router, prefix="/api")
+app.include_router(search_router, prefix="/api")
 
 
 @app.get("/api/health")

--- a/backend/migrations/026_fts5_search.sql
+++ b/backend/migrations/026_fts5_search.sql
@@ -1,0 +1,104 @@
+-- FTS5 full-text search indexes for user content (issue #592, design doc
+-- docs/design/fts5-in-app-search.md). External content mode: the FTS5 virtual
+-- tables store only the inverted index; the source tables remain authoritative.
+
+-- ── annotations_fts ──────────────────────────────────────────────────────────
+CREATE VIRTUAL TABLE IF NOT EXISTS annotations_fts USING fts5(
+    sentence_text,
+    note_text,
+    content='annotations',
+    content_rowid='id',
+    tokenize='unicode61'
+);
+
+INSERT INTO annotations_fts(rowid, sentence_text, note_text)
+SELECT id, sentence_text, note_text FROM annotations;
+
+CREATE TRIGGER annotations_ai AFTER INSERT ON annotations BEGIN
+    INSERT INTO annotations_fts(rowid, sentence_text, note_text)
+    VALUES (new.id, new.sentence_text, new.note_text);
+END;
+CREATE TRIGGER annotations_ad BEFORE DELETE ON annotations BEGIN
+    INSERT INTO annotations_fts(annotations_fts, rowid, sentence_text, note_text)
+    VALUES ('delete', old.id, old.sentence_text, old.note_text);
+END;
+CREATE TRIGGER annotations_au AFTER UPDATE ON annotations BEGIN
+    INSERT INTO annotations_fts(annotations_fts, rowid, sentence_text, note_text)
+    VALUES ('delete', old.id, old.sentence_text, old.note_text);
+    INSERT INTO annotations_fts(rowid, sentence_text, note_text)
+    VALUES (new.id, new.sentence_text, new.note_text);
+END;
+
+-- ── word_occurrences_fts ─────────────────────────────────────────────────────
+CREATE VIRTUAL TABLE IF NOT EXISTS word_occurrences_fts USING fts5(
+    sentence_text,
+    content='word_occurrences',
+    content_rowid='id',
+    tokenize='unicode61'
+);
+
+INSERT INTO word_occurrences_fts(rowid, sentence_text)
+SELECT id, sentence_text FROM word_occurrences;
+
+CREATE TRIGGER word_occ_ai AFTER INSERT ON word_occurrences BEGIN
+    INSERT INTO word_occurrences_fts(rowid, sentence_text)
+    VALUES (new.id, new.sentence_text);
+END;
+CREATE TRIGGER word_occ_ad BEFORE DELETE ON word_occurrences BEGIN
+    INSERT INTO word_occurrences_fts(word_occurrences_fts, rowid, sentence_text)
+    VALUES ('delete', old.id, old.sentence_text);
+END;
+CREATE TRIGGER word_occ_au AFTER UPDATE ON word_occurrences BEGIN
+    INSERT INTO word_occurrences_fts(word_occurrences_fts, rowid, sentence_text)
+    VALUES ('delete', old.id, old.sentence_text);
+    INSERT INTO word_occurrences_fts(rowid, sentence_text)
+    VALUES (new.id, new.sentence_text);
+END;
+
+-- ── user_chapters_fts ────────────────────────────────────────────────────────
+-- Depends on user_book_chapters (migration 025).
+-- Draft rows (is_draft=1) must NOT appear in the index — both the triggers
+-- and the search router filter is_draft=0 (belt-and-braces).
+CREATE VIRTUAL TABLE IF NOT EXISTS user_chapters_fts USING fts5(
+    title,
+    text,
+    content='user_book_chapters',
+    content_rowid='id',
+    tokenize='unicode61'
+);
+
+-- Only seed confirmed (non-draft) chapters.
+INSERT INTO user_chapters_fts(rowid, title, text)
+SELECT id, title, text FROM user_book_chapters WHERE is_draft = 0;
+
+CREATE TRIGGER user_chapters_ai AFTER INSERT ON user_book_chapters
+WHEN NEW.is_draft = 0
+BEGIN
+    INSERT INTO user_chapters_fts(rowid, title, text)
+    VALUES (new.id, new.title, new.text);
+END;
+
+CREATE TRIGGER user_chapters_ad BEFORE DELETE ON user_book_chapters
+WHEN OLD.is_draft = 0
+BEGIN
+    INSERT INTO user_chapters_fts(user_chapters_fts, rowid, title, text)
+    VALUES ('delete', old.id, old.title, old.text);
+END;
+
+-- Two composed AU triggers cover all four draft/confirm transitions:
+--   0→0 : delete old + insert new = re-index
+--   0→1 : delete old only         = defensive un-confirm
+--   1→0 : insert new only         = added on confirm
+--   1→1 : neither                 = draft-only edit stays out
+CREATE TRIGGER user_chapters_au_del AFTER UPDATE ON user_book_chapters
+WHEN OLD.is_draft = 0
+BEGIN
+    INSERT INTO user_chapters_fts(user_chapters_fts, rowid, title, text)
+    VALUES ('delete', old.id, old.title, old.text);
+END;
+CREATE TRIGGER user_chapters_au_ins AFTER UPDATE ON user_book_chapters
+WHEN NEW.is_draft = 0
+BEGIN
+    INSERT INTO user_chapters_fts(rowid, title, text)
+    VALUES (new.id, new.title, new.text);
+END;

--- a/backend/routers/search.py
+++ b/backend/routers/search.py
@@ -1,0 +1,45 @@
+"""In-app full-text search across the user's annotations, vocabulary, and uploaded chapters.
+
+Issue #592 / #648. See docs/design/fts5-in-app-search.md.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from services.auth import get_current_user
+from services.search import MAX_LIMIT, MAX_QUERY_LEN, SCOPES, search_content
+
+router = APIRouter(prefix="/search", tags=["search"])
+
+
+def _parse_scope(raw: str | None) -> list[str]:
+    if not raw:
+        return list(SCOPES)
+    parts = [p.strip() for p in raw.split(",") if p.strip()]
+    invalid = [p for p in parts if p not in SCOPES]
+    if invalid:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown scope(s): {','.join(invalid)}. Valid: {','.join(SCOPES)}.",
+        )
+    return parts or list(SCOPES)
+
+
+@router.get("")
+async def search(
+    q: str = Query(..., min_length=1, max_length=MAX_QUERY_LEN),
+    scope: str | None = Query(None, max_length=200),
+    limit: int = Query(20, ge=1, le=MAX_LIMIT),
+    user: dict = Depends(get_current_user),
+):
+    """Return ranked FTS5 matches from the caller's own content.
+
+    Query params:
+      q     : required, 1..200 chars (trimmed; whitespace-only rejected)
+      scope : optional CSV of scope names (annotations,vocabulary,chapters).
+              Omitted → all scopes.
+      limit : optional, 1..50 results per scope.
+    """
+    if not q.strip():
+        raise HTTPException(status_code=400, detail="Query cannot be empty.")
+    scopes = _parse_scope(scope)
+    return await search_content(user_id=user["id"], q=q, scope=scopes, limit=limit)

--- a/backend/services/migrations.py
+++ b/backend/services/migrations.py
@@ -26,6 +26,65 @@ import aiosqlite
 _MIGRATIONS_DIR = os.path.join(os.path.dirname(__file__), "..", "migrations")
 
 
+def _split_sql_statements(sql: str) -> list[str]:
+    """Split a migration SQL blob into individual statements.
+
+    Splits on `;` at top level but keeps `BEGIN ... END` blocks (SQLite
+    triggers) intact — trigger bodies contain `;` separators that must not
+    terminate the outer CREATE TRIGGER statement.
+
+    Line comments (`-- ...`) are stripped first so semicolons inside
+    comments don't produce spurious empty/invalid fragments (#544).
+    """
+    sql_no_comments = re.sub(r"--[^\n]*", "", sql)
+
+    statements: list[str] = []
+    current: list[str] = []
+    in_trigger = 0  # BEGIN/END nesting depth
+    i = 0
+    n = len(sql_no_comments)
+
+    # Walk token-by-token on word boundaries to detect BEGIN/END
+    # (case-insensitive). Semicolons while in_trigger>0 are kept in current.
+    word_re = re.compile(r"\b(BEGIN|END)\b", re.IGNORECASE)
+    while i < n:
+        m = word_re.search(sql_no_comments, i)
+        # Find the next ';' in the remaining text (tracked for splitting).
+        next_semi = sql_no_comments.find(";", i)
+
+        # No more BEGIN/END tokens ahead of the next ';' — process the
+        # semicolon at the top level (or if none, consume the rest).
+        if not m or (next_semi != -1 and next_semi < m.start()):
+            if next_semi == -1:
+                current.append(sql_no_comments[i:])
+                break
+            current.append(sql_no_comments[i:next_semi])
+            if in_trigger > 0:
+                current.append(";")  # keep inner semi; it's part of the trigger body
+                i = next_semi + 1
+                continue
+            statements.append("".join(current).strip())
+            current = []
+            i = next_semi + 1
+            continue
+
+        # Consume up through the BEGIN/END token as part of current.
+        current.append(sql_no_comments[i:m.end()])
+        if m.group(0).upper() == "BEGIN":
+            in_trigger += 1
+        else:
+            # END — matches a BEGIN. Only semantically relevant inside trigger bodies.
+            if in_trigger > 0:
+                in_trigger -= 1
+        i = m.end()
+
+    if current:
+        stmt = "".join(current).strip()
+        if stmt:
+            statements.append(stmt)
+    return [s for s in statements if s]
+
+
 async def run(db_path: str) -> list[str]:
     """Apply all pending migrations and return the list of versions applied.
 
@@ -148,15 +207,13 @@ async def run(db_path: str) -> list[str]:
                 continue
 
             # Apply each statement in the migration file inside one transaction.
-            # We split on `;` because aiosqlite's execute() only runs one
-            # statement at a time. Strip -- line comments first so semicolons
-            # inside comments don't produce spurious empty/invalid fragments.
+            # We split on `;` at top level (keeping CREATE TRIGGER ... BEGIN ...
+            # END; blocks intact) because aiosqlite's execute() runs one
+            # statement at a time. Line comments are stripped first so
+            # semicolons inside comments don't produce spurious fragments (#544).
             try:
-                sql_no_comments = re.sub(r"--[^\n]*", "", sql)
-                for statement in sql_no_comments.split(";"):
-                    stmt = statement.strip()
-                    if stmt:
-                        await db.execute(stmt)
+                for stmt in _split_sql_statements(sql):
+                    await db.execute(stmt)
 
                 # Record this version as applied.
                 await db.execute(

--- a/backend/services/search.py
+++ b/backend/services/search.py
@@ -1,0 +1,153 @@
+"""Unified FTS5 search over user annotations, vocabulary context, and uploaded chapters.
+
+Issue #592, implementation of docs/design/fts5-in-app-search.md.
+
+Results are ALWAYS user-scoped — the user_id filter is applied on every
+JOIN back to the source table so one user's query never returns another
+user's content.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+import services.db as _db
+
+# Max chars per query — enforced at the router layer too, but we also
+# defensively cap inside the service in case of direct callers.
+MAX_QUERY_LEN = 200
+MAX_LIMIT = 50
+
+SCOPES = ("annotations", "vocabulary", "chapters")
+
+
+def _prepare_fts_query(q: str) -> str:
+    """Escape a user query for FTS5 MATCH.
+
+    FTS5 MATCH is not plain text — raw user input can produce parser errors
+    on unbalanced quotes, `AND`/`OR`/`NOT`, bare `*`, column filters, etc.
+    We wrap the stripped query in double quotes after escaping any internal
+    double quotes, turning the whole thing into a phrase search. Advanced
+    syntax (opt-in) is a follow-up design.
+    """
+    cleaned = q.strip()
+    # Escape embedded double quotes by doubling them, then wrap.
+    return '"' + cleaned.replace('"', '""') + '"'
+
+
+async def search_content(
+    user_id: int,
+    q: str,
+    scope: list[str] | None = None,
+    limit: int = 20,
+) -> dict:
+    """Run the FTS5 query across the requested scopes and return merged results.
+
+    Returns a dict with shape:
+        {"query": q, "results": [...], "total": int}
+    Each result has a "type" key in {"annotation", "vocabulary", "chapter"}.
+    """
+    q = (q or "").strip()
+    if not q:
+        return {"query": q, "results": [], "total": 0}
+    if len(q) > MAX_QUERY_LEN:
+        q = q[:MAX_QUERY_LEN]
+    if scope is None:
+        scope = list(SCOPES)
+    scope = [s for s in scope if s in SCOPES]
+    if not scope:
+        return {"query": q, "results": [], "total": 0}
+    if limit < 1:
+        limit = 1
+    if limit > MAX_LIMIT:
+        limit = MAX_LIMIT
+
+    match_q = _prepare_fts_query(q)
+    results: list[dict] = []
+
+    async with aiosqlite.connect(_db.DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+
+        if "annotations" in scope:
+            async with db.execute(
+                """
+                SELECT a.id, a.book_id, b.title AS book_title, a.chapter_index,
+                       a.note_text,
+                       snippet(annotations_fts, 0, '<b>', '</b>', '…', 20) AS snippet
+                FROM annotations_fts
+                JOIN annotations a ON annotations_fts.rowid = a.id
+                LEFT JOIN books b ON a.book_id = b.id
+                WHERE annotations_fts MATCH ? AND a.user_id = ?
+                ORDER BY rank
+                LIMIT ?
+                """,
+                (match_q, user_id, limit),
+            ) as cur:
+                async for row in cur:
+                    results.append({
+                        "type": "annotation",
+                        "id": row["id"],
+                        "book_id": row["book_id"],
+                        "book_title": row["book_title"] or "",
+                        "chapter_index": row["chapter_index"],
+                        "snippet": row["snippet"],
+                        "note_text": row["note_text"],
+                    })
+
+        if "vocabulary" in scope:
+            async with db.execute(
+                """
+                SELECT v.word, wo.id AS occurrence_id, wo.book_id,
+                       b.title AS book_title, wo.chapter_index,
+                       snippet(word_occurrences_fts, 0, '<b>', '</b>', '…', 20) AS snippet
+                FROM word_occurrences_fts
+                JOIN word_occurrences wo ON word_occurrences_fts.rowid = wo.id
+                JOIN vocabulary v ON wo.vocabulary_id = v.id
+                LEFT JOIN books b ON wo.book_id = b.id
+                WHERE word_occurrences_fts MATCH ? AND v.user_id = ?
+                ORDER BY rank
+                LIMIT ?
+                """,
+                (match_q, user_id, limit),
+            ) as cur:
+                async for row in cur:
+                    results.append({
+                        "type": "vocabulary",
+                        "word": row["word"],
+                        "occurrence_id": row["occurrence_id"],
+                        "book_id": row["book_id"],
+                        "book_title": row["book_title"] or "",
+                        "chapter_index": row["chapter_index"],
+                        "snippet": row["snippet"],
+                    })
+
+        if "chapters" in scope:
+            async with db.execute(
+                """
+                SELECT uc.id, uc.book_id, b.title AS book_title, uc.chapter_index,
+                       uc.title AS chapter_title,
+                       snippet(user_chapters_fts, 1, '<b>', '</b>', '…', 30) AS snippet
+                FROM user_chapters_fts
+                JOIN user_book_chapters uc ON user_chapters_fts.rowid = uc.id
+                JOIN books b ON uc.book_id = b.id
+                WHERE user_chapters_fts MATCH ?
+                  AND uc.is_draft = 0
+                  AND b.source = 'upload'
+                  AND b.owner_user_id = ?
+                ORDER BY rank
+                LIMIT ?
+                """,
+                (match_q, user_id, limit),
+            ) as cur:
+                async for row in cur:
+                    results.append({
+                        "type": "chapter",
+                        "id": row["id"],
+                        "book_id": row["book_id"],
+                        "book_title": row["book_title"] or "",
+                        "chapter_index": row["chapter_index"],
+                        "chapter_title": row["chapter_title"],
+                        "snippet": row["snippet"],
+                    })
+
+    return {"query": q, "results": results, "total": len(results)}

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -93,19 +93,27 @@ def auth_headers(test_user):
 def insert_private_book():
     """Return a coroutine that inserts an upload-sourced private book owned by the given user.
 
+    Chapters are written to `user_book_chapters` (issue #357). `books.text`
+    stays empty, matching the post-migration contract.
+
     Usage in tests::
 
         await insert_private_book(book_id=8801, owner_user_id=owner["id"])
     """
     async def _impl(book_id: int, owner_user_id: int) -> None:
-        chapters = json.dumps({"draft": False, "chapters": [{"title": "Ch1", "text": "private"}]})
         async with aiosqlite.connect(db_module.DB_PATH) as db:
             await db.execute(
                 """INSERT OR REPLACE INTO books
                    (id, title, authors, languages, subjects, download_count,
                     cover, text, images, source, owner_user_id)
-                   VALUES (?, 'Private', '[]', '["en"]', '[]', 0, '', ?, '[]', 'upload', ?)""",
-                (book_id, chapters, owner_user_id),
+                   VALUES (?, 'Private', '[]', '["en"]', '[]', 0, '', '', '[]', 'upload', ?)""",
+                (book_id, owner_user_id),
+            )
+            await db.execute(
+                "INSERT OR REPLACE INTO user_book_chapters "
+                "(book_id, chapter_index, title, text, is_draft) "
+                "VALUES (?, 0, 'Ch1', 'private', 0)",
+                (book_id,),
             )
             await db.commit()
     return _impl

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -846,6 +846,38 @@ async def test_migration_025_user_book_chapters_table_created(tmp_db):
     assert cols == {"id", "book_id", "chapter_index", "title", "text", "is_draft"}
 
 
+# ── SQL splitter keeps CREATE TRIGGER BEGIN...END blocks intact ─────────────
+
+async def test_trigger_migration_applies_cleanly(tmp_db, tmp_migrations, monkeypatch):
+    """Regression for #648: migration files containing CREATE TRIGGER ... BEGIN
+    statement1; statement2; END; must apply cleanly — the runner must keep
+    the BEGIN..END block together and not split it on the inner semicolons."""
+    sql = (
+        "CREATE TABLE trigger_test_src (id INTEGER PRIMARY KEY, v TEXT);\n"
+        "CREATE TABLE trigger_test_dst (src_id INTEGER, v1 TEXT, v2 TEXT);\n"
+        "CREATE TRIGGER tts_ai AFTER INSERT ON trigger_test_src\n"
+        "BEGIN\n"
+        "    INSERT INTO trigger_test_dst (src_id, v1, v2) VALUES (new.id, new.v, 'a');\n"
+        "    INSERT INTO trigger_test_dst (src_id, v1, v2) VALUES (new.id, new.v, 'b');\n"
+        "END;\n"
+    )
+    (open(os.path.join(tmp_migrations, "001_trigger.sql"), "w")).write(sql)
+    monkeypatch.setattr("services.migrations._MIGRATIONS_DIR", tmp_migrations)
+
+    applied = await run_migrations(tmp_db)
+    assert "001_trigger" in applied
+
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute("INSERT INTO trigger_test_src (v) VALUES ('x')")
+        await db.commit()
+        async with db.execute(
+            "SELECT COUNT(*) FROM trigger_test_dst WHERE src_id=1"
+        ) as cur:
+            count = (await cur.fetchone())[0]
+        # Both trigger-body statements ran — splitter preserved BEGIN..END.
+        assert count == 2
+
+
 async def test_migration_025_unique_constraint_enforced(tmp_db):
     """user_book_chapters (book_id, chapter_index) UNIQUE must reject duplicates."""
     await run_migrations(tmp_db)

--- a/backend/tests/test_router_search.py
+++ b/backend/tests/test_router_search.py
@@ -1,0 +1,288 @@
+"""FTS5 in-app search router + service tests (issue #592, #648).
+
+Covers:
+  - user-scoping on every scope (one user cannot see another user's content)
+  - input validation (empty query, max length, invalid scope)
+  - snippet highlighting + rank ordering
+  - draft chapters excluded from search
+  - FTS sync triggers keep the index consistent on insert/update/delete
+  - search-query sanitisation (special FTS5 syntax does not crash)
+"""
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+import services.db as db_module
+from services.db import get_or_create_user
+from services.search import search_content, _prepare_fts_query
+
+
+OTHER_USER = {
+    "google_id": "other-google-id",
+    "email": "other@example.com",
+    "name": "Other",
+    "picture": "",
+}
+
+
+async def _seed_annotation(db, user_id: int, book_id: int, chapter_index: int,
+                           sentence: str, note: str = ""):
+    cur = await db.execute(
+        """INSERT INTO annotations (user_id, book_id, chapter_index, sentence_text, note_text)
+           VALUES (?, ?, ?, ?, ?)""",
+        (user_id, book_id, chapter_index, sentence, note),
+    )
+    return cur.lastrowid
+
+
+async def _seed_vocab_occurrence(db, user_id: int, word: str, book_id: int,
+                                 chapter_index: int, sentence: str):
+    cur = await db.execute(
+        "INSERT INTO vocabulary (user_id, word, lemma, language) VALUES (?, ?, ?, 'en')",
+        (user_id, word, word),
+    )
+    vid = cur.lastrowid
+    cur2 = await db.execute(
+        """INSERT INTO word_occurrences (vocabulary_id, book_id, chapter_index, sentence_text)
+           VALUES (?, ?, ?, ?)""",
+        (vid, book_id, chapter_index, sentence),
+    )
+    return vid, cur2.lastrowid
+
+
+async def _seed_upload(db, owner_user_id: int, book_id: int, chapters: list[tuple[str, str]],
+                      is_draft: int = 0):
+    """Seed an upload-sourced book with user_book_chapters rows."""
+    await db.execute(
+        """INSERT OR REPLACE INTO books
+           (id, title, authors, languages, subjects, download_count,
+            cover, text, images, source, owner_user_id)
+           VALUES (?, ?, '[]', '[]', '[]', 0, '', '', '[]', 'upload', ?)""",
+        (book_id, f"book-{book_id}", owner_user_id),
+    )
+    for i, (title, text) in enumerate(chapters):
+        await db.execute(
+            "INSERT OR REPLACE INTO user_book_chapters "
+            "(book_id, chapter_index, title, text, is_draft) VALUES (?, ?, ?, ?, ?)",
+            (book_id, i, title, text, is_draft),
+        )
+
+
+# ── Service-level coverage ────────────────────────────────────────────────────
+
+async def test_search_annotation_match(client, test_user):
+    """Happy path: a word in the user's annotation is findable."""
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await _seed_annotation(db, test_user["id"], 42, 3,
+                               "The foreshadowing is clear in this passage.", "K's first court")
+        await db.commit()
+
+    res = await client.get("/api/search?q=foreshadowing")
+    assert res.status_code == 200, res.text
+    data = res.json()
+    assert data["total"] == 1
+    hit = data["results"][0]
+    assert hit["type"] == "annotation"
+    assert "<b>foreshadowing</b>" in hit["snippet"]
+    assert hit["note_text"] == "K's first court"
+
+
+async def test_search_vocabulary_match(client, test_user):
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await _seed_vocab_occurrence(db, test_user["id"], "Weltschmerz", 1234, 2,
+                                     "The protagonist is filled with Weltschmerz today.")
+        await db.commit()
+
+    res = await client.get("/api/search?q=Weltschmerz")
+    assert res.status_code == 200, res.text
+    data = res.json()
+    assert data["total"] == 1
+    hit = data["results"][0]
+    assert hit["type"] == "vocabulary"
+    assert hit["word"] == "Weltschmerz"
+
+
+async def test_search_chapter_match_and_skips_drafts(client, test_user):
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        # Confirmed chapter: should be searchable.
+        await _seed_upload(db, test_user["id"], 5001,
+                           [("Chapter One", "The kestrel flew across the sky.")], is_draft=0)
+        # Draft chapter: must NOT appear in search results.
+        await _seed_upload(db, test_user["id"], 5002,
+                           [("Draft", "The kestrel screamed loudly here.")], is_draft=1)
+        await db.commit()
+
+    res = await client.get("/api/search?q=kestrel")
+    assert res.status_code == 200, res.text
+    data = res.json()
+    assert data["total"] == 1
+    hit = data["results"][0]
+    assert hit["type"] == "chapter"
+    assert hit["book_id"] == 5001
+    assert hit["chapter_title"] == "Chapter One"
+
+
+async def test_search_user_scoped_annotations(client, test_user):
+    """User A's query must not surface user B's annotations."""
+    other = await get_or_create_user(**OTHER_USER)
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await _seed_annotation(db, other["id"], 42, 3, "secret foreshadowing content", "")
+        await db.commit()
+
+    res = await client.get("/api/search?q=foreshadowing")
+    assert res.status_code == 200
+    assert res.json()["total"] == 0
+
+
+async def test_search_user_scoped_vocabulary(client, test_user):
+    other = await get_or_create_user(**OTHER_USER)
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await _seed_vocab_occurrence(db, other["id"], "Schadenfreude", 1234, 2,
+                                     "filled with Schadenfreude")
+        await db.commit()
+    res = await client.get("/api/search?q=Schadenfreude")
+    assert res.json()["total"] == 0
+
+
+async def test_search_user_scoped_chapters(client, test_user):
+    other = await get_or_create_user(**OTHER_USER)
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await _seed_upload(db, other["id"], 6001,
+                           [("Secret", "a zebra roamed the plains")], is_draft=0)
+        await db.commit()
+    res = await client.get("/api/search?q=zebra")
+    assert res.json()["total"] == 0
+
+
+async def test_confirm_transition_makes_chapter_searchable(client, test_user):
+    """A chapter that starts as draft appears in search only after is_draft=0."""
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await _seed_upload(db, test_user["id"], 7001,
+                           [("Hidden", "a unicorn wandered in")], is_draft=1)
+        await db.commit()
+
+    # Before confirm: 0 hits.
+    res = await client.get("/api/search?q=unicorn")
+    assert res.json()["total"] == 0
+
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            "UPDATE user_book_chapters SET is_draft=0 WHERE book_id=7001"
+        )
+        await db.commit()
+
+    res = await client.get("/api/search?q=unicorn")
+    assert res.json()["total"] == 1
+
+
+async def test_word_occurrence_update_reindexes(client, test_user):
+    """Updating word_occurrence.sentence_text rebuilds the FTS entry (word_occ_au)."""
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        _, occ_id = await _seed_vocab_occurrence(
+            db, test_user["id"], "aurora", 1, 0, "The old sentence about clouds."
+        )
+        await db.commit()
+
+    res = await client.get("/api/search?q=clouds")
+    assert res.json()["total"] == 1
+
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            "UPDATE word_occurrences SET sentence_text = 'A new sentence about meteors.' WHERE id=?",
+            (occ_id,),
+        )
+        await db.commit()
+
+    # Old term gone, new term indexed.
+    assert (await client.get("/api/search?q=clouds")).json()["total"] == 0
+    assert (await client.get("/api/search?q=meteors")).json()["total"] == 1
+
+
+async def test_scope_filter_annotations_only(client, test_user):
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await _seed_annotation(db, test_user["id"], 1, 0, "cat hat bat", "")
+        await _seed_vocab_occurrence(db, test_user["id"], "bat", 1, 0, "a vampire bat at night")
+        await db.commit()
+
+    res = await client.get("/api/search?q=bat&scope=annotations")
+    hits = res.json()["results"]
+    assert all(h["type"] == "annotation" for h in hits)
+    assert len(hits) == 1
+
+
+async def test_invalid_scope_returns_400(client, test_user):
+    res = await client.get("/api/search?q=foo&scope=bogus")
+    assert res.status_code == 400
+    assert "scope" in res.json()["detail"].lower()
+
+
+async def test_empty_query_returns_422(client, test_user):
+    # FastAPI enforces min_length=1 at the query-param layer before our handler.
+    res = await client.get("/api/search?q=")
+    assert res.status_code == 422
+
+
+async def test_whitespace_only_query_returns_400(client, test_user):
+    res = await client.get("/api/search?q=%20%20")
+    assert res.status_code == 400
+
+
+async def test_query_max_length_rejected(client, test_user):
+    res = await client.get(f"/api/search?q={'x' * 201}")
+    assert res.status_code == 422
+
+
+async def test_limit_capped(client, test_user):
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        for i in range(60):
+            await _seed_annotation(db, test_user["id"], 1, i, f"needle match {i}", "")
+        await db.commit()
+    # Limit clamp: request 500 → 422 (Query ge/le enforced).
+    res = await client.get("/api/search?q=needle&limit=500")
+    assert res.status_code == 422
+    # Max valid limit = 50.
+    res = await client.get("/api/search?q=needle&limit=50")
+    assert res.status_code == 200
+    assert len(res.json()["results"]) == 50
+
+
+async def test_query_with_fts5_special_chars_does_not_crash(client, test_user):
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await _seed_annotation(db, test_user["id"], 1, 0,
+                               "AND OR NOT are special FTS5 operators", "")
+        await db.commit()
+    # Raw 'AND OR' would error without escaping; our phrase-wrap avoids that.
+    res = await client.get("/api/search?q=AND+OR")
+    assert res.status_code == 200
+    # The escaped phrase search should still find the annotation with that literal substring.
+    assert res.json()["total"] == 1
+
+
+async def test_prepare_fts_query_escapes_double_quotes():
+    assert _prepare_fts_query('he said "hello"') == '"he said ""hello"""'
+
+
+# ── Delete-cascade of FTS entries ────────────────────────────────────────────
+
+async def test_annotation_delete_removes_fts_entry(client, test_user):
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        aid = await _seed_annotation(db, test_user["id"], 1, 0, "kraken rising", "")
+        await db.commit()
+    assert (await client.get("/api/search?q=kraken")).json()["total"] == 1
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute("DELETE FROM annotations WHERE id=?", (aid,))
+        await db.commit()
+    assert (await client.get("/api/search?q=kraken")).json()["total"] == 0
+
+
+async def test_confirmed_chapter_delete_removes_fts_entry(client, test_user):
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await _seed_upload(db, test_user["id"], 7500,
+                           [("C", "narwhals are magnificent")], is_draft=0)
+        await db.commit()
+    assert (await client.get("/api/search?q=narwhals")).json()["total"] == 1
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute("DELETE FROM user_book_chapters WHERE book_id=7500")
+        await db.commit()
+    assert (await client.get("/api/search?q=narwhals")).json()["total"] == 0

--- a/frontend/e2e/home.spec.ts
+++ b/frontend/e2e/home.spec.ts
@@ -41,7 +41,7 @@ test("search for Faust returns result and displays it", async ({ page }) => {
   await page.goto("/");
   // No library → already on Discover tab
   await page.getByPlaceholder(/Search by title or author/).fill("Faust");
-  await page.getByRole("button", { name: "Search" }).click();
+  await page.getByRole("button", { name: "Search", exact: true }).click();
   await expect(page.getByText("Faust").first()).toBeVisible();
 });
 

--- a/frontend/e2e/modal.spec.ts
+++ b/frontend/e2e/modal.spec.ts
@@ -21,7 +21,7 @@ test.beforeEach(async ({ page }) => {
 test("clicking a search result opens the book detail modal", async ({ page }) => {
   await page.goto("/");
   await page.getByPlaceholder(/Search by title or author/).fill("Faust");
-  await page.getByRole("button", { name: "Search" }).click();
+  await page.getByRole("button", { name: "Search", exact: true }).click();
   await expect(page.getByText("Faust").first()).toBeVisible();
 
   await page.getByRole("button").filter({ hasText: "Goethe" }).first().click();
@@ -50,7 +50,7 @@ test("modal shows Continue Reading for a book in the library", async ({ page }) 
 test("modal CTA navigates to reader", async ({ page }) => {
   await page.goto("/");
   await page.getByPlaceholder(/Search by title or author/).fill("Faust");
-  await page.getByRole("button", { name: "Search" }).click();
+  await page.getByRole("button", { name: "Search", exact: true }).click();
 
   await page.getByRole("button").filter({ hasText: "Goethe" }).first().click();
   await page.getByRole("button", { name: /Start Reading/ }).click();
@@ -62,7 +62,7 @@ test("modal CTA navigates to reader", async ({ page }) => {
 test("modal closes when clicking the close button", async ({ page }) => {
   await page.goto("/");
   await page.getByPlaceholder(/Search by title or author/).fill("Faust");
-  await page.getByRole("button", { name: "Search" }).click();
+  await page.getByRole("button", { name: "Search", exact: true }).click();
 
   await page.getByRole("button").filter({ hasText: "Goethe" }).first().click();
   await expect(page.getByRole("heading", { name: "Faust" })).toBeVisible();
@@ -74,7 +74,7 @@ test("modal closes when clicking the close button", async ({ page }) => {
 test("modal closes on Escape key", async ({ page }) => {
   await page.goto("/");
   await page.getByPlaceholder(/Search by title or author/).fill("Faust");
-  await page.getByRole("button", { name: "Search" }).click();
+  await page.getByRole("button", { name: "Search", exact: true }).click();
 
   await page.getByRole("button").filter({ hasText: "Goethe" }).first().click();
   await expect(page.getByRole("heading", { name: "Faust" })).toBeVisible();
@@ -86,7 +86,7 @@ test("modal closes on Escape key", async ({ page }) => {
 test("modal shows language tag for the book", async ({ page }) => {
   await page.goto("/");
   await page.getByPlaceholder(/Search by title or author/).fill("Faust");
-  await page.getByRole("button", { name: "Search" }).click();
+  await page.getByRole("button", { name: "Search", exact: true }).click();
 
   await page.getByRole("button").filter({ hasText: "Goethe" }).first().click();
 

--- a/frontend/src/__tests__/HomePage.test.tsx
+++ b/frontend/src/__tests__/HomePage.test.tsx
@@ -328,7 +328,8 @@ describe("HomePage — Library tab with books", () => {
     await act(flushPromises);
     await user.click(screen.getByRole("button", { name: /Home/i }));
     await user.click(screen.getByRole("button", { name: "Discover Books" }));
-    expect(screen.getByRole("button", { name: /Search/i })).toBeInTheDocument();
+    // Use exact-match to avoid matching the global header "Open search" button (SearchBar).
+    expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/__tests__/SearchBar.test.tsx
+++ b/frontend/src/__tests__/SearchBar.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+import { SearchBar } from "@/components/SearchBar";
+
+describe("SearchBar", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+  });
+
+  it("starts collapsed with an aria-labeled open button", () => {
+    render(<SearchBar />);
+    expect(screen.getByRole("button", { name: /open search/i })).toBeInTheDocument();
+    expect(screen.queryByRole("search")).not.toBeInTheDocument();
+  });
+
+  it("expands on click and shows an input", async () => {
+    const user = userEvent.setup();
+    render(<SearchBar />);
+    await user.click(screen.getByRole("button", { name: /open search/i }));
+    const input = screen.getByLabelText(/search your content/i);
+    expect(input).toBeInTheDocument();
+  });
+
+  it("navigates to /search with encoded query on Enter", async () => {
+    const user = userEvent.setup();
+    render(<SearchBar />);
+    await user.click(screen.getByRole("button", { name: /open search/i }));
+    const input = screen.getByLabelText(/search your content/i);
+    await user.type(input, "Kafka & Trial{Enter}");
+    expect(mockPush).toHaveBeenCalledWith("/search?q=Kafka%20%26%20Trial");
+  });
+
+  it("does not navigate for whitespace-only queries", async () => {
+    const user = userEvent.setup();
+    render(<SearchBar />);
+    await user.click(screen.getByRole("button", { name: /open search/i }));
+    const input = screen.getByLabelText(/search your content/i);
+    await user.type(input, "   {Enter}");
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("collapses on Escape", async () => {
+    const user = userEvent.setup();
+    render(<SearchBar />);
+    await user.click(screen.getByRole("button", { name: /open search/i }));
+    const input = screen.getByLabelText(/search your content/i);
+    await user.type(input, "foo{Escape}");
+    expect(screen.queryByLabelText(/search your content/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /open search/i })).toBeInTheDocument();
+  });
+
+  it("caps input at 200 characters", async () => {
+    const user = userEvent.setup();
+    render(<SearchBar />);
+    await user.click(screen.getByRole("button", { name: /open search/i }));
+    const input = screen.getByLabelText(/search your content/i) as HTMLInputElement;
+    expect(input.getAttribute("maxLength")).toBe("200");
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,6 +6,7 @@ import BookCard from "@/components/BookCard";
 import BookDetailModal from "@/components/BookDetailModal";
 import ReadingStats from "@/components/ReadingStats";
 import { FireIcon, ArrowLeftIcon, ArrowRightIcon, BookOpenIcon, NoteIcon, InsightIcon, VocabIcon, BookCoverPlaceholderIcon, GlobeIcon, SummaryIcon, SpeakerIcon, GridViewIcon, ListViewIcon } from "@/components/Icons";
+import { SearchBar } from "@/components/SearchBar";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 
@@ -172,29 +173,32 @@ export default function Home() {
               <p className="text-xs md:text-sm text-amber-800 mt-0.5">Public domain classics with AI assistance</p>
             </div>
           </div>
-          {status === "unauthenticated" ? (
-            <button
-              onClick={() => router.push("/login")}
-              className="rounded-lg border border-amber-300 px-4 py-2.5 md:py-1.5 text-sm font-medium text-amber-700 hover:bg-amber-50 transition-colors min-h-[44px]"
-            >
-              Sign in
-            </button>
-          ) : (
-            <button
-              onClick={() => router.push("/profile")}
-              title={session?.backendUser?.name ?? "Profile & Settings"}
-              className="w-10 h-10 md:w-9 md:h-9 rounded-full overflow-hidden border border-amber-200 hover:border-amber-400 transition-colors"
-            >
-              {session?.backendUser?.picture ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img src={session.backendUser.picture} alt="profile" className="w-full h-full object-cover" />
-              ) : (
-                <span className="w-full h-full flex items-center justify-center bg-amber-100 text-amber-700 text-sm font-bold">
-                  {session?.backendUser?.name?.[0] ?? "?"}
-                </span>
-              )}
-            </button>
-          )}
+          <div className="flex items-center gap-2">
+            {status === "authenticated" ? <SearchBar /> : null}
+            {status === "unauthenticated" ? (
+              <button
+                onClick={() => router.push("/login")}
+                className="rounded-lg border border-amber-300 px-4 py-2.5 md:py-1.5 text-sm font-medium text-amber-700 hover:bg-amber-50 transition-colors min-h-[44px]"
+              >
+                Sign in
+              </button>
+            ) : (
+              <button
+                onClick={() => router.push("/profile")}
+                title={session?.backendUser?.name ?? "Profile & Settings"}
+                className="w-10 h-10 md:w-9 md:h-9 rounded-full overflow-hidden border border-amber-200 hover:border-amber-400 transition-colors"
+              >
+                {session?.backendUser?.picture ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={session.backendUser.picture} alt="profile" className="w-full h-full object-cover" />
+                ) : (
+                  <span className="w-full h-full flex items-center justify-center bg-amber-100 text-amber-700 text-sm font-bold">
+                    {session?.backendUser?.name?.[0] ?? "?"}
+                  </span>
+                )}
+              </button>
+            )}
+          </div>
         </div>
       </header>
 

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
+
+import { SearchIcon } from "@/components/Icons";
+import { InAppSearchResponse, InAppSearchResult, searchInAppContent } from "@/lib/api";
+
+function SnippetHtml({ snippet }: { snippet: string }) {
+  // Backend returns snippets containing only `<b>…</b>` wrappers; safe to render.
+  // We strip any other angle brackets defensively before rendering.
+  const clean = snippet.replace(/<(?!\/?b\b)[^>]*>/g, "");
+  return (
+    <span
+      className="text-sm text-ink"
+      dangerouslySetInnerHTML={{ __html: clean }}
+    />
+  );
+}
+
+function AnnotationCard({ r }: { r: Extract<InAppSearchResult, { type: "annotation" }> }) {
+  const href = `/reader/${r.book_id}?chapter=${r.chapter_index}`;
+  return (
+    <Link
+      href={href}
+      className="block p-4 rounded-md border border-amber-200 bg-parchment hover:-translate-y-0.5 transition-all duration-200"
+      style={{ boxShadow: "var(--shadow-card)" }}
+    >
+      <div className="flex items-baseline justify-between gap-2 mb-1">
+        <div className="font-serif text-base text-ink">{r.book_title || `Book #${r.book_id}`}</div>
+        <div className="text-xs text-stone-500">Annotation · Ch.&nbsp;{r.chapter_index + 1}</div>
+      </div>
+      <SnippetHtml snippet={r.snippet} />
+      {r.note_text ? (
+        <div className="mt-2 text-xs text-stone-600 italic">{r.note_text}</div>
+      ) : null}
+    </Link>
+  );
+}
+
+function VocabularyCard({ r }: { r: Extract<InAppSearchResult, { type: "vocabulary" }> }) {
+  const href = `/vocabulary`;
+  return (
+    <Link
+      href={href}
+      className="block p-4 rounded-md border border-amber-200 bg-parchment hover:-translate-y-0.5 transition-all duration-200"
+      style={{ boxShadow: "var(--shadow-card)" }}
+    >
+      <div className="flex items-baseline justify-between gap-2 mb-1">
+        <div className="font-serif text-base text-ink">{r.word}</div>
+        <div className="text-xs text-stone-500">Vocabulary · Ch.&nbsp;{r.chapter_index + 1}</div>
+      </div>
+      <SnippetHtml snippet={r.snippet} />
+      <div className="mt-2 text-xs text-stone-600">in {r.book_title || `Book #${r.book_id}`}</div>
+    </Link>
+  );
+}
+
+function ChapterCard({ r }: { r: Extract<InAppSearchResult, { type: "chapter" }> }) {
+  const href = `/reader/${r.book_id}?chapter=${r.chapter_index}`;
+  return (
+    <Link
+      href={href}
+      className="block p-4 rounded-md border border-amber-200 bg-parchment hover:-translate-y-0.5 transition-all duration-200"
+      style={{ boxShadow: "var(--shadow-card)" }}
+    >
+      <div className="flex items-baseline justify-between gap-2 mb-1">
+        <div className="font-serif text-base text-ink">
+          {r.book_title || `Book #${r.book_id}`} — {r.chapter_title || `Chapter ${r.chapter_index + 1}`}
+        </div>
+        <div className="text-xs text-stone-500">Chapter</div>
+      </div>
+      <SnippetHtml snippet={r.snippet} />
+    </Link>
+  );
+}
+
+function ResultCard({ r }: { r: InAppSearchResult }) {
+  if (r.type === "annotation") return <AnnotationCard r={r} />;
+  if (r.type === "vocabulary") return <VocabularyCard r={r} />;
+  return <ChapterCard r={r} />;
+}
+
+function ResultsSection({ title, items }: { title: string; items: InAppSearchResult[] }) {
+  if (!items.length) return null;
+  return (
+    <section className="space-y-3">
+      <h2 className="text-sm uppercase tracking-wide text-stone-500">
+        {title} · {items.length}
+      </h2>
+      <div className="grid gap-3">
+        {items.map((r, i) => (
+          <ResultCard key={`${r.type}-${i}`} r={r} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function SearchResultsInner() {
+  const params = useSearchParams();
+  const q = params?.get("q") ?? "";
+  const [data, setData] = useState<InAppSearchResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!q.trim()) {
+      setData(null);
+      setError(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    searchInAppContent(q)
+      .then((d) => {
+        setData(d);
+        setLoading(false);
+      })
+      .catch((e) => {
+        setError(e?.message ?? "Search failed");
+        setLoading(false);
+      });
+  }, [q]);
+
+  if (!q.trim()) {
+    return (
+      <div className="text-center text-stone-500 py-16">
+        <SearchIcon className="w-10 h-10 mx-auto mb-2 text-stone-400" />
+        <p className="font-serif text-lg text-ink">Search your notes, vocabulary, and uploads</p>
+        <p className="text-sm mt-2">Start typing in the search bar.</p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return <div className="text-sm text-stone-500 py-8">Searching…</div>;
+  }
+  if (error) {
+    return <div className="text-sm text-red-700 py-8">Error: {error}</div>;
+  }
+  if (!data || data.total === 0) {
+    return (
+      <div className="text-center text-stone-500 py-12">
+        <p className="font-serif text-lg text-ink">No matches for “{q}”.</p>
+        <p className="text-sm mt-2">Try a shorter or different word.</p>
+      </div>
+    );
+  }
+
+  const annotations = data.results.filter((r): r is Extract<InAppSearchResult, { type: "annotation" }> => r.type === "annotation");
+  const vocabulary = data.results.filter((r): r is Extract<InAppSearchResult, { type: "vocabulary" }> => r.type === "vocabulary");
+  const chapters = data.results.filter((r): r is Extract<InAppSearchResult, { type: "chapter" }> => r.type === "chapter");
+
+  return (
+    <div className="space-y-10">
+      <ResultsSection title="Annotations" items={annotations} />
+      <ResultsSection title="Vocabulary" items={vocabulary} />
+      <ResultsSection title="Chapters" items={chapters} />
+    </div>
+  );
+}
+
+export default function SearchPage() {
+  return (
+    <main className="max-w-3xl mx-auto p-4 md:p-8">
+      <h1 className="font-serif text-2xl text-ink mb-6">Search</h1>
+      <Suspense fallback={<div className="text-sm text-stone-500 py-8">Loading…</div>}>
+        <SearchResultsInner />
+      </Suspense>
+    </main>
+  );
+}

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -413,3 +413,12 @@ export function ListViewIcon({ className = "w-4 h-4" }: IconProps) {
     </svg>
   );
 }
+
+export function SearchIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="11" cy="11" r="7"/>
+      <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+    </svg>
+  );
+}

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { SearchIcon } from "@/components/Icons";
+
+/** Collapsible header search. Click the icon to expand an input; submit navigates
+ *  to /search?q=... Keyboard shortcut `/` focuses the input (if not typing elsewhere). */
+export function SearchBar() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const focusInput = useCallback(() => {
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, []);
+
+  // Global keyboard shortcut: "/" opens the search bar unless the user is
+  // already typing inside an input/textarea/contentEditable.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "/") return;
+      const el = e.target as HTMLElement | null;
+      if (!el) return;
+      const tag = el.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || el.isContentEditable) return;
+      e.preventDefault();
+      setOpen(true);
+      focusInput();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [focusInput]);
+
+  const submit = () => {
+    const q = query.trim();
+    if (!q) return;
+    router.push(`/search?q=${encodeURIComponent(q)}`);
+    setOpen(false);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      submit();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setQuery("");
+      setOpen(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        aria-label="Open search"
+        onClick={() => {
+          setOpen(true);
+          focusInput();
+        }}
+        className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded-md text-ink hover:bg-amber-100 transition-colors"
+      >
+        <SearchIcon className="w-5 h-5" />
+      </button>
+    );
+  }
+
+  return (
+    <form
+      role="search"
+      onSubmit={(e) => {
+        e.preventDefault();
+        submit();
+      }}
+      className="inline-flex items-center gap-2 min-h-[44px] px-2 border border-amber-200 rounded-md bg-parchment animate-fade-in"
+    >
+      <SearchIcon className="w-4 h-4 text-ink" />
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder="Search notes, vocabulary, chapters…"
+        aria-label="Search your content"
+        maxLength={200}
+        className="bg-transparent outline-none min-w-[14rem] py-1 text-sm text-ink placeholder:text-stone-400"
+      />
+      <button
+        type="button"
+        aria-label="Close search"
+        onClick={() => {
+          setQuery("");
+          setOpen(false);
+        }}
+        className="text-xs text-stone-500 hover:text-ink"
+      >
+        Esc
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -77,6 +77,52 @@ export function searchBooks(query: string, language = "", page = 1) {
   return request<{ count: number; books: BookMeta[] }>(`/books/search?${params}`);
 }
 
+// In-app FTS5 search over user content (issue #648).
+export type InAppSearchResult =
+  | {
+      type: "annotation";
+      id: number;
+      book_id: number;
+      book_title: string;
+      chapter_index: number;
+      snippet: string;
+      note_text: string;
+    }
+  | {
+      type: "vocabulary";
+      word: string;
+      occurrence_id: number;
+      book_id: number;
+      book_title: string;
+      chapter_index: number;
+      snippet: string;
+    }
+  | {
+      type: "chapter";
+      id: number;
+      book_id: number;
+      book_title: string;
+      chapter_index: number;
+      chapter_title: string;
+      snippet: string;
+    };
+
+export interface InAppSearchResponse {
+  query: string;
+  results: InAppSearchResult[];
+  total: number;
+}
+
+export function searchInAppContent(
+  q: string,
+  scope?: Array<"annotations" | "vocabulary" | "chapters">,
+  limit = 20,
+) {
+  const params = new URLSearchParams({ q, limit: String(limit) });
+  if (scope && scope.length) params.set("scope", scope.join(","));
+  return request<InAppSearchResponse>(`/search?${params}`);
+}
+
 export function getCachedBooks() {
   return request<BookMeta[]>("/books/cached");
 }


### PR DESCRIPTION
## Summary

Implements the FTS5 design merged in PR #596. Adds a unified full-text search across each user's own annotations, vocabulary context, and confirmed uploaded chapters.

Closes #648.

## What shipped

**Schema (migration 026)**
- `annotations_fts`, `word_occurrences_fts`, `user_chapters_fts` — all external-content FTS5.
- Triggers (AI / AD / AU) keep indexes in sync. `user_chapters_*` triggers are gated on `is_draft=0` so drafts never appear in search.

**Migration runner**
- `services/migrations._split_sql_statements` now keeps `CREATE TRIGGER ... BEGIN ... END;` blocks intact — required because 026 contains triggers whose bodies contain their own semicolons.

**Backend**
- `services/search.py::search_content` — user-scoped queries with snippet highlighting, rank ordering, and phrase-quoted input so raw `AND`/`OR`/`NOT`/`*` do not break the FTS parser.
- `routers/search.py::GET /search` — `q` (1..200 chars, whitespace-only rejected), `scope` (csv subset of `annotations,vocabulary,chapters`), `limit` (1..50).

**Frontend**
- `SearchBar` component in the home header (auth-gated): collapsed icon button → expanded input, `/` keyboard shortcut, 44px touch target, aria-labelled.
- `/search` results page: sectioned cards per scope, snippet HTML sanitised to a `<b>`-only whitelist before `dangerouslySetInnerHTML`.
- `SearchIcon` added to `Icons.tsx`, `searchInAppContent()` client helper in `lib/api.ts`.

## Tests

- **Backend**: 18 new tests in `test_router_search.py` + 1 trigger-splitter regression in `test_migrations.py` + the `insert_private_book` conftest fixture migrated to the post-#357 contract. **Full backend suite: 1236 passed.**
- **Frontend**: 6 new SearchBar tests; minor exact-match fix in `HomePage.test.tsx` to disambiguate from the new global "Open search" button. **Full frontend suite: 1641 passed (`--runInBand`).**

## Deployment

Migration 026 applies on backend deploy. Populate happens in the `INSERT INTO <fts> SELECT ... FROM <source>` seed line — so the search index is live as soon as the migration runs. For databases with no prior annotations/vocabulary/chapters, the index is empty until rows appear.

## PM design-review conditions (honored)

1. ✅ Missing `word_occ_au` trigger added.
2. ✅ `user_chapters_*` triggers gated on `is_draft=0`; composed AU triggers cover all four draft/confirm transitions.
3. ✅ Implementation order lock: this PR is opened only after #357 (user_book_chapters, PR #649) merged.

## Test plan

- [ ] Migration applies cleanly on an existing DB with pre-existing annotations + vocabulary + confirmed uploaded chapters
- [ ] User A's search does not return user B's content
- [ ] Draft chapter is NOT found; after confirm it IS found
- [ ] Query with `AND OR NOT` does not 500 (phrase-quoted)
- [ ] Frontend search bar collapses/expands with `/` and Esc; enter navigates to `/search?q=...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
