### PR TITLE
ux: add aria-label to decks 'New deck' header button (closes #1023)

### DIFF
--- a/frontend/src/__tests__/DecksNewBtnAria.test.ts
+++ b/frontend/src/__tests__/DecksNewBtnAria.test.ts
@@ -1,0 +1,24 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/decks/page.tsx"),
+  "utf8"
+);
+
+describe("Decks page 'New deck' header button aria-label (closes #1023)", () => {
+  it("New deck header button has aria-label attribute", () => {
+    // Find the header button (not the empty-state button)
+    const idx = src.indexOf('data-testid="decks-new-btn"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 200);
+    expect(window).toContain("aria-label");
+  });
+
+  it("New deck header button aria-label is 'New deck'", () => {
+    const idx = src.indexOf('data-testid="decks-new-btn"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 200);
+    expect(window).toMatch(/aria-label=["']New deck["']/);
+  });
+});

--- a/frontend/src/app/decks/page.tsx
+++ b/frontend/src/app/decks/page.tsx
@@ -66,6 +66,7 @@ export default function DecksPage() {
             type="button"
             onClick={() => router.push("/decks/new")}
             data-testid="decks-new-btn"
+            aria-label="New deck"
             className="flex items-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 shrink-0"
           >
             <DeckIcon className="w-4 h-4" />


### PR DESCRIPTION
Closes #1023

The **New deck** header button in the decks page becomes icon-only on screens below the `sm` breakpoint (< 640 px):

```jsx
<button data-testid="decks-new-btn" ...>
  <DeckIcon className="w-4 h-4" />
  <span className="hidden sm:inline">New deck</span>
</button>
```

At < 640 px the label text is hidden and there is no `aria-label`, leaving screen readers with no accessible name — a WCAG 4.1.2 (Name, Role, Value) Level A violation.

## Changes

- `frontend/src/app/decks/page.tsx`: added `aria-label="New deck"` to the header button
- `frontend/src/__tests__/DecksNewBtnAria.test.ts`: 2 static assertions confirming the button has the correct `aria-label`

## Test plan

- [x] 2 new tests pass
- [x] Full frontend suite — 2000/2000 passing

🤖 Generated with Claude Code
