### PR TITLE
ux: raise BookDetailModal close button from 32px to 44px touch target (closes #811)

### DIFF
--- a/frontend/src/__tests__/BookDetailModalTouchTarget.test.ts
+++ b/frontend/src/__tests__/BookDetailModalTouchTarget.test.ts
@@ -1,0 +1,35 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/BookDetailModal.tsx"),
+  "utf8"
+);
+
+describe("BookDetailModal touch targets (closes #811)", () => {
+  it("Close button has aria-label", () => {
+    expect(src).toContain('aria-label="Close"');
+  });
+
+  it("Close button has min-h-[44px]", () => {
+    const idx = src.indexOf('aria-label="Close"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 100);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("Close button has min-w-[44px]", () => {
+    const idx = src.indexOf('aria-label="Close"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 100);
+    expect(window).toContain("min-w-[44px]");
+  });
+
+  it("Close button does not use hard-coded w-8 h-8", () => {
+    const idx = src.indexOf('aria-label="Close"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 100);
+    expect(window).not.toMatch(/\bw-8\b/);
+    expect(window).not.toMatch(/\bh-8\b/);
+  });
+});

--- a/frontend/src/components/BookDetailModal.tsx
+++ b/frontend/src/components/BookDetailModal.tsx
@@ -80,7 +80,7 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
           <button
             onClick={onClose}
             aria-label="Close"
-            className="shrink-0 w-8 h-8 flex items-center justify-center rounded-full text-stone-400 hover:bg-stone-100 hover:text-stone-600 transition-colors"
+            className="shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-full text-stone-400 hover:bg-stone-100 hover:text-stone-600 transition-colors"
           >
             <CloseIcon className="w-4 h-4" />
           </button>


### PR DESCRIPTION
Closes #811

BookDetailModal close button used `w-8 h-8` (32px) with no min-h override. Added `min-h-[44px] min-w-[44px] flex items-center justify-center` to meet the 44px touch target minimum.

## Test plan
- [x] `BookDetailModalTouchTarget.test.ts` passes
- [x] Full frontend suite passes (1818 tests)

🤖 Generated with Claude Code
