### PR TITLE
fix: add ge=1 to admin uploads user_id query param and QueuePlanRequest.book_ids elements (closes #736)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -926,7 +926,7 @@ async def queue_stop(_admin: dict = Depends(_require_admin)):
 
 class QueuePlanRequest(BaseModel):
     target_language: str = Field(..., max_length=20)
-    book_ids: list[int] | None = None
+    book_ids: list[Annotated[int, Field(ge=1)]] | None = None
 
 
 @router.post("/queue/plan")
@@ -1291,7 +1291,7 @@ async def queue_enqueue_all(admin: dict = Depends(_require_admin)):
 
 @router.get("/uploads")
 async def get_uploads(
-    user_id: int | None = Query(default=None),
+    user_id: int | None = Query(default=None, ge=1),
     _admin: dict = Depends(_require_admin),
 ):
     """Return all user-uploaded books with uploader information.

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1095,7 +1095,7 @@ async def queue_set_settings(
 @router.get("/queue/items")
 async def queue_items(
     status: str | None = Query(default=None, max_length=20),
-    book_id: int | None = None,
+    book_id: int | None = Query(default=None, ge=1),
     limit: int = Query(default=200, ge=1, le=1000),
     _admin: dict = Depends(_require_admin),
 ):

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -2731,3 +2731,9 @@ async def test_queue_dry_run_negative_book_id_in_list_returns_422(admin_client):
         json={"target_language": "zh", "book_ids": [-1]},
     )
     assert res.status_code == 422, f"Expected 422 for negative book_id in list, got {res.status_code}: {res.text}"
+
+
+async def test_queue_items_negative_book_id_returns_422(admin_client):
+    """Regression #736: GET /admin/queue/items?book_id=-1 must return 422."""
+    res = await admin_client.get("/api/admin/queue/items?book_id=-1")
+    assert res.status_code == 422, f"Expected 422 for negative book_id, got {res.status_code}: {res.text}"

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -2698,3 +2698,36 @@ async def test_retry_failed_negative_book_id_returns_422(admin_client):
         json={"book_id": -1},
     )
     assert res.status_code == 422, f"Expected 422, got {res.status_code}"
+
+
+# ── Issue #736: ge=1 on admin uploads user_id and QueuePlanRequest.book_ids ──
+
+
+async def test_get_uploads_negative_user_id_returns_422(admin_client):
+    """Regression #736: GET /admin/uploads?user_id=-1 must return 422."""
+    res = await admin_client.get("/api/admin/uploads?user_id=-1")
+    assert res.status_code == 422, f"Expected 422 for negative user_id, got {res.status_code}: {res.text}"
+
+
+async def test_get_uploads_zero_user_id_returns_422(admin_client):
+    """Regression #736: GET /admin/uploads?user_id=0 must return 422."""
+    res = await admin_client.get("/api/admin/uploads?user_id=0")
+    assert res.status_code == 422, f"Expected 422 for user_id=0, got {res.status_code}: {res.text}"
+
+
+async def test_queue_plan_negative_book_id_in_list_returns_422(admin_client):
+    """Regression #736: POST /admin/queue/plan with book_ids containing negative must return 422."""
+    res = await admin_client.post(
+        "/api/admin/queue/plan",
+        json={"target_language": "zh", "book_ids": [-1]},
+    )
+    assert res.status_code == 422, f"Expected 422 for negative book_id in list, got {res.status_code}: {res.text}"
+
+
+async def test_queue_dry_run_negative_book_id_in_list_returns_422(admin_client):
+    """Regression #736: POST /admin/queue/dry-run with book_ids containing negative must return 422."""
+    res = await admin_client.post(
+        "/api/admin/queue/dry-run",
+        json={"target_language": "zh", "book_ids": [-1]},
+    )
+    assert res.status_code == 422, f"Expected 422 for negative book_id in list, got {res.status_code}: {res.text}"


### PR DESCRIPTION
## Summary

- Add `ge=1` to `user_id: int | None = Query(default=None, ge=1)` on `GET /admin/uploads` — negative/zero user_id was accepted and passed to SQL
- Add per-element `ge=1` to `QueuePlanRequest.book_ids` — negative book IDs in the list were accepted and forwarded to `plan_work_for_queue()` and the dry-run endpoint

## Test plan
- [x] `test_get_uploads_negative_user_id_returns_422` — GET /admin/uploads?user_id=-1 → 422
- [x] `test_get_uploads_zero_user_id_returns_422` — GET /admin/uploads?user_id=0 → 422
- [x] `test_queue_plan_negative_book_id_in_list_returns_422` — POST /admin/queue/plan with book_ids=[-1] → 422
- [x] `test_queue_dry_run_negative_book_id_in_list_returns_422` — POST /admin/queue/dry-run with book_ids=[-1] → 422
- [x] Full backend suite: 1279 passed

Closes #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)
