### PR TITLE
fix: suppress raw exception details in vocabulary Obsidian export 500 response

### DIFF
--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -479,5 +479,5 @@ async def export_obsidian(
             return {"urls": urls}
     except HTTPException:
         raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception:
+        raise HTTPException(status_code=500, detail="Export to GitHub failed")

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -759,3 +759,19 @@ async def test_export_obsidian_zero_book_id_returns_422(client, test_user):
     """Regression #734: POST /vocabulary/export/obsidian with book_id=0 must return 422."""
     resp = await client.post("/api/vocabulary/export/obsidian", json={"book_id": 0})
     assert resp.status_code == 422, f"Expected 422 for book_id=0 in export, got {resp.status_code}: {resp.text}"
+
+
+# ── Issue #760: Obsidian export exception must not leak in 500 response ───────
+
+@pytest.mark.asyncio
+async def test_export_obsidian_error_does_not_leak_exception_detail(client, test_user):
+    """Regression #760: GitHub export errors must use a static message, not str(e)."""
+    await _setup_export(test_user)
+    with patch("routers.vocabulary._github_put", new_callable=AsyncMock,
+               side_effect=RuntimeError("github-token-secret-xyzzy leaked")), \
+         patch("routers.vocabulary.translate_text", new_callable=AsyncMock, return_value=[]):
+        resp = await client.post("/api/vocabulary/export/obsidian", json={"book_id": BOOK_ID})
+    assert resp.status_code == 500
+    detail = resp.json()["detail"]
+    assert "github-token-secret-xyzzy" not in detail
+    assert "leaked" not in detail

--- a/backend/tests/test_router_vocabulary_extended.py
+++ b/backend/tests/test_router_vocabulary_extended.py
@@ -515,7 +515,8 @@ async def test_export_wraps_generic_exception_as_500(client, test_user):
         resp = await client.post("/api/vocabulary/export/obsidian", json={"book_id": BOOK_ID})
 
     assert resp.status_code == 500
-    assert "unexpected failure" in resp.json()["detail"]
+    assert "unexpected failure" not in resp.json()["detail"]
+    assert resp.json()["detail"] == "Export to GitHub failed"
 
 
 async def test_export_uses_default_path_when_obsidian_path_not_set(client, test_user):


### PR DESCRIPTION
## What changed
- `routers/vocabulary.py` `export_obsidian`: changed `except Exception as e: raise HTTPException(status_code=500, detail=str(e))` to `except Exception: raise HTTPException(status_code=500, detail="Export to GitHub failed")` — raw exception text (which may include GitHub tokens, repo paths, or network error details) no longer leaks into the 500 response body.
- `tests/test_router_vocabulary.py`: added `test_export_obsidian_error_does_not_leak_exception_detail` — patches `_github_put` to raise a RuntimeError with a sentinel string and asserts the sentinel is absent from the 500 response detail.

## Why
The Obsidian GitHub export `except Exception as e` clause forwarded `str(e)` directly to the HTTP client. A GitHub API error or network failure could expose the repo name, token hint, or internal path in the response body.

## Test plan
- [x] `test_export_obsidian_error_does_not_leak_exception_detail` — 500 with static message, no sentinel in detail
- [x] Full vocabulary test suite: 42 passed

Closes #760
