### PR TITLE
fix: add min_length=1 to paragraphs list items in SaveTranslationRequest and ImportTranslationEntry (closes #906)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -588,7 +588,7 @@ class ImportTranslationEntry(BaseModel):
     book_id: int = Field(..., ge=1)
     chapter_index: int = Field(..., ge=0)
     target_language: str = Field(..., min_length=1, max_length=20)
-    paragraphs: list[Annotated[str, Field(max_length=50000)]] = Field(..., max_length=2000)
+    paragraphs: list[Annotated[str, Field(min_length=1, max_length=50000)]] = Field(..., max_length=2000)
     provider: str | None = Field(default=None, max_length=100)
     model: str | None = Field(default=None, max_length=200)
     title_translation: str | None = Field(default=None, max_length=500)

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -270,7 +270,7 @@ class SaveTranslationRequest(BaseModel):
     book_id: int = Field(..., ge=1)
     chapter_index: int = Field(..., ge=0)
     target_language: str = Field(..., min_length=1, max_length=20)
-    paragraphs: list[Annotated[str, Field(max_length=50000)]] = Field(..., max_length=2000)
+    paragraphs: list[Annotated[str, Field(min_length=1, max_length=50000)]] = Field(..., max_length=2000)
     provider: str | None = Field(default=None, max_length=100)
     model: str | None = Field(default=None, max_length=200)
 

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -2366,6 +2366,20 @@ async def test_import_translations_oversized_paragraph_item_returns_422(admin_cl
     )
 
 
+@pytest.mark.asyncio
+async def test_import_translations_empty_paragraph_item_returns_422(admin_client, admin_db):
+    """Regression #906: POST /admin/translations/import with an empty string paragraph item
+    must return 422."""
+    res = await admin_client.post(
+        "/api/admin/translations/import",
+        json={"entries": [{"book_id": 1, "chapter_index": 0,
+                           "target_language": "en", "paragraphs": [""]}]},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for empty paragraph item in import, got {res.status_code}: {res.text}"
+    )
+
+
 # ── Issue #531: QueueSettingsRequest list item bounds ────────────────────────
 
 

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -1163,6 +1163,21 @@ async def test_translate_cache_put_oversized_paragraph_item_returns_422(client, 
     )
 
 
+async def test_translate_cache_put_empty_paragraph_item_returns_422(client, test_user):
+    """Regression #906: PUT /ai/translate/cache with an empty string paragraph must return 422."""
+    await save_book(9826, {"title": "T", "authors": [], "languages": ["de"],
+                           "subjects": [], "download_count": 0, "cover": ""}, "text")
+    resp = await client.put(
+        "/api/ai/translate/cache",
+        json={"book_id": 9826, "chapter_index": 0, "target_language": "fr",
+              "paragraphs": [""]},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for empty paragraph item in PUT /translate/cache, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+
+
 # ── Oversized query param bounds checks (regression for #576) ─────────────────
 
 async def test_translate_cache_get_oversized_target_language_returns_422(client, test_user):


### PR DESCRIPTION
## What changed
Added `min_length=1` to the `paragraphs` list item annotation in two request models:
- `SaveTranslationRequest.paragraphs` (`routers/ai.py:273`)
- `ImportTranslationEntry.paragraphs` (`routers/admin.py:591`)

Both had `Field(max_length=50000)` on items but no lower bound, so empty strings `""` passed Pydantic validation and reached the database layer.

## Why
Same pattern caught in #776 (QueueSettingsRequest) and #786 (books router target_language). Empty paragraph strings in a translation payload are semantically invalid and could produce blank translation rows.

## Test plan
- [x] `test_translate_cache_put_empty_paragraph_item_returns_422` — PUT `/ai/translate/cache` with `paragraphs: [""]` now returns 422
- [x] `test_import_translations_empty_paragraph_item_returns_422` — POST `/admin/translations/import` with `paragraphs: [""]` now returns 422
- [x] Full backend suite: 1474 passed
- [x] Full frontend suite: 1750 passed
