### PR TITLE
ux: raise reader annotation list buttons to 44px touch target (closes #946)

### DIFF
--- a/frontend/src/__tests__/ReaderAnnotationListTouchTarget.test.ts
+++ b/frontend/src/__tests__/ReaderAnnotationListTouchTarget.test.ts
@@ -1,0 +1,19 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("reader annotation list button touch target (closes #946)", () => {
+  it("annotation list button has min-h-[44px]", () => {
+    // The annotation list button navigates to a sentence on click.
+    // Find the button containing the annotation sentence display.
+    const idx = src.indexOf("ann.sentence_text}</div>");
+    expect(idx).toBeGreaterThan(-1);
+    // The className is within 400 chars before the content
+    const window = src.slice(Math.max(0, idx - 400), idx + 50);
+    expect(window).toContain("min-h-[44px]");
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2138,7 +2138,7 @@ export default function ReaderPage() {
                         }
                         setNotesExpanded(false);
                       }}
-                      className="w-full text-left px-3 py-2 rounded-lg border border-amber-200 bg-amber-50 text-xs"
+                      className="w-full text-left px-3 py-2 min-h-[44px] flex flex-col justify-center rounded-lg border border-amber-200 bg-amber-50 text-xs"
                     >
                       <div className="text-ink line-clamp-2">{ann.sentence_text}</div>
                       {ann.note_text && (


### PR DESCRIPTION
Closes #946

The annotation list buttons in the reader's notes panel had only `py-2` (8px each side) with `text-xs` content. A single-line annotation snippet renders at ~34px — below the 44×44px WCAG 2.5.5 minimum.

## Changes
- `frontend/src/app/reader/[bookId]/page.tsx`: Added `min-h-[44px] flex flex-col justify-center` to annotation list buttons
- `frontend/src/__tests__/ReaderAnnotationListTouchTarget.test.ts`: Regression test

## Test plan
- [x] ReaderAnnotationListTouchTarget.test.ts passes (1 assertion)
- [x] Full frontend suite passes (1938 tests)

🤖 Generated with Claude Code
