### PR TITLE
ux: add aria-label to TTSControls voice gender toggle button (closes #1018)

### DIFF
--- a/frontend/src/__tests__/TTSControlsGenderAria.test.ts
+++ b/frontend/src/__tests__/TTSControlsGenderAria.test.ts
@@ -1,0 +1,23 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/TTSControls.tsx"),
+  "utf8"
+);
+
+describe("TTSControls gender toggle aria-label (closes #1018)", () => {
+  it("gender toggle button has aria-label attribute", () => {
+    const idx = src.indexOf("onClick={toggleGender}");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 400);
+    expect(window).toContain("aria-label");
+  });
+
+  it("gender toggle button aria-label references the gender/voice", () => {
+    const idx = src.indexOf("onClick={toggleGender}");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 400);
+    expect(window).toMatch(/aria-label=.*[Vv]oice/);
+  });
+});

--- a/frontend/src/components/TTSControls.tsx
+++ b/frontend/src/components/TTSControls.tsx
@@ -459,6 +459,7 @@ export default function TTSControls({
       <button
         onClick={toggleGender}
         title={`Voice: ${gender}. Click to switch.`}
+        aria-label={`Voice: ${gender === "female" ? "Female" : "Male"}. Click to switch.`}
         className="text-xs px-3 py-2 md:px-2 md:py-1 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 transition-colors min-h-[44px] md:min-h-0 font-medium"
         disabled={status === "loading"}
       >


### PR DESCRIPTION
Closes #1018

## Problem

The TTS voice gender toggle button in `TTSControls.tsx` shows only `F` or `M` with a `title` attribute but no `aria-label`. Screen readers announce the bare letter without context (WCAG 4.1.2 violation — no accessible name).

## Changes

- `TTSControls.tsx`: add `aria-label={"Voice: Female/Male. Click to switch."}` to the gender toggle button
- `TTSControlsGenderAria.test.ts`: 2 static assertions confirming the button has a `aria-label` referencing "Voice"

## Test plan

- [x] 2 new tests pass
- [x] Full frontend suite — 1988/1988 passing