### PR TITLE
ux: add aria-label to QueueTab service-settings inputs (closes #1030)

### DIFF
--- a/frontend/src/__tests__/QueueTabFormAria.test.ts
+++ b/frontend/src/__tests__/QueueTabFormAria.test.ts
@@ -1,0 +1,25 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/QueueTab.tsx"),
+  "utf8"
+);
+
+describe("QueueTab service-settings inputs have accessible labels (closes #1030)", () => {
+  it("auto-translate languages input has aria-label", () => {
+    // The <label> at line ~781 has no htmlFor and does not wrap the <input>,
+    // so the input needs its own aria-label for an accessible name.
+    const idx = src.indexOf('placeholder="zh, de, ja"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 300), idx + 100);
+    expect(window).toMatch(/aria-label=/);
+  });
+
+  it("Gemini API key input has aria-label", () => {
+    const idx = src.indexOf('"•••• (leave empty to keep)"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 300), idx + 100);
+    expect(window).toMatch(/aria-label=/);
+  });
+});

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -783,6 +783,7 @@ export default function QueueTab({ adminFetch }: Props) {
             </label>
             <div className="flex gap-2">
               <input
+                aria-label="Auto-translate languages"
                 value={langs}
                 onChange={(e) => setLangs(e.target.value)}
                 className="flex-1 rounded border border-amber-300 px-2 py-1 text-sm"
@@ -812,6 +813,7 @@ export default function QueueTab({ adminFetch }: Props) {
             <div className="flex gap-2">
               <input
                 type="password"
+                aria-label="Gemini API key"
                 value={apiKey}
                 onChange={(e) => setApiKey(e.target.value)}
                 className="flex-1 rounded border border-amber-300 px-2 py-1 text-sm"


### PR DESCRIPTION
Closes #1030

Two text inputs in the QueueTab `Service settings` panel had descriptive `<label>` text but no `htmlFor` and did not wrap the corresponding `<input>` elements, so screen readers could not announce the field name — a WCAG 1.3.1 + 4.1.2 (Level A) violation.

## Changes

- `frontend/src/components/QueueTab.tsx`: added `aria-label` to the auto-translate languages input and the Gemini API key password input
- `frontend/src/__tests__/QueueTabFormAria.test.ts`: 2 static assertions confirming each input carries an `aria-label`

## Test plan

- [x] 2 new tests pass
- [x] Full frontend suite — 2004/2004 passing

🤖 Generated with Claude Code
