### PR TITLE
fix: ai_lookup returns empty url instead of broken Wiktionary link

### DIFF
--- a/backend/services/wiktionary.py
+++ b/backend/services/wiktionary.py
@@ -151,7 +151,7 @@ async def ai_lookup(word: str, lang: str, api_key: str) -> dict:
             "lemma": data.get("lemma") or word,
             "language": lang,
             "definitions": definitions,
-            "url": wikt_url,
+            "url": "",
         }
     except Exception:
         return empty

--- a/backend/tests/test_wiktionary.py
+++ b/backend/tests/test_wiktionary.py
@@ -366,3 +366,15 @@ async def test_ai_lookup_returns_empty_on_exception():
     with patch("services.gemini._generate", new=AsyncMock(side_effect=Exception("api error"))):
         result = await ai_lookup("word", "en", api_key="test-key")
     assert result["definitions"] == []
+
+
+@pytest.mark.asyncio
+async def test_ai_lookup_url_is_empty_string():
+    """ai_lookup must return url='' — not a Wiktionary link — because wiktionary
+    had no entry for this word (that's why AI was called). Closes #551."""
+    gemini_json = '{"lemma":"Aufmerksamkeit","definitions":[{"pos":"noun","text":"attention"}]}'
+    with patch("services.gemini._generate", new=AsyncMock(return_value=gemini_json)):
+        result = await ai_lookup("Aufmerksamkeitsdefizit", "de", api_key="test-key")
+    assert result["url"] == "", (
+        "AI fallback must not return a Wiktionary URL — the user would land on a missing page"
+    )


### PR DESCRIPTION
Closes #551

When Wiktionary has no entry for a word, the AI fallback (`ai_lookup`) still returned `url: https://en.wiktionary.org/wiki/<word>` — a link to a page that doesn't exist. Clicking it would send users to a Wiktionary 404.

**Fix:** return `url: ""` from `ai_lookup` (`services/wiktionary.py:154`) so the frontend omits the look-up link entirely when AI was used.

## Test plan

- [x] `test_ai_lookup_url_is_empty_string` — new regression test asserts `url == ""` when Gemini fallback is used
- [x] All existing `ai_lookup` tests still pass (26 total in `test_wiktionary.py`)
- [x] Frontend suite: 1754 tests passing
- [x] Backend suite: 1394 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
