### PR TITLE
feat: /decks index + /decks/new + DeckCard (#741 slice 3a)

### DIFF
--- a/frontend/src/__tests__/DeckCard.test.tsx
+++ b/frontend/src/__tests__/DeckCard.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Tests for the DeckCard component (slice 3a of #741).
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DeckCard from "@/components/DeckCard";
+import type { DeckSummary } from "@/lib/api";
+
+const MANUAL_DECK: DeckSummary = {
+  id: 1,
+  name: "German verbs",
+  description: "Regular and irregular verbs from my reading",
+  mode: "manual",
+  rules_json: null,
+  created_at: "2026-04-24T08:00:00",
+  updated_at: "2026-04-24T08:00:00",
+  member_count: 12,
+  due_today: 3,
+};
+
+const SMART_DECK: DeckSummary = {
+  id: 2,
+  name: "All A1 German",
+  description: "",
+  mode: "smart",
+  rules_json: '{"language":"de"}',
+  created_at: "2026-04-24T08:00:00",
+  updated_at: "2026-04-24T08:00:00",
+  member_count: 45,
+  due_today: 0,
+};
+
+test("renders name, description, member count and due-today badge", () => {
+  render(<DeckCard deck={MANUAL_DECK} />);
+  expect(screen.getByText("German verbs")).toBeInTheDocument();
+  expect(screen.getByText(/Regular and irregular verbs/)).toBeInTheDocument();
+  expect(screen.getByTestId(`deck-member-count-${MANUAL_DECK.id}`)).toHaveTextContent("12");
+  expect(screen.getByTestId(`deck-due-today-${MANUAL_DECK.id}`)).toHaveTextContent("3");
+});
+
+test("renders the mode badge ('manual' vs 'smart')", () => {
+  const { rerender } = render(<DeckCard deck={MANUAL_DECK} />);
+  expect(screen.getByTestId(`deck-mode-${MANUAL_DECK.id}`)).toHaveTextContent(/manual/i);
+
+  rerender(<DeckCard deck={SMART_DECK} />);
+  expect(screen.getByTestId(`deck-mode-${SMART_DECK.id}`)).toHaveTextContent(/smart/i);
+});
+
+test("hides the due-today badge when nothing is due", () => {
+  render(<DeckCard deck={SMART_DECK} />);
+  expect(screen.queryByTestId(`deck-due-today-${SMART_DECK.id}`)).not.toBeInTheDocument();
+});
+
+test("calls onDelete with deck id when the delete button is clicked", async () => {
+  const onDelete = jest.fn();
+  render(<DeckCard deck={MANUAL_DECK} onDelete={onDelete} />);
+  const user = userEvent.setup();
+  await user.click(screen.getByTestId(`deck-delete-${MANUAL_DECK.id}`));
+  expect(onDelete).toHaveBeenCalledWith(MANUAL_DECK.id);
+});
+
+test("does not render delete button when no onDelete prop is supplied", () => {
+  render(<DeckCard deck={MANUAL_DECK} />);
+  expect(screen.queryByTestId(`deck-delete-${MANUAL_DECK.id}`)).not.toBeInTheDocument();
+});
+
+test("delete button has an accessible label", () => {
+  render(<DeckCard deck={MANUAL_DECK} onDelete={jest.fn()} />);
+  expect(screen.getByTestId(`deck-delete-${MANUAL_DECK.id}`)).toHaveAttribute(
+    "aria-label",
+    expect.stringMatching(/delete/i),
+  );
+});

--- a/frontend/src/__tests__/DecksNewPage.test.tsx
+++ b/frontend/src/__tests__/DecksNewPage.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Tests for /decks/new create-deck page (slice 3a of #741).
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ status: "authenticated", data: { backendToken: "token" } }),
+}));
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  createDeck: jest.fn(),
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+import * as api from "@/lib/api";
+import DecksNewPage from "@/app/decks/new/page";
+
+const mockCreateDeck = api.createDeck as jest.MockedFunction<typeof api.createDeck>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test("renders form fields with 'manual' as default mode", () => {
+  render(<DecksNewPage />);
+  expect(screen.getByTestId("deck-name-input")).toBeInTheDocument();
+  expect(screen.getByTestId("deck-description-input")).toBeInTheDocument();
+  const manualRadio = screen.getByTestId("deck-mode-manual") as HTMLInputElement;
+  expect(manualRadio.checked).toBe(true);
+});
+
+test("submitting a valid form creates a manual deck and navigates to /decks", async () => {
+  mockCreateDeck.mockResolvedValue({
+    id: 42,
+    name: "German verbs",
+    description: "",
+    mode: "manual",
+    rules_json: null,
+    created_at: "2026-04-24T08:00:00",
+    updated_at: "2026-04-24T08:00:00",
+    member_count: 0,
+    members: [],
+  });
+
+  render(<DecksNewPage />);
+  const user = userEvent.setup();
+  await user.type(screen.getByTestId("deck-name-input"), "German verbs");
+  await user.type(screen.getByTestId("deck-description-input"), "Top-frequency verbs");
+  await user.click(screen.getByTestId("deck-submit-btn"));
+
+  await waitFor(() => {
+    expect(mockCreateDeck).toHaveBeenCalledWith({
+      name: "German verbs",
+      description: "Top-frequency verbs",
+      mode: "manual",
+    });
+  });
+  expect(mockPush).toHaveBeenCalledWith("/decks");
+});
+
+test("blocks submission when the name is blank", async () => {
+  render(<DecksNewPage />);
+  const user = userEvent.setup();
+  await user.click(screen.getByTestId("deck-submit-btn"));
+  expect(mockCreateDeck).not.toHaveBeenCalled();
+  expect(await screen.findByTestId("deck-form-error")).toHaveTextContent(/name/i);
+});
+
+test("surfaces the API error instead of navigating on failure", async () => {
+  mockCreateDeck.mockRejectedValue(
+    new (api as typeof api & { ApiError: new (status: number, message: string) => Error }).ApiError(
+      409,
+      "A deck with this name already exists",
+    ),
+  );
+
+  render(<DecksNewPage />);
+  const user = userEvent.setup();
+  await user.type(screen.getByTestId("deck-name-input"), "German verbs");
+  await user.click(screen.getByTestId("deck-submit-btn"));
+
+  expect(await screen.findByTestId("deck-form-error")).toHaveTextContent(/already exists/i);
+  expect(mockPush).not.toHaveBeenCalledWith("/decks");
+});
+
+test("notes that smart decks are coming in a later slice (disabled mode)", () => {
+  render(<DecksNewPage />);
+  const smartRadio = screen.getByTestId("deck-mode-smart") as HTMLInputElement;
+  expect(smartRadio.disabled).toBe(true);
+});

--- a/frontend/src/__tests__/DecksPage.test.tsx
+++ b/frontend/src/__tests__/DecksPage.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Tests for /decks index page (slice 3a of #741).
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ status: "authenticated", data: { backendToken: "token" } }),
+}));
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  listDecks: jest.fn(),
+  deleteDeck: jest.fn(),
+}));
+
+import * as api from "@/lib/api";
+import DecksPage from "@/app/decks/page";
+
+const mockListDecks = api.listDecks as jest.MockedFunction<typeof api.listDecks>;
+const mockDeleteDeck = api.deleteDeck as jest.MockedFunction<typeof api.deleteDeck>;
+
+const SAMPLE_DECKS = [
+  {
+    id: 1,
+    name: "German verbs",
+    description: "Regular + irregular verbs",
+    mode: "manual" as const,
+    rules_json: null,
+    created_at: "2026-04-24T08:00:00",
+    updated_at: "2026-04-24T08:00:00",
+    member_count: 12,
+    due_today: 3,
+  },
+  {
+    id: 2,
+    name: "A1 Spanish",
+    description: "",
+    mode: "smart" as const,
+    rules_json: '{"language":"es"}',
+    created_at: "2026-04-24T08:00:00",
+    updated_at: "2026-04-24T08:00:00",
+    member_count: 40,
+    due_today: 0,
+  },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test("renders an empty state with a New-deck CTA when the user has no decks", async () => {
+  mockListDecks.mockResolvedValue([]);
+  render(<DecksPage />);
+  expect(await screen.findByTestId("decks-empty-state")).toBeInTheDocument();
+  const cta = screen.getByTestId("decks-empty-new-btn");
+  expect(cta).toBeInTheDocument();
+
+  const user = userEvent.setup();
+  await user.click(cta);
+  expect(mockPush).toHaveBeenCalledWith("/decks/new");
+});
+
+test("renders one DeckCard per deck returned from the API", async () => {
+  mockListDecks.mockResolvedValue(SAMPLE_DECKS);
+  render(<DecksPage />);
+  expect(await screen.findByText("German verbs")).toBeInTheDocument();
+  expect(screen.getByText("A1 Spanish")).toBeInTheDocument();
+  expect(screen.getByTestId("deck-member-count-1")).toHaveTextContent("12");
+  expect(screen.getByTestId("deck-member-count-2")).toHaveTextContent("40");
+});
+
+test("'New deck' header button navigates to /decks/new", async () => {
+  mockListDecks.mockResolvedValue(SAMPLE_DECKS);
+  render(<DecksPage />);
+  await screen.findByText("German verbs");
+  const user = userEvent.setup();
+  await user.click(screen.getByTestId("decks-new-btn"));
+  expect(mockPush).toHaveBeenCalledWith("/decks/new");
+});
+
+test("deleting a deck removes it from the list and calls the API", async () => {
+  mockListDecks.mockResolvedValue(SAMPLE_DECKS);
+  mockDeleteDeck.mockResolvedValue(undefined);
+  render(<DecksPage />);
+  await screen.findByText("German verbs");
+
+  const user = userEvent.setup();
+  await user.click(screen.getByTestId("deck-delete-1"));
+
+  await waitFor(() => {
+    expect(mockDeleteDeck).toHaveBeenCalledWith(1);
+  });
+  await waitFor(() => {
+    expect(screen.queryByText("German verbs")).not.toBeInTheDocument();
+  });
+  expect(screen.getByText("A1 Spanish")).toBeInTheDocument();
+});
+
+test("falls back to the empty state when the API errors", async () => {
+  mockListDecks.mockRejectedValue(new Error("boom"));
+  render(<DecksPage />);
+  expect(await screen.findByTestId("decks-empty-state")).toBeInTheDocument();
+});

--- a/frontend/src/app/decks/new/page.tsx
+++ b/frontend/src/app/decks/new/page.tsx
@@ -1,0 +1,167 @@
+"use client";
+import { FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ApiError, createDeck, DeckMode } from "@/lib/api";
+import { ArrowLeftIcon, DeckIcon } from "@/components/Icons";
+
+export default function DecksNewPage() {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [mode] = useState<DeckMode>("manual");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setError("Name is required.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await createDeck({
+        name: trimmedName,
+        description: description.trim(),
+        mode,
+      });
+      router.push("/decks");
+    } catch (e) {
+      const message =
+        e instanceof ApiError && e.message
+          ? e.message
+          : "Could not create the deck. Please try again.";
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-parchment">
+      <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
+        <button
+          onClick={() => router.push("/decks")}
+          className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] flex items-center"
+        >
+          <ArrowLeftIcon className="w-4 h-4 shrink-0" /> Decks
+        </button>
+        <div className="flex-1 min-w-0">
+          <h1 className="font-serif font-bold text-ink truncate">New deck</h1>
+        </div>
+      </header>
+
+      <div className="max-w-lg mx-auto px-4 md:px-6 py-6 md:py-8">
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div>
+            <label
+              htmlFor="deck-name"
+              className="block text-sm font-medium text-ink mb-1"
+            >
+              Name
+            </label>
+            <input
+              id="deck-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              maxLength={80}
+              data-testid="deck-name-input"
+              className="w-full rounded-xl border border-amber-200 bg-white px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+              placeholder="e.g. German verbs"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="deck-description"
+              className="block text-sm font-medium text-ink mb-1"
+            >
+              Description <span className="text-stone-400 font-normal">(optional)</span>
+            </label>
+            <textarea
+              id="deck-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              maxLength={500}
+              rows={3}
+              data-testid="deck-description-input"
+              className="w-full rounded-xl border border-amber-200 bg-white px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+              placeholder="What kind of words will go here?"
+            />
+          </div>
+
+          <fieldset>
+            <legend className="block text-sm font-medium text-ink mb-2">Mode</legend>
+            <div className="space-y-2">
+              <label className="flex items-start gap-3 rounded-lg border border-amber-200 bg-white p-3 cursor-pointer has-[:checked]:border-amber-500 has-[:checked]:bg-amber-50">
+                <input
+                  type="radio"
+                  name="mode"
+                  value="manual"
+                  checked={mode === "manual"}
+                  onChange={() => {}}
+                  data-testid="deck-mode-manual"
+                  className="mt-1"
+                />
+                <span className="text-sm">
+                  <span className="font-medium text-ink block">Manual</span>
+                  <span className="text-stone-500">
+                    Pick members by hand. You add and remove words one at a time.
+                  </span>
+                </span>
+              </label>
+              <label className="flex items-start gap-3 rounded-lg border border-amber-100 bg-stone-50 p-3 opacity-60 cursor-not-allowed">
+                <input
+                  type="radio"
+                  name="mode"
+                  value="smart"
+                  disabled
+                  data-testid="deck-mode-smart"
+                  className="mt-1"
+                />
+                <span className="text-sm">
+                  <span className="font-medium text-ink block">Smart</span>
+                  <span className="text-stone-500">
+                    Rule-based — membership recomputed at query time. Coming in a later slice.
+                  </span>
+                </span>
+              </label>
+            </div>
+          </fieldset>
+
+          {error && (
+            <p
+              data-testid="deck-form-error"
+              role="alert"
+              className="text-sm text-red-600"
+            >
+              {error}
+            </p>
+          )}
+
+          <div className="flex items-center gap-3 pt-1">
+            <button
+              type="submit"
+              disabled={submitting}
+              data-testid="deck-submit-btn"
+              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] disabled:opacity-50"
+            >
+              <DeckIcon className="w-4 h-4" />
+              {submitting ? "Creating…" : "Create deck"}
+            </button>
+            <button
+              type="button"
+              onClick={() => router.push("/decks")}
+              className="text-sm text-amber-700 hover:text-amber-900 min-h-[44px] px-3"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/decks/page.tsx
+++ b/frontend/src/app/decks/page.tsx
@@ -1,0 +1,115 @@
+"use client";
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { DeckSummary, deleteDeck, listDecks } from "@/lib/api";
+import DeckCard from "@/components/DeckCard";
+import { ArrowLeftIcon, DeckIcon } from "@/components/Icons";
+
+export default function DecksPage() {
+  const { data: session } = useSession();
+  const router = useRouter();
+  const [decks, setDecks] = useState<DeckSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    listDecks()
+      .then((d) => {
+        if (!alive) return;
+        setDecks(d);
+      })
+      .catch(() => {
+        if (!alive) return;
+        setError(true);
+      })
+      .finally(() => {
+        if (!alive) return;
+        setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [session?.backendToken]);
+
+  const handleDelete = useCallback(async (id: number) => {
+    try {
+      await deleteDeck(id);
+      setDecks((prev) => prev.filter((d) => d.id !== id));
+    } catch {
+      // leave the deck in place if the delete failed; a toast system isn't wired yet.
+    }
+  }, []);
+
+  const isEmpty = !loading && (error || decks.length === 0);
+
+  return (
+    <div className="min-h-screen bg-parchment">
+      <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
+        <button
+          onClick={() => router.push("/")}
+          className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] flex items-center"
+        >
+          <ArrowLeftIcon className="w-4 h-4 shrink-0" /> Library
+        </button>
+        <div className="flex-1 min-w-0">
+          <h1 className="font-serif font-bold text-ink truncate">Decks</h1>
+          {!loading && !error && (
+            <p className="text-xs text-stone-400 mt-0.5">
+              {decks.length} deck{decks.length !== 1 ? "s" : ""}
+            </p>
+          )}
+        </div>
+        {!isEmpty && (
+          <button
+            type="button"
+            onClick={() => router.push("/decks/new")}
+            data-testid="decks-new-btn"
+            className="flex items-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 shrink-0"
+          >
+            <DeckIcon className="w-4 h-4" />
+            <span className="hidden sm:inline">New deck</span>
+          </button>
+        )}
+      </header>
+
+      <div className="max-w-2xl mx-auto px-4 md:px-6 py-6 md:py-8">
+        {loading ? (
+          <div className="space-y-3 animate-pulse">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="h-24 bg-amber-100 rounded-xl" />
+            ))}
+          </div>
+        ) : isEmpty ? (
+          <div
+            data-testid="decks-empty-state"
+            className="text-center mt-16 flex flex-col items-center gap-3"
+          >
+            <DeckIcon className="w-14 h-14 text-amber-300" />
+            <p className="font-serif text-lg text-stone-500 mt-1">No study decks yet.</p>
+            <p className="text-sm text-stone-400 max-w-xs">
+              Build focused review lists from your saved vocabulary. Start with a manual
+              deck — pick a few words and study just them.
+            </p>
+            <button
+              type="button"
+              onClick={() => router.push("/decks/new")}
+              data-testid="decks-empty-new-btn"
+              className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px]"
+            >
+              <DeckIcon className="w-4 h-4" />
+              New deck
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {decks.map((d) => (
+              <DeckCard key={d.id} deck={d} onDelete={handleDelete} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/DeckCard.tsx
+++ b/frontend/src/components/DeckCard.tsx
@@ -1,0 +1,66 @@
+"use client";
+import type { DeckSummary } from "@/lib/api";
+import { DeckIcon, TrashIcon } from "@/components/Icons";
+
+interface DeckCardProps {
+  deck: DeckSummary;
+  onDelete?: (id: number) => void | Promise<void>;
+}
+
+export default function DeckCard({ deck, onDelete }: DeckCardProps) {
+  const modeLabel = deck.mode === "smart" ? "Smart" : "Manual";
+  return (
+    <article
+      data-testid={`deck-card-${deck.id}`}
+      className="rounded-xl border border-amber-100 bg-white p-4 transition-all duration-200 hover:-translate-y-0.5"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <DeckIcon className="w-4 h-4 text-amber-600 shrink-0" />
+            <h2 className="font-serif font-semibold text-ink text-base truncate">
+              {deck.name}
+            </h2>
+            <span
+              data-testid={`deck-mode-${deck.id}`}
+              className="text-xs text-amber-700 bg-amber-50 rounded-full px-2 py-0.5 border border-amber-200"
+            >
+              {modeLabel}
+            </span>
+          </div>
+          {deck.description && (
+            <p className="text-sm text-stone-500 mt-1.5 line-clamp-2">{deck.description}</p>
+          )}
+          <div className="mt-3 flex items-center gap-3 text-xs text-stone-500">
+            <span>
+              <span
+                data-testid={`deck-member-count-${deck.id}`}
+                className="font-medium text-ink"
+              >
+                {deck.member_count}
+              </span>{" "}
+              {deck.member_count === 1 ? "word" : "words"}
+            </span>
+            {deck.due_today > 0 && (
+              <span className="rounded-full bg-amber-700 text-white px-2 py-0.5">
+                <span data-testid={`deck-due-today-${deck.id}`}>{deck.due_today}</span>{" "}
+                due today
+              </span>
+            )}
+          </div>
+        </div>
+        {onDelete && (
+          <button
+            type="button"
+            onClick={() => onDelete(deck.id)}
+            aria-label={`Delete deck ${deck.name}`}
+            data-testid={`deck-delete-${deck.id}`}
+            className="min-h-[44px] min-w-[44px] flex items-center justify-center text-stone-400 hover:text-red-600 transition-colors shrink-0"
+          >
+            <TrashIcon className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -439,3 +439,12 @@ export function SettingsIcon({ className = "w-4 h-4" }: IconProps) {
     </svg>
   );
 }
+
+export function DeckIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="3" y="7" width="14" height="14" rx="2" />
+      <path d="M7 3h12a2 2 0 0 1 2 2v12" />
+    </svg>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -722,6 +722,65 @@ export function removeVocabularyWordTag(vocabularyId: number, tag: string) {
   );
 }
 
+export type DeckMode = "manual" | "smart";
+
+export interface DeckSummary {
+  id: number;
+  name: string;
+  description: string;
+  mode: DeckMode;
+  rules_json: string | null;
+  created_at: string;
+  updated_at: string;
+  member_count: number;
+  due_today: number;
+}
+
+export interface DeckDetail extends Omit<DeckSummary, "due_today"> {
+  members: number[];
+}
+
+export interface DeckCreatePayload {
+  name: string;
+  description?: string;
+  mode: DeckMode;
+  rules_json?: Record<string, unknown> | null;
+}
+
+export function listDecks() {
+  return request<DeckSummary[]>("/decks");
+}
+
+export function getDeck(id: number) {
+  return request<DeckDetail>(`/decks/${id}`);
+}
+
+export function createDeck(payload: DeckCreatePayload) {
+  return request<DeckDetail>("/decks", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
+export function deleteDeck(id: number) {
+  return request<void>(`/decks/${id}`, { method: "DELETE" });
+}
+
+export function addDeckMember(deckId: number, vocabularyId: number) {
+  return request<{ vocabulary_id: number }>(`/decks/${deckId}/members`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ vocabulary_id: vocabularyId }),
+  });
+}
+
+export function removeDeckMember(deckId: number, vocabularyId: number) {
+  return request<void>(`/decks/${deckId}/members/${vocabularyId}`, {
+    method: "DELETE",
+  });
+}
+
 // ── Book Insights (saved AI Q&A) ──────────────────────────────────────────────
 
 export interface BookInsight {


### PR DESCRIPTION
## Summary

- Implements Slice 3a of vocabulary tags & custom study decks (#741): the minimum end-to-end deck UX — create a manual deck, see decks listed, delete decks.
- Backend was already shipped in #745; this slice wires the frontend onto the existing `/decks` endpoints.
- Deck detail, member management, flashcards deck selector, and the smart-rule builder are deliberately **out of scope** — they land in slice 3b.

## What changed

- **`lib/api.ts`** — `DeckSummary`, `DeckDetail`, `DeckMode` types; `listDecks`, `getDeck`, `createDeck`, `deleteDeck`, `addDeckMember`, `removeDeckMember` helpers against the existing FastAPI routes.
- **`components/Icons.tsx`** — new `DeckIcon` (stacked cards) using the existing SVG / `currentColor` / `aria-hidden="true"` pattern.
- **`components/DeckCard.tsx`** — presentational card: name, mode badge (`Manual` / `Smart`), member count, optional `N due today` pill, and an accessible delete button (`aria-label="Delete deck <name>"`, 44px touch target).
- **`app/decks/page.tsx`** — decks index. Parchment empty state with illustration + CTA when the user has none; otherwise one `DeckCard` per deck. Delete removes the deck optimistically and falls back gracefully on API error.
- **`app/decks/new/page.tsx`** — creation form. Name + description fields, a manual/smart mode radio picker (`smart` is disabled for now), inline error surfacing via `role="alert"`, and navigation back to `/decks` on success.

## Test plan

- [x] **New `DeckCard.test.tsx`** (6 tests): name/description/counts render, mode badge toggles manual↔smart, due-today pill hides at 0, delete button invokes `onDelete`, delete button hidden without `onDelete`, delete has `aria-label`.
- [x] **New `DecksPage.test.tsx`** (5 tests): empty-state CTA navigation, renders one card per deck, header "New deck" navigation, delete removes from list and hits API, API error falls back to empty state.
- [x] **New `DecksNewPage.test.tsx`** (5 tests): default mode is `manual`, valid submit calls `createDeck` + navigates to `/decks`, blank name blocks submit with inline error, API failure surfaces the server message, smart-mode radio is disabled.
- [x] Full frontend suite: **1790 passed, 156 suites**.
- [x] Full backend suite: **1399 passed**.

## Design references

- Design doc: `docs/design/vocab-tags-decks.md` (#646)
- Backend slice: #745
- Frontend slice 1 (TagEditor + tagFilter state): #791
- Frontend slice 2 (tag filter pill bar): #801
- Tracking issue: #741 (pm-approved)

Closes #741 (slice 3a; slice 3b — deck detail, member edit, flashcards deck selector, smart-rule builder — tracked on the issue).
