### PR TITLE
ux: add role="alert" to admin page error messages (closes #1040)

### DIFF
--- a/frontend/src/__tests__/AdminErrorRoleAlert.test.ts
+++ b/frontend/src/__tests__/AdminErrorRoleAlert.test.ts
@@ -1,0 +1,48 @@
+import * as fs from "fs";
+import * as path from "path";
+
+function readPage(rel: string) {
+  return fs.readFileSync(path.join(__dirname, rel), "utf8");
+}
+
+function hasRoleAlertNearError(src: string): boolean {
+  // Find error-styled divs and check they have role="alert" within 50 chars before
+  const matches = [...src.matchAll(/role="alert"[^>]*>|<div\s[^>]*role="alert"[^>]*>/g)];
+  return matches.length > 0;
+}
+
+describe("Admin page error messages have role=\"alert\" (closes #1040)", () => {
+  it("admin/books error div has role=\"alert\"", () => {
+    const src = readPage("../app/admin/books/page.tsx");
+    // Find the dynamic error render: {error && <div ...>
+    const idx = src.indexOf("{error &&");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 200);
+    expect(window).toMatch(/role="alert"/);
+  });
+
+  it("admin/uploads error div has role=\"alert\"", () => {
+    const src = readPage("../app/admin/uploads/page.tsx");
+    const idx = src.indexOf("{error &&");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 200);
+    expect(window).toMatch(/role="alert"/);
+  });
+
+  it("admin/users error div has role=\"alert\"", () => {
+    const src = readPage("../app/admin/users/page.tsx");
+    // This one returns early: return <div>error</div>
+    const idx = src.indexOf("bg-red-50");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 100), idx + 100);
+    expect(window).toMatch(/role="alert"/);
+  });
+
+  it("admin/audio error div has role=\"alert\"", () => {
+    const src = readPage("../app/admin/audio/page.tsx");
+    const idx = src.indexOf("bg-red-50");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 100), idx + 100);
+    expect(window).toMatch(/role="alert"/);
+  });
+});

--- a/frontend/src/app/admin/audio/page.tsx
+++ b/frontend/src/app/admin/audio/page.tsx
@@ -49,7 +49,7 @@ export default function AudioPage() {
       </div>
     );
   if (error)
-    return <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm">{error}</div>;
+    return <div role="alert" className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm">{error}</div>;
 
   return (
     <div className="bg-white rounded-xl border border-amber-200 divide-y divide-amber-100 overflow-hidden">

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -222,7 +222,7 @@ export default function BooksPage() {
   return (
     <div className="space-y-4">
       {error && (
-        <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm">{error}</div>
+        <div role="alert" className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm">{error}</div>
       )}
 
       <div className="flex gap-2">

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -81,7 +81,7 @@ export default function UploadsPage() {
   return (
     <div className="space-y-4">
       {error && (
-        <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm">{error}</div>
+        <div role="alert" className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm">{error}</div>
       )}
 
       <div className="flex gap-2 items-center">

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -47,7 +47,7 @@ export default function UsersPage() {
 
   if (loading) return <SpinnerRow />;
   if (error)
-    return <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm">{error}</div>;
+    return <div role="alert" className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm">{error}</div>;
 
   return (
     <div className="bg-white rounded-xl border border-amber-200 divide-y divide-amber-100 overflow-hidden">


### PR DESCRIPTION
Closes #1040

Four admin pages rendered error messages as plain divs with no ARIA role, violating WCAG 4.1.3 (Status Messages, Level AA): screen readers would not automatically announce the error text when it appeared.

## Changes
- `admin/books/page.tsx`: added `role="alert"` to the conditional error div
- `admin/uploads/page.tsx`: added `role="alert"` to the conditional error div
- `admin/users/page.tsx`: added `role="alert"` to the early-return error div
- `admin/audio/page.tsx`: added `role="alert"` to the early-return error div
- `AdminErrorRoleAlert.test.ts`: 4 static source assertions confirming each page has `role="alert"` on its error element

## Test plan
- [x] 4 new tests pass
- [x] Full frontend suite — 2015/2015 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
