### PR TITLE
fix: add min_length=1 bounds to QueueSettingsRequest list elements and RetryFailedRequest.target_language (closes #776)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1043,11 +1043,11 @@ async def queue_get_settings(_admin: dict = Depends(_require_admin)):
 class QueueSettingsRequest(BaseModel):
     enabled: bool | None = None
     api_key: str | None = Field(default=None, max_length=500)
-    auto_translate_languages: list[Annotated[str, Field(max_length=20)]] | None = Field(default=None, max_length=50)
+    auto_translate_languages: list[Annotated[str, Field(min_length=1, max_length=20)]] | None = Field(default=None, max_length=50)
     rpm: int | None = Field(default=None, ge=1)
     rpd: int | None = Field(default=None, ge=1)
     model: str | None = Field(default=None, max_length=200)
-    model_chain: list[Annotated[str, Field(max_length=200)]] | None = Field(default=None, max_length=20)
+    model_chain: list[Annotated[str, Field(min_length=1, max_length=200)]] | None = Field(default=None, max_length=20)
     max_output_tokens: int | None = Field(default=None, ge=1)
 
 
@@ -1224,7 +1224,7 @@ async def queue_retry_item(
 
 class RetryFailedRequest(BaseModel):
     book_id: int | None = Field(default=None, ge=1)
-    target_language: str | None = Field(default=None, max_length=20)
+    target_language: str | None = Field(default=None, min_length=1, max_length=20)
 
 
 @router.post("/queue/retry-failed")

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -2173,14 +2173,14 @@ async def test_queue_settings_rejects_empty_model_chain(admin_client, admin_db):
 
 
 async def test_queue_settings_rejects_model_chain_with_empty_entry(admin_client, admin_db):
-    """Regression #474: model_chain with empty-string entry must return 400
-    (would set SETTING_MODEL to '' causing AI calls to fail)."""
+    """Regression #474/#776: model_chain with empty-string entry must be rejected.
+    Now returns 422 (Pydantic min_length=1 fires before business logic)."""
     res = await admin_client.put(
         "/api/admin/queue/settings",
         json={"model_chain": ["", "gemini-1.5-flash"]},
     )
-    assert res.status_code == 400, (
-        f"Expected 400 for model_chain with empty entry, got {res.status_code}: {res.text}"
+    assert res.status_code == 422, (
+        f"Expected 422 for model_chain with empty entry, got {res.status_code}: {res.text}"
     )
 
 
@@ -2905,3 +2905,36 @@ async def test_enqueue_book_empty_target_language_in_list_returns_422(admin_clie
         json={"book_id": 1, "target_languages": [""]},
     )
     assert res.status_code == 422, f"Expected 422 for empty target_language in list, got {res.status_code}: {res.text}"
+
+
+# ── Issue #776: QueueSettingsRequest list elements and RetryFailedRequest.target_language ──
+
+
+@pytest.mark.asyncio
+async def test_queue_settings_empty_auto_translate_language_returns_422(admin_client):
+    """Regression #776: PUT /admin/queue/settings with empty string in auto_translate_languages must return 422."""
+    res = await admin_client.put(
+        "/api/admin/queue/settings",
+        json={"auto_translate_languages": [""]},
+    )
+    assert res.status_code == 422, f"Expected 422 for empty lang in auto_translate_languages, got {res.status_code}: {res.text}"
+
+
+@pytest.mark.asyncio
+async def test_queue_settings_empty_model_chain_entry_returns_422(admin_client):
+    """Regression #776: PUT /admin/queue/settings with empty string in model_chain must return 422."""
+    res = await admin_client.put(
+        "/api/admin/queue/settings",
+        json={"model_chain": [""]},
+    )
+    assert res.status_code == 422, f"Expected 422 for empty entry in model_chain, got {res.status_code}: {res.text}"
+
+
+@pytest.mark.asyncio
+async def test_retry_failed_empty_target_language_returns_422(admin_client):
+    """Regression #776: POST /admin/queue/retry-failed with target_language="" must return 422."""
+    res = await admin_client.post(
+        "/api/admin/queue/retry-failed",
+        json={"target_language": ""},
+    )
+    assert res.status_code == 422, f"Expected 422 for empty target_language, got {res.status_code}: {res.text}"


### PR DESCRIPTION
## What changed
- `QueueSettingsRequest`: added `min_length=1` to `auto_translate_languages` list element type and `model_chain` list element type — empty strings are now rejected at the Pydantic level (422) before reaching business logic.
- `RetryFailedRequest`: added `min_length=1` to `target_language` field — empty string is rejected with 422.
- `tests/test_router_admin.py`: added three regression tests for the new bounds; updated existing `test_queue_settings_rejects_model_chain_with_empty_entry` to expect 422 (Pydantic now fires before the 400 business-logic check).

## Why
`auto_translate_languages`, `model_chain`, and `target_language` in the queue settings/retry-failed endpoints accepted empty strings. Storing an empty model name or language code caused downstream AI calls to fail with cryptic errors.

## Test plan
- [x] `test_queue_settings_empty_auto_translate_language_returns_422` — 422 for `[""]` in auto_translate_languages
- [x] `test_queue_settings_empty_model_chain_entry_returns_422` — 422 for `[""]` in model_chain
- [x] `test_retry_failed_empty_target_language_returns_422` — 422 for `target_language: ""`
- [x] Full backend suite: 1387 passed
- [x] Full frontend suite: 1750 passed

Closes #776
