### PR TITLE
fix: migration 029 invalidates shifted chapter cache for Faust + Kafka after #780 (closes #783)

### DIFF
--- a/backend/migrations/029_invalidate_shifted_chapter_cache.sql
+++ b/backend/migrations/029_invalidate_shifted_chapter_cache.sql
@@ -1,0 +1,24 @@
+-- Invalidate chapter-indexed cache rows for Faust (Gutenberg #2229) and
+-- Der Prozess / Kafka (Gutenberg #69327) after PR #780 corrected the EPUB
+-- splitter to drop the rogue chapter-0 frontmatter. All cached rows with
+-- chapter_index >= 1 are now off by one and must be cleared so readers
+-- see correct content on re-request.
+--
+-- Issue #783.
+
+DELETE FROM translations
+ WHERE book_id IN (2229, 69327)
+   AND chapter_index >= 1;
+
+DELETE FROM chapter_summaries
+ WHERE book_id IN (2229, 69327)
+   AND chapter_index >= 1;
+
+DELETE FROM translation_queue
+ WHERE book_id IN (2229, 69327)
+   AND chapter_index >= 1;
+
+DELETE FROM book_insights
+ WHERE book_id IN (2229, 69327)
+   AND chapter_index IS NOT NULL
+   AND chapter_index >= 1;

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1055,3 +1055,84 @@ async def test_migration_028_recorded_in_schema_migrations(tmp_db):
             "SELECT version FROM schema_migrations WHERE version = '028_fk_orphan_cleanup'"
         ) as cur:
             assert (await cur.fetchone()) is not None
+
+
+# ── Migration 029 (issue #783): invalidate shifted chapter cache ──────────────
+
+
+async def test_migration_029_clears_shifted_translations(tmp_db):
+    """Regression #783: migration 029 must delete translations with chapter_index >= 1
+    for Faust (#2229) and Kafka (#69327), but leave chapter 0 and other books untouched."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute("PRAGMA foreign_keys = OFF")
+        await db.executemany(
+            "INSERT INTO translations (book_id, chapter_index, target_language, paragraphs) "
+            "VALUES (?, ?, 'zh', '[]')",
+            [(2229, 0), (2229, 1), (2229, 2), (69327, 0), (69327, 1), (1, 1)],
+        )
+        await db.executemany(
+            "INSERT INTO chapter_summaries (book_id, chapter_index, content) VALUES (?, ?, 'summary')",
+            [(2229, 1), (69327, 1)],
+        )
+        await db.executemany(
+            "INSERT INTO translation_queue (book_id, chapter_index, target_language, status) "
+            "VALUES (?, ?, 'zh', 'pending')",
+            [(2229, 1), (69327, 2)],
+        )
+        await db.execute(
+            "INSERT INTO users (id, google_id, email, name, picture) VALUES (1, 'x', 'a@b.com', 'A', '')"
+        )
+        await db.executemany(
+            "INSERT INTO book_insights (user_id, book_id, chapter_index, question, answer) "
+            "VALUES (1, ?, ?, 'Q?', 'A')",
+            [(2229, 1), (2229, 2), (69327, 1)],
+        )
+        await db.execute(
+            "INSERT INTO book_insights (user_id, book_id, chapter_index, question, answer) "
+            "VALUES (1, 2229, NULL, 'Book-level?', 'A')"
+        )
+        await db.execute(
+            "DELETE FROM schema_migrations WHERE version = '029_invalidate_shifted_chapter_cache'"
+        )
+        await db.commit()
+
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute(
+            "SELECT COUNT(*) FROM translations WHERE book_id IN (2229, 69327) AND chapter_index >= 1"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 0, "stale chapter >= 1 translations must be deleted"
+
+        async with db.execute(
+            "SELECT COUNT(*) FROM translations WHERE book_id=2229 AND chapter_index=0"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 1, "chapter 0 must survive"
+
+        async with db.execute(
+            "SELECT COUNT(*) FROM translations WHERE book_id=1 AND chapter_index=1"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 1, "unrelated book must survive"
+
+        async with db.execute(
+            "SELECT COUNT(*) FROM chapter_summaries WHERE book_id IN (2229, 69327) AND chapter_index >= 1"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 0, "stale chapter summaries must be deleted"
+
+        async with db.execute(
+            "SELECT COUNT(*) FROM translation_queue WHERE book_id IN (2229, 69327) AND chapter_index >= 1"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 0, "stale queue rows must be deleted"
+
+        async with db.execute(
+            "SELECT COUNT(*) FROM book_insights "
+            "WHERE book_id IN (2229, 69327) AND chapter_index IS NOT NULL AND chapter_index >= 1"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 0, "stale per-chapter insights must be deleted"
+
+        async with db.execute(
+            "SELECT COUNT(*) FROM book_insights WHERE book_id=2229 AND chapter_index IS NULL"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 1, "book-level insights (NULL chapter) must survive"


### PR DESCRIPTION
## What changed

Adds `backend/migrations/029_invalidate_shifted_chapter_cache.sql` which deletes stale chapter-indexed rows for Faust (Gutenberg #2229) and Der Prozess / Kafka (Gutenberg #69327) where `chapter_index >= 1`.

Tables cleaned:
- `translations` — primary chapter translation cache
- `chapter_summaries` — AI-generated chapter summaries
- `translation_queue` — pending/failed queue rows with wrong indices
- `book_insights` — per-chapter AI insights (NULL chapter rows preserved)

## Why

PR #780 fixed the EPUB splitter to drop a rogue chapter-0 frontmatter page for these two books, reducing their chapter counts by one. Any cached data keyed on `chapter_index >= 1` was recorded before the fix and is now shifted by one — readers would see the wrong translated content for every chapter after the first. This migration clears those rows so they are re-requested and re-translated with correct indices.

Chapter 0 rows and rows for all other books are untouched.

## Test plan

- New regression test `test_migration_029_clears_shifted_translations` in `test_migrations.py`: seeds stale rows across all four affected tables, re-runs migration 029, and verifies stale rows deleted while chapter-0 and unrelated-book rows survive.
- Full backend suite: 1394 passed.
- Full frontend suite: 1754 passed.

Closes #783
