### PR TITLE
fix: show error banner when notes fetch fails instead of silent empty state (closes #844)

### DIFF
--- a/frontend/src/__tests__/BookNotesPage.fetcherror.test.tsx
+++ b/frontend/src/__tests__/BookNotesPage.fetcherror.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * Regression #844: BookNotesPage (notes/[bookId]) must show an error state
+ * when the Promise.all() fetch rejects, not the "No notes yet" empty state.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { backendToken: "tok" }, status: "authenticated" }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  useParams: () => ({ bookId: "10" }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getBookChapters: jest.fn(),
+  getAnnotations: jest.fn(),
+  getInsights: jest.fn(),
+  getVocabulary: jest.fn(),
+  updateAnnotation: jest.fn(),
+  deleteAnnotation: jest.fn(),
+  deleteInsight: jest.fn(),
+  exportVocabularyToObsidian: jest.fn(),
+}));
+
+import * as api from "@/lib/api";
+import BookNotesPage from "@/app/notes/[bookId]/page";
+
+const mockGetBookChapters = api.getBookChapters as jest.MockedFunction<typeof api.getBookChapters>;
+const mockGetAnnotations = api.getAnnotations as jest.MockedFunction<typeof api.getAnnotations>;
+const mockGetInsights = api.getInsights as jest.MockedFunction<typeof api.getInsights>;
+const mockGetVocabulary = api.getVocabulary as jest.MockedFunction<typeof api.getVocabulary>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("BookNotesPage — fetch error state (regression #844)", () => {
+  it("shows error message when fetch rejects, not the empty-notes state", async () => {
+    mockGetBookChapters.mockRejectedValue(new Error("Network error"));
+    mockGetAnnotations.mockResolvedValue([]);
+    mockGetInsights.mockResolvedValue([]);
+    mockGetVocabulary.mockResolvedValue([]);
+
+    render(<BookNotesPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Failed to load notes.")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("No notes yet")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/NotesPage.fetcherror.test.tsx
+++ b/frontend/src/__tests__/NotesPage.fetcherror.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * Regression #844: NotesOverviewPage must show an error state when
+ * the Promise.all() fetch rejects, not the empty "No notes yet" state.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { backendToken: "token" }, status: "authenticated" }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getAllAnnotations: jest.fn(),
+  getAllInsights: jest.fn(),
+  getVocabulary: jest.fn(),
+}));
+
+import * as api from "@/lib/api";
+import NotesPage from "@/app/notes/page";
+
+const mockGetAllAnnotations = api.getAllAnnotations as jest.MockedFunction<typeof api.getAllAnnotations>;
+const mockGetAllInsights = api.getAllInsights as jest.MockedFunction<typeof api.getAllInsights>;
+const mockGetVocabulary = api.getVocabulary as jest.MockedFunction<typeof api.getVocabulary>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("NotesOverviewPage — fetch error state (regression #844)", () => {
+  it("shows error message when Promise.all rejects, not the empty-notes state", async () => {
+    mockGetAllAnnotations.mockRejectedValue(new Error("Network error"));
+    mockGetAllInsights.mockResolvedValue([]);
+    mockGetVocabulary.mockResolvedValue([]);
+
+    render(<NotesPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Failed to load notes.")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("No notes yet")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -257,6 +257,7 @@ export default function BookNotesPage() {
   const [insights, setInsights] = useState<BookInsight[]>([]);
   const [vocab, setVocab] = useState<VocabularyWord[]>([]);
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState(false);
 
   // Collapse state
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
@@ -278,6 +279,7 @@ export default function BookNotesPage() {
   useEffect(() => {
     if (status === "unauthenticated") { router.replace("/login"); return; }
     if (status !== "authenticated") return;
+    setFetchError(false);
     Promise.all([
       getBookChapters(bookId),
       getAnnotations(bookId),
@@ -289,7 +291,7 @@ export default function BookNotesPage() {
       setAnnotations(anns);
       setInsights(ins);
       setVocab(voc);
-    }).catch(() => {})
+    }).catch(() => setFetchError(true))
       .finally(() => setLoading(false));
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [status, bookId]);
@@ -679,6 +681,11 @@ export default function BookNotesPage() {
         {loading ? (
           <div className="flex justify-center py-24">
             <span className="w-6 h-6 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+          </div>
+        ) : fetchError ? (
+          <div className="text-center text-stone-400 mt-20 flex flex-col items-center gap-2">
+            <p className="font-serif text-lg text-red-500 mt-1">Failed to load notes.</p>
+            <p className="text-sm">Please refresh the page to try again.</p>
           </div>
         ) : annCount + insCount + vocCount === 0 ? (
           <div className="text-center py-24 text-stone-400">

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -32,18 +32,20 @@ export default function NotesOverviewPage() {
   const [insights, setInsights] = useState<BookInsightWithBook[]>([]);
   const [vocab, setVocab] = useState<VocabularyWord[]>([]);
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState(false);
   const [search, setSearch] = useState("");
 
   useEffect(() => {
     if (status === "unauthenticated") { router.replace("/login"); return; }
     if (status !== "authenticated") return;
+    setFetchError(false);
     Promise.all([getAllAnnotations(), getAllInsights(), getVocabulary()])
       .then(([anns, ins, voc]) => {
         setAnnotations(anns);
         setInsights(ins);
         setVocab(voc);
       })
-      .catch(() => {})
+      .catch(() => setFetchError(true))
       .finally(() => setLoading(false));
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [status]);
@@ -137,6 +139,11 @@ export default function NotesOverviewPage() {
         {loading ? (
           <div className="flex justify-center py-20">
             <span className="w-6 h-6 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+          </div>
+        ) : fetchError ? (
+          <div className="text-center text-stone-400 mt-20 flex flex-col items-center gap-2">
+            <p className="font-serif text-lg text-red-500 mt-1">Failed to load notes.</p>
+            <p className="text-sm">Please refresh the page to try again.</p>
           </div>
         ) : filtered.length === 0 ? (
           <div className="text-center py-20 text-stone-400">


### PR DESCRIPTION
## Summary
- Both `notes/page.tsx` (overview) and `notes/[bookId]/page.tsx` (book-specific notes) had `Promise.all(...).catch(() => {})` silently swallowing fetch errors
- When all three APIs (annotations, insights, vocabulary) failed, the user saw the misleading "No notes yet" empty state instead of an error message
- Both pages now show a "Failed to load notes. Please refresh the page to try again." error banner when the fetch fails

## Test plan
- [x] `NotesPage.fetcherror.test.tsx`: regression test for overview page — mocks `getAllAnnotations` to reject, asserts error banner shown and "No notes yet" not shown
- [x] `BookNotesPage.fetcherror.test.tsx`: regression test for book-specific page — mocks `getBookChapters` to reject, asserts error banner shown and "No notes yet" not shown
- [x] Full frontend test suite passes

Closes #844
