### PR TITLE
ux: add aria-label to reader page chapter-nav and translation selects (closes #969)

### DIFF
--- a/frontend/e2e/mobile-reader.spec.ts
+++ b/frontend/e2e/mobile-reader.spec.ts
@@ -48,7 +48,7 @@ test.describe("Mobile reader bottom bar", () => {
   });
 
   test("translation button toggles on with single tap and off with second tap", async ({ page }) => {
-    const translateBtn = page.getByLabel("Translation");
+    const translateBtn = page.getByRole("button", { name: "Translation" });
     await translateBtn.click();
     // Options panel (Inline / Side by side) should appear
     await expect(page.getByText("Inline")).toBeVisible({ timeout: 3000 });

--- a/frontend/src/__tests__/ReaderSelectAriaLabels.test.ts
+++ b/frontend/src/__tests__/ReaderSelectAriaLabels.test.ts
@@ -1,0 +1,40 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("reader page select elements aria-label (closes #969)", () => {
+  it("desktop chapter navigation select has aria-label", () => {
+    // The desktop chapter nav select sits near goToChapter — find the first occurrence
+    const idx = src.indexOf("goToChapter(Number(e.target.value))");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 450), idx + 50);
+    expect(window).toContain('aria-label="Go to chapter"');
+  });
+
+  it("translation sidebar target language select has id for label association", () => {
+    const idx = src.indexOf('"reader-trans-lang"');
+    expect(idx).toBeGreaterThan(-1);
+  });
+
+  it("mobile translation expand panel select has aria-label", () => {
+    // The mobile expand panel select has translateExpanded context and setTranslationLang
+    const idx = src.indexOf("translateExpanded && translationEnabled");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 600);
+    expect(window).toContain('aria-label="Translation language"');
+  });
+
+  it("mobile chapter navigation select has aria-label", () => {
+    // The mobile chapter nav select is the second goToChapter occurrence
+    const first = src.indexOf("goToChapter(Number(e.target.value))");
+    expect(first).toBeGreaterThan(-1);
+    const idx = src.indexOf("goToChapter(Number(e.target.value))", first + 1);
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 450), idx + 50);
+    expect(window).toContain('aria-label="Go to chapter"');
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -961,6 +961,7 @@ export default function ReaderPage() {
                 </button>
                 <div className="relative">
                   <select
+                    aria-label="Go to chapter"
                     className="appearance-none text-xs rounded-lg border border-amber-300 pl-2.5 pr-7 py-1.5 text-ink bg-white max-w-[160px] cursor-pointer hover:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-300 focus:border-amber-400 transition-colors"
                     value={chapterIndex}
                     onChange={(e) => goToChapter(Number(e.target.value))}
@@ -1885,8 +1886,9 @@ export default function ReaderPage() {
 
                     {/* Language selector */}
                     <div className="mb-4">
-                      <label className="block text-xs text-amber-700 mb-1">Target language</label>
+                      <label htmlFor="reader-trans-lang" className="block text-xs text-amber-700 mb-1">Target language</label>
                       <select
+                        id="reader-trans-lang"
                         className="w-full text-sm rounded-lg border border-amber-300 px-3 py-2 text-ink bg-white"
                         value={translationLang}
                         onChange={(e) => {
@@ -2090,6 +2092,7 @@ export default function ReaderPage() {
           {translateExpanded && translationEnabled && (
             <div className="bg-white/95 backdrop-blur border-t border-amber-200 px-3 py-2 flex items-center gap-2 animate-slide-up">
               <select
+                aria-label="Translation language"
                 className="text-xs rounded border border-amber-300 px-2 py-2 text-ink bg-white flex-1 min-h-[44px]"
                 value={translationLang}
                 onChange={(e) => setTranslationLang(e.target.value)}
@@ -2187,6 +2190,7 @@ export default function ReaderPage() {
 
             <div className="relative flex-1 min-w-0 max-w-[110px]">
               <select
+                aria-label="Go to chapter"
                 className="appearance-none h-11 w-full text-xs rounded-lg border border-amber-200 pl-2 pr-6 text-amber-700 bg-white truncate cursor-pointer focus:outline-none focus:ring-2 focus:ring-amber-300 transition-colors"
                 value={chapterIndex}
                 onChange={(e) => goToChapter(Number(e.target.value))}


### PR DESCRIPTION
Closes #969

Four `<select>` elements in the reader page lacked programmatic labels (WCAG 1.3.1 / 4.1.2):
- **Desktop chapter nav select** — adds `aria-label="Go to chapter"`
- **Translation sidebar language select** — adds `htmlFor="reader-trans-lang"` on the label and `id="reader-trans-lang"` on the select (programmatic association)
- **Mobile translation expand panel select** — adds `aria-label="Translation language"`
- **Mobile chapter nav select** — adds `aria-label="Go to chapter"`

## Test plan
- [x] `ReaderSelectAriaLabels.test.ts` — 4 assertions passing
- [x] Full frontend suite — 1967 tests passing

🤖 Generated with Claude Code
