### PR TITLE
ux: raise login OAuth buttons, notes Library, and upload CTA to 44px touch targets (closes #836)

### DIFF
--- a/frontend/src/__tests__/LoginNotesUploadTouchTargets.test.ts
+++ b/frontend/src/__tests__/LoginNotesUploadTouchTargets.test.ts
@@ -1,0 +1,52 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const login = fs.readFileSync(
+  path.join(__dirname, "../app/login/page.tsx"),
+  "utf8"
+);
+const notes = fs.readFileSync(
+  path.join(__dirname, "../app/notes/page.tsx"),
+  "utf8"
+);
+const upload = fs.readFileSync(
+  path.join(__dirname, "../app/upload/page.tsx"),
+  "utf8"
+);
+
+describe("Login, Notes, and Upload page touch targets (closes #836)", () => {
+  it("Google sign-in button has min-h-[44px]", () => {
+    const idx = login.indexOf('signIn("google"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = login.slice(idx, idx + 200);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("GitHub sign-in button has min-h-[44px]", () => {
+    const idx = login.indexOf('signIn("github"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = login.slice(idx, idx + 200);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("Apple sign-in button has min-h-[44px]", () => {
+    const idx = login.indexOf('signIn("apple"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = login.slice(idx, idx + 200);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("Notes Library back button has min-h-[44px]", () => {
+    const idx = notes.indexOf("Library");
+    expect(idx).toBeGreaterThan(-1);
+    const window = notes.slice(Math.max(0, idx - 200), idx + 20);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("Upload sign-in CTA button has min-h-[44px]", () => {
+    const idx = upload.indexOf("Sign in to upload");
+    expect(idx).toBeGreaterThan(-1);
+    const window = upload.slice(idx, idx + 400);
+    expect(window).toContain("min-h-[44px]");
+  });
+});

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -28,7 +28,7 @@ function LoginForm() {
           <div className="space-y-3">
             <button
               onClick={() => signIn("google", { callbackUrl })}
-              className="w-full flex items-center justify-center gap-3 bg-white border border-stone-300 text-stone-700 rounded-lg px-4 py-3 text-sm font-medium hover:bg-stone-50 transition-colors shadow-sm"
+              className="w-full flex items-center justify-center gap-3 bg-white border border-stone-300 text-stone-700 rounded-lg px-4 min-h-[44px] text-sm font-medium hover:bg-stone-50 transition-colors shadow-sm"
             >
               <svg width="18" height="18" viewBox="0 0 48 48" aria-hidden="true">
                 <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
@@ -42,7 +42,7 @@ function LoginForm() {
 
             <button
               onClick={() => signIn("github", { callbackUrl })}
-              className="w-full flex items-center justify-center gap-3 bg-stone-800 text-white rounded-lg px-4 py-3 text-sm font-medium hover:bg-stone-900 transition-colors shadow-sm"
+              className="w-full flex items-center justify-center gap-3 bg-stone-800 text-white rounded-lg px-4 min-h-[44px] text-sm font-medium hover:bg-stone-900 transition-colors shadow-sm"
             >
               <svg width="18" height="18" viewBox="0 0 24 24" fill="white" aria-hidden="true">
                 <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
@@ -52,7 +52,7 @@ function LoginForm() {
 
             <button
               onClick={() => signIn("apple", { callbackUrl })}
-              className="w-full flex items-center justify-center gap-3 bg-black text-white rounded-lg px-4 py-3 text-sm font-medium hover:bg-stone-900 transition-colors shadow-sm"
+              className="w-full flex items-center justify-center gap-3 bg-black text-white rounded-lg px-4 min-h-[44px] text-sm font-medium hover:bg-stone-900 transition-colors shadow-sm"
             >
               <svg width="18" height="18" viewBox="0 0 24 24" fill="white" aria-hidden="true">
                 <path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.54 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701"/>

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -104,7 +104,7 @@ export default function NotesOverviewPage() {
         <div className="max-w-3xl mx-auto flex items-center gap-4">
           <button
             onClick={() => router.push("/")}
-            className="text-amber-700 hover:text-amber-900 text-sm font-medium shrink-0"
+            className="text-amber-700 hover:text-amber-900 text-sm font-medium shrink-0 min-h-[44px] flex items-center"
           >
             <ArrowLeftIcon className="w-3.5 h-3.5 mr-1 inline" aria-hidden="true" />Library
           </button>

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -73,7 +73,7 @@ export default function UploadPage() {
           </p>
           <button
             onClick={() => router.push("/login")}
-            className="rounded-lg bg-amber-700 px-6 py-2.5 text-white font-medium hover:bg-amber-800 transition-colors"
+            className="rounded-lg bg-amber-700 px-6 min-h-[44px] flex items-center text-white font-medium hover:bg-amber-800 transition-colors"
           >
             Sign in
           </button>


### PR DESCRIPTION
Closes #836

Login page Google/GitHub OAuth buttons, notes page Library button, and upload page CTA button were all below 44px touch targets. Added `min-h-[44px]` with flex alignment to each.

## Test plan
- [x] `LoginNotesUploadTouchTargets.test.ts` passes
- [x] Full frontend suite passes (1862 tests)

🤖 Generated with Claude Code
