### PR TITLE
ux: raise notes/[bookId] collapse, delete, back and empty-state buttons to 44px touch targets (closes #849)

### DIFF
--- a/frontend/src/__tests__/NotesBookIdTouchTargets.test.ts
+++ b/frontend/src/__tests__/NotesBookIdTouchTargets.test.ts
@@ -29,4 +29,11 @@ describe("notes/[bookId] page touch targets (closes #849)", () => {
     const window = src.slice(idx, idx + 200);
     expect(window).toContain("min-h-[44px]");
   });
+
+  it("empty-state Open reader button has min-h-[44px]", () => {
+    const idx = src.indexOf("Open reader");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 20);
+    expect(window).toContain("min-h-[44px]");
+  });
 });

--- a/frontend/src/__tests__/NotesBookIdTouchTargets.test.ts
+++ b/frontend/src/__tests__/NotesBookIdTouchTargets.test.ts
@@ -1,0 +1,32 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("notes/[bookId] page touch targets (closes #849)", () => {
+  it("section collapse toggle button has min-h-[44px]", () => {
+    // className comes after onClick in the JSX — check a forward window
+    const idx = src.indexOf("onClick={onToggle}");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 200);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("insight delete button has min-h-[44px]", () => {
+    const idx = src.indexOf("Delete insight");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 300), idx + 20);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("back to Notes header button has min-h-[44px]", () => {
+    // className comes after onClick — check a forward window
+    const idx = src.indexOf('router.push("/notes")');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 200);
+    expect(window).toContain("min-h-[44px]");
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -42,7 +42,7 @@ function CollapseHeading({
   return (
     <button
       onClick={onToggle}
-      className={`w-full flex items-center gap-2 text-left group ${
+      className={`w-full flex items-center gap-2 text-left group min-h-[44px] ${
         level === 2
           ? "mt-8 mb-3 pb-1.5 border-b border-amber-200"
           : "mt-5 mb-2"
@@ -199,7 +199,7 @@ function InsightCard({
         <button
           onClick={onDelete}
           disabled={isDeleting}
-          className="text-red-400 hover:text-red-600 disabled:opacity-40 transition-colors"
+          className="text-red-400 hover:text-red-600 disabled:opacity-40 transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
           title="Delete insight"
           aria-label="Delete insight"
         >
@@ -619,7 +619,7 @@ export default function BookNotesPage() {
         <div className="max-w-3xl mx-auto flex items-center gap-3 flex-wrap">
           <button
             onClick={() => router.push("/notes")}
-            className="text-amber-700 hover:text-amber-900 text-sm font-medium shrink-0"
+            className="text-amber-700 hover:text-amber-900 text-sm font-medium shrink-0 min-h-[44px] flex items-center"
           >
             <ArrowLeftIcon className="w-3.5 h-3.5 mr-1 inline" aria-hidden="true" />Notes
           </button>

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -694,7 +694,7 @@ export default function BookNotesPage() {
             <p className="text-sm">Annotate sentences, save AI insights, or add words to vocabulary while reading.</p>
             <button
               onClick={() => router.push(`/reader/${bookId}`)}
-              className="mt-4 px-5 py-2 rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 inline-flex items-center gap-1"
+              className="mt-4 px-5 py-2 min-h-[44px] rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 inline-flex items-center gap-1"
             >
               Open reader <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
             </button>


### PR DESCRIPTION
Closes #849

The notes page for a specific book had several interactive elements below 44px:
- Collapse/expand toggle button
- Delete note button
- Back button
- Empty-state "Open reader" button

Added `min-h-[44px]` with `flex items-center` to each.

## Test plan
- [x] Static regression tests pass (file-read assertions)
- [x] Full frontend suite passes (1873 tests)

🤖 Generated with Claude Code
