### PR TITLE
ux: associate profile page form controls with their labels (closes #956)

### DIFF
--- a/frontend/src/__tests__/ProfileFormLabels.test.ts
+++ b/frontend/src/__tests__/ProfileFormLabels.test.ts
@@ -1,0 +1,44 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/profile/page.tsx"),
+  "utf8"
+);
+
+describe("profile page form control label associations (closes #956)", () => {
+  it("Gemini API key input has aria-label", () => {
+    const idx = src.indexOf('placeholder="AIza…"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 50);
+    expect(window).toContain('aria-label="Gemini API key"');
+  });
+
+  it("GitHub Token input is associated via id/htmlFor", () => {
+    const idx = src.indexOf("obsidian-token");
+    expect(idx).toBeGreaterThan(-1);
+    // Both id and htmlFor should reference the same value
+    expect(src).toContain('id="obsidian-token"');
+    expect(src).toContain('htmlFor="obsidian-token"');
+  });
+
+  it("Obsidian Repo input is associated via id/htmlFor", () => {
+    expect(src).toContain('id="obsidian-repo"');
+    expect(src).toContain('htmlFor="obsidian-repo"');
+  });
+
+  it("Vault Path input is associated via id/htmlFor", () => {
+    expect(src).toContain('id="obsidian-path"');
+    expect(src).toContain('htmlFor="obsidian-path"');
+  });
+
+  it("Insight language select is associated via id/htmlFor", () => {
+    expect(src).toContain('id="pref-insight-lang"');
+    expect(src).toContain('htmlFor="pref-insight-lang"');
+  });
+
+  it("Translation language select is associated via id/htmlFor", () => {
+    expect(src).toContain('id="pref-translation-lang"');
+    expect(src).toContain('htmlFor="pref-translation-lang"');
+  });
+});

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -243,6 +243,7 @@ export default function ProfilePage() {
           ) : (
             <div className="space-y-3">
               <input
+                aria-label="Gemini API key"
                 type="password"
                 placeholder="AIza…"
                 value={keyInput}
@@ -293,7 +294,7 @@ export default function ProfilePage() {
             <div className="px-6 pb-6 space-y-4 border-t border-amber-100">
               <div className="pt-4">
                 <div className="flex items-center justify-between mb-1">
-                  <label className="block text-sm font-medium text-ink">
+                  <label htmlFor="obsidian-token" className="block text-sm font-medium text-ink">
                     GitHub Token
                   </label>
                   {hasObsidianToken && (
@@ -313,6 +314,7 @@ export default function ProfilePage() {
                   )}
                 </div>
                 <input
+                  id="obsidian-token"
                   type="password"
                   placeholder={hasObsidianToken ? "Enter new token to replace existing" : "ghp_… (never shown back)"}
                   value={obsidianToken}
@@ -325,10 +327,11 @@ export default function ProfilePage() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-ink mb-1">
+                <label htmlFor="obsidian-repo" className="block text-sm font-medium text-ink mb-1">
                   Obsidian Repo
                 </label>
                 <input
+                  id="obsidian-repo"
                   type="text"
                   placeholder="username/obsidian-notes"
                   value={obsidianRepo}
@@ -338,10 +341,11 @@ export default function ProfilePage() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-ink mb-1">
+                <label htmlFor="obsidian-path" className="block text-sm font-medium text-ink mb-1">
                   Vault Path
                 </label>
                 <input
+                  id="obsidian-path"
                   type="text"
                   placeholder="All Notes/002 Literature Notes/000 Books"
                   value={obsidianPath}
@@ -381,10 +385,11 @@ export default function ProfilePage() {
 
           {/* Insight & chat language */}
           <div>
-            <label className="block text-sm font-medium text-ink mb-1.5">
+            <label htmlFor="pref-insight-lang" className="block text-sm font-medium text-ink mb-1.5">
               Insight &amp; chat language
             </label>
             <select
+              id="pref-insight-lang"
               className="w-full rounded-lg border border-amber-300 px-3 py-2.5 text-sm text-ink bg-white focus:outline-none focus:ring-2 focus:ring-amber-400"
               value={settings.insightLang}
               onChange={(e) => updatePref("insightLang", e.target.value)}
@@ -400,10 +405,11 @@ export default function ProfilePage() {
 
           {/* Translation language */}
           <div>
-            <label className="block text-sm font-medium text-ink mb-1.5">
+            <label htmlFor="pref-translation-lang" className="block text-sm font-medium text-ink mb-1.5">
               Translation language
             </label>
             <select
+              id="pref-translation-lang"
               className="w-full rounded-lg border border-amber-300 px-3 py-2.5 text-sm text-ink bg-white focus:outline-none focus:ring-2 focus:ring-amber-400"
               value={settings.translationLang}
               onChange={(e) => updatePref("translationLang", e.target.value)}


### PR DESCRIPTION
Closes #956

Six form controls had no programmatic label or a sibling `<label>` without `htmlFor`/`id` pairing (WCAG 1.3.1 / 4.1.2):

- **Gemini API key input** — adds `aria-label="Gemini API key"`
- **GitHub Token input** — adds `id="obsidian-token"` + `htmlFor` on label
- **Obsidian Repo input** — adds `id="obsidian-repo"` + `htmlFor` on label
- **Vault Path input** — adds `id="obsidian-path"` + `htmlFor` on label
- **Insight language select** — adds `id="pref-insight-lang"` + `htmlFor` on label
- **Translation language select** — adds `id="pref-translation-lang"` + `htmlFor` on label

Radio groups (TTS voice, translation provider) already use wrapping `<label>` elements — no change needed.

## Test plan
- [x] `ProfileFormLabels.test.ts` — 6 assertions passing
- [x] Full frontend suite — 1958 tests passing
- [x] Backend suite — 1382 tests passing

🤖 Generated with Claude Code
