### PR TITLE
ux: raise AuthPromptModal Sign in and Maybe later buttons to 44px touch targets (closes #835)

### DIFF
--- a/frontend/src/__tests__/AuthPromptModalTouchTargets.test.ts
+++ b/frontend/src/__tests__/AuthPromptModalTouchTargets.test.ts
@@ -1,0 +1,23 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/AuthPromptModal.tsx"),
+  "utf8"
+);
+
+describe("AuthPromptModal touch targets (closes #835)", () => {
+  it("Sign in link has min-h-[44px]", () => {
+    const idx = src.indexOf("/api/auth/signin");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 200);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("Maybe later button has min-h-[44px]", () => {
+    const idx = src.indexOf("Maybe later");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 20);
+    expect(window).toContain("min-h-[44px]");
+  });
+});

--- a/frontend/src/components/AuthPromptModal.tsx
+++ b/frontend/src/components/AuthPromptModal.tsx
@@ -27,13 +27,13 @@ export default function AuthPromptModal({ open, feature, onClose }: Props) {
         </p>
         <a
           href="/api/auth/signin"
-          className="block w-full py-3 bg-amber-700 hover:bg-amber-800 text-white text-center rounded-xl font-medium transition-colors"
+          className="flex items-center justify-center w-full min-h-[44px] bg-amber-700 hover:bg-amber-800 text-white text-center rounded-xl font-medium transition-colors"
         >
           Sign in
         </a>
         <button
           onClick={onClose}
-          className="block w-full py-2 text-sm text-stone-500 mt-2 hover:text-stone-700 transition-colors"
+          className="flex items-center justify-center w-full min-h-[44px] text-sm text-stone-500 mt-2 hover:text-stone-700 transition-colors"
         >
           Maybe later
         </button>


### PR DESCRIPTION
Closes #835

The AuthPromptModal Sign in and Maybe later buttons lacked `min-h-[44px]`. Added the class to both buttons with flex alignment.

## Test plan
- [x] `AuthPromptModalTouchTargets.test.ts` passes
- [x] Full frontend suite passes (1853 tests)

🤖 Generated with Claude Code
