### PR TITLE
ux: raise upload/chapters Remove chapter button to 44px touch target (closes #942)

### DIFF
--- a/frontend/src/__tests__/UploadChaptersRemoveTouchTarget.test.ts
+++ b/frontend/src/__tests__/UploadChaptersRemoveTouchTarget.test.ts
@@ -1,0 +1,23 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/upload/[bookId]/chapters/page.tsx"),
+  "utf8"
+);
+
+describe("upload/chapters Remove chapter button touch target (closes #942)", () => {
+  it("Remove chapter button has min-h-[44px]", () => {
+    const idx = src.indexOf('aria-label={`Remove chapter');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 300);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("Remove chapter button has min-w-[44px]", () => {
+    const idx = src.indexOf('aria-label={`Remove chapter');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 300);
+    expect(window).toContain("min-w-[44px]");
+  });
+});

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -173,7 +173,7 @@ export default function ChapterEditorPage() {
                   <button
                     aria-label={`Remove chapter ${i + 1}`}
                     onClick={(e) => { e.stopPropagation(); handleRemove(i); }}
-                    className="shrink-0 p-1 rounded text-stone-300 hover:text-red-500 hover:bg-red-50 transition-colors"
+                    className="shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded text-stone-300 hover:text-red-500 hover:bg-red-50 transition-colors"
                   >
                     <TrashIcon className="w-3.5 h-3.5" />
                   </button>


### PR DESCRIPTION
Closes #942

The Remove chapter button in the upload/chapters editor had a touch target of ~28px (just `p-1`), well below the 44px WCAG 2.5.5 minimum. Added `min-h-[44px] min-w-[44px] flex items-center justify-center` to bring it to spec.

## Changes
- `frontend/src/app/upload/[bookId]/chapters/page.tsx`: Remove chapter button className updated
- `frontend/src/__tests__/UploadChaptersRemoveTouchTarget.test.ts`: 2 regression tests verifying min-h and min-w

## Test plan
- [x] UploadChaptersRemoveTouchTarget.test.ts passes (2 assertions)
- [x] Full frontend suite passes

🤖 Generated with Claude Code
