### PR TITLE
feat: paragraph-count + structural speaker-cue signals for EPUB audit (#834)

### DIFF
--- a/backend/scripts/epub_split_audit.py
+++ b/backend/scripts/epub_split_audit.py
@@ -1,19 +1,32 @@
-"""EPUB split quality audit (issue #769).
+"""EPUB split quality audit (issues #769, #834).
 
-Compares the character counts produced by the EPUB-path splitter and the
-plain-text-path splitter for every book with a stored EPUB. Books where the
-EPUB split yields substantially fewer characters than the text split are
-flagged as likely hitting a splitter edge case (see #758, #767 for the
-regressions that motivated this audit).
+Compares the **character count** and **paragraph count** produced by the
+EPUB-path splitter and the plain-text-path splitter for every book with a
+stored EPUB, and surfaces a third **structural** signal for the specific
+"verse-collapse" pattern that bit us in #820 — paragraphs where an embedded
+newline is followed by an all-caps speaker cue, indicating the EPUB path
+collapsed poetry / drama into a single visual block.
+
+Three signals, independently flagged:
+
+- **Character ratio** (#769 / #758 / #767) — EPUB chars drop substantially
+  below the plain-text baseline. Default gate: < 50%.
+- **Paragraph ratio** (#834) — EPUB paragraphs fewer than the plain-text
+  paragraph count. Invisible to the char-count check. Default gate: < 80%.
+- **Structural speaker-cue collapse** (#834 / #820) — a paragraph exceeds
+  `--structural-paragraph-len` characters AND contains an embedded newline
+  followed by an all-caps name + period (`\\n  HELENA.`). No plain-text
+  baseline needed.
 
 Usage:
     python -m scripts.epub_split_audit                      # all books, stdout
     python -m scripts.epub_split_audit --book-id 69327      # single book
     python -m scripts.epub_split_audit --csv out.csv        # write CSV report
-    python -m scripts.epub_split_audit --threshold 0.7      # stricter gate
+    python -m scripts.epub_split_audit --threshold 0.7      # stricter char gate
+    python -m scripts.epub_split_audit --para-threshold 0.9 # stricter para gate
 
-Exit code is 1 when at least one book is flagged — the script can be wired
-into CI as a data-quality gate.
+Exit code is 1 when at least one book is flagged by any of the three
+signals — the script can be wired into CI as a data-quality gate.
 """
 
 from __future__ import annotations
@@ -21,8 +34,9 @@ from __future__ import annotations
 import argparse
 import asyncio
 import csv
+import re
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
 
@@ -31,20 +45,76 @@ from services.db import (
     get_cached_book,
     list_cached_books,
 )
-from services.splitter import build_chapters, build_chapters_from_epub
+from services.splitter import Chapter, build_chapters, build_chapters_from_epub
 
 
-DEFAULT_THRESHOLD = 0.5
+DEFAULT_CHAR_THRESHOLD = 0.5
+DEFAULT_PARAGRAPH_THRESHOLD = 0.8
+DEFAULT_STRUCTURAL_MIN_LEN = 400
+
+_PARA_SPLIT_RE = re.compile(r"\n\s*\n")
+# Matches an embedded-newline speaker cue: newline, optional indent, >=2
+# uppercase (incl. German umlauts) possibly separated by spaces, then a period.
+# Example: "\n  HELENA." or "\nDER KAISER."
+_SPEAKER_CUE_RE = re.compile(r"\n[ \t]*[A-ZÄÖÜ]{2,}[A-ZÄÖÜ ]*\.")
 
 
 @dataclass
 class AuditRow:
     book_id: int
     title: str
+    # Character ratio (signal 1 — #769)
     epub_chars: int
     text_chars: int
     ratio: float
     suspicious: bool
+    # Paragraph ratio (signal 2 — #834)
+    epub_paragraphs: int = 0
+    text_paragraphs: int = 0
+    para_ratio: float = 1.0
+    paragraph_suspicious: bool = False
+    # Structural speaker-cue collapse (signal 3 — #834/#820).
+    # Each entry: (chapter_index, first-100-chars-of-paragraph).
+    structural_flags: list[tuple[int, str]] = field(default_factory=list)
+
+    @property
+    def is_flagged(self) -> bool:
+        """True when any of the three signals fired — drives the CLI exit code."""
+        return (
+            self.suspicious
+            or self.paragraph_suspicious
+            or bool(self.structural_flags)
+        )
+
+
+def _count_paragraphs(chapters: list[Chapter]) -> int:
+    total = 0
+    for c in chapters:
+        if not c.text:
+            continue
+        total += sum(1 for p in _PARA_SPLIT_RE.split(c.text) if p.strip())
+    return total
+
+
+def _find_structural_flags(
+    chapters: list[Chapter],
+    min_len: int = DEFAULT_STRUCTURAL_MIN_LEN,
+) -> list[tuple[int, str]]:
+    """Return (chapter_index, excerpt) for each paragraph that is long *and*
+    contains an embedded-newline speaker cue — the #820 verse-collapse
+    signature.
+    """
+    flags: list[tuple[int, str]] = []
+    for idx, c in enumerate(chapters):
+        if not c.text:
+            continue
+        for p in _PARA_SPLIT_RE.split(c.text):
+            if len(p) < min_len:
+                continue
+            if _SPEAKER_CUE_RE.search(p):
+                excerpt = p[:100].replace("\n", " / ").strip()
+                flags.append((idx, excerpt))
+    return flags
 
 
 def compute_audit_row(
@@ -52,20 +122,30 @@ def compute_audit_row(
     title: str,
     text: str,
     epub_bytes: bytes,
-    threshold: float = DEFAULT_THRESHOLD,
+    threshold: float = DEFAULT_CHAR_THRESHOLD,
+    paragraph_threshold: float = DEFAULT_PARAGRAPH_THRESHOLD,
+    structural_min_len: int = DEFAULT_STRUCTURAL_MIN_LEN,
 ) -> AuditRow:
     """Run both splitters and produce the comparison row.
 
     Intentionally side-effect-free and DB-free so tests can cover edge cases
     without spinning up the full stack. When the plain-text baseline is empty
-    (book has an EPUB but no cached text) the book is reported but not
-    flagged — we can't meaningfully compare.
+    (book has an EPUB but no cached text) the char and paragraph ratios
+    cannot be computed; the structural signal is still evaluated because it
+    only needs the EPUB chapters.
     """
     text_chapters = build_chapters(text) if text else []
     epub_chapters = build_chapters_from_epub(epub_bytes) if epub_bytes else []
+
     text_chars = sum(len(c.text) for c in text_chapters)
     epub_chars = sum(len(c.text) for c in epub_chapters)
+    text_paragraphs = _count_paragraphs(text_chapters)
+    epub_paragraphs = _count_paragraphs(epub_chapters)
+    structural_flags = _find_structural_flags(epub_chapters, min_len=structural_min_len)
+
     if text_chars == 0:
+        # No baseline for ratio-based signals; keep them non-suspicious but
+        # still surface the structural flags (they stand on their own).
         return AuditRow(
             book_id=book_id,
             title=title,
@@ -73,8 +153,15 @@ def compute_audit_row(
             text_chars=0,
             ratio=1.0,
             suspicious=False,
+            epub_paragraphs=epub_paragraphs,
+            text_paragraphs=0,
+            para_ratio=1.0,
+            paragraph_suspicious=False,
+            structural_flags=structural_flags,
         )
+
     ratio = epub_chars / text_chars
+    para_ratio = epub_paragraphs / text_paragraphs if text_paragraphs > 0 else 1.0
     return AuditRow(
         book_id=book_id,
         title=title,
@@ -82,11 +169,18 @@ def compute_audit_row(
         text_chars=text_chars,
         ratio=ratio,
         suspicious=ratio < threshold,
+        epub_paragraphs=epub_paragraphs,
+        text_paragraphs=text_paragraphs,
+        para_ratio=para_ratio,
+        paragraph_suspicious=para_ratio < paragraph_threshold,
+        structural_flags=structural_flags,
     )
 
 
 async def run_audit(
-    threshold: float = DEFAULT_THRESHOLD,
+    threshold: float = DEFAULT_CHAR_THRESHOLD,
+    paragraph_threshold: float = DEFAULT_PARAGRAPH_THRESHOLD,
+    structural_min_len: int = DEFAULT_STRUCTURAL_MIN_LEN,
     book_id: int | None = None,
 ) -> list[AuditRow]:
     rows: list[AuditRow] = []
@@ -108,6 +202,8 @@ async def run_audit(
                 text=book.get("text") or "",
                 epub_bytes=epub_bytes,
                 threshold=threshold,
+                paragraph_threshold=paragraph_threshold,
+                structural_min_len=structural_min_len,
             )
         )
     return rows
@@ -117,7 +213,20 @@ def write_csv(rows: Iterable[AuditRow], out_path: Path) -> None:
     with out_path.open("w", newline="") as f:
         w = csv.writer(f)
         w.writerow(
-            ["book_id", "title", "epub_chars", "text_chars", "ratio", "suspicious"]
+            [
+                "book_id",
+                "title",
+                "epub_chars",
+                "text_chars",
+                "ratio",
+                "suspicious",
+                "epub_paragraphs",
+                "text_paragraphs",
+                "para_ratio",
+                "paragraph_suspicious",
+                "structural_flag_count",
+                "structural_flag_sample",
+            ]
         )
         for r in rows:
             w.writerow(
@@ -128,29 +237,46 @@ def write_csv(rows: Iterable[AuditRow], out_path: Path) -> None:
                     r.text_chars,
                     f"{r.ratio:.3f}",
                     "yes" if r.suspicious else "",
+                    r.epub_paragraphs,
+                    r.text_paragraphs,
+                    f"{r.para_ratio:.3f}",
+                    "yes" if r.paragraph_suspicious else "",
+                    len(r.structural_flags),
+                    r.structural_flags[0][1] if r.structural_flags else "",
                 ]
             )
 
 
-def _print_summary(rows: list[AuditRow], threshold: float) -> None:
+def _print_summary(
+    rows: list[AuditRow],
+    threshold: float,
+    paragraph_threshold: float,
+) -> None:
     if not rows:
         print("No books with stored EPUBs to audit.")
         return
-    suspicious = [r for r in rows if r.suspicious]
-    print(
-        f"Audited {len(rows)} book(s); "
-        f"threshold: epub_chars / text_chars < {threshold:.0%}"
-    )
-    print(f"Suspicious: {len(suspicious)}")
-    if suspicious:
+    char_flagged = [r for r in rows if r.suspicious]
+    para_flagged = [r for r in rows if r.paragraph_suspicious]
+    struct_flagged = [r for r in rows if r.structural_flags]
+    any_flagged = [r for r in rows if r.is_flagged]
+
+    print(f"Audited {len(rows)} book(s).")
+    print(f"  Char-ratio gate:      < {threshold:.0%}    flagged {len(char_flagged)}")
+    print(f"  Paragraph-ratio gate: < {paragraph_threshold:.0%}    flagged {len(para_flagged)}")
+    print(f"  Structural speaker-cue collapse:      flagged {len(struct_flagged)}")
+    print(f"  Any signal:                           flagged {len(any_flagged)}")
+
+    if any_flagged:
         print()
-        print(f"{'book_id':<10}{'ratio':<10}{'epub_chars':<14}{'text_chars':<14}title")
+        print(
+            f"{'book_id':<10}{'ratio':<8}{'para':<8}{'struct':<8}title"
+        )
         print("-" * 80)
-        for r in sorted(suspicious, key=lambda x: x.ratio):
+        for r in sorted(any_flagged, key=lambda x: (x.ratio, x.para_ratio)):
             title = (r.title or "")[:40]
             print(
-                f"{r.book_id:<10}{r.ratio:<10.2f}"
-                f"{r.epub_chars:<14}{r.text_chars:<14}{title}"
+                f"{r.book_id:<10}{r.ratio:<8.2f}{r.para_ratio:<8.2f}"
+                f"{len(r.structural_flags):<8}{title}"
             )
 
 
@@ -162,20 +288,40 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--threshold",
         type=float,
-        default=DEFAULT_THRESHOLD,
-        help="Ratio below which a book is flagged suspicious (default: 0.5).",
+        default=DEFAULT_CHAR_THRESHOLD,
+        help="Char ratio below which a book is flagged (default: 0.5).",
+    )
+    parser.add_argument(
+        "--para-threshold",
+        type=float,
+        default=DEFAULT_PARAGRAPH_THRESHOLD,
+        help="Paragraph ratio below which a book is flagged (default: 0.8).",
+    )
+    parser.add_argument(
+        "--structural-paragraph-len",
+        type=int,
+        default=DEFAULT_STRUCTURAL_MIN_LEN,
+        help="Min paragraph length (chars) to consider for the structural "
+        "speaker-cue check (default: 400).",
     )
     parser.add_argument(
         "--csv", type=Path, default=None, help="Optional CSV output path."
     )
     args = parser.parse_args(argv)
 
-    rows = asyncio.run(run_audit(threshold=args.threshold, book_id=args.book_id))
-    _print_summary(rows, args.threshold)
+    rows = asyncio.run(
+        run_audit(
+            threshold=args.threshold,
+            paragraph_threshold=args.para_threshold,
+            structural_min_len=args.structural_paragraph_len,
+            book_id=args.book_id,
+        )
+    )
+    _print_summary(rows, args.threshold, args.para_threshold)
     if args.csv is not None:
         write_csv(rows, args.csv)
         print(f"\nCSV written to {args.csv}")
-    return 1 if any(r.suspicious for r in rows) else 0
+    return 1 if any(r.is_flagged for r in rows) else 0
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_epub_split_audit.py
+++ b/backend/tests/test_epub_split_audit.py
@@ -150,7 +150,7 @@ def test_main_returns_nonzero_when_suspicious_rows_exist(monkeypatch):
         ),
     ]
 
-    async def fake_run_audit(threshold, book_id=None):
+    async def fake_run_audit(**kwargs):
         return sample
 
     monkeypatch.setattr(audit, "run_audit", fake_run_audit)
@@ -167,7 +167,7 @@ def test_main_returns_zero_when_all_rows_pass(monkeypatch):
         ),
     ]
 
-    async def fake_run_audit(threshold, book_id=None):
+    async def fake_run_audit(**kwargs):
         return sample
 
     monkeypatch.setattr(audit, "run_audit", fake_run_audit)
@@ -184,7 +184,7 @@ def test_main_writes_csv_when_flag_given(monkeypatch, tmp_path):
         ),
     ]
 
-    async def fake_run_audit(threshold, book_id=None):
+    async def fake_run_audit(**kwargs):
         return sample
 
     monkeypatch.setattr(audit, "run_audit", fake_run_audit)
@@ -196,3 +196,209 @@ def test_main_writes_csv_when_flag_given(monkeypatch, tmp_path):
     assert "Moby Dick" in content
     assert "0.050" in content
     assert "yes" in content
+
+
+# ── paragraph-count signal (#834) ────────────────────────────────────────────
+
+
+def test_paragraph_suspicious_when_epub_paras_below_threshold():
+    # 1 EPUB paragraph vs 5 text paragraphs = 0.2 ratio → flagged at default 0.8.
+    text_chapters = [Chapter(title="Ch", text="p1\n\np2\n\np3\n\np4\n\np5")]
+    epub_chapters = [Chapter(title="Ch", text="one huge paragraph")]
+    with _stub_splitters(text_chapters=text_chapters, epub_chapters=epub_chapters):
+        row = audit.compute_audit_row(
+            book_id=1, title="Faust", text="ignored", epub_bytes=b"ignored",
+        )
+    assert row.epub_paragraphs == 1
+    assert row.text_paragraphs == 5
+    assert row.para_ratio == pytest.approx(0.2)
+    assert row.paragraph_suspicious is True
+    assert row.is_flagged is True
+
+
+def test_paragraph_signal_does_not_fire_when_ratios_align():
+    text_chapters = [Chapter(title="Ch", text="p1\n\np2\n\np3\n\np4")]
+    epub_chapters = [Chapter(title="Ch", text="p1\n\np2\n\np3\n\np4")]
+    with _stub_splitters(text_chapters=text_chapters, epub_chapters=epub_chapters):
+        row = audit.compute_audit_row(
+            book_id=1, title="Aligned", text="t", epub_bytes=b"e",
+        )
+    assert row.epub_paragraphs == 4
+    assert row.text_paragraphs == 4
+    assert row.para_ratio == pytest.approx(1.0)
+    assert row.paragraph_suspicious is False
+
+
+def test_paragraph_threshold_is_configurable():
+    # Ratio = 0.75 — flagged at default 0.8, safe at 0.7.
+    text_chapters = [Chapter(title="Ch", text="p1\n\np2\n\np3\n\np4")]
+    epub_chapters = [Chapter(title="Ch", text="p1\n\np2\n\np3")]
+    with _stub_splitters(text_chapters=text_chapters, epub_chapters=epub_chapters):
+        lenient = audit.compute_audit_row(
+            book_id=1, title="X", text="t", epub_bytes=b"e",
+            paragraph_threshold=0.7,
+        )
+        strict = audit.compute_audit_row(
+            book_id=1, title="X", text="t", epub_bytes=b"e",
+            paragraph_threshold=0.8,
+        )
+    assert lenient.paragraph_suspicious is False
+    assert strict.paragraph_suspicious is True
+
+
+# ── structural speaker-cue signal (#834 / #820) ──────────────────────────────
+
+
+def _faust_like_collapsed_paragraph() -> str:
+    """A single long paragraph with an embedded-newline speaker cue — the
+    pattern seen in Faust (#820) after the EPUB splitter collapses verse."""
+    return (
+        "Und weißt du was? ich glaub', er liebt dich eben.\n"
+        "Ja, freilich! wir verstehn uns nicht auf gleichen Ton.\n"
+        "Und leg' den Schmuck nur wieder weg, mein Sohn.\n"
+        "  HELENA.\n"
+        "Das Dunkel hebt sich auf, mein Blick gewinnt;\n"
+        "Ich seh' die Berge frei, die Fluten blau.\n"
+        "Mich stützte eine Hand, die mich erfand\n"
+        "Und wieder schuf aus Liebe, Leid und Zeit.\n"
+        "Wie weit das reicht, wie tief, wie hoch hinan —\n"
+        "wir müssen uns noch weiter trauen; komm!\n"
+    )
+
+
+def test_structural_flag_catches_embedded_speaker_cue_in_long_paragraph():
+    long_para = _faust_like_collapsed_paragraph()
+    assert len(long_para) >= 400  # sanity: meets default structural-min threshold
+    epub_chapters = [Chapter(title="Ch1", text=long_para)]
+    # Plain-text baseline is fine — char/para ratios should NOT fire; only
+    # the structural signal should.
+    text_chapters = [Chapter(title="Ch1", text=long_para)]
+    with _stub_splitters(text_chapters=text_chapters, epub_chapters=epub_chapters):
+        row = audit.compute_audit_row(
+            book_id=999, title="Faust", text="t", epub_bytes=b"e",
+        )
+    assert row.suspicious is False
+    assert row.paragraph_suspicious is False
+    assert len(row.structural_flags) == 1
+    idx, excerpt = row.structural_flags[0]
+    assert idx == 0
+    assert excerpt  # non-empty excerpt
+    assert row.is_flagged is True  # structural alone flips the overall flag
+
+
+def test_structural_flag_does_not_fire_on_short_paragraphs():
+    epub_chapters = [
+        Chapter(title="Ch1", text="Short.\n  HELENA.\nStill short."),
+    ]
+    text_chapters = [Chapter(title="Ch1", text="baseline")]
+    with _stub_splitters(text_chapters=text_chapters, epub_chapters=epub_chapters):
+        row = audit.compute_audit_row(
+            book_id=1, title="X", text="t", epub_bytes=b"e",
+        )
+    assert row.structural_flags == []
+
+
+def test_structural_flag_does_not_fire_without_embedded_speaker_cue():
+    # Long paragraph (>400 chars) with no speaker cue — pure prose.
+    body = " ".join(["wanderer"] * 80) + "\n" + " ".join(["foo"] * 40)
+    assert len(body) >= 400
+    epub_chapters = [Chapter(title="Ch1", text=body)]
+    text_chapters = [Chapter(title="Ch1", text=body)]
+    with _stub_splitters(text_chapters=text_chapters, epub_chapters=epub_chapters):
+        row = audit.compute_audit_row(
+            book_id=1, title="X", text="t", epub_bytes=b"e",
+        )
+    assert row.structural_flags == []
+
+
+def test_structural_min_len_is_configurable():
+    # A short paragraph with a speaker cue should flag when the min_len is
+    # dropped low enough to include it.
+    p = "Line1.\n  HELENA.\nLine3."
+    epub_chapters = [Chapter(title="Ch1", text=p)]
+    text_chapters = [Chapter(title="Ch1", text=p)]
+    with _stub_splitters(text_chapters=text_chapters, epub_chapters=epub_chapters):
+        row = audit.compute_audit_row(
+            book_id=1, title="X", text="t", epub_bytes=b"e",
+            structural_min_len=5,
+        )
+    assert len(row.structural_flags) == 1
+
+
+# ── is_flagged property and main() exit-code broadening ──────────────────────
+
+
+def test_is_flagged_ors_all_three_signals():
+    base = dict(
+        book_id=1, title="x", epub_chars=0, text_chars=0, ratio=1.0,
+    )
+    assert audit.AuditRow(**base, suspicious=True).is_flagged is True
+    assert (
+        audit.AuditRow(**base, suspicious=False, paragraph_suspicious=True).is_flagged
+        is True
+    )
+    assert (
+        audit.AuditRow(
+            **base,
+            suspicious=False,
+            paragraph_suspicious=False,
+            structural_flags=[(0, "...HELENA...")],
+        ).is_flagged
+        is True
+    )
+    assert audit.AuditRow(**base, suspicious=False).is_flagged is False
+
+
+def test_main_exits_nonzero_on_structural_only_flag(monkeypatch):
+    # A row with no char/para flag but a structural flag must still trigger
+    # the CI gate — this is exactly the #820 class.
+    sample = [
+        audit.AuditRow(
+            book_id=1, title="Faust", epub_chars=100_000,
+            text_chars=100_000, ratio=1.0, suspicious=False,
+            epub_paragraphs=50, text_paragraphs=50, para_ratio=1.0,
+            paragraph_suspicious=False,
+            structural_flags=[(3, "...HELENA...")],
+        ),
+    ]
+
+    async def fake_run_audit(**kwargs):
+        return sample
+
+    monkeypatch.setattr(audit, "run_audit", fake_run_audit)
+
+    assert audit.main([]) == 1
+
+
+def test_csv_includes_paragraph_and_structural_columns(monkeypatch, tmp_path):
+    sample = [
+        audit.AuditRow(
+            book_id=7, title="Faust", epub_chars=100_000,
+            text_chars=100_000, ratio=1.0, suspicious=False,
+            epub_paragraphs=20, text_paragraphs=50, para_ratio=0.4,
+            paragraph_suspicious=True,
+            structural_flags=[(1, "HELENA / paragraph excerpt")],
+        ),
+    ]
+
+    async def fake_run_audit(**kwargs):
+        return sample
+
+    monkeypatch.setattr(audit, "run_audit", fake_run_audit)
+    out = tmp_path / "report.csv"
+    audit.main(["--csv", str(out)])
+
+    content = out.read_text()
+    # New header columns present
+    for col in (
+        "epub_paragraphs",
+        "text_paragraphs",
+        "para_ratio",
+        "paragraph_suspicious",
+        "structural_flag_count",
+        "structural_flag_sample",
+    ):
+        assert col in content
+    # Data row carries the paragraph ratio and the structural excerpt
+    assert "0.400" in content
+    assert "HELENA" in content


### PR DESCRIPTION
## Summary

Extends the EPUB split audit (#832 / `scripts/epub_split_audit.py`) with two additional signals that catch bugs **invisible to a char-count comparison** — specifically the #820 class, where `<br>` inside `<p>` collapses verse into one visual block, leaving the char count intact but dropping the paragraph count by an order of magnitude.

Three independent signals now:

1. **Character ratio** (existing, from #769) — `epub_chars / text_chars < --threshold` (default 0.5).
2. **Paragraph ratio** (new) — `epub_paragraphs / text_paragraphs < --para-threshold` (default 0.8). Uses blank-line paragraph counting against both splitter outputs.
3. **Structural speaker-cue collapse** (new, #820-specific) — any paragraph longer than `--structural-paragraph-len` chars (default 400) that contains an embedded-newline all-caps speaker cue like `"\n  HELENA."`. No plain-text baseline required.

`main()` now exits `1` when **any** signal fires, so a single-book regression like #820 no longer slips the CI gate.

## Why

The char-count audit I shipped in #832 cleanly catches the #758 / #767 class (verse-dropping, wrapper-div skipping). But #820 showed it has a blind spot: the collapsed-verse paragraphs in Faust keep 100% of the characters — they just rearrange them. A paragraph-count check catches that shift directly; the structural signal catches it without needing any baseline.

## What changed

- **`backend/scripts/epub_split_audit.py`**
  - `AuditRow` gains `epub_paragraphs`, `text_paragraphs`, `para_ratio`, `paragraph_suspicious`, and `structural_flags: list[(chapter_index, excerpt)]`. All new fields default-initialize so the constructor remains backward-compatible with the existing test-stub rows.
  - `is_flagged` property ORs the three signals and drives the CLI exit code.
  - `_count_paragraphs()` and `_find_structural_flags()` helpers; speaker-cue regex `\n[ \t]*[A-ZÄÖÜ]{2,}[A-ZÄÖÜ ]*\.` (requires ≥2 uppercase chars to skip initials/single letters).
  - `compute_audit_row()` populates all three signals. When the plain-text baseline is empty, ratio signals stay off but structural flags are still evaluated — they stand on their own.
  - CSV output extended with six new columns; CLI summary breaks down flag count per signal.
  - New flags: `--para-threshold`, `--structural-paragraph-len`.
- **`backend/tests/test_epub_split_audit.py`**
  - Pre-existing tests (8) still pass unchanged.
  - +10 new tests covering paragraph-count, structural-flag, `is_flagged`, CSV columns, and the `main()` exit-code gate on a structural-only flag (the #820 case).

## Test plan

- [x] Full audit test module: **18 passed** (was 8).
- [x] Full backend suite after rebase onto main (now containing #832): **1419 passed**.
- [x] Manual spot-check: a Faust-like paragraph with `\n  HELENA.` embedded in a >400-char block produces one structural flag, zero char/para flags, and `main()` returns 1.

## How to run

```bash
# All signals
python -m scripts.epub_split_audit

# Single book
python -m scripts.epub_split_audit --book-id 2229

# Tighter paragraph gate + CSV
python -m scripts.epub_split_audit --para-threshold 0.9 --csv /tmp/audit.csv

# Looser structural threshold (catch shorter verse collapses)
python -m scripts.epub_split_audit --structural-paragraph-len 250
```

## References

- Parent audit: #769 (closed by #832)
- Bug this signal catches: #820 (Faust verse-collapse umbrella — 108 paragraphs across 21 chapters)

Closes #834.
