### PR TITLE
fix: preserve chapter-body wrapper div in EPUB path (book 69327 Kafka)

### DIFF
--- a/backend/services/splitter.py
+++ b/backend/services/splitter.py
@@ -412,9 +412,14 @@ def build_chapters_from_html(html: str) -> list[Chapter]:
                     subtitle_elem = nxt
 
         # Extract body text from all children except the title heading
-        # (and the subtitle paragraph, if any).
+        # (and the subtitle paragraph, if any). HTML path enables
+        # skip_nested_chapter_divs — we iterate every chapter div via
+        # XPath at the top of this function, so nested ones would be
+        # double-processed if we let them through here.
         body_text = _html_body_text(
-            div, skip_first_heading=True, skip_elems=(subtitle_elem,) if subtitle_elem is not None else (),
+            div, skip_first_heading=True,
+            skip_elems=(subtitle_elem,) if subtitle_elem is not None else (),
+            skip_nested_chapter_divs=True,
         )
         word_count = len(body_text.split())
 
@@ -488,6 +493,7 @@ def _html_body_text(
     *,
     skip_first_heading: bool = False,
     skip_elems: tuple = (),
+    skip_nested_chapter_divs: bool = False,
 ) -> str:
     """Extract readable text from an HTML element, preserving paragraph breaks.
 
@@ -496,6 +502,13 @@ def _html_body_text(
     is skipped when `skip_first_heading=True` (since the caller already used
     it as the chapter title). `skip_elems` lets the caller exclude specific
     elements (e.g. a subtitle `<p>` already folded into the title).
+
+    `skip_nested_chapter_divs=True` is only for the HTML path
+    (`build_chapters_from_html`), which iterates every ``*[class~="chapter"]``
+    element via XPath and skips nested chapter divs to avoid double-counting.
+    The EPUB path (`build_chapters_from_epub`) already picks one spine item
+    per chapter — setting this flag there would wrongly drop Gutenberg's
+    common ``<div class="div1 chapter">`` chapter-body wrapper (Kafka, etc).
     """
     parts: list[str] = []
     skipped_heading = not skip_first_heading
@@ -511,7 +524,11 @@ def _html_body_text(
         if tag in ("h1", "h2", "h3") and not skipped_heading:
             skipped_heading = True
             continue
-        if tag == "div" and "chapter" in (child.get("class") or ""):
+        if (
+            skip_nested_chapter_divs
+            and tag == "div"
+            and "chapter" in (child.get("class") or "")
+        ):
             # Nested chapter div (seen in book-section wrappers) — skip
             continue
         if tag == "p":
@@ -519,7 +536,11 @@ def _html_body_text(
             if text.strip():
                 parts.append(text.strip())
         elif tag in ("blockquote",):
-            nested = _html_body_text(child, skip_first_heading=False)
+            nested = _html_body_text(
+                child,
+                skip_first_heading=False,
+                skip_nested_chapter_divs=skip_nested_chapter_divs,
+            )
             if nested.strip():
                 parts.append(nested.strip())
         elif tag in ("pre",):
@@ -541,7 +562,11 @@ def _html_body_text(
             if not has_block_child:
                 text = _html_inline_text(child)
             else:
-                text = _html_body_text(child, skip_first_heading=False)
+                text = _html_body_text(
+                    child,
+                    skip_first_heading=False,
+                    skip_nested_chapter_divs=skip_nested_chapter_divs,
+                )
             if text.strip():
                 parts.append(text.strip())
 

--- a/backend/tests/test_chapter_source.py
+++ b/backend/tests/test_chapter_source.py
@@ -68,3 +68,41 @@ async def test_chapters_endpoint_marks_epub_when_blob_stored(client, test_user):
     resp = await client.get("/api/books/4011/chapters")
     assert resp.status_code == 200
     assert resp.json()["chapter_source"] == "epub"
+
+
+def test_html_body_text_preserves_div_chapter_wrapper_in_epub():
+    """Regression for book 69327 (Kafka, Der Prozess): modern Gutenberg
+    prose EPUBs wrap each chapter body in <div class="div1 chapter">. The
+    EPUB splitter must not skip that wrapper as a "nested chapter div" —
+    that's the top-level body, not a sub-chapter. The HTML path (which
+    iterates every chapter div via XPath) still needs the skip, so the
+    behaviour is controlled by an opt-in flag."""
+    from lxml import html as lxml_html
+    from services.splitter import _html_body_text
+
+    html = """
+    <body>
+      <div class="body">
+        <div class="div1 chapter" id="ch1">
+          <h2>ERSTES KAPITEL</h2>
+          <div class="divBody">
+            <p class="first">Jemand mußte Josef K. verleumdet haben, denn ohne daß er etwas Böses getan hätte, wurde er eines Morgens verhaftet.</p>
+            <p>Die Köchin der Frau Grubach kam diesmal nicht.</p>
+          </div>
+        </div>
+      </div>
+    </body>
+    """
+    body = lxml_html.fromstring(html)
+
+    # EPUB path (default): chapter-body wrapper is NOT skipped, prose survives.
+    text = _html_body_text(body, skip_first_heading=True)
+    assert "Jemand mußte Josef K. verleumdet haben" in text, text
+    assert "Die Köchin der Frau Grubach" in text, text
+
+    # HTML path: nested chapter divs ARE skipped (the XPath caller already
+    # iterates them separately).
+    text_html_path = _html_body_text(
+        body, skip_first_heading=True, skip_nested_chapter_divs=True,
+    )
+    assert "Jemand mußte Josef K." not in text_html_path, text_html_path

--- a/backend/tests/test_splitter.py
+++ b/backend/tests/test_splitter.py
@@ -1144,7 +1144,9 @@ def test_build_chapters_from_html_empty_body_text():
 
 # Line 512: nested chapter div inside another chapter div → skip
 def test_html_body_text_skips_nested_chapter_div():
-    """A nested div with class='chapter' should be skipped during body extraction."""
+    """In the HTML path (opt-in flag), a nested div with class='chapter'
+    is skipped during body extraction — the top-level XPath loop already
+    iterates every chapter div separately."""
     from lxml import html as lxml_html
     html = (
         '<div class="chapter outer">'
@@ -1155,7 +1157,7 @@ def test_html_body_text_skips_nested_chapter_div():
     root = lxml_html.fromstring(html)
     # Get the outer chapter div
     outer = root.xpath("//*[contains(@class, 'outer')]")[0]
-    text = _html_body_text(outer)
+    text = _html_body_text(outer, skip_nested_chapter_divs=True)
     assert "Outer paragraph" in text
     assert "Inner paragraph should be skipped" not in text
 


### PR DESCRIPTION
## Summary

Fixes book 69327 (Kafka, *Der Prozess*) which was rendering only the cover boilerplate + afterword (~1.8 KB) with all 10 actual chapters missing.

## Root cause

The splitter's `_html_body_text` unconditionally skipped nested divs whose class contains `"chapter"` to avoid double-counting in the HTML path (where `build_chapters_from_html` iterates every `*[class~="chapter"]` element via XPath).

That skip is wrong for the EPUB path: `build_chapters_from_epub` picks one spine item per chapter, then Kafka's EPUB stores the chapter body as `<div class="div1 chapter">…</div>` — the wrapper div _is_ the chapter body, not a sub-chapter. The skip dropped 99.6% of the novel.

## Fix

- Add opt-in `skip_nested_chapter_divs` flag to `_html_body_text`, default `False`. Propagated through both the blockquote and the fall-through div recursion so deeply-nested wrappers stay consistent.
- `build_chapters_from_html` passes `skip_nested_chapter_divs=True` — existing behaviour preserved.
- `build_chapters_from_epub` leaves it at `False`.

## Verification

- Regression test `test_html_body_text_preserves_div_chapter_wrapper_in_epub` in `tests/test_chapter_source.py` covers the Kafka-shaped `<div class="div1 chapter">` in both modes.
- Existing `test_html_body_text_skips_nested_chapter_div` updated to pass the flag explicitly — confirms HTML-path behaviour unchanged.
- Full backend suite: **1360 passing.**
- Local verify against `gutenberg.org/ebooks/69327.epub3.images`: **12 chapters, 467 KB** (was 2 chapters, 1.8 KB).

## Test plan

- [ ] After deploy + cold start, reload https://book-reader-ai.vercel.app/reader/69327 — ten numbered Kapitel + Nachwort visible, with chapter titles from the NCX (ERSTES KAPITEL VERHAFTUNG · …, etc.).
- [ ] Book 2229 (Faust, HTML-path) still splits correctly — no regression on the HTML splitter.
- [ ] Book 24288 (Rilke, post-#758 poetry fix) still renders with EPUB content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
