### PR TITLE
feat: docs site nightly journal workflow (#864 PR C, closes #896)

### DIFF
--- a/.github/workflows/docs-journal.yml
+++ b/.github/workflows/docs-journal.yml
@@ -1,0 +1,67 @@
+name: Docs journal
+
+# Generates a dated 7-section journal stub in docs/journal/daily/ each
+# night and commits it to main. PM fills the hand sections (3, 5, 6) in
+# the next morning's cycle; sections 1, 2, 4, 7 are stubs that future
+# tooling will auto-populate from merged PRs + touched paths.
+#
+# Cadence: 01:07 UTC daily. Off-minute to avoid the midnight burst on
+# GitHub Actions.
+#
+# Manual dispatch is available so PM can backfill a missing day.
+
+on:
+  schedule:
+    - cron: '7 1 * * *'
+  workflow_dispatch:
+    inputs:
+      day:
+        description: 'ISO date to generate (YYYY-MM-DD). Defaults to today.'
+        required: false
+        default: ''
+
+permissions:
+  contents: write  # commit the stub file to main
+
+concurrency:
+  group: docs-journal
+  cancel-in-progress: false
+
+jobs:
+  stub:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Resolve day
+        id: day
+        run: |
+          if [ -n "${{ inputs.day }}" ]; then
+            echo "date=${{ inputs.day }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate journal stub
+        run: |
+          python -m backend.scripts.generate_docs \
+            --journal-day "${{ steps.day.outputs.date }}"
+
+      - name: Commit stub if new
+        # Stub is idempotent — if the file already exists, the generator
+        # prints "leaving in place" and we skip the commit. Guard below
+        # keeps us from pushing empty commits.
+        run: |
+          git config user.name  "book-reader-ai-journal-bot"
+          git config user.email "noreply@github.com"
+          git add docs/journal/daily/ || true
+          if git diff --cached --quiet; then
+            echo "No new stub to commit (file already existed)."
+            exit 0
+          fi
+          git commit -m "chore(journal): stub for ${{ steps.day.outputs.date }}"
+          git push

--- a/backend/scripts/generate_docs.py
+++ b/backend/scripts/generate_docs.py
@@ -378,6 +378,10 @@ def _run_all(repo_root: Path) -> None:
     generate_migration_index(migrations, out_dir / "architecture" / "migrations.md")
 
 
+def _journal_stub_path(repo_root: Path, day: date) -> Path:
+    return repo_root / "docs" / "journal" / "daily" / f"{day.isoformat()}.md"
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Generate auto docs pages.")
     parser.add_argument(
@@ -386,9 +390,30 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Repo root (default: two levels up from this file).",
     )
+    parser.add_argument(
+        "--journal-day",
+        type=str,
+        default=None,
+        help=(
+            "If set, generate ONLY a daily journal stub for the given ISO date "
+            "(YYYY-MM-DD) and exit. Intended for the nightly docs-journal "
+            "workflow. Skips the index generators."
+        ),
+    )
     args = parser.parse_args(argv)
 
     repo_root = args.repo_root or Path(__file__).resolve().parents[2]
+
+    if args.journal_day is not None:
+        day = date.fromisoformat(args.journal_day)
+        out = _journal_stub_path(repo_root, day)
+        if out.exists():
+            print(f"{out} already exists — leaving in place so PM edits are preserved.")
+            return 0
+        generate_daily_journal_stub(day, out)
+        print(f"Wrote journal stub at {out}")
+        return 0
+
     _run_all(repo_root)
     print(f"Generated docs under {repo_root / 'docs'}")
     return 0

--- a/backend/tests/test_generate_docs.py
+++ b/backend/tests/test_generate_docs.py
@@ -275,3 +275,62 @@ def test_main_runs_all_generators_end_to_end(tmp_path, monkeypatch):
     assert (tmp_path / "docs" / "reference" / "reports.md").exists()
     assert (tmp_path / "docs" / "architecture" / "design-index.md").exists()
     assert (tmp_path / "docs" / "architecture" / "migrations.md").exists()
+
+
+# ── --journal-day CLI flag (PR C, #896) ─────────────────────────────────────
+
+
+def test_journal_day_writes_stub_at_expected_path(tmp_path):
+    (tmp_path / "docs").mkdir()
+    rc = generate_docs.main(
+        ["--repo-root", str(tmp_path), "--journal-day", "2026-04-24"]
+    )
+    assert rc == 0
+
+    stub = tmp_path / "docs" / "journal" / "daily" / "2026-04-24.md"
+    assert stub.exists()
+    text = stub.read_text(encoding="utf-8")
+    assert "# 2026-04-24" in text
+    assert "## 1. What shipped" in text
+    assert "## 7. User-facing changelog" in text
+
+
+def test_journal_day_is_idempotent_when_stub_already_exists(tmp_path):
+    # Pre-create the stub with user edits that must be preserved.
+    stub = tmp_path / "docs" / "journal" / "daily" / "2026-04-24.md"
+    stub.parent.mkdir(parents=True)
+    stub.write_text("# Pre-existing\n\nPM already filled section 3.\n", encoding="utf-8")
+
+    rc = generate_docs.main(
+        ["--repo-root", str(tmp_path), "--journal-day", "2026-04-24"]
+    )
+    assert rc == 0
+
+    # File is unchanged — the flag is safe to re-run.
+    assert "PM already filled section 3." in stub.read_text(encoding="utf-8")
+    assert "# Pre-existing" in stub.read_text(encoding="utf-8")
+
+
+def test_journal_day_skips_the_index_generators(tmp_path, monkeypatch):
+    # When --journal-day is set, the index generators must NOT run — otherwise
+    # the nightly job would clobber tracked auto pages on every nightly commit.
+    called = {"count": 0}
+
+    def _boom(*args, **kwargs):
+        called["count"] += 1
+
+    monkeypatch.setattr(generate_docs, "_run_all", _boom)
+
+    (tmp_path / "docs").mkdir()
+    rc = generate_docs.main(
+        ["--repo-root", str(tmp_path), "--journal-day", "2026-04-24"]
+    )
+    assert rc == 0
+    assert called["count"] == 0
+
+
+def test_journal_day_rejects_invalid_date_format(tmp_path):
+    with pytest.raises(ValueError):
+        generate_docs.main(
+            ["--repo-root", str(tmp_path), "--journal-day", "yesterday"]
+        )

--- a/docs/journal/daily/2026-04-22.md
+++ b/docs/journal/daily/2026-04-22.md
@@ -1,0 +1,32 @@
+<!-- THIS PAGE IS AUTO-GENERATED. Edit the source script or report, not this file. Re-run `python -m scripts.generate_docs` after changes. -->
+
+
+# 2026-04-22
+
+## 1. What shipped
+
+_Auto-populated by the nightly workflow from merged PRs grouped by role._
+
+## 2. Reports generated
+
+_Auto-populated from changes in the `reports/` folder._
+
+## 3. Pipeline / workflow lessons
+
+_PM to fill._
+
+## 4. Next things
+
+_Auto-populated from open architecture / feat / bug issues ranked by priority._
+
+## 5. Incidents / near-misses
+
+_PM to fill._
+
+## 6. Decisions and abandoned paths
+
+_PM to fill._
+
+## 7. User-facing changelog
+
+_Auto-drafted from PR titles; PM edits for tone._

--- a/docs/journal/daily/2026-04-23.md
+++ b/docs/journal/daily/2026-04-23.md
@@ -1,0 +1,32 @@
+<!-- THIS PAGE IS AUTO-GENERATED. Edit the source script or report, not this file. Re-run `python -m scripts.generate_docs` after changes. -->
+
+
+# 2026-04-23
+
+## 1. What shipped
+
+_Auto-populated by the nightly workflow from merged PRs grouped by role._
+
+## 2. Reports generated
+
+_Auto-populated from changes in the `reports/` folder._
+
+## 3. Pipeline / workflow lessons
+
+_PM to fill._
+
+## 4. Next things
+
+_Auto-populated from open architecture / feat / bug issues ranked by priority._
+
+## 5. Incidents / near-misses
+
+_PM to fill._
+
+## 6. Decisions and abandoned paths
+
+_PM to fill._
+
+## 7. User-facing changelog
+
+_Auto-drafted from PR titles; PM edits for tone._

--- a/docs/journal/daily/2026-04-24.md
+++ b/docs/journal/daily/2026-04-24.md
@@ -1,0 +1,32 @@
+<!-- THIS PAGE IS AUTO-GENERATED. Edit the source script or report, not this file. Re-run `python -m scripts.generate_docs` after changes. -->
+
+
+# 2026-04-24
+
+## 1. What shipped
+
+_Auto-populated by the nightly workflow from merged PRs grouped by role._
+
+## 2. Reports generated
+
+_Auto-populated from changes in the `reports/` folder._
+
+## 3. Pipeline / workflow lessons
+
+_PM to fill._
+
+## 4. Next things
+
+_Auto-populated from open architecture / feat / bug issues ranked by priority._
+
+## 5. Incidents / near-misses
+
+_PM to fill._
+
+## 6. Decisions and abandoned paths
+
+_PM to fill._
+
+## 7. User-facing changelog
+
+_Auto-drafted from PR titles; PM edits for tone._

--- a/docs/journal/index.md
+++ b/docs/journal/index.md
@@ -2,33 +2,40 @@
 
 A time-ordered record of how Book Reader AI evolves. Captures the "why we built this the way we did" story that commit history alone doesn't tell.
 
-!!! note "Auto-generation coming in PR C"
+## How entries are created
 
-    Daily entries are **not yet auto-generated**. That lands in PR C of the docs-site rollout (#864), which also introduces the nightly `docs-journal.yml` workflow. Until then, this page is a placeholder for the structure described in the [docs site design doc](../design/docs-site.md).
+- **Nightly** at 01:07 UTC the `docs-journal.yml` workflow runs `python -m backend.scripts.generate_docs --journal-day YYYY-MM-DD` and commits the resulting stub to `main`.
+- **Manually** (for backfill) via **Actions → Docs journal → Run workflow** with a specific date.
+- The generator is **idempotent** — if today's stub already exists, the workflow logs "leaving in place" and skips the commit. PM edits to hand sections are never clobbered.
 
-## Entry template (coming)
+## Entry structure
 
-Every daily entry will follow this structure:
+Every daily entry follows the same 7-section template:
 
-1. **What shipped** — merged PRs of the day, grouped by role.
-2. **Reports generated** — audit outputs, benchmarks, deploy reports landed in-repo that day.
-3. **Pipeline / workflow lessons** — chore-class learnings (hand-written).
-4. **Next things** — current unclaimed top-priority issues.
-5. **Incidents / near-misses** — what went wrong and the lesson (hand-written).
-6. **Decisions and abandoned paths** — things we considered and chose *not* to do (hand-written).
-7. **User-facing changelog** — 1–2 lines per shipped feature/fix in plain language.
+1. **What shipped** — merged PRs of the day, grouped by role. *(auto-populated from merged PRs, future tooling)*
+2. **Reports generated** — audit outputs, benchmarks, deploy reports landed in-repo that day. *(auto-populated)*
+3. **Pipeline / workflow lessons** — chore-class learnings. *(hand-written by PM)*
+4. **Next things** — current unclaimed top-priority issues. *(auto-populated)*
+5. **Incidents / near-misses** — what went wrong and the lesson. *(hand-written)*
+6. **Decisions and abandoned paths** — things we considered and chose *not* to do. *(hand-written)*
+7. **User-facing changelog** — 1–2 lines per shipped feature/fix in plain language. *(auto-drafted, hand-edited)*
 
-Sections 1, 2, 4, 7 are auto-derivable from git + `gh issue list` + `review-state.md`. Sections 3, 5, 6 are where human writing earns its keep.
+Sections 1, 2, 4, 7 will become filled automatically as we layer in git-log / issue-list / reports-folder scrapers in follow-ups. Sections 3, 5, 6 are where human writing earns its keep.
 
-## Cadence (coming)
+## Recent entries
 
-- **Daily entry** — auto-generated each night; PM fills the hand sections in the next morning's cycle.
-- **Weekly editorial rollup** — hand-written Sunday post pulling themes from the week's seven daily entries.
+Seeded for validation of the generator; the nightly workflow commits new stubs from 2026-04-25 onward.
 
----
+- [2026-04-24](daily/2026-04-24.md)
+- [2026-04-23](daily/2026-04-23.md)
+- [2026-04-22](daily/2026-04-22.md)
 
-Until the generator lands, the closest thing to a development journal lives at:
+## Weekly editorial rollup
 
-- `product/review-state.md` — PM's rolling cycle-by-cycle state (semi-hand-written).
+Not wired yet — planned as a hand-written Sunday post pulling themes from the week's seven daily entries. Tracked under a future follow-up issue.
+
+## Related
+
+- `product/review-state.md` — PM's rolling cycle-by-cycle state.
 - **[Reports](../reference/reports.md)** — the audit outputs and benchmarks as they land.
 - The repo's `git log` — authoritative change history.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,3 +93,6 @@ nav:
       - Graphic design: development/design-rules.md
   - Journal:
       - Introduction: journal/index.md
+      - '2026-04-24': journal/daily/2026-04-24.md
+      - '2026-04-23': journal/daily/2026-04-23.md
+      - '2026-04-22': journal/daily/2026-04-22.md


### PR DESCRIPTION
## Summary

**PR C of 3** — final piece of the docs-site rollout (#864 user-approved umbrella; design doc `docs/design/docs-site.md` merged #892). Ships the nightly journal-stub workflow plus 3 seeded days' stubs to validate the generator.

PRs A (#900) and B (#912) already shipped the site scaffolding and the index auto-generators. After this PR merges, the full docs site flow works end-to-end: content auto-regenerates on every push and a fresh journal stub commits itself every night.

## What ships

### `backend/scripts/generate_docs.py` — new `--journal-day` CLI flag

Generates a single dated 7-section stub at `docs/journal/daily/<date>.md` and exits. Explicitly **skips** the index generators so the nightly job can't clobber tracked auto pages. **Idempotent** — if the stub already exists, prints `"leaving in place"` and returns 0 so PM edits to hand sections (3, 5, 6) are never overwritten.

### `.github/workflows/docs-journal.yml`

- Cron-driven at 01:07 UTC (off-minute to avoid midnight API burst).
- `workflow_dispatch` with optional `day:` input for backfill via the Actions UI.
- Runs the generator, `git add docs/journal/daily/`, commits only if the index actually changed (`git diff --cached --quiet` guard — no empty commits).
- `concurrency: docs-journal` so overlapping runs don't race.

### `docs/journal/daily/` — 3 seeded stubs

2026-04-22, 2026-04-23, 2026-04-24. Validates the generator end-to-end and gives the Journal nav section something to render today. From 2026-04-25 onward the workflow takes over.

### `docs/journal/index.md`

Rewritten from placeholder to real documentation: how entries are created, the 7-section template with auto-vs-hand labels, a recent-entries list, and a note about the future weekly-editorial rollup.

### `mkdocs.yml`

Three seeded days listed in the Journal nav sub-menu.

## Test plan

- [x] **4 new tests** in `test_generate_docs.py` covering the `--journal-day` flag (writes stub, idempotent on re-run, skips indexes, rejects invalid dates). 20 tests total in the file — all pass.
- [x] Full backend suite: **1476 passed**.
- [x] `mkdocs build --strict` succeeds locally with all 3 seeded stubs in nav.
- [x] Ran `python -m backend.scripts.generate_docs --journal-day 2026-04-24` manually — stub appeared where expected.

## Follow-ups to file after merge

1. **Auto-populate sections 1, 2, 4, 7** from merged PRs / touched paths / open issues / PR titles. Filed as a separate issue once we see how the nightly cadence shakes out.
2. **Weekly editorial rollup** — hand-written Sunday post. Separate workflow + template.
3. **Drift check** (carry-over from PR B) — CI step that runs the 4 index generators and fails on non-empty `git diff docs/`.

## References

- Design doc: `docs/design/docs-site.md` (#892)
- Umbrella: #864 (user-approved)
- Predecessors: #900 (PR A scaffolding), #912 (PR B auto-generators)
- This PR's tracker: #896

Closes #896. Also lands the final PR needed to close #864.
