### PR TITLE
ux: raise BookDetailModal Start/Continue Reading CTA to 44px touch target (closes #811)

### DIFF
--- a/frontend/src/__tests__/BookDetailModalTouchTarget.test.ts
+++ b/frontend/src/__tests__/BookDetailModalTouchTarget.test.ts
@@ -32,4 +32,11 @@ describe("BookDetailModal touch targets (closes #811)", () => {
     expect(window).not.toMatch(/\bw-8\b/);
     expect(window).not.toMatch(/\bh-8\b/);
   });
+
+  it("Start/Continue Reading CTA button has min-h-[44px]", () => {
+    const idx = src.indexOf("Start Reading");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 300), idx + 20);
+    expect(window).toContain("min-h-[44px]");
+  });
 });

--- a/frontend/src/components/BookDetailModal.tsx
+++ b/frontend/src/components/BookDetailModal.tsx
@@ -119,7 +119,7 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
         {/* Primary CTA */}
         <button
           onClick={onRead}
-          className="w-full rounded-xl bg-amber-700 text-white py-3 text-sm font-medium hover:bg-amber-800 transition-colors"
+          className="w-full rounded-xl bg-amber-700 text-white py-3 min-h-[44px] text-sm font-medium hover:bg-amber-800 transition-colors"
         >
           {recentBook
             ? `Continue Reading — Ch. ${recentBook.lastChapter + 1}`


### PR DESCRIPTION
Closes #811

`BookDetailModal`'s primary CTA button ("Start Reading" / "Continue Reading") was below the 44px touch-target minimum. Added `min-h-[44px]` to the button (it already uses `py-3` which gives ~44px on desktop, but this makes it explicit and safe across all viewports).

## Test plan
- [x] `BookDetailModalTouchTarget.test.ts` — assertion verifying the CTA button has `min-h-[44px]`
- [x] Full frontend suite passes (1933 tests)

🤖 Generated with Claude Code
