### PR TITLE
docs: sync FEATURES.md status — mark shipped/declined features

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -259,11 +259,11 @@ A distraction-free reading experience with typography customisation and paragrap
 
 ---
 
-## Feature 5: Chapter Comprehension Quiz (FUTURE)
+## Feature 5: Chapter Comprehension Quiz (DECLINED)
 
 After reading a chapter, ask 3-5 AI-generated multiple-choice questions to test comprehension. Results stored per user/chapter.
 
-Estimated: 4 hours. Requires approval for DB schema.
+**Status**: user declined in [#557](https://github.com/alfmunny/book-reader-ai/issues/557) ("Dont do it for now"). Duplicate entry kept below as "Feature 12"; both marked declined.
 
 ---
 
@@ -380,9 +380,9 @@ python scripts/pretranslate.py --book-id 1342 --lang de --force   # overwrite ca
 
 ### Filed / awaiting approval
 
-- [ ] Feature 11: user_book_chapters table — replace JSON-in-books.text (design PR #555, issue #357)
-- [ ] Feature 2: Vocabulary Flashcards / SRS (design in FEATURES.md Feature 2, issue #556)
-- [ ] Feature 12: Chapter Comprehension Quiz (issue #557)
+- [x] Feature 11: user_book_chapters table — replace JSON-in-books.text (shipped — migration 025, PR #649)
+- [x] Feature 2: Vocabulary Flashcards / SRS (shipped — issue #556 closed)
+- ~~Feature 12: Chapter Comprehension Quiz~~ — declined in #557 ("Dont do it for now")
 
 ---
 
@@ -431,16 +431,13 @@ Uploaded books now store their chapters in a dedicated `user_book_chapters` tabl
 
 ---
 
-## Feature 12: Chapter Comprehension Quiz (Issue #557 — future)
+## Feature 12: Chapter Comprehension Quiz (Issue #557 — DECLINED)
 
 ### Overview
 After reading a chapter, users get 3–5 AI-generated multiple-choice questions. Results stored per user/chapter. New tables: `quiz_questions`, `quiz_attempts`. New "Quiz" tab in reader sidebar.
 
 ### Status
-Needs design doc. See issue #557.
-
-### Estimated effort
-~5 hours after design approval.
+**Declined.** User commented "Dont do it for now" on [#557](https://github.com/alfmunny/book-reader-ai/issues/557); the issue carries the `wontfix` label. Do not start a design doc against this feature without the user reopening the discussion.
 
 ---
 


### PR DESCRIPTION
## Summary

FEATURES.md had three out-of-date statuses that caused a real mistake: Feature 12 (Quiz) was listed as "FUTURE" in two places, which led me to file a full design doc in idle mode (#991 → #992) before noticing #557 carries `wontfix` and a direct user decline — reverted in #994.

## What changed

- **Feature 11** (user_book_chapters): `[ ] awaiting approval` → `[x] shipped` (actually merged in PR #649).
- **Feature 2** (Vocabulary Flashcards / SRS): `[ ] awaiting approval` → `[x] shipped` (#556 closed).
- **Feature 12** (Chapter Comprehension Quiz): both listings (Feature 5 and Feature 12 — it's duplicated in the doc) → "DECLINED", with a pointer to #557 and an explicit note warning future idle-mode iterations not to file design work against it.

## Why

The idle-mode loop reads FEATURES.md to identify proposal targets. When the doc disagrees with the issue tracker, the loop files dead-on-arrival work. This fix closes that particular failure mode.

## Test plan

Pure docs change. Path-scoped CI should skip all code test jobs.

## Not in scope

Larger audit of every feature status in the doc. Only the three that were directly wrong are corrected here.
