### PR TITLE
ux: add aria-label to notes and vocabulary page search inputs (closes #954)

### DIFF
--- a/frontend/src/__tests__/NotesVocabSearchAriaLabels.test.ts
+++ b/frontend/src/__tests__/NotesVocabSearchAriaLabels.test.ts
@@ -1,0 +1,28 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const notesSrc = fs.readFileSync(
+  path.join(__dirname, "../app/notes/page.tsx"),
+  "utf8"
+);
+
+const vocabSrc = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8"
+);
+
+describe("notes and vocabulary page search inputs aria-label (closes #954)", () => {
+  it("notes page search input has aria-label", () => {
+    const idx = notesSrc.indexOf('placeholder="Search books…"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = notesSrc.slice(Math.max(0, idx - 300), idx + 50);
+    expect(window).toContain('aria-label="Search notes by book"');
+  });
+
+  it("vocabulary page search input has aria-label", () => {
+    const idx = vocabSrc.indexOf('placeholder="Search words…"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = vocabSrc.slice(Math.max(0, idx - 300), idx + 50);
+    expect(window).toContain('aria-label="Search vocabulary words"');
+  });
+});

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -130,6 +130,7 @@ export default function NotesOverviewPage() {
       <div className="max-w-3xl mx-auto px-4 md:px-6 py-6 space-y-4">
         {/* Search */}
         <input
+          aria-label="Search notes by book"
           className="w-full rounded-lg border border-amber-300 bg-white px-4 py-2 text-sm text-ink shadow-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
           placeholder="Search books…"
           value={search}

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -464,6 +464,7 @@ function VocabularyPageContent() {
         {words.length > 5 && (
           <div className="mb-6 space-y-3">
             <input
+              aria-label="Search vocabulary words"
               type="search"
               value={search}
               onChange={(e) => setSearch(e.target.value)}


### PR DESCRIPTION
Closes #954

Two search inputs relied on placeholder text alone with no programmatic label (WCAG 1.3.1 / 4.1.2):
- Notes page: `<input placeholder="Search books…">` → adds `aria-label="Search notes by book"`
- Vocabulary page: `<input type="search" placeholder="Search words…">` → adds `aria-label="Search vocabulary words"`

## Test plan
- [x] `NotesVocabSearchAriaLabels.test.ts` — 2 assertions passing
- [x] Full frontend suite — 1952 tests passing
- [x] Backend suite — 1382 tests passing

🤖 Generated with Claude Code
