### PR TITLE
ux: add role="dialog" and aria-modal to WordActionDrawer (closes #1046)

### DIFF
--- a/frontend/src/__tests__/WordActionDrawerDialogRole.test.ts
+++ b/frontend/src/__tests__/WordActionDrawerDialogRole.test.ts
@@ -1,0 +1,21 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/WordActionDrawer.tsx"),
+  "utf8",
+);
+
+describe("WordActionDrawer has ARIA dialog role (closes #1046)", () => {
+  it("drawer div has role=\"dialog\"", () => {
+    expect(src).toMatch(/role="dialog"/);
+  });
+
+  it("drawer div has aria-modal=\"true\"", () => {
+    expect(src).toMatch(/aria-modal="true"/);
+  });
+
+  it("drawer div has aria-label", () => {
+    expect(src).toMatch(/aria-label=/);
+  });
+});

--- a/frontend/src/components/WordActionDrawer.tsx
+++ b/frontend/src/components/WordActionDrawer.tsx
@@ -112,6 +112,9 @@ export default function WordActionDrawer({
       {/* Drawer */}
       <div
         ref={drawerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Word lookup: ${word}`}
         className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl border-t border-amber-200 max-h-[60vh] overflow-y-auto safe-bottom animate-slide-up"
       >
         {/* Drag handle */}


### PR DESCRIPTION
Closes #1046

`WordActionDrawer` is a bottom-sheet modal (fixed backdrop, Escape-key handler, click-outside-close) but its drawer `<div>` had no ARIA dialog role, violating WCAG 4.1.2 (Name, Role, Value, Level A). Screen readers treated it as ordinary content with no indication the user was inside a modal.

## Changes
- `WordActionDrawer.tsx`: added `role="dialog"`, `aria-modal="true"`, `aria-label={`Word lookup: ${word}`}` to the inner drawer div
- `WordActionDrawerDialogRole.test.ts`: 3 static assertions confirming the required ARIA attributes are present

## Test plan
- [x] 3 new tests pass
- [x] Full frontend suite — 2020/2020 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
