### PR TITLE
ux: add aria-expanded to notes section header and reader vocab chapter toggle buttons (closes #948)

### DIFF
--- a/frontend/src/__tests__/ReaderMiscSmallButtonsTouchTargets.test.ts
+++ b/frontend/src/__tests__/ReaderMiscSmallButtonsTouchTargets.test.ts
@@ -28,7 +28,7 @@ describe("reader miscellaneous small button touch targets (closes #882)", () => 
     const anchor = "Chapter {ch + 1}";
     const idx = src.indexOf(anchor);
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(Math.max(0, idx - 620), idx + 20);
+    const window = src.slice(Math.max(0, idx - 750), idx + 20);
     expect(window).toContain("min-h-[44px]");
   });
 

--- a/frontend/src/__tests__/ReaderNotesChapterTouchTarget.test.ts
+++ b/frontend/src/__tests__/ReaderNotesChapterTouchTarget.test.ts
@@ -10,7 +10,7 @@ describe("Reader notes chapter-section collapse button touch target (closes #831
   it("chapter-section collapse button has min-h-[44px]", () => {
     const idx = src.indexOf("Chapter {ch + 1}");
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(Math.max(0, idx - 600), idx + 50);
+    const window = src.slice(Math.max(0, idx - 750), idx + 50);
     expect(window).toContain("min-h-[44px]");
   });
 

--- a/frontend/src/__tests__/ToggleButtonsAriaExpanded.test.ts
+++ b/frontend/src/__tests__/ToggleButtonsAriaExpanded.test.ts
@@ -1,0 +1,32 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const notesSrc = fs.readFileSync(
+  path.join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf8"
+);
+const readerSrc = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("notes SectionHeader toggle button aria-expanded (closes #948)", () => {
+  it("SectionHeader toggle button has aria-expanded", () => {
+    // Find the SectionHeader toggle button — it's the onClick={onToggle} button
+    const idx = notesSrc.indexOf("onClick={onToggle}");
+    expect(idx).toBeGreaterThan(-1);
+    const window = notesSrc.slice(idx, idx + 300);
+    expect(window).toContain("aria-expanded");
+  });
+});
+
+describe("reader vocab chapter collapse toggle aria-expanded (closes #948)", () => {
+  it("reader vocab chapter collapse button has aria-expanded", () => {
+    // Find the vocab chapter collapse button by its unique class string
+    const idx = readerSrc.indexOf("setCollapsedNoteChapters((prev)");
+    expect(idx).toBeGreaterThan(-1);
+    // aria-expanded should be within 200 chars before the onClick
+    const window = readerSrc.slice(Math.max(0, idx - 300), idx + 50);
+    expect(window).toContain("aria-expanded");
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -42,6 +42,7 @@ function CollapseHeading({
   return (
     <button
       onClick={onToggle}
+      aria-expanded={!isCollapsed}
       className={`w-full flex items-center gap-2 text-left group min-h-[44px] ${
         level === 2
           ? "mt-8 mb-3 pb-1.5 border-b border-amber-200"

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1740,6 +1740,7 @@ export default function ReaderPage() {
                             <div key={ch}>
                               <button
                                 className="flex items-center gap-1 w-full text-left text-xs font-semibold text-stone-400 uppercase tracking-wide min-h-[44px]"
+                                aria-expanded={!isCollapsed}
                                 onClick={() => setCollapsedNoteChapters((prev) => {
                                   const next = new Set(prev);
                                   if (next.has(ch)) next.delete(ch); else next.add(ch);


### PR DESCRIPTION
Closes #948

Two collapse/expand toggle buttons were missing `aria-expanded`, leaving screen readers unable to communicate the current expanded/collapsed state to users.

### 1. Notes page `CollapseHeading` component
- **File:** `frontend/src/app/notes/[bookId]/page.tsx` line ~43
- Used for ALL section headers (annotations, insights, vocab, by-chapter subsections)
- Added `aria-expanded={!isCollapsed}`

### 2. Reader sidebar vocab chapter collapse toggle
- **File:** `frontend/src/app/reader/[bookId]/page.tsx` line ~1742
- Added `aria-expanded={!isCollapsed}`

## Test plan
- [x] ToggleButtonsAriaExpanded.test.ts passes (2 assertions)
- [x] Full frontend suite passes (1943 tests)
- [x] Adjusted window sizes in ReaderMiscSmallButtonsTouchTargets.test.ts and ReaderNotesChapterTouchTarget.test.ts to accommodate the new attribute

🤖 Generated with Claude Code
