### PR TITLE
fix: add max_length=1000 to QueuePlanRequest.book_ids list field in admin router

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -934,7 +934,7 @@ async def queue_stop(_admin: dict = Depends(_require_admin)):
 
 class QueuePlanRequest(BaseModel):
     target_language: str = Field(..., max_length=20)
-    book_ids: list[Annotated[int, Field(ge=1)]] | None = None
+    book_ids: list[Annotated[int, Field(ge=1)]] | None = Field(default=None, max_length=1000)
 
 
 @router.post("/queue/plan")

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -2733,6 +2733,24 @@ async def test_queue_dry_run_negative_book_id_in_list_returns_422(admin_client):
     assert res.status_code == 422, f"Expected 422 for negative book_id in list, got {res.status_code}: {res.text}"
 
 
+async def test_queue_plan_oversized_book_ids_list_returns_422(admin_client):
+    """Regression #765: POST /admin/queue/plan with book_ids list > 1000 items must return 422."""
+    res = await admin_client.post(
+        "/api/admin/queue/plan",
+        json={"target_language": "zh", "book_ids": list(range(1, 1002))},
+    )
+    assert res.status_code == 422, f"Expected 422 for oversized book_ids list, got {res.status_code}: {res.text}"
+
+
+async def test_queue_dry_run_oversized_book_ids_list_returns_422(admin_client):
+    """Regression #765: POST /admin/queue/dry-run with book_ids list > 1000 items must return 422."""
+    res = await admin_client.post(
+        "/api/admin/queue/dry-run",
+        json={"target_language": "zh", "book_ids": list(range(1, 1002))},
+    )
+    assert res.status_code == 422, f"Expected 422 for oversized book_ids list, got {res.status_code}: {res.text}"
+
+
 async def test_queue_items_negative_book_id_returns_422(admin_client):
     """Regression #736: GET /admin/queue/items?book_id=-1 must return 422."""
     res = await admin_client.get("/api/admin/queue/items?book_id=-1")


### PR DESCRIPTION
## What changed
- `routers/admin.py`: `QueuePlanRequest.book_ids` changed from `list[Annotated[int, Field(ge=1)]] | None = None` to `list[Annotated[int, Field(ge=1)]] | None = Field(default=None, max_length=1000)` — list-level cap of 1000 entries
- `tests/test_router_admin.py`: two regression tests — `test_queue_plan_oversized_book_ids_list_returns_422` and `test_queue_dry_run_oversized_book_ids_list_returns_422` — both submit 1001-element lists and assert 422

## Why
The `book_ids` list field on `QueuePlanRequest` had per-element `ge=1` bounds but no list-level `max_length` cap. A caller could submit an arbitrarily large list of book IDs, causing the planning query to expand into an equally large SQL `IN (...)` clause with no upper bound.

## Test plan
- [x] `test_queue_plan_oversized_book_ids_list_returns_422` — 1001-element list → 422
- [x] `test_queue_dry_run_oversized_book_ids_list_returns_422` — 1001-element list → 422
- [x] Full backend suite: 1368 passed

Closes #765
