### PR TITLE
ux: add role="dialog" and aria-modal to AuthPromptModal and BookDetailModal (closes #1037)

### DIFF
--- a/frontend/src/__tests__/ModalDialogRole.test.ts
+++ b/frontend/src/__tests__/ModalDialogRole.test.ts
@@ -1,0 +1,30 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const authModal = fs.readFileSync(
+  path.join(__dirname, "../components/AuthPromptModal.tsx"),
+  "utf8"
+);
+
+const bookModal = fs.readFileSync(
+  path.join(__dirname, "../components/BookDetailModal.tsx"),
+  "utf8"
+);
+
+describe("Modal components have role=\"dialog\" and aria-modal (closes #1037)", () => {
+  it("AuthPromptModal has role=\"dialog\"", () => {
+    expect(authModal).toContain('role="dialog"');
+  });
+
+  it("AuthPromptModal has aria-modal=\"true\"", () => {
+    expect(authModal).toContain('aria-modal="true"');
+  });
+
+  it("BookDetailModal has role=\"dialog\"", () => {
+    expect(bookModal).toContain('role="dialog"');
+  });
+
+  it("BookDetailModal has aria-modal=\"true\"", () => {
+    expect(bookModal).toContain('aria-modal="true"');
+  });
+});

--- a/frontend/src/components/AuthPromptModal.tsx
+++ b/frontend/src/components/AuthPromptModal.tsx
@@ -20,7 +20,7 @@ export default function AuthPromptModal({ open, feature, onClose }: Props) {
   return (
     <div className="fixed inset-0 z-[200] flex items-end md:items-center justify-center">
       <div className="absolute inset-0 bg-black/40" onClick={onClose} />
-      <div className="relative bg-white rounded-t-2xl md:rounded-2xl shadow-xl p-6 w-full max-w-sm animate-slide-up">
+      <div role="dialog" aria-modal="true" aria-label="Sign in required" className="relative bg-white rounded-t-2xl md:rounded-2xl shadow-xl p-6 w-full max-w-sm animate-slide-up">
         <p className="font-serif text-lg text-ink mb-1">Sign in to {feature}</p>
         <p className="text-sm text-stone-500 mb-5">
           Create a free account or sign in to unlock this feature.

--- a/frontend/src/components/BookDetailModal.tsx
+++ b/frontend/src/components/BookDetailModal.tsx
@@ -50,6 +50,9 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="book-detail-title"
         className="w-full sm:max-w-md bg-white rounded-t-2xl sm:rounded-2xl shadow-xl p-6 max-h-[85vh] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
       >
@@ -62,7 +65,7 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
               : <BookCoverPlaceholderIcon className="w-8 h-12 text-amber-600" />}
           </div>
           <div className="flex-1 min-w-0">
-            <h2 className="font-serif font-bold text-ink text-lg leading-tight mb-1">
+            <h2 id="book-detail-title" className="font-serif font-bold text-ink text-lg leading-tight mb-1">
               {book.title}
             </h2>
             <p className="text-sm text-amber-700">{book.authors.join(", ")}</p>


### PR DESCRIPTION
Closes #1037

Two modal overlays lacked the ARIA dialog role, failing WCAG 4.1.2 (Name, Role, Value, Level A): screen readers announced the modal content as ordinary content with no indication that it was a dialog requiring attention.

## Changes
- `AuthPromptModal.tsx`: added `role="dialog"`, `aria-modal="true"`, `aria-label="Sign in required"` to the inner modal div
- `BookDetailModal.tsx`: added `role="dialog"`, `aria-modal="true"`, `aria-labelledby="book-detail-title"` to inner div; added `id="book-detail-title"` to the h2 heading
- `ModalDialogRole.test.ts`: 4 static source assertions confirming each modal has the required ARIA attributes

## Test plan
- [x] 4 new tests pass
- [x] Full frontend suite — 2013/2013 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
