### PR TITLE
fix: use CJK-aware token count in EPUB word-count thresholds (closes #966)

### DIFF
--- a/backend/services/splitter.py
+++ b/backend/services/splitter.py
@@ -648,7 +648,7 @@ def build_chapters_from_epub(epub_bytes: bytes) -> list[Chapter]:
         except Exception:
             continue
 
-        if not text.strip() or len(text.split()) < 30:
+        if not text.strip() or _token_count(text) < 30:
             continue
 
         title = (
@@ -679,7 +679,7 @@ def build_chapters_from_epub(epub_bytes: bytes) -> list[Chapter]:
     # the correct chapter structure (e.g. Kafka's Die Verwandlung → 3 Kapitel).
     if chapters:
         combined = "\n\n".join(c.text for c in chapters)
-        if len(combined.split()) >= 300:
+        if _token_count(combined) >= 300:
             sub = build_chapters(combined)
             if len(sub) >= 2:
                 return sub
@@ -709,6 +709,37 @@ def _epub_frontmatter_blocks(body) -> list:
         if any(c in _FRONTMATTER_CLASSES for c in classes):
             out.append(elem)
     return out
+
+
+# Unicode ranges that cover CJK ideographs, Hiragana, Katakana, and Hangul.
+# Used by _token_count to decide whether to estimate word count from
+# characters rather than whitespace-delimited tokens.
+_CJK_RANGES = (
+    (0x3040, 0x30FF),   # Hiragana + Katakana
+    (0x3400, 0x4DBF),   # CJK Extension A
+    (0x4E00, 0x9FFF),   # CJK Unified Ideographs
+    (0xAC00, 0xD7AF),   # Hangul Syllables
+)
+
+
+def _token_count(text: str) -> int:
+    """Estimate word / token count in a language-aware way.
+
+    CJK scripts (Chinese, Japanese, Korean) have no whitespace word
+    boundaries, so ``len(text.split())`` returns a near-1 count even for
+    full-length chapters.  Sample the first 500 characters; if more than
+    30 % are in a CJK Unicode block, approximate word count as
+    ``len(text) // 3`` (≈ 1 word per 3 CJK characters).
+    """
+    if not text:
+        return 0
+    sample = text[:500]
+    cjk_chars = sum(
+        1 for c in sample if any(lo <= ord(c) <= hi for lo, hi in _CJK_RANGES)
+    )
+    if cjk_chars > len(sample) * 0.3:
+        return len(text) // 3
+    return len(text.split())
 
 
 def _normalize_for_title_match(s: str) -> str:

--- a/backend/tests/test_splitter.py
+++ b/backend/tests/test_splitter.py
@@ -1600,3 +1600,83 @@ def test_build_chapters_from_epub_single_chapter_short_story():
     )
     assert chapters[0].title == "Rashomon"
     assert "Rashomon gate" in chapters[0].text
+
+
+# --- #966 regression: CJK word-count ---
+
+def test_token_count_english():
+    from services.splitter import _token_count
+    assert _token_count("Hello world foo bar baz") == 5
+    assert _token_count("") == 0
+    assert _token_count("   ") == 0
+
+
+def test_token_count_cjk_uses_char_estimate():
+    from services.splitter import _token_count
+    # A paragraph of Japanese text has no spaces — split() returns 1 token,
+    # but _token_count should estimate ~len/3.
+    ja_text = "あの男は羅生門の下に雨やみを待っていた。" * 20  # ~420 chars
+    result = _token_count(ja_text)
+    # Should be >> 1 (not the raw split() count) and ≈ len/3
+    assert result > 30, f"CJK token_count too low: {result}"
+    assert result == len(ja_text) // 3
+
+
+def test_build_chapters_from_epub_cjk_chapters_not_discarded():
+    """Regression #966: multi-chapter CJK EPUBs must not return [].
+
+    The 30-word whitespace-split threshold discarded every Japanese spine
+    item because 'text.split()' on CJK text produces near-1 tokens even
+    for full-length chapters. _token_count() falls back to len(text)//3
+    for CJK-dominant text, so the chapters are accepted."""
+    import io
+    from ebooklib import epub
+
+    ja_sentence = "あの男は羅生門の下で雨やみを待っていた。老婆が梯子を上った。"
+    # Each chapter body: 8 paragraphs × 5 copies of the sentence
+    body_text = ja_sentence * 5
+
+    scenes = [
+        ("第一章", body_text),
+        ("第二章", body_text),
+        ("第三章", body_text),
+    ]
+
+    epub_book = epub.EpubBook()
+    epub_book.set_title("羅生門")
+    epub_book.set_language("ja")
+    epub_book.add_author("芥川龍之介")
+
+    spine = ["nav"]
+    toc = []
+    for i, (title, body) in enumerate(scenes):
+        uid = f"ch{i+1:02d}"
+        fname = f"{uid}.xhtml"
+        content = (
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<html xmlns="http://www.w3.org/1999/xhtml">'
+            f"<head><title>{title}</title></head><body>"
+            f"<h2>{title}</h2>"
+            + "".join(f"<p>{body}</p>" for _ in range(6))
+            + "</body></html>"
+        )
+        item = epub.EpubHtml(title=title, file_name=fname, lang="ja")
+        item.content = content.encode("utf-8")
+        epub_book.add_item(item)
+        spine.append(item)
+        toc.append(epub.Link(fname, title, uid))
+
+    epub_book.toc = toc
+    epub_book.add_item(epub.EpubNcx())
+    epub_book.add_item(epub.EpubNav())
+    epub_book.spine = spine
+
+    buf = io.BytesIO()
+    epub.write_epub(buf, epub_book)
+    chapters = build_chapters_from_epub(buf.getvalue())
+
+    assert len(chapters) == 3, (
+        f"Expected 3 chapters for CJK EPUB, got {len(chapters)} — "
+        f"CJK word-count threshold may be discarding valid chapters"
+    )
+    assert "羅生門" in chapters[0].text or "老婆" in chapters[0].text


### PR DESCRIPTION
## What changed

CJK (Chinese, Japanese, Korean) text has no whitespace word boundaries, so `len(text.split())` returns near-1 even for full-length chapters. The EPUB splitter used this count in two threshold checks:

1. **30-word minimum** (spine item filter) — every Japanese chapter was discarded, producing an empty chapter list for 8+ Japanese books in the catalog.
2. **300-word sub-split gate** (single-spine fallback) — CJK single-spine EPUBs never triggered the keyword-based sub-splitter, even when the content was long enough.

## Fix

Added `_token_count(text: str) -> int`:
- Samples the first 500 characters of the text.
- If >30% are in a CJK Unicode block (Hiragana, Katakana, CJK Unified Ideographs, Hangul), returns `len(text) // 3` as a word-count proxy (≈ 1 word per 3 CJK characters).
- Otherwise falls back to `len(text.split())`.

Replaced both threshold checks in `build_chapters_from_epub` with `_token_count`.

## Test plan

- [x] `test_token_count_english` — verifies `_token_count` returns correct word count for English text.
- [x] `test_token_count_cjk_uses_char_estimate` — verifies CJK-dominant text returns `len(text) // 3`.
- [x] `test_build_chapters_from_epub_cjk_chapters_not_discarded` — creates a 3-chapter Japanese EPUB and asserts all 3 chapters are returned (was returning 0 before fix).
- [x] Full backend suite: 1486 tests pass, 0 failures.

Closes #966
