### PR TITLE
ci: skip heavy jobs for docs-only / design-only / PM-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,35 @@ on:
     branches: [main]
 
 jobs:
+  # Detect whether the PR touches code that actually needs CI. If only docs,
+  # design files, CLAUDE.md, product/, or issue templates changed, skip the
+  # heavy test + build jobs. They remain required for the branch protection,
+  # but a skipped `if:` job is reported as success so merges stay unblocked.
+  changes:
+    name: Detect code changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!product/**'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.claude/**'
+              - '!LICENSE'
+              - '!.gitignore'
+
   test-frontend:
     name: Frontend tests (Jest)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -65,6 +92,8 @@ jobs:
 
   test-e2e:
     name: Frontend E2E (Playwright)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -150,6 +179,8 @@ jobs:
 
   test-backend:
     name: Backend tests (pytest)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -204,9 +235,9 @@ jobs:
 
   coverage-comment:
     name: Post coverage comment
-    needs: [test-frontend, test-backend, test-e2e]
+    needs: [changes, test-frontend, test-backend, test-e2e]
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && always()
+    if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true' && always()
     permissions:
       pull-requests: write
     steps:
@@ -332,6 +363,8 @@ jobs:
 
   docker-build:
     name: Verify Docker build
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -33,6 +33,17 @@ name: Smoke test (post-deploy)
 on:
   push:
     branches: [main]
+    # Skip when the push is docs/design/PM-only — nothing was deployed,
+    # so there is nothing new to smoke-test. The 6-hour cron and manual
+    # workflow_dispatch still cover everything.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'product/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.claude/**'
+      - 'LICENSE'
+      - '.gitignore'
   workflow_dispatch:
   schedule:
     # Every 6 hours, catch any silent outage between deploys.


### PR DESCRIPTION
## Summary

Skip the 5 heavy CI jobs (Frontend Jest, E2E Playwright, Backend pytest, Docker build, coverage comment) on PRs that only touch docs, design files, CLAUDE.md, product/, issue templates, or .claude/ settings. Today those changes run the full ~8-minute pipeline — that's pure waste and saturates the Actions runner queue.

## Why now

We just filed 4 docs-only PRs (#702, #703, #710, #712) in rapid succession. Each sat in the CI queue for >1 hour despite not touching a single line of testable code. Meanwhile real bugfix PRs from Dev/UX sessions sat behind them.

## How it works

New lightweight `changes` job uses `dorny/paths-filter@v3`:

```yaml
code:
  - '**'
  - '!**/*.md'
  - '!docs/**'
  - '!product/**'
  - '!.github/ISSUE_TEMPLATE/**'
  - '!.claude/**'
  - '!LICENSE'
  - '!.gitignore'
```

It outputs `code: true` when any file outside the excluded set changed. The 5 heavy jobs gain `needs: changes` + `if: needs.changes.outputs.code == 'true'`.

GitHub treats a skipped `if:` job as success for branch protection, so docs-only PRs still pass required checks and auto-merge. No changes needed to branch protection config.

### smoke-test.yml

The push-triggered smoke test gains a `paths-ignore` clause so docs-only pushes to main don't smoke-test a deploy that never happened. The 6-hour cron and `workflow_dispatch` still cover silent outages.

## What still runs CI (i.e. counts as "code"):

- `backend/**`, `frontend/**` — source code.
- `.github/workflows/**` — workflow edits themselves.
- Config (`package.json`, `requirements.txt`, Dockerfile, etc.).
- `scripts/**` — not tested directly but some are imported by CI itself.

## Expected impact

Before: every docs PR = 8 min CI + queue wait (hours during bursts).
After: every docs PR = ~30s (just the `changes` job + auto-merge).

This PR itself only touches `.github/workflows/*.yml`, so it still runs full CI — correct behavior: workflow edits must be validated.

## Test plan

- [x] YAML parses (ci.yml passes python-yaml strict parse; smoke-test.yml has a pre-existing quirk unrelated to this change)
- [x] Full backend + frontend test suite passes locally
- [ ] Post-merge: next docs/CLAUDE.md-only PR should have only `changes` + Vercel jobs run, with the 5 heavy jobs showing as skipped/success
- [ ] Next backend-only PR still runs the full pipeline
