### PR TITLE
feat: declared FKs on annotations + vocabulary (#754 PR 1/4)

### DIFF
--- a/backend/migrations/031_fk_annotations_vocabulary.sql
+++ b/backend/migrations/031_fk_annotations_vocabulary.sql
@@ -1,0 +1,98 @@
+-- Issue #754 / design doc: docs/design/declared-fks-schema.md
+-- PR 1 of 4: declare REFERENCES … ON DELETE CASCADE on annotations and
+-- vocabulary. Both tables had soft user_id / book_id columns (no FK clause),
+-- so runtime FK enforcement (#751) never cascaded deletions for them — we
+-- were carrying manual shadow cascades in delete_user and admin.delete_book
+-- instead.
+--
+-- Per CLAUDE.md migration policy this runs unconditional orphan DELETEs
+-- before the rewrite, even though #774 already cleaned these tables. If the
+-- counts are zero the DELETEs are no-ops; if something slipped the net, we
+-- still produce a consistent post-state for the new FKs to accept.
+--
+-- Runner context: migrations run with PRAGMA foreign_keys = OFF, so
+--   - INSERT INTO …_new SELECT * FROM … does not validate FKs yet
+--   - DROP TABLE does not cascade to children
+--   - ALTER TABLE … RENAME updates FK clauses in other tables by name
+--
+-- Existing FKs that already point at vocabulary(id) keep working after the
+-- drop+rename because references are resolved by parent table name:
+--   word_occurrences, flashcard_reviews, vocabulary_tags, deck_members.
+
+
+-- ── Orphan cleanup (mandatory per policy; near-zero today) ────────────────
+
+DELETE FROM annotations WHERE user_id NOT IN (SELECT id FROM users);
+DELETE FROM annotations WHERE book_id NOT IN (SELECT id FROM books);
+DELETE FROM vocabulary  WHERE user_id NOT IN (SELECT id FROM users);
+
+
+-- ── annotations: rewrite with declared FKs on user_id and book_id ─────────
+
+CREATE TABLE annotations_new (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id        INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    book_id        INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    chapter_index  INTEGER NOT NULL,
+    sentence_text  TEXT    NOT NULL,
+    note_text      TEXT    NOT NULL DEFAULT '',
+    color          TEXT    NOT NULL DEFAULT 'yellow',
+    created_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO annotations_new SELECT * FROM annotations;
+
+DROP TABLE annotations;
+
+ALTER TABLE annotations_new RENAME TO annotations;
+
+-- Recreate the UNIQUE index that migration 015 created on the original
+-- annotations table — dropped along with the table and required by the
+-- ON CONFLICT (user_id, book_id, chapter_index, sentence_text) upsert in
+-- services/db.save_annotation.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_annotations_sentence
+    ON annotations (user_id, book_id, chapter_index, sentence_text);
+
+-- Recreate the FTS5 triggers that migration 026 created on the original
+-- annotations table. SQLite auto-drops triggers when their parent table is
+-- dropped, so we must re-attach them to the new table. The annotations_fts
+-- virtual table itself (content='annotations', content_rowid='id') survives
+-- the drop + rename because it references the parent by name — its existing
+-- rows still line up with the new table because INSERT … SELECT * preserves
+-- ids.
+CREATE TRIGGER annotations_ai AFTER INSERT ON annotations BEGIN
+    INSERT INTO annotations_fts(rowid, sentence_text, note_text)
+    VALUES (new.id, new.sentence_text, new.note_text);
+END;
+CREATE TRIGGER annotations_ad BEFORE DELETE ON annotations BEGIN
+    INSERT INTO annotations_fts(annotations_fts, rowid, sentence_text, note_text)
+    VALUES ('delete', old.id, old.sentence_text, old.note_text);
+END;
+CREATE TRIGGER annotations_au AFTER UPDATE ON annotations BEGIN
+    INSERT INTO annotations_fts(annotations_fts, rowid, sentence_text, note_text)
+    VALUES ('delete', old.id, old.sentence_text, old.note_text);
+    INSERT INTO annotations_fts(rowid, sentence_text, note_text)
+    VALUES (new.id, new.sentence_text, new.note_text);
+END;
+
+
+-- ── vocabulary: rewrite with declared FK on user_id ───────────────────────
+-- Column order preserved so INSERT … SELECT * works:
+--   id, user_id, word, created_at, lemma, language
+-- (lemma and language were appended via migration 017.)
+
+CREATE TABLE vocabulary_new (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    word        TEXT    NOT NULL,
+    created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    lemma       TEXT,
+    language    TEXT,
+    UNIQUE(user_id, word)
+);
+
+INSERT INTO vocabulary_new SELECT * FROM vocabulary;
+
+DROP TABLE vocabulary;
+
+ALTER TABLE vocabulary_new RENAME TO vocabulary;

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -262,7 +262,9 @@ async def delete_book(book_id: int = Path(..., ge=1), _admin: dict = Depends(_re
         await db.execute(
             "DELETE FROM vocabulary WHERE id NOT IN (SELECT DISTINCT vocabulary_id FROM word_occurrences)"
         )
-        await db.execute("DELETE FROM annotations WHERE book_id = ?", (book_id,))
+        # annotations.book_id carries a declared FK with ON DELETE CASCADE
+        # since migration 031 (#754 PR 1/4) — the row below (DELETE FROM books)
+        # will cascade to annotations automatically.
         await db.execute("DELETE FROM book_insights WHERE book_id = ?", (book_id,))
         await db.execute("DELETE FROM chapter_summaries WHERE book_id = ?", (book_id,))
         await db.execute("DELETE FROM reading_history WHERE book_id = ?", (book_id,))

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -309,11 +309,10 @@ async def set_user_role(user_id: int, role: str) -> None:
 
 async def delete_user(user_id: int) -> None:
     async with aiosqlite.connect(DB_PATH) as db:
-        # FK enforcement (#748) cascades vocabulary → word_occurrences,
-        # flashcard_reviews, vocabulary_tags, deck_members via declared FKs.
-        # vocabulary itself has no FK to users so delete it explicitly.
-        await db.execute("DELETE FROM vocabulary WHERE user_id = ?", (user_id,))
-        await db.execute("DELETE FROM annotations WHERE user_id = ?", (user_id,))
+        # annotations.user_id and vocabulary.user_id carry declared FKs with
+        # ON DELETE CASCADE since migration 031 (#754 PR 1/4), so deleting the
+        # user row cascades both tables automatically under PRAGMA
+        # foreign_keys = ON (#751). No manual shadow delete needed.
         await db.execute("DELETE FROM book_insights WHERE user_id = ?", (user_id,))
         await db.execute("DELETE FROM user_reading_progress WHERE user_id = ?", (user_id,))
         await db.execute("DELETE FROM reading_history WHERE user_id = ?", (user_id,))
@@ -326,8 +325,8 @@ async def delete_user(user_id: int) -> None:
         await db.execute(f"DELETE FROM chapter_summaries WHERE book_id IN ({_owned})", (user_id,))
         await db.execute(f"DELETE FROM translation_queue WHERE book_id IN ({_owned})", (user_id,))
         await db.execute(f"DELETE FROM word_occurrences WHERE book_id IN ({_owned})", (user_id,))
-        # Prune flashcard_reviews and vocabulary for entries left without any occurrence.
-        # FK enforcement is OFF so ON DELETE CASCADE never fires automatically.
+        # Prune flashcard_reviews entries left without any occurrence (still
+        # needed until word_occurrences gets its declared FK in PR 4/4).
         await db.execute(
             "DELETE FROM flashcard_reviews WHERE vocabulary_id NOT IN "
             "(SELECT DISTINCT vocabulary_id FROM word_occurrences)"
@@ -335,7 +334,8 @@ async def delete_user(user_id: int) -> None:
         await db.execute(
             "DELETE FROM vocabulary WHERE id NOT IN (SELECT DISTINCT vocabulary_id FROM word_occurrences)"
         )
-        await db.execute(f"DELETE FROM annotations WHERE book_id IN ({_owned})", (user_id,))
+        # annotations.book_id now cascades via its declared FK (migration 031),
+        # so books deleted below carry their annotations with them automatically.
         await db.execute(f"DELETE FROM book_insights WHERE book_id IN ({_owned})", (user_id,))
         await db.execute(f"DELETE FROM user_reading_progress WHERE book_id IN ({_owned})", (user_id,))
         await db.execute(f"DELETE FROM reading_history WHERE book_id IN ({_owned})", (user_id,))

--- a/backend/tests/test_db_extended.py
+++ b/backend/tests/test_db_extended.py
@@ -39,6 +39,15 @@ async def tmp_db(monkeypatch, tmp_path):
     path = str(tmp_path / "test.db")
     monkeypatch.setattr(db_module, "DB_PATH", path)
     await init_db()
+    # Annotations now carry a declared FK to books(id) (migration 031, #754),
+    # so pre-seed the book ids referenced in this module's annotation tests.
+    import aiosqlite
+    async with aiosqlite.connect(path) as db:
+        await db.executemany(
+            "INSERT OR IGNORE INTO books (id, title, images) VALUES (?, 'T', '[]')",
+            [(i,) for i in (1, 5, 7)],
+        )
+        await db.commit()
 
 
 # ── GitHub auth ───────────────────────────────────────────────────────────────

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1216,3 +1216,207 @@ async def test_migration_030_clears_chapter0_cache(tmp_db):
             "SELECT COUNT(*) FROM book_insights WHERE book_id=1 AND chapter_index=0"
         ) as cur:
             assert (await cur.fetchone())[0] == 1, "unrelated book chapter-0 insights must survive"
+
+
+# ── Migration 031 (issue #754): declared FKs on annotations + vocabulary ─────
+
+
+async def test_migration_031_cleans_orphan_annotations_and_vocabulary(tmp_db):
+    """Seed rows pointing at missing parents, re-run migration 031, and
+    confirm the pre-rewrite orphan DELETEs wiped them so the subsequent
+    INSERT INTO …_new SELECT * does not violate the new FKs."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute("PRAGMA foreign_keys = OFF")
+        # Two valid parents we keep.
+        await db.execute(
+            "INSERT INTO users (id, google_id, email, name, picture) "
+            "VALUES (1, 'g1', 'a@b.com', 'A', '')"
+        )
+        await db.execute(
+            "INSERT INTO books (id, title, images) VALUES (100, 'A Book', '[]')"
+        )
+        # Valid annotation + valid vocabulary row — both must survive.
+        await db.execute(
+            "INSERT INTO annotations (id, user_id, book_id, chapter_index, sentence_text) "
+            "VALUES (1, 1, 100, 0, 'alive')"
+        )
+        await db.execute(
+            "INSERT INTO vocabulary (id, user_id, word) VALUES (1, 1, 'alive')"
+        )
+        # Orphan rows: bogus parent ids.
+        await db.execute(
+            "INSERT INTO annotations (id, user_id, book_id, chapter_index, sentence_text) "
+            "VALUES (2, 999, 100, 0, 'bad-user')"
+        )
+        await db.execute(
+            "INSERT INTO annotations (id, user_id, book_id, chapter_index, sentence_text) "
+            "VALUES (3, 1, 888, 0, 'bad-book')"
+        )
+        await db.execute(
+            "INSERT INTO vocabulary (id, user_id, word) VALUES (2, 999, 'bad-user')"
+        )
+        await db.execute(
+            "DELETE FROM schema_migrations WHERE version = '031_fk_annotations_vocabulary'"
+        )
+        await db.commit()
+
+    # Re-run migrations — this exercises the orphan cleanup + table rewrite.
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute("SELECT id FROM annotations ORDER BY id") as cur:
+            rows = [r[0] for r in await cur.fetchall()]
+        assert rows == [1], f"only the valid annotation should survive; got {rows}"
+
+        async with db.execute("SELECT id FROM vocabulary ORDER BY id") as cur:
+            rows = [r[0] for r in await cur.fetchall()]
+        assert rows == [1], f"only the valid vocabulary row should survive; got {rows}"
+
+
+async def test_migration_031_annotations_carries_declared_fks(tmp_db):
+    """After migration 031 runs, PRAGMA foreign_key_list must report
+    annotations.user_id → users(id) CASCADE and annotations.book_id →
+    books(id) CASCADE. This is the load-bearing assertion of the design —
+    if these slip, the whole series is pointless."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute("PRAGMA foreign_key_list(annotations)") as cur:
+            fks = await cur.fetchall()
+
+    fk_map = {(row[2], row[3]): (row[4], row[5], row[6]) for row in fks}
+    # key = (referenced_table, from_column) → (to_column, on_update, on_delete)
+    assert ("users", "user_id") in fk_map, f"missing users FK: {fk_map}"
+    assert ("books", "book_id") in fk_map, f"missing books FK: {fk_map}"
+    assert fk_map[("users", "user_id")][2] == "CASCADE"
+    assert fk_map[("books", "book_id")][2] == "CASCADE"
+
+
+async def test_migration_031_vocabulary_carries_declared_fk(tmp_db):
+    """Vocabulary has only user_id as a soft reference — verify it is now
+    declared as REFERENCES users(id) ON DELETE CASCADE."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute("PRAGMA foreign_key_list(vocabulary)") as cur:
+            fks = await cur.fetchall()
+
+    fk_map = {(row[2], row[3]): (row[4], row[5], row[6]) for row in fks}
+    assert ("users", "user_id") in fk_map, f"missing users FK: {fk_map}"
+    assert fk_map[("users", "user_id")][2] == "CASCADE"
+
+
+async def test_migration_031_preserves_existing_rows(tmp_db):
+    """The rewrite copies data via INSERT … SELECT *. Data in annotations
+    and vocabulary that existed before 031 must still be present after."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute("PRAGMA foreign_keys = OFF")
+        await db.execute(
+            "INSERT INTO users (id, google_id, email, name, picture) "
+            "VALUES (5, 'g5', 'e@b.com', 'E', '')"
+        )
+        await db.execute(
+            "INSERT INTO books (id, title, images) VALUES (500, 'T', '[]')"
+        )
+        await db.execute(
+            "INSERT INTO annotations (id, user_id, book_id, chapter_index, "
+            "sentence_text, note_text, color) VALUES "
+            "(777, 5, 500, 3, 'a sentence', 'a note', 'blue')"
+        )
+        await db.execute(
+            "INSERT INTO vocabulary (id, user_id, word, lemma, language) "
+            "VALUES (777, 5, 'the-word', 'the', 'en')"
+        )
+        await db.execute(
+            "DELETE FROM schema_migrations WHERE version = '031_fk_annotations_vocabulary'"
+        )
+        await db.commit()
+
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute(
+            "SELECT user_id, book_id, chapter_index, sentence_text, note_text, color "
+            "FROM annotations WHERE id = 777"
+        ) as cur:
+            row = await cur.fetchone()
+        assert row == (5, 500, 3, "a sentence", "a note", "blue")
+
+        async with db.execute(
+            "SELECT user_id, word, lemma, language FROM vocabulary WHERE id = 777"
+        ) as cur:
+            row = await cur.fetchone()
+        assert row == (5, "the-word", "the", "en")
+
+
+async def test_migration_031_cascade_deletes_annotations_on_user_delete(tmp_db):
+    """End-to-end: with runtime FK enforcement, deleting a user must
+    automatically cascade to annotations and vocabulary via the declared
+    FKs introduced in 031 — no manual shadow delete required."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        # Default connection has FK on (services.db patches aiosqlite.connect).
+        # Explicitly enable to mirror production runtime behavior.
+        await db.execute("PRAGMA foreign_keys = ON")
+        await db.execute(
+            "INSERT INTO users (id, google_id, email, name, picture) "
+            "VALUES (77, 'g', 'k@b.com', 'K', '')"
+        )
+        await db.execute(
+            "INSERT INTO books (id, title, images) VALUES (900, 'T', '[]')"
+        )
+        await db.execute(
+            "INSERT INTO annotations (user_id, book_id, chapter_index, sentence_text) "
+            "VALUES (77, 900, 0, 's')"
+        )
+        await db.execute(
+            "INSERT INTO vocabulary (user_id, word) VALUES (77, 'w')"
+        )
+        await db.commit()
+
+        # Drop the user — FK cascade should remove both child rows.
+        await db.execute("DELETE FROM users WHERE id = 77")
+        await db.commit()
+
+        async with db.execute(
+            "SELECT COUNT(*) FROM annotations WHERE user_id = 77"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 0, "annotations must cascade"
+        async with db.execute(
+            "SELECT COUNT(*) FROM vocabulary WHERE user_id = 77"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 0, "vocabulary must cascade"
+
+
+async def test_migration_031_cascade_deletes_annotations_on_book_delete(tmp_db):
+    """Same end-to-end test on the book_id side: annotations must cascade
+    when the parent book goes away."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute("PRAGMA foreign_keys = ON")
+        await db.execute(
+            "INSERT INTO users (id, google_id, email, name, picture) "
+            "VALUES (88, 'g', 'm@b.com', 'M', '')"
+        )
+        await db.execute(
+            "INSERT INTO books (id, title, images) VALUES (910, 'T', '[]')"
+        )
+        await db.execute(
+            "INSERT INTO annotations (user_id, book_id, chapter_index, sentence_text) "
+            "VALUES (88, 910, 0, 's')"
+        )
+        await db.commit()
+
+        await db.execute("DELETE FROM books WHERE id = 910")
+        await db.commit()
+
+        async with db.execute(
+            "SELECT COUNT(*) FROM annotations WHERE book_id = 910"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 0, "annotations must cascade on book delete"

--- a/backend/tests/test_router_search.py
+++ b/backend/tests/test_router_search.py
@@ -28,6 +28,13 @@ OTHER_USER = {
 
 async def _seed_annotation(db, user_id: int, book_id: int, chapter_index: int,
                            sentence: str, note: str = ""):
+    # Migration 031 added a declared FK annotations.book_id → books(id); make
+    # sure the referenced book exists before inserting so tests that use
+    # made-up book ids don't fail the constraint.
+    await db.execute(
+        "INSERT OR IGNORE INTO books (id, title, images) VALUES (?, 'T', '[]')",
+        (book_id,),
+    )
     cur = await db.execute(
         """INSERT INTO annotations (user_id, book_id, chapter_index, sentence_text, note_text)
            VALUES (?, ?, ?, ?, ?)""",


### PR DESCRIPTION
## Summary

First of four implementation PRs for the declared-FKs design doc merged in #821. This PR promotes the soft `user_id` / `book_id` columns on `annotations` and `vocabulary` to declared `REFERENCES … ON DELETE CASCADE` against `users` / `books`, so deletions cascade automatically under runtime FK enforcement (#751) without any Python-side shadow cleanup.

## What changed

### Migration `031_fk_annotations_vocabulary.sql`

- **Orphan cleanup first** (mandatory per CLAUDE.md migration policy). Expected to be a no-op on prod — #774 already cleaned these — but the seeded-orphan test in `test_migrations` verifies the cleanup path runs.
- **Table rewrite** for `annotations` and `vocabulary` following the `010_rate_limiter_per_model.sql` shape: `CREATE …_new` → `INSERT SELECT *` → `DROP` → `RENAME`. Column order preserved so `INSERT SELECT *` is safe.
- **UNIQUE index `uq_annotations_sentence`** from migration 015 is recreated — SQLite drops indexes alongside the table, and `services.db.save_annotation` relies on it for its `ON CONFLICT` upsert.
- **FTS5 triggers** `annotations_ai` / `annotations_ad` / `annotations_au` from migration 026 are re-attached — they were dropped with the parent table. `annotations_fts` itself survives (`content='annotations'` is resolved by name) and its rowids still line up because `INSERT SELECT *` preserves ids.

### Service-layer cleanup (same PR per the design)

- **`services/db.delete_user`** — drops `DELETE FROM vocabulary WHERE user_id = ?` and `DELETE FROM annotations WHERE user_id = ?` / `WHERE book_id IN (…)`. They now cascade automatically when the parent users / owner-books rows are deleted.
- **`routers/admin.delete_book`** — drops `DELETE FROM annotations WHERE book_id = ?`. Cascades from the `DELETE FROM books` line above.
- Manual cascades for the other six tables (`translations`, `word_occurrences`, `chapter_summaries`, `audio_cache`, `book_insights`, `translation_queue`) are intentionally **kept** — they land in PRs 2/3/4 per the series plan in the design doc.

### Test infrastructure fixes

Several pre-existing tests in `test_db_extended.py` and `test_router_search.py` seeded annotations with made-up `book_id`s relying on the missing FK. Those now violate the new constraint; the fixes pre-seed the referenced books via `INSERT OR IGNORE`. No production behavior changed by these edits.

## Test plan

- [x] **Six new migration tests in `test_migrations.py`**:
  - Orphan cleanup removes rows with missing parent ids while valid rows survive.
  - `PRAGMA foreign_key_list(annotations)` reports both `users` + `books` CASCADE FKs.
  - `PRAGMA foreign_key_list(vocabulary)` reports the `users` CASCADE FK.
  - Pre-existing rows round-trip through the rewrite with all columns intact.
  - End-to-end cascade tests: deleting a user cascades both `annotations` and `vocabulary`; deleting a book cascades `annotations`.
- [x] Full backend suite: **1415 passed**.

## Design references

- Design doc: `docs/design/declared-fks-schema.md` (#821)
- Tracking issue: #754
- Runtime FK enforcement (dependency): #751 / #700

Tracks against #754 — do not close. Series continues with PR 2/4 (`book_insights` + `chapter_summaries`) once this lands.
