### PR TITLE
ux: add aria-label to homepage search input and language select (closes #953)

### DIFF
--- a/frontend/src/__tests__/HomepageSearchAriaLabels.test.ts
+++ b/frontend/src/__tests__/HomepageSearchAriaLabels.test.ts
@@ -1,0 +1,25 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/page.tsx"),
+  "utf8"
+);
+
+describe("homepage search controls aria-label (closes #953)", () => {
+  it("search input has aria-label", () => {
+    const idx = src.indexOf('placeholder="Search by title or author..."');
+    expect(idx).toBeGreaterThan(-1);
+    // aria-label sits before a long className, so look back 350 chars
+    const window = src.slice(Math.max(0, idx - 350), idx + 50);
+    expect(window).toContain('aria-label="Search by title or author"');
+  });
+
+  it("language filter select has aria-label", () => {
+    // Anchor on the select's onChange which is unique; aria-label precedes it
+    const idx = src.indexOf('setLang(e.target.value)');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 300), idx + 10);
+    expect(window).toContain('aria-label="Filter by language"');
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -537,6 +537,7 @@ export default function Home() {
 
               <div className="flex flex-col sm:flex-row gap-2 mb-3">
                 <input
+                  aria-label="Search by title or author"
                   className="flex-1 rounded-lg border border-amber-300 bg-white px-4 py-2.5 font-serif text-ink shadow-sm focus:outline-none focus:ring-2 focus:ring-amber-400 text-base"
                   placeholder="Search by title or author..."
                   value={query}
@@ -545,6 +546,7 @@ export default function Home() {
                 />
                 <div className="flex gap-2">
                   <select
+                    aria-label="Filter by language"
                     className="rounded-lg border border-amber-300 bg-white px-3 py-2.5 text-sm text-ink flex-1 sm:flex-none"
                     value={lang}
                     onChange={(e) => setLang(e.target.value)}


### PR DESCRIPTION
Closes #953

The Gutenberg search section's `<input>` and `<select>` controls had no programmatic label — only placeholder text, which screen readers cannot rely on (WCAG 1.3.1 / 4.1.2).

Adds:
- `aria-label="Search by title or author"` on the search input
- `aria-label="Filter by language"` on the language select

## Test plan
- [x] `HomepageSearchAriaLabels.test.ts` — 2 assertions passing
- [x] Full frontend suite — 1957 tests passing
- [x] Backend suite — 1382 tests passing

🤖 Generated with Claude Code
