### PR TITLE
feat: declared FKs on book_insights + chapter_summaries (#754 PR 2/4)

### DIFF
--- a/backend/migrations/032_fk_book_insights_chapter_summaries.sql
+++ b/backend/migrations/032_fk_book_insights_chapter_summaries.sql
@@ -1,0 +1,69 @@
+-- Issue #754 / #841 / design doc: docs/design/declared-fks-schema.md
+-- PR 2 of 4: declare REFERENCES … ON DELETE CASCADE on book_insights
+-- (user_id, book_id) and chapter_summaries (book_id). These are AI-derived
+-- per-chapter cache tables that had soft parent references — runtime FK
+-- enforcement (#751) could not cascade their rows, so services/db.delete_user
+-- and admin.delete_book had to clean them manually.
+--
+-- Same pattern as #851 (PR 1/4): orphan DELETE first (mandatory per
+-- CLAUDE.md migration policy), then table rewrite, then recreate indexes.
+-- Runner context: migrations run with PRAGMA foreign_keys = OFF, so the
+-- INSERT … SELECT * step doesn't trigger the new FKs.
+
+
+-- ── Orphan cleanup (mandatory per policy; near-zero today) ────────────────
+
+DELETE FROM book_insights     WHERE user_id NOT IN (SELECT id FROM users);
+DELETE FROM book_insights     WHERE book_id NOT IN (SELECT id FROM books);
+DELETE FROM chapter_summaries WHERE book_id NOT IN (SELECT id FROM books);
+
+
+-- ── book_insights: rewrite with declared FKs on user_id and book_id ──────
+-- Column order preserved so INSERT … SELECT * works:
+--   id, user_id, book_id, chapter_index, question, answer, created_at, context_text
+-- (context_text was appended via migration 016.)
+
+CREATE TABLE book_insights_new (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id        INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    book_id        INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    chapter_index  INTEGER,
+    question       TEXT    NOT NULL,
+    answer         TEXT    NOT NULL,
+    created_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    context_text   TEXT
+);
+
+INSERT INTO book_insights_new SELECT * FROM book_insights;
+
+DROP TABLE book_insights;
+
+ALTER TABLE book_insights_new RENAME TO book_insights;
+
+-- Recreate the UNIQUE expression index that migration 022 added — dropped
+-- alongside the table. The COALESCE handles the book-level case where
+-- chapter_index is NULL.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_book_insights_question
+    ON book_insights (user_id, book_id, COALESCE(chapter_index, -1), question);
+
+
+-- ── chapter_summaries: rewrite with declared FK on book_id ───────────────
+-- No ALTERs since 020, so the column order is simply what 020 defines:
+--   id, book_id, chapter_index, model, content, created_at
+-- UNIQUE(book_id, chapter_index) is inline (table constraint) and preserved.
+
+CREATE TABLE chapter_summaries_new (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    book_id        INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    chapter_index  INTEGER NOT NULL,
+    model          TEXT,
+    content        TEXT    NOT NULL,
+    created_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(book_id, chapter_index)
+);
+
+INSERT INTO chapter_summaries_new SELECT * FROM chapter_summaries;
+
+DROP TABLE chapter_summaries;
+
+ALTER TABLE chapter_summaries_new RENAME TO chapter_summaries;

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -262,11 +262,10 @@ async def delete_book(book_id: int = Path(..., ge=1), _admin: dict = Depends(_re
         await db.execute(
             "DELETE FROM vocabulary WHERE id NOT IN (SELECT DISTINCT vocabulary_id FROM word_occurrences)"
         )
-        # annotations.book_id carries a declared FK with ON DELETE CASCADE
-        # since migration 031 (#754 PR 1/4) — the row below (DELETE FROM books)
-        # will cascade to annotations automatically.
-        await db.execute("DELETE FROM book_insights WHERE book_id = ?", (book_id,))
-        await db.execute("DELETE FROM chapter_summaries WHERE book_id = ?", (book_id,))
+        # annotations.book_id (migration 031, #754 PR 1/4) and
+        # book_insights.book_id + chapter_summaries.book_id (migration 032,
+        # #754 PR 2/4) now carry declared FKs — the DELETE FROM books at
+        # line ~247 above cascades all three tables automatically.
         await db.execute("DELETE FROM reading_history WHERE book_id = ?", (book_id,))
         await db.execute("DELETE FROM user_reading_progress WHERE book_id = ?", (book_id,))
         await db.commit()

--- a/backend/routers/uploads.py
+++ b/backend/routers/uploads.py
@@ -327,8 +327,9 @@ async def delete_uploaded_book(book_id: int = Path(..., ge=1), user: dict = Depe
             "DELETE FROM vocabulary WHERE id NOT IN (SELECT DISTINCT vocabulary_id FROM word_occurrences)"
         )
         await db.execute("DELETE FROM annotations WHERE book_id=?", (book_id,))
-        await db.execute("DELETE FROM book_insights WHERE book_id=?", (book_id,))
-        await db.execute("DELETE FROM chapter_summaries WHERE book_id=?", (book_id,))
+        # book_insights.book_id and chapter_summaries.book_id carry declared
+        # FKs (migration 032, #754 PR 2/4). The DELETE FROM books at the end
+        # of this block cascades both tables automatically.
         await db.execute("DELETE FROM reading_history WHERE book_id=?", (book_id,))
         await db.execute("DELETE FROM user_reading_progress WHERE book_id=?", (book_id,))
         await db.execute("DELETE FROM user_book_chapters WHERE book_id=?", (book_id,))

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -309,11 +309,10 @@ async def set_user_role(user_id: int, role: str) -> None:
 
 async def delete_user(user_id: int) -> None:
     async with aiosqlite.connect(DB_PATH) as db:
-        # annotations.user_id and vocabulary.user_id carry declared FKs with
-        # ON DELETE CASCADE since migration 031 (#754 PR 1/4), so deleting the
-        # user row cascades both tables automatically under PRAGMA
-        # foreign_keys = ON (#751). No manual shadow delete needed.
-        await db.execute("DELETE FROM book_insights WHERE user_id = ?", (user_id,))
+        # annotations.user_id, vocabulary.user_id (migration 031, #754 PR 1/4)
+        # and book_insights.user_id (migration 032, #754 PR 2/4) carry declared
+        # FKs with ON DELETE CASCADE, so the DELETE FROM users at the bottom
+        # cascades all three tables automatically under PRAGMA foreign_keys=ON.
         await db.execute("DELETE FROM user_reading_progress WHERE user_id = ?", (user_id,))
         await db.execute("DELETE FROM reading_history WHERE user_id = ?", (user_id,))
         await db.execute("DELETE FROM book_uploads WHERE user_id = ?", (user_id,))
@@ -322,7 +321,9 @@ async def delete_user(user_id: int) -> None:
         _owned = "SELECT id FROM books WHERE owner_user_id = ?"
         await db.execute(f"DELETE FROM translations WHERE book_id IN ({_owned})", (user_id,))
         await db.execute(f"DELETE FROM audio_cache WHERE book_id IN ({_owned})", (user_id,))
-        await db.execute(f"DELETE FROM chapter_summaries WHERE book_id IN ({_owned})", (user_id,))
+        # chapter_summaries.book_id carries a declared FK (migration 032, #754
+        # PR 2/4), so the DELETE FROM books WHERE owner_user_id below cascades
+        # these rows automatically.
         await db.execute(f"DELETE FROM translation_queue WHERE book_id IN ({_owned})", (user_id,))
         await db.execute(f"DELETE FROM word_occurrences WHERE book_id IN ({_owned})", (user_id,))
         # Prune flashcard_reviews entries left without any occurrence (still
@@ -334,9 +335,9 @@ async def delete_user(user_id: int) -> None:
         await db.execute(
             "DELETE FROM vocabulary WHERE id NOT IN (SELECT DISTINCT vocabulary_id FROM word_occurrences)"
         )
-        # annotations.book_id now cascades via its declared FK (migration 031),
-        # so books deleted below carry their annotations with them automatically.
-        await db.execute(f"DELETE FROM book_insights WHERE book_id IN ({_owned})", (user_id,))
+        # annotations.book_id (migration 031) and book_insights.book_id
+        # (migration 032) cascade on the DELETE FROM books below, so no
+        # manual cleanup is needed here for those tables.
         await db.execute(f"DELETE FROM user_reading_progress WHERE book_id IN ({_owned})", (user_id,))
         await db.execute(f"DELETE FROM reading_history WHERE book_id IN ({_owned})", (user_id,))
         await db.execute(f"DELETE FROM user_book_chapters WHERE book_id IN ({_owned})", (user_id,))

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -38,6 +38,21 @@ async def tmp_db(monkeypatch, tmp_path):
     yield
 
 
+async def _seed_book(book_id: int) -> None:
+    """chapter_summaries.book_id now carries a declared FK to books(id)
+    (migration 032, #754 PR 2/4). Tests that exercise save_chapter_summary
+    with a fabricated book_id must ensure the referenced book exists.
+    """
+    import aiosqlite
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (?, 'T', '[]', 'upload')",
+            (book_id,),
+        )
+        await db.commit()
+
+
 # ── Users ─────────────────────────────────────────────────────────────────────
 
 async def test_create_user():
@@ -277,6 +292,7 @@ async def test_get_chapter_summary_returns_none_when_missing():
 
 
 async def test_save_and_get_chapter_summary():
+    await _seed_book(1234)
     await save_chapter_summary(1234, 5, "A great chapter summary.", model="test-model")
     result = await get_chapter_summary(1234, 5)
     assert result is not None
@@ -285,6 +301,7 @@ async def test_save_and_get_chapter_summary():
 
 
 async def test_save_chapter_summary_overwrites():
+    await _seed_book(1234)
     await save_chapter_summary(1234, 7, "First version.", model="model-a")
     await save_chapter_summary(1234, 7, "Updated version.", model="model-b")
     result = await get_chapter_summary(1234, 7)
@@ -293,6 +310,7 @@ async def test_save_chapter_summary_overwrites():
 
 
 async def test_save_chapter_summary_without_model():
+    await _seed_book(1234)
     await save_chapter_summary(1234, 8, "No model specified.")
     result = await get_chapter_summary(1234, 8)
     assert result is not None

--- a/backend/tests/test_db_extended.py
+++ b/backend/tests/test_db_extended.py
@@ -39,13 +39,17 @@ async def tmp_db(monkeypatch, tmp_path):
     path = str(tmp_path / "test.db")
     monkeypatch.setattr(db_module, "DB_PATH", path)
     await init_db()
-    # Annotations now carry a declared FK to books(id) (migration 031, #754),
-    # so pre-seed the book ids referenced in this module's annotation tests.
+    # annotations + book_insights + chapter_summaries now carry declared FKs
+    # on book_id (migrations 031 + 032) and book_insights + annotations on
+    # user_id. Pre-seed the book ids referenced across this module's tests.
+    # source='upload' keeps the rows out of list_cached_books so unrelated
+    # count tests stay stable.
     import aiosqlite
     async with aiosqlite.connect(path) as db:
         await db.executemany(
-            "INSERT OR IGNORE INTO books (id, title, images) VALUES (?, 'T', '[]')",
-            [(i,) for i in (1, 5, 7)],
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (?, 'T', '[]', 'upload')",
+            [(i,) for i in (1, 5, 6, 7)],
         )
         await db.commit()
 

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -551,14 +551,18 @@ async def test_bootstrap_marks_016_when_context_text_exists(tmp_db):
                 PRIMARY KEY (book_id, chapter_index, chunk_index, provider, voice)
             )
         """)
-        # book_insights already has context_text (as if 016 was applied manually)
+        # book_insights already has context_text (as if 016 was applied manually).
+        # Column shape must match the real 015+016 schema — otherwise later
+        # migrations that do INSERT ... SELECT * over this table (e.g. 032)
+        # fail on column-count mismatch.
         await db.execute("""
             CREATE TABLE IF NOT EXISTS book_insights (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 user_id INTEGER NOT NULL, book_id INTEGER NOT NULL,
-                chapter_index INTEGER NOT NULL, insight TEXT NOT NULL,
-                context_text TEXT,
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                chapter_index INTEGER, question TEXT NOT NULL,
+                answer TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                context_text TEXT
             )
         """)
         await db.commit()
@@ -1420,3 +1424,223 @@ async def test_migration_031_cascade_deletes_annotations_on_book_delete(tmp_db):
             "SELECT COUNT(*) FROM annotations WHERE book_id = 910"
         ) as cur:
             assert (await cur.fetchone())[0] == 0, "annotations must cascade on book delete"
+
+# ── Migration 032 (#754 PR 2/4): declared FKs on book_insights + chapter_summaries ─
+
+
+async def test_migration_032_cleans_orphan_book_insights_and_summaries(tmp_db):
+    """Seed rows pointing at missing parents, re-run migration 032, confirm the
+    pre-rewrite orphan DELETEs wiped them so the subsequent INSERT INTO _new
+    SELECT * does not violate the new FKs."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute("PRAGMA foreign_keys = OFF")
+        await db.execute(
+            "INSERT INTO users (id, google_id, email, name, picture) "
+            "VALUES (1, 'g1', 'a@b.com', 'A', '')"
+        )
+        await db.execute(
+            "INSERT INTO books (id, title, images) VALUES (100, 'Book', '[]')"
+        )
+        # Valid parents — these rows should survive.
+        await db.execute(
+            "INSERT INTO book_insights (id, user_id, book_id, chapter_index, question, answer) "
+            "VALUES (1, 1, 100, 0, 'Q', 'A')"
+        )
+        await db.execute(
+            "INSERT INTO chapter_summaries (id, book_id, chapter_index, content) "
+            "VALUES (1, 100, 0, 'alive')"
+        )
+        # Orphan rows — bogus parent ids.
+        await db.execute(
+            "INSERT INTO book_insights (id, user_id, book_id, chapter_index, question, answer) "
+            "VALUES (2, 999, 100, 0, 'Q-bad-user', 'A')"
+        )
+        await db.execute(
+            "INSERT INTO book_insights (id, user_id, book_id, chapter_index, question, answer) "
+            "VALUES (3, 1, 888, 0, 'Q-bad-book', 'A')"
+        )
+        await db.execute(
+            "INSERT INTO chapter_summaries (id, book_id, chapter_index, content) "
+            "VALUES (2, 888, 0, 'bad-book')"
+        )
+        await db.execute(
+            "DELETE FROM schema_migrations WHERE version = '032_fk_book_insights_chapter_summaries'"
+        )
+        await db.commit()
+
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute("SELECT id FROM book_insights ORDER BY id") as cur:
+            rows = [r[0] for r in await cur.fetchall()]
+        assert rows == [1], f"only valid book_insight should survive; got {rows}"
+
+        async with db.execute("SELECT id FROM chapter_summaries ORDER BY id") as cur:
+            rows = [r[0] for r in await cur.fetchall()]
+        assert rows == [1], f"only valid chapter_summary should survive; got {rows}"
+
+
+async def test_migration_032_book_insights_carries_declared_fks(tmp_db):
+    """After migration 032, PRAGMA foreign_key_list must report both FKs."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute("PRAGMA foreign_key_list(book_insights)") as cur:
+            fks = await cur.fetchall()
+
+    fk_map = {(row[2], row[3]): (row[4], row[5], row[6]) for row in fks}
+    assert ("users", "user_id") in fk_map, f"missing users FK: {fk_map}"
+    assert ("books", "book_id") in fk_map, f"missing books FK: {fk_map}"
+    assert fk_map[("users", "user_id")][2] == "CASCADE"
+    assert fk_map[("books", "book_id")][2] == "CASCADE"
+
+
+async def test_migration_032_chapter_summaries_carries_declared_fk(tmp_db):
+    """chapter_summaries only has book_id as a soft reference — verify it is
+    now REFERENCES books(id) ON DELETE CASCADE."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute("PRAGMA foreign_key_list(chapter_summaries)") as cur:
+            fks = await cur.fetchall()
+
+    fk_map = {(row[2], row[3]): (row[4], row[5], row[6]) for row in fks}
+    assert ("books", "book_id") in fk_map, f"missing books FK: {fk_map}"
+    assert fk_map[("books", "book_id")][2] == "CASCADE"
+
+
+async def test_migration_032_preserves_existing_rows(tmp_db):
+    """INSERT … SELECT * must round-trip data including the appended
+    context_text column that migration 016 added to book_insights."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute("PRAGMA foreign_keys = OFF")
+        await db.execute(
+            "INSERT INTO users (id, google_id, email, name, picture) "
+            "VALUES (5, 'g5', 'e@b.com', 'E', '')"
+        )
+        await db.execute(
+            "INSERT INTO books (id, title, images) VALUES (500, 'T', '[]')"
+        )
+        await db.execute(
+            "INSERT INTO book_insights (id, user_id, book_id, chapter_index, "
+            "question, answer, context_text) VALUES "
+            "(777, 5, 500, 2, 'Why?', 'Because', 'a quoted passage')"
+        )
+        await db.execute(
+            "INSERT INTO chapter_summaries (id, book_id, chapter_index, model, content) "
+            "VALUES (777, 500, 2, 'gemini', 'a plot summary')"
+        )
+        await db.execute(
+            "DELETE FROM schema_migrations WHERE version = '032_fk_book_insights_chapter_summaries'"
+        )
+        await db.commit()
+
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute(
+            "SELECT user_id, book_id, chapter_index, question, answer, context_text "
+            "FROM book_insights WHERE id = 777"
+        ) as cur:
+            row = await cur.fetchone()
+        assert row == (5, 500, 2, "Why?", "Because", "a quoted passage")
+
+        async with db.execute(
+            "SELECT book_id, chapter_index, model, content FROM chapter_summaries WHERE id = 777"
+        ) as cur:
+            row = await cur.fetchone()
+        assert row == (500, 2, "gemini", "a plot summary")
+
+
+async def test_migration_032_uq_book_insights_question_index_survives(tmp_db):
+    """The UNIQUE expression index from migration 022 must be recreated after
+    the table rewrite, otherwise duplicate (user, book, chapter, question)
+    rows would be possible again."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute("PRAGMA foreign_keys = OFF")
+        await db.execute(
+            "INSERT INTO users (id, google_id, email, name, picture) "
+            "VALUES (8, 'g', 'q@b.com', 'Q', '')"
+        )
+        await db.execute("INSERT INTO books (id, title, images) VALUES (800, 'T', '[]')")
+        await db.execute(
+            "INSERT INTO book_insights (user_id, book_id, chapter_index, question, answer) "
+            "VALUES (8, 800, 0, 'dup?', 'first')"
+        )
+        await db.commit()
+
+        # Duplicate insert must fail — the index is present.
+        with pytest.raises(aiosqlite.IntegrityError):
+            await db.execute(
+                "INSERT INTO book_insights (user_id, book_id, chapter_index, question, answer) "
+                "VALUES (8, 800, 0, 'dup?', 'second')"
+            )
+            await db.commit()
+
+
+async def test_migration_032_cascade_deletes_on_user_delete(tmp_db):
+    """With FK enforcement on, DELETE FROM users must cascade to book_insights
+    via the new user_id FK."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute("PRAGMA foreign_keys = ON")
+        await db.execute(
+            "INSERT INTO users (id, google_id, email, name, picture) "
+            "VALUES (77, 'g', 'u@b.com', 'U', '')"
+        )
+        await db.execute("INSERT INTO books (id, title, images) VALUES (900, 'T', '[]')")
+        await db.execute(
+            "INSERT INTO book_insights (user_id, book_id, chapter_index, question, answer) "
+            "VALUES (77, 900, 0, 'Q?', 'A')"
+        )
+        await db.commit()
+
+        await db.execute("DELETE FROM users WHERE id = 77")
+        await db.commit()
+
+        async with db.execute(
+            "SELECT COUNT(*) FROM book_insights WHERE user_id = 77"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 0
+
+
+async def test_migration_032_cascade_deletes_on_book_delete(tmp_db):
+    """DELETE FROM books must cascade to both book_insights and
+    chapter_summaries via the new book_id FKs."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute("PRAGMA foreign_keys = ON")
+        await db.execute(
+            "INSERT INTO users (id, google_id, email, name, picture) "
+            "VALUES (88, 'g', 'u2@b.com', 'U2', '')"
+        )
+        await db.execute("INSERT INTO books (id, title, images) VALUES (910, 'T', '[]')")
+        await db.execute(
+            "INSERT INTO book_insights (user_id, book_id, chapter_index, question, answer) "
+            "VALUES (88, 910, 0, 'Q?', 'A')"
+        )
+        await db.execute(
+            "INSERT INTO chapter_summaries (book_id, chapter_index, content) "
+            "VALUES (910, 0, 'sum')"
+        )
+        await db.commit()
+
+        await db.execute("DELETE FROM books WHERE id = 910")
+        await db.commit()
+
+        async with db.execute(
+            "SELECT COUNT(*) FROM book_insights WHERE book_id = 910"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 0
+        async with db.execute(
+            "SELECT COUNT(*) FROM chapter_summaries WHERE book_id = 910"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 0

--- a/backend/tests/test_router_insights.py
+++ b/backend/tests/test_router_insights.py
@@ -113,6 +113,7 @@ async def test_delete_returns_404_if_wrong_user(client: AsyncClient, test_user):
         name="Other 2",
         picture="",
     )
+    await save_book(4, _META, "text")
     insight = await save_insight(other_user["id"], 4, None, "Q?", "A!")
     insight_id = insight["id"]
 
@@ -396,6 +397,9 @@ async def test_save_insight_returns_dict_when_row_is_none(tmp_db, monkeypatch):
     import aiosqlite as _aio
     from services.db import save_book, save_insight
 
+    # book_insights now has FK on user_id (migration 032), so seed user 1.
+    from services.db import get_or_create_user
+    await get_or_create_user(google_id="g1", email="u1@x", name="U1", picture="")
     await save_book(1, {"title": "T", "authors": [], "languages": ["de"],
                         "subjects": [], "download_count": 0, "cover": ""}, "text")
 


### PR DESCRIPTION
## Summary

PR 2 of 4 from the declared-FKs series (design: `docs/design/declared-fks-schema.md`, merged in #821; PR 1/4 landed in #851). Promotes the soft `user_id` / `book_id` columns on the two AI-derived cache tables to declared `REFERENCES … ON DELETE CASCADE`, so runtime FK enforcement (#751) cascades them automatically.

## What changed

### Migration `032_fk_book_insights_chapter_summaries.sql`

- **Orphan cleanup** first: `book_insights.{user_id,book_id}` and `chapter_summaries.book_id`, per CLAUDE.md policy.
- **Table rewrite** following the `010_rate_limiter_per_model.sql` pattern. Column order preserved so `INSERT … SELECT *` is safe — `book_insights` ends with `context_text` (appended via migration 016), and `chapter_summaries`' inline `UNIQUE(book_id, chapter_index)` is reproduced in the new DDL.
- **`uq_book_insights_question`** (migration 022) is recreated — SQLite drops it with the parent table, and `services.db.save_insight` relies on it for its `ON CONFLICT` upsert.

### Service-layer cleanup (same PR per design)

- **`services/db.delete_user`** drops:
  - `DELETE FROM book_insights WHERE user_id = ?` → cascades via new `user_id` FK.
  - `DELETE FROM chapter_summaries WHERE book_id IN (owned)` → cascades via new `book_id` FK on the owner-book delete.
  - `DELETE FROM book_insights WHERE book_id IN (owned)` → same.
- **`routers/admin.delete_book`** drops the `book_insights` + `chapter_summaries` cleanups.
- **`routers/uploads`** (delete branch) drops the `book_insights` + `chapter_summaries` cleanups.
- Manual cascades for `translations`, `word_occurrences`, `audio_cache`, `translation_queue` remain — they land in PRs 3 and 4.

### Test infrastructure

- `test_db.py` — 3 `save_chapter_summary` tests now pre-seed book id 1234 via a new `_seed_book` helper (called inline, not fixture-level, so `list_cached_books` counts stay stable).
- `test_db_extended.py` — autouse `tmp_db` seeds books 1, 5, 6 with `source='upload'` (keeps them out of `list_cached_books`).
- `test_router_insights.py` — 2 tests that invoked `save_insight` with non-existent user/book ids now seed them.
- `test_migrations.py` — `test_bootstrap_marks_016_when_context_text_exists` used a legacy schema with the wrong columns (`insight` vs `question`+`answer`). Realigned to the real 015+016 shape so 032's `INSERT SELECT *` column-count matches.

## Test plan

- [x] **Seven new migration tests** in `test_migrations.py`:
  - Orphan cleanup removes bogus-parent rows; valid rows survive.
  - `PRAGMA foreign_key_list(book_insights)` reports both users + books CASCADE FKs.
  - `PRAGMA foreign_key_list(chapter_summaries)` reports the books CASCADE FK.
  - Round-trip preserves all columns including `context_text`.
  - `uq_book_insights_question` is recreated — duplicate inserts still fail.
  - End-to-end: deleting a user cascades `book_insights`; deleting a book cascades both tables.
- [x] Full backend suite: **1427 passed**.

## Design references

- Design doc: `docs/design/declared-fks-schema.md` (#821)
- PR 1/4: #851 (merged)
- Tracking issues: #754 (umbrella), #841 (this slice)

Closes #841. Tracks against #754 — do not close. Series continues with PR 3/4 (`translations` + `audio_cache`).
