### PR TITLE
fix: add min_length=1 to QueueSettingsRequest.model (closes #1003)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1049,7 +1049,7 @@ class QueueSettingsRequest(BaseModel):
     auto_translate_languages: list[Annotated[str, Field(min_length=1, max_length=20)]] | None = Field(default=None, max_length=50)
     rpm: int | None = Field(default=None, ge=1)
     rpd: int | None = Field(default=None, ge=1)
-    model: str | None = Field(default=None, max_length=200)
+    model: str | None = Field(default=None, min_length=1, max_length=200)
     model_chain: list[Annotated[str, Field(min_length=1, max_length=200)]] | None = Field(default=None, max_length=20)
     max_output_tokens: int | None = Field(default=None, ge=1)
 

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -2362,6 +2362,22 @@ async def test_queue_settings_oversized_model_returns_422(admin_client, admin_db
 
 
 @pytest.mark.asyncio
+async def test_queue_settings_empty_model_returns_422(admin_client, admin_db):
+    """Regression #1003: PUT /admin/queue/settings with model="" must return 422.
+
+    Without min_length=1 the empty string passes Pydantic validation and is
+    written to SETTING_MODEL, causing all subsequent translations to fail with
+    an undiagnosable AI-API error using model name ""."""
+    res = await admin_client.put(
+        "/api/admin/queue/settings",
+        json={"model": ""},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for empty model in queue settings, got {res.status_code}: {res.text}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_enqueue_book_oversized_target_language_returns_422(admin_client, admin_db):
     """Regression #521: POST /admin/queue/enqueue-book with a target_language > 20 chars
     must return 422, not store a huge string in translation_queue."""


### PR DESCRIPTION
## What changed

Added `min_length=1` to `QueueSettingsRequest.model` in `routers/admin.py`.

## Why

`PUT /admin/queue/settings` with `{"model": ""}` passed Pydantic validation (only `max_length=200` was set) and wrote an empty string to `SETTING_MODEL` in the DB. All subsequent translations would then fail with an undiagnosable AI API error using model name `""`.

PR #779 added `min_length=1` to `auto_translate_languages` list elements and `model_chain` list elements, but missed the scalar `model` field.

Note: `api_key: str | None` intentionally accepts `""` (explicit clear behaviour — the handler checks `if req.api_key == ""`). Only `model` needed the fix.

## Test plan

- Added `test_queue_settings_empty_model_returns_422` — confirmed failure before fix (200 returned, empty model stored), passes after
- Full suite: 1509 backend tests passing
