### PR TITLE
ux: replace ▶/▼ Unicode with ChevronRightIcon/ChevronDownIcon in reader sidebar

### DIFF
--- a/frontend/src/__tests__/ReaderChapterCollapseUnicodeIcons.test.ts
+++ b/frontend/src/__tests__/ReaderChapterCollapseUnicodeIcons.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Regression test for issue #795 — reader sidebar chapter collapse uses
+ * ▶/▼ Unicode instead of ChevronRightIcon/ChevronDownIcon from Icons.tsx.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf-8"
+);
+
+describe("Reader chapter collapse icon (#795)", () => {
+  it("does not use ▶ Unicode character as collapse icon", () => {
+    expect(src).not.toMatch(/[▶]/);
+  });
+
+  it("does not use ▼ Unicode character as expand icon", () => {
+    expect(src).not.toMatch(/[▼]/);
+  });
+
+  it("imports ChevronRightIcon from Icons", () => {
+    expect(src).toMatch(/ChevronRightIcon/);
+  });
+
+  it("ChevronRightIcon has aria-hidden", () => {
+    expect(src).toMatch(/ChevronRightIcon[\s\S]{0,50}aria-hidden/);
+  });
+
+  it("ChevronDownIcon has aria-hidden on collapse toggle", () => {
+    expect(src).toMatch(/ChevronDownIcon[\s\S]{0,50}aria-hidden/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -18,7 +18,7 @@ import UndoToast from "@/components/UndoToast";
 import VocabWordTooltip from "@/components/VocabWordTooltip";
 import ChapterSummary from "@/components/ChapterSummary";
 import AuthPromptModal from "@/components/AuthPromptModal";
-import { SunIcon, MoonIcon, SepiaIcon, ChatIcon, GlobeIcon, NoteIcon, EditIcon, BookmarkIcon, BookOpenIcon, ExportIcon, SummaryIcon, PlayIcon, PauseIcon, CloseIcon, KeyboardIcon, FocusIcon, ArrowLeftIcon, ArrowRightIcon, ChevronDownIcon, EmptyVocabIcon, ArrowUpRightIcon } from "@/components/Icons";
+import { SunIcon, MoonIcon, SepiaIcon, ChatIcon, GlobeIcon, NoteIcon, EditIcon, BookmarkIcon, BookOpenIcon, ExportIcon, SummaryIcon, PlayIcon, PauseIcon, CloseIcon, KeyboardIcon, FocusIcon, ArrowLeftIcon, ArrowRightIcon, ChevronDownIcon, ChevronRightIcon, EmptyVocabIcon, ArrowUpRightIcon } from "@/components/Icons";
 
 // In-memory cache: bookId → chapters (survives client-side navigation)
 const chaptersCache = new Map<string, BookChapter[]>();
@@ -1746,7 +1746,7 @@ export default function ReaderPage() {
                                   return next;
                                 })}
                               >
-                                <span>{isCollapsed ? "▶" : "▼"}</span>
+                                {isCollapsed ? <ChevronRightIcon className="w-3 h-3" aria-hidden="true" /> : <ChevronDownIcon className="w-3 h-3" aria-hidden="true" />}
                                 <span>Chapter {ch + 1}</span>
                               </button>
                               {!isCollapsed && (


### PR DESCRIPTION
Closes #795

The reader sidebar annotations panel used raw Unicode ▶/▼ triangle characters as collapse/expand indicators (`reader/[bookId]/page.tsx:1749`). These render inconsistently across OS/browser and violate the CLAUDE.md icon system rule.

**Fix:** replaced with `ChevronRightIcon` (collapsed) / `ChevronDownIcon` (expanded) from `Icons.tsx`, both with `aria-hidden="true"`. Added `ChevronRightIcon` to the existing import.

## Test plan

- [x] 5 static-analysis regression tests: no ▶/▼ in source, `ChevronRightIcon` imported and has `aria-hidden`, `ChevronDownIcon` has `aria-hidden` on collapse toggle
- [x] Frontend suite: 1771 tests passing
- [x] Backend suite: 1394 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
