### PR TITLE
fix: add min_length=1 to language fields across admin, ai, books, vocabulary routers

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -587,13 +587,13 @@ async def retranslate(
 
 
 class BulkRetranslateRequest(BaseModel):
-    target_language: str = Field(..., max_length=20)
+    target_language: str = Field(..., min_length=1, max_length=20)
 
 
 class ImportTranslationEntry(BaseModel):
     book_id: int = Field(..., ge=1)
     chapter_index: int = Field(..., ge=0)
-    target_language: str = Field(..., max_length=20)
+    target_language: str = Field(..., min_length=1, max_length=20)
     paragraphs: list[Annotated[str, Field(max_length=50000)]] = Field(..., max_length=2000)
     provider: str | None = Field(default=None, max_length=100)
     model: str | None = Field(default=None, max_length=200)
@@ -933,7 +933,7 @@ async def queue_stop(_admin: dict = Depends(_require_admin)):
 
 
 class QueuePlanRequest(BaseModel):
-    target_language: str = Field(..., max_length=20)
+    target_language: str = Field(..., min_length=1, max_length=20)
     book_ids: list[Annotated[int, Field(ge=1)]] | None = Field(default=None, max_length=1000)
 
 
@@ -1112,7 +1112,7 @@ async def queue_items(
 
 class EnqueueBookRequest(BaseModel):
     book_id: int = Field(..., ge=1)
-    target_languages: list[Annotated[str, Field(max_length=20)]] | None = Field(default=None, max_length=100)
+    target_languages: list[Annotated[str, Field(min_length=1, max_length=20)]] | None = Field(default=None, max_length=100)
     priority: int = 50   # lower than default so admin enqueues jump the line
     reset_failed: bool = False
 

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -49,7 +49,7 @@ class InsightRequest(BaseModel):
     chapter_text: str = Field(..., max_length=50_000)
     book_title: str = Field(..., max_length=500)
     author: str = Field(..., max_length=500)
-    response_language: str = Field(default="en", max_length=20)
+    response_language: str = Field(default="en", min_length=1, max_length=20)
 
 
 class QARequest(BaseModel):
@@ -57,7 +57,7 @@ class QARequest(BaseModel):
     passage: str = Field(..., max_length=50_000)
     book_title: str = Field(..., max_length=500)
     author: str = Field(..., max_length=500)
-    response_language: str = Field(default="en", max_length=20)
+    response_language: str = Field(default="en", min_length=1, max_length=20)
 
 
 class ReferencesRequest(BaseModel):
@@ -65,7 +65,7 @@ class ReferencesRequest(BaseModel):
     author: str = Field(..., max_length=500)
     chapter_title: str = Field(default="", max_length=500)
     chapter_excerpt: str = Field(default="", max_length=10_000)
-    response_language: str = Field(default="en", max_length=20)
+    response_language: str = Field(default="en", min_length=1, max_length=20)
 
 
 class SummaryRequest(BaseModel):
@@ -79,8 +79,8 @@ class SummaryRequest(BaseModel):
 
 class TranslateRequest(BaseModel):
     text: str = Field(..., max_length=50_000)
-    source_language: str = Field(default="de", max_length=20)
-    target_language: str = Field(default="en", max_length=20)
+    source_language: str = Field(default="de", min_length=1, max_length=20)
+    target_language: str = Field(default="en", min_length=1, max_length=20)
     book_id: int | None = Field(default=None, ge=1)
     chapter_index: int | None = Field(default=None, ge=0)
     # "auto" → Gemini if user has a key, else Google Translate (free).
@@ -89,7 +89,7 @@ class TranslateRequest(BaseModel):
 
 class TTSRequest(BaseModel):
     text: str = Field(..., max_length=50_000)
-    language: str = Field(default="en", max_length=20)
+    language: str = Field(default="en", min_length=1, max_length=20)
     rate: float = Field(default=1.0, ge=0.25, le=4.0)
     gender: Literal["female", "male"] = "female"
 
@@ -269,7 +269,7 @@ async def translate_cache(
 class SaveTranslationRequest(BaseModel):
     book_id: int = Field(..., ge=1)
     chapter_index: int = Field(..., ge=0)
-    target_language: str = Field(..., max_length=20)
+    target_language: str = Field(..., min_length=1, max_length=20)
     paragraphs: list[Annotated[str, Field(max_length=50000)]] = Field(..., max_length=2000)
     provider: str | None = Field(default=None, max_length=100)
     model: str | None = Field(default=None, max_length=200)

--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -207,7 +207,7 @@ async def get_chapter_translation(
 
 
 class RequestTranslationBody(BaseModel):
-    target_language: str = Field(..., max_length=20)
+    target_language: str = Field(..., min_length=1, max_length=20)
 
 
 @router.post("/{book_id}/chapters/{chapter_index}/translation")

--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -34,7 +34,7 @@ class WordSave(BaseModel):
 
 class ExportRequest(BaseModel):
     book_id: int | None = Field(default=None, ge=1)
-    target_language: str = Field(default="zh", max_length=20)
+    target_language: str = Field(default="zh", min_length=1, max_length=20)
 
 
 @router.post("")

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -2788,3 +2788,42 @@ async def test_queue_dry_run_error_does_not_leak_exception_detail(admin_client):
     detail = res.json()["detail"]
     assert "api-key-secret-xyzzy" not in detail
     assert "leaked" not in detail
+
+
+# ── Issue #772: target_language fields accept empty string ────────────────────
+
+
+async def test_queue_plan_empty_target_language_returns_422(admin_client):
+    """Regression #772: POST /admin/queue/plan with target_language="" must return 422."""
+    res = await admin_client.post(
+        "/api/admin/queue/plan",
+        json={"target_language": ""},
+    )
+    assert res.status_code == 422, f"Expected 422 for empty target_language, got {res.status_code}: {res.text}"
+
+
+async def test_queue_dry_run_empty_target_language_returns_422(admin_client):
+    """Regression #772: POST /admin/queue/dry-run with target_language="" must return 422."""
+    res = await admin_client.post(
+        "/api/admin/queue/dry-run",
+        json={"target_language": ""},
+    )
+    assert res.status_code == 422, f"Expected 422 for empty target_language, got {res.status_code}: {res.text}"
+
+
+async def test_bulk_retranslate_empty_target_language_returns_422(admin_client):
+    """Regression #772: POST /admin/translations/{id}/retranslate-all with target_language="" must return 422."""
+    res = await admin_client.post(
+        "/api/admin/translations/9901/retranslate-all",
+        json={"target_language": ""},
+    )
+    assert res.status_code == 422, f"Expected 422 for empty target_language, got {res.status_code}: {res.text}"
+
+
+async def test_enqueue_book_empty_target_language_in_list_returns_422(admin_client):
+    """Regression #772: POST /admin/queue/enqueue-book with empty string in target_languages must return 422."""
+    res = await admin_client.post(
+        "/api/admin/queue/enqueue-book",
+        json={"book_id": 1, "target_languages": [""]},
+    )
+    assert res.status_code == 422, f"Expected 422 for empty target_language in list, got {res.status_code}: {res.text}"

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -1230,3 +1230,33 @@ async def test_save_translation_negative_book_id_returns_422(client, test_user):
         "paragraphs": ["Hello."],
     })
     assert resp.status_code == 422, f"Expected 422 for book_id=-1 in save_translation, got {resp.status_code}: {resp.text}"
+
+
+# ── Issue #772: min_length=1 on target/source language fields ─────────────────
+
+
+async def test_translate_empty_target_language_returns_422(client, test_user):
+    """Regression #772: POST /ai/translate with target_language="" must return 422."""
+    resp = await client.post("/api/ai/translate", json={
+        "text": "Hallo Welt",
+        "target_language": "",
+    })
+    assert resp.status_code == 422, f"Expected 422 for empty target_language, got {resp.status_code}: {resp.text}"
+
+
+async def test_translate_empty_source_language_returns_422(client, test_user):
+    """Regression #772: POST /ai/translate with source_language="" must return 422."""
+    resp = await client.post("/api/ai/translate", json={
+        "text": "Hello World",
+        "source_language": "",
+    })
+    assert resp.status_code == 422, f"Expected 422 for empty source_language, got {resp.status_code}: {resp.text}"
+
+
+async def test_save_translation_empty_target_language_returns_422(client, test_user):
+    """Regression #772: PUT /ai/translate/cache with target_language="" must return 422."""
+    resp = await client.put("/api/ai/translate/cache", json={
+        "book_id": 1, "chapter_index": 0, "target_language": "",
+        "paragraphs": ["Hello."],
+    })
+    assert resp.status_code == 422, f"Expected 422 for empty target_language in save_translation, got {resp.status_code}: {resp.text}"

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -1206,3 +1206,15 @@ async def test_popular_books_page_too_large_returns_422(client):
     """Regression #739: GET /books/popular?page=10001 must return 422."""
     resp = await client.get("/api/books/popular?page=10001")
     assert resp.status_code == 422, f"Expected 422 for page > 10000, got {resp.status_code}: {resp.text}"
+
+
+# ── Issue #772: min_length=1 on target_language in RequestTranslationBody ────
+
+
+async def test_request_translation_empty_target_language_returns_422(client, test_user):
+    """Regression #772: POST /books/{id}/chapters/{i}/translation with target_language="" must return 422."""
+    resp = await client.post(
+        "/api/books/1/chapters/0/translation",
+        json={"target_language": ""},
+    )
+    assert resp.status_code == 422, f"Expected 422 for empty target_language, got {resp.status_code}: {resp.text}"


### PR DESCRIPTION
## What changed
- `routers/admin.py`: added `min_length=1` to `BulkRetranslateRequest.target_language`, `ImportTranslationEntry.target_language`, `QueuePlanRequest.target_language`, and per-element on `EnqueueBookRequest.target_languages`
- `routers/ai.py`: added `min_length=1` to `response_language` (InsightRequest, QARequest, ReferencesRequest), `source_language`/`target_language` (TranslateRequest), `language` (TTSRequest), `target_language` (SaveTranslationRequest)
- `routers/books.py`: added `min_length=1` to `RequestTranslationBody.target_language`
- `routers/vocabulary.py`: added `min_length=1` to `ExportRequest.target_language`
- `tests/test_router_admin.py`: 4 regression tests for empty language fields
- `tests/test_router_ai.py`: 3 regression tests for empty language fields
- `tests/test_router_books.py`: 1 regression test for empty language field

## Why
All language `str` fields had `max_length` but no `min_length`, so an empty string `""` passed Pydantic validation and reached service/DB/AI code. An empty language code causes unexpected AI provider errors or silent bad data.

## Test plan
- [x] `test_queue_plan_empty_target_language_returns_422`
- [x] `test_queue_dry_run_empty_target_language_returns_422`
- [x] `test_bulk_retranslate_empty_target_language_returns_422`
- [x] `test_enqueue_book_empty_target_language_in_list_returns_422`
- [x] `test_translate_empty_target_language_returns_422`
- [x] `test_translate_empty_source_language_returns_422`
- [x] `test_save_translation_empty_target_language_returns_422`
- [x] `test_request_translation_empty_target_language_returns_422`
- [x] Full backend suite: 1379 passed

Closes #772
