### PR TITLE
fix: extend auto-merge gate to needs-pm-review and needs-user-approval (closes #897)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,7 +8,10 @@ jobs:
   auto-merge:
     name: Enable auto-merge
     runs-on: ubuntu-latest
-    if: "!contains(github.event.pull_request.labels.*.name, 'blocked')"
+    if: >-
+      !contains(github.event.pull_request.labels.*.name, 'blocked') &&
+      !contains(github.event.pull_request.labels.*.name, 'needs-pm-review') &&
+      !contains(github.event.pull_request.labels.*.name, 'needs-user-approval')
     permissions:
       pull-requests: write
       contents: write
@@ -19,10 +22,13 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  disable-auto-merge-if-blocked:
-    name: Disable auto-merge if blocked
+  disable-auto-merge-if-gated:
+    name: Disable auto-merge if gated
     runs-on: ubuntu-latest
-    if: "contains(github.event.pull_request.labels.*.name, 'blocked')"
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'blocked') ||
+      contains(github.event.pull_request.labels.*.name, 'needs-pm-review') ||
+      contains(github.event.pull_request.labels.*.name, 'needs-user-approval')
     permissions:
       pull-requests: write
       contents: write


### PR DESCRIPTION
## What changed
Extended the `auto-merge.yml` workflow gate from only blocking on the `blocked` label to also blocking on `needs-pm-review` and `needs-user-approval`.

- **Enable job** (`auto-merge`): conditions now require the absence of all three gate labels.
- **Disable job** (`disable-auto-merge-if-gated`): triggers on any of the three gate labels being present, and disables auto-merge.

## Why
CLAUDE.md documents `needs-pm-review` and `needs-user-approval` as explicit merge gates for Path B design docs and opt-in PM review. Previously the workflow only enforced the `blocked` gate — a PR labeled `needs-pm-review` or `needs-user-approval` could still auto-merge if CI passed, bypassing the review process.

## Test plan
- [x] Full backend suite (1455 tests) passes
- [x] Frontend suite (1750 tests) passes
- CI: confirm `disable-auto-merge-if-gated` job triggers on labeled events with each gate label
