### PR TITLE
ux: add aria-label to InsightChat message textarea (closes #1031)

### DIFF
--- a/frontend/src/__tests__/InsightChatTextareaAria.test.ts
+++ b/frontend/src/__tests__/InsightChatTextareaAria.test.ts
@@ -1,0 +1,21 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/InsightChat.tsx"),
+  "utf8"
+);
+
+describe("InsightChat message textarea has aria-label (closes #1031)", () => {
+  it("chat textarea element exists", () => {
+    const idx = src.indexOf("<textarea");
+    expect(idx).toBeGreaterThan(-1);
+  });
+
+  it("chat textarea has aria-label attribute", () => {
+    const idx = src.indexOf("<textarea");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 400);
+    expect(window).toMatch(/aria-label=/);
+  });
+});

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -501,6 +501,7 @@ export default function InsightChat({
 
         <div className="flex gap-2 items-end">
           <textarea
+            aria-label="Ask about this chapter"
             className="flex-1 rounded-xl border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:bg-white focus:border-transparent resize-none leading-relaxed transition-colors placeholder:text-gray-400"
             rows={2}
             placeholder={hasGeminiKey ? "Ask about this chapter…" : "Gemini API key required"}


### PR DESCRIPTION
Closes #1031

The chat textarea in \`InsightChat.tsx\` had only a \`placeholder\` attribute but no \`aria-label\`. Placeholder text disappears once the user starts typing and is not a reliable accessible name, violating WCAG 4.1.2 Name, Role, Value (Level A).

## Changes

- \`frontend/src/components/InsightChat.tsx\`: added \`aria-label="Ask about this chapter"\` to the message textarea
- \`frontend/src/__tests__/InsightChatTextareaAria.test.ts\`: 2 static assertions confirming the textarea has an \`aria-label\`

## Test plan

- [x] 2 new tests pass
- [x] Full frontend suite — 2004/2004 passing

🤖 Generated with Claude Code