### PR TITLE
ux: raise TypographyPanel paragraph-focus toggle to 44px touch target (closes #812)

### DIFF
--- a/frontend/src/__tests__/TypographyPanelToggleTouchTarget.test.ts
+++ b/frontend/src/__tests__/TypographyPanelToggleTouchTarget.test.ts
@@ -1,0 +1,41 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/TypographyPanel.tsx"),
+  "utf8"
+);
+
+describe("TypographyPanel paragraph-focus toggle touch target (closes #812)", () => {
+  it("toggle button has min-h-[44px]", () => {
+    const idx = src.indexOf('aria-label="Paragraph focus"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 300), idx + 100);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("toggle button has min-w-[44px]", () => {
+    const idx = src.indexOf('aria-label="Paragraph focus"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 300), idx + 100);
+    expect(window).toContain("min-w-[44px]");
+  });
+
+  it("visual toggle track is an inner span, not on the button itself", () => {
+    const idx = src.indexOf('aria-label="Paragraph focus"');
+    expect(idx).toBeGreaterThan(-1);
+    // The button element should NOT have h-5 or w-9 (those are on the inner span track)
+    const btnWindow = src.slice(Math.max(0, idx - 300), idx + 50);
+    expect(btnWindow).not.toContain("h-5");
+    expect(btnWindow).not.toContain("w-9");
+  });
+
+  it("visual toggle track span has h-5 w-9", () => {
+    const idx = src.indexOf('aria-label="Paragraph focus"');
+    expect(idx).toBeGreaterThan(-1);
+    // After the button opening, there should be a span with h-5 w-9
+    const after = src.slice(idx, idx + 400);
+    expect(after).toContain("h-5");
+    expect(after).toContain("w-9");
+  });
+});

--- a/frontend/src/components/TypographyPanel.tsx
+++ b/frontend/src/components/TypographyPanel.tsx
@@ -158,18 +158,22 @@ export default function TypographyPanel({
               onParagraphFocus(next);
               saveSettings({ paragraphFocus: next });
             }}
-            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
-              paragraphFocus ? "bg-amber-700" : "bg-stone-200"
-            }`}
+            className="min-h-[44px] min-w-[44px] flex items-center justify-center -mr-1.5"
             role="switch"
             aria-label="Paragraph focus"
             aria-checked={paragraphFocus}
           >
             <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
-                paragraphFocus ? "translate-x-4" : "translate-x-0.5"
+              className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+                paragraphFocus ? "bg-amber-700" : "bg-stone-200"
               }`}
-            />
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                  paragraphFocus ? "translate-x-4" : "translate-x-0.5"
+                }`}
+              />
+            </span>
           </button>
         </div>
       </div>


### PR DESCRIPTION
Closes #812

The TypographyPanel paragraph-focus toggle button was 20×36px (w-5 h-9), below the 44px minimum touch target. Raised to `min-h-[44px] min-w-[44px]`.

## Test plan
- [x] `TypographyPanelToggleTouchTarget.test.ts` passes
- [x] Full frontend suite passes (1851 tests)
- [x] Full backend suite passes (1382 tests)

🤖 Generated with Claude Code
