### PR TITLE
fix: accept single-chapter EPUB result in book_chapters.py (closes #980)

### DIFF
--- a/backend/services/book_chapters.py
+++ b/backend/services/book_chapters.py
@@ -63,7 +63,7 @@ async def split_with_html_preference(book_id: int, text: str) -> list[Chapter]:
             epub_bytes = await get_book_epub_bytes(book_id)
             if epub_bytes:
                 chapters = await asyncio.to_thread(build_chapters_from_epub, epub_bytes)
-                if len(chapters) >= 2:
+                if len(chapters) >= 1:
                     _chapter_cache[book_id] = chapters
                     return chapters
             elif book_id not in _epub_fetch_attempted:

--- a/backend/tests/test_book_chapters.py
+++ b/backend/tests/test_book_chapters.py
@@ -46,15 +46,30 @@ async def test_uses_epub_when_available_and_has_two_or_more_chapters():
     mock_text.assert_not_called()
 
 
-async def test_falls_back_to_text_when_epub_produces_only_one_chapter():
+async def test_uses_epub_for_single_chapter_short_story():
+    """Regression #980: a single-chapter EPUB (short story) must NOT fall back
+    to the plain-text splitter. build_chapters_from_epub returns [chapter] since
+    PR #970 fixed the splitter; book_chapters.py must accept >= 1, not >= 2."""
     epub_chapters = _make_chapters("Only One")
-    text_chapters = _make_chapters("Part 1", "Part 2")
     with (
         patch("services.db.get_book_epub_bytes", new_callable=AsyncMock, return_value=b"fake_epub"),
         patch("services.book_chapters.build_chapters_from_epub", return_value=epub_chapters),
-        patch("services.book_chapters.build_chapters", return_value=text_chapters),
+        patch("services.book_chapters.build_chapters") as mock_text,
     ):
         result = await split_with_html_preference(2, "plain text")
+    assert result == epub_chapters
+    mock_text.assert_not_called()
+
+
+async def test_falls_back_to_text_when_epub_produces_no_chapters():
+    """EPUB that returns [] (completely empty) must still fall back to plain text."""
+    text_chapters = _make_chapters("Part 1", "Part 2")
+    with (
+        patch("services.db.get_book_epub_bytes", new_callable=AsyncMock, return_value=b"fake_epub"),
+        patch("services.book_chapters.build_chapters_from_epub", return_value=[]),
+        patch("services.book_chapters.build_chapters", return_value=text_chapters),
+    ):
+        result = await split_with_html_preference(3, "plain text")
     assert result == text_chapters
 
 


### PR DESCRIPTION
## What changed

`book_chapters.py` had a `>= 2` guard that discarded any EPUB result with fewer than two chapters. PR #970 fixed the EPUB splitter to return a single `Chapter` for short stories and novellas — but `book_chapters.py` then silently fell through to the plain-text regex path, undoing the fix.

Changed the threshold from `>= 2` to `>= 1` so a single-chapter EPUB is accepted and cached correctly.

## Why

Short stories stored as EPUBs were being re-split via plain-text regex, losing HTML paragraph structure and producing degraded chapter boundaries.

## Test plan

- `test_uses_epub_for_single_chapter_short_story` (new) — confirms single-chapter EPUB is returned directly, plain-text path not called (regression for #980)
- `test_falls_back_to_text_when_epub_produces_no_chapters` (new) — confirms empty `[]` result still falls back to text
- Full existing chapter-cache suite (12 tests) — all pass

Closes #980
