### PR TITLE
ux: add aria-label to reader header icon-only buttons (closes #1015)

### DIFF
--- a/frontend/src/__tests__/ReaderHeaderAria.test.ts
+++ b/frontend/src/__tests__/ReaderHeaderAria.test.ts
@@ -1,0 +1,48 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Reader header buttons aria-label (closes #1015)", () => {
+  it("Library back button has aria-label", () => {
+    // Find the back-to-library button
+    const idx = src.indexOf('router.push("/")');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 50);
+    expect(window).toContain("aria-label");
+  });
+
+  it("Library back button aria-label references Library", () => {
+    const idx = src.indexOf('router.push("/")');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 50);
+    expect(window).toMatch(/aria-label=.*[Ll]ibrary/);
+  });
+
+  it("Typography header button has aria-label", () => {
+    // Find the Typography panel toggle button (title="Typography settings")
+    const idx = src.indexOf('title="Typography settings"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 50), idx + 100);
+    expect(window).toContain("aria-label");
+  });
+
+  it("Focus mode toggle button has aria-label", () => {
+    // Find the focus mode button (title="Focus mode (F)")
+    const idx = src.indexOf('title="Focus mode (F)"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 50), idx + 100);
+    expect(window).toContain("aria-label");
+  });
+
+  it("Profile avatar button has aria-label", () => {
+    // Find the profile button (router.push("/profile") in header)
+    const idx = src.indexOf('router.push("/profile")');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 50), idx + 200);
+    expect(window).toContain("aria-label");
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -894,6 +894,7 @@ export default function ReaderPage() {
         <div className="flex items-center gap-2 md:gap-3 px-3 md:px-4 py-2 md:py-3">
           <button
             onClick={() => router.push("/")}
+            aria-label="Library"
             className="text-amber-700 hover:text-amber-900 text-sm shrink-0 min-h-[44px] flex items-center"
           >
             <ArrowLeftIcon className="w-4 h-4 shrink-0" aria-hidden="true" /><span className="hidden sm:inline ml-1">Library</span>
@@ -995,6 +996,7 @@ export default function ReaderPage() {
                 setShowTypographyPanel((v) => !v);
               }}
               title="Typography settings"
+              aria-label="Typography settings"
               className={`flex shrink-0 items-center gap-1 px-2 py-1 min-h-[44px] rounded-lg border text-xs font-bold transition-colors ${
                 showTypographyPanel || paragraphFocus
                   ? "bg-amber-100 border-amber-400 text-amber-800"
@@ -1150,6 +1152,7 @@ export default function ReaderPage() {
               setShowTypographyPanel(false);
             }}
             title="Focus mode (F)"
+            aria-label="Focus mode"
             className={`hidden md:flex shrink-0 items-center gap-1.5 px-2 lg:px-3 py-1.5 min-h-[44px] rounded-lg border text-xs font-medium transition-colors ${
               focusMode
                 ? "bg-amber-700 text-white border-amber-700"
@@ -1204,6 +1207,7 @@ export default function ReaderPage() {
             <button
               onClick={() => router.push("/profile")}
               title={session.backendUser?.name ?? "Profile"}
+              aria-label={session.backendUser?.name ?? "Profile"}
               className="shrink-0 min-w-[44px] min-h-[44px] w-10 h-10 md:w-8 md:h-8 rounded-full overflow-hidden border border-amber-300 hover:border-amber-500 transition-colors ml-auto md:ml-0"
             >
               {session.backendUser?.picture ? (


### PR DESCRIPTION
Closes #1015

Four buttons in the reader page header have no `aria-label`, violating WCAG 4.1.2 (Name, Role, Value, Level A):

- **Library back button**: `ArrowLeftIcon` is `aria-hidden`; label text is `hidden sm:inline` → the button has **no accessible name at all** on mobile.
- **Typography toggle**: shows "Aa" text only; `title="Typography settings"` not announced by screen readers.
- **Focus mode toggle**: text is `hidden lg:inline` → icon-only at `md` breakpoints; `title` only.
- **Profile avatar**: shows picture or initials; `title={name ?? "Profile"}` not announced.

## Changes
- `reader/[bookId]/page.tsx`: add `aria-label` to Library back, Typography, Focus mode, and Profile buttons
- `ReaderHeaderAria.test.ts`: 5 static assertions confirming each button has an `aria-label`

## Test plan
- [x] 5 new tests pass
- [x] Full frontend suite — 1986/1986 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
