### PR TITLE
fix: add min_length=1 to target_language query param in GET /ai/translate/cache (closes #792)

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -238,7 +238,7 @@ async def delete_summary(book_id: int = Query(..., ge=1), chapter_index: int = Q
 async def translate_cache(
     book_id: int = Query(..., ge=1),
     chapter_index: int = Query(..., ge=0),
-    target_language: str = Query(..., max_length=20),
+    target_language: str = Query(..., min_length=1, max_length=20),
     _user: dict = Depends(get_current_user),
 ):
     """Check if a translation is cached. Returns paragraphs + provider/model if yes, 404 if not."""

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -1260,3 +1260,14 @@ async def test_save_translation_empty_target_language_returns_422(client, test_u
         "paragraphs": ["Hello."],
     })
     assert resp.status_code == 422, f"Expected 422 for empty target_language in save_translation, got {resp.status_code}: {resp.text}"
+
+
+# ── Issue #792: min_length=1 on GET /ai/translate/cache target_language ───────
+
+
+async def test_get_translate_cache_empty_target_language_returns_422(client, test_user):
+    """Regression #792: GET /ai/translate/cache?target_language="" must return 422."""
+    resp = await client.get("/api/ai/translate/cache?book_id=1&chapter_index=0&target_language=")
+    assert resp.status_code == 422, (
+        f"Expected 422 for empty target_language in GET /ai/translate/cache, got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## What changed

Added `min_length=1` to the `target_language` query parameter on `GET /ai/translate/cache` in `backend/routers/ai.py` (line 241):

```python
# before
target_language: str = Query(..., max_length=20),
# after
target_language: str = Query(..., min_length=1, max_length=20),
```

## Why

`GET /ai/translate/cache?target_language=` accepted an empty string, which passed Pydantic validation, was normalized to `""`, and then queried the translation cache with a nonsensical language key. The companion `PUT /ai/translate/cache` already correctly used `min_length=1` — this brings the GET endpoint into parity.

Same class of validation gap as #786 (books router) and #772 (translate request body).

## Test plan

- New regression test `test_get_translate_cache_empty_target_language_returns_422` confirms `GET /ai/translate/cache?book_id=1&chapter_index=0&target_language=` returns 422.
- Full backend suite: 1395 passed.
- Full frontend suite: 1766 passed.

Closes #792
