### PR TITLE
ux: InsightChat aria-labels/touch targets, QuickHighlightPanel 44px

### DIFF
--- a/frontend/src/__tests__/InsightChatToolbarButtons.test.tsx
+++ b/frontend/src/__tests__/InsightChatToolbarButtons.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Regression tests for issue #573 — InsightChat toolbar buttons missing
+ * aria-label, below 44px touch target, and using inline SVG.
+ */
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+
+jest.mock("@/lib/api", () => ({
+  getInsight: jest.fn().mockResolvedValue({ insight: "test insight" }),
+  askQuestion: jest.fn(),
+}));
+
+jest.mock("@/lib/settings", () => ({
+  getSettings: jest.fn(() => ({
+    translationLang: "en",
+    insightLang: "en",
+    translationEnabled: false,
+    ttsGender: "female",
+    chatFontSize: "xs",
+    translationProvider: "auto",
+    fontSize: "base",
+    theme: "light",
+  })),
+  saveSettings: jest.fn(),
+}));
+
+jest.mock("react-markdown", () => ({
+  __esModule: true,
+  default: ({ children }: { children: string }) => <span>{children}</span>,
+}));
+
+jest.mock("remark-gfm", () => ({ __esModule: true, default: () => () => {} }));
+
+import InsightChat from "@/components/InsightChat";
+
+const flushPromises = () => new Promise<void>((r) => setTimeout(r, 0));
+
+const BASE_PROPS = {
+  bookId: 1,
+  userId: 1,
+  hasGeminiKey: true,
+  isVisible: true,
+  chapterText: "Some chapter text",
+  chapterTitle: "Chapter 1",
+  selectedText: null,
+  bookTitle: "Test Book",
+  author: "Test Author",
+};
+
+describe("InsightChat toolbar — font size button (#573)", () => {
+  it("has aria-label", async () => {
+    render(<InsightChat {...BASE_PROPS} />);
+    await act(async () => await flushPromises());
+
+    const btn = screen.getByRole("button", { name: /font size/i });
+    expect(btn).toBeInTheDocument();
+  });
+
+  it("has min-h-[44px] min-w-[44px] touch target", async () => {
+    render(<InsightChat {...BASE_PROPS} />);
+    await act(async () => await flushPromises());
+
+    const btn = screen.getByRole("button", { name: /font size/i });
+    expect(btn.className).toContain("min-h-[44px]");
+    expect(btn.className).toContain("min-w-[44px]");
+  });
+});
+
+describe("InsightChat toolbar — refresh button (#573)", () => {
+  it("has aria-label", async () => {
+    render(<InsightChat {...BASE_PROPS} />);
+    await act(async () => await flushPromises());
+
+    const btn = screen.getByRole("button", { name: /insight/i });
+    expect(btn).toBeInTheDocument();
+  });
+
+  it("has min-h-[44px] min-w-[44px] touch target", async () => {
+    render(<InsightChat {...BASE_PROPS} />);
+    await act(async () => await flushPromises());
+
+    const btn = screen.getByRole("button", { name: /insight/i });
+    expect(btn.className).toContain("min-h-[44px]");
+    expect(btn.className).toContain("min-w-[44px]");
+  });
+
+  it("does not use inline SVG — icon comes from Icons.tsx (has aria-hidden svg)", async () => {
+    const { container } = render(<InsightChat {...BASE_PROPS} />);
+    await act(async () => await flushPromises());
+
+    const refreshBtn = screen.getByRole("button", { name: /insight/i });
+    const svg = refreshBtn.querySelector("svg");
+    // SVG from Icons.tsx always has aria-hidden="true"
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute("aria-hidden")).toBe("true");
+  });
+});

--- a/frontend/src/__tests__/QuickHighlightPanelTouchTarget.test.tsx
+++ b/frontend/src/__tests__/QuickHighlightPanelTouchTarget.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Regression tests for issue #785 — QuickHighlightPanel buttons below 44px touch target.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("@/lib/api", () => ({
+  createAnnotation: jest.fn(),
+  updateAnnotation: jest.fn(),
+  deleteAnnotation: jest.fn(),
+}));
+
+import QuickHighlightPanel from "@/components/QuickHighlightPanel";
+
+const baseProps = {
+  sentenceText: "Call me Ishmael.",
+  chapterIndex: 0,
+  bookId: 10,
+  position: { x: 200, y: 200 },
+  onClose: jest.fn(),
+  onSaved: jest.fn(),
+  onDeleted: jest.fn(),
+  onOpenNote: jest.fn(),
+};
+
+afterEach(() => jest.clearAllMocks());
+
+test("colour picker buttons have min-h-[44px] min-w-[44px] touch target", () => {
+  render(<QuickHighlightPanel {...baseProps} />);
+  const yellowBtn = screen.getByRole("button", { name: "Yellow" });
+  expect(yellowBtn.className).toContain("min-h-[44px]");
+  expect(yellowBtn.className).toContain("min-w-[44px]");
+});
+
+test("Note button has min-h-[44px] min-w-[44px] touch target", () => {
+  render(<QuickHighlightPanel {...baseProps} />);
+  const noteBtn = screen.getByRole("button", { name: "Add note" });
+  expect(noteBtn.className).toContain("min-h-[44px]");
+  expect(noteBtn.className).toContain("min-w-[44px]");
+});
+
+test("Delete button has min-h-[44px] min-w-[44px] touch target when annotation exists", () => {
+  render(
+    <QuickHighlightPanel
+      {...baseProps}
+      existingAnnotation={{
+        id: 1,
+        book_id: 10,
+        chapter_index: 0,
+        sentence_text: "Call me Ishmael.",
+        note_text: "",
+        color: "yellow",
+      }}
+    />,
+  );
+  const deleteBtn = screen.getByRole("button", { name: "Delete highlight" });
+  expect(deleteBtn.className).toContain("min-h-[44px]");
+  expect(deleteBtn.className).toContain("min-w-[44px]");
+});

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -7,7 +7,7 @@ import {
   askQuestion,
 } from "@/lib/api";
 import { getSettings, saveSettings } from "@/lib/settings";
-import { PaperclipIcon, CloseIcon } from "@/components/Icons";
+import { PaperclipIcon, CloseIcon, RetryIcon } from "@/components/Icons";
 
 export const LANGUAGES = [
   { code: "en", label: "English" },
@@ -311,7 +311,8 @@ export default function InsightChat({
             saveSettings({ chatFontSize: next });
           }}
           title={`Toggle font size (${chatFontSize === "xs" ? "small" : "medium"})`}
-          className={`shrink-0 w-7 h-7 flex items-center justify-center rounded text-xs font-bold transition-colors ${
+          aria-label={chatFontSize === "xs" ? "Increase chat font size" : "Decrease chat font size"}
+          className={`shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded text-xs font-bold transition-colors ${
             chatFontSize === "sm"
               ? "bg-amber-100 text-amber-800 hover:bg-amber-200"
               : "text-gray-500 hover:bg-gray-200 hover:text-gray-700"
@@ -322,12 +323,11 @@ export default function InsightChat({
         <button
           onClick={() => setRefreshTick((n) => n + 1)}
           title={hasGeminiKey ? "Append a fresh insight" : "Gemini API key required"}
+          aria-label="Append a fresh insight"
           disabled={!hasGeminiKey}
-          className="shrink-0 w-7 h-7 flex items-center justify-center rounded hover:bg-gray-200 text-gray-500 hover:text-gray-700 disabled:opacity-40 disabled:cursor-not-allowed"
+          className="shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded hover:bg-gray-200 text-gray-500 hover:text-gray-700 disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="2">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-          </svg>
+          <RetryIcon className="w-3.5 h-3.5" />
         </button>
       </div>
 

--- a/frontend/src/components/QuickHighlightPanel.tsx
+++ b/frontend/src/components/QuickHighlightPanel.tsx
@@ -110,21 +110,27 @@ export default function QuickHighlightPanel({
           title={c.label}
           onClick={() => handleColor(c.key)}
           disabled={busy}
-          className={`w-7 h-7 rounded-full ${c.bg} border-2 transition-all hover:scale-110 disabled:opacity-50 ${
-            existingAnnotation?.color === c.key ? `${c.border} scale-110` : "border-transparent"
-          }`}
           aria-label={c.label}
-        />
+          className="min-h-[44px] min-w-[44px] flex items-center justify-center disabled:opacity-50"
+        >
+          <span
+            className={`w-7 h-7 rounded-full ${c.bg} border-2 transition-all hover:scale-110 ${
+              existingAnnotation?.color === c.key ? `${c.border} scale-110` : "border-transparent"
+            }`}
+          />
+        </button>
       ))}
       {onOpenNote && (
         <button
           title="Add note"
           onClick={onOpenNote}
           disabled={busy}
-          className="w-7 h-7 rounded-full bg-stone-100 border border-stone-300 flex items-center justify-center text-stone-500 hover:bg-stone-200 transition-colors"
           aria-label="Add note"
+          className="min-h-[44px] min-w-[44px] flex items-center justify-center text-stone-500 hover:text-stone-700 disabled:opacity-50 transition-colors"
         >
-          <NoteIcon className="w-3.5 h-3.5" />
+          <span className="w-7 h-7 rounded-full bg-stone-100 border border-stone-300 flex items-center justify-center hover:bg-stone-200 transition-colors">
+            <NoteIcon className="w-3.5 h-3.5" />
+          </span>
         </button>
       )}
       {existingAnnotation && (
@@ -132,10 +138,12 @@ export default function QuickHighlightPanel({
           title="Delete highlight"
           onClick={handleDelete}
           disabled={busy}
-          className="w-7 h-7 rounded-full bg-red-50 border border-red-200 flex items-center justify-center text-red-500 hover:bg-red-100 transition-colors disabled:opacity-50"
           aria-label="Delete highlight"
+          className="min-h-[44px] min-w-[44px] flex items-center justify-center text-red-500 disabled:opacity-50 transition-colors"
         >
-          <TrashIcon className="w-3.5 h-3.5" />
+          <span className="w-7 h-7 rounded-full bg-red-50 border border-red-200 flex items-center justify-center hover:bg-red-100 transition-colors">
+            <TrashIcon className="w-3.5 h-3.5" />
+          </span>
         </button>
       )}
     </div>


### PR DESCRIPTION
Closes #573
Closes #785

## Changes

- **InsightChat toolbar buttons** (`InsightChat.tsx`): added `aria-label` to all icon-only buttons, raised touch targets to 44px min-height, replaced inline SVG with `RetryIcon` from `Icons.tsx`
- **QuickHighlightPanel colour/action buttons** (`QuickHighlightPanel.tsx`): raised button height from 28px to 44px to meet mobile touch target minimum

## Test plan

- [x] Frontend test suite: 1746 tests passing
- [x] Backend test suite: 1393 tests passing
- [ ] Visually verify InsightChat toolbar buttons are accessible and tappable on mobile
- [ ] Visually verify QuickHighlightPanel colour swatches meet 44px height

🤖 Generated with [Claude Code](https://claude.com/claude-code)
