### PR TITLE
ux: add aria-label to reader theme-cycle button (closes #1012)

### DIFF
--- a/frontend/src/__tests__/ReaderThemeButtonAria.test.ts
+++ b/frontend/src/__tests__/ReaderThemeButtonAria.test.ts
@@ -1,0 +1,25 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Reader theme-cycle button aria-label (closes #1012)", () => {
+  it("theme button has aria-label attribute", () => {
+    // Find the cycleTheme button
+    const idx = src.indexOf("onClick={cycleTheme}");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 300);
+    expect(window).toContain("aria-label");
+  });
+
+  it("theme button aria-label references the theme", () => {
+    const idx = src.indexOf("onClick={cycleTheme}");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 300);
+    // aria-label should include the theme variable or the word "Theme"
+    expect(window).toMatch(/aria-label=.*[Tt]heme/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1009,6 +1009,7 @@ export default function ReaderPage() {
           <button
             onClick={cycleTheme}
             title={`Theme: ${theme} — click to cycle`}
+            aria-label={`Theme: ${theme} — click to cycle`}
             className="hidden md:flex shrink-0 items-center gap-1.5 px-2 py-1 min-h-[44px] rounded-lg border border-amber-300 hover:bg-amber-100 text-xs text-amber-700 transition-colors"
           >
             {theme === "light" ? <SunIcon className="w-3.5 h-3.5" /> : theme === "sepia" ? <SepiaIcon className="w-3.5 h-3.5" /> : <MoonIcon className="w-3.5 h-3.5" />}


### PR DESCRIPTION
Closes #1012

The **Theme** button in the reader toolbar was icon-only at `md` breakpoints — the text label (`{theme}`) is `hidden lg:inline`, and the button relied solely on `title` for its accessible name. `title` is not reliably announced by screen readers and is never surfaced on touch devices, violating WCAG 4.1.2 (Name, Role, Value, Level A).

## Changes
- `reader/[bookId]/page.tsx`: add `aria-label={`Theme: ${theme} — click to cycle`}` to the theme-cycle button (matching the existing `title` value)
- `ReaderThemeButtonAria.test.ts`: 2 static assertions confirming the button has an `aria-label` referencing "Theme"

## Test plan
- [x] 2 new tests pass
- [x] Full frontend suite — 1981/1981 passing

🤖 Generated with Claude Code
