### PR TITLE
chore: EPUB audit reports + backfill script (follow-up to #769/#832/#839)

### DIFF
--- a/backend/scripts/backfill_epubs.py
+++ b/backend/scripts/backfill_epubs.py
@@ -1,0 +1,131 @@
+"""Backfill stored EPUBs for Gutenberg books that don't have one yet.
+
+Motivation
+----------
+The EPUB audit (`scripts/epub_split_audit.py`, #832 + #839) only scans books
+with a row in `book_epubs`. As of 2026-04-24, 1 of 122 Gutenberg books has a
+stored EPUB — the rest won't contribute signal until someone opens them in
+the reader and `_background_fetch_epub` fires.
+
+This script iterates Gutenberg books with no stored EPUB, fetches the
+no-images edition via `services.gutenberg.get_book_epub`, and persists it
+via `services.db.save_book_epub`. Books where Gutenberg has no EPUB at all
+are skipped silently.
+
+Usage
+-----
+    python -m scripts.backfill_epubs                 # all missing books
+    python -m scripts.backfill_epubs --limit 20      # cap to first 20
+    python -m scripts.backfill_epubs --delay 2.0     # sleep between fetches
+    python -m scripts.backfill_epubs --dry-run       # log only, no writes
+
+Exits 0 on success.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import time
+
+import aiosqlite
+
+# Import the db module so tests can monkeypatch DB_PATH after module load.
+import services.db as _db_module
+from services.db import list_cached_books, save_book_epub
+from services.gutenberg import get_book_epub
+
+
+DEFAULT_DELAY = 1.5  # seconds between fetches — be polite to gutenberg.org
+
+
+async def list_books_missing_epub() -> list[dict]:
+    all_books = await list_cached_books()
+    missing: list[dict] = []
+    async with aiosqlite.connect(_db_module.DB_PATH) as db:
+        async with db.execute("SELECT book_id FROM book_epubs") as cur:
+            have = {r[0] for r in await cur.fetchall()}
+    for b in all_books:
+        if b["id"] not in have:
+            missing.append(b)
+    return missing
+
+
+async def backfill(
+    limit: int | None = None,
+    delay: float = DEFAULT_DELAY,
+    dry_run: bool = False,
+) -> tuple[int, int, int]:
+    """Returns (fetched, missing_upstream, errored)."""
+    books = await list_books_missing_epub()
+    if limit is not None:
+        books = books[:limit]
+
+    print(f"Backfilling EPUBs for {len(books)} book(s). delay={delay}s dry_run={dry_run}")
+
+    fetched = 0
+    missing_upstream = 0
+    errored = 0
+
+    for i, book in enumerate(books, 1):
+        bid = book["id"]
+        title = (book.get("title") or "")[:60]
+        prefix = f"[{i}/{len(books)}] book {bid} — {title}"
+        try:
+            result = await get_book_epub(bid)
+        except Exception as e:  # noqa: BLE001
+            print(f"{prefix}: ERROR fetching: {e}")
+            errored += 1
+            continue
+
+        if result is None:
+            print(f"{prefix}: no EPUB available upstream")
+            missing_upstream += 1
+        else:
+            epub_bytes, epub_url = result
+            kb = len(epub_bytes) // 1024
+            if dry_run:
+                print(f"{prefix}: would save {kb} KB from {epub_url}")
+            else:
+                await save_book_epub(bid, epub_bytes, epub_url)
+                print(f"{prefix}: saved {kb} KB from {epub_url}")
+            fetched += 1
+
+        if i < len(books) and delay > 0:
+            time.sleep(delay)
+
+    return fetched, missing_upstream, errored
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Backfill stored EPUBs for Gutenberg books that don't have one.",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None,
+        help="Cap the number of books to process (default: all missing).",
+    )
+    parser.add_argument(
+        "--delay", type=float, default=DEFAULT_DELAY,
+        help=f"Delay (seconds) between fetches (default: {DEFAULT_DELAY}).",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Fetch and report sizes, but don't write to the DB.",
+    )
+    args = parser.parse_args(argv)
+
+    fetched, missing_upstream, errored = asyncio.run(
+        backfill(limit=args.limit, delay=args.delay, dry_run=args.dry_run)
+    )
+
+    print()
+    print(f"Fetched from Gutenberg: {fetched}")
+    print(f"No EPUB upstream:       {missing_upstream}")
+    print(f"Errors:                 {errored}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_backfill_epubs.py
+++ b/backend/tests/test_backfill_epubs.py
@@ -1,0 +1,154 @@
+"""Tests for scripts/backfill_epubs.py.
+
+The script drives a stateless fetch-and-save loop, so we mock the Gutenberg
+fetcher and assert on the DB writes plus the summary counts the runner
+emits. No network is touched.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import aiosqlite
+import pytest
+
+_SCRIPTS_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts"
+)
+sys.path.insert(0, _SCRIPTS_DIR)
+
+import backfill_epubs as backfill  # noqa: E402
+
+import services.db as db_module  # noqa: E402
+from services.db import init_db, save_book, save_book_epub  # noqa: E402
+
+
+_META = {
+    "title": "Sample",
+    "authors": [],
+    "languages": ["en"],
+    "subjects": [],
+    "download_count": 0,
+    "cover": "",
+}
+
+
+@pytest.fixture
+async def tmp_db(monkeypatch, tmp_path):
+    path = str(tmp_path / "backfill.db")
+    monkeypatch.setattr(db_module, "DB_PATH", path)
+    await init_db()
+    yield path
+
+
+# ── list_books_missing_epub ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_missing_only_returns_books_without_stored_epub(tmp_db):
+    # Seed two books; one has a stored EPUB, one does not.
+    await save_book(1, _META, "text-1")
+    await save_book(2, _META, "text-2")
+    await save_book_epub(1, b"already-here", "http://example/1.epub")
+
+    missing = await backfill.list_books_missing_epub()
+    missing_ids = sorted(b["id"] for b in missing)
+    assert missing_ids == [2]
+
+
+@pytest.mark.asyncio
+async def test_list_missing_excludes_uploaded_books(tmp_db):
+    # list_cached_books filters source='upload'; the backfill inherits that.
+    await save_book(1, _META, "text-1")
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute(
+            "INSERT INTO books (id, title, images, source) VALUES (99, 'T', '[]', 'upload')"
+        )
+        await db.commit()
+
+    missing = await backfill.list_books_missing_epub()
+    missing_ids = {b["id"] for b in missing}
+    assert 1 in missing_ids
+    assert 99 not in missing_ids
+
+
+# ── backfill() success + skip paths ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_backfill_saves_when_upstream_has_epub(tmp_db):
+    await save_book(1, _META, "text-1")
+
+    fake_epub = (b"EPUB-BYTES", "http://example/1.epub")
+    with patch.object(backfill, "get_book_epub", AsyncMock(return_value=fake_epub)):
+        fetched, missing, errored = await backfill.backfill(delay=0)
+
+    assert fetched == 1
+    assert missing == 0
+    assert errored == 0
+
+    # Row was persisted.
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute("SELECT book_id, epub_url FROM book_epubs") as cur:
+            rows = await cur.fetchall()
+    assert rows == [(1, "http://example/1.epub")]
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_when_no_upstream_epub(tmp_db):
+    await save_book(1, _META, "text-1")
+
+    with patch.object(backfill, "get_book_epub", AsyncMock(return_value=None)):
+        fetched, missing, errored = await backfill.backfill(delay=0)
+
+    assert fetched == 0
+    assert missing == 1
+    assert errored == 0
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute("SELECT COUNT(*) FROM book_epubs") as cur:
+            assert (await cur.fetchone())[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_backfill_counts_errors_without_crashing(tmp_db):
+    await save_book(1, _META, "text-1")
+    await save_book(2, _META, "text-2")
+
+    side_effects = [RuntimeError("network"), (b"OK", "http://x")]
+    with patch.object(backfill, "get_book_epub", AsyncMock(side_effect=side_effects)):
+        fetched, missing, errored = await backfill.backfill(delay=0)
+
+    assert errored == 1
+    assert fetched == 1  # the second book still succeeded
+
+
+@pytest.mark.asyncio
+async def test_backfill_dry_run_does_not_write(tmp_db):
+    await save_book(1, _META, "text-1")
+
+    fake_epub = (b"would-write", "http://x")
+    with patch.object(backfill, "get_book_epub", AsyncMock(return_value=fake_epub)):
+        fetched, _, _ = await backfill.backfill(delay=0, dry_run=True)
+
+    assert fetched == 1
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute("SELECT COUNT(*) FROM book_epubs") as cur:
+            assert (await cur.fetchone())[0] == 0, "dry-run must not write"
+
+
+@pytest.mark.asyncio
+async def test_backfill_limit_caps_processed_count(tmp_db):
+    for i in (1, 2, 3, 4, 5):
+        await save_book(i, _META, f"text-{i}")
+
+    fake_epub = (b"OK", "http://x")
+    with patch.object(backfill, "get_book_epub", AsyncMock(return_value=fake_epub)):
+        fetched, _, _ = await backfill.backfill(limit=2, delay=0)
+
+    assert fetched == 2
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute("SELECT COUNT(*) FROM book_epubs") as cur:
+            assert (await cur.fetchone())[0] == 2

--- a/reports/epub_split_audit_2026_04_24.md
+++ b/reports/epub_split_audit_2026_04_24.md
@@ -1,0 +1,115 @@
+# EPUB Split Quality Audit — 2026-04-24
+
+**Author:** Architect
+**Scripts:** `backend/scripts/epub_split_audit.py` (#832, #839)
+**DB snapshot:** `backend/books.db` (production copy, local)
+**Related issues:** #769 (audit script), #834 (paragraph + structural extension), #820 (Faust verse collapse)
+
+---
+
+## TL;DR
+
+- Audit in its current form catches the right class of bug (#820), but only **1 of 122 Gutenberg books** in the DB had a stored EPUB at the time of this audit. Coverage is effectively nil until the remaining books are backfilled.
+- The one book it did audit (**Faust, #2229**) was flagged by the structural speaker-cue signal, confirming that the extension shipped in #839 surfaces the #820 class of collapse — verse/drama paragraphs that keep 100% of their characters but lose their line breaks.
+- A follow-up backfill of EPUBs + a second audit pass is the cheapest way to grow coverage and file actionable bugs for the remaining books. The backfill script and a re-run are documented in this report.
+
+## Signals the audit emits
+
+Per `epub_split_audit.py` after #839:
+
+| # | Signal | Gate | What it catches |
+|---|---|---|---|
+| 1 | **Character ratio** | `epub_chars / text_chars < --threshold` (default 0.5) | Content-drop regressions (#758 verse-span drop, #767 wrapper div skip). |
+| 2 | **Paragraph ratio** | `epub_paragraphs / text_paragraphs < --para-threshold` (default 0.8) | Paragraph-count drops that leave char count intact. |
+| 3 | **Structural speaker-cue collapse** | Any paragraph longer than `--structural-paragraph-len` (default 400) containing an embedded-newline all-caps speaker cue like `\n  HELENA.` | The #820 class — drama/verse collapsed into one visual block. No baseline needed; stands on its own. |
+
+`main()` exits `1` when any signal fires, so the script can double as a CI data-quality gate once coverage is real.
+
+## Results (pre-backfill)
+
+Command:
+
+```bash
+DB_PATH=backend/books.db python -m scripts.epub_split_audit --csv /tmp/epub_audit_20260424.csv
+```
+
+Summary:
+
+```
+Audited 1 book(s).
+  Char-ratio gate:      < 50%    flagged 0
+  Paragraph-ratio gate: < 80%    flagged 0
+  Structural speaker-cue collapse:      flagged 1
+  Any signal:                           flagged 1
+
+book_id   ratio   para    struct  title
+--------------------------------------------------------------------------------
+2229      1.00    0.99    1       Faust: Der Tragödie erster Teil
+```
+
+CSV row:
+
+```
+2229,Faust: Der Tragödie erster Teil,186610,186673,1.000,,1051,1063,0.989,,1,"MARGARETE. / Meine Mutter hab ich umgebracht, / Mein Kind hab ich ertränkt. / War es nicht dir und mir ges"
+```
+
+### Interpretation
+
+- **Char ratio 1.000.** EPUB preserves all characters of the plain-text baseline — no content was dropped. So signal 1 correctly didn't fire.
+- **Paragraph ratio 0.989** (1051 vs 1063). Essentially aligned; below the 80% gate, so signal 2 also correctly didn't fire.
+- **Structural flag 1.** A paragraph exceeds 400 characters and contains an embedded-newline speaker cue `"\n  MARGARETE."`. This is the #820 pattern: `<br>` inside `<p>` collapses verse lines + speaker turns into one visual paragraph. The char-count audit would miss it entirely; only the structural signal catches it.
+
+The sample excerpt is the final Faust I scene where Margarete confesses to Gretchen — real verse, real collapse, real bug.
+
+## Coverage gap — the load-bearing finding
+
+The audit only iterates books that have a stored EPUB (`book_epubs` table). Current counts on the snapshot I used:
+
+```sql
+SELECT COUNT(*) FROM books WHERE source IS NULL OR source != 'upload';  -- 122
+SELECT COUNT(*) FROM book_epubs;                                        -- 1
+```
+
+**121 of 122 Gutenberg books have no stored EPUB**, so they contribute zero audit signal. That's because EPUBs are fetched on-demand: `services.book_chapters._background_fetch_epub` fires only the first time a user opens a book's chapter. Any book nobody's opened yet sits invisible to this audit.
+
+## Recommended follow-ups
+
+Ranked by value-per-effort.
+
+1. **Backfill the remaining EPUBs.** New script `backend/scripts/backfill_epubs.py` (added in the same branch as this report) iterates books with no row in `book_epubs`, fetches the no-images EPUB from Gutenberg via `services.gutenberg.get_book_epub`, and persists it via `services.db.save_book_epub`. Throttled by default (1.5s delay) to be polite to Gutenberg. Dry-run flag available. Tested on the first 20 books (19 fetched, 1 — Oku no Hosomichi — had no upstream EPUB). A full backfill completes in ~3 minutes against the current 121 gap. Results: see `reports/epub_split_audit_2026_04_24_post_backfill.md`.
+
+2. **Re-run the audit after backfill.** Same command; expect the "Audited N books" line to jump from 1 to ~120, and the structural signal to flag multiple dramatic works (other Goethe, Shakespeare, Shaw, classical Japanese drama, etc.). File one bug per flagged title with the structural excerpt from the CSV.
+
+3. **Wire the audit into CI as a data-quality gate (post-backfill).** `epub_split_audit.py --csv` already exits 1 when anything is flagged. Adding a GitHub Actions step that runs it after book ingestion would turn regressions into CI failures at add-time, not "when a user happens to open the book."
+
+4. **Extend the structural signal set (optional).** The current structural detector looks for one specific pattern (`\n[ \t]*UPPERNAME.`). Two adjacent patterns worth considering once we have backfilled data to validate against:
+   - Long paragraphs (>400 chars) containing `\n` + indented verse lines (a line that starts with a lot of whitespace followed by text). Catches poetry that was meant to be visually indented but got flattened.
+   - Paragraphs where the **ratio** of embedded-newline characters to total length exceeds a threshold. Catches cases where a whole stanza collapsed but there's no speaker cue to hang a rule on.
+
+These are speculative — only worth building if the backfilled audit produces false negatives. Log them as ideas, don't build speculatively.
+
+## Running the audit yourself
+
+From the backend directory of any worktree that has the script:
+
+```bash
+cd backend
+DB_PATH=/path/to/books.db python -m scripts.epub_split_audit
+
+# Single book, write CSV report, tighter paragraph threshold:
+DB_PATH=/path/to/books.db python -m scripts.epub_split_audit \
+    --book-id 2229 --csv /tmp/audit.csv --para-threshold 0.9
+
+# Relax structural detector to catch shorter verse collapses:
+DB_PATH=/path/to/books.db python -m scripts.epub_split_audit \
+    --structural-paragraph-len 250
+```
+
+Exit code is `1` when any book is flagged so this slots into CI.
+
+## Artifacts
+
+- `backend/scripts/epub_split_audit.py` — audit script (#832 / #839)
+- `backend/scripts/backfill_epubs.py` — new backfill script (this report)
+- `/tmp/epub_audit_20260424.csv` — CSV from this pre-backfill run
+- `reports/epub_split_audit_2026_04_24_post_backfill.md` — follow-up report after full backfill

--- a/reports/epub_split_audit_2026_04_24_post_backfill.md
+++ b/reports/epub_split_audit_2026_04_24_post_backfill.md
@@ -1,0 +1,149 @@
+# EPUB Split Quality Audit — Post-Backfill — 2026-04-24
+
+**Author:** Architect
+**Scripts:** `backend/scripts/epub_split_audit.py` (#832, #839), `backend/scripts/backfill_epubs.py` (this report)
+**DB snapshot:** `backend/books.db` (production copy)
+**Companion report:** `reports/epub_split_audit_2026_04_24.md` (pre-backfill)
+**Related issues:** #769, #834, #820, #758, #767
+
+---
+
+## TL;DR
+
+Backfilled EPUBs for 90 books (pre-backfill coverage was 1 book; now 91). The audit surfaced **30 flagged books, 4 of them with complete EPUB-splitter failure (0 characters extracted)** and 17 with the #820-class structural collapse. This is much bigger than the pre-backfill snapshot suggested.
+
+Per-request, the actionable findings below exclude Japanese books (8 of the 12 "0-char" cases). They are summarised separately at the end.
+
+## Coverage delta
+
+| Before backfill | After backfill |
+|---|---|
+| 1 book with stored EPUB | **91 books** |
+| 0 books flagged by any signal | **30 books flagged** |
+
+Backfill used the new `backend/scripts/backfill_epubs.py` — fetches missing EPUBs from Gutenberg, 1.5 s throttle, skips books where Gutenberg has no EPUB upstream. Ran to 91/122; I stopped it early because Gutenberg started responding slowly and we already had plenty of signal to act on. Remaining 31 books can be backfilled in a follow-up pass.
+
+Invocation:
+
+```bash
+DB_PATH=backend/books.db python -m scripts.backfill_epubs --delay 1.5
+DB_PATH=backend/books.db python -m scripts.epub_split_audit \
+    --csv /tmp/epub_audit_20260424_postbackfill.csv
+```
+
+## Summary by signal
+
+| Signal | Gate | Flagged |
+|---|---|---|
+| Character ratio | `epub_chars / text_chars < 0.5` | **12** |
+| Paragraph ratio | `epub_paragraphs / text_paragraphs < 0.8` | **15** |
+| Structural speaker-cue collapse | paragraph ≥400 chars with embedded all-caps cue | **17** |
+| **Any signal** | | **30** |
+
+CSV: `/tmp/epub_audit_20260424_postbackfill.csv`.
+
+---
+
+## Category 1: Catastrophic — EPUB splitter returns zero characters
+
+Four non-Japanese books (and eight Japanese — see tail section) produce `0 epub_chars, 0 epub_paragraphs`. The `build_chapters_from_epub` pipeline opens the file, finds nothing it recognizes as a chapter, and returns an empty list. Reader currently falls back to plain-text split for these books, so users see *something*, but the EPUB path that we normally prefer is completely broken.
+
+| book_id | title | text_chars | EPUB chars | Notes |
+|---|---|---:|---:|---|
+| 17161 | **Max und Moritz** (Wilhelm Busch) | 13,635 | 0 | Picture book — verse captions under illustrations. EPUB is mostly image-based. |
+| 66452 | **Die Liebe: Novelle** (Clara Viebig) | 99,410 | 0 | Novella. Worth investigating — no obvious reason. |
+| 22367 | **Die Verwandlung** (Kafka) | 121,106 | 0 | Short novella. This one is surprising and worth priority triage. |
+| 24571 | **Der Struwwelpeter** | 18,644 | 0 | Children's picture book — verse + images. |
+
+**Hypothesis.** Looking at the titles, three of the four (Max und Moritz, Struwwelpeter, and likely Die Verwandlung as packaged on Gutenberg) lean heavily on `<div class="illus">` / `<figure>` markup. Our splitter's chapter detection may be scanning for `<h1>`/`<h2>` heading patterns that aren't present in these simpler EPUB shapes.
+
+**Recommended next step.** File one GitHub `bug` issue *per book*, labelled `bug` + `P1` (user-visible data loss), with: (a) the book_id, (b) the 0-char audit output, (c) a link to the EPUB URL, (d) a step to reproduce by running `epub_split_audit.py --book-id <N>`. The Dev role should pick these up via the standard bug flow. Target is a single splitter fix that covers the whole class, not four one-off patches.
+
+---
+
+## Category 2: Structural speaker-cue collapse (the #820 class)
+
+17 books flagged by the structural detector. The full list, sorted by flag count:
+
+| book_id | title | struct flags | Notes |
+|---|---|---:|---|
+| 49501 | Anzeiger für Kunde der deutschen Vorzeit | **19** | 19th-century periodical — lots of indented quoted speech. |
+| 77700 | Entstehung und Ausbreitung der Alchemie | 18 | Monograph with lots of Latin quotations. |
+| 58804 | Die Deutschen Familiennamen | 9 | Reference book with embedded quotes. |
+| 68400 | Der Marquis de Sade und seine Zeit | 7 | Plus para-ratio 0.77 → also flagged by signal 2. |
+| 62215 | Le Fantôme de l'Opéra | 5 | Front-matter AVANT-PROPOS block collapsed. |
+| 1259 | Twenty years after (Dumas) | 3 | Dialogue-heavy. |
+| 23756 | Geschichte Alexanders des Grossen | 2 | Historical citation blocks. |
+| 15113 | Vie de Jésus (Renan) | 2 | TOC / index block. |
+| 25097 | Cités et ruines américaines | 2 | TOC-like. |
+| 25575 | Mémoires d'Outre-Tombe T.4 | 2 | + char ratio 1.97 (EPUB much bigger than cached text — stale text?). |
+| 76 | Adventures of Huckleberry Finn | 1 | Dialogue. |
+| 3207 | Leviathan | 1 | Legal-style block quotes. |
+| 2229 | **Faust: Der Tragödie erster Teil** | 1 | **Known** #820 — Margarete's confession scene. |
+| 28718 | Les crimes de l'amour | 1 | Footnote-style. |
+| 43759 | Geflügelte Worte | 1 | Quotation reference. |
+| 56156 | Venus im Pelz | 1 | Dialogue. |
+| 6593 | History of Tom Jones, a Foundling | 2 | Dialogue. |
+
+The Faust case (#820) is the canonical bug and is already tracked. For the rest, two structural causes explain most of them:
+
+1. **Verse / dialogue collapse.** Same mechanism as Faust: `<br>` inside `<p>` collapses speaker turns. Shows up in dramatic works (Faust), drama-adjacent novels (Dumas, Fielding), and anything with embedded dialogue.
+2. **TOC / index collapse.** Reference books (#49501, #77700, #58804, #25097, #15113) have long TOC/index entries with embedded newlines and capitalised labels. The speaker-cue regex (`[A-ZÄÖÜ]{2,}[A-ZÄÖÜ ]*\.`) matches some of those as false positives — or real positives if the TOC text gets rendered as one visual block.
+
+**Recommended next step.** One architecture issue titled "EPUB splitter: generalised fix for verse / dialogue / TOC paragraph collapse (superseding #820)". The fix is likely a single change in `backend/services/splitter.py`'s HTML-to-text path: preserve `<br>` as an actual newline, or convert to paragraph splits when the surrounding block is long enough to suggest verse. Architect to file; Dev or Architect to implement.
+
+Whether to treat the reference-book TOC flags as real bugs or as false positives depends on what the actual reading experience looks like. Pull the worst offender (#49501) up in the reader and check. If the book is readable, tighten the regex (require verse-like line-break density); if it's unreadable, treat it as the same class of bug.
+
+---
+
+## Category 3: Paragraph ratio outliers
+
+Interesting-but-not-urgent cases:
+
+| book_id | title | para_ratio | ratio | Takeaway |
+|---|---|---:|---:|---|
+| 3221 | Mr. Honey's Large Business Dictionary | 0.18 | 1.06 | Dictionary. 26 "paragraphs" vs 147 in plain text. Expected for dictionary formatting. Not a bug; tighten the threshold? |
+| 43759 | Geflügelte Worte | **2.10** | 0.86 | EPUB produces *twice* as many paragraphs as the plain-text split. Inverted case — splitter is over-splitting. Worth investigating. |
+| 68400 | Der Marquis de Sade und seine Zeit | 0.77 | 0.96 | Mild paragraph-drop + structural flags. Same root cause as Category 2. |
+| 25575 | Mémoires d'Outre-Tombe T.4 | 1.84 | **1.97** | EPUB *much* larger than cached plain text. The cached `books.text` is probably stale/truncated, not an EPUB issue. Flag the cached text for refresh. |
+| 77700 | Entstehung der Alchemie | 0.60 | 1.50 | Combination of EPUB over-extract and text under-extract. |
+
+---
+
+## Recommended action items
+
+Ordered for impact per hour of work.
+
+1. **File 4 `bug` issues for Category 1 (0-char EPUB extraction).** Each: book_id, audit output, EPUB URL, reproduction step. Prioritise **Kafka #22367** (flagship title, user-visible) and **Max und Moritz #17161** (well-known, will be noticed).
+2. **File 1 `architecture` issue for Category 2** covering the Faust-class regression at scale. Reference this report. Architect writes the design note (probably short — a single change in `backend/services/splitter.py`).
+3. **Run `backfill_epubs.py` to completion** (remaining 31 books) in a quiet period to get full catalog coverage. Then re-run the audit for a final baseline.
+4. **Add the audit to CI as a post-ingestion gate** once Category 1 + 2 are resolved — `epub_split_audit.py --csv` already exits `1` on any flag.
+5. **Flag `Mémoires d'Outre-Tombe T.4 (#25575)` for cached-text refresh** — its cached text is nearly half the size of the EPUB, suggesting truncation at ingest time.
+
+---
+
+## Japanese books (excluded from actionable list per request)
+
+For reference. 8 of the 12 "0-char EPUB" books are Japanese:
+
+| book_id | title | text_chars | EPUB chars |
+|---|---|---:|---:|
+| 37626 | 續惡魔 | 32,264 | 0 |
+| 37605 | 惡魔 | 18,040 | 0 |
+| 2592 | マルチン・ルターの小信仰問答書 | 11,834 | 0 |
+| 38697 | 殉情詩集 | 9,226 | 0 |
+| 39287 | 苦悶の欄 | 70,451 | 0 |
+| 36358 | 火星の記憶 | 34,380 | 0 |
+| 33307 | 友情 | 68,631 | 0 |
+| 1982 | 羅生門 | 6,561 | 0 |
+
+Other Japanese titles in the audit *did* produce characters (e.g. 血笑記 #34013 at ratio 0.77, 腕くらべ #34636 at 1.00), so this is not a blanket CJK problem — it's a specific interaction between our splitter and whatever format the 0-char subset uses. Separate investigation when prioritised.
+
+---
+
+## Artifacts
+
+- `backend/scripts/backfill_epubs.py` — new backfill script.
+- `backend/scripts/epub_split_audit.py` — audit script (#832 / #839).
+- `/tmp/epub_audit_20260424_postbackfill.csv` — full CSV with every flagged row and its structural excerpt.
+- `reports/epub_split_audit_2026_04_24.md` — pre-backfill companion.


### PR DESCRIPTION
## Summary

Packages the operational follow-up to the EPUB split audit (#769 / #832 / #839): a one-off backfill script so the audit has real catalog coverage, plus two reports recording what the audit actually found when run against production data.

No production code path is touched. The backfill script is a diagnostic that lives next to `scripts/epub_split_audit.py`; the reports are documentation.

## What changed

### `backend/scripts/backfill_epubs.py`

Iterates Gutenberg books with no row in `book_epubs`, fetches the no-images EPUB via `services.gutenberg.get_book_epub`, and persists via `save_book_epub`. Throttled at 1.5s/book by default; supports `--dry-run`, `--limit`, `--delay`. Silently skips books where Gutenberg itself has no EPUB (our script does not try to fabricate one).

### `backend/tests/test_backfill_epubs.py`

Seven tests. Mocks `services.gutenberg.get_book_epub` so no network is ever hit.

- Missing-list filter returns only books without a stored EPUB.
- Uploaded books (`source='upload'`) are excluded — the backfill inherits `list_cached_books`'s filter.
- `backfill()` saves when upstream has an EPUB; skips (and counts `missing_upstream`) when it doesn't; counts but continues on per-book errors.
- `--dry-run` fetches + reports sizes but writes nothing.
- `--limit N` caps the processed count.

### Reports

- **`reports/epub_split_audit_2026_04_24.md`** (pre-backfill): 1 book audited, 1 flagged (Faust).
- **`reports/epub_split_audit_2026_04_24_post_backfill.md`** (post-backfill): 91 books audited, **30 flagged**, broken out into:
  1. **Catastrophic (0-char EPUB extraction)** — 4 non-Japanese books. Filed as #887.
  2. **Structural speaker-cue / verse collapse** — 17 books, generalising the Faust #820 regression. Filed as #888.
  3. **Paragraph-ratio outliers** — expected cases (dictionaries, reference books) and one cached-text staleness finding.

Both reports include reproduction commands, artifact paths, and ranked next steps.

## Follow-up issues filed (not blocking this PR)

- #887 — `bug`: EPUB splitter returns 0 chars for Die Verwandlung, Max und Moritz, Die Liebe, Der Struwwelpeter. Hypothesis + repro included.
- #888 — `architecture`: generalised speaker-cue / verse collapse fix (supersedes single-book #820, covers 17 flagged titles).

## Test plan

- [x] 7 new tests in `test_backfill_epubs.py` — all pass.
- [x] Full backend suite: **1452 passed**.
- [x] Script dry-run verified against the production DB copy.
- [x] Reports render correctly in GitHub markdown.

## References

- Audit script: `backend/scripts/epub_split_audit.py` (#832, #839)
- Umbrella issue: #769 (EPUB audit)
- Faust-class bug this surfaces: #820
