### PR TITLE
fix: retranslate-all continues after per-chapter Google fallback failure (closes #1006)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -716,9 +716,13 @@ async def retranslate_all(
             )
         except Exception:
             if provider == "gemini":
-                paragraphs = await do_translate(
-                    ch.text, source_language, target_language, provider="google",
-                )
+                try:
+                    paragraphs = await do_translate(
+                        ch.text, source_language, target_language, provider="google",
+                    )
+                except Exception:
+                    results.append({"chapter": i, "status": "failed"})
+                    continue
             else:
                 results.append({"chapter": i, "status": "failed"})
                 continue

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -3045,3 +3045,47 @@ async def test_seed_popular_manager_run_raises_runtime_error_without_start():
 
     with pytest.raises(RuntimeError, match="_run\\(\\) called before start\\(\\)"):
         await mgr._run("some_path.json")
+
+
+# ── Issue #1006: retranslate-all aborts on per-chapter fallback failure ─────────
+
+
+@pytest.mark.asyncio
+async def test_retranslate_all_continues_after_per_chapter_translation_failure(admin_user, admin_client, admin_db):
+    """Regression #1006: retranslate-all must record a chapter as 'failed' and
+    continue to the next chapter when both Gemini and the Google fallback raise.
+
+    Without the fix, the exception from the Google fallback propagates out of
+    the for-loop and aborts the entire operation with a 500, silently skipping
+    all subsequent chapters."""
+    from services.db import set_user_gemini_key
+    from services.auth import encrypt_api_key
+    await set_user_gemini_key(admin_user["id"], encrypt_api_key("fake-api-key"))
+
+    await save_book(100, BOOK_META, MOVE_BOOK_TEXT)
+
+    call_count = 0
+
+    async def _do_translate_side_effect(text, src, tgt, *, provider="google", gemini_key=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            # Calls 1+2: Gemini primary + Google fallback for chapter 0 both fail.
+            raise RuntimeError("simulated translation failure")
+        # Subsequent calls (chapters 1+ Gemini, etc.) succeed.
+        return ["ok"]
+
+    with patch("routers.admin.do_translate", side_effect=_do_translate_side_effect):
+        res = await admin_client.post(
+            "/api/admin/translations/100/retranslate-all",
+            json={"target_language": "zh"},
+        )
+
+    assert res.status_code == 200, (
+        f"Expected 200 for partial-failure retranslate-all, got {res.status_code}: {res.text}"
+    )
+    body = res.json()
+    assert body["ok"] is True
+    results = {r["chapter"]: r["status"] for r in body["results"]}
+    assert results.get(0) == "failed", "chapter 0 must be recorded as failed"
+    assert results.get(1) == "ok", "chapter 1 must succeed after chapter 0 failed"


### PR DESCRIPTION
## What changed

In `POST /admin/translations/{book_id}/retranslate-all`, when `provider=gemini` and the primary Gemini translation fails, the endpoint falls back to Google Translate. Previously, if the Google fallback **also** raised (network error, quota exhausted, etc.), that exception propagated out of the chapter loop, aborting the entire retranslate-all with a 500 error.

**Before the fix:**
- Chapters already saved remain translated.
- All subsequent chapters are silently skipped.
- The admin receives a 500 with no partial-success breakdown.

**After the fix:**
- The Google fallback failure is caught.
- The failing chapter is recorded as `{"chapter": N, "status": "failed"}`.
- The loop continues to the next chapter.
- The endpoint returns 200 with a complete per-chapter report.

## Why

The `else` branch (non-Gemini provider) already handled failure-and-continue correctly. The Gemini branch was missing the equivalent try-except around the fallback call.

## Test plan

- [x] New regression test `test_retranslate_all_continues_after_per_chapter_translation_failure`: sets a Gemini key on the admin, patches both Gemini and Google calls for chapter 0 to raise, verifies chapter 0 is recorded as `"failed"` and chapter 1 (and beyond) is still attempted and succeeds.
- [x] Full backend suite: 1512 passed
- [x] Full frontend suite: 1750 passed

Closes #1006
