### PR TITLE
ux: replace ▶ Unicode with ChevronRightIcon in profile Obsidian collapse toggle (closes #804)

### DIFF
--- a/frontend/src/__tests__/ProfileObsidianCollapseUnicode.test.ts
+++ b/frontend/src/__tests__/ProfileObsidianCollapseUnicode.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Regression test for issue #804 — profile page Obsidian collapse toggle
+ * uses ▶ Unicode instead of ChevronRightIcon from Icons.tsx.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/profile/page.tsx"),
+  "utf-8"
+);
+
+describe("Profile Obsidian collapse icon (#804)", () => {
+  it("does not use ▶ Unicode character", () => {
+    expect(src).not.toMatch(/[▶]/);
+  });
+
+  it("imports ChevronRightIcon from Icons", () => {
+    expect(src).toMatch(/ChevronRightIcon/);
+  });
+
+  it("ChevronRightIcon has aria-hidden on collapse toggle", () => {
+    expect(src).toMatch(/ChevronRightIcon[\s\S]{0,200}aria-hidden/);
+  });
+
+  it("collapse toggle uses rotate-90 transition", () => {
+    expect(src).toMatch(/ChevronRightIcon[\s\S]{0,200}rotate-90/);
+  });
+});

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -3,7 +3,7 @@ import { useSession, signOut } from "next-auth/react";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { saveGeminiKey, deleteGeminiKey, getMe, getObsidianSettings, saveObsidianSettings } from "@/lib/api";
-import { ArrowLeftIcon, CheckIcon } from "@/components/Icons";
+import { ArrowLeftIcon, CheckIcon, ChevronRightIcon } from "@/components/Icons";
 import { getSettings, saveSettings, AppSettings } from "@/lib/settings";
 
 const LANGUAGES = [
@@ -282,12 +282,10 @@ export default function ProfilePage() {
                   : "Configure GitHub integration to push vocab to Obsidian"}
               </p>
             </div>
-            <span
-              className={`text-amber-600 transition-transform duration-200 ${obsidianOpen ? "rotate-90" : ""}`}
+            <ChevronRightIcon
+              className={`w-4 h-4 text-amber-600 transition-transform duration-200 ${obsidianOpen ? "rotate-90" : ""}`}
               aria-hidden="true"
-            >
-              ▶
-            </span>
+            />
           </button>
 
           {/* Collapsible body */}


### PR DESCRIPTION
Closes #804

The Obsidian export collapsible section in `profile/page.tsx` used a raw `▶` Unicode triangle (`<span aria-hidden="true">▶</span>`) as its expand/collapse indicator. This violates CLAUDE.md's icon system rule (never use emoji/Unicode as UI icons).

**Fix:** replaced with `ChevronRightIcon` from `Icons.tsx` with `rotate-90` transition when expanded and `aria-hidden="true"`.

## Test plan
- [x] Regression test `ProfileObsidianCollapseUnicode.test.ts` — 4 assertions (no ▶ char, ChevronRightIcon imported + aria-hidden, rotate-90 present)
- [x] Frontend suite: 1778 passing
- [x] Backend suite: 1399 passing

🤖 Generated with Claude Code
