### PR TITLE
feat: EPUB split quality audit script (#769)

### DIFF
--- a/backend/scripts/epub_split_audit.py
+++ b/backend/scripts/epub_split_audit.py
@@ -1,0 +1,182 @@
+"""EPUB split quality audit (issue #769).
+
+Compares the character counts produced by the EPUB-path splitter and the
+plain-text-path splitter for every book with a stored EPUB. Books where the
+EPUB split yields substantially fewer characters than the text split are
+flagged as likely hitting a splitter edge case (see #758, #767 for the
+regressions that motivated this audit).
+
+Usage:
+    python -m scripts.epub_split_audit                      # all books, stdout
+    python -m scripts.epub_split_audit --book-id 69327      # single book
+    python -m scripts.epub_split_audit --csv out.csv        # write CSV report
+    python -m scripts.epub_split_audit --threshold 0.7      # stricter gate
+
+Exit code is 1 when at least one book is flagged — the script can be wired
+into CI as a data-quality gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from services.db import (
+    get_book_epub_bytes,
+    get_cached_book,
+    list_cached_books,
+)
+from services.splitter import build_chapters, build_chapters_from_epub
+
+
+DEFAULT_THRESHOLD = 0.5
+
+
+@dataclass
+class AuditRow:
+    book_id: int
+    title: str
+    epub_chars: int
+    text_chars: int
+    ratio: float
+    suspicious: bool
+
+
+def compute_audit_row(
+    book_id: int,
+    title: str,
+    text: str,
+    epub_bytes: bytes,
+    threshold: float = DEFAULT_THRESHOLD,
+) -> AuditRow:
+    """Run both splitters and produce the comparison row.
+
+    Intentionally side-effect-free and DB-free so tests can cover edge cases
+    without spinning up the full stack. When the plain-text baseline is empty
+    (book has an EPUB but no cached text) the book is reported but not
+    flagged — we can't meaningfully compare.
+    """
+    text_chapters = build_chapters(text) if text else []
+    epub_chapters = build_chapters_from_epub(epub_bytes) if epub_bytes else []
+    text_chars = sum(len(c.text) for c in text_chapters)
+    epub_chars = sum(len(c.text) for c in epub_chapters)
+    if text_chars == 0:
+        return AuditRow(
+            book_id=book_id,
+            title=title,
+            epub_chars=epub_chars,
+            text_chars=0,
+            ratio=1.0,
+            suspicious=False,
+        )
+    ratio = epub_chars / text_chars
+    return AuditRow(
+        book_id=book_id,
+        title=title,
+        epub_chars=epub_chars,
+        text_chars=text_chars,
+        ratio=ratio,
+        suspicious=ratio < threshold,
+    )
+
+
+async def run_audit(
+    threshold: float = DEFAULT_THRESHOLD,
+    book_id: int | None = None,
+) -> list[AuditRow]:
+    rows: list[AuditRow] = []
+    if book_id is not None:
+        ids = [book_id]
+    else:
+        ids = [b["id"] for b in await list_cached_books()]
+    for bid in ids:
+        epub_bytes = await get_book_epub_bytes(bid)
+        if epub_bytes is None:
+            continue
+        book = await get_cached_book(bid)
+        if book is None:
+            continue
+        rows.append(
+            compute_audit_row(
+                book_id=bid,
+                title=book.get("title") or f"book {bid}",
+                text=book.get("text") or "",
+                epub_bytes=epub_bytes,
+                threshold=threshold,
+            )
+        )
+    return rows
+
+
+def write_csv(rows: Iterable[AuditRow], out_path: Path) -> None:
+    with out_path.open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(
+            ["book_id", "title", "epub_chars", "text_chars", "ratio", "suspicious"]
+        )
+        for r in rows:
+            w.writerow(
+                [
+                    r.book_id,
+                    r.title,
+                    r.epub_chars,
+                    r.text_chars,
+                    f"{r.ratio:.3f}",
+                    "yes" if r.suspicious else "",
+                ]
+            )
+
+
+def _print_summary(rows: list[AuditRow], threshold: float) -> None:
+    if not rows:
+        print("No books with stored EPUBs to audit.")
+        return
+    suspicious = [r for r in rows if r.suspicious]
+    print(
+        f"Audited {len(rows)} book(s); "
+        f"threshold: epub_chars / text_chars < {threshold:.0%}"
+    )
+    print(f"Suspicious: {len(suspicious)}")
+    if suspicious:
+        print()
+        print(f"{'book_id':<10}{'ratio':<10}{'epub_chars':<14}{'text_chars':<14}title")
+        print("-" * 80)
+        for r in sorted(suspicious, key=lambda x: x.ratio):
+            title = (r.title or "")[:40]
+            print(
+                f"{r.book_id:<10}{r.ratio:<10.2f}"
+                f"{r.epub_chars:<14}{r.text_chars:<14}{title}"
+            )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Audit EPUB split quality.")
+    parser.add_argument(
+        "--book-id", type=int, default=None, help="Audit a single book by id."
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=DEFAULT_THRESHOLD,
+        help="Ratio below which a book is flagged suspicious (default: 0.5).",
+    )
+    parser.add_argument(
+        "--csv", type=Path, default=None, help="Optional CSV output path."
+    )
+    args = parser.parse_args(argv)
+
+    rows = asyncio.run(run_audit(threshold=args.threshold, book_id=args.book_id))
+    _print_summary(rows, args.threshold)
+    if args.csv is not None:
+        write_csv(rows, args.csv)
+        print(f"\nCSV written to {args.csv}")
+    return 1 if any(r.suspicious for r in rows) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_epub_split_audit.py
+++ b/backend/tests/test_epub_split_audit.py
@@ -1,0 +1,198 @@
+"""Tests for scripts/epub_split_audit.py (issue #769).
+
+The audit logic itself must be regression-protected — if the ratio
+computation or the suspicious-flag threshold drift, we lose the signal that
+motivated the script in the first place.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+_SCRIPTS_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts"
+)
+sys.path.insert(0, _SCRIPTS_DIR)
+
+import epub_split_audit as audit  # noqa: E402
+from services.splitter import Chapter  # noqa: E402
+
+
+# ── compute_audit_row (pure) ─────────────────────────────────────────────────
+
+
+def _stub_splitters(text_chapters, epub_chapters):
+    """Patch both splitter entry points so compute_audit_row is deterministic."""
+    return patch.multiple(
+        audit,
+        build_chapters=lambda text: text_chapters,
+        build_chapters_from_epub=lambda eb: epub_chapters,
+    )
+
+
+def test_compute_audit_row_flags_epub_shortfall_below_threshold():
+    with _stub_splitters(
+        text_chapters=[Chapter(title="Ch1", text="x" * 10_000)],
+        epub_chapters=[Chapter(title="Ch1", text="x" * 2_000)],
+    ):
+        row = audit.compute_audit_row(
+            book_id=42, title="Faust", text="ignored", epub_bytes=b"ignored",
+            threshold=0.5,
+        )
+    assert row.book_id == 42
+    assert row.title == "Faust"
+    assert row.epub_chars == 2_000
+    assert row.text_chars == 10_000
+    assert row.ratio == pytest.approx(0.2)
+    assert row.suspicious is True
+
+
+def test_compute_audit_row_is_not_suspicious_when_epub_matches_text():
+    with _stub_splitters(
+        text_chapters=[Chapter(title="Ch1", text="x" * 9_800)],
+        epub_chapters=[Chapter(title="Ch1", text="x" * 9_850)],
+    ):
+        row = audit.compute_audit_row(
+            book_id=1, title="Moby Dick", text="t", epub_bytes=b"e",
+        )
+    assert row.suspicious is False
+    assert row.ratio > 0.99
+
+
+def test_compute_audit_row_skips_gracefully_when_text_is_empty():
+    # Book with a stored EPUB but no cached plain text — can't compare.
+    # Script must not crash and must not flag it.
+    with _stub_splitters(
+        text_chapters=[],
+        epub_chapters=[Chapter(title="Ch1", text="x" * 5000)],
+    ):
+        row = audit.compute_audit_row(
+            book_id=7, title="X", text="", epub_bytes=b"epubbytes",
+        )
+    assert row.text_chars == 0
+    assert row.suspicious is False
+
+
+def test_compute_audit_row_honours_custom_threshold():
+    with _stub_splitters(
+        text_chapters=[Chapter(title="Ch1", text="x" * 1000)],
+        epub_chapters=[Chapter(title="Ch1", text="x" * 700)],
+    ):
+        lenient = audit.compute_audit_row(
+            book_id=1, title="X", text="t", epub_bytes=b"e", threshold=0.5,
+        )
+        strict = audit.compute_audit_row(
+            book_id=1, title="X", text="t", epub_bytes=b"e", threshold=0.9,
+        )
+    assert lenient.suspicious is False  # 0.7 > 0.5
+    assert strict.suspicious is True  # 0.7 < 0.9
+
+
+# ── run_audit (integration with the DB fixture) ──────────────────────────────
+
+
+@pytest.fixture
+async def tmp_db(monkeypatch, tmp_path):
+    import services.db as db_module
+    from services.db import init_db
+
+    path = str(tmp_path / "audit.db")
+    monkeypatch.setattr(db_module, "DB_PATH", path)
+    await init_db()
+    yield path
+
+
+@pytest.mark.asyncio
+async def test_run_audit_iterates_books_with_stored_epubs(tmp_db, monkeypatch):
+    from services.db import save_book, save_book_epub
+
+    await save_book(101, {"title": "Has EPUB", "authors": [], "languages": [], "subjects": []}, text="x" * 10_000)
+    await save_book_epub(101, b"epubA", "http://example/a")
+
+    await save_book(102, {"title": "No EPUB", "authors": [], "languages": [], "subjects": []}, text="x" * 10_000)
+    # no save_book_epub for 102 — must be skipped
+
+    call_count = {"n": 0}
+
+    def fake_build_text(text):
+        return [Chapter(title="Ch", text=text[: 8_000])]
+
+    def fake_build_epub(epub_bytes):
+        call_count["n"] += 1
+        # Simulate the regression: EPUB splitter drops 90% of content.
+        return [Chapter(title="Ch", text="x" * 500)]
+
+    monkeypatch.setattr(audit, "build_chapters", fake_build_text)
+    monkeypatch.setattr(audit, "build_chapters_from_epub", fake_build_epub)
+
+    rows = await audit.run_audit()
+
+    assert call_count["n"] == 1  # only the book with an EPUB was audited
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.book_id == 101
+    assert row.title == "Has EPUB"
+    assert row.suspicious is True
+
+
+# ── main() CLI gate behavior ─────────────────────────────────────────────────
+
+
+def test_main_returns_nonzero_when_suspicious_rows_exist(monkeypatch):
+    sample = [
+        audit.AuditRow(
+            book_id=1, title="t", epub_chars=100, text_chars=1000,
+            ratio=0.1, suspicious=True,
+        ),
+    ]
+
+    async def fake_run_audit(threshold, book_id=None):
+        return sample
+
+    monkeypatch.setattr(audit, "run_audit", fake_run_audit)
+
+    rc = audit.main([])
+    assert rc == 1
+
+
+def test_main_returns_zero_when_all_rows_pass(monkeypatch):
+    sample = [
+        audit.AuditRow(
+            book_id=1, title="t", epub_chars=900, text_chars=1000,
+            ratio=0.9, suspicious=False,
+        ),
+    ]
+
+    async def fake_run_audit(threshold, book_id=None):
+        return sample
+
+    monkeypatch.setattr(audit, "run_audit", fake_run_audit)
+
+    rc = audit.main([])
+    assert rc == 0
+
+
+def test_main_writes_csv_when_flag_given(monkeypatch, tmp_path):
+    sample = [
+        audit.AuditRow(
+            book_id=7, title="Moby Dick", epub_chars=500,
+            text_chars=10_000, ratio=0.05, suspicious=True,
+        ),
+    ]
+
+    async def fake_run_audit(threshold, book_id=None):
+        return sample
+
+    monkeypatch.setattr(audit, "run_audit", fake_run_audit)
+
+    out = tmp_path / "report.csv"
+    audit.main(["--csv", str(out)])
+    content = out.read_text()
+    assert "book_id" in content  # header
+    assert "Moby Dick" in content
+    assert "0.050" in content
+    assert "yes" in content


### PR DESCRIPTION
## Summary

Adds `backend/scripts/epub_split_audit.py` — a diagnostic that compares the character count produced by the **EPUB-path splitter** vs the **plain-text-path splitter** for every book with a stored EPUB. Books where the EPUB split yields less than 50% of the text split's character count are flagged as likely splitter edge cases.

## Why

Two silent-data-loss EPUB splitter bugs fixed in quick succession:

- **PR #758** — span-wrapped verse lines dropped (poetry EPUBs, e.g. Rilke #24288)
- **PR #767** — chapter-body wrapper div skipped (div-based EPUBs, e.g. Kafka #69327)

Both left books that looked fine in the catalog but had nearly empty chapters once opened. This script would have caught both before users noticed.

## What changed

- **`backend/scripts/epub_split_audit.py`**
  - `compute_audit_row(...)` — pure function: runs both splitters against supplied text/bytes, returns an `AuditRow` with `epub_chars`, `text_chars`, `ratio`, `suspicious`. Testable without a DB.
  - `run_audit(threshold, book_id=None)` — walks `list_cached_books()`, resolves each book's EPUB bytes + cached text, emits one `AuditRow` per book that actually has an EPUB. Books with no EPUB are silently skipped (nothing to audit); books with an EPUB but no cached text are reported but not flagged (no baseline).
  - CLI flags: `--book-id`, `--threshold` (default 0.5), `--csv`. Exit code is `1` when any book is flagged so this can double as a CI data-quality gate later.
- **No production code touched.** No new dependencies, no schema changes.

## Test plan

- [x] **New `backend/tests/test_epub_split_audit.py`** (8 tests):
  - threshold logic: flags below, safe above, honours custom threshold, graceful when text is empty
  - DB iteration: only books with stored EPUBs are audited
  - `main()` CLI: exit `1` on suspicious rows, exit `0` on clean runs, CSV output contains header + flagged row
- [x] Full backend suite: **1408 passed**.

## How to run

```bash
# Audit everything
python -m scripts.epub_split_audit

# Single book
python -m scripts.epub_split_audit --book-id 69327

# Write CSV + stricter threshold
python -m scripts.epub_split_audit --threshold 0.7 --csv /tmp/audit.csv
```

Closes #769.
