### PR TITLE
ux: redesign AnnotationToolbar as centered modal, remove deprecated onAnnotate from SentenceReader

### DIFF
--- a/frontend/src/__tests__/AnnotationToolbar.branches.test.tsx
+++ b/frontend/src/__tests__/AnnotationToolbar.branches.test.tsx
@@ -26,7 +26,6 @@ const BASE_PROPS = {
   sentenceText: "It is a truth universally acknowledged.",
   chapterIndex: 0,
   bookId: 1,
-  position: { x: 100, y: 200 },
   onClose: jest.fn(),
   onSaved: jest.fn(),
   onDeleted: jest.fn(),
@@ -36,21 +35,15 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-// ── Line 48: outside click calls onClose ─────────────────────────────────────
+// ── Backdrop click calls onClose ─────────────────────────────────────────────
 
-describe("AnnotationToolbar — outside click closes panel (line 48)", () => {
-  it("calls onClose when clicking outside the panel", () => {
+describe("AnnotationToolbar — backdrop click closes modal", () => {
+  it("calls onClose when clicking the backdrop", () => {
     const onClose = jest.fn();
-    render(
-      <div>
-        <AnnotationToolbar {...BASE_PROPS} onClose={onClose} />
-        <div data-testid="outside">Outside element</div>
-      </div>,
-    );
+    render(<AnnotationToolbar {...BASE_PROPS} onClose={onClose} />);
 
-    // Dispatch mousedown on an element outside the panel
-    const outside = screen.getByTestId("outside");
-    fireEvent.mouseDown(outside);
+    const backdrop = screen.getByTestId("annotation-backdrop");
+    fireEvent.click(backdrop);
 
     expect(onClose).toHaveBeenCalled();
   });
@@ -59,28 +52,8 @@ describe("AnnotationToolbar — outside click closes panel (line 48)", () => {
     const onClose = jest.fn();
     render(<AnnotationToolbar {...BASE_PROPS} onClose={onClose} />);
 
-    // Dispatch mousedown on the panel itself
     const panel = screen.getByTestId("annotation-toolbar");
-    fireEvent.mouseDown(panel);
-
-    expect(onClose).not.toHaveBeenCalled();
-  });
-
-  it("removes listener on unmount — no call after unmount", () => {
-    const onClose = jest.fn();
-    const { unmount } = render(
-      <div>
-        <AnnotationToolbar {...BASE_PROPS} onClose={onClose} />
-        <div data-testid="outside2">Outside</div>
-      </div>,
-    );
-
-    unmount();
-
-    const outside = document.createElement("div");
-    document.body.appendChild(outside);
-    fireEvent.mouseDown(outside);
-    document.body.removeChild(outside);
+    fireEvent.click(panel);
 
     expect(onClose).not.toHaveBeenCalled();
   });
@@ -193,7 +166,7 @@ describe("AnnotationToolbar — handleDelete error paths (line 106)", () => {
     );
   });
 
-  it("shows deleting indicator while delete is in progress", async () => {
+  it("disables delete button while delete is in progress", async () => {
     let resolveDelete: (v: unknown) => void = () => {};
     mockDeleteAnnotation.mockReturnValue(new Promise((res) => { resolveDelete = res; }));
 
@@ -204,8 +177,7 @@ describe("AnnotationToolbar — handleDelete error paths (line 106)", () => {
 
     await user.click(screen.getByRole("button", { name: /delete/i }));
 
-    // During delete "…" is shown
-    expect(screen.getByText("…")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /delete/i })).toBeDisabled();
 
     resolveDelete({ ok: true });
   });
@@ -230,9 +202,8 @@ describe("AnnotationToolbar — color picker", () => {
   it("selects yellow by default", () => {
     render(<AnnotationToolbar {...BASE_PROPS} />);
 
-    const yellowBtn = screen.getByLabelText("Yellow");
-    // Default selected color = yellow → scale-110 class
-    expect(yellowBtn.className).toMatch(/scale-110/);
+    expect(screen.getByLabelText("Yellow")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByLabelText("Blue")).toHaveAttribute("aria-pressed", "false");
   });
 
   it("switches selected color when a different color is clicked", async () => {
@@ -241,10 +212,7 @@ describe("AnnotationToolbar — color picker", () => {
 
     await user.click(screen.getByLabelText("Pink"));
 
-    const pinkBtn = screen.getByLabelText("Pink");
-    expect(pinkBtn.className).toMatch(/scale-110/);
-
-    const yellowBtn = screen.getByLabelText("Yellow");
-    expect(yellowBtn.className).not.toMatch(/scale-110/);
+    expect(screen.getByLabelText("Pink")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByLabelText("Yellow")).toHaveAttribute("aria-pressed", "false");
   });
 });

--- a/frontend/src/__tests__/AnnotationToolbar.test.tsx
+++ b/frontend/src/__tests__/AnnotationToolbar.test.tsx
@@ -22,7 +22,6 @@ const BASE_PROPS = {
   sentenceText: "It is a truth universally acknowledged.",
   chapterIndex: 0,
   bookId: 1,
-  position: { x: 100, y: 200 },
   onClose: jest.fn(),
   onSaved: jest.fn(),
   onDeleted: jest.fn(),
@@ -64,7 +63,7 @@ test("pre-fills color and note from existingAnnotation", () => {
       existingAnnotation={{ id: 42, note_text: "Interesting passage", color: "green" }}
     />,
   );
-  const textarea = screen.getByPlaceholderText(/Add a note/i) as HTMLTextAreaElement;
+  const textarea = screen.getByPlaceholderText(/Your thoughts/i) as HTMLTextAreaElement;
   expect(textarea.value).toBe("Interesting passage");
   // Green button should appear selected (scale-110 class)
   const greenBtn = screen.getByLabelText("Green");
@@ -83,10 +82,10 @@ test("calls createAnnotation and onSaved when saving new annotation", async () =
 
   render(<AnnotationToolbar {...BASE_PROPS} />);
 
-  const textarea = screen.getByPlaceholderText(/Add a note/i);
+  const textarea = screen.getByPlaceholderText(/Your thoughts/i);
   await userEvent.type(textarea, "My note");
 
-  await userEvent.click(screen.getByRole("button", { name: /save/i }));
+  await userEvent.click(screen.getByRole("button", { name: /save note/i }));
 
   await waitFor(() => {
     expect(mockCreateAnnotation).toHaveBeenCalledWith({
@@ -121,7 +120,7 @@ test("calls updateAnnotation when saving existing annotation", async () => {
   // Change color to blue
   await userEvent.click(screen.getByLabelText("Blue"));
 
-  await userEvent.click(screen.getByRole("button", { name: /save/i }));
+  await userEvent.click(screen.getByRole("button", { name: /update/i }));
 
   await waitFor(() => {
     expect(mockUpdateAnnotation).toHaveBeenCalledWith(42, expect.objectContaining({ color: "blue" }));

--- a/frontend/src/__tests__/AnnotationToolbarTouchTarget.test.tsx
+++ b/frontend/src/__tests__/AnnotationToolbarTouchTarget.test.tsx
@@ -16,7 +16,6 @@ const baseProps = {
   sentenceText: "Call me Ishmael.",
   chapterIndex: 0,
   bookId: 10,
-  position: { x: 100, y: 100 },
   onClose: jest.fn(),
   onSaved: jest.fn(),
   onDeleted: jest.fn(),

--- a/frontend/src/__tests__/ReaderPage.branches2.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches2.test.tsx
@@ -310,24 +310,16 @@ jest.mock("@/components/UndoToast", () => {
   return { __esModule: true, default: UndoToast };
 });
 
-// ─── SentenceReader: exposes onAnnotate / onSegmentClick / onAnnotationClick ──
+// ─── SentenceReader: exposes onSegmentClick / onAnnotationClick ───────────────
 jest.mock("@/components/SentenceReader", () => {
   const SentenceReader = ({
-    onAnnotate,
     onSegmentClick,
     onAnnotationClick,
   }: {
-    onAnnotate?: (sentenceText: string, ci: number, position: { x: number; y: number }) => void;
     onSegmentClick?: (startTime: number) => void;
     onAnnotationClick?: (ann: unknown, position: { x: number; y: number }) => void;
   }) => (
     <div data-testid="sentence-reader">
-      <button
-        data-testid="trigger-annotate"
-        onClick={() => onAnnotate?.("Test sentence", 0, { x: 100, y: 200 })}
-      >
-        annotate
-      </button>
       <button data-testid="trigger-segment-click" onClick={() => onSegmentClick?.(1.5)}>
         segment
       </button>
@@ -523,8 +515,8 @@ describe("ReaderPage.branches2 — AnnotationToolbar onSaved new annotation", ()
     render(<ReaderPage />);
     await flushPromises();
 
-    // Trigger annotation panel via SentenceReader mock button
-    const annotateBtn = await screen.findByTestId("trigger-annotate");
+    // Trigger annotation panel via SelectionToolbar note button
+    const annotateBtn = await screen.findByTestId("trigger-note");
     await userEvent.click(annotateBtn);
 
     const toolbar = await screen.findByTestId("annotation-toolbar");
@@ -610,7 +602,7 @@ describe("ReaderPage.branches2 — AnnotationToolbar onDeleted", () => {
     render(<ReaderPage />);
     await flushPromises();
 
-    const annotateBtn = await screen.findByTestId("trigger-annotate");
+    const annotateBtn = await screen.findByTestId("trigger-note");
     await userEvent.click(annotateBtn);
 
     const toolbar = await screen.findByTestId("annotation-toolbar");
@@ -1973,18 +1965,16 @@ describe("ReaderPage.branches2 — chapter nav loading state", () => {
   });
 });
 
-// ─── Annotation toolbar shown when SentenceReader onAnnotate fires ────────────
+// ─── Annotation toolbar shown when SelectionToolbar onNote fires ──────────────
 
-describe("ReaderPage.branches2 — SentenceReader onAnnotate opens toolbar", () => {
-  it("annotation toolbar appears when SentenceReader triggers onAnnotate", async () => {
+describe("ReaderPage.branches2 — SelectionToolbar onNote opens toolbar", () => {
+  it("annotation toolbar appears when SelectionToolbar triggers onNote", async () => {
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
     render(<ReaderPage />);
     await flushPromises();
 
-    await screen.findByTestId("sentence-reader");
-
-    const annotateBtn = await screen.findByTestId("trigger-annotate");
-    await userEvent.click(annotateBtn);
+    const noteBtn = await screen.findByTestId("trigger-note");
+    await userEvent.click(noteBtn);
 
     expect(await screen.findByTestId("annotation-toolbar")).toBeInTheDocument();
   });
@@ -2753,12 +2743,12 @@ describe("ReaderPage.branches2 — spacebar toggles TTS play/pause", () => {
 // ─── Annotation delete undo toast ─────────────────────────────────────────────
 
 describe("ReaderPage.branches2 — annotation delete shows undo toast", () => {
-  // id: 77 matches what SentenceReader mock sends in trigger-annotation-click
+  // id: 77 and sentence_text "annotated" match what SentenceReader mock sends in trigger-annotation-click
   const SAMPLE_ANN = {
     id: 77,
     book_id: 42,
     chapter_index: 0,
-    sentence_text: "Test sentence",
+    sentence_text: "annotated",
     note_text: "",
     color: "yellow",
   };
@@ -2811,9 +2801,12 @@ describe("ReaderPage.branches2 — annotation delete shows undo toast", () => {
     render(<ReaderPage />);
     await flushPromises();
 
-    // Open annotation toolbar via long-press trigger
-    const longPressTrigger = await screen.findByTestId("trigger-annotate");
-    await userEvent.click(longPressTrigger);
+    // Open annotation panel via annotation-click → qhp-open-note so existingAnnotation is loaded
+    const annClickBtn = await screen.findByTestId("trigger-annotation-click");
+    await userEvent.click(annClickBtn);
+
+    const openNoteBtn = await screen.findByTestId("qhp-open-note");
+    await userEvent.click(openNoteBtn);
 
     const deleteBtn = await screen.findByTestId("annotation-delete");
     await userEvent.click(deleteBtn);

--- a/frontend/src/__tests__/SentenceReader.branches.test.tsx
+++ b/frontend/src/__tests__/SentenceReader.branches.test.tsx
@@ -183,39 +183,12 @@ describe("SentenceReader — scrollTargetSentence flash effect (lines 388-396)",
   });
 });
 
-// ── Lines 476-477: handleSegLongPress fallback to handlePointerDown ─────────
+// ── Long-press is a no-op when onWordTap is not provided ─────────────────────
 
-describe("SentenceReader — handleSegLongPress falls back to handlePointerDown (lines 476-477)", () => {
+describe("SentenceReader — long-press is noop without onWordTap", () => {
   afterEach(() => jest.useRealTimers());
 
-  it("invokes onAnnotate via handlePointerDown when onWordTap is NOT provided", () => {
-    jest.useFakeTimers();
-    const onAnnotate = jest.fn();
-    const { container } = render(
-      <SentenceReader
-        text="Annotate via fallback sentence."
-        duration={0}
-        currentTime={0}
-        isPlaying={false}
-        onSegmentClick={noop}
-        onAnnotate={onAnnotate}
-        // No onWordTap → handleSegLongPress falls back to handlePointerDown
-      />
-    );
-
-    const segs = getSegments(container);
-    dispatchPointerEvent(segs[0], "pointerdown", { clientX: 10, clientY: 10 });
-
-    act(() => { jest.advanceTimersByTime(450); });
-
-    // onAnnotate should fire (via the fallback handlePointerDown path)
-    expect(onAnnotate).toHaveBeenCalledTimes(1);
-    const [sentenceText, chapterIdx] = onAnnotate.mock.calls[0];
-    expect(sentenceText).toContain("Annotate via fallback");
-    expect(chapterIdx).toBe(0);
-  });
-
-  it("no annotation when neither onAnnotate nor onWordTap provided (pointerdown is noop)", () => {
+  it("does not crash and fires nothing when onWordTap is not provided", () => {
     jest.useFakeTimers();
     const { container } = render(
       <SentenceReader
@@ -224,15 +197,12 @@ describe("SentenceReader — handleSegLongPress falls back to handlePointerDown 
         currentTime={0}
         isPlaying={false}
         onSegmentClick={noop}
-        // No onAnnotate, no onWordTap
       />
     );
 
     const segs = getSegments(container);
-    // Should not crash
     dispatchPointerEvent(segs[0], "pointerdown", { clientX: 10, clientY: 10 });
     act(() => { jest.advanceTimersByTime(600); });
-    // Just verifying no crash
     expect(segs.length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/__tests__/SentenceReader.coverage.test.tsx
+++ b/frontend/src/__tests__/SentenceReader.coverage.test.tsx
@@ -360,7 +360,7 @@ describe("SentenceReader — pointer move cancels long press (lines 455-458)", (
 
   it("cancels long press if pointer moves more than 10px", () => {
     jest.useFakeTimers();
-    const onAnnotate = jest.fn();
+    const onWordTap = jest.fn();
     const { container } = render(
       <SentenceReader
         text="Move and cancel sentence."
@@ -368,25 +368,23 @@ describe("SentenceReader — pointer move cancels long press (lines 455-458)", (
         currentTime={0}
         isPlaying={false}
         onSegmentClick={noop}
-        onAnnotate={onAnnotate}
+        onWordTap={onWordTap}
       />
     );
 
     const segs = getSegments(container);
-    // Start press at (10, 10)
     dispatchPointerEvent(segs[0], "pointerdown", { clientX: 10, clientY: 10 });
     // Move more than 10px away → should cancel the long-press timer
     dispatchPointerEvent(segs[0], "pointermove", { clientX: 25, clientY: 10 });
 
     act(() => { jest.advanceTimersByTime(500); });
 
-    // onAnnotate should NOT have been called
-    expect(onAnnotate).not.toHaveBeenCalled();
+    expect(onWordTap).not.toHaveBeenCalled();
   });
 
   it("does not cancel if pointer moves less than 10px", () => {
     jest.useFakeTimers();
-    const onAnnotate = jest.fn();
+    const onWordTap = jest.fn();
     const { container } = render(
       <SentenceReader
         text="Small move sentence here."
@@ -394,7 +392,7 @@ describe("SentenceReader — pointer move cancels long press (lines 455-458)", (
         currentTime={0}
         isPlaying={false}
         onSegmentClick={noop}
-        onAnnotate={onAnnotate}
+        onWordTap={onWordTap}
         chapterIndex={1}
       />
     );
@@ -406,12 +404,12 @@ describe("SentenceReader — pointer move cancels long press (lines 455-458)", (
 
     act(() => { jest.advanceTimersByTime(500); });
 
-    expect(onAnnotate).toHaveBeenCalledTimes(1);
+    expect(onWordTap).toHaveBeenCalledTimes(1);
   });
 
   it("pointerCancel clears the long-press timer", () => {
     jest.useFakeTimers();
-    const onAnnotate = jest.fn();
+    const onWordTap = jest.fn();
     const { container } = render(
       <SentenceReader
         text="Cancel event sentence."
@@ -419,18 +417,17 @@ describe("SentenceReader — pointer move cancels long press (lines 455-458)", (
         currentTime={0}
         isPlaying={false}
         onSegmentClick={noop}
-        onAnnotate={onAnnotate}
+        onWordTap={onWordTap}
       />
     );
 
     const segs = getSegments(container);
     dispatchPointerEvent(segs[0], "pointerdown", { clientX: 10, clientY: 10 });
-    // pointerCancel should call cancelLongPress
     dispatchPointerEvent(segs[0], "pointercancel", { clientX: 10, clientY: 10 });
 
     act(() => { jest.advanceTimersByTime(500); });
 
-    expect(onAnnotate).not.toHaveBeenCalled();
+    expect(onWordTap).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/__tests__/SentenceReader.extended.test.tsx
+++ b/frontend/src/__tests__/SentenceReader.extended.test.tsx
@@ -439,63 +439,6 @@ describe("SentenceReader annotations", () => {
   });
 });
 
-describe("SentenceReader long-press annotation (onAnnotate)", () => {
-  it("calls onAnnotate after long press (400ms)", async () => {
-    jest.useFakeTimers();
-    const onAnnotate = jest.fn();
-    const { container } = render(
-      <SentenceReader
-        text="Press this sentence."
-        duration={0}
-        currentTime={0}
-        isPlaying={false}
-        onSegmentClick={noop}
-        onAnnotate={onAnnotate}
-        chapterIndex={2}
-      />
-    );
-
-    const segs = getSegments(container);
-    fireEvent.pointerDown(segs[0]);
-
-    act(() => {
-      jest.advanceTimersByTime(450);
-    });
-
-    expect(onAnnotate).toHaveBeenCalledTimes(1);
-    // onAnnotate called with (sentenceText, chapterIndex, {x, y})
-    const [sentenceText, chapterIdx] = onAnnotate.mock.calls[0];
-    expect(sentenceText).toContain("Press this sentence");
-    expect(chapterIdx).toBe(2);
-    jest.useRealTimers();
-  });
-
-  it("does not call onAnnotate if pointer is released before 400ms", async () => {
-    jest.useFakeTimers();
-    const onAnnotate = jest.fn();
-    const { container } = render(
-      <SentenceReader
-        text="Short tap sentence."
-        duration={0}
-        currentTime={0}
-        isPlaying={false}
-        onSegmentClick={noop}
-        onAnnotate={onAnnotate}
-      />
-    );
-
-    const segs = getSegments(container);
-    fireEvent.pointerDown(segs[0], { clientX: 50, clientY: 50 });
-    fireEvent.pointerUp(segs[0]);
-
-    act(() => {
-      jest.advanceTimersByTime(450);
-    });
-
-    expect(onAnnotate).not.toHaveBeenCalled();
-    jest.useRealTimers();
-  });
-});
 
 describe("SentenceReader click interactions", () => {
   it("single click does nothing when TTS is idle", () => {

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -56,7 +56,6 @@ export default function ReaderPage() {
   const [annotationPanel, setAnnotationPanel] = useState<{
     sentenceText: string;
     chapterIndex: number;
-    position: { x: number; y: number };
   } | null>(null);
   const [quickHighlightPanel, setQuickHighlightPanel] = useState<{
     sentenceText: string;
@@ -1354,9 +1353,6 @@ export default function ReaderPage() {
                   translationLoading={translationLoading}
                   annotations={session?.backendToken ? annotations.filter((a) => a.chapter_index === chapterIndex) : undefined}
                   chapterIndex={chapterIndex}
-                  onAnnotate={session?.backendToken ? (sentenceText, ci, position) => {
-                    setAnnotationPanel({ sentenceText, chapterIndex: ci, position });
-                  } : undefined}
                   onAnnotationClick={session?.backendToken ? (annotation, position) => {
                     setQuickHighlightPanel({
                       sentenceText: annotation.sentence_text,
@@ -1436,11 +1432,7 @@ export default function ReaderPage() {
               setQuickHighlightPanel({ sentenceText: text, chapterIndex, position });
             } : undefined}
             onNote={session?.backendToken ? (text) => {
-              setAnnotationPanel({
-                sentenceText: text,
-                chapterIndex,
-                position: { x: window.innerWidth / 2, y: window.innerHeight / 2 },
-              });
+              setAnnotationPanel({ sentenceText: text, chapterIndex });
             } : undefined}
             onChat={(text) => {
               setChatSheetText(text);
@@ -1457,7 +1449,6 @@ export default function ReaderPage() {
               sentenceText={annotationPanel.sentenceText}
               chapterIndex={annotationPanel.chapterIndex}
               bookId={Number(bookId)}
-              position={annotationPanel.position}
               existingAnnotation={annotations.find(
                 (a) =>
                   a.sentence_text === annotationPanel.sentenceText &&
@@ -1513,7 +1504,6 @@ export default function ReaderPage() {
                 setAnnotationPanel({
                   sentenceText: quickHighlightPanel.sentenceText,
                   chapterIndex: quickHighlightPanel.chapterIndex,
-                  position: quickHighlightPanel.position,
                 });
               }}
             />
@@ -1695,7 +1685,6 @@ export default function ReaderPage() {
                           setAnnotationPanel({
                             sentenceText: ann.sentence_text,
                             chapterIndex: ann.chapter_index,
-                            position: { x: window.innerWidth / 2, y: window.innerHeight / 2 },
                           });
                         }}
                         className="shrink-0 text-xs opacity-60 hover:opacity-100 mt-0.5"

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -1,13 +1,13 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
 import { createAnnotation, updateAnnotation, deleteAnnotation, Annotation } from "@/lib/api";
-import { CloseIcon } from "@/components/Icons";
+import { CloseIcon, NoteIcon, TrashIcon } from "@/components/Icons";
 
 const COLORS = [
-  { key: "yellow", label: "Yellow", bg: "bg-yellow-400", border: "border-yellow-500" },
-  { key: "blue", label: "Blue", bg: "bg-blue-400", border: "border-blue-500" },
-  { key: "green", label: "Green", bg: "bg-green-400", border: "border-green-500" },
-  { key: "pink", label: "Pink", bg: "bg-pink-400", border: "border-pink-500" },
+  { key: "yellow", label: "Yellow", bg: "bg-yellow-400", border: "border-yellow-500", ring: "ring-yellow-400" },
+  { key: "blue",   label: "Blue",   bg: "bg-blue-400",   border: "border-blue-500",   ring: "ring-blue-400"   },
+  { key: "green",  label: "Green",  bg: "bg-green-400",  border: "border-green-500",  ring: "ring-green-400"  },
+  { key: "pink",   label: "Pink",   bg: "bg-pink-400",   border: "border-pink-500",   ring: "ring-pink-400"   },
 ] as const;
 
 type ColorKey = (typeof COLORS)[number]["key"];
@@ -16,7 +16,6 @@ interface Props {
   sentenceText: string;
   chapterIndex: number;
   bookId: number;
-  position: { x: number; y: number };
   existingAnnotation?: { id: number; note_text: string; color: string };
   onClose: () => void;
   onSaved: (annotation: Annotation) => void;
@@ -27,7 +26,6 @@ export default function AnnotationToolbar({
   sentenceText,
   chapterIndex,
   bookId,
-  position,
   existingAnnotation,
   onClose,
   onSaved,
@@ -41,19 +39,12 @@ export default function AnnotationToolbar({
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  // Close on outside click
   useEffect(() => {
-    function handleClick(e: MouseEvent) {
-      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [onClose]);
+    textareaRef.current?.focus();
+  }, []);
 
-  // Close on Escape
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {
       if (e.key === "Escape") onClose();
@@ -61,14 +52,6 @@ export default function AnnotationToolbar({
     document.addEventListener("keydown", handleKey);
     return () => document.removeEventListener("keydown", handleKey);
   }, [onClose]);
-
-  // Position the panel so it doesn't overflow viewport
-  const panelStyle: React.CSSProperties = {
-    position: "fixed",
-    top: Math.min(position.y, window.innerHeight - 240),
-    left: Math.min(position.x, window.innerWidth - 280),
-    zIndex: 1000,
-  };
 
   async function handleSave() {
     setSaving(true);
@@ -112,65 +95,101 @@ export default function AnnotationToolbar({
 
   return (
     <div
-      ref={panelRef}
-      style={panelStyle}
-      className="w-64 bg-white border border-amber-200 rounded-xl shadow-xl p-4 space-y-3"
-      data-testid="annotation-toolbar"
+      className="fixed inset-0 z-[1000] flex items-center justify-center p-4"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
-      {/* Color picker */}
-      <div className="flex items-center gap-2">
-        {COLORS.map((c) => (
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/20 backdrop-blur-[2px]" aria-hidden="true" data-testid="annotation-backdrop" onClick={onClose} />
+
+      {/* Panel */}
+      <div
+        ref={panelRef}
+        className="relative w-full max-w-sm bg-parchment border border-amber-200 rounded-2xl shadow-2xl animate-fade-in overflow-hidden"
+        data-testid="annotation-toolbar"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 pt-4 pb-3 border-b border-amber-100">
+          <div className="flex items-center gap-2 text-amber-800">
+            <NoteIcon className="w-4 h-4" aria-hidden="true" />
+            <span className="font-serif font-semibold text-sm">
+              {existingAnnotation ? "Edit note" : "Add note"}
+            </span>
+          </div>
           <button
-            key={c.key}
-            title={c.label}
-            onClick={() => setColor(c.key)}
-            className={`w-7 h-7 rounded-full ${c.bg} border-2 transition-all ${
-              color === c.key ? `${c.border} scale-110` : "border-transparent"
-            }`}
-            aria-label={c.label}
-          />
-        ))}
-      </div>
-
-      {/* Note textarea */}
-      <textarea
-        value={note}
-        onChange={(e) => setNote(e.target.value)}
-        placeholder="Add a note… (optional)"
-        rows={3}
-        className="w-full text-sm border border-stone-300 rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-amber-400"
-      />
-
-      {/* Error */}
-      {error && (
-        <p className="text-xs text-red-600 bg-red-50 rounded px-2 py-1">{error}</p>
-      )}
-
-      {/* Actions */}
-      <div className="flex items-center gap-2">
-        <button
-          onClick={handleSave}
-          disabled={saving}
-          className="flex-1 rounded-lg bg-amber-700 text-white text-sm py-1.5 min-h-[44px] hover:bg-amber-800 disabled:opacity-50 transition-colors"
-        >
-          {saving ? "Saving…" : "Save"}
-        </button>
-        {existingAnnotation && (
-          <button
-            onClick={handleDelete}
-            disabled={deleting}
-            className="rounded-lg border border-red-300 text-red-600 text-sm px-3 py-1.5 min-h-[44px] hover:bg-red-50 disabled:opacity-50 transition-colors"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-lg p-1.5 min-h-[44px] min-w-[44px] flex items-center justify-center text-stone-400 hover:text-stone-600 hover:bg-amber-50 transition-colors"
           >
-            {deleting ? "…" : "Delete"}
+            <CloseIcon className="w-4 h-4" />
           </button>
-        )}
-        <button
-          onClick={onClose}
-          aria-label="Close"
-          className="rounded-lg border border-stone-300 text-stone-500 px-2.5 py-1.5 min-h-[44px] hover:bg-stone-50 transition-colors flex items-center justify-center"
-        >
-          <CloseIcon className="w-4 h-4" />
-        </button>
+        </div>
+
+        <div className="px-5 pt-3 pb-5 space-y-4">
+          {/* Quoted sentence */}
+          <p className="text-xs text-amber-700 font-serif italic line-clamp-2 leading-relaxed border-l-2 border-amber-300 pl-3">
+            {sentenceText}
+          </p>
+
+          {/* Color picker */}
+          <div>
+            <p className="text-xs text-stone-500 mb-2">Highlight colour</p>
+            <div className="flex items-center gap-2.5">
+              {COLORS.map((c) => (
+                <button
+                  key={c.key}
+                  title={c.label}
+                  onClick={() => setColor(c.key)}
+                  aria-label={c.label}
+                  aria-pressed={color === c.key}
+                  className={`w-8 h-8 rounded-full ${c.bg} border-2 transition-all duration-150 hover:scale-110 ${
+                    color === c.key
+                      ? `${c.border} scale-110 ring-2 ring-offset-1 ${c.ring}`
+                      : "border-transparent"
+                  }`}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Note textarea */}
+          <div>
+            <p className="text-xs text-stone-500 mb-1.5">Note <span className="text-stone-400">(optional)</span></p>
+            <textarea
+              ref={textareaRef}
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="Your thoughts on this passage…"
+              rows={4}
+              className="w-full text-sm font-serif text-ink bg-white border border-amber-200 rounded-xl px-3 py-2.5 resize-none focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400 placeholder:text-stone-300 leading-relaxed"
+            />
+          </div>
+
+          {/* Error */}
+          {error && (
+            <p className="text-xs text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">{error}</p>
+          )}
+
+          {/* Actions */}
+          <div className="flex items-center gap-2 pt-1">
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="flex-1 rounded-xl bg-amber-700 text-white text-sm font-medium py-2.5 min-h-[44px] hover:bg-amber-800 disabled:opacity-50 transition-colors"
+            >
+              {saving ? "Saving…" : existingAnnotation ? "Update" : "Save note"}
+            </button>
+            {existingAnnotation && (
+              <button
+                onClick={handleDelete}
+                disabled={deleting}
+                aria-label="Delete note"
+                className="rounded-xl border border-red-200 text-red-500 px-3 py-2.5 min-h-[44px] hover:bg-red-50 disabled:opacity-50 transition-colors flex items-center justify-center"
+              >
+                <TrashIcon className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -288,15 +288,6 @@ interface Props {
   /** Sentence text to scroll to and briefly highlight. */
   scrollTargetSentence?: string;
   /**
-   * Called when the user long-presses a sentence (400ms hold).
-   * Provides the sentence text, chapter index, and pointer position.
-   */
-  onAnnotate?: (
-    sentenceText: string,
-    chapterIndex: number,
-    position: { x: number; y: number },
-  ) => void;
-  /**
    * Called when the user clicks an already-annotated segment.
    * Provides the annotation and the click position so the parent can open
    * an inline color-picker / delete panel without navigating away.
@@ -305,7 +296,7 @@ interface Props {
     annotation: Annotation,
     position: { x: number; y: number },
   ) => void;
-  /** Chapter index — used with onAnnotate. */
+  /** Chapter index — used to scope annotations to the current chapter. */
   chapterIndex?: number;
   /** Existing annotations to highlight matching segments. */
   annotations?: Annotation[];
@@ -433,7 +424,6 @@ export default function SentenceReader({
   translations,
   translationDisplayMode = "parallel",
   translationLoading = false,
-  onAnnotate,
   onAnnotationClick,
   chapterIndex = 0,
   annotations,
@@ -596,22 +586,7 @@ export default function SentenceReader({
     };
   }, [annotations, annotationMap]);
 
-  // Long-press handlers (shared across segments)
-  function handlePointerDown(e: React.PointerEvent, seg: Segment) {
-    if (!onAnnotate) return;
-    // Prevent the browser's native text-selection loupe on touch devices so
-    // the 400ms hold cleanly triggers annotation without a competing selection.
-    if (e.pointerType === "touch") e.preventDefault();
-    const startX = e.clientX;
-    const startY = e.clientY;
-    longPressStartPos.current = { x: startX, y: startY };
-    longPressTimer.current = setTimeout(() => {
-      longPressTimer.current = null;
-      longPressStartPos.current = null;
-      onAnnotate(seg.text, chapterIndex, { x: startX, y: startY });
-    }, 400);
-  }
-
+  // Long-press cancel (shared across segments)
   function cancelLongPress() {
     if (longPressTimer.current) {
       clearTimeout(longPressTimer.current);
@@ -653,11 +628,7 @@ export default function SentenceReader({
 
         // Long press (500ms) → open word action drawer
         const handleSegLongPress = (e: React.PointerEvent, seg: Segment) => {
-          if (!onWordTap) {
-            // Fallback to legacy annotation long-press
-            handlePointerDown(e, seg);
-            return;
-          }
+          if (!onWordTap) return;
           // Prevent the browser's native text-selection loupe on touch so
           // the hold gesture cleanly triggers the word-tap drawer.
           if (e.pointerType === "touch") e.preventDefault();
@@ -726,10 +697,10 @@ export default function SentenceReader({
                   onSegmentClick(seg.startTime, seg.text);
                 }
               }}
-              onPointerDown={(e) => onWordTap ? handleSegLongPress(e, seg) : handlePointerDown(e, seg)}
-              onPointerUp={cancelLongPress}
-              onPointerCancel={cancelLongPress}
-              onPointerMove={handlePointerMove}
+              onPointerDown={onWordTap ? (e) => handleSegLongPress(e, seg) : undefined}
+              onPointerUp={onWordTap ? cancelLongPress : undefined}
+              onPointerCancel={onWordTap ? cancelLongPress : undefined}
+              onPointerMove={onWordTap ? handlePointerMove : undefined}
               className={`rounded px-0.5 -mx-0.5 transition-colors duration-200 ${segClass(seg)} ${annotationClass} ${flashClass} ${extraClass}`}
             >
               {buildSegContent(seg.text, isJumpTarget ? scrollTargetWord : undefined, vocabWords)}


### PR DESCRIPTION
## What changed

### AnnotationToolbar — modal redesign
- Changed from a cursor-positioned tooltip panel to a fixed full-screen modal with a semi-transparent backdrop; removes fragile `position: { x, y }` prop and `window.innerWidth/Height` math
- Backdrop div has `onClick={onClose}` so clicking outside closes the modal
- Removed the `position` prop entirely from the component and all callers in `page.tsx`
- Added: NoteIcon header ("Add note" / "Edit note"), quoted sentence preview, `aria-pressed` on colour swatches, `TrashIcon` icon-only delete button with `aria-label="Delete note"`, textarea auto-focus, `animate-fade-in` entrance
- Save button now reads "Save note" (new) or "Update" (existing)

### SentenceReader — `onAnnotate` removal
- Removed deprecated `onAnnotate` prop and `handlePointerDown` long-press path; notes are now opened via SelectionToolbar "Note" button (`onNote`) or annotation-click → QuickHighlightPanel → "Add note"
- Pointer-event handlers are now only wired when `onWordTap` is provided

### `page.tsx`
- Removed `position` from `annotationPanel` state shape and all three `setAnnotationPanel` call sites
- Removed `onAnnotate` prop pass-through to `SentenceReader`

## Why

The old tooltip-style panel caused UX problems on mobile (could render off-screen, used `window.innerWidth/Height` which is unavailable in SSR/tests). The modal pattern is standard for note-taking on touch devices. The `onAnnotate` long-press path was a parallel annotation entry point that bypassed the SelectionToolbar flow.

## Test plan
- [x] All 1746 frontend tests pass
- [x] `AnnotationToolbar` suite: 24 tests (backdrop click, Escape, save/update/delete, error paths, colour picker)
- [x] `AnnotationToolbarTouchTarget`: 3 touch-target (44px) tests
- [x] `SentenceReader` pointer-move tests rewritten to use `onWordTap`
- [x] `ReaderPage.branches2` updated to use `trigger-note` / `qhp-open-note` for annotation flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
