### PR TITLE
ux: add aria-label to InsightChat toolbar language select (closes #1000)

### DIFF
--- a/frontend/src/__tests__/InsightChatLangSelectAria.test.ts
+++ b/frontend/src/__tests__/InsightChatLangSelectAria.test.ts
@@ -1,0 +1,24 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/InsightChat.tsx"),
+  "utf8"
+);
+
+describe("InsightChat language select aria-label (closes #1000)", () => {
+  it("toolbar language select has aria-label attribute", () => {
+    // Find the select in the toolbar (before the chat messages area)
+    const idx = src.indexOf("<select");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 300);
+    expect(window).toContain('aria-label=');
+  });
+
+  it("toolbar language select aria-label describes the insight language", () => {
+    const idx = src.indexOf("<select");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 300);
+    expect(window).toMatch(/aria-label=["']Insight language["']/);
+  });
+});

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -296,6 +296,7 @@ export default function InsightChat({
       {/* ── Toolbar ──────────────────────────────────────────────────── */}
       <div className="flex items-center gap-2 px-3 py-1.5 border-b border-gray-100 shrink-0 bg-gray-50">
         <select
+          aria-label="Insight language"
           className="flex-1 text-xs rounded border border-gray-200 px-2 py-1 text-gray-700 bg-white focus:outline-none focus:ring-1 focus:ring-amber-400"
           value={lang}
           onChange={(e) => { setLang(e.target.value); saveSettings({ insightLang: e.target.value }); }}


### PR DESCRIPTION
Closes #1000

The `<select>` in the InsightChat toolbar (`InsightChat.tsx` line 298) was missing an accessible name, violating WCAG 1.3.1 / 4.1.2. Screen readers announced it as an unlabeled control.

## Changes
- `InsightChat.tsx`: add `aria-label="Insight language"` to the toolbar language select
- `InsightChatLangSelectAria.test.ts`: 2 static assertions confirming the aria-label is present

## Test plan
- [x] 2 new tests pass: select has aria-label, value matches "Insight language"
- [x] Full frontend suite — 1975 tests passing

🤖 Generated with Claude Code
