### PR TITLE
fix: suppress raw exception details in admin router 500/400 error responses

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -215,8 +215,8 @@ async def import_book(req: ImportBookRequest, _admin: dict = Depends(_require_ad
         text = await get_book_text(req.book_id)
         await save_book(req.book_id, meta, text)
         return {"ok": True, "status": "imported", "title": meta.get("title", ""), "text_length": len(text)}
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"Failed to import book {req.book_id}: {e}")
+    except Exception:
+        raise HTTPException(status_code=400, detail=f"Failed to import book {req.book_id}")
 
 
 @router.delete("/books/{book_id}")
@@ -1013,8 +1013,8 @@ async def queue_dry_run(req: QueuePlanRequest, _admin: dict = Depends(_require_a
             model=chain[0] or TRANSLATOR_MODEL,
             max_output_tokens=max_output_tokens,
         )
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Translation failed: {e}")
+    except Exception:
+        raise HTTPException(status_code=500, detail="Translation service request failed")
 
     return {
         "preview": translations,

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -2755,3 +2755,36 @@ async def test_queue_items_negative_book_id_returns_422(admin_client):
     """Regression #736: GET /admin/queue/items?book_id=-1 must return 422."""
     res = await admin_client.get("/api/admin/queue/items?book_id=-1")
     assert res.status_code == 422, f"Expected 422 for negative book_id, got {res.status_code}: {res.text}"
+
+
+@pytest.mark.asyncio
+async def test_import_book_error_does_not_leak_exception_detail(admin_client):
+    """Regression #756: import_book must not expose raw exception text in 400 response."""
+    with patch("routers.admin.get_book_meta", new_callable=AsyncMock,
+               side_effect=RuntimeError("gutenberg-internal-error-xyzzy")):
+        res = await admin_client.post("/api/admin/books/import", json={"book_id": 42})
+    assert res.status_code == 400
+    detail = res.json()["detail"]
+    assert "gutenberg-internal-error-xyzzy" not in detail
+    assert ":" not in detail or detail.count(":") == 0
+
+
+@pytest.mark.asyncio
+async def test_queue_dry_run_error_does_not_leak_exception_detail(admin_client):
+    """Regression #756: queue_dry_run must not expose raw exception text in 500 response."""
+    with patch("routers.admin.get_setting", new_callable=AsyncMock, return_value="encrypted-key"), \
+         patch("routers.admin.decrypt_api_key", return_value="sk-fake"), \
+         patch("routers.admin.plan_work_for_queue", new_callable=AsyncMock,
+               return_value=[{"book_id": 1, "book_title": "T", "source_language": "de",
+                              "chapters": [type("C", (), {"chapter_index": 0, "chapter_text": "hello world"})()]}]), \
+         patch("routers.admin.group_chapters_for_batch",
+               return_value=[[type("C", (), {"chapter_index": 0, "chapter_text": "hello world"})()]]), \
+         patch("routers.admin.get_model_chain", new_callable=AsyncMock, return_value=["gemini-pro"]), \
+         patch("routers.admin.translate_chapters_batch", new_callable=AsyncMock,
+               side_effect=RuntimeError("api-key-secret-xyzzy leaked")):
+        res = await admin_client.post("/api/admin/queue/dry-run",
+                                      json={"target_language": "zh"})
+    assert res.status_code == 500
+    detail = res.json()["detail"]
+    assert "api-key-secret-xyzzy" not in detail
+    assert "leaked" not in detail


### PR DESCRIPTION
## What changed
- `routers/admin.py`: `import_book` outer catch now drops `str(e)` — was `f"Failed to import book {req.book_id}: {e}"`, now `f"Failed to import book {req.book_id}"`
- `routers/admin.py`: `queue_dry_run` translation outer catch was `f"Translation failed: {e}"`, now `"Translation service request failed"`
- `tests/test_router_admin.py`: two regression tests added — one confirming no exception text in 400 import response, one confirming no exception text in 500 translation response

## Why
Both endpoints are admin-only but raw exception strings from internal services (book meta fetch, translation backend) were forwarded to HTTP response detail. Part of the systematic exception-detail-leak audit.

## Test plan
- [x] `test_import_book_error_does_not_leak_exception_detail` — patches get_book_meta to raise RuntimeError, asserts secret not in 400 detail
- [x] `test_queue_dry_run_error_does_not_leak_exception_detail` — mocks translation pipeline, asserts RuntimeError message not in 500 detail
- [x] Full backend suite: 1362 passed

Closes #756
