### PR TITLE
fix: reject whitespace-only deck names in create and patch endpoints (closes #1033)

### DIFF
--- a/backend/routers/decks.py
+++ b/backend/routers/decks.py
@@ -16,7 +16,7 @@ from typing import Annotated, Literal
 
 import aiosqlite
 from fastapi import APIRouter, Depends, HTTPException, Path
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from services import decks as decks_service
 from services.auth import get_current_user
@@ -43,11 +43,25 @@ class DeckCreate(BaseModel):
     mode: Literal["manual", "smart"]
     rules_json: SmartRules | None = None
 
+    @field_validator("name")
+    @classmethod
+    def name_not_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("name cannot be blank")
+        return v
+
 
 class DeckPatch(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=80)
     description: str | None = Field(default=None, max_length=500)
     rules_json: SmartRules | None = None
+
+    @field_validator("name")
+    @classmethod
+    def name_not_blank(cls, v: str | None) -> str | None:
+        if v is not None and not v.strip():
+            raise ValueError("name cannot be blank")
+        return v
 
 
 class MemberAdd(BaseModel):

--- a/backend/tests/test_router_decks_blank_name.py
+++ b/backend/tests/test_router_decks_blank_name.py
@@ -1,0 +1,47 @@
+"""Regression tests for #1033 — deck create/patch must reject whitespace-only names.
+
+A name like "   " passes Pydantic's min_length=1 check (3 chars) but the router
+calls .strip() before passing to the service, resulting in "" stored in the DB.
+"""
+
+import pytest
+
+
+async def test_create_deck_whitespace_only_name_returns_422(client, test_user):
+    """POST /decks with a whitespace-only name must be rejected (422)."""
+    resp = await client.post("/api/decks", json={"name": "   ", "mode": "manual"})
+    assert resp.status_code == 422
+
+
+async def test_create_deck_single_space_returns_422(client, test_user):
+    """POST /decks with a single space name must be rejected (422)."""
+    resp = await client.post("/api/decks", json={"name": " ", "mode": "manual"})
+    assert resp.status_code == 422
+
+
+async def test_create_deck_valid_name_succeeds(client, test_user):
+    """POST /decks with a real name must still work (regression guard)."""
+    resp = await client.post("/api/decks", json={"name": "My Deck", "mode": "manual"})
+    assert resp.status_code == 201
+    assert resp.json()["name"] == "My Deck"
+
+
+async def test_patch_deck_whitespace_only_name_returns_422(client, test_user):
+    """PATCH /decks/{id} with a whitespace-only name must be rejected (422)."""
+    create = await client.post("/api/decks", json={"name": "Valid", "mode": "manual"})
+    assert create.status_code == 201
+    deck_id = create.json()["id"]
+
+    resp = await client.patch(f"/api/decks/{deck_id}", json={"name": "   "})
+    assert resp.status_code == 422
+
+
+async def test_patch_deck_valid_name_succeeds(client, test_user):
+    """PATCH /decks/{id} with a trimmed non-empty name must still work."""
+    create = await client.post("/api/decks", json={"name": "Original", "mode": "manual"})
+    assert create.status_code == 201
+    deck_id = create.json()["id"]
+
+    resp = await client.patch(f"/api/decks/{deck_id}", json={"name": "Renamed"})
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Renamed"


### PR DESCRIPTION
## What changed

Added `field_validator` to `DeckCreate` and `DeckPatch` in `backend/routers/decks.py` that rejects whitespace-only deck names (e.g. `"   "`) before they reach the service layer.

## Why

`DeckCreate.name` has `min_length=1` on the Pydantic field, but a string of spaces like `"   "` passes that check (length=3). The router then calls `req.name.strip()` before passing to the service, resulting in an empty string `""` stored as the deck name in the DB — bypassing the intended validation.

Same issue existed in `DeckPatch`.

## Test plan

- Added `backend/tests/test_router_decks_blank_name.py` with 5 regression tests:
  - `POST /decks` with `"   "` → 422
  - `POST /decks` with `" "` → 422
  - `POST /decks` with `"My Deck"` → 201 (regression guard)
  - `PATCH /decks/{id}` with `"   "` → 422
  - `PATCH /decks/{id}` with `"Renamed"` → 200 (regression guard)
- Full backend suite: 1522 passed
