### PR TITLE
test: add missing regression test for empty target_language in vocabulary Obsidian export (closes #777)

### DIFF
--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -775,3 +775,17 @@ async def test_export_obsidian_error_does_not_leak_exception_detail(client, test
     detail = resp.json()["detail"]
     assert "github-token-secret-xyzzy" not in detail
     assert "leaked" not in detail
+
+
+# ── Issue #777: ExportRequest.target_language min_length ─────────────────────
+
+
+async def test_export_obsidian_empty_target_language_returns_422(client, test_user):
+    """Regression #777: POST /vocabulary/export/obsidian with target_language="" must return 422."""
+    resp = await client.post(
+        "/api/vocabulary/export/obsidian",
+        json={"target_language": ""},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for empty target_language in export/obsidian, got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## What changed
- `tests/test_router_vocabulary.py`: added `test_export_obsidian_empty_target_language_returns_422` — POSTs `{"target_language": ""}` to `/vocabulary/export/obsidian` and asserts 422.

## Why
PR #773 added `min_length=1` to `ExportRequest.target_language` in `vocabulary.py` but shipped without a regression test for the empty-string case. All 8 other language fields patched in that PR have matching empty-string tests. This adds the missing one so the behaviour is verified and cannot silently regress.

## Test plan
- [x] `test_export_obsidian_empty_target_language_returns_422` — 422 for `target_language: ""`
- [x] Full backend suite: 1386 passed
- [x] Full frontend suite: 1750 passed

Closes #777
