### PR TITLE
fix: suppress raw exception details in books router error responses

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -562,8 +562,8 @@ async def import_stream(
             else:
                 try:
                     meta, text = await _fetch_and_cache(book_id)
-                except Exception as e:
-                    yield _sse("error", {"stage": "fetching", "message": str(e)})
+                except Exception:
+                    yield _sse("error", {"stage": "fetching", "message": "Could not fetch book from Gutenberg"})
                     return
 
             source_language = (meta.get("languages") or ["en"])[0]
@@ -589,9 +589,9 @@ async def import_stream(
         except asyncio.CancelledError:
             # Client disconnected — FastAPI will raise this
             raise
-        except Exception as e:
+        except Exception:
             logger.exception("Import stream crashed")
-            yield _sse("error", {"stage": "unknown", "message": str(e)})
+            yield _sse("error", {"stage": "unknown", "message": "Import failed unexpectedly"})
 
     return StreamingResponse(
         generator(),

--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -442,8 +442,8 @@ async def book_meta(book_id: int = Path(..., ge=1), user: dict | None = Depends(
         return {k: v for k, v in cached.items() if k not in ("text", "cached_at", "images")}
     try:
         return await get_book_meta(book_id)
-    except Exception as e:
-        raise HTTPException(status_code=404, detail=str(e))
+    except Exception:
+        raise HTTPException(status_code=404, detail="Book not found")
 
 
 @router.get("/{book_id}/chapters")
@@ -480,9 +480,8 @@ async def book_chapters(book_id: int = Path(..., ge=1), user: dict | None = Depe
     else:
         try:
             meta, text = await _fetch_and_cache(book_id)
-        except Exception as e:
-            msg = str(e) or type(e).__name__
-            raise HTTPException(status_code=404, detail=msg)
+        except Exception:
+            raise HTTPException(status_code=404, detail="Could not load book")
 
     from services.book_chapters import split_with_html_preference, get_chapter_source
     chapters = await split_with_html_preference(book_id, text)

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -58,6 +58,9 @@ async def test_book_meta_404_when_gutenberg_fails(client):
     with patch("routers.books.get_book_meta", side_effect=Exception("Not found")):
         resp = await client.get("/api/books/99999")
     assert resp.status_code == 404
+    detail = resp.json()["detail"]
+    assert "Not found" not in detail
+    assert ":" not in detail
 
 
 async def test_book_chapters_served_from_cache(client):
@@ -85,6 +88,9 @@ async def test_book_chapters_404_when_fetch_fails(client):
     with patch("routers.books._fetch_and_cache", side_effect=Exception("Network error")):
         resp = await client.get("/api/books/99999/chapters")
     assert resp.status_code == 404
+    detail = resp.json()["detail"]
+    assert "Network error" not in detail
+    assert ":" not in detail
 
 
 async def test_search_delegates_to_gutenberg(client):


### PR DESCRIPTION
## What changed
- `routers/books.py`: 5 exception paths that used `str(e)` or `f"...: {e}"` in HTTPException detail now use static messages
- Endpoints fixed: book meta 404, chapter fetch 404, SSE import-stream outer catch
- `tests/test_router_books.py`: updated tests assert raw error strings are absent from responses

## Why
GET /books/{id}/meta and /books/{id}/chapters are unauthenticated. Raw network/DB exception strings were reachable by anonymous users and could expose internal service details.

## Test plan
- [x] Updated tests confirm no raw exception text in responses
- [x] Full backend suite: 1354 passed
- [x] Full frontend suite: 1750 passed

Closes #749
