### PR TITLE
fix: add le=10000 upper bound to page query param in /books/search and /books/popular (closes #739)

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -31,7 +31,7 @@ router = APIRouter(prefix="/books", tags=["books"])
 async def search(
     q: str = Query(..., max_length=200, description="Search query"),
     language: str = Query("", max_length=20, description="Language code e.g. en, de, fr"),
-    page: int = Query(1, ge=1),
+    page: int = Query(1, ge=1, le=10000),
 ):
     return await search_books(q, language, page)
 
@@ -45,7 +45,7 @@ async def cached_books():
 @router.get("/popular")
 async def popular_books(
     language: str = Query(default="", max_length=20),
-    page: int = Query(1, ge=1),
+    page: int = Query(1, ge=1, le=10000),
     per_page: int = Query(50, ge=1, le=200),
 ):
     """Return a paginated slice of the curated popular Gutenberg books manifest.

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -1185,3 +1185,18 @@ async def test_import_stream_negative_book_id_returns_422(client):
     """Regression #727: GET /books/{book_id}/import-stream with negative book_id must return 422."""
     resp = await client.get("/api/books/-1/import-stream")
     assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+# ── Issue #739: le=10000 on page query param ──────────────────────────────────
+
+
+async def test_search_page_too_large_returns_422(client):
+    """Regression #739: GET /books/search?page=10001 must return 422."""
+    resp = await client.get("/api/books/search?q=test&page=10001")
+    assert resp.status_code == 422, f"Expected 422 for page > 10000, got {resp.status_code}: {resp.text}"
+
+
+async def test_popular_books_page_too_large_returns_422(client):
+    """Regression #739: GET /books/popular?page=10001 must return 422."""
+    resp = await client.get("/api/books/popular?page=10001")
+    assert resp.status_code == 422, f"Expected 422 for page > 10000, got {resp.status_code}: {resp.text}"


### PR DESCRIPTION
## Summary

- Add `le=10000` to `page` query param on `GET /books/search` — an unbounded page number caused a real HTTP request to the Gutenberg API
- Add `le=10000` to `page` query param on `GET /books/popular` — was inconsistent with `per_page` which already has `le=200`

## Test plan
- [x] `test_search_page_too_large_returns_422` — GET /books/search?page=10001 → 422
- [x] `test_popular_books_page_too_large_returns_422` — GET /books/popular?page=10001 → 422
- [x] Full backend suite: 1284 passed

Closes #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)
