### PR TITLE
feat: CI path-scoped job gates — frontend / backend / docker (#885 Opt 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,30 +7,53 @@ on:
     branches: [main]
 
 jobs:
-  # Detect whether the PR touches code that actually needs CI. If only docs,
-  # design files, CLAUDE.md, product/, or issue templates changed, skip the
-  # heavy test + build jobs. They remain required for the branch protection,
-  # but a skipped `if:` job is reported as success so merges stay unblocked.
+  # Detect whether the PR touches code that actually needs CI, and which
+  # parts of the stack it touches. Each heavy job below gates on one of
+  # the outputs so a frontend-only PR doesn't rerun backend+docker tests
+  # (#885 Opt 2, design doc docs/design/ci-speedup.md). A skipped `if:`
+  # job is reported as success, so merges stay unblocked — branch
+  # protection gets its green check without us burning the wall clock.
+  #
+  # Scoping rules:
+  #   frontend  — anything under frontend/ or the CI workflow itself
+  #   backend   — anything under backend/ or the CI workflow itself
+  #   docker    — Dockerfile, compose, or backend deps (which invalidate
+  #               the image layer cache); also runs on any backend change
+  #               since the Docker image carries the backend code.
+  #
+  # The workflow file intentionally appears in both frontend and backend
+  # so any CI-config change still runs the full matrix — we never want a
+  # workflow edit that breaks CI to skip the very jobs we need to see it.
   changes:
     name: Detect code changes
     runs-on: ubuntu-latest
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      backend:  ${{ steps.filter.outputs.backend }}
+      docker:   ${{ steps.filter.outputs.docker }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
-            code:
-              - 'backend/**'
+            frontend:
               - 'frontend/**'
-              - '.github/workflows/**'
+              - '.github/workflows/ci.yml'
+            backend:
+              - 'backend/**'
+              - '.github/workflows/ci.yml'
+            docker:
+              - 'backend/Dockerfile'
+              - 'docker-compose.yml'
+              - 'backend/requirements.txt'
+              - 'backend/pyproject.toml'
+              - '.github/workflows/ci.yml'
 
   test-frontend:
     name: Frontend tests (Jest)
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -88,7 +111,7 @@ jobs:
   test-e2e:
     name: Frontend E2E (Playwright)
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -175,7 +198,7 @@ jobs:
   test-backend:
     name: Backend tests (pytest)
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -232,7 +255,7 @@ jobs:
     name: Post coverage comment
     needs: [changes, test-frontend, test-backend, test-e2e]
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true' && always()
+    if: github.event_name == 'pull_request' && (needs.changes.outputs.frontend == 'true' || needs.changes.outputs.backend == 'true') && always()
     permissions:
       pull-requests: write
     steps:
@@ -359,7 +382,9 @@ jobs:
   docker-build:
     name: Verify Docker build
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    # Backend code changes also rebuild the image (image carries backend/)
+    # so we OR docker-specific files + backend/**.
+    if: needs.changes.outputs.docker == 'true' || needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,12 @@ jobs:
   test-e2e:
     name: Frontend E2E (Playwright)
     needs: changes
-    if: needs.changes.outputs.frontend == 'true'
+    # E2E tests the full stack — backend-only changes (API contract,
+    # auth, request validation, service logic) can break end-to-end flows
+    # without surfacing in pytest. Skipping E2E on backend changes would
+    # defeat its purpose. Docker-only changes can still skip (Docker is
+    # config, not code paths). Revision requested on #919 by user / PM.
+    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Weekly full-matrix run, Sundays at 03:17 UTC (off-minute). Safety net
+  # for drift the path-scoped PR CI might miss — e.g. backend contract
+  # changes that didn't touch the frontend but break it, or vice versa.
+  # The `changes` job below forces all path outputs to 'true' on schedule
+  # so the full matrix actually runs. (#885 Opt 2 follow-up per user.)
+  schedule:
+    - cron: '17 3 * * 0'
+  workflow_dispatch:
 
 jobs:
   # Detect whether the PR touches code that actually needs CI, and which
@@ -27,14 +35,18 @@ jobs:
   changes:
     name: Detect code changes
     runs-on: ubuntu-latest
+    # On schedule + workflow_dispatch, force all path outputs to 'true' so
+    # the full matrix runs regardless of what the last push touched.
+    # On push/PR events, the filter step drives the outputs normally.
     outputs:
-      frontend: ${{ steps.filter.outputs.frontend }}
-      backend:  ${{ steps.filter.outputs.backend }}
-      docker:   ${{ steps.filter.outputs.docker }}
+      frontend: ${{ steps.filter.outputs.frontend == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+      backend:  ${{ steps.filter.outputs.backend  == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+      docker:   ${{ steps.filter.outputs.docker   == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
         with:
           filters: |
             frontend:
@@ -203,7 +215,13 @@ jobs:
   test-backend:
     name: Backend tests (pytest)
     needs: changes
-    if: needs.changes.outputs.backend == 'true'
+    # Broadened to run on frontend changes too: frontend contract drift
+    # against backend API types is hand-caught today (api.ts is hand-written,
+    # not OpenAPI-generated). Running pytest on frontend-only PRs is cheap
+    # insurance against silently breaking an end-to-end flow through a
+    # backend response-shape mismatch. Revisit this gate if we ever switch
+    # to generated API types. Revision requested by user on #919.
+    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     permissions:
       checks: write


### PR DESCRIPTION
## Summary

**Opt 2 of 4** from the merged CI speedup design doc (`docs/design/ci-speedup.md`, #901). Single-file diff on `.github/workflows/ci.yml`.

Split the single `code` paths-filter output into three path-scoped outputs — `frontend`, `backend`, `docker` — and gate each heavy job on one. Baseline already in place at `reports/ci_baseline_2026_04_24.md` (#914).

## What changed

Before:

```yaml
changes:
  outputs:
    code: ${{ steps.filter.outputs.code }}
  filters: |
    code:
      - 'backend/**'
      - 'frontend/**'
      - '.github/workflows/**'

test-frontend: { if: needs.changes.outputs.code == 'true' }
test-e2e:      { if: needs.changes.outputs.code == 'true' }
test-backend:  { if: needs.changes.outputs.code == 'true' }
verify-docker: { if: needs.changes.outputs.code == 'true' }
```

After:

```yaml
changes:
  outputs:
    frontend: ${{ steps.filter.outputs.frontend }}
    backend:  ${{ steps.filter.outputs.backend }}
    docker:   ${{ steps.filter.outputs.docker }}
  filters: |
    frontend: [ 'frontend/**', '.github/workflows/ci.yml' ]
    backend:  [ 'backend/**',  '.github/workflows/ci.yml' ]
    docker:   [ 'backend/Dockerfile', 'docker-compose.yml',
                'backend/requirements.txt', 'backend/pyproject.toml',
                '.github/workflows/ci.yml' ]

test-frontend: { if: needs.changes.outputs.frontend == 'true' }
test-e2e:      { if: needs.changes.outputs.frontend == 'true' }
test-backend:  { if: needs.changes.outputs.backend  == 'true' }
verify-docker: { if: outputs.docker == 'true' || outputs.backend == 'true' }
coverage-comment: { if: outputs.frontend == 'true' || outputs.backend == 'true' }
```

**Belt-and-braces rule**: the workflow file (`.github/workflows/ci.yml`) is listed in every filter. Any edit to this file runs the full matrix — we never skip the jobs we need to see the workflow itself pass.

## Expected saving

Per the design doc (`docs/design/ci-speedup.md` §Opt 2): ~50 % of PRs today touch only one side of the stack. A frontend-only PR now skips `test-backend` + `verify-docker`; a backend-only PR skips `test-frontend` + `test-e2e`; a docs-/chore-only PR already skipped everything (via #875, the prerequisite).

Baseline (pre-this-PR): **311 s median** for code-touching PRs. Target: **≤ 180 s median** after Opts 1+2+3+5. Opt 2 alone buys the biggest chunk of that.

## Test plan

- [x] YAML parses (checked with `python -c "import yaml; yaml.safe_load(open(...))"`).
- [x] All 5 `needs.changes.outputs.*` references migrated from `code` to the split outputs — `grep -n "outputs\\.code"` returns nothing.
- [x] This PR itself will verify the belt-and-braces rule — touching only `ci.yml`, all three filters fire, so every heavy job runs. If they don't, the guard is broken.

Follow-up verification PRs (separate from this PR):

- Frontend-only change → `test-backend` + `verify-docker` skipped in the Actions log.
- Backend-only change → `test-frontend` + `test-e2e` skipped.
- Docs-only change → all heavy jobs skipped (existing behaviour from #875).

## Rollback

`git revert`. CI reverts to the pre-Opt-2 behaviour (single `code` output). No data / state consequences.

## Post-merge action

Update `reports/ci_baseline_2026_04_24.md` with the new median wall time observed over the next 10 merged code PRs. Tick the success-criteria checkbox if the ≤180 s target is met.

## References

- Design doc: `docs/design/ci-speedup.md` (#901)
- Baseline report: `reports/ci_baseline_2026_04_24.md` (#914)
- Dependency (already landed): #875 (paths-filter fix)
- Tracking issue: #885

## Path B gate

The tracking issue #885 carries a `needs-user-approval` label. Auto-merge is deliberately **not** enabled on this PR so PM / user can review before merge.
