### PR TITLE
fix: add min_length=1 to vocabulary definition lang query param (closes #981)

### DIFF
--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -71,7 +71,7 @@ async def list_vocabulary(user: dict = Depends(get_current_user)):
 @router.get("/definition/{word}")
 async def get_definition(
     word: str = Path(..., max_length=200),
-    lang: str = Query(default="en", max_length=20),
+    lang: str = Query(default="en", min_length=1, max_length=20),
     user: dict = Depends(get_current_user),
 ):
     from services import wiktionary

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -635,6 +635,18 @@ async def test_definition_oversized_lang_returns_422(client, test_user):
     )
 
 
+async def test_definition_empty_lang_returns_422(client, test_user):
+    """Regression #981: GET /vocabulary/definition/word?lang= (empty) must return 422.
+
+    An explicit lang= overrides the default 'en' with an empty string, which is then
+    passed to wiktionary.lookup() as the language code. The response would include
+    'language: \"\"' and potentially garbled AI fallback output."""
+    resp = await client.get("/api/vocabulary/definition/test?lang=")
+    assert resp.status_code == 422, (
+        f"Expected 422 for empty lang in /definition, got {resp.status_code}: {resp.text}"
+    )
+
+
 async def test_remove_word_oversized_word_returns_422(client, test_user):
     """Regression #529: DELETE /vocabulary/{word>200chars} must return 422."""
     resp = await client.delete("/api/vocabulary/" + "w" * 201)


### PR DESCRIPTION
## What changed

`GET /vocabulary/definition/{word}` accepted `lang=` (empty string) because the `lang` Query param had `default="en"` and `max_length=20` but no `min_length`. An explicit `?lang=` bypasses the default, passing an empty string to `wiktionary.lookup()` which returns `"language": ""` in the response — silently wrong data.

Added `min_length=1` to the `lang` Query parameter so an empty `lang=` now returns 422 instead of silently proceeding.

## Why

Empty language string is semantically invalid. `wiktionary.lookup()` cannot look up a word in an empty-string language — the response contains `"language": ""` with no useful content.

## Test plan

- `test_definition_empty_lang_returns_422` (new) — confirms `GET /api/vocabulary/definition/test?lang=` returns 422 (regression for #981)
- Existing `test_definition_oversized_lang_returns_422` continues to pass
- Full backend suite (1498 tests) passes

Closes #981
