### PR TITLE
feat: Docker build layer cache via GHA (#885 Opt 5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,7 +365,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
       - name: Build backend image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           # Match Railway's default build context (repo root). The Dockerfile
           # at backend/Dockerfile uses COPY backend/... paths because the
@@ -375,3 +375,11 @@ jobs:
           context: .
           file: backend/Dockerfile
           push: false
+          # GitHub Actions cache for Docker layers. type=gha is built in —
+          # no registry config needed — and GHA auto-evicts the cache.
+          # mode=max caches intermediate layers too (not just the final
+          # image), so Python / Node dep layers survive across runs.
+          # Expected saving: 1–2 min on PRs where base deps are unchanged
+          # (the common case). See docs/design/ci-speedup.md §Opt 5, #901.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

**Opt 5 of 4** from the merged CI speedup design doc (`docs/design/ci-speedup.md`, #901). The last self-contained optimization before Opt 4 (sharding) — and per the design, Opt 4 is contingent on whether Opts 1+2+3+5 don't already hit the ≤180 s median target.

Single-file `ci.yml` diff. `docker/build-push-action` upgraded to `v6` and given `cache-from: type=gha` / `cache-to: type=gha,mode=max`.

## What changed

```diff
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: .
           file: backend/Dockerfile
           push: false
+          # GitHub Actions cache for Docker layers.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
```

- **v5 → v6** matches the design doc and is the current stable.
- **`type=gha`** is the built-in GitHub Actions cache. No registry config, no credentials, no manual eviction.
- **`mode=max`** caches intermediate layers, not just the final image. Python + Node dep layers survive across runs.

## Expected saving

Per `docs/design/ci-speedup.md` §Opt 5: **1–2 minutes on PRs where base deps are unchanged** (the common case). `Dockerfile` or `requirements.txt` changes invalidate the affected layer only; everything cheaper downstream still hits the cache.

Stacks cleanly with Opt 2 (#919, path-scoping) and Opt 3 (#921, coverage-skip) — order of landing doesn't matter. Baseline is `reports/ci_baseline_2026_04_24.md` (#914): **311 s median, target ≤ 180 s**.

## Test plan

- [x] YAML parses (`python -c "import yaml; yaml.safe_load(...)"`).
- [x] This PR itself verifies:
  - First run (cold): no cache to pull from; build time ≈ baseline ~5 min. Writes full cache to GHA.
  - Second run on main (warm): pulls cache; should see `CACHED` log lines on the unchanged layers.

## Rollback

`git revert`. Reverts to `docker/build-push-action@v5` without cache. No data / state consequences. GHA auto-evicts unused entries.

## Post-merge action

After ~10 main merges warm the cache, append the new docker-build median to `reports/ci_baseline_2026_04_24.md` and tick the design's success-criterion checkbox if the overall ≤180 s target is met with Opts 1+2+3+5 stacked. If yes, **Opt 4 (sharding) is explicitly deferred** per the design's sequencing rule.

## Path B gate

Tracker #885 carries `needs-user-approval`. Auto-merge **not** enabled on this PR — PM / user please review before merge.

## References

- Design doc: `docs/design/ci-speedup.md` (#901)
- Baseline: `reports/ci_baseline_2026_04_24.md` (#914)
- Siblings in flight: #919 (Opt 2 path-scoping), #921 (Opt 3 coverage-skip)
- Tracking issue: #885
