### PR TITLE
fix: add min_length=1 to target_language query params in books router (closes #786)

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -90,7 +90,7 @@ async def popular_books(
 
 
 @router.get("/{book_id}/translation-status")
-async def translation_status(book_id: int = Path(..., ge=1), target_language: str = Query(..., max_length=20), user: dict | None = Depends(get_optional_user)):
+async def translation_status(book_id: int = Path(..., ge=1), target_language: str = Query(..., min_length=1, max_length=20), user: dict | None = Depends(get_optional_user)):
     """Return book-level translation progress for the reader banner.
 
     Includes:
@@ -148,7 +148,7 @@ async def translation_status(book_id: int = Path(..., ge=1), target_language: st
 async def chapter_queue_status(
     book_id: int = Path(..., ge=1),
     chapter_index: int = Path(..., ge=0),
-    target_language: str = Query(..., max_length=20),
+    target_language: str = Query(..., min_length=1, max_length=20),
     user: dict = Depends(get_current_user),
 ):
     """Per-chapter queue lookup for the reader page.
@@ -177,7 +177,7 @@ async def chapter_queue_status(
 async def get_chapter_translation(
     book_id: int = Path(..., ge=1),
     chapter_index: int = Path(..., ge=0),
-    target_language: str = Query(..., max_length=20),
+    target_language: str = Query(..., min_length=1, max_length=20),
     user: dict | None = Depends(get_optional_user),
 ):
     """Return the cached translation if available, 404 otherwise. Never enqueues."""

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -1218,3 +1218,30 @@ async def test_request_translation_empty_target_language_returns_422(client, tes
         json={"target_language": ""},
     )
     assert resp.status_code == 422, f"Expected 422 for empty target_language, got {resp.status_code}: {resp.text}"
+
+
+# ── Issue #786: min_length=1 on target_language query params in books router ──
+
+
+async def test_translation_status_empty_target_language_returns_422(client, test_user):
+    """Regression #786: GET /books/{id}/translation-status?target_language="" must return 422."""
+    resp = await client.get("/api/books/1/translation-status?target_language=")
+    assert resp.status_code == 422, (
+        f"Expected 422 for empty target_language in translation-status, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_chapter_queue_status_empty_target_language_returns_422(client, test_user):
+    """Regression #786: GET /books/{id}/chapters/{i}/queue-status?target_language="" must return 422."""
+    resp = await client.get("/api/books/1/chapters/0/queue-status?target_language=")
+    assert resp.status_code == 422, (
+        f"Expected 422 for empty target_language in queue-status, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_chapter_translation_get_empty_target_language_returns_422(client, test_user):
+    """Regression #786: GET /books/{id}/chapters/{i}/translation?target_language="" must return 422."""
+    resp = await client.get("/api/books/1/chapters/0/translation?target_language=")
+    assert resp.status_code == 422, (
+        f"Expected 422 for empty target_language in GET translation, got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## What changed

Added `min_length=1` to the `target_language` query parameter on three endpoints in `backend/routers/books.py`:

- `GET /books/{book_id}/translation-status`
- `GET /books/{book_id}/chapters/{chapter_index}/queue-status`
- `GET /books/{book_id}/chapters/{chapter_index}/translation`

Previously these accepted an empty string `""`, which could pass into translation logic and produce nonsensical results. FastAPI now rejects empty values with `422 Unprocessable Entity` before the handler runs.

## Why

Issue #786: empty `target_language` in query params was not validated on these three routes, unlike the request body params fixed in #779 (closes #776).

## Test plan

- 3 regression tests added to `backend/tests/test_router_books.py` — one per endpoint — confirming `target_language=""` returns 422.
- Full backend suite: 1395 passed.
- Full frontend suite: 1746 passed.

Closes #786
