### PR TITLE
fix: single-spine EPUB fallback via text splitter (closes #887)

### DIFF
--- a/backend/services/splitter.py
+++ b/backend/services/splitter.py
@@ -669,9 +669,22 @@ def build_chapters_from_epub(epub_bytes: bytes) -> list[Chapter]:
         text = _split_dramatic_speakers(text)
         chapters.append(Chapter(title=_clean_title(title), text=text))
 
-    # EPUB spine is authoritative structure, not a heuristic guess.
-    # Skip the regex-oriented _validate() and just require >= 2 chapters.
-    return chapters if len(chapters) >= 2 else []
+    if len(chapters) >= 2:
+        return chapters
+
+    # Single-spine-item EPUBs (novellas, short story collections) package the
+    # entire text in one HTML file. The spine gives us exactly 1 chapter, which
+    # fails the >= 2 guard above. Apply the keyword/roman-numeral text splitter
+    # on the combined body text so Kapitel/Chapter/Act headings still produce
+    # the correct chapter structure (e.g. Kafka's Die Verwandlung → 3 Kapitel).
+    if chapters:
+        combined = "\n\n".join(c.text for c in chapters)
+        if len(combined.split()) >= 300:
+            sub = build_chapters(combined)
+            if len(sub) >= 2:
+                return sub
+
+    return []
 
 
 _FRONTMATTER_CLASSES = (

--- a/backend/tests/test_splitter.py
+++ b/backend/tests/test_splitter.py
@@ -1313,6 +1313,56 @@ def test_build_chapters_from_epub_returns_empty_on_invalid_bytes():
     assert build_chapters_from_epub(b"") == []
 
 
+def test_build_chapters_from_epub_single_spine_item_with_keyword_chapters():
+    """Single-spine-item EPUBs (e.g. Kafka novellas) must split via text splitter.
+
+    Gutenberg packages some short works as one HTML file with keyword headings
+    (Kapitel I / II / III). The EPUB path used to return [] because its
+    len(chapters) >= 2 guard rejected the single spine item. This verifies the
+    fallback splits the body text and returns the expected chapter count.
+    """
+    import io
+    from ebooklib import epub
+
+    word = "Gregor Samsa erwachte eines Morgens aus unruhigen Träumen"
+    para = f"<p>{word}. " + " ".join(["Ein Wort"] * 40) + ".</p>"
+
+    content = (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<html xmlns="http://www.w3.org/1999/xhtml">'
+        "<head><title>Die Verwandlung</title></head><body>"
+        f"<h2>Kapitel I</h2>{para * 10}"
+        f"<h2>Kapitel II</h2>{para * 10}"
+        f"<h2>Kapitel III</h2>{para * 10}"
+        "</body></html>"
+    )
+
+    book = epub.EpubBook()
+    book.set_title("Die Verwandlung")
+    book.set_language("de")
+    book.add_author("Franz Kafka")
+
+    item = epub.EpubHtml(title="Die Verwandlung", file_name="verwandlung.xhtml", lang="de")
+    item.content = content.encode("utf-8")
+    book.add_item(item)
+
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.toc = [epub.Link("verwandlung.xhtml", "Die Verwandlung", "main")]
+    book.spine = ["nav", item]
+
+    buf = io.BytesIO()
+    epub.write_epub(buf, book)
+
+    chapters = build_chapters_from_epub(buf.getvalue())
+    assert len(chapters) >= 2, (
+        f"Expected >= 2 chapters for single-spine-item EPUB, got {len(chapters)}"
+    )
+    titles = [c.title for c in chapters]
+    assert any("Kapitel" in t or "I" in t for t in titles), f"Chapter titles: {titles}"
+    assert all(len(c.text.split()) >= 10 for c in chapters), "Each chapter must have real content"
+
+
 def test_build_chapters_from_epub_skips_short_items():
     """Items with fewer than 30 words should be skipped (nav/cover pages)."""
     import io


### PR DESCRIPTION
## What changed
`build_chapters_from_epub` in `services/splitter.py` now handles single-spine-item EPUBs. When the spine yields exactly 1 chapter with >= 300 words, the text splitter (`build_chapters`) is applied to recover keyword-based structure (e.g. "Kapitel I / II / III"). If text splitting produces >= 2 chapters, those are returned; otherwise `[]` is returned so callers fall through gracefully.

## Why
Gutenberg packages some short works (Kafka's *Die Verwandlung*, Viebig's *Die Liebe*) as a single HTML file in the EPUB spine. The previous `len(chapters) >= 2` guard returned `[]` for these books, causing the reader to fall back to the plain-text path and misaligning translations/audio-cache against the EPUB chapter layout. Closes #887.

Root cause: the original guard was designed to reject cover+nav-only EPUBs, but over-rejected legitimate single-file novellas.

## Test plan
- New regression test: `test_build_chapters_from_epub_single_spine_item_with_keyword_chapters` — single-spine EPUB with three "Kapitel" headings now produces >= 2 chapters.
- All 1453 backend + 1851 frontend tests pass.
- Picture-book EPUBs (Max und Moritz, Struwwelpeter) that have no substantial text still return `[]` and fall back gracefully to the plain-text path.
