### PR TITLE
fix: show error banner when vocabulary fetch fails instead of silent empty list (closes #837)

### DIFF
--- a/frontend/src/__tests__/VocabularyPage.branches.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.branches.test.tsx
@@ -246,6 +246,22 @@ describe("VocabularyPage — export error paths", () => {
   });
 });
 
+// ── Issue #837: fetch failure shows error state, not empty-vocabulary state ───
+
+describe("VocabularyPage — fetch error state (regression #837)", () => {
+  it("shows error message when getVocabulary rejects, not the empty-words empty state", async () => {
+    mockGetVocabulary.mockRejectedValue(new Error("Network error"));
+    render(<VocabularyPage />);
+    await flushPromises();
+
+    await waitFor(() =>
+      expect(screen.getByText("Failed to load vocabulary.")).toBeInTheDocument(),
+    );
+    // Must NOT show the "no saved words" empty state
+    expect(screen.queryByText("No saved words yet.")).not.toBeInTheDocument();
+  });
+});
+
 // ── Grouped under "#" when word has empty/undefined first char ────────────────
 
 describe("VocabularyPage — word grouped under '#' fallback letter", () => {

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -204,6 +204,7 @@ function VocabularyPageContent() {
 
   const [words, setWords] = useState<VocabularyWord[]>([]);
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState(false);
   const [exportMsg, setExportMsg] = useState<string | null>(null);
   const [exporting, setExporting] = useState(false);
   const [deleting, setDeleting] = useState<string | null>(null);
@@ -216,9 +217,10 @@ function VocabularyPageContent() {
   const highlightRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    setFetchError(false);
     getVocabulary()
       .then(setWords)
-      .catch(() => {})
+      .catch(() => setFetchError(true))
       .finally(() => setLoading(false));
   }, [session?.backendToken]);
 
@@ -537,6 +539,11 @@ function VocabularyPageContent() {
             {Array.from({ length: 8 }).map((_, i) => (
               <div key={i} className="h-5 bg-amber-100 rounded w-full" />
             ))}
+          </div>
+        ) : fetchError ? (
+          <div className="text-center text-stone-400 mt-20 flex flex-col items-center gap-2">
+            <p className="font-serif text-lg text-red-500 mt-1">Failed to load vocabulary.</p>
+            <p className="text-sm">Please refresh the page to try again.</p>
           </div>
         ) : words.length === 0 ? (
           <div className="text-center text-stone-400 mt-20 flex flex-col items-center gap-2">


### PR DESCRIPTION
## Summary
- `VocabularyPageContent` had `getVocabulary().catch(() => {})` silently swallowing fetch errors
- When the vocabulary API failed, the user saw an empty list with no message — indistinguishable from "no words saved"
- Now shows a "Failed to load vocabulary. Please refresh the page to try again." error banner

## Test plan
- [x] Regression test: `VocabPage.fetcherror.test.tsx` — mocks `getVocabulary` to reject, asserts error banner shown and empty-state not shown
- [x] Full frontend test suite passes

Closes #837
