### PR TITLE
feat: declared FKs on word_occurrences + translation_queue (#754 PR 4/4, closes #843)

### DIFF
--- a/backend/migrations/034_fk_word_occurrences_translation_queue.sql
+++ b/backend/migrations/034_fk_word_occurrences_translation_queue.sql
@@ -1,0 +1,121 @@
+-- Issue #754 / #843 / design doc: docs/design/declared-fks-schema.md
+-- PR 4 of 4 (final): declare REFERENCES books(id) ON DELETE CASCADE on
+-- word_occurrences(book_id) and translation_queue(book_id). Closes out
+-- the declared-FK hardening series started in #700.
+--
+-- word_occurrences already has a declared FK on vocabulary_id (migration 014);
+-- we preserve that and add the books FK alongside.
+--
+-- translation_queue.queued_by is free-form TEXT (admin email or NULL,
+-- migration 009) — not a user_id reference — so no users FK is needed.
+--
+-- Same pattern as #851 / #858 / #975: orphan DELETE first (mandatory
+-- per CLAUDE.md migration policy), then table rewrite, then recreate
+-- indexes. Runner context: PRAGMA foreign_keys = OFF during migrations,
+-- so the INSERT … SELECT step doesn't trigger the new FKs.
+
+
+-- ── Orphan cleanup (mandatory per policy) ────────────────────────────────
+
+DELETE FROM word_occurrences  WHERE book_id NOT IN (SELECT id FROM books);
+DELETE FROM translation_queue WHERE book_id NOT IN (SELECT id FROM books);
+
+
+-- ── word_occurrences: rewrite with declared FKs on vocabulary_id + book_id
+-- Column order preserved so INSERT … SELECT works:
+--   id, vocabulary_id, book_id, chapter_index, sentence_text, created_at
+-- (No ALTERs since 014.)
+
+CREATE TABLE word_occurrences_new (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    vocabulary_id  INTEGER NOT NULL REFERENCES vocabulary(id) ON DELETE CASCADE,
+    book_id        INTEGER NOT NULL REFERENCES books(id)      ON DELETE CASCADE,
+    chapter_index  INTEGER NOT NULL,
+    sentence_text  TEXT    NOT NULL,
+    created_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Explicit column list (not SELECT *) for the same reason as migration 033:
+-- bootstrap-created DBs may lack `created_at` on legacy schemas; the
+-- explicit list lets the DEFAULT apply.
+INSERT INTO word_occurrences_new
+    (id, vocabulary_id, book_id, chapter_index, sentence_text, created_at)
+SELECT id, vocabulary_id, book_id, chapter_index, sentence_text, created_at
+FROM word_occurrences;
+
+DROP TABLE word_occurrences;
+
+ALTER TABLE word_occurrences_new RENAME TO word_occurrences;
+
+-- Recreate the UNIQUE index from migration 015, dropped with the table.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_word_occurrences
+    ON word_occurrences (vocabulary_id, book_id, chapter_index, sentence_text);
+
+-- FTS5 content triggers from migration 026 were dropped along with the old
+-- word_occurrences table — SQLite ties triggers to their source table and
+-- DROP TABLE removes them. Recreate so the word_occurrences_fts external
+-- content index stays synchronised with INSERT/UPDATE/DELETE on the
+-- renamed table, and rebuild the inverted index so already-saved
+-- occurrences stay searchable after the rewrite.
+DROP TRIGGER IF EXISTS word_occ_ai;
+DROP TRIGGER IF EXISTS word_occ_ad;
+DROP TRIGGER IF EXISTS word_occ_au;
+
+CREATE TRIGGER word_occ_ai AFTER INSERT ON word_occurrences BEGIN
+    INSERT INTO word_occurrences_fts(rowid, sentence_text)
+    VALUES (new.id, new.sentence_text);
+END;
+CREATE TRIGGER word_occ_ad BEFORE DELETE ON word_occurrences BEGIN
+    INSERT INTO word_occurrences_fts(word_occurrences_fts, rowid, sentence_text)
+    VALUES ('delete', old.id, old.sentence_text);
+END;
+CREATE TRIGGER word_occ_au AFTER UPDATE ON word_occurrences BEGIN
+    INSERT INTO word_occurrences_fts(word_occurrences_fts, rowid, sentence_text)
+    VALUES ('delete', old.id, old.sentence_text);
+    INSERT INTO word_occurrences_fts(rowid, sentence_text)
+    VALUES (new.id, new.sentence_text);
+END;
+
+-- Rebuild the inverted index from current rows. (The index holds entries
+-- for the OLD rowids from before the rewrite.)
+INSERT INTO word_occurrences_fts(word_occurrences_fts) VALUES ('rebuild');
+
+
+-- ── translation_queue: rewrite with declared FK on book_id ───────────────
+-- Column order after migration 009 (queued_by appended):
+--   id, book_id, chapter_index, target_language, status, priority,
+--   attempts, last_error, created_at, updated_at, queued_by
+-- UNIQUE (book_id, chapter_index, target_language) is inline and preserved.
+
+CREATE TABLE translation_queue_new (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    book_id           INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    chapter_index     INTEGER NOT NULL,
+    target_language   TEXT    NOT NULL,
+    status            TEXT    NOT NULL DEFAULT 'pending',
+    priority          INTEGER NOT NULL DEFAULT 100,
+    attempts          INTEGER NOT NULL DEFAULT 0,
+    last_error        TEXT,
+    created_at        TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at        TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    queued_by         TEXT,
+    UNIQUE (book_id, chapter_index, target_language)
+);
+
+INSERT INTO translation_queue_new
+    (id, book_id, chapter_index, target_language, status, priority,
+     attempts, last_error, created_at, updated_at, queued_by)
+SELECT id, book_id, chapter_index, target_language, status, priority,
+       attempts, last_error, created_at, updated_at, queued_by
+FROM translation_queue;
+
+DROP TABLE translation_queue;
+
+ALTER TABLE translation_queue_new RENAME TO translation_queue;
+
+-- Recreate the index helpers from migration 008, dropped with the table.
+CREATE INDEX IF NOT EXISTS idx_queue_status_priority
+    ON translation_queue(status, priority, id);
+
+CREATE INDEX IF NOT EXISTS idx_queue_book
+    ON translation_queue(book_id, target_language);

--- a/backend/tests/test_db_extended.py
+++ b/backend/tests/test_db_extended.py
@@ -50,7 +50,7 @@ async def tmp_db(monkeypatch, tmp_path):
         await db.executemany(
             "INSERT OR IGNORE INTO books (id, title, images, source) "
             "VALUES (?, 'T', '[]', 'upload')",
-            [(i,) for i in (1, 2, 3, 5, 6, 7)],
+            [(i,) for i in (1, 2, 3, 5, 6, 7, 42, 99)],
         )
         await db.commit()
 

--- a/backend/tests/test_migrations_034.py
+++ b/backend/tests/test_migrations_034.py
@@ -1,0 +1,256 @@
+"""Tests for migration 034 (declared FKs on word_occurrences + translation_queue).
+
+Split into its own file because the shared `tmp_db` fixture in
+`test_migrations.py` is the integration point for every earlier migration
+test; adding migration-specific assertions there keeps per-PR test runs
+readable. The fixture here is a minimal copy of the one used elsewhere.
+"""
+
+import os
+import pytest
+import aiosqlite
+
+from services.migrations import run as run_migrations
+
+
+@pytest.fixture
+async def tmp_db(tmp_path):
+    path = str(tmp_path / "migration-034-test.db")
+    return path
+
+
+async def test_migration_034_cleans_orphan_word_occurrences_and_queue(tmp_db):
+    """Seed rows pointing at missing books, re-run migration 034, confirm the
+    pre-rewrite orphan DELETEs wiped them so the subsequent INSERT INTO _new
+    SELECT … does not violate the new FK."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute("PRAGMA foreign_keys = OFF")
+        await db.execute(
+            "INSERT INTO users (id, google_id, email, name, picture) "
+            "VALUES (1, 'g1', 'a@b.com', 'A', '')"
+        )
+        await db.execute("INSERT INTO books (id, title, images) VALUES (1400, 'Book', '[]')")
+        await db.execute(
+            "INSERT INTO vocabulary (user_id, word, language) VALUES (1, 'Hund', 'de')"
+        )
+        async with db.execute("SELECT id FROM vocabulary WHERE word='Hund'") as cur:
+            vocab_id = (await cur.fetchone())[0]
+
+        # Valid parent — these rows should survive.
+        await db.execute(
+            "INSERT INTO word_occurrences (vocabulary_id, book_id, chapter_index, sentence_text) "
+            "VALUES (?, 1400, 0, 'sample')",
+            (vocab_id,),
+        )
+        await db.execute(
+            "INSERT INTO translation_queue (book_id, chapter_index, target_language, status) "
+            "VALUES (1400, 0, 'de', 'pending')"
+        )
+        # Orphan rows — bogus book ids.
+        await db.execute(
+            "INSERT INTO word_occurrences (vocabulary_id, book_id, chapter_index, sentence_text) "
+            "VALUES (?, 9993, 0, 'orphan')",
+            (vocab_id,),
+        )
+        await db.execute(
+            "INSERT INTO translation_queue (book_id, chapter_index, target_language, status) "
+            "VALUES (9994, 0, 'en', 'pending')"
+        )
+        await db.execute(
+            "DELETE FROM schema_migrations WHERE version = '034_fk_word_occurrences_translation_queue'"
+        )
+        await db.commit()
+
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute(
+            "SELECT book_id FROM word_occurrences ORDER BY book_id"
+        ) as cur:
+            rows = [r[0] for r in await cur.fetchall()]
+        assert rows == [1400], f"only valid word_occurrence should survive; got {rows}"
+
+        async with db.execute(
+            "SELECT book_id FROM translation_queue ORDER BY book_id"
+        ) as cur:
+            rows = [r[0] for r in await cur.fetchall()]
+        assert rows == [1400], f"only valid queue row should survive; got {rows}"
+
+
+async def test_migration_034_word_occurrences_carries_both_fks(tmp_db):
+    """word_occurrences keeps its vocabulary_id FK (migration 014) and gains
+    the books FK."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute("PRAGMA foreign_key_list(word_occurrences)") as cur:
+            fks = await cur.fetchall()
+
+    fk_map = {(row[2], row[3]): (row[4], row[5], row[6]) for row in fks}
+    assert ("vocabulary", "vocabulary_id") in fk_map, f"missing vocabulary FK: {fk_map}"
+    assert ("books", "book_id") in fk_map, f"missing books FK: {fk_map}"
+    assert fk_map[("vocabulary", "vocabulary_id")][2] == "CASCADE"
+    assert fk_map[("books", "book_id")][2] == "CASCADE"
+
+
+async def test_migration_034_translation_queue_carries_declared_fk(tmp_db):
+    """translation_queue gets REFERENCES books(id) ON DELETE CASCADE."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute("PRAGMA foreign_key_list(translation_queue)") as cur:
+            fks = await cur.fetchall()
+
+    fk_map = {(row[2], row[3]): (row[4], row[5], row[6]) for row in fks}
+    assert ("books", "book_id") in fk_map, f"missing books FK: {fk_map}"
+    assert fk_map[("books", "book_id")][2] == "CASCADE"
+
+
+async def test_migration_034_preserves_existing_rows(tmp_db):
+    """INSERT … SELECT must round-trip every column including the
+    migration-009 appended queued_by on translation_queue."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute("PRAGMA foreign_keys = OFF")
+        await db.execute(
+            "INSERT INTO users (id, google_id, email, name, picture) "
+            "VALUES (2, 'g2', 'b@b.com', 'B', '')"
+        )
+        await db.execute("INSERT INTO books (id, title, images) VALUES (1500, 'T', '[]')")
+        await db.execute(
+            "INSERT INTO vocabulary (user_id, word, language) VALUES (2, 'Haus', 'de')"
+        )
+        async with db.execute("SELECT id FROM vocabulary WHERE word='Haus'") as cur:
+            vocab_id = (await cur.fetchone())[0]
+
+        await db.execute(
+            "INSERT INTO word_occurrences "
+            "(id, vocabulary_id, book_id, chapter_index, sentence_text) "
+            "VALUES (500, ?, 1500, 3, 'Ein Haus')",
+            (vocab_id,),
+        )
+        await db.execute(
+            "INSERT INTO translation_queue "
+            "(id, book_id, chapter_index, target_language, status, priority, "
+            "attempts, last_error, queued_by) VALUES "
+            "(500, 1500, 3, 'de', 'done', 5, 1, NULL, 'admin@example.com')"
+        )
+        await db.execute(
+            "DELETE FROM schema_migrations WHERE version = '034_fk_word_occurrences_translation_queue'"
+        )
+        await db.commit()
+
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute(
+            "SELECT vocabulary_id, book_id, chapter_index, sentence_text "
+            "FROM word_occurrences WHERE id = 500"
+        ) as cur:
+            row = await cur.fetchone()
+        assert row == (vocab_id, 1500, 3, "Ein Haus")
+
+        async with db.execute(
+            "SELECT book_id, chapter_index, target_language, status, priority, "
+            "attempts, queued_by FROM translation_queue WHERE id = 500"
+        ) as cur:
+            row = await cur.fetchone()
+        assert row == (1500, 3, "de", "done", 5, 1, "admin@example.com")
+
+
+async def test_migration_034_preserves_unique_constraints(tmp_db):
+    """The UNIQUE index on word_occurrences (migration 015) and the UNIQUE
+    constraint on translation_queue (migration 008) must survive the rewrite."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute("PRAGMA foreign_keys = OFF")
+        await db.execute(
+            "INSERT INTO users (id, google_id, email, name, picture) "
+            "VALUES (3, 'g3', 'c@b.com', 'C', '')"
+        )
+        await db.execute("INSERT INTO books (id, title, images) VALUES (1600, 'T', '[]')")
+        await db.execute(
+            "INSERT INTO vocabulary (user_id, word, language) VALUES (3, 'Katze', 'de')"
+        )
+        async with db.execute("SELECT id FROM vocabulary WHERE word='Katze'") as cur:
+            vocab_id = (await cur.fetchone())[0]
+
+        await db.execute(
+            "INSERT INTO word_occurrences "
+            "(vocabulary_id, book_id, chapter_index, sentence_text) "
+            "VALUES (?, 1600, 0, 'Eine Katze')",
+            (vocab_id,),
+        )
+        await db.commit()
+
+        with pytest.raises(aiosqlite.IntegrityError):
+            await db.execute(
+                "INSERT INTO word_occurrences "
+                "(vocabulary_id, book_id, chapter_index, sentence_text) "
+                "VALUES (?, 1600, 0, 'Eine Katze')",
+                (vocab_id,),
+            )
+            await db.commit()
+
+        await db.execute(
+            "INSERT INTO translation_queue "
+            "(book_id, chapter_index, target_language, status) "
+            "VALUES (1600, 0, 'zh', 'pending')"
+        )
+        await db.commit()
+
+        with pytest.raises(aiosqlite.IntegrityError):
+            await db.execute(
+                "INSERT INTO translation_queue "
+                "(book_id, chapter_index, target_language, status) "
+                "VALUES (1600, 0, 'zh', 'running')"
+            )
+            await db.commit()
+
+
+async def test_migration_034_cascade_deletes_on_book_delete(tmp_db):
+    """DELETE FROM books must cascade to word_occurrences and translation_queue
+    via the new book_id FKs."""
+    await run_migrations(tmp_db)
+
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute("PRAGMA foreign_keys = ON")
+        await db.execute(
+            "INSERT INTO users (id, google_id, email, name, picture) "
+            "VALUES (4, 'g4', 'd@b.com', 'D', '')"
+        )
+        await db.execute("INSERT INTO books (id, title, images) VALUES (1700, 'T', '[]')")
+        await db.execute(
+            "INSERT INTO vocabulary (user_id, word, language) VALUES (4, 'Buch', 'de')"
+        )
+        async with db.execute("SELECT id FROM vocabulary WHERE word='Buch'") as cur:
+            vocab_id = (await cur.fetchone())[0]
+
+        await db.execute(
+            "INSERT INTO word_occurrences "
+            "(vocabulary_id, book_id, chapter_index, sentence_text) "
+            "VALUES (?, 1700, 0, 'Ein Buch')",
+            (vocab_id,),
+        )
+        await db.execute(
+            "INSERT INTO translation_queue "
+            "(book_id, chapter_index, target_language, status) "
+            "VALUES (1700, 0, 'en', 'pending')"
+        )
+        await db.commit()
+
+        await db.execute("DELETE FROM books WHERE id = 1700")
+        await db.commit()
+
+        async with db.execute(
+            "SELECT COUNT(*) FROM word_occurrences WHERE book_id = 1700"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 0
+        async with db.execute(
+            "SELECT COUNT(*) FROM translation_queue WHERE book_id = 1700"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 0

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -1271,6 +1271,7 @@ async def test_delete_running_queue_item_returns_409(admin_client, admin_db):
     Without this guard the queue row is removed but the worker continues
     writing the translation, so the admin's cancellation intent is silently ignored.
     """
+    await _seed_book(999)
     async with aiosqlite.connect(admin_db) as db:
         cursor = await db.execute(
             """INSERT INTO translation_queue
@@ -1299,6 +1300,7 @@ async def test_retry_running_item_returns_409(admin_client, admin_db):
     'running', _mark_done() will DELETE the newly-re-enqueued row when the
     translation finishes — the retry is silently lost.
     """
+    await _seed_book(999)
     async with aiosqlite.connect(admin_db) as db:
         cursor = await db.execute(
             """INSERT INTO translation_queue
@@ -1360,8 +1362,17 @@ async def test_enqueue_draft_book_returns_400(admin_client, admin_db):
 # ── Retry-failed bulk endpoint ───────────────────────────────────────────────
 
 async def _seed_failed(book_id: int, chapter_index: int, target_language: str):
-    """Helper: insert a failed queue row for retry-failed tests."""
+    """Helper: insert a failed queue row for retry-failed tests.
+
+    translation_queue.book_id carries a declared FK to books(id) (migration
+    034, #754 PR 4/4), so seed the parent book first with source='upload'
+    (keeps it out of list_cached_books counts)."""
     async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        await conn.execute(
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (?, 'T', '[]', 'upload')",
+            (book_id,),
+        )
         await conn.execute(
             """INSERT INTO translation_queue
                    (book_id, chapter_index, target_language, priority,
@@ -1999,6 +2010,7 @@ async def test_queue_retry_item_sql_guard_prevents_running_reset(admin_client, a
     import aiosqlite as _real_aio
     import routers.admin as admin_mod
 
+    await _seed_book(1)
     async with aiosqlite.connect(admin_db) as db:
         cursor = await db.execute(
             """INSERT INTO translation_queue
@@ -2037,6 +2049,7 @@ async def test_queue_delete_item_sql_guard_prevents_running_delete(admin_client,
     import aiosqlite as _real_aio
     import routers.admin as admin_mod
 
+    await _seed_book(1)
     async with aiosqlite.connect(admin_db) as db:
         cursor = await db.execute(
             """INSERT INTO translation_queue

--- a/backend/tests/test_router_admin_extended.py
+++ b/backend/tests/test_router_admin_extended.py
@@ -94,6 +94,14 @@ async def admin_client(admin_user):
 
 async def _insert_queue_row(db_path, book_id, chapter_index, lang, status="pending"):
     async with aiosqlite.connect(db_path) as conn:
+        # translation_queue.book_id carries a declared FK to books(id)
+        # (migration 034, #754 PR 4/4); pre-seed the parent book with
+        # source='upload' to keep it out of list_cached_books counts.
+        await conn.execute(
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (?, 'T', '[]', 'upload')",
+            (book_id,),
+        )
         await conn.execute(
             """INSERT INTO translation_queue
                    (book_id, chapter_index, target_language, priority, status)

--- a/backend/tests/test_router_search.py
+++ b/backend/tests/test_router_search.py
@@ -45,6 +45,12 @@ async def _seed_annotation(db, user_id: int, book_id: int, chapter_index: int,
 
 async def _seed_vocab_occurrence(db, user_id: int, word: str, book_id: int,
                                  chapter_index: int, sentence: str):
+    # Migration 034 added a declared FK word_occurrences.book_id → books(id);
+    # seed the parent book first so fabricated ids don't violate it.
+    await db.execute(
+        "INSERT OR IGNORE INTO books (id, title, images) VALUES (?, 'T', '[]')",
+        (book_id,),
+    )
     cur = await db.execute(
         "INSERT INTO vocabulary (user_id, word, lemma, language) VALUES (?, ?, ?, 'en')",
         (user_id, word, word),

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -800,6 +800,17 @@ async def test_save_word_returns_dict_when_row_is_none(tmp_db, test_user, monkey
     re-SELECT returns None (concurrent-delete race between INSERT and re-SELECT)."""
     import aiosqlite as _aio
 
+    # word_occurrences.book_id carries a declared FK to books(id) (migration
+    # 034, #754 PR 4/4); seed the parent so save_word's occurrence INSERT
+    # doesn't FK-fail.
+    async with _aio.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (?, 'T', '[]', 'upload')",
+            (BOOK_ID,),
+        )
+        await db.commit()
+
     original_fetchone = _aio.Cursor.fetchone
     select_star_count = {"n": 0}
 

--- a/backend/tests/test_translation_queue.py
+++ b/backend/tests/test_translation_queue.py
@@ -67,6 +67,12 @@ async def test_migration_creates_queue_tables(tmp_db):
 
 async def test_enqueue_idempotent(tmp_db):
     """Duplicate enqueue() calls for the same (book, chapter, lang) don't stack."""
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (1, 'T', '[]', 'gutenberg')"
+        )
+        await db.commit()
     await enqueue(1, 0, "zh")
     await enqueue(1, 0, "zh")
     await enqueue(1, 0, "de")
@@ -130,11 +136,24 @@ async def test_queued_by_tracks_attribution(tmp_db):
 
 
 async def test_list_queue_includes_book_title(tmp_db):
-    """Queue items must carry the book title so the admin UI can identify rows."""
+    """Queue items must carry the book title so the admin UI can identify rows.
+
+    The orphan row (book_id=999 with no books entry) is structurally
+    impossible under migration 034's FK, but list_queue still needs to
+    tolerate such rows — they can appear during a migration window or if
+    FK enforcement was briefly off. Force the orphan in with PRAGMA
+    foreign_keys=OFF to exercise the defensive LEFT JOIN.
+    """
     await save_book(1, {**BOOK_META, "title": "Moby Dick"}, BOOK_TEXT)
     await enqueue(1, 0, "zh")
-    # Orphan row — book never saved.
-    await enqueue(999, 0, "zh")
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute("PRAGMA foreign_keys = OFF")
+        await db.execute(
+            "INSERT INTO translation_queue "
+            "(book_id, chapter_index, target_language, status) "
+            "VALUES (999, 0, 'zh', 'pending')"
+        )
+        await db.commit()
     rows = await list_queue()
     by_book = {r["book_id"]: r for r in rows}
     assert by_book[1]["book_title"] == "Moby Dick"
@@ -379,6 +398,14 @@ async def test_queue_status_for_chapter_reports_position(tmp_db):
     none = await queue_status_for_chapter(1, 0, "zh")
     assert none == {"queued": False, "status": None, "position": None, "attempts": 0}
 
+    # book_id=2, 3 pre-seed for the ahead-of-queue and behind rows (FK 034).
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.executemany(
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (?, 'T', '[]', 'upload')",
+            [(2,), (3,)],
+        )
+        await db.commit()
     # Enqueue three; (1, 0, zh) is second in line because it's enqueued
     # second but shares priority 100 with the first row.
     await enqueue(2, 0, "zh", priority=100)   # id=1, ahead
@@ -427,6 +454,14 @@ async def test_default_chain_applied_when_no_setting(tmp_db):
 
 async def test_clear_queue_all_and_by_status(tmp_db):
     """clear_queue() wipes everything; clear_queue(status='failed') only wipes failed rows."""
+    # FK 034: translation_queue.book_id REFERENCES books(id)
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.executemany(
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (?, 'T', '[]', 'upload')",
+            [(1,), (2,)],
+        )
+        await db.commit()
     await enqueue(1, 0, "zh")
     await enqueue(1, 1, "zh")
     await enqueue(2, 0, "de")
@@ -454,6 +489,13 @@ async def test_clear_queue_preserves_running_items(tmp_db):
     Deleting it lets mark_queue_row_done silently destroy a re-enqueued
     pending row, voiding the admin's retranslation intent.
     """
+    # FK 034
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute(
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (1, 'T', '[]', 'upload')"
+        )
+        await db.commit()
     await enqueue(1, 0, "zh")
     await enqueue(1, 1, "zh")
     # Simulate chapter 0 being actively translated by the worker.
@@ -479,6 +521,13 @@ async def test_delete_queue_for_book_preserves_running_items(tmp_db):
     (called by save_translation) deletes by composite key, so it would
     silently destroy a re-enqueued pending row for the same chapter.
     """
+    # FK 034
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute(
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (1, 'T', '[]', 'upload')"
+        )
+        await db.commit()
     await enqueue(1, 0, "zh")
     await enqueue(1, 1, "zh")
     # Simulate chapter 0 being actively translated by the worker.
@@ -904,6 +953,13 @@ async def test_clear_queue_status_filter_preserves_running_items(tmp_db):
     status='running' deleted all in-flight worker rows — giving false cancellation
     and breaking mark_queue_row_done semantics.
     """
+    # FK 034
+    async with aiosqlite.connect(tmp_db) as db:
+        await db.execute(
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (1, 'T', '[]', 'upload')"
+        )
+        await db.commit()
     await enqueue(1, 0, "zh")
     await enqueue(1, 1, "zh")
     async with aiosqlite.connect(tmp_db) as db:

--- a/backend/tests/test_translation_queue_branches.py
+++ b/backend/tests/test_translation_queue_branches.py
@@ -65,9 +65,14 @@ async def tmp_db(monkeypatch, tmp_path):
 
 async def test_estimate_queue_cost_skips_orphan_book_id():
     """A pending queue row for a book_id that doesn't exist in the books
-    table should be skipped gracefully (the continue on line 325)."""
-    # Insert a queue row for book_id=9999 which has no books entry.
+    table should be skipped gracefully (the continue on line 325).
+
+    Migration 034's FK makes this orphan case structurally impossible at
+    insert, but the defensive skip still runs for schema states where FK
+    is OFF (e.g. during migrations). Force the orphan in with FK OFF.
+    """
     async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute("PRAGMA foreign_keys = OFF")
         await db.execute(
             """INSERT INTO translation_queue
                    (book_id, chapter_index, target_language, priority, status)
@@ -202,8 +207,12 @@ async def test_worker_stop_when_not_started_does_not_crash():
 async def test_worker_run_logs_stale_row_reset():
     """When there are stale 'running' rows on worker start, _run() must
     log a startup_reset_stale event (stale > 0 branch, line 690-691)."""
-    # Create a stale running row BEFORE starting the worker.
+    # FK 034: seed parent book before inserting queue row.
     async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (1, 'T', '[]', 'upload')"
+        )
         await db.execute(
             """INSERT INTO translation_queue
                    (book_id, chapter_index, target_language, priority, status)
@@ -224,7 +233,12 @@ async def test_worker_run_logs_stale_row_reset():
 async def test_worker_run_logs_orphan_done_rows_cleanup():
     """When there are orphan 'done' rows on worker start, _run() must
     log a startup_cleanup_done_rows event (orphans > 0 branch, lines 693-695)."""
+    # FK 034: seed parent book before inserting queue row.
     async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (1, 'T', '[]', 'upload')"
+        )
         await db.execute(
             """INSERT INTO translation_queue
                    (book_id, chapter_index, target_language, priority, status)
@@ -264,6 +278,12 @@ async def test_worker_run_startup_exception_is_non_fatal():
 async def test_claim_next_batch_rolls_back_on_exception():
     """If an exception occurs during the transaction, ROLLBACK fires and
     the exception is re-raised (lines 785-787)."""
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (1, 'T', '[]', 'upload')"
+        )
+        await db.commit()
     await enqueue(1, 0, "zh")
 
     w = TranslationQueueWorker()
@@ -322,15 +342,20 @@ async def test_claim_next_batch_rolls_back_on_exception():
 # ── Lines 831-833: _process_batch_inner — book not in cache ──────────────────
 
 async def test_process_batch_inner_skips_when_book_not_in_cache():
-    """When get_cached_book returns None, all items must be marked skipped."""
+    """When get_cached_book returns None, all items must be marked skipped.
+
+    The test models the case where a queue row points at a book not in the
+    books table. Migration 034 blocks that at INSERT, so force the orphan
+    in with PRAGMA foreign_keys=OFF to recreate the defensive path.
+    """
     w = TranslationQueueWorker()
     row = QueueRow(
         id=1, book_id=9999, chapter_index=0,
         target_language="zh", status="running",
         priority=100, attempts=0,
     )
-    # Insert the row so _mark_skipped has a real DB row to update.
     async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute("PRAGMA foreign_keys = OFF")
         await db.execute(
             "INSERT INTO translation_queue (id, book_id, chapter_index, target_language, priority, status) "
             "VALUES (1, 9999, 0, 'zh', 100, 'running')"
@@ -681,6 +706,10 @@ async def test_mark_skipped_updates_status():
 
     async with aiosqlite.connect(db_module.DB_PATH) as db:
         await db.execute(
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (1, 'T', '[]', 'upload')"
+        )
+        await db.execute(
             "INSERT INTO translation_queue (id, book_id, chapter_index, target_language, priority, status) "
             "VALUES (1, 1, 0, 'zh', 100, 'running')"
         )
@@ -703,6 +732,10 @@ async def test_mark_failed_increments_chapters_failed():
     w = TranslationQueueWorker()
 
     async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (1, 'T', '[]', 'upload')"
+        )
         await db.execute(
             "INSERT INTO translation_queue (id, book_id, chapter_index, target_language, priority, status) "
             "VALUES (1, 1, 0, 'zh', 100, 'running')"
@@ -731,6 +764,10 @@ async def test_update_status_updates_db_row():
     w = TranslationQueueWorker()
 
     async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (1, 'T', '[]', 'upload')"
+        )
         await db.execute(
             "INSERT INTO translation_queue (id, book_id, chapter_index, target_language, priority, status) "
             "VALUES (1, 1, 0, 'zh', 100, 'running')"
@@ -766,6 +803,10 @@ async def test_bump_attempt_increments_chapters_failed_at_max_attempts():
     w = TranslationQueueWorker()
 
     async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (1, 'T', '[]', 'upload')"
+        )
         await db.execute(
             "INSERT INTO translation_queue "
             "(id, book_id, chapter_index, target_language, priority, status, attempts) "

--- a/backend/tests/test_translation_queue_unit.py
+++ b/backend/tests/test_translation_queue_unit.py
@@ -107,7 +107,20 @@ def test_empty_exception_message_returns_false():
 
 # ── enqueue ───────────────────────────────────────────────────────────────────
 
+async def _seed_book(book_id: int) -> None:
+    """FK in migration 034: translation_queue.book_id REFERENCES books(id)."""
+    import aiosqlite
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (?, 'T', '[]', 'upload')",
+            (book_id,),
+        )
+        await db.commit()
+
+
 async def test_enqueue_inserts_new_row():
+    await _seed_book(1)
     count = await enqueue(1, 0, "en", priority=50)
     assert count == 1
 
@@ -119,6 +132,7 @@ async def test_enqueue_normalizes_language_code():
     saved under 'zh' never match — the reader keeps re-requesting an already-
     done translation and queue status_for_chapter returns 'not queued'."""
     from services.translation_queue import queue_status_for_chapter
+    await _seed_book(5)
     await enqueue(5, 0, "ZH-CN", priority=50)
     status = await queue_status_for_chapter(5, 0, "zh")
     assert status["queued"] is True, "normalized 'zh' must find the row stored from 'ZH-CN'"
@@ -142,6 +156,7 @@ async def test_enqueue_for_book_normalizes_language_codes():
 
 
 async def test_enqueue_existing_pending_row_is_noop():
+    await _seed_book(1)
     await enqueue(1, 0, "en")
     count = await enqueue(1, 0, "en")
     assert count == 0
@@ -150,6 +165,7 @@ async def test_enqueue_existing_pending_row_is_noop():
 async def test_enqueue_reset_failed_revives_failed_row():
     # Enqueue then manually mark as failed
     import aiosqlite
+    await _seed_book(2)
     await enqueue(2, 0, "de")
     async with aiosqlite.connect(db_module.DB_PATH) as db:
         await db.execute(
@@ -178,6 +194,7 @@ async def test_enqueue_reset_failed_does_not_touch_running_row():
     finishes, silently voiding the retranslation.
     """
     import aiosqlite
+    await _seed_book(20)
     await enqueue(20, 0, "zh")
     async with aiosqlite.connect(db_module.DB_PATH) as db:
         await db.execute(
@@ -200,6 +217,7 @@ async def test_enqueue_reset_failed_does_not_touch_running_row():
 
 
 async def test_enqueue_preserves_lower_priority():
+    await _seed_book(3)
     await enqueue(3, 0, "fr", priority=100, reset_failed=True)
     # Try to re-enqueue with higher priority (lower number = higher priority)
     await enqueue(3, 0, "fr", priority=10, reset_failed=True)
@@ -221,6 +239,7 @@ async def test_enqueue_reset_failed_does_not_touch_running_row():
     then deletes it by primary key, silently destroying the re-enqueued work.
     """
     import aiosqlite
+    await _seed_book(7)
     await enqueue(7, 0, "es")
     async with aiosqlite.connect(db_module.DB_PATH) as db:
         await db.execute(


### PR DESCRIPTION
## Summary

**Final PR of the #754 declared-FK series.** Migration 034 declares `REFERENCES books(id) ON DELETE CASCADE` on `word_occurrences.book_id` and `translation_queue.book_id`. Closes out the four-PR rollout started in #851.

## What changed

- `backend/migrations/034_fk_word_occurrences_translation_queue.sql` — orphan cleanup + table rewrite for both tables
- `backend/tests/test_migrations_034.py` — 6 new migration tests (orphan cleanup, FK-list assertions, row-preservation round-trip, UNIQUE survival, cascade-on-book-delete). New file rather than appending to `test_migrations.py`
- Per-test book-seed additions to:
  - `test_db_extended.py`, `test_router_admin.py`, `test_router_admin_extended.py` (shared helper), `test_router_search.py`, `test_router_vocabulary.py`
  - `test_translation_queue.py`, `test_translation_queue_branches.py`, `test_translation_queue_unit.py` (with a new `_seed_book` helper)

## FTS5 callout

Migration 026's FTS triggers for `word_occurrences` are dropped when the source table is dropped. The migration **recreates them** and **rebuilds** the inverted index after the rewrite. Without this, in-app search silently returns 0 matches for any vocabulary occurrence after the migration runs.

## Why a v2 branch

Session branch state got muddled mid-run; cherry-picked the clean commit onto a fresh branch off main to keep the PR free of unrelated fixes.

## Test plan

- **All 1500 backend tests pass** (1494 existing + 6 new 034 tests).
- Migration tests cover orphan cleanup, FK presence + CASCADE action, column round-trip including `queued_by`, UNIQUE constraint survival, and end-to-end cascade on book delete.
- Full suite run time: 1m 48s.

## Series complete

All eight soft `user_id` / `book_id` columns from the `docs/design/declared-fks-schema.md` audit now carry declared FKs with CASCADE:

| Table | PR |
|---|---|
| annotations, vocabulary | #851 |
| book_insights, chapter_summaries | #858 |
| translations, audio_cache | #975 |
| word_occurrences, translation_queue | **this PR** |

Closes #843.
