### PR TITLE
fix: preserve span-wrapped verse lines in Gutenberg poetry EPUBs (#757)

### DIFF
--- a/backend/services/splitter.py
+++ b/backend/services/splitter.py
@@ -501,6 +501,9 @@ def _html_body_text(
     skipped_heading = not skip_first_heading
     skip_set = {id(e) for e in skip_elems}
 
+    _BLOCK_TAGS = {"p", "div", "blockquote", "pre", "h1", "h2", "h3", "h4", "h5", "h6",
+                   "ul", "ol", "table", "section", "article", "aside", "header", "footer"}
+
     for child in elem.iterchildren():
         tag = child.tag if isinstance(child.tag, str) else ""
         if id(child) in skip_set:
@@ -524,8 +527,21 @@ def _html_body_text(
         elif tag == "hr":
             continue
         else:
-            # Fall-through: if it's another container (section, div) recurse
-            text = _html_body_text(child, skip_first_heading=False)
+            # Fall-through: a div whose own children are all inline (span/a/
+            # br/em/strong/text) is itself a paragraph — common in Gutenberg
+            # poetry EPUBs where each verse line is wrapped in
+            # <span class="i0">…<br/></span> inside <div class="stanza">.
+            # Treat it as one paragraph via _html_inline_text so the line
+            # text survives (the recursive variant only looks at children
+            # and drops each span's .text).
+            has_block_child = any(
+                isinstance(gc.tag, str) and gc.tag in _BLOCK_TAGS
+                for gc in child.iterchildren()
+            )
+            if not has_block_child:
+                text = _html_inline_text(child)
+            else:
+                text = _html_body_text(child, skip_first_heading=False)
             if text.strip():
                 parts.append(text.strip())
 
@@ -574,6 +590,10 @@ def build_chapters_from_epub(epub_bytes: bytes) -> list[Chapter]:
         basename = item.get_name().split("/")[-1].lower()
         if basename in _SKIP_SUFFIXES:
             continue
+        # Modern Gutenberg EPUBs include a `pg-footer` spine item carrying
+        # the PG trademark license. Never a real chapter.
+        if item_id in ("pg-footer",):
+            continue
 
         raw = item.get_content()
         try:
@@ -581,6 +601,11 @@ def build_chapters_from_epub(epub_bytes: bytes) -> list[Chapter]:
             body = doc.find(".//body")
             if body is None:
                 body = doc
+            # Drop PG boilerplate <section> wrappers from the body before
+            # extracting text. These hold the legal header and aren't part
+            # of the chapter content.
+            for boiler in body.xpath(".//section[contains(@class, 'pg-boilerplate')]"):
+                boiler.getparent().remove(boiler)
             text = _html_body_text(body, skip_first_heading=True)
         except Exception:
             continue

--- a/backend/tests/test_splitter.py
+++ b/backend/tests/test_splitter.py
@@ -936,6 +936,40 @@ def test_html_body_text_div_fallthrough():
     assert "word" in text
 
 
+def test_html_body_text_preserves_span_wrapped_verse_lines():
+    """Regression for book 24288 (Rilke, Das Stunden-Buch): Project Gutenberg
+    EPUBs for poetry wrap each verse line in ``<span class="i0">…<br/></span>``
+    inside ``<div class="stanza">`` inside ``<div class="poem">``. Without
+    treating a span-only stanza as a paragraph, the recursive div walker
+    drops every span's .text and the entire poem body disappears."""
+    from lxml import html as lxml_html
+    html = """
+    <body>
+      <h1>Das Stunden-Buch</h1>
+      <div class="poem">
+        <div class="stanza">
+          <span class="i0">Da neigt sich die Stunde und rührt mich an<br/></span>
+          <span class="i0">mit klarem metallenem Schlag:<br/></span>
+          <span class="i0">mir zittern die Sinne. Ich fühle: ich kann –<br/></span>
+          <span class="i0">und ich fasse den plastischen Tag.<br/></span>
+        </div>
+        <div class="stanza">
+          <span class="i0">Nichts war noch vollendet, eh ich es erschaut,<br/></span>
+          <span class="i0">ein jedes Werden stand still.<br/></span>
+        </div>
+      </div>
+    </body>
+    """
+    body = lxml_html.fromstring(html)
+    text = _html_body_text(body, skip_first_heading=True)
+    assert "Da neigt sich die Stunde" in text, text
+    assert "plastischen Tag" in text, text
+    assert "Nichts war noch vollendet" in text, text
+    # Two stanzas => two paragraphs, separated by a blank line.
+    paragraphs = [p for p in text.split("\n\n") if p.strip()]
+    assert len(paragraphs) == 2
+
+
 # Lines 571->562: _split_dramatic_speakers — speaker cue mid-paragraph
 def test_split_dramatic_speakers_splits_at_cue():
     """A speaker cue (ALL-CAPS word(s) ending with period) should split the paragraph."""


### PR DESCRIPTION
## Summary

Closes #757. Restores ~99 KB of missing poetry content for Gutenberg poetry EPUBs like Rilke's *Das Stunden-Buch* (book 24288), which was rendering with only 873 characters.

## Root cause

`_html_body_text` only extracted readable text from `<p>` / `<blockquote>` / `<pre>` containers. Every other container fell through to a recursive branch that walks children but never reads element `.text`. Modern Gutenberg poetry EPUBs wrap each verse line as `<span class="i0">line<br/></span>` inside `<div class="stanza">`. The recursion walked the spans, found only `<br/>` children, and returned empty. Every line of every poem was silently dropped.

## Fix

- In the fall-through branch of `_html_body_text`, detect inline-only containers (no block-level children) and extract via `_html_inline_text`, which already handles `.text`, `<br/>`, and trailing whitespace. Containers with real block children recurse as before — no behaviour change for prose.
- Drop the `pg-footer` spine item plus `<section class="pg-boilerplate">` wrappers so the Project Gutenberg legal boilerplate doesn't become a chapter once the extractor starts pulling text out of those spans too.

## Verification

- New regression test `test_html_body_text_preserves_span_wrapped_verse_lines` captures the Rilke stanza structure — asserts that two stanzas' worth of lines round-trip intact.
- Local run against book 24288's EPUB: **2 chapters, 98 986 chars** (was 2 chapters, 873 chars).
- Full backend suite: **1354 passing.**

## Deployment note

`book_chapters._chapter_cache` is a process-level dict. Existing running backends will keep serving the broken split until the next cold start — Railway redeploy on merge clears it automatically.

## Test plan

- [ ] After deploy, reload https://book-reader-ai.vercel.app/reader/24288 — poetry content (`Da neigt sich die Stunde und rührt mich an …`) is visible.
- [ ] Other Gutenberg prose books (e.g. Faust, Ulysses) still split correctly — no regression on prose.
- [ ] `/api/search?q=Stunde&scope=chapters` now returns hits from book 24288 (previously empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
