### PR TITLE
ux: replace InsightChat inline SVGs with Icons.tsx components (closes #983)

### DIFF
--- a/frontend/src/__tests__/InsightChatIconSystem.test.ts
+++ b/frontend/src/__tests__/InsightChatIconSystem.test.ts
@@ -1,0 +1,45 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const chat = fs.readFileSync(
+  path.join(__dirname, "../components/InsightChat.tsx"),
+  "utf8"
+);
+const icons = fs.readFileSync(
+  path.join(__dirname, "../components/Icons.tsx"),
+  "utf8"
+);
+
+describe("InsightChat icon system compliance (closes #983)", () => {
+  it("send button uses ArrowUpIcon from Icons.tsx, not inline SVG", () => {
+    // The send button (aria-label="Send message") must use ArrowUpIcon
+    const sendBtnIdx = chat.indexOf('aria-label="Send message"');
+    expect(sendBtnIdx).toBeGreaterThan(-1);
+    const window = chat.slice(sendBtnIdx, sendBtnIdx + 200);
+    expect(window).toContain("ArrowUpIcon");
+    expect(window).not.toContain("<svg");
+  });
+
+  it("save-to-notes button uses BookmarkIcon from Icons.tsx, not inline SVG", () => {
+    // Anchor on the JSX text node (second occurrence, the ternary for display)
+    const first = chat.indexOf('"Save to notes"');
+    expect(first).toBeGreaterThan(-1);
+    const saveIdx = chat.indexOf('"Save to notes"', first + 1);
+    expect(saveIdx).toBeGreaterThan(-1);
+    // BookmarkIcon appears just before the text node in the JSX
+    const window = chat.slice(Math.max(0, saveIdx - 200), saveIdx + 50);
+    expect(window).toContain("BookmarkIcon");
+    expect(window).not.toContain("<svg");
+  });
+
+  it("ArrowUpIcon is exported from Icons.tsx", () => {
+    expect(icons).toContain("export function ArrowUpIcon");
+  });
+
+  it("BookmarkIcon in Icons.tsx accepts a fill prop", () => {
+    const idx = icons.indexOf("export function BookmarkIcon");
+    expect(idx).toBeGreaterThan(-1);
+    const window = icons.slice(idx, idx + 150);
+    expect(window).toContain("fill");
+  });
+});

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -83,9 +83,9 @@ export function GlobeIcon({ className = "w-4 h-4" }: IconProps) {
   );
 }
 
-export function BookmarkIcon({ className = "w-4 h-4" }: IconProps) {
+export function BookmarkIcon({ className = "w-4 h-4", fill = "none" }: IconProps & { fill?: string }) {
   return (
-    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <svg className={className} viewBox="0 0 24 24" fill={fill} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
       <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/>
     </svg>
   );
@@ -454,6 +454,14 @@ export function ClockIcon({ className = "w-4 h-4" }: IconProps) {
     <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
       <circle cx="12" cy="12" r="9" />
       <path d="M12 6v6l4 2" />
+    </svg>
+  );
+}
+
+export function ArrowUpIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M12 19V5m0 0l-7 7m7-7l7 7" />
     </svg>
   );
 }

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -7,7 +7,7 @@ import {
   askQuestion,
 } from "@/lib/api";
 import { getSettings, saveSettings } from "@/lib/settings";
-import { PaperclipIcon, CloseIcon, RetryIcon } from "@/components/Icons";
+import { PaperclipIcon, CloseIcon, RetryIcon, BookmarkIcon, ArrowUpIcon } from "@/components/Icons";
 
 export const LANGUAGES = [
   { code: "en", label: "English" },
@@ -454,9 +454,7 @@ export default function InsightChat({
                           : "text-gray-400 hover:text-amber-700"
                       }`}
                     >
-                      <svg className="w-3 h-3" fill={isSaved ? "currentColor" : "none"} stroke="currentColor" viewBox="0 0 24 24" strokeWidth="2">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-                      </svg>
+                      <BookmarkIcon className="w-3 h-3" fill={isSaved ? "currentColor" : "none"} />
                       {isSaved ? "Saved" : "Save to notes"}
                     </button>
                   );
@@ -521,9 +519,7 @@ export default function InsightChat({
             aria-label="Send message"
             title="Send (Enter)"
           >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="2">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 19V5m0 0l-7 7m7-7l7 7" />
-            </svg>
+            <ArrowUpIcon className="w-4 h-4" />
           </button>
         </div>
         <p className="text-[11px] text-gray-400 mt-1">Enter to send · Shift+Enter for newline</p>


### PR DESCRIPTION
Closes #983

Two interactive buttons in `InsightChat.tsx` used raw `<svg>` elements instead of the shared icon system, violating CLAUDE.md's rule ("All interactive icons must come from `@/components/Icons.tsx`").

## Changes

- **`Icons.tsx`**: Add `ArrowUpIcon` (send/up arrow); update `BookmarkIcon` to accept an optional `fill` prop (default `"none"`, preserving all existing callers)
- **`InsightChat.tsx`**: Replace send-button inline SVG with `ArrowUpIcon`; replace save-to-notes button inline SVG with `BookmarkIcon` (fill toggles on save state)
- The decorative AI avatar circle at line 415 is non-interactive and exempt from the rule

## Test plan
- [x] `InsightChatIconSystem.test.ts` — 4 assertions: ArrowUpIcon exported, BookmarkIcon accepts fill, both buttons use Icons.tsx not inline SVG
- [x] Full frontend suite — 1973 tests passing
- [x] Full backend suite — 1382 tests passing

🤖 Generated with Claude Code
