### PR TITLE
ux: add aria-label to admin/books page form controls (closes #959)

### DIFF
--- a/frontend/src/__tests__/AdminBooksAriaLabels.test.ts
+++ b/frontend/src/__tests__/AdminBooksAriaLabels.test.ts
@@ -1,0 +1,31 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/admin/books/page.tsx"),
+  "utf8"
+);
+
+describe("admin/books page form controls aria-label (closes #959)", () => {
+  it("Gutenberg Book ID import input has aria-label", () => {
+    const idx = src.indexOf('placeholder="Gutenberg Book ID (e.g. 2229)"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 50);
+    expect(window).toContain('aria-label="Gutenberg Book ID to import"');
+  });
+
+  it("translation language select has aria-label", () => {
+    const idx = src.indexOf('title="Pick a language to queue for translation"');
+    expect(idx).toBeGreaterThan(-1);
+    // aria-label sits before a long className, look back 350 chars
+    const window = src.slice(Math.max(0, idx - 350), idx + 60);
+    expect(window).toContain('aria-label="Translation language"');
+  });
+
+  it("chapter move input has aria-label", () => {
+    const idx = src.indexOf('placeholder="→Ch"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 50);
+    expect(window).toContain('aria-label="Move to chapter number"');
+  });
+});

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -227,6 +227,7 @@ export default function BooksPage() {
 
       <div className="flex gap-2">
         <input
+          aria-label="Gutenberg Book ID to import"
           placeholder="Gutenberg Book ID (e.g. 2229)"
           value={importId}
           onChange={(e) => setImportId(e.target.value)}
@@ -373,6 +374,7 @@ export default function BooksPage() {
                 </button>
 
                 <select
+                  aria-label="Translation language"
                   value={newLangInput[b.id] ?? "zh"}
                   onChange={(e) => setNewLangInput({ ...newLangInput, [b.id]: e.target.value })}
                   className="text-xs rounded border border-amber-300 px-1.5 py-0.5 shrink-0 bg-white"
@@ -506,6 +508,7 @@ export default function BooksPage() {
                                               realignment cases where paragraphs are
                                               correct but the chapter_index is wrong. */}
                                           <input
+                                            aria-label="Move to chapter number"
                                             type="number"
                                             min={1}
                                             placeholder="→Ch"


### PR DESCRIPTION
Closes #959

Three inputs in the admin books page lacked programmatic labels (WCAG 1.3.1 / 4.1.2):
- **Gutenberg Book ID import input** — adds `aria-label="Gutenberg Book ID to import"`
- **Translation language select** — adds `aria-label="Translation language"` (keeps existing `title` as tooltip)
- **Chapter move input** — adds `aria-label="Move to chapter number"` (replaces cryptic `→Ch` placeholder as the accessible label)

## Test plan
- [x] `AdminBooksAriaLabels.test.ts` — 3 assertions passing
- [x] Full frontend suite — 1961 tests passing

🤖 Generated with Claude Code
