### PR TITLE
ux: add aria-label to QueueTab dry-run language select and custom model input (closes #961)

### DIFF
--- a/frontend/src/__tests__/QueueTabAriaLabels.test.ts
+++ b/frontend/src/__tests__/QueueTabAriaLabels.test.ts
@@ -1,0 +1,24 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/QueueTab.tsx"),
+  "utf8"
+);
+
+describe("QueueTab form controls aria-label (closes #961)", () => {
+  it("dry-run language select has aria-label", () => {
+    // value={dryRunLang} appears on the select element; aria-label is just before it
+    const idx = src.indexOf('value={dryRunLang}');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 50);
+    expect(window).toContain('aria-label="Preview language"');
+  });
+
+  it("custom model input has aria-label", () => {
+    const idx = src.indexOf('placeholder="Custom model (e.g. gemini-exp-1206)"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 50);
+    expect(window).toContain('aria-label="Custom model name"');
+  });
+});

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -659,6 +659,7 @@ export default function QueueTab({ adminFetch }: Props) {
         <h3 className="font-medium text-ink text-sm">Preview &amp; plan</h3>
         <div className="flex gap-2 items-center">
           <select
+            aria-label="Preview language"
             value={dryRunLang}
             onChange={(e) => { setDryRunLang(e.target.value); setDryRunResult(null); setPlanResult(null); }}
             className="rounded border border-amber-300 px-2 py-1 text-sm bg-white"
@@ -1061,6 +1062,7 @@ export default function QueueTab({ adminFetch }: Props) {
               </div>
               <div className="mt-2 flex gap-2">
                 <input
+                  aria-label="Custom model name"
                   value={customModel}
                   onChange={(e) => setCustomModel(e.target.value)}
                   placeholder="Custom model (e.g. gemini-exp-1206)"


### PR DESCRIPTION
Closes #961

Two form controls in `QueueTab.tsx` lacked programmatic labels (WCAG 1.3.1 / 4.1.2):
- **Dry-run language select** — adds `aria-label="Preview language"`
- **Custom model input** — adds `aria-label="Custom model name"` (placeholder alone is insufficient per WCAG 1.3.5)

## Test plan
- [x] `QueueTabAriaLabels.test.ts` — 2 assertions passing
- [x] Full frontend suite — 1963 tests passing

🤖 Generated with Claude Code
