### PR TITLE
fix: GET /vocabulary/{id}/tags returns 404 for foreign words (closes #1042)

### DIFF
--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -156,7 +156,10 @@ async def get_tags(
     vocabulary_id: int = Path(..., ge=1),
     user: dict = Depends(get_current_user),
 ):
-    return await vocab_tags.get_vocab_tags(user["id"], vocabulary_id)
+    tags = await vocab_tags.get_vocab_tags(user["id"], vocabulary_id)
+    if tags is None:
+        raise HTTPException(status_code=404, detail="Vocabulary word not found")
+    return tags
 
 
 @router.post("/{vocabulary_id}/tags", status_code=201)

--- a/backend/services/vocab_tags.py
+++ b/backend/services/vocab_tags.py
@@ -43,9 +43,18 @@ async def list_user_tags(user_id: int) -> list[dict]:
             return [dict(r) for r in await cur.fetchall()]
 
 
-async def get_vocab_tags(user_id: int, vocabulary_id: int) -> list[str]:
-    """Return the tags on a specific vocabulary word (user-scoped)."""
+async def get_vocab_tags(user_id: int, vocabulary_id: int) -> list[str] | None:
+    """Return the tags on a specific vocabulary word (user-scoped).
+
+    Returns None if vocabulary_id does not belong to user_id (caller raises 404).
+    """
     async with aiosqlite.connect(_db_module.DB_PATH) as db:
+        async with db.execute(
+            "SELECT 1 FROM vocabulary WHERE id = ? AND user_id = ?",
+            (vocabulary_id, user_id),
+        ) as cur:
+            if await cur.fetchone() is None:
+                return None
         async with db.execute(
             """
             SELECT tag FROM vocabulary_tags

--- a/backend/tests/test_router_vocabulary_tags.py
+++ b/backend/tests/test_router_vocabulary_tags.py
@@ -87,6 +87,16 @@ async def test_add_tag_404_for_foreign_word(client, test_user):
     assert resp.status_code == 404
 
 
+async def test_get_tags_404_for_foreign_word(client, test_user):
+    """GET tags on another user's word must return 404, not 200 with empty list (closes #1042)."""
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    other = await get_or_create_user("tag-other2", "tag-other2@ex.com", "Other2", "")
+    vid = await _save("foreignget", other["id"])
+
+    resp = await client.get(f"/api/vocabulary/{vid}/tags")
+    assert resp.status_code == 404
+
+
 async def test_add_tag_dedup(client, test_user):
     """Adding the same tag twice is idempotent."""
     await save_book(BOOK_ID, _BOOK_META, "text")


### PR DESCRIPTION
## What changed

`GET /vocabulary/{vocabulary_id}/tags` was returning `200 []` when the `vocabulary_id` belonged to another user. `POST` and `DELETE` on the same resource correctly returned 404 for foreign words; `GET` was missing the ownership check.

**Root cause:** `vocab_tags.get_vocab_tags()` only scoped the tag SELECT by `user_id` but never verified the vocabulary row itself belonged to that user. When the word is foreign the tag query returns no rows → empty list → 200.

## Fix

- `services/vocab_tags.py`: `get_vocab_tags()` now pre-checks `SELECT 1 FROM vocabulary WHERE id=? AND user_id=?` and returns `None` on mismatch.
- `routers/vocabulary.py`: router raises 404 when service returns `None`.

## Test plan

- Added `test_get_tags_404_for_foreign_word` — creates word for user B, then GETs tags as user A, asserts 404.
- All 1523 backend tests pass; 1750 frontend tests pass.
