### PR TITLE
fix: single-chapter retranslate returns 502 when both providers fail (closes #1010)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -565,12 +565,21 @@ async def retranslate(
         )
     except Exception:
         if provider == "gemini":
-            paragraphs = await do_translate(
-                chapter_text, source_language, target_language, provider="google",
-            )
-            provider = "google"
+            try:
+                paragraphs = await do_translate(
+                    chapter_text, source_language, target_language, provider="google",
+                )
+                provider = "google"
+            except Exception:
+                raise HTTPException(
+                    status_code=502,
+                    detail="Translation failed: both Gemini and Google Translate could not process this chapter.",
+                )
         else:
-            raise
+            raise HTTPException(
+                status_code=502,
+                detail="Translation failed: Google Translate could not process this chapter.",
+            )
 
     # 5. Cache the new translation
     await save_translation(book_id, chapter_index, target_language, paragraphs)

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -1073,6 +1073,28 @@ async def test_retranslate_chapter_out_of_range(admin_client):
     assert res.status_code == 400
 
 
+@pytest.mark.asyncio
+async def test_retranslate_returns_502_when_both_gemini_and_google_fail(admin_user, admin_client, admin_db):
+    """Regression #1010: single-chapter retranslate must return 502 (not 500) when
+    both the Gemini provider and the Google fallback raise."""
+    from services.auth import encrypt_api_key
+    from services.db import set_user_gemini_key
+    await set_user_gemini_key(admin_user["id"], encrypt_api_key("fake-api-key"))
+    await save_book(100, BOOK_META, BOOK_TEXT)
+
+    async def _always_fail(text, src, tgt, *, provider="google", gemini_key=None):
+        raise RuntimeError("simulated translation failure")
+
+    with patch("routers.admin.do_translate", side_effect=_always_fail):
+        res = await admin_client.post(
+            "/api/admin/translations/100/0/de/retranslate",
+        )
+
+    assert res.status_code == 502, (
+        f"Expected 502 when both providers fail, got {res.status_code}: {res.text}"
+    )
+
+
 async def test_retranslate_non_admin_forbidden(admin_db, admin_user):
     user2 = await get_or_create_user(
         google_id="user2", email="user2@example.com", name="User 2", picture=""

--- a/backend/tests/test_router_admin_extended.py
+++ b/backend/tests/test_router_admin_extended.py
@@ -845,9 +845,11 @@ async def test_retranslate_preserves_old_translation_on_failure(admin_client, ad
         raise Exception("simulated network error")
 
     with patch("routers.admin.do_translate", side_effect=always_fail):
-        # The unhandled exception propagates through the ASGI transport in tests.
-        with pytest.raises(Exception, match="simulated network error"):
-            await admin_client.post("/api/admin/translations/200/0/fr/retranslate")
+        res = await admin_client.post("/api/admin/translations/200/0/fr/retranslate")
+
+    assert res.status_code == 502, (
+        f"Expected 502 when translation fails, got {res.status_code}: {res.text}"
+    )
 
     # Old translation must survive regardless of the translate failure
     cached = await get_cached_translation(200, 0, "fr")


### PR DESCRIPTION
## What changed

`POST /api/admin/translations/{book_id}/{chapter_index}/{target_language}/retranslate` had the same fallback exception-handling bug fixed in retranslate-all (#1006 / #1008):

- When `provider="gemini"` and Gemini fails, the Google fallback was called without a try/except. If Google also failed, the raw exception propagated uncaught, yielding a generic 500.
- When `provider="google"` and it fails, the `raise` statement re-raised the raw exception instead of returning a structured HTTP error.

Both paths now return `HTTPException(502)` with a clear message when their provider(s) fail.

## Why

Admin UI would receive an opaque 500 instead of a usable error message, making it hard to diagnose translation failures.

## Test plan

- Regression test added: `test_retranslate_returns_502_when_both_gemini_and_google_fail` — mocks both providers to always raise, asserts 502 response.
- Existing test `test_retranslate_preserves_old_translation_on_failure` updated to assert 502 (was asserting the old exception-propagation behaviour, which is now fixed).
- Full backend suite: 1513 passed.
