### PR TITLE
ux: add descriptive aria-label to InsightChat context expand/collapse buttons (closes #1007)

### DIFF
--- a/frontend/src/__tests__/InsightChat.coverage2.test.tsx
+++ b/frontend/src/__tests__/InsightChat.coverage2.test.tsx
@@ -61,27 +61,27 @@ describe("InsightChat — ContextChip expand/collapse (L78)", () => {
     await act(async () => await flushPromises());
 
     // Initially shows "more"
-    const moreBtn = screen.getByRole("button", { name: "more" });
+    const moreBtn = screen.getByRole("button", { name: "Expand context" });
     expect(moreBtn).toBeInTheDocument();
 
     fireEvent.click(moreBtn);
     await act(async () => await flushPromises());
 
     // After expanding, shows "less"
-    expect(screen.getByRole("button", { name: "less" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Collapse context" })).toBeInTheDocument();
   });
 
   it("toggles ContextChip back from 'less' to 'more' on second click", async () => {
     render(<InsightChat {...BASE} selectedText={LONG_TEXT} />);
     await act(async () => await flushPromises());
 
-    fireEvent.click(screen.getByRole("button", { name: "more" }));
+    fireEvent.click(screen.getByRole("button", { name: "Expand context" }));
     await act(async () => await flushPromises());
 
-    fireEvent.click(screen.getByRole("button", { name: "less" }));
+    fireEvent.click(screen.getByRole("button", { name: "Collapse context" }));
     await act(async () => await flushPromises());
 
-    expect(screen.getByRole("button", { name: "more" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Expand context" })).toBeInTheDocument();
   });
 });
 
@@ -274,7 +274,7 @@ describe("InsightChat — MsgContextBlock onToggle (L389-L390)", () => {
     // The user message's MsgContextBlock shows "more" (context > 160 chars, collapsed)
     // There may be multiple "more" buttons (ContextChip in input area is gone after send,
     // but MsgContextBlock in the user bubble should now be present)
-    const moreBtns = screen.getAllByRole("button", { name: "more" });
+    const moreBtns = screen.getAllByRole("button", { name: "Expand context" });
     expect(moreBtns.length).toBeGreaterThanOrEqual(1);
 
     // Click the MsgContextBlock's "more" button (last one, as ContextChip was cleared on send)
@@ -282,7 +282,7 @@ describe("InsightChat — MsgContextBlock onToggle (L389-L390)", () => {
     await act(async () => await flushPromises());
 
     // After expanding, the MsgContextBlock shows "less"
-    const lessBtns = screen.getAllByRole("button", { name: "less" });
+    const lessBtns = screen.getAllByRole("button", { name: "Collapse context" });
     expect(lessBtns.length).toBeGreaterThanOrEqual(1);
   });
 
@@ -296,15 +296,15 @@ describe("InsightChat — MsgContextBlock onToggle (L389-L390)", () => {
 
     await waitFor(() => expect(screen.getByText("Answer.")).toBeInTheDocument());
 
-    const moreBtns = screen.getAllByRole("button", { name: "more" });
+    const moreBtns = screen.getAllByRole("button", { name: "Expand context" });
     fireEvent.click(moreBtns[moreBtns.length - 1]);
     await act(async () => await flushPromises());
 
-    const lessBtns = screen.getAllByRole("button", { name: "less" });
+    const lessBtns = screen.getAllByRole("button", { name: "Collapse context" });
     fireEvent.click(lessBtns[lessBtns.length - 1]);
     await act(async () => await flushPromises());
 
     // Back to "more"
-    expect(screen.getAllByRole("button", { name: "more" }).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByRole("button", { name: "Expand context" }).length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/frontend/src/__tests__/InsightChatContextToggleAria.test.ts
+++ b/frontend/src/__tests__/InsightChatContextToggleAria.test.ts
@@ -1,0 +1,47 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/InsightChat.tsx"),
+  "utf8"
+);
+
+describe("InsightChat context expand/collapse aria-labels (closes #1007)", () => {
+  it("ContextChip toggle button has aria-label attribute", () => {
+    // ContextChip is the first component — find its toggle button
+    const contextChipIdx = src.indexOf("function ContextChip");
+    expect(contextChipIdx).toBeGreaterThan(-1);
+    const nextComponentIdx = src.indexOf("\nfunction ", contextChipIdx + 1);
+    const contextChipSrc = src.slice(contextChipIdx, nextComponentIdx);
+    const btnIdx = contextChipSrc.indexOf('onClick={() => setExpanded');
+    expect(btnIdx).toBeGreaterThan(-1);
+    const btnWindow = contextChipSrc.slice(Math.max(0, btnIdx - 20), btnIdx + 300);
+    expect(btnWindow).toContain("aria-label");
+  });
+
+  it("MsgContextBlock toggle button has aria-label attribute", () => {
+    const msgCtxIdx = src.indexOf("function MsgContextBlock");
+    expect(msgCtxIdx).toBeGreaterThan(-1);
+    const nextIdx = src.indexOf("\nfunction ", msgCtxIdx + 1);
+    const msgCtxSrc = src.slice(msgCtxIdx, nextIdx > -1 ? nextIdx : undefined);
+    // Search for the onClick={onToggle} button, then check nearby for aria-label
+    const onClickIdx = msgCtxSrc.indexOf("onClick={onToggle}");
+    expect(onClickIdx).toBeGreaterThan(-1);
+    const btnWindow = msgCtxSrc.slice(Math.max(0, onClickIdx - 20), onClickIdx + 200);
+    expect(btnWindow).toContain("aria-label");
+  });
+
+  it("ContextChip toggle button aria-label describes context expansion", () => {
+    const contextChipIdx = src.indexOf("function ContextChip");
+    const nextComponentIdx = src.indexOf("\nfunction ", contextChipIdx + 1);
+    const contextChipSrc = src.slice(contextChipIdx, nextComponentIdx);
+    expect(contextChipSrc).toMatch(/aria-label=.*[Cc]ontext|aria-label=.*[Ee]xpand|aria-label=.*[Cc]ollapse/);
+  });
+
+  it("MsgContextBlock toggle button aria-label describes context expansion", () => {
+    const msgCtxIdx = src.indexOf("function MsgContextBlock");
+    const nextIdx = src.indexOf("\nfunction ", msgCtxIdx + 1);
+    const msgCtxSrc = src.slice(msgCtxIdx, nextIdx > -1 ? nextIdx : undefined);
+    expect(msgCtxSrc).toMatch(/aria-label=.*[Cc]ontext|aria-label=.*[Ee]xpand|aria-label=.*[Cc]ollapse/);
+  });
+});

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -75,6 +75,7 @@ function ContextChip({
             <button
               onClick={() => setExpanded((v) => !v)}
               className="ml-1.5 text-amber-500 hover:text-amber-700 font-medium not-italic min-h-[44px] inline-flex items-center"
+              aria-label={expanded ? "Collapse context" : "Expand context"}
             >
               {expanded ? "less" : "more"}
             </button>
@@ -550,6 +551,7 @@ function MsgContextBlock({
           <button
             onClick={onToggle}
             className="ml-1.5 text-amber-500 hover:text-amber-700 font-medium not-italic min-h-[44px] inline-flex items-center"
+            aria-label={expanded ? "Collapse context" : "Expand context"}
           >
             {expanded ? "less" : "more"}
           </button>


### PR DESCRIPTION
Closes #1007

The `ContextChip` and `MsgContextBlock` sub-components in `InsightChat.tsx` both rendered a toggle button whose only accessible name was `"more"` / `"less"` — a screen reader would announce "more, button" with no indication of what it expands. This violates WCAG 4.1.2 (Name, Role, Value, Level A).

## Changes
- `InsightChat.tsx`: added `aria-label={expanded ? "Collapse context" : "Expand context"}` to both toggle buttons
- `InsightChatContextToggleAria.test.ts`: 4 static assertions confirming both buttons have descriptive `aria-label`
- `InsightChat.coverage2.test.tsx`: updated button queries from `{ name: "more" }` / `{ name: "less" }` to match the new aria-label values

## Test plan
- [x] 4 new static tests pass
- [x] Full frontend suite — 1979/1979 passing

🤖 Generated with Claude Code
