### PR TITLE
fix: add ge=1 and max_length bounds to SmartRules list fields in decks router

### DIFF
--- a/backend/routers/decks.py
+++ b/backend/routers/decks.py
@@ -12,7 +12,7 @@ Endpoints:
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Annotated, Literal
 
 import aiosqlite
 from fastapi import APIRouter, Depends, HTTPException, Path
@@ -28,9 +28,9 @@ class SmartRules(BaseModel):
     """Allowed filter keys on a smart deck. All fields optional; unknown keys
     are rejected at the Pydantic layer (`extra='forbid'`)."""
     language: str | None = Field(default=None, max_length=20)
-    book_ids: list[int] | None = None
-    tags_any: list[str] | None = None
-    tags_all: list[str] | None = None
+    book_ids: list[Annotated[int, Field(ge=1)]] | None = Field(default=None, max_length=200)
+    tags_any: list[Annotated[str, Field(max_length=50)]] | None = Field(default=None, max_length=100)
+    tags_all: list[Annotated[str, Field(max_length=50)]] | None = Field(default=None, max_length=100)
     saved_after: str | None = Field(default=None, max_length=10)
     saved_before: str | None = Field(default=None, max_length=10)
 

--- a/backend/tests/test_router_decks.py
+++ b/backend/tests/test_router_decks.py
@@ -95,6 +95,62 @@ async def test_create_smart_rules_reject_unknown_key(client, test_user):
     assert resp.status_code == 422
 
 
+async def test_smart_rules_book_ids_rejects_zero(client, test_user):
+    resp = await client.post(
+        "/api/decks",
+        json={"name": "ZeroBook", "mode": "smart", "rules_json": {"book_ids": [0]}},
+    )
+    assert resp.status_code == 422
+
+
+async def test_smart_rules_book_ids_rejects_negative(client, test_user):
+    resp = await client.post(
+        "/api/decks",
+        json={"name": "NegBook", "mode": "smart", "rules_json": {"book_ids": [-1]}},
+    )
+    assert resp.status_code == 422
+
+
+async def test_smart_rules_book_ids_rejects_oversized_list(client, test_user):
+    resp = await client.post(
+        "/api/decks",
+        json={"name": "HugeList", "mode": "smart", "rules_json": {"book_ids": list(range(1, 202))}},
+    )
+    assert resp.status_code == 422
+
+
+async def test_smart_rules_tags_any_rejects_oversized_string(client, test_user):
+    resp = await client.post(
+        "/api/decks",
+        json={"name": "LongTag", "mode": "smart", "rules_json": {"tags_any": ["a" * 51]}},
+    )
+    assert resp.status_code == 422
+
+
+async def test_smart_rules_tags_all_rejects_oversized_list(client, test_user):
+    resp = await client.post(
+        "/api/decks",
+        json={"name": "HugeTags", "mode": "smart", "rules_json": {"tags_all": ["t"] * 101}},
+    )
+    assert resp.status_code == 422
+
+
+async def test_smart_rules_valid_bounds_accepted(client, test_user):
+    resp = await client.post(
+        "/api/decks",
+        json={
+            "name": "ValidBounds",
+            "mode": "smart",
+            "rules_json": {
+                "book_ids": [1, 2, 3],
+                "tags_any": ["b2", "vocab"],
+                "tags_all": ["saved"],
+            },
+        },
+    )
+    assert resp.status_code == 201
+
+
 async def test_get_deck_404_for_other_user(client, test_user):
     other = await get_or_create_user("deck-other", "deck-other@ex.com", "Other", "")
 


### PR DESCRIPTION
## What changed
- `routers/decks.py`: `SmartRules.book_ids` now uses `list[Annotated[int, Field(ge=1)]] | None = Field(default=None, max_length=200)` — per-element ge=1 and list capped at 200 entries
- `SmartRules.tags_any` and `tags_all` now use `list[Annotated[str, Field(max_length=50)]] | None = Field(default=None, max_length=100)` — per-tag 50-char limit, list capped at 100
- `tests/test_router_decks.py`: 6 new regression tests covering zero/negative book_id, oversized list, oversized tag string, and valid-bounds acceptance

## Why
The `SmartRules` Pydantic model accepted arbitrary-length lists with no per-element bounds: a caller could submit `book_ids: [0, -1, 99999]` or a list of 10 000 tags without any validation error, risking invalid DB lookups and unbounded query parameters.

## Test plan
- [x] `test_smart_rules_book_ids_rejects_zero` — 422 on book_id=0
- [x] `test_smart_rules_book_ids_rejects_negative` — 422 on book_id=-1
- [x] `test_smart_rules_book_ids_rejects_oversized_list` — 422 on 201-element list
- [x] `test_smart_rules_tags_any_rejects_oversized_string` — 422 on 51-char tag
- [x] `test_smart_rules_tags_all_rejects_oversized_list` — 422 on 101-element list
- [x] `test_smart_rules_valid_bounds_accepted` — 201 for well-formed rules
- [x] Full backend suite: 1366 passed, full frontend suite: 1750 passed

Closes #750
