### PR TITLE
fix: replace assert with explicit RuntimeError in worker _run() methods (closes #999)

### DIFF
--- a/backend/services/seed_popular.py
+++ b/backend/services/seed_popular.py
@@ -85,9 +85,10 @@ class SeedPopularManager:
                 self._task.cancel()
 
     async def _run(self, manifest_path: str) -> None:
+        if self._stop_event is None:
+            raise RuntimeError("_run() called before start()")
         state = self._state
         stop_event = self._stop_event
-        assert stop_event is not None
 
         try:
             if not os.path.isfile(manifest_path):

--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -728,7 +728,8 @@ class TranslationQueueWorker:
     # ── Main loop ────────────────────────────────────────────────────────
 
     async def _run(self) -> None:
-        assert self._stop_event is not None
+        if self._stop_event is None:
+            raise RuntimeError("_run() called before start()")
         stop_event = self._stop_event
 
         # Startup housekeeping: only reset rows left 'running' from a

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -3009,3 +3009,23 @@ async def test_queue_clear_empty_status_returns_422(admin_client):
     assert res.status_code == 422, (
         f"Expected 422 for empty status in DELETE /admin/queue, got {res.status_code}: {res.text}"
     )
+
+
+# ── Issue #999: assert anti-pattern in SeedPopularManager._run() ──────────────
+
+
+@pytest.mark.asyncio
+async def test_seed_popular_manager_run_raises_runtime_error_without_start():
+    """Regression #999: SeedPopularManager._run() must raise RuntimeError (not
+    AssertionError) when _stop_event is None.
+
+    AssertionError is silently stripped under Python -O, causing the worker to
+    proceed with stop_event=None and crash later with an unrelated AttributeError
+    instead of a clear diagnostic message."""
+    from services.seed_popular import SeedPopularManager
+
+    mgr = SeedPopularManager()
+    assert mgr._stop_event is None
+
+    with pytest.raises(RuntimeError, match="_run\\(\\) called before start\\(\\)"):
+        await mgr._run("some_path.json")

--- a/backend/tests/test_translation_queue_unit.py
+++ b/backend/tests/test_translation_queue_unit.py
@@ -356,3 +356,22 @@ async def test_get_auto_languages_filters_empty_strings():
     await set_setting(SETTING_AUTO_LANGS, '["en", "", "de", ""]')
     langs = await get_auto_languages()
     assert langs == ["en", "de"]
+
+
+# ── Issue #999: assert anti-pattern in TranslationQueueWorker._run() ──────────
+
+
+async def test_translation_queue_worker_run_raises_runtime_error_without_start():
+    """Regression #999: TranslationQueueWorker._run() must raise RuntimeError (not
+    AssertionError) when _stop_event is None.
+
+    AssertionError is silently stripped under Python -O, causing the worker to
+    proceed with stop_event=None and crash later with an unrelated AttributeError
+    instead of a clear diagnostic message."""
+    from services.translation_queue import TranslationQueueWorker
+
+    worker = TranslationQueueWorker()
+    assert worker._stop_event is None
+
+    with pytest.raises(RuntimeError, match="_run\\(\\) called before start\\(\\)"):
+        await worker._run()


### PR DESCRIPTION
## What changed

Replace two `assert` statements in background worker `_run()` methods with explicit `RuntimeError` checks:

- `services/translation_queue.py:TranslationQueueWorker._run()` — `assert self._stop_event is not None`
- `services/seed_popular.py:SeedPopularManager._run()` — `assert stop_event is not None`

Same anti-pattern fixed in `services/decks.py` (PR #997 / issue #995).

## Why

`assert` statements are silently stripped by `python -O` (optimized mode). If the invariant were ever violated in a production deployment running with `-O`, the worker would proceed with `stop_event = None` and crash later with an unrelated `AttributeError: 'NoneType' object has no attribute 'wait'` instead of a clear diagnostic `RuntimeError`.

## Test plan

- Added `test_translation_queue_worker_run_raises_runtime_error_without_start` in `test_translation_queue_unit.py` — instantiates `TranslationQueueWorker` without calling `start()` and verifies `RuntimeError` is raised
- Added `test_seed_popular_manager_run_raises_runtime_error_without_start` in `test_router_admin.py` — same pattern for `SeedPopularManager`
- Both tests confirmed to fail before fix and pass after
- Full suite: 1510 backend + 1750 frontend tests passing
