### PR TITLE
feat: tag filter pill bar on /vocabulary (#741 slice 2)

### DIFF
--- a/frontend/src/__tests__/VocabularyPage.tagfilter.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.tagfilter.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * Tests for vocabulary page tag filter pill bar (slice 2 of #741).
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { backendToken: "token123" } }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+const listVocabularyTags = jest.fn();
+const getVocabularyWordTags = jest.fn();
+
+jest.mock("@/lib/api", () => ({
+  getVocabulary: jest.fn(),
+  deleteVocabularyWord: jest.fn(),
+  exportVocabularyToObsidian: jest.fn(),
+  getWordDefinition: jest.fn(),
+  listVocabularyTags: (...args: unknown[]) => listVocabularyTags(...args),
+  getVocabularyWordTags: (...args: unknown[]) => getVocabularyWordTags(...args),
+  addVocabularyWordTag: jest.fn().mockResolvedValue({ tag: "" }),
+  removeVocabularyWordTag: jest.fn().mockResolvedValue(undefined),
+  ApiError: class ApiError extends Error {
+    status = 500;
+  },
+}));
+
+import * as api from "@/lib/api";
+import VocabularyPage from "@/app/vocabulary/page";
+
+const mockGetVocabulary = api.getVocabulary as jest.MockedFunction<typeof api.getVocabulary>;
+
+const WORDS = [
+  {
+    id: 10,
+    word: "ephemeral",
+    occurrences: [
+      {
+        book_id: 1,
+        book_title: "Moby Dick",
+        chapter_index: 2,
+        sentence_text: "The ephemeral whale loomed.",
+      },
+    ],
+  },
+  {
+    id: 20,
+    word: "ardent",
+    occurrences: [
+      {
+        book_id: 1,
+        book_title: "Moby Dick",
+        chapter_index: 5,
+        sentence_text: "His ardent gaze swept the sea.",
+      },
+    ],
+  },
+];
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetVocabulary.mockResolvedValue(WORDS);
+  listVocabularyTags.mockResolvedValue([]);
+  getVocabularyWordTags.mockResolvedValue([]);
+});
+
+test("pill bar does not render when the user has no tags", async () => {
+  listVocabularyTags.mockResolvedValue([]);
+  render(<VocabularyPage />);
+  await screen.findByText("ephemeral");
+  await flushPromises();
+  expect(screen.queryByTestId("tag-filter-bar")).not.toBeInTheDocument();
+});
+
+test("pill bar renders one pill per tag plus an 'All' pill, with word counts", async () => {
+  listVocabularyTags.mockResolvedValue([
+    { tag: "verbs", word_count: 3 },
+    { tag: "nouns", word_count: 1 },
+  ]);
+  render(<VocabularyPage />);
+  await screen.findByText("ephemeral");
+  await flushPromises();
+
+  const bar = await screen.findByTestId("tag-filter-bar");
+  expect(bar).toBeInTheDocument();
+  expect(screen.getByTestId("tag-filter-all")).toHaveAttribute("aria-pressed", "true");
+
+  const verbsPill = screen.getByTestId("tag-filter-verbs");
+  expect(verbsPill).toHaveAttribute("aria-pressed", "false");
+  expect(verbsPill).toHaveTextContent("verbs");
+  expect(verbsPill).toHaveTextContent("3");
+
+  const nounsPill = screen.getByTestId("tag-filter-nouns");
+  expect(nounsPill).toHaveTextContent("nouns");
+  expect(nounsPill).toHaveTextContent("1");
+});
+
+test("clicking a pill filters the word list to words carrying that tag", async () => {
+  listVocabularyTags.mockResolvedValue([{ tag: "verbs", word_count: 1 }]);
+  getVocabularyWordTags.mockImplementation((id: number) =>
+    Promise.resolve(id === 10 ? ["verbs"] : []),
+  );
+
+  render(<VocabularyPage />);
+  await screen.findByText("ephemeral");
+  await screen.findByTestId("tag-filter-verbs");
+
+  const user = userEvent.setup();
+  await user.click(screen.getByTestId("tag-filter-verbs"));
+
+  await waitFor(() => {
+    expect(screen.getByTestId("tag-filter-verbs")).toHaveAttribute("aria-pressed", "true");
+  });
+  expect(screen.getByTestId("tag-filter-all")).toHaveAttribute("aria-pressed", "false");
+
+  await waitFor(() => {
+    expect(screen.queryByText("ardent")).not.toBeInTheDocument();
+  });
+  expect(screen.getByText("ephemeral")).toBeInTheDocument();
+});
+
+test("clicking 'All' clears an active tag filter", async () => {
+  listVocabularyTags.mockResolvedValue([{ tag: "verbs", word_count: 1 }]);
+  getVocabularyWordTags.mockImplementation((id: number) =>
+    Promise.resolve(id === 10 ? ["verbs"] : []),
+  );
+
+  render(<VocabularyPage />);
+  await screen.findByText("ephemeral");
+  await screen.findByTestId("tag-filter-verbs");
+
+  const user = userEvent.setup();
+  await user.click(screen.getByTestId("tag-filter-verbs"));
+  await waitFor(() => {
+    expect(screen.queryByText("ardent")).not.toBeInTheDocument();
+  });
+
+  await user.click(screen.getByTestId("tag-filter-all"));
+  await waitFor(() => {
+    expect(screen.getByText("ardent")).toBeInTheDocument();
+  });
+  expect(screen.getByText("ephemeral")).toBeInTheDocument();
+  expect(screen.getByTestId("tag-filter-all")).toHaveAttribute("aria-pressed", "true");
+});
+
+test("clicking the active pill again toggles the filter off", async () => {
+  listVocabularyTags.mockResolvedValue([{ tag: "verbs", word_count: 1 }]);
+  getVocabularyWordTags.mockImplementation((id: number) =>
+    Promise.resolve(id === 10 ? ["verbs"] : []),
+  );
+
+  render(<VocabularyPage />);
+  await screen.findByText("ephemeral");
+  await screen.findByTestId("tag-filter-verbs");
+
+  const user = userEvent.setup();
+  await user.click(screen.getByTestId("tag-filter-verbs"));
+  await waitFor(() => {
+    expect(screen.queryByText("ardent")).not.toBeInTheDocument();
+  });
+  await user.click(screen.getByTestId("tag-filter-verbs"));
+  await waitFor(() => {
+    expect(screen.getByText("ardent")).toBeInTheDocument();
+  });
+  expect(screen.getByTestId("tag-filter-verbs")).toHaveAttribute("aria-pressed", "false");
+});
+
+test("shows a tag-specific empty state message when filter matches nothing", async () => {
+  listVocabularyTags.mockResolvedValue([{ tag: "orphan", word_count: 0 }]);
+  getVocabularyWordTags.mockResolvedValue([]);
+
+  render(<VocabularyPage />);
+  await screen.findByText("ephemeral");
+  await screen.findByTestId("tag-filter-orphan");
+
+  const user = userEvent.setup();
+  await user.click(screen.getByTestId("tag-filter-orphan"));
+
+  expect(await screen.findByText(/no words tagged with/i)).toBeInTheDocument();
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -486,6 +486,51 @@ function VocabularyPageContent() {
           </div>
         )}
 
+        {!loading && words.length > 0 && allTags.length > 0 && (
+          <div
+            data-testid="tag-filter-bar"
+            role="group"
+            aria-label="Filter by tag"
+            className="mb-6 flex gap-2 overflow-x-auto pb-1"
+          >
+            <button
+              type="button"
+              onClick={() => setSelectedTag(null)}
+              aria-pressed={selectedTag === null}
+              data-testid="tag-filter-all"
+              className={`shrink-0 min-h-[44px] px-3 rounded-full text-xs font-medium border transition-colors ${
+                selectedTag === null
+                  ? "bg-amber-700 text-white border-amber-700"
+                  : "bg-white text-amber-700 border-amber-200 hover:bg-amber-50"
+              }`}
+            >
+              All
+            </button>
+            {allTags.map(({ tag, word_count }) => {
+              const active = selectedTag === tag;
+              return (
+                <button
+                  type="button"
+                  key={tag}
+                  onClick={() => setSelectedTag(active ? null : tag)}
+                  aria-pressed={active}
+                  data-testid={`tag-filter-${tag}`}
+                  className={`shrink-0 min-h-[44px] px-3 rounded-full text-xs font-medium border transition-colors ${
+                    active
+                      ? "bg-amber-700 text-white border-amber-700"
+                      : "bg-white text-amber-700 border-amber-200 hover:bg-amber-50"
+                  }`}
+                >
+                  {tag}
+                  <span className={`ml-1 ${active ? "opacity-80" : "text-stone-400"}`}>
+                    · {word_count}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+
         {loading ? (
           <div className="space-y-3 animate-pulse">
             {Array.from({ length: 8 }).map((_, i) => (
@@ -499,7 +544,13 @@ function VocabularyPageContent() {
             <p className="text-sm">Double-click any word while reading to save it here.</p>
           </div>
         ) : filtered.length === 0 ? (
-          <p className="text-center text-stone-400 mt-12 text-sm">No words match &ldquo;{search}&rdquo;</p>
+          selectedTag ? (
+            <p className="text-center text-stone-400 mt-12 text-sm">
+              No words tagged with &ldquo;<span className="font-medium text-ink">{selectedTag}</span>&rdquo;
+            </p>
+          ) : (
+            <p className="text-center text-stone-400 mt-12 text-sm">No words match &ldquo;{search}&rdquo;</p>
+          )
         ) : (
           <div className="space-y-8">
             {sections.map(({ heading, groups: sectionGroups }) => (


### PR DESCRIPTION
## Summary

- Implements Slice 2 of vocabulary tags & custom study decks (#741): tag filter pill bar on `/vocabulary`.
- Slice 1 (#791) already shipped the `selectedTag` state, lazy per-word tag fetching, and the filter predicate — this slice adds the UI surface that lets a user actually set `selectedTag`.
- Decks (DeckCard, `/decks` pages, flashcard deck selector) remain out of scope — slice 3 per the #741 plan.

## What changed

- **Tag filter pill bar** on `/vocabulary` (above the list, below the search/sort controls):
  - An **All** pill (active when no filter is set), followed by one pill per user tag from `listVocabularyTags()`, each showing its `word_count`.
  - `aria-pressed` reflects the active state; 44px min touch target; amber/white palette via existing semantic classes (no raw hex).
  - Bar is `role="group"` with `aria-label="Filter by tag"` and horizontally scrollable on narrow viewports (`overflow-x-auto`).
  - Clicking the active pill toggles it off; clicking **All** clears the filter.
  - Bar is hidden when the user has no tags yet.
- **Tag-aware empty state:** when the filter returns zero groups, we now render `No words tagged with "<tag>"` instead of the misleading search-centric copy.

## Test plan

- [x] **New `VocabularyPage.tagfilter.test.tsx`** (6 tests):
  - Bar is absent when the user has no tags.
  - Bar renders correct pills with `aria-pressed` + `word_count` badges.
  - Clicking a tag pill filters the word list.
  - Clicking **All** clears an active filter.
  - Clicking the active pill again toggles it off.
  - Tag-specific empty-state copy renders when filter matches nothing.
- [x] Full frontend suite: **1772 passed, 152 suites**.
- [x] Full backend suite: **1393 passed**.

## Design references

- Design doc: `docs/design/vocab-tags-decks.md` (#646)
- Backend slice: #745
- Slice 1 (frontend TagEditor + filter state): #791
- Tracking issue: #741 (pm-approved)

Closes #741 (slice 2; slice 3 — decks — tracked on the issue).
