### PR TITLE
ux: raise reader vocab lemma header and profile avatar buttons to 44px touch targets (closes #944)

### DIFF
--- a/frontend/src/__tests__/ReaderVocabLemmaProfileAvatarTouchTargets.test.ts
+++ b/frontend/src/__tests__/ReaderVocabLemmaProfileAvatarTouchTargets.test.ts
@@ -1,0 +1,55 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const readerSrc = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+const homeSrc = fs.readFileSync(
+  path.join(__dirname, "../app/page.tsx"),
+  "utf8"
+);
+
+describe("reader vocab lemma header button touch target (closes #944)", () => {
+  it("vocab lemma header button has min-h-[44px]", () => {
+    // Find the lemma header button that navigates to /vocabulary
+    const idx = readerSrc.indexOf('router.push(`/vocabulary?word=');
+    expect(idx).toBeGreaterThan(-1);
+    // className comes after onClick in the JSX
+    const window = readerSrc.slice(idx, idx + 300);
+    expect(window).toContain("min-h-[44px]");
+  });
+});
+
+describe("reader profile avatar button touch target (closes #944)", () => {
+  it("reader header profile avatar button has min-w-[44px]", () => {
+    const idx = readerSrc.indexOf('router.push("/profile")');
+    expect(idx).toBeGreaterThan(-1);
+    const window = readerSrc.slice(idx, idx + 300);
+    expect(window).toContain("min-w-[44px]");
+  });
+
+  it("reader header profile avatar button has min-h-[44px]", () => {
+    const idx = readerSrc.indexOf('router.push("/profile")');
+    expect(idx).toBeGreaterThan(-1);
+    const window = readerSrc.slice(idx, idx + 300);
+    expect(window).toContain("min-h-[44px]");
+  });
+});
+
+describe("homepage profile avatar button touch target (closes #944)", () => {
+  it("homepage header profile avatar button has min-w-[44px]", () => {
+    // Find the profile button that navigates to /profile
+    const idx = homeSrc.indexOf('router.push("/profile")');
+    expect(idx).toBeGreaterThan(-1);
+    const window = homeSrc.slice(idx, idx + 300);
+    expect(window).toContain("min-w-[44px]");
+  });
+
+  it("homepage header profile avatar button has min-h-[44px]", () => {
+    const idx = homeSrc.indexOf('router.push("/profile")');
+    expect(idx).toBeGreaterThan(-1);
+    const window = homeSrc.slice(idx, idx + 300);
+    expect(window).toContain("min-h-[44px]");
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -187,7 +187,7 @@ export default function Home() {
                 onClick={() => router.push("/profile")}
                 title={session?.backendUser?.name ?? "Profile & Settings"}
                 aria-label={session?.backendUser?.name ?? "Profile & Settings"}
-                className="w-11 h-11 md:w-9 md:h-9 rounded-full overflow-hidden border border-amber-200 hover:border-amber-400 transition-colors"
+                className="min-w-[44px] min-h-[44px] w-11 h-11 md:w-9 md:h-9 rounded-full overflow-hidden border border-amber-200 hover:border-amber-400 transition-colors"
               >
                 {session?.backendUser?.picture ? (
                   // eslint-disable-next-line @next/next/no-img-element

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1202,7 +1202,7 @@ export default function ReaderPage() {
             <button
               onClick={() => router.push("/profile")}
               title={session.backendUser?.name ?? "Profile"}
-              className="shrink-0 w-10 h-10 md:w-8 md:h-8 rounded-full overflow-hidden border border-amber-300 hover:border-amber-500 transition-colors ml-auto md:ml-0"
+              className="shrink-0 min-w-[44px] min-h-[44px] w-10 h-10 md:w-8 md:h-8 rounded-full overflow-hidden border border-amber-300 hover:border-amber-500 transition-colors ml-auto md:ml-0"
             >
               {session.backendUser?.picture ? (
                 // eslint-disable-next-line @next/next/no-img-element
@@ -1826,7 +1826,7 @@ export default function ReaderPage() {
                               {/* Lemma header */}
                               <button
                                 onClick={() => router.push(`/vocabulary?word=${encodeURIComponent(w.word)}`)}
-                                className="w-full flex items-center justify-between gap-2 px-3 py-2 hover:bg-amber-100 transition-colors text-left"
+                                className="w-full min-h-[44px] flex items-center justify-between gap-2 px-3 py-2 hover:bg-amber-100 transition-colors text-left"
                               >
                                 <span className="text-sm font-semibold text-ink">{lemma}</span>
                                 {isForm && (


### PR DESCRIPTION
Closes #944

Three interactive elements had touch targets below the WCAG 2.5.5 44×44px minimum:

1. **Reader sidebar vocab lemma header button** — `py-2` only (~36px). Added `min-h-[44px]`.
2. **Reader header profile avatar button** — `w-10 h-10 / md:w-8 md:h-8` (40px/32px). Added `min-w-[44px] min-h-[44px]`.
3. **Homepage header profile avatar button** — `w-11 h-11 / md:w-9 md:h-9` (44px/36px). Added `min-w-[44px] min-h-[44px]`.

## Test plan
- [x] ReaderVocabLemmaProfileAvatarTouchTargets.test.ts passes (5 assertions)
- [x] Full frontend suite passes (1940 tests)

🤖 Generated with Claude Code
