### PR TITLE
fix: strip Gutenberg EPUB frontmatter + duplicate chapter-title body prefix (#778)

### DIFF
--- a/backend/services/splitter.py
+++ b/backend/services/splitter.py
@@ -631,6 +631,19 @@ def build_chapters_from_epub(epub_bytes: bytes) -> list[Chapter]:
             # of the chapter content.
             for boiler in body.xpath(".//section[contains(@class, 'pg-boilerplate')]"):
                 boiler.getparent().remove(boiler)
+            # Drop internal-anchor TOC tables and lists. Gutenberg pg-header
+            # items often carry a <table> or <ol> full of
+            # <a class="pginternal"> links to other spine items — a rendered
+            # reading of those looks like "chapter 0 = title + TOC" and
+            # shifts every real chapter's translation by one (#762, Faust).
+            for toc in _epub_toc_containers(body):
+                toc.getparent().remove(toc)
+            # Drop Gutenberg-marked frontmatter blocks (cover, title page,
+            # copyright, dedication, etc.) by class — Kafka's pg-header
+            # uses <div class="div1 titlepage">, <div class="div1
+            # copyright"> and so on for every frontmatter element.
+            for fm in _epub_frontmatter_blocks(body):
+                fm.getparent().remove(fm)
             text = _html_body_text(body, skip_first_heading=True)
         except Exception:
             continue
@@ -643,11 +656,86 @@ def build_chapters_from_epub(epub_bytes: bytes) -> list[Chapter]:
             or _epub_heading_title(raw)
             or f"Section {len(chapters) + 1}"
         )
+        # Drop the chapter title if it repeats as the first body paragraph
+        # (Faust Nacht: spine item holds a stand-alone part-title <div class="chapter">
+        # followed by the real scene <div class="chapter">; the recursive
+        # body walker otherwise renders both into text).
+        text = _strip_title_from_body_prefix(text, title)
         chapters.append(Chapter(title=_clean_title(title), text=text))
 
     # EPUB spine is authoritative structure, not a heuristic guess.
     # Skip the regex-oriented _validate() and just require >= 2 chapters.
     return chapters if len(chapters) >= 2 else []
+
+
+_FRONTMATTER_CLASSES = (
+    "cover", "titlepage", "frenchtitle", "halftitle",
+    "colophon", "copyright", "dedication",
+)
+
+
+def _epub_frontmatter_blocks(body) -> list:
+    """Return top-level div/section elements tagged as frontmatter by
+    Gutenberg-specific class markers. Kafka's pg-header wraps each piece
+    (cover image, titlepage, frenchtitle, copyright) in its own
+    ``<div class="div1 titlepage">``-style container; this lets us drop
+    them cleanly without hard-coding item IDs."""
+    out = []
+    for elem in body.xpath(".//div[@class] | .//section[@class]"):
+        classes = (elem.get("class") or "").split()
+        if any(c in _FRONTMATTER_CLASSES for c in classes):
+            out.append(elem)
+    return out
+
+
+def _normalize_for_title_match(s: str) -> str:
+    """Lowercase + whitespace-collapse + trim. Used to detect whether a body
+    paragraph is really a repetition of the chapter title."""
+    import re
+    return re.sub(r"\s+", " ", (s or "").strip().lower())
+
+
+def _strip_title_from_body_prefix(body_text: str, title: str) -> str:
+    """If the body text's first non-empty paragraph(s) are just the chapter
+    title (or a close variant), drop them.
+
+    Happens when a spine item's HTML carries a <div class="chapter">
+    wrapper whose sole payload is the part/book title heading — the
+    recursive body walker otherwise renders that into body text verbatim,
+    duplicating the chapter header in the reader (book 2229, Faust Nacht).
+    """
+    if not body_text or not title:
+        return body_text
+    target = _normalize_for_title_match(title)
+    paragraphs = body_text.split("\n\n")
+    while paragraphs and _normalize_for_title_match(paragraphs[0]) == target:
+        paragraphs.pop(0)
+    return "\n\n".join(paragraphs).lstrip("\n")
+
+
+def _epub_toc_containers(body) -> list:
+    """Return <table> / <ol> / <ul> elements whose direct entries are
+    overwhelmingly (>=60%) Gutenberg-internal TOC links.
+
+    Marker used: ``<a class="pginternal">`` — Gutenberg emits exactly this
+    class on every TOC anchor it auto-generates, so the signal is narrow.
+    We look at direct-descendant cell/li nodes rather than every nested
+    anchor, which prevents a legitimate chapter that quotes a cross-link
+    from being mistaken for a TOC.
+    """
+    out = []
+    for container in body.xpath(".//table | .//ol | .//ul"):
+        entries = container.xpath(".//tr | .//li")
+        if not entries:
+            continue
+        internal = 0
+        for entry in entries:
+            entry_anchors = entry.xpath(".//a[contains(@class, 'pginternal')]")
+            if entry_anchors:
+                internal += 1
+        if internal >= max(3, int(len(entries) * 0.6)):
+            out.append(container)
+    return out
 
 
 def _epub_nav_titles(book) -> dict[str, str]:

--- a/backend/tests/test_chapter_source.py
+++ b/backend/tests/test_chapter_source.py
@@ -106,3 +106,71 @@ def test_html_body_text_preserves_div_chapter_wrapper_in_epub():
         body, skip_first_heading=True, skip_nested_chapter_divs=True,
     )
     assert "Jemand mußte Josef K." not in text_html_path, text_html_path
+
+
+# ── Faust / Kafka title-page + duplicate-title regressions ─────────────────
+
+def test_strip_title_from_body_prefix_drops_matching_line():
+    """If a chapter's body text opens with the chapter title itself,
+    _strip_title_from_body_prefix drops that line so the reader doesn't
+    render the header twice (Faust Nacht, book 2229)."""
+    from services.splitter import _strip_title_from_body_prefix
+    body = "FAUST: Der Tragödie erster Teil\n\nNacht\n\nIn einem hochgewölbten..."
+    out = _strip_title_from_body_prefix(body, "FAUST: Der Tragödie erster Teil")
+    assert out.startswith("Nacht")
+
+
+def test_strip_title_leaves_unrelated_body_alone():
+    from services.splitter import _strip_title_from_body_prefix
+    body = "Once upon a time\n\nmore prose"
+    out = _strip_title_from_body_prefix(body, "Chapter 1")
+    assert out == body
+
+
+def test_epub_frontmatter_blocks_detects_gutenberg_classes():
+    """Kafka's pg-header wraps each frontmatter piece in
+    <div class="div1 titlepage"> / cover / frenchtitle / copyright. The
+    helper finds them all by class so build_chapters_from_epub can strip
+    them before the word-count filter runs."""
+    from lxml import html as lxml_html
+    from services.splitter import _epub_frontmatter_blocks
+    html = """
+    <body>
+      <div class="body">
+        <div class="div1 cover"><p>cover text</p></div>
+        <div class="div1 titlepage"><h1>Title</h1></div>
+        <div class="div1 frenchtitle"><p>AUTHOR</p></div>
+        <div class="div1 copyright"><p>(c) 1925</p></div>
+        <div class="chapter"><p>real prose</p></div>
+      </div>
+    </body>
+    """
+    body = lxml_html.fromstring(html)
+    fm = _epub_frontmatter_blocks(body)
+    assert len(fm) == 4
+
+
+def test_epub_toc_containers_detects_pginternal_table():
+    """Gutenberg title-page spine items often hold a <table> whose every
+    row is a single <a class="pginternal"> link to another spine item
+    (book 2229 Faust). Dropping the table lets the 30-word cutoff filter
+    the whole spine item out so it doesn't become a rogue chapter 0."""
+    from lxml import html as lxml_html
+    from services.splitter import _epub_toc_containers
+    html = """
+    <body>
+      <table>
+        <tr><td><a class="pginternal" href="ch1.xhtml#c1">Zueignung</a></td></tr>
+        <tr><td><a class="pginternal" href="ch2.xhtml#c2">Vorspiel</a></td></tr>
+        <tr><td><a class="pginternal" href="ch3.xhtml#c3">Prolog im Himmel</a></td></tr>
+        <tr><td><a class="pginternal" href="ch4.xhtml#c4">Nacht</a></td></tr>
+      </table>
+      <p>This is not a TOC.</p>
+      <table>
+        <tr><td>Random</td><td>table cell</td></tr>
+      </table>
+    </body>
+    """
+    body = lxml_html.fromstring(html)
+    toc = _epub_toc_containers(body)
+    assert len(toc) == 1  # only the pginternal-dominated table qualifies


### PR DESCRIPTION
Closes #778.

## What changed

Three targeted filters in `backend/services/splitter.py` `build_chapters_from_epub()`:

1. `_epub_toc_containers(body)` drops `<table>` / `<ol>` whose rows are ≥60% `<a class="pginternal">` internal-anchor TOC links. Catches Faust's pg-header title-page chapter-0 content.
2. `_epub_frontmatter_blocks(body)` drops `<div>` / `<section>` carrying Gutenberg frontmatter class markers (`titlepage`, `cover`, `frenchtitle`, `copyright`, `dedication`, …). Catches Kafka pg-header.
3. `_strip_title_from_body_prefix(text, title)` drops a leading paragraph that normalizes to the chapter title, preventing `"FAUST: Der Tragödie erster Teil"` from showing up twice in the body of the Nacht scene.

## Why

Both 2229 (Faust) and 69327 (Der Prozess) rendered a rogue chapter 0 built from title-page / copyright / TOC HTML, shifting every real chapter by one and misaligning cached translations. The existing `pg-boilerplate` filter only catches `<section class="pg-boilerplate">`, which misses both the TOC table and the class-tagged div frontmatter.

## Test plan

- [x] `test_chapter_source.py` (68 new lines) covers all three mechanisms with representative HTML fixtures.
- [x] Full backend suite: **1388 passed**.

## Local verification (manual)

- Faust (2229): 28 chapters (was 29); chapter 0 = Zueignung. Chapter 3 (Nacht) body no longer repeats the chapter title.
- Kafka (69327): 11 chapters (was 12); chapter 0 = ERSTES KAPITEL.
- Rilke (24288) poetry: unchanged at 2 chapters — no regression.

## Follow-up

Translation-cache index re-alignment for Faust chapters 5+ (Studierzimmer split + previously cached translations shifted by one) is a separate data-migration problem, tracked on the audit issue.
