### PR TITLE
feat: vocabulary TagEditor + tag filter on /vocabulary (#741 slice 1)

### DIFF
--- a/frontend/src/__tests__/TagEditor.test.tsx
+++ b/frontend/src/__tests__/TagEditor.test.tsx
@@ -1,0 +1,124 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("@/lib/api", () => ({
+  listVocabularyTags: jest.fn().mockResolvedValue([]),
+  getVocabularyWordTags: jest.fn(),
+  addVocabularyWordTag: jest.fn(),
+  removeVocabularyWordTag: jest.fn(),
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+import * as api from "@/lib/api";
+import TagEditor from "@/components/TagEditor";
+
+const mockGetTags = api.getVocabularyWordTags as jest.MockedFunction<
+  typeof api.getVocabularyWordTags
+>;
+const mockAddTag = api.addVocabularyWordTag as jest.MockedFunction<
+  typeof api.addVocabularyWordTag
+>;
+const mockRemoveTag = api.removeVocabularyWordTag as jest.MockedFunction<
+  typeof api.removeVocabularyWordTag
+>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("TagEditor", () => {
+  it("renders supplied initial tags without fetching", async () => {
+    render(
+      <TagEditor vocabularyId={42} initialTags={["verb", "b2"]} />,
+    );
+    expect(screen.getByTestId("tag-chip-verb")).toBeInTheDocument();
+    expect(screen.getByTestId("tag-chip-b2")).toBeInTheDocument();
+    expect(mockGetTags).not.toHaveBeenCalled();
+  });
+
+  it("fetches tags when no initialTags provided", async () => {
+    mockGetTags.mockResolvedValue(["idiom"]);
+    render(<TagEditor vocabularyId={7} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("tag-chip-idiom")).toBeInTheDocument();
+    });
+    expect(mockGetTags).toHaveBeenCalledWith(7);
+  });
+
+  it("adds a new tag via keyboard and shows the chip", async () => {
+    mockAddTag.mockResolvedValue({ tag: "noun" });
+    const onChange = jest.fn();
+    render(
+      <TagEditor vocabularyId={3} initialTags={[]} onTagsChange={onChange} />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("add-tag-3"));
+    const input = await screen.findByTestId("tag-input-3");
+    await user.type(input, "Noun{Enter}");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("tag-chip-noun")).toBeInTheDocument();
+    });
+    expect(mockAddTag).toHaveBeenCalledWith(3, "Noun");
+    expect(onChange).toHaveBeenLastCalledWith(["noun"]);
+  });
+
+  it("removes a tag when its X button is clicked", async () => {
+    mockRemoveTag.mockResolvedValue(undefined);
+    const onChange = jest.fn();
+    render(
+      <TagEditor
+        vocabularyId={9}
+        initialTags={["keep", "drop"]}
+        onTagsChange={onChange}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByLabelText("Remove tag drop"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("tag-chip-drop")).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId("tag-chip-keep")).toBeInTheDocument();
+    expect(mockRemoveTag).toHaveBeenCalledWith(9, "drop");
+    expect(onChange).toHaveBeenLastCalledWith(["keep"]);
+  });
+
+  it("shows an error message when the backend rejects a tag", async () => {
+    const { ApiError } = jest.requireMock("@/lib/api");
+    mockAddTag.mockRejectedValue(new ApiError(400, "tag exceeds 50 chars"));
+    render(<TagEditor vocabularyId={1} initialTags={[]} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("add-tag-1"));
+    const input = await screen.findByTestId("tag-input-1");
+    await user.type(input, "something{Enter}");
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "tag exceeds 50 chars",
+    );
+  });
+
+  it("cancels add mode on Escape without calling the API", async () => {
+    render(<TagEditor vocabularyId={5} initialTags={[]} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("add-tag-5"));
+    const input = await screen.findByTestId("tag-input-5");
+    await user.type(input, "nope{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("tag-input-5")).not.toBeInTheDocument();
+    });
+    expect(mockAddTag).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/VocabularyPage.branches.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.branches.test.tsx
@@ -30,6 +30,11 @@ jest.mock("@/lib/api", () => ({
   deleteVocabularyWord: jest.fn(),
   exportVocabularyToObsidian: jest.fn(),
   getWordDefinition: jest.fn(),
+  listVocabularyTags: jest.fn().mockResolvedValue([]),
+  getVocabularyWordTags: jest.fn().mockResolvedValue([]),
+  addVocabularyWordTag: jest.fn().mockResolvedValue({ tag: "" }),
+  removeVocabularyWordTag: jest.fn().mockResolvedValue(undefined),
+  ApiError: class ApiError extends Error { status = 500; },
 }));
 
 import * as api from "@/lib/api";

--- a/frontend/src/__tests__/VocabularyPage.coverage2.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.coverage2.test.tsx
@@ -24,6 +24,11 @@ jest.mock("@/lib/api", () => ({
   deleteVocabularyWord: jest.fn(),
   exportVocabularyToObsidian: jest.fn(),
   getWordDefinition: jest.fn(),
+  listVocabularyTags: jest.fn().mockResolvedValue([]),
+  getVocabularyWordTags: jest.fn().mockResolvedValue([]),
+  addVocabularyWordTag: jest.fn().mockResolvedValue({ tag: "" }),
+  removeVocabularyWordTag: jest.fn().mockResolvedValue(undefined),
+  ApiError: class ApiError extends Error { status = 500; },
 }));
 
 import * as api from "@/lib/api";

--- a/frontend/src/__tests__/VocabularyPage.definition.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.definition.test.tsx
@@ -20,6 +20,11 @@ jest.mock("@/lib/api", () => ({
   deleteVocabularyWord: jest.fn(),
   exportVocabularyToObsidian: jest.fn(),
   getWordDefinition: jest.fn(),
+  listVocabularyTags: jest.fn().mockResolvedValue([]),
+  getVocabularyWordTags: jest.fn().mockResolvedValue([]),
+  addVocabularyWordTag: jest.fn().mockResolvedValue({ tag: "" }),
+  removeVocabularyWordTag: jest.fn().mockResolvedValue(undefined),
+  ApiError: class ApiError extends Error { status = 500; },
 }));
 
 import * as api from "@/lib/api";

--- a/frontend/src/__tests__/VocabularyPage.sort.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.sort.test.tsx
@@ -23,6 +23,11 @@ jest.mock("@/lib/api", () => ({
   deleteVocabularyWord: jest.fn(),
   exportVocabularyToObsidian: jest.fn(),
   getWordDefinition: jest.fn(),
+  listVocabularyTags: jest.fn().mockResolvedValue([]),
+  getVocabularyWordTags: jest.fn().mockResolvedValue([]),
+  addVocabularyWordTag: jest.fn().mockResolvedValue({ tag: "" }),
+  removeVocabularyWordTag: jest.fn().mockResolvedValue(undefined),
+  ApiError: class ApiError extends Error { status = 500; },
 }));
 
 import * as api from "@/lib/api";

--- a/frontend/src/__tests__/VocabularyPage.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.test.tsx
@@ -22,6 +22,11 @@ jest.mock("@/lib/api", () => ({
   deleteVocabularyWord: jest.fn(),
   exportVocabularyToObsidian: jest.fn(),
   getWordDefinition: jest.fn(),
+  listVocabularyTags: jest.fn().mockResolvedValue([]),
+  getVocabularyWordTags: jest.fn().mockResolvedValue([]),
+  addVocabularyWordTag: jest.fn().mockResolvedValue({ tag: "" }),
+  removeVocabularyWordTag: jest.fn().mockResolvedValue(undefined),
+  ApiError: class ApiError extends Error { status = 500; },
 }));
 
 import * as api from "@/lib/api";

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -7,10 +7,14 @@ import {
   deleteVocabularyWord,
   exportVocabularyToObsidian,
   getWordDefinition,
+  listVocabularyTags,
+  getVocabularyWordTags,
+  VocabTagSummary,
   VocabularyWord,
   WordDefinition,
 } from "@/lib/api";
 import { EmptyVocabIcon, ArrowLeftIcon, FlashcardIcon, ArrowUpRightIcon } from "@/components/Icons";
+import TagEditor from "@/components/TagEditor";
 
 type SortMode = "alpha" | "language" | "book" | "recent";
 
@@ -206,6 +210,9 @@ function VocabularyPageContent() {
   const [search, setSearch] = useState("");
   const [sortMode, setSortMode] = useState<SortMode>("alpha");
   const [activeWord, setActiveWord] = useState<{ word: string; lang: string | null } | null>(null);
+  const [allTags, setAllTags] = useState<VocabTagSummary[]>([]);
+  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const [tagsByVocabId, setTagsByVocabId] = useState<Record<number, string[]>>({});
   const highlightRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -215,17 +222,61 @@ function VocabularyPageContent() {
       .finally(() => setLoading(false));
   }, [session?.backendToken]);
 
+  useEffect(() => {
+    listVocabularyTags()
+      .then(setAllTags)
+      .catch(() => {});
+  }, [session?.backendToken]);
+
+  useEffect(() => {
+    if (!selectedTag || words.length === 0) return;
+    const missing = words
+      .map((w) => w.id)
+      .filter((id) => !(id in tagsByVocabId));
+    if (missing.length === 0) return;
+    let alive = true;
+    Promise.all(
+      missing.map((id) =>
+        getVocabularyWordTags(id)
+          .then((t) => [id, t] as const)
+          .catch(() => [id, [] as string[]] as const),
+      ),
+    ).then((pairs) => {
+      if (!alive) return;
+      setTagsByVocabId((prev) => {
+        const next = { ...prev };
+        for (const [id, t] of pairs) next[id] = t;
+        return next;
+      });
+    });
+    return () => {
+      alive = false;
+    };
+  }, [selectedTag, words, tagsByVocabId]);
+
+  const updateVocabTags = useCallback((vocabId: number, tags: string[]) => {
+    setTagsByVocabId((prev) => ({ ...prev, [vocabId]: tags }));
+  }, []);
+
   const groups = useMemo(() => buildGroups(words), [words]);
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
-    if (!q) return groups;
-    return groups.filter(
-      (g) =>
-        g.lemma.toLowerCase().includes(q) ||
-        g.forms.some((f) => f.word.toLowerCase().includes(q)),
-    );
-  }, [groups, search]);
+    let result = groups;
+    if (q) {
+      result = result.filter(
+        (g) =>
+          g.lemma.toLowerCase().includes(q) ||
+          g.forms.some((f) => f.word.toLowerCase().includes(q)),
+      );
+    }
+    if (selectedTag) {
+      result = result.filter((g) =>
+        g.forms.some((f) => (tagsByVocabId[f.id] ?? []).includes(selectedTag)),
+      );
+    }
+    return result;
+  }, [groups, search, selectedTag, tagsByVocabId]);
 
   const sections = useMemo(() => buildSections(filtered, sortMode), [filtered, sortMode]);
 
@@ -349,6 +400,13 @@ function VocabularyPageContent() {
               </div>
             ))
           )}
+        </div>
+        <div className="mt-3 pt-3 border-t border-amber-50">
+          <TagEditor
+            vocabularyId={group.forms[0].id}
+            initialTags={tagsByVocabId[group.forms[0].id]}
+            onTagsChange={(t) => updateVocabTags(group.forms[0].id, t)}
+          />
         </div>
       </div>
     );

--- a/frontend/src/components/TagEditor.tsx
+++ b/frontend/src/components/TagEditor.tsx
@@ -1,0 +1,170 @@
+"use client";
+import { useState, useEffect, useRef, KeyboardEvent } from "react";
+import {
+  addVocabularyWordTag,
+  removeVocabularyWordTag,
+  getVocabularyWordTags,
+  ApiError,
+} from "@/lib/api";
+import { CloseIcon } from "@/components/Icons";
+
+interface TagEditorProps {
+  vocabularyId: number;
+  initialTags?: string[];
+  onTagsChange?: (tags: string[]) => void;
+}
+
+export default function TagEditor({
+  vocabularyId,
+  initialTags,
+  onTagsChange,
+}: TagEditorProps) {
+  const [tags, setTags] = useState<string[]>(initialTags ?? []);
+  const [loaded, setLoaded] = useState(initialTags !== undefined);
+  const [draft, setDraft] = useState("");
+  const [adding, setAdding] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const submittingRef = useRef(false);
+
+  useEffect(() => {
+    if (loaded) return;
+    let alive = true;
+    getVocabularyWordTags(vocabularyId)
+      .then((list) => {
+        if (!alive) return;
+        setTags(list);
+        onTagsChange?.(list);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (alive) setLoaded(true);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [vocabularyId, loaded, onTagsChange]);
+
+  useEffect(() => {
+    if (adding) inputRef.current?.focus();
+  }, [adding]);
+
+  async function submitTag() {
+    if (submittingRef.current) return;
+    const raw = draft.trim();
+    if (!raw) {
+      setAdding(false);
+      setDraft("");
+      return;
+    }
+    if (raw.length > 50) {
+      setError("Tag is too long (max 50 chars).");
+      return;
+    }
+    submittingRef.current = true;
+    setError(null);
+    try {
+      const { tag } = await addVocabularyWordTag(vocabularyId, raw);
+      const next = tags.includes(tag) ? tags : [...tags, tag].sort();
+      setTags(next);
+      onTagsChange?.(next);
+      setDraft("");
+      setAdding(false);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setError(e.message);
+      } else {
+        setError("Failed to add tag.");
+      }
+    } finally {
+      submittingRef.current = false;
+    }
+  }
+
+  async function handleRemove(tag: string) {
+    setBusy(tag);
+    setError(null);
+    try {
+      await removeVocabularyWordTag(vocabularyId, tag);
+      const next = tags.filter((t) => t !== tag);
+      setTags(next);
+      onTagsChange?.(next);
+    } catch {
+      setError("Failed to remove tag.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  function onKey(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      submitTag();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setAdding(false);
+      setDraft("");
+      setError(null);
+    }
+  }
+
+  return (
+    <div
+      className="flex items-center gap-1.5 flex-wrap"
+      data-testid={`tag-editor-${vocabularyId}`}
+    >
+      {tags.map((tag) => (
+        <span
+          key={tag}
+          className="inline-flex items-center gap-1 rounded-full bg-amber-50 border border-amber-200 pl-2 pr-1 py-0.5 text-xs text-amber-800"
+          data-testid={`tag-chip-${tag}`}
+        >
+          <span>{tag}</span>
+          <button
+            type="button"
+            onClick={() => handleRemove(tag)}
+            disabled={busy === tag}
+            aria-label={`Remove tag ${tag}`}
+            className="rounded-full p-0.5 hover:bg-amber-100 disabled:opacity-50 transition-colors"
+          >
+            <CloseIcon className="w-3 h-3" />
+          </button>
+        </span>
+      ))}
+
+      {adding ? (
+        <input
+          ref={inputRef}
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={onKey}
+          onBlur={submitTag}
+          maxLength={50}
+          placeholder="new tag"
+          aria-label="New tag"
+          className="rounded-full border border-amber-300 bg-white px-2 py-0.5 text-xs text-ink focus:outline-none focus:ring-2 focus:ring-amber-400 w-24"
+          data-testid={`tag-input-${vocabularyId}`}
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => setAdding(true)}
+          aria-label="Add tag"
+          className="inline-flex items-center gap-0.5 rounded-full border border-dashed border-amber-300 px-2 py-0.5 text-xs text-amber-700 hover:bg-amber-50 transition-colors"
+          data-testid={`add-tag-${vocabularyId}`}
+        >
+          <span aria-hidden="true">+</span>
+          <span>tag</span>
+        </button>
+      )}
+
+      {error && (
+        <span className="text-xs text-red-600" role="alert">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -67,6 +67,7 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
     const err = await res.json().catch(() => ({ detail: res.statusText }));
     throw new ApiError(res.status, err.detail || "Request failed");
   }
+  if (res.status === 204) return undefined as T;
   return res.json();
 }
 
@@ -691,6 +692,34 @@ export function exportVocabularyToObsidian(bookId?: number, targetLanguage = "zh
       target_language: targetLanguage,
     }),
   });
+}
+
+export interface VocabTagSummary {
+  tag: string;
+  word_count: number;
+}
+
+export function listVocabularyTags() {
+  return request<VocabTagSummary[]>("/vocabulary/tags");
+}
+
+export function getVocabularyWordTags(vocabularyId: number) {
+  return request<string[]>(`/vocabulary/${vocabularyId}/tags`);
+}
+
+export function addVocabularyWordTag(vocabularyId: number, tag: string) {
+  return request<{ tag: string }>(`/vocabulary/${vocabularyId}/tags`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ tag }),
+  });
+}
+
+export function removeVocabularyWordTag(vocabularyId: number, tag: string) {
+  return request<void>(
+    `/vocabulary/${vocabularyId}/tags/${encodeURIComponent(tag)}`,
+    { method: "DELETE" },
+  );
 }
 
 // ── Book Insights (saved AI Q&A) ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Implements Slice 1 of vocabulary tags & custom study decks (#741): per-word tagging on the `/vocabulary` page.
- Backend (migration 027, tag endpoints, `vocab_tags` service) already shipped in #745; this wires the frontend onto those endpoints.
- Tag filter pill bar and decks pages are deliberately **out of scope** — they land in slice 2 and slice 3 per the plan in #741.

## What changed

- **`TagEditor` component** (`src/components/TagEditor.tsx`): per-word tag chips with inline add/remove. Keyboard-driven — `+ tag` button opens an input, `Enter` submits, `Escape` cancels. API errors surface inline via `role="alert"`.
- **API client** (`src/lib/api.ts`): `listVocabularyTags`, `getVocabularyWordTags`, `addVocabularyWordTag`, `removeVocabularyWordTag`. The shared `request()` helper now returns `undefined` for `204 No Content` so the `DELETE` path parses cleanly.
- **`/vocabulary` page**: renders a `TagEditor` under each lemma group's occurrences, attached to `group.forms[0].id` (one tag set per lemma). When the filter is active, groups are filtered to those whose forms carry the tag; per-word tags are lazily fetched on first filter use and cached in `tagsByVocabId`.

## Test plan

- [x] **New `TagEditor.test.tsx`** (6 tests): renders initial tags, fetches when none supplied, adds via keyboard, removes via X, surfaces API error, cancels on `Escape`.
- [x] `VocabularyPage*.test.tsx` mocks updated with the four new tag API functions and `ApiError` so existing coverage still runs.
- [x] Full frontend suite after rebase onto latest main: **1760 passed, 150 suites**.

## Design references

- Design doc: `docs/design/vocab-tags-decks.md` (merged via #646)
- Backend slice: #745 (migration 027 + endpoints)
- Tracking issue: #741 (pm-approved)

Closes #741 (slice 1; remaining slices tracked on the issue).