### PR TITLE
ux: raise color picker, tag remove, and annotation edit to 44px touch targets (closes #826, #827, #828)

### DIFF
--- a/frontend/src/__tests__/AnnotationToolbar.test.tsx
+++ b/frontend/src/__tests__/AnnotationToolbar.test.tsx
@@ -65,9 +65,10 @@ test("pre-fills color and note from existingAnnotation", () => {
   );
   const textarea = screen.getByPlaceholderText(/Your thoughts/i) as HTMLTextAreaElement;
   expect(textarea.value).toBe("Interesting passage");
-  // Green button should appear selected (scale-110 class)
+  // Green button should appear selected (scale-110 class on inner swatch span)
   const greenBtn = screen.getByLabelText("Green");
-  expect(greenBtn.className).toMatch(/scale-110/);
+  const swatch = greenBtn.querySelector("span");
+  expect(swatch?.className).toMatch(/scale-110/);
 });
 
 test("calls createAnnotation and onSaved when saving new annotation", async () => {

--- a/frontend/src/__tests__/AnnotationToolbarColorTouchTargets.test.ts
+++ b/frontend/src/__tests__/AnnotationToolbarColorTouchTargets.test.ts
@@ -1,0 +1,30 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/AnnotationToolbar.tsx"),
+  "utf8"
+);
+
+describe("AnnotationToolbar color picker touch targets (closes #826)", () => {
+  it("color button wrapper has min-h-[44px]", () => {
+    const idx = src.indexOf("Highlight colour");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 600);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("color button wrapper has min-w-[44px]", () => {
+    const idx = src.indexOf("Highlight colour");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 600);
+    expect(window).toContain("min-w-[44px]");
+  });
+
+  it("visual circle swatch stays w-8 h-8", () => {
+    const idx = src.indexOf("Highlight colour");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 600);
+    expect(window).toContain("w-8 h-8");
+  });
+});

--- a/frontend/src/__tests__/ReaderAnnotationEditTouchTarget.test.ts
+++ b/frontend/src/__tests__/ReaderAnnotationEditTouchTarget.test.ts
@@ -1,0 +1,23 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Reader annotation edit button touch target (closes #828)", () => {
+  it("Edit annotation button has min-h-[44px]", () => {
+    const idx = src.indexOf("Edit annotation");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 300), idx + 50);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("Edit annotation button has min-w-[44px]", () => {
+    const idx = src.indexOf("Edit annotation");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 300), idx + 50);
+    expect(window).toContain("min-w-[44px]");
+  });
+});

--- a/frontend/src/__tests__/TagEditorTouchTarget.test.ts
+++ b/frontend/src/__tests__/TagEditorTouchTarget.test.ts
@@ -1,0 +1,23 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/TagEditor.tsx"),
+  "utf8"
+);
+
+describe("TagEditor remove-tag touch target (closes #827)", () => {
+  it("remove-tag button has min-h-[44px]", () => {
+    const idx = src.indexOf("Remove tag");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 100);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("remove-tag button has min-w-[44px]", () => {
+    const idx = src.indexOf("Remove tag");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 100);
+    expect(window).toContain("min-w-[44px]");
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1687,7 +1687,7 @@ export default function ReaderPage() {
                             chapterIndex: ann.chapter_index,
                           });
                         }}
-                        className="shrink-0 text-xs opacity-60 hover:opacity-100 mt-0.5"
+                        className="shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center opacity-60 hover:opacity-100"
                         aria-label="Edit annotation"
                       >
                         <EditIcon className="w-3.5 h-3.5" />

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -133,7 +133,7 @@ export default function AnnotationToolbar({
           {/* Color picker */}
           <div>
             <p className="text-xs text-stone-500 mb-2">Highlight colour</p>
-            <div className="flex items-center gap-2.5">
+            <div className="flex items-center gap-0.5">
               {COLORS.map((c) => (
                 <button
                   key={c.key}
@@ -141,12 +141,16 @@ export default function AnnotationToolbar({
                   onClick={() => setColor(c.key)}
                   aria-label={c.label}
                   aria-pressed={color === c.key}
-                  className={`w-8 h-8 rounded-full ${c.bg} border-2 transition-all duration-150 hover:scale-110 ${
-                    color === c.key
-                      ? `${c.border} scale-110 ring-2 ring-offset-1 ${c.ring}`
-                      : "border-transparent"
-                  }`}
-                />
+                  className="min-h-[44px] min-w-[44px] flex items-center justify-center"
+                >
+                  <span
+                    className={`w-8 h-8 rounded-full ${c.bg} border-2 transition-all duration-150 hover:scale-110 inline-block ${
+                      color === c.key
+                        ? `${c.border} scale-110 ring-2 ring-offset-1 ${c.ring}`
+                        : "border-transparent"
+                    }`}
+                  />
+                </button>
               ))}
             </div>
           </div>

--- a/frontend/src/components/TagEditor.tsx
+++ b/frontend/src/components/TagEditor.tsx
@@ -126,7 +126,7 @@ export default function TagEditor({
             onClick={() => handleRemove(tag)}
             disabled={busy === tag}
             aria-label={`Remove tag ${tag}`}
-            className="rounded-full p-0.5 hover:bg-amber-100 disabled:opacity-50 transition-colors"
+            className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-full hover:bg-amber-100 disabled:opacity-50 transition-colors"
           >
             <CloseIcon className="w-3 h-3" />
           </button>


### PR DESCRIPTION
Closes #826
Closes #827
Closes #828

Three icon-only or small buttons had touch targets below 44px:

1. **AnnotationToolbar color picker** (`AnnotationToolbar.tsx`): four `w-8 h-8` (32px) circle buttons. Wrapped each in a `min-h-[44px] min-w-[44px] flex items-center justify-center` button; visual swatch moved to inner `<span>` to preserve the circle shape.

2. **TagEditor remove-tag button** (`TagEditor.tsx`): `p-0.5` padding with `w-3 h-3` icon (~16px total). Added `min-h-[44px] min-w-[44px] flex items-center justify-center`.

3. **Reader annotation edit button** (`reader/[bookId]/page.tsx`): no size/padding at all, just a 14px icon. Added `min-h-[44px] min-w-[44px] flex items-center justify-center`.

## Test plan
- [x] `AnnotationToolbarColorTouchTargets.test.ts` — 3 assertions (min-h, min-w, w-8 h-8 visual intact)
- [x] `TagEditorTouchTarget.test.ts` — 2 assertions
- [x] `ReaderAnnotationEditTouchTarget.test.ts` — 2 assertions
- [x] Updated `AnnotationToolbar.test.tsx` to query inner swatch `<span>` for scale-110
- [x] Full frontend suite: 1806 tests passing
- [x] Backend suite: 1400 tests passing

🤖 Generated with Claude Code
