### PR TITLE
fix: replace asyncio.get_event_loop() with get_running_loop() in translate.py and rate_limiter.py (closes #1014)

### DIFF
--- a/backend/services/rate_limiter.py
+++ b/backend/services/rate_limiter.py
@@ -69,7 +69,7 @@ class AsyncRateLimiter:
         self.rpd = rpd
         self.provider = provider
         self.model = model
-        self._time = time_fn or (lambda: asyncio.get_event_loop().time())
+        self._time = time_fn or (lambda: asyncio.get_running_loop().time())
         self._sleep = sleep_fn or asyncio.sleep
         self._rpm_window: deque[float] = deque()
         self._lock = asyncio.Lock()

--- a/backend/services/translate.py
+++ b/backend/services/translate.py
@@ -101,7 +101,7 @@ async def _google_translate(text: str, source: str, target: str) -> list[str]:
 
     # Run sync translator in a thread pool to avoid blocking the event loop.
     # Google Translate handles one paragraph at a time well.
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     results = []
     for para in paragraphs:
         # Skip chapter headings — translating "I" or "Chapter XIV" produces

--- a/backend/tests/test_rate_limiter.py
+++ b/backend/tests/test_rate_limiter.py
@@ -133,3 +133,15 @@ async def test_different_providers_have_separate_counters(tmp_db):
     await gemini.acquire()
     assert await gemini.daily_remaining() == 98
     assert await google.daily_remaining() == 100
+
+
+async def test_default_time_fn_works_inside_running_loop(tmp_db):
+    """Regression #1014: AsyncRateLimiter default _time must work inside async context.
+
+    get_running_loop().time() is correct here; get_event_loop() is deprecated
+    in Python 3.10+ and would emit DeprecationWarning.
+    """
+    limiter = AsyncRateLimiter(rpm=60, rpd=1000)
+    t = limiter._time()
+    assert isinstance(t, float)
+    assert t > 0


### PR DESCRIPTION
## What changed

- `backend/services/translate.py:104` — `asyncio.get_event_loop()` → `asyncio.get_running_loop()`
- `backend/services/rate_limiter.py:72` — `asyncio.get_event_loop().time()` → `asyncio.get_running_loop().time()` (inside the default `time_fn` lambda)

## Why

`asyncio.get_event_loop()` is deprecated since Python 3.10 and emits `DeprecationWarning` in Python 3.12+. Both callsites are inside async contexts where a loop is guaranteed to be running; `get_running_loop()` is the correct API — it raises `RuntimeError` if no loop is running (instead of silently creating one), which is the desired fail-fast behaviour.

## Test plan

- New regression test `test_default_time_fn_works_inside_running_loop` in `tests/test_rate_limiter.py` verifies the default `_time` lambda works correctly when called from within a running event loop.
- All existing rate limiter, translate, and router tests continue to pass (1514 backend, 1750 frontend).

Closes #1014
