### PR TITLE
fix: replace assert with RuntimeError in services/decks.py create_deck (closes #995)

### DIFF
--- a/backend/services/decks.py
+++ b/backend/services/decks.py
@@ -128,7 +128,8 @@ async def create_deck(
         deck_id = cur.lastrowid
         await db.commit()
     created = await get_deck(user_id, deck_id)
-    assert created is not None
+    if created is None:
+        raise RuntimeError("deck INSERT succeeded but SELECT returned None")
     return created
 
 

--- a/backend/tests/test_router_decks.py
+++ b/backend/tests/test_router_decks.py
@@ -368,3 +368,22 @@ async def test_smart_rules_valid_iso_dates_accepted(client, test_user):
     assert resp.status_code == 201, (
         f"Expected 201 for valid ISO dates, got {resp.status_code}: {resp.text}"
     )
+
+
+# ── Issue #995: assert anti-pattern in create_deck ────────────────────────────
+
+
+async def test_create_deck_raises_runtime_error_not_assertion_error_on_get_failure(
+    client, test_user
+):
+    """Regression #995: services.decks.create_deck must raise RuntimeError (not
+    AssertionError) when the post-INSERT get_deck unexpectedly returns None.
+
+    AssertionError is silently dropped under Python -O, causing create_deck to
+    return None and the caller to receive a null JSON body instead of the deck."""
+    from unittest.mock import AsyncMock, patch
+    import services.decks as decks_service
+
+    with patch.object(decks_service, "get_deck", new=AsyncMock(return_value=None)):
+        with pytest.raises(RuntimeError, match="deck INSERT succeeded"):
+            await decks_service.create_deck(test_user["id"], "TestDeck", "", "manual", None)


### PR DESCRIPTION
## What changed

Replaced `assert created is not None` with an explicit `RuntimeError` in `services/decks.py:create_deck`.

`assert` statements are silently stripped when Python runs with the `-O` (optimize) flag (e.g. `PYTHONOPTIMIZE=1`). Without this guard, if the post-INSERT `get_deck` call ever returned `None`, `create_deck` would silently return `None` instead of raising — and the caller would receive a `null` JSON body instead of the created deck object.

## Why

`AssertionError` is both non-descriptive and removable. A `RuntimeError` with a clear message is never optimised away and produces a meaningful log entry if it ever fires.

## Test plan

- Added `test_create_deck_raises_runtime_error_not_assertion_error_on_get_failure` in `tests/test_router_decks.py` — mocks `get_deck` to return `None` and asserts `RuntimeError` is raised (not `AssertionError`).
- Full backend suite: 1506 tests passed.
