### PR TITLE
fix: suppress raw parser exception details in file upload 422 response

### DIFF
--- a/backend/routers/uploads.py
+++ b/backend/routers/uploads.py
@@ -119,9 +119,9 @@ async def upload_book(
             parsed = parse_txt(file_bytes.decode("utf-8", errors="replace"))
         else:
             parsed = parse_epub(file_bytes)
-    except Exception as exc:
+    except Exception:
         logger.exception("Failed to parse uploaded file")
-        raise HTTPException(status_code=422, detail=f"Could not parse file: {exc}")
+        raise HTTPException(status_code=422, detail="Could not parse uploaded file")
 
     chapters = parsed["chapters"]
     if not chapters:

--- a/backend/tests/test_router_uploads.py
+++ b/backend/tests/test_router_uploads.py
@@ -813,3 +813,16 @@ async def test_delete_uploaded_book_negative_id_returns_422(client, test_user):
     """Regression #731: DELETE /books/upload/{id} with negative id must return 422."""
     resp = await client.delete("/api/books/upload/-1")
     assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
+
+
+# ── Issue #761: parser exception must not leak in 422 response ────────────────
+
+@pytest.mark.asyncio
+async def test_upload_parse_error_does_not_leak_exception_detail(client, test_user):
+    """Regression #761: when file parsing raises, the 422 detail must be a static message."""
+    with patch("services.book_parser.parse_txt", side_effect=RuntimeError("internal-parser-secret-xyzzy")):
+        resp = await client.post("/api/books/upload", files=_txt_upload())
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert "internal-parser-secret-xyzzy" not in detail
+    assert ":" not in detail or "Could not parse" in detail


### PR DESCRIPTION
## What changed
- `routers/uploads.py`: the outer exception handler in `upload_book` that was `raise HTTPException(status_code=422, detail=f"Could not parse file: {exc}")` is now `raise HTTPException(status_code=422, detail="Could not parse uploaded file")` — `exc` string dropped
- `tests/test_router_uploads.py`: new test `test_upload_parse_error_does_not_leak_exception_detail` patches `services.book_parser.parse_txt` to raise a RuntimeError with a sentinel string and asserts the sentinel does not appear in the 422 response detail

## Why
The parse failure path in the upload handler forwarded the raw exception message (which could contain internal file parser details, path info, or library error strings) directly into the 422 HTTP response visible to the uploading user.

## Test plan
- [x] `test_upload_parse_error_does_not_leak_exception_detail` — 422 returned, "internal-parser-secret-xyzzy" absent from detail
- [x] Full uploads test file: 34 passed

Closes #761
