### PR TITLE
ux: wrap vocabulary export status message in aria-live region (closes #1038)

### DIFF
--- a/frontend/src/__tests__/VocabExportAriaLive.test.ts
+++ b/frontend/src/__tests__/VocabExportAriaLive.test.ts
@@ -1,0 +1,25 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8"
+);
+
+describe("Vocabulary export status message has aria-live region (closes #1038)", () => {
+  it("exportMsg JSX area has role=\"status\"", () => {
+    // Anchor on the JSX conditional render, not the state declaration
+    const idx = src.indexOf("{exportMsg &&");
+    expect(idx).toBeGreaterThan(-1);
+    // Check the 300 chars before the conditional (the wrapping live region)
+    const region = src.slice(idx - 300, idx + 50);
+    expect(region).toMatch(/role="status"/);
+  });
+
+  it("exportMsg JSX area has aria-live=\"polite\"", () => {
+    const idx = src.indexOf("{exportMsg &&");
+    expect(idx).toBeGreaterThan(-1);
+    const region = src.slice(idx - 300, idx + 50);
+    expect(region).toMatch(/aria-live="polite"/);
+  });
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -450,15 +450,17 @@ function VocabularyPageContent() {
         </button>
       </header>
 
-      {exportMsg && (
-        <div className="mx-6 mt-4 border border-amber-300 bg-amber-50 rounded-xl px-4 py-3 text-sm text-ink">
-          {exportMsg.startsWith("http") ? (
-            <>Exported! <a href={exportMsg} target="_blank" rel="noopener noreferrer" className="text-amber-700 underline break-all">{exportMsg}</a></>
-          ) : (
-            <span className="text-red-600">{exportMsg}</span>
-          )}
-        </div>
-      )}
+      <div role="status" aria-live="polite" aria-atomic="true" className="mx-6 mt-4">
+        {exportMsg && (
+          <div className="border border-amber-300 bg-amber-50 rounded-xl px-4 py-3 text-sm text-ink">
+            {exportMsg.startsWith("http") ? (
+              <>Exported! <a href={exportMsg} target="_blank" rel="noopener noreferrer" className="text-amber-700 underline break-all">{exportMsg}</a></>
+            ) : (
+              <span className="text-red-600">{exportMsg}</span>
+            )}
+          </div>
+        )}
+      </div>
 
       <div className="max-w-2xl mx-auto px-4 md:px-6 py-6 md:py-8">
         {words.length > 5 && (


### PR DESCRIPTION
Closes #1038

The vocabulary page's export status message was conditionally rendered — when it appeared, the `aria-live` container wasn't yet in the DOM, so screen readers never announced it. Fixed by always rendering a persistent `role="status" aria-live="polite"` wrapper in the DOM, with the message conditionally shown inside it.

## Changes
- `vocabulary/page.tsx`: wrapped `{exportMsg && ...}` in a persistent `<div role="status" aria-live="polite" aria-atomic="true">` container
- `VocabExportAriaLive.test.ts`: 2 static assertions confirming the persistent wrapper and live region attribute are present

## Test plan
- [x] 2 new tests pass
- [x] Full frontend suite — 2011/2011 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
