### PR TITLE
fix: add min_length=1 to queue_delete_book target_language query param (closes #1019)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1195,7 +1195,7 @@ async def queue_clear(
 @router.delete("/queue/book/{book_id}")
 async def queue_delete_book(
     book_id: int = Path(..., ge=1),
-    target_language: str | None = Query(default=None, max_length=20),
+    target_language: str | None = Query(default=None, min_length=1, max_length=20),
     _admin: dict = Depends(_require_admin),
 ):
     norm = target_language.lower().split("-")[0] if target_language else None

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -2584,6 +2584,12 @@ async def test_queue_delete_book_oversized_target_language_returns_422(admin_cli
     assert res.status_code == 422
 
 
+async def test_queue_delete_book_empty_target_language_returns_422(admin_client):
+    """Regression #1019: DELETE /admin/queue/book/{id}?target_language= must return 422, not silently delete all."""
+    res = await admin_client.delete("/api/admin/queue/book/1?target_language=")
+    assert res.status_code == 422, f"Expected 422 for empty target_language, got {res.status_code}: {res.text}"
+
+
 # ── Translation path param bounds checks (regression for #583) ────────────────
 
 async def test_delete_language_translations_oversized_target_language_returns_422(admin_client):


### PR DESCRIPTION
## What changed

Added `min_length=1` to the `target_language` query param on `DELETE /admin/queue/book/{id}`.

## Why

Without `min_length=1`, sending `?target_language=` (empty string) was silently accepted. The empty string is falsy, so the truthiness check on line 1201 treated it as `None`, causing the endpoint to delete **all** queue rows for the book instead of filtering by language. This is inconsistent with #772 which added `min_length=1` to all other admin `target_language` fields but missed this query param.

## Test plan

- Added `test_queue_delete_book_empty_target_language_returns_422` — regression test for #1019
- Existing `test_queue_delete_book_oversized_target_language_returns_422` still passes
- Full backend suite: 1515 passed
- Full frontend suite: 1986 passed

Closes #1019
