### PR TITLE
ux: raise InsightChat send, close, expand toggles and save-to-notes to 44px touch targets (closes #847)

### DIFF
--- a/frontend/src/__tests__/InsightChatSendCloseTouchTargets.test.ts
+++ b/frontend/src/__tests__/InsightChatSendCloseTouchTargets.test.ts
@@ -1,0 +1,35 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/InsightChat.tsx"),
+  "utf8"
+);
+
+describe("InsightChat send/close touch targets (closes #847)", () => {
+  it("context-chip close button has min-h-[44px]", () => {
+    const idx = src.indexOf("Remove context");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 20);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("context-chip close button has min-w-[44px]", () => {
+    const idx = src.indexOf("Remove context");
+    const window = src.slice(Math.max(0, idx - 200), idx + 20);
+    expect(window).toContain("min-w-[44px]");
+  });
+
+  it("send button has min-h-[44px]", () => {
+    const idx = src.indexOf("Send (Enter)");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 20);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("send button has min-w-[44px]", () => {
+    const idx = src.indexOf("Send (Enter)");
+    const window = src.slice(Math.max(0, idx - 200), idx + 20);
+    expect(window).toContain("min-w-[44px]");
+  });
+});

--- a/frontend/src/__tests__/InsightChatSendCloseTouchTargets.test.ts
+++ b/frontend/src/__tests__/InsightChatSendCloseTouchTargets.test.ts
@@ -32,4 +32,28 @@ describe("InsightChat send/close touch targets (closes #847)", () => {
     const window = src.slice(Math.max(0, idx - 200), idx + 20);
     expect(window).toContain("min-w-[44px]");
   });
+
+  it("save-to-notes button has min-h-[44px]", () => {
+    // className follows title="Save to notes" — check forward window
+    const idx = src.indexOf('"Save to notes"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 200);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("context-chip expand toggle has min-h-[44px]", () => {
+    // The expand toggle inside the ContextChip sub-component (setExpanded)
+    const idx = src.indexOf('setExpanded((v) => !v)');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 200);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("quoted-text expand toggle has min-h-[44px]", () => {
+    // The expand toggle inside the QuotedContext sub-component (onToggle)
+    const idx = src.indexOf('onClick={onToggle}');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 200);
+    expect(window).toContain("min-h-[44px]");
+  });
 });

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -74,7 +74,7 @@ function ContextChip({
           {needsToggle && (
             <button
               onClick={() => setExpanded((v) => !v)}
-              className="ml-1.5 text-amber-500 hover:text-amber-700 font-medium not-italic"
+              className="ml-1.5 text-amber-500 hover:text-amber-700 font-medium not-italic min-h-[44px] inline-flex items-center"
             >
               {expanded ? "less" : "more"}
             </button>
@@ -448,7 +448,7 @@ export default function InsightChat({
                         onSaveInsight(prevUserMsg.content, msg.content, prevUserMsg.context);
                       }}
                       title={isSaved ? "Already saved" : "Save to notes"}
-                      className={`mt-1.5 flex items-center gap-1 text-[11px] transition-colors ${
+                      className={`mt-1.5 flex items-center gap-1 min-h-[44px] text-[11px] transition-colors ${
                         isSaved
                           ? "text-gray-300 cursor-default"
                           : "text-gray-400 hover:text-amber-700"
@@ -552,7 +552,7 @@ function MsgContextBlock({
         {needsToggle && (
           <button
             onClick={onToggle}
-            className="ml-1.5 text-amber-500 hover:text-amber-700 font-medium not-italic"
+            className="ml-1.5 text-amber-500 hover:text-amber-700 font-medium not-italic min-h-[44px] inline-flex items-center"
           >
             {expanded ? "less" : "more"}
           </button>

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -83,7 +83,7 @@ function ContextChip({
         {onRemove && (
           <button
             onClick={onRemove}
-            className="shrink-0 text-amber-400 hover:text-amber-700"
+            className="shrink-0 text-amber-400 hover:text-amber-700 min-h-[44px] min-w-[44px] flex items-center justify-center"
             title="Remove context"
             aria-label="Remove context"
           >
@@ -517,7 +517,8 @@ export default function InsightChat({
           <button
             onClick={sendMessage}
             disabled={chatLoading || !input.trim() || !hasGeminiKey}
-            className="rounded-xl bg-amber-600 p-2 text-white hover:bg-amber-700 disabled:opacity-40 shrink-0 transition-colors"
+            className="rounded-xl bg-amber-600 p-2 min-h-[44px] min-w-[44px] flex items-center justify-center text-white hover:bg-amber-700 disabled:opacity-40 shrink-0 transition-colors"
+            aria-label="Send message"
             title="Send (Enter)"
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="2">


### PR DESCRIPTION
Closes #847

InsightChat send button, context-chip close button, expand toggles, and save-to-notes button were all below 44px. Added `min-h-[44px]` with `inline-flex items-center` to each.

## Test plan
- [x] `InsightChatSendCloseTouchTargets.test.ts` passes (7 tests)
- [x] Full frontend suite passes (1869 tests)

🤖 Generated with Claude Code
