### PR TITLE
fix: enforce ISO-date pattern on SmartRules saved_after/saved_before (closes #979)

### DIFF
--- a/backend/routers/decks.py
+++ b/backend/routers/decks.py
@@ -31,8 +31,8 @@ class SmartRules(BaseModel):
     book_ids: list[Annotated[int, Field(ge=1)]] | None = Field(default=None, max_length=200)
     tags_any: list[Annotated[str, Field(min_length=1, max_length=50)]] | None = Field(default=None, max_length=100)
     tags_all: list[Annotated[str, Field(min_length=1, max_length=50)]] | None = Field(default=None, max_length=100)
-    saved_after: str | None = Field(default=None, max_length=10)
-    saved_before: str | None = Field(default=None, max_length=10)
+    saved_after: str | None = Field(default=None, pattern=r'^\d{4}-\d{2}-\d{2}$')
+    saved_before: str | None = Field(default=None, pattern=r'^\d{4}-\d{2}-\d{2}$')
 
     model_config = {"extra": "forbid"}
 

--- a/backend/tests/test_router_decks.py
+++ b/backend/tests/test_router_decks.py
@@ -325,3 +325,46 @@ async def test_smart_rules_empty_tag_in_tags_all_returns_422(client, test_user):
     assert resp.status_code == 422, (
         f"Expected 422 for empty tag in tags_all, got {resp.status_code}: {resp.text}"
     )
+
+
+# ── Issue #979: ISO-date format enforcement on saved_after/saved_before ────────
+
+
+async def test_smart_rules_invalid_saved_after_returns_422(client, test_user):
+    """Regression #979: SmartRules.saved_after with a non-ISO date must be rejected with 422.
+
+    SQLite's date('not-date') evaluates to NULL, so a bad date silently returns
+    zero members instead of raising an error."""
+    resp = await client.post(
+        "/api/decks",
+        json={"name": "BadDate", "mode": "smart", "rules_json": {"saved_after": "not-date!"}},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for non-ISO saved_after, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_smart_rules_invalid_saved_before_returns_422(client, test_user):
+    """Regression #979: SmartRules.saved_before with a non-ISO date must be rejected with 422."""
+    resp = await client.post(
+        "/api/decks",
+        json={"name": "BadDate2", "mode": "smart", "rules_json": {"saved_before": "2024/01/01"}},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for non-ISO saved_before, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_smart_rules_valid_iso_dates_accepted(client, test_user):
+    """Regression #979: valid YYYY-MM-DD dates in saved_after/saved_before must be accepted."""
+    resp = await client.post(
+        "/api/decks",
+        json={
+            "name": "GoodDate",
+            "mode": "smart",
+            "rules_json": {"saved_after": "2024-01-01", "saved_before": "2025-12-31"},
+        },
+    )
+    assert resp.status_code == 201, (
+        f"Expected 201 for valid ISO dates, got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## What changed

`SmartRules.saved_after` and `saved_before` accepted any string ≤10 characters (e.g. `"not-date!"`, `"2024/01/01"`) with no format enforcement. SQLite's `date()` function silently returns `NULL` for non-ISO strings, causing smart-deck member queries to match zero rows and return an empty deck — no error, just wrong data.

Added `pattern=r'^\d{4}-\d{2}-\d{2}$'` to both fields so Pydantic rejects malformed date strings with a 422 before they reach the DB layer.

## Why

`date("not-date")` → `NULL` in SQLite → the `saved_after`/`saved_before` filter silently drops all members. Users see an empty deck with no feedback.

## Test plan

- `test_smart_rules_invalid_saved_after_returns_422` — rejects `"not-date!"`
- `test_smart_rules_invalid_saved_before_returns_422` — rejects `"2024/01/01"` (slash-separated)
- `test_smart_rules_valid_iso_dates_accepted` — confirms `"2024-01-01"` / `"2025-12-31"` still accepted (201)

Closes #979
