### PR TITLE
fix: add min_length=1 to q param in GET /books/search (closes #794)

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -29,7 +29,7 @@ router = APIRouter(prefix="/books", tags=["books"])
 
 @router.get("/search")
 async def search(
-    q: str = Query(..., max_length=200, description="Search query"),
+    q: str = Query(..., min_length=1, max_length=200, description="Search query"),
     language: str = Query("", max_length=20, description="Language code e.g. en, de, fr"),
     page: int = Query(1, ge=1, le=10000),
 ):

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -1245,3 +1245,14 @@ async def test_chapter_translation_get_empty_target_language_returns_422(client,
     assert resp.status_code == 422, (
         f"Expected 422 for empty target_language in GET translation, got {resp.status_code}: {resp.text}"
     )
+
+
+# ── Issue #794: min_length=1 on q in GET /books/search ───────────────────────
+
+
+async def test_search_empty_q_returns_422(client):
+    """Regression #794: GET /books/search?q="" must return 422, not call Gutendex with empty query."""
+    resp = await client.get("/api/books/search?q=")
+    assert resp.status_code == 422, (
+        f"Expected 422 for empty q in /books/search, got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## What changed
`GET /books/search` accepted an empty `q` query parameter (`?q=`) without validation. An empty query would call the Gutendex external API with a blank search term, returning unexpected results (or a 400 from Gutendex) instead of a client-side 422.

## Fix
Added `min_length=1` to the `q` Query param in `backend/routers/books.py` so FastAPI rejects empty strings before handler logic runs.

## Test plan
- New regression test `test_search_empty_q_returns_422` verifies `GET /books/search?q=` returns 422.
- Full backend (1399) and frontend (1772) test suites pass.

Closes #794
