### PR TITLE
ux: replace hourglass emoji with ClockIcon SVG and raise Sign out to 44px touch target in pending page (closes #852)

### DIFF
--- a/frontend/src/__tests__/PendingPageEmojiTouchTarget.test.ts
+++ b/frontend/src/__tests__/PendingPageEmojiTouchTarget.test.ts
@@ -1,0 +1,32 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const pendingSrc = fs.readFileSync(
+  path.join(__dirname, "../app/pending/page.tsx"),
+  "utf8"
+);
+const iconsSrc = fs.readFileSync(
+  path.join(__dirname, "../components/Icons.tsx"),
+  "utf8"
+);
+
+describe("pending/page.tsx emoji and touch target (closes #852)", () => {
+  it("does not use hourglass emoji", () => {
+    expect(pendingSrc).not.toContain("⏳");
+  });
+
+  it("imports ClockIcon from Icons", () => {
+    expect(pendingSrc).toContain("ClockIcon");
+  });
+
+  it("Sign out button has min-h-[44px]", () => {
+    const idx = pendingSrc.indexOf("Sign out");
+    expect(idx).toBeGreaterThan(-1);
+    const window = pendingSrc.slice(Math.max(0, idx - 200), idx + 20);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("ClockIcon is defined in Icons.tsx", () => {
+    expect(iconsSrc).toContain("export function ClockIcon");
+  });
+});

--- a/frontend/src/app/pending/page.tsx
+++ b/frontend/src/app/pending/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 import { signOut } from "next-auth/react";
+import { ClockIcon } from "@/components/Icons";
 
 export default function PendingApprovalPage() {
   return (
     <div className="min-h-screen bg-parchment flex items-center justify-center px-4">
       <div className="w-full max-w-sm text-center">
-        <div className="text-5xl mb-4">⏳</div>
+        <ClockIcon className="w-16 h-16 text-amber-400 mx-auto mb-4" />
         <h1 className="font-serif text-2xl font-bold text-ink mb-2">Account Pending</h1>
         <p className="text-amber-700 text-sm mb-6">
           Your account is waiting for admin approval. You&apos;ll be able to use the
@@ -13,7 +14,7 @@ export default function PendingApprovalPage() {
         </p>
         <button
           onClick={() => signOut({ callbackUrl: "/login" })}
-          className="text-sm text-red-600 hover:text-red-800"
+          className="text-sm text-red-600 hover:text-red-800 min-h-[44px] flex items-center justify-center mx-auto"
         >
           Sign out
         </button>

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -448,3 +448,12 @@ export function DeckIcon({ className = "w-4 h-4" }: IconProps) {
     </svg>
   );
 }
+
+export function ClockIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 6v6l4 2" />
+    </svg>
+  );
+}


### PR DESCRIPTION
Closes #852

The pending-approval page used a hourglass emoji ⏳ as a UI icon and the Sign out button was below 44px.

- Replaced `⏳` with `ClockIcon` SVG from `Icons.tsx`
- Added `min-h-[44px] flex items-center` to the Sign out button

## Test plan
- [x] `PendingPageEmojiTouchTarget.test.ts` passes (file-read assertions)
- [x] Full frontend suite passes (1879 tests)

🤖 Generated with Claude Code
