### PR TITLE
ux: add scope="col" to admin uploads table headers (closes #1036)

### DIFF
--- a/frontend/src/__tests__/AdminUploadsTableScope.test.ts
+++ b/frontend/src/__tests__/AdminUploadsTableScope.test.ts
@@ -1,0 +1,23 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/admin/uploads/page.tsx"),
+  "utf8"
+);
+
+describe("Admin uploads table headers have scope=\"col\" (closes #1036)", () => {
+  it("all th elements have scope=\"col\"", () => {
+    // Find all <th occurrences and verify each has scope="col"
+    const thMatches = [...src.matchAll(/<th\b([^>]*)>/g)];
+    expect(thMatches.length).toBeGreaterThan(0);
+    for (const match of thMatches) {
+      expect(match[1]).toMatch(/scope="col"/);
+    }
+  });
+
+  it("table has at least 6 column headers", () => {
+    const thMatches = [...src.matchAll(/<th\b[^>]*>/g)];
+    expect(thMatches.length).toBeGreaterThanOrEqual(6);
+  });
+});

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -140,13 +140,13 @@ export default function UploadsPage() {
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-amber-200 bg-amber-50/60">
-                  <th className="px-4 py-2.5 text-left font-medium text-amber-800">Title</th>
-                  <th className="px-4 py-2.5 text-left font-medium text-amber-800">File</th>
-                  <th className="px-4 py-2.5 text-left font-medium text-amber-800">Format</th>
-                  <th className="px-4 py-2.5 text-left font-medium text-amber-800">Size</th>
-                  <th className="px-4 py-2.5 text-left font-medium text-amber-800">Uploader</th>
-                  <th className="px-4 py-2.5 text-left font-medium text-amber-800">Date</th>
-                  <th className="px-4 py-2.5 text-left font-medium text-amber-800"></th>
+                  <th scope="col" className="px-4 py-2.5 text-left font-medium text-amber-800">Title</th>
+                  <th scope="col" className="px-4 py-2.5 text-left font-medium text-amber-800">File</th>
+                  <th scope="col" className="px-4 py-2.5 text-left font-medium text-amber-800">Format</th>
+                  <th scope="col" className="px-4 py-2.5 text-left font-medium text-amber-800">Size</th>
+                  <th scope="col" className="px-4 py-2.5 text-left font-medium text-amber-800">Uploader</th>
+                  <th scope="col" className="px-4 py-2.5 text-left font-medium text-amber-800">Date</th>
+                  <th scope="col" className="px-4 py-2.5 text-left font-medium text-amber-800"></th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-amber-100">


### PR DESCRIPTION
Closes #1036

The uploads table in `admin/uploads/page.tsx` had 7 `<th>` column headers without `scope="col"` attributes. Without `scope`, screen readers cannot reliably associate column headers with their data cells, violating WCAG 1.3.1 Info and Relationships (Level A).

## Changes

- `frontend/src/app/admin/uploads/page.tsx`: added `scope="col"` to all 7 `<th>` elements (Title, File, Format, Size, Uploader, Date, and the empty actions column)
- `frontend/src/__tests__/AdminUploadsTableScope.test.ts`: 2 static assertions confirming every `<th>` has `scope="col"`

## Test plan

- [x] 2 new tests pass
- [x] Full frontend suite — 2009/2009 passing

🤖 Generated with Claude Code