### PR TITLE
feat: EPUB NCX fragment-anchor chapter segmentation (#964)

### DIFF
--- a/backend/services/splitter.py
+++ b/backend/services/splitter.py
@@ -595,6 +595,7 @@ def build_chapters_from_epub(epub_bytes: bytes) -> list[Chapter]:
         return []
 
     nav_titles = _epub_nav_titles(book)
+    nav_anchors = _epub_nav_anchors(book)
     book_title = book.title or ""
     id_to_item = {
         item.get_id(): item
@@ -645,34 +646,41 @@ def build_chapters_from_epub(epub_bytes: bytes) -> list[Chapter]:
             # copyright"> and so on for every frontmatter element.
             for fm in _epub_frontmatter_blocks(body):
                 fm.getparent().remove(fm)
-            text = _html_body_text(body, skip_first_heading=True)
         except Exception:
             continue
 
-        if not text.strip() or _token_count(text) < 30:
-            continue
+        # NCX fragment-anchor segmentation (#964). If the NCX declares
+        # ≥2 navPoints targeting this spine item with distinct `#anchor`
+        # fragments, split the DOM at those anchors so each navPoint
+        # becomes its own Chapter. Falls through to single-chapter
+        # extraction when there's only one navPoint, when anchors can't
+        # be resolved in the DOM, or on any lxml error.
+        item_anchors = nav_anchors.get(item_id, [])
+        if len(item_anchors) >= 2 and any(a for a, _ in item_anchors):
+            slices = _segment_body_by_anchors(body, item_anchors, book_title)
+        else:
+            slices = []
 
-        title = (
-            nav_titles.get(item_id)
-            or _epub_heading_title(raw)
-            or f"Section {len(chapters) + 1}"
-        )
-        # Drop the chapter title if it repeats as the first body paragraph
-        # (Faust Nacht: spine item holds a stand-alone part-title <div class="chapter">
-        # followed by the real scene <div class="chapter">; the recursive
-        # body walker otherwise renders both into text).
-        text = _strip_title_from_body_prefix(text, title)
-        # Strip the book title if it appears as the first paragraph — Faust
-        # (#923): spine items open with "FAUST: Der Tragödie erster Teil" as a
-        # stand-alone <p> that predates the actual scene heading.
-        text = _strip_title_from_body_prefix(text, book_title)
-        # Split paragraphs that pack multiple speaker turns into one block
-        # (Faust / Dumas / Leviathan class — #888 supersedes #820). The
-        # plain-text and HTML builders already call this; wiring the EPUB
-        # path closes the remaining miss catalogued in the post-backfill
-        # audit (reports/epub_split_audit_2026_04_24_post_backfill.md).
-        text = _split_dramatic_speakers(text)
-        chapters.append(Chapter(title=_clean_title(title), text=text))
+        if slices:
+            for slice_title, slice_body in slices:
+                text = _extract_and_clean_chapter_text(
+                    slice_body, slice_title, book_title
+                )
+                if not text or _token_count(text) < 30:
+                    continue
+                chapters.append(Chapter(title=_clean_title(slice_title), text=text))
+        else:
+            fallback_title = (
+                nav_titles.get(item_id)
+                or _epub_heading_title(raw)
+                or f"Section {len(chapters) + 1}"
+            )
+            text = _extract_and_clean_chapter_text(
+                body, fallback_title, book_title
+            )
+            if not text or _token_count(text) < 30:
+                continue
+            chapters.append(Chapter(title=_clean_title(fallback_title), text=text))
 
     if len(chapters) >= 2:
         return chapters
@@ -797,6 +805,21 @@ def _epub_toc_containers(body) -> list:
     return out
 
 
+def _extract_and_clean_chapter_text(body, title: str, book_title: str) -> str:
+    """Walk a (possibly sliced) body element, extract plain-text, and apply the
+    per-chapter cleanups used by `build_chapters_from_epub`: strip the chapter
+    heading if it repeats as body prose, strip the book title prefix if it
+    leaks in, and split dramatic speaker cues.
+    """
+    text = _html_body_text(body, skip_first_heading=True)
+    if not text.strip():
+        return ""
+    text = _strip_title_from_body_prefix(text, title)
+    text = _strip_title_from_body_prefix(text, book_title)
+    text = _split_dramatic_speakers(text)
+    return text
+
+
 def _epub_nav_titles(book) -> dict[str, str]:
     """Return {item_id: chapter_title} from the EPUB TOC (NCX or EPUB3 nav)."""
     import ebooklib
@@ -833,6 +856,150 @@ def _epub_nav_titles(book) -> dict[str, str]:
 
     _walk(book.toc)
     return titles
+
+
+def _epub_nav_anchors(book) -> dict[str, list[tuple[str | None, str]]]:
+    """Return {item_id: [(anchor_id_or_None, title), …]} from the EPUB TOC.
+
+    Unlike `_epub_nav_titles` which only picks the first title per item_id,
+    this preserves the full ordered list of navPoints that target each spine
+    item — including fragment anchors (`file.xhtml#anchor`). Used by
+    `build_chapters_from_epub` to segment a single xhtml spine file into
+    multiple chapters when the NCX declares them via `#anchor` fragments
+    (design doc: `docs/design/epub-ncx-fragment-anchors.md`, issue #964).
+
+    The list order matches the NCX playOrder (depth-first walk of the
+    navMap). Length-1 lists reproduce the current behaviour (one chapter
+    per spine item); length-≥2 lists trigger DOM segmentation.
+    """
+    import ebooklib
+
+    name_to_id: dict[str, str] = {
+        item.get_name(): item.get_id()
+        for item in book.get_items_of_type(ebooklib.ITEM_DOCUMENT)
+    }
+
+    def _resolve(href: str) -> tuple[str | None, str | None]:
+        # Split on '#' into (bare_path, anchor_or_None).
+        if "#" in href:
+            bare, anchor = href.split("#", 1)
+            anchor = anchor or None
+        else:
+            bare, anchor = href, None
+        bare = bare.lstrip("/")
+        if bare in name_to_id:
+            return name_to_id[bare], anchor
+        for name, item_id in name_to_id.items():
+            if name.endswith("/" + bare) or name == bare:
+                return item_id, anchor
+        return None, anchor
+
+    result: dict[str, list[tuple[str | None, str]]] = {}
+
+    def _walk(toc_items) -> None:
+        for entry in toc_items:
+            if isinstance(entry, tuple):
+                section, children = entry
+                if getattr(section, "href", None):
+                    item_id, anchor = _resolve(section.href)
+                    title = getattr(section, "title", None)
+                    if item_id and title:
+                        result.setdefault(item_id, []).append((anchor, title))
+                _walk(children)
+            elif getattr(entry, "href", None):
+                item_id, anchor = _resolve(entry.href)
+                title = getattr(entry, "title", None)
+                if item_id and title:
+                    result.setdefault(item_id, []).append((anchor, title))
+
+    _walk(book.toc)
+    return result
+
+
+def _segment_body_by_anchors(
+    body,
+    anchors: list[tuple[str | None, str]],
+    book_title: str,
+):
+    """Split an lxml body element at anchor ids into ordered (title, sub_body) pairs.
+
+    Each `(anchor_id, title)` tuple in `anchors` becomes one sub-chapter.
+    Content before the first anchor is attached to that first slice
+    (typically a chapter's lead-in text or a navigable page-break marker).
+
+    If any anchor can't be located in the DOM, return `[]` — the caller
+    falls back to treating the whole spine item as one chapter. Partial
+    segmentation would silently drop content; better to degrade cleanly.
+
+    Algorithm:
+    1. Walk body.iter() once, building a flat list of elements in document
+       order. For each anchor id, record its index.
+    2. For each ordered pair `(start_index, end_index)`, slice the top-level
+       children list into a sub-body containing just those nodes.
+
+    The sub-body is a standalone lxml Element (detached), safe for
+    `_html_body_text` to walk without disturbing the source DOM.
+    """
+    from lxml import html as lxmlhtml
+
+    # Which anchors actually exist in the DOM? Walk once.
+    anchor_positions: dict[str, int] = {}
+    elements_in_order: list = []
+    for i, el in enumerate(body.iter()):
+        elements_in_order.append(el)
+        el_id = el.get("id")
+        if el_id:
+            anchor_positions.setdefault(el_id, i)
+        # HTML5/EPUB3 commonly uses `id=...`; some older Gutenberg files
+        # use `<a name="anchor">`. Treat name attributes on anchors as ids
+        # to preserve compatibility.
+        if el.tag == "a":
+            name = el.get("name")
+            if name:
+                anchor_positions.setdefault(name, i)
+
+    # Require every non-None anchor to resolve. If any is missing, bail out
+    # and let the caller fall back to single-chapter treatment.
+    for anchor_id, _ in anchors:
+        if anchor_id is None:
+            continue
+        if anchor_id not in anchor_positions:
+            return []
+
+    # Build positional ordered list: each entry's position is its anchor
+    # position, or 0 for a None anchor (which means "from the top of the
+    # file"). Then sort by position so the slices line up with DOM order.
+    # (NCX order usually matches DOM order already, but guard against it.)
+    indexed: list[tuple[int, str]] = []
+    for anchor_id, title in anchors:
+        pos = anchor_positions[anchor_id] if anchor_id else 0
+        indexed.append((pos, title))
+    indexed.sort(key=lambda p: p[0])
+
+    # For each pair of consecutive positions [start, next_start), gather
+    # the top-level descendants of body whose DOM index falls in that range.
+    # We only pick up top-level children of body to keep the slice clean —
+    # descendants come with their subtree automatically.
+    body_children = list(body)
+    # Map each top-level child to its position in the flat `elements_in_order`.
+    child_positions = [elements_in_order.index(c) for c in body_children]
+
+    slices: list = []
+    for i, (start_pos, _) in enumerate(indexed):
+        end_pos = indexed[i + 1][0] if i + 1 < len(indexed) else float("inf")
+        kept = [
+            body_children[j]
+            for j, cpos in enumerate(child_positions)
+            if start_pos <= cpos < end_pos
+        ]
+        # Build a detached body element from the kept children so
+        # _html_body_text can walk it like a real body.
+        new_body = lxmlhtml.Element("body")
+        for c in kept:
+            new_body.append(lxmlhtml.fromstring(lxmlhtml.tostring(c)))
+        slices.append(new_body)
+
+    return list(zip([t for _, t in indexed], slices))
 
 
 def _epub_heading_title(raw_xhtml: bytes) -> str:

--- a/backend/tests/test_splitter.py
+++ b/backend/tests/test_splitter.py
@@ -1821,3 +1821,263 @@ def test_epub_verse_br_lines_preserved_in_single_p():
     assert len(lines) >= 7, (
         f"Expected ≥7 verse lines preserved via \\n, got {len(lines)}: {faust_para!r}"
     )
+
+
+# ── #964 NCX fragment-anchor chapter boundaries ───────────────────────────────
+
+
+def _make_epub_single_file_with_anchors():
+    """Minimal EPUB with ONE xhtml spine item whose body has three anchor
+    sections — 3 navPoints point to (same_file, #anchor_N). This is the
+    Le Fantôme / Mémoires d'Outre-Tombe pattern the splitter used to collapse
+    to one chapter per spine file.
+    """
+    import io
+    from ebooklib import epub
+
+    book = epub.EpubBook()
+    book.set_title("Test Fragment-Anchors")
+    book.set_language("en")
+    book.add_author("Author")
+
+    # Long per-section body to pass the 30-word gate after segmentation.
+    section_body = (
+        "<p>This is a section of at least thirty words so that the splitter does "
+        "not reject it as a nav / cover page after the slice. Adding more padding "
+        "text here to meet the gate comfortably.</p>"
+    )
+    content = (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Body</title></head>'
+        '<body>'
+        '<h2 id="ch1">Chapter One</h2>' + section_body +
+        '<h2 id="ch2">Chapter Two</h2>' + section_body +
+        '<h2 id="ch3">Chapter Three</h2>' + section_body +
+        '</body></html>'
+    ).encode("utf-8")
+
+    doc = epub.EpubHtml(title="Body", file_name="body.xhtml", lang="en")
+    doc.content = content
+    book.add_item(doc)
+
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.toc = [
+        epub.Link("body.xhtml#ch1", "Chapter One", "ch1"),
+        epub.Link("body.xhtml#ch2", "Chapter Two", "ch2"),
+        epub.Link("body.xhtml#ch3", "Chapter Three", "ch3"),
+    ]
+    book.spine = [doc]
+
+    buf = io.BytesIO()
+    epub.write_epub(buf, book)
+    return buf.getvalue()
+
+
+def test_build_chapters_from_epub_ncx_fragment_anchors_segment_single_file():
+    """Three anchors in one spine xhtml must yield three Chapter entries,
+    each titled from the NCX navLabel."""
+    epub_bytes = _make_epub_single_file_with_anchors()
+    chapters = build_chapters_from_epub(epub_bytes)
+    titles = [c.title for c in chapters]
+    assert titles == ["Chapter One", "Chapter Two", "Chapter Three"], titles
+
+
+def test_build_chapters_from_epub_ncx_fragment_anchors_content_split_correctly():
+    """Each sliced Chapter must carry only its own anchor-delimited text
+    — Chapter Two's text must not contain Chapter Three's body."""
+    epub_bytes = _make_epub_single_file_with_anchors()
+    chapters = build_chapters_from_epub(epub_bytes)
+    assert len(chapters) == 3
+
+    # The only way "not reject" would appear three times is if each slice
+    # correctly owns one section. Chapter One should contain exactly one.
+    assert chapters[0].text.count("section of at least thirty") == 1
+    # Chapter Three should contain the same marker exactly once too.
+    assert chapters[2].text.count("section of at least thirty") == 1
+
+
+def test_build_chapters_from_epub_ncx_single_anchor_file_keeps_one_chapter():
+    """Regression — a spine item with exactly ONE navPoint (no fragment
+    or one anchor) must stay a single chapter. Anchor segmentation is
+    gated on len(anchors) >= 2, so this exercises the else branch."""
+    import io
+    from ebooklib import epub
+
+    book = epub.EpubBook()
+    book.set_title("Single-Anchor")
+    book.set_language("en")
+
+    body = (
+        '<p>This is a chapter with enough words to pass the thirty-word '
+        'gate and show that without multiple anchors we produce one Chapter '
+        'entry per spine item, not one per heading.</p>'
+    )
+    content = (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<html xmlns="http://www.w3.org/1999/xhtml"><head><title>A</title></head>'
+        '<body><h2 id="top">Alpha</h2>' + body +
+        '<h3 id="mid">Alpha mid</h3>' + body +
+        '</body></html>'
+    ).encode("utf-8")
+
+    doc = epub.EpubHtml(title="A", file_name="a.xhtml", lang="en")
+    doc.content = content
+    # Add a filler spine item so the existing >= 2 guard is satisfied.
+    filler = epub.EpubHtml(title="B", file_name="b.xhtml", lang="en")
+    filler_body = "".join(
+        f"<p>Filler {i} with enough words to pass the thirty word gate "
+        "padding padding padding padding padding.</p>"
+        for i in range(3)
+    )
+    filler.content = (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<html xmlns="http://www.w3.org/1999/xhtml"><head><title>B</title></head>'
+        f'<body><h2>B</h2>{filler_body}</body></html>'
+    ).encode("utf-8")
+
+    book.add_item(doc)
+    book.add_item(filler)
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.toc = [
+        epub.Link("a.xhtml#top", "Alpha", "top"),
+        epub.Link("b.xhtml", "B", "b"),
+    ]
+    book.spine = [doc, filler]
+
+    buf = io.BytesIO()
+    epub.write_epub(buf, book)
+
+    chapters = build_chapters_from_epub(buf.getvalue())
+    # Even though a.xhtml has TWO id attributes (top, mid), only ONE navPoint
+    # targets it — segmentation must NOT fire.
+    assert len(chapters) == 2
+    assert chapters[0].title == "Alpha"
+
+
+def test_build_chapters_from_epub_ncx_missing_anchor_falls_back_gracefully():
+    """If an NCX navPoint targets a `#nonexistent` anchor that isn't in the
+    DOM, segmentation bails out for that spine item and the file is kept
+    as one chapter (rather than silently dropping content)."""
+    import io
+    from ebooklib import epub
+
+    book = epub.EpubBook()
+    book.set_title("Missing Anchor")
+    book.set_language("en")
+
+    body_html = (
+        '<h2 id="real">Real Section</h2>'
+        '<p>This paragraph is in the only real anchor of the file, padded '
+        'with enough words to pass the thirty-word gate comfortably so the '
+        'splitter keeps it in the output. Adding a few more words here '
+        'for safety margin above the gate threshold.</p>'
+    )
+    content = (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<html xmlns="http://www.w3.org/1999/xhtml"><head><title>X</title></head>'
+        f'<body>{body_html}</body></html>'
+    ).encode("utf-8")
+
+    doc = epub.EpubHtml(title="X", file_name="x.xhtml", lang="en")
+    doc.content = content
+    filler = epub.EpubHtml(title="Y", file_name="y.xhtml", lang="en")
+    filler_body = "".join(
+        f"<p>Filler {i} with enough words to pass the thirty word gate "
+        "padding padding padding padding padding.</p>"
+        for i in range(3)
+    )
+    filler.content = (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Y</title></head>'
+        f'<body><h2>Y</h2>{filler_body}</body></html>'
+    ).encode("utf-8")
+
+    book.add_item(doc)
+    book.add_item(filler)
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    # Two navPoints target x.xhtml — one real, one pointing at #ghost
+    # (doesn't exist). The splitter should bail and treat x.xhtml as a
+    # single chapter.
+    book.toc = [
+        epub.Link("x.xhtml#real", "Real Section", "real"),
+        epub.Link("x.xhtml#ghost", "Ghost Section", "ghost"),
+        epub.Link("y.xhtml", "Y", "y"),
+    ]
+    book.spine = [doc, filler]
+
+    buf = io.BytesIO()
+    epub.write_epub(buf, book)
+
+    chapters = build_chapters_from_epub(buf.getvalue())
+    # x.xhtml should produce ONE chapter despite the two nav entries,
+    # because #ghost doesn't resolve in the DOM.
+    assert len(chapters) == 2
+    # The first chapter carries content from the real section.
+    assert "only real anchor" in chapters[0].text
+
+
+def test_build_chapters_from_epub_ncx_fragment_anchors_preserves_playorder():
+    """If NCX navPoint order disagrees with DOM order (unusual but valid),
+    the slices still line up with DOM order — anchor positions are resolved
+    from the DOM, not from the list order."""
+    import io
+    from ebooklib import epub
+
+    book = epub.EpubBook()
+    book.set_title("Order Test")
+    book.set_language("en")
+
+    section = "<p>Section " + "word " * 40 + "text.</p>"
+    # DOM order: A, B, C
+    content = (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<html xmlns="http://www.w3.org/1999/xhtml"><head><title>O</title></head>'
+        '<body>'
+        '<h2 id="a">Alpha</h2>' + section +
+        '<h2 id="b">Beta</h2>' + section +
+        '<h2 id="c">Gamma</h2>' + section +
+        '</body></html>'
+    ).encode("utf-8")
+
+    doc = epub.EpubHtml(title="O", file_name="o.xhtml", lang="en")
+    doc.content = content
+    book.add_item(doc)
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    # NCX order swapped: C first, then A, then B
+    book.toc = [
+        epub.Link("o.xhtml#c", "Gamma", "c"),
+        epub.Link("o.xhtml#a", "Alpha", "a"),
+        epub.Link("o.xhtml#b", "Beta", "b"),
+    ]
+    book.spine = [doc]
+
+    buf = io.BytesIO()
+    epub.write_epub(buf, book)
+
+    chapters = build_chapters_from_epub(buf.getvalue())
+    # Titles should come out in DOM order, not NCX listing order.
+    assert [c.title for c in chapters] == ["Alpha", "Beta", "Gamma"]
+
+
+def test_build_chapters_from_epub_ncx_fragment_anchors_real_file_62215():
+    """Integration check against the cached Le Fantôme de l'Opéra EPUB.
+    The book has 36 navPoints across 5 xhtml files; before this change
+    the splitter produced 4 chapters (one per file). Post-fix we expect
+    20+ — the full chapter structure of the novel plus frontmatter
+    anchors. Lower bound is defensive; the real count today is 30."""
+    import os
+    path = "/tmp/epub_investigation/book_62215.epub"
+    if not os.path.exists(path):
+        import pytest
+        pytest.skip(f"investigation EPUB not available at {path}")
+
+    with open(path, "rb") as f:
+        data = f.read()
+    chapters = build_chapters_from_epub(data)
+    assert len(chapters) >= 20, (
+        f"Expected ≥20 chapters from #62215 after fragment-anchor split, got {len(chapters)}"
+    )


### PR DESCRIPTION
## Summary

Implements the design in `docs/design/epub-ncx-fragment-anchors.md` (merged #968, user-approved). Closes the single largest class of chapter-structure bug in the Gutenberg catalog.

## What this fixes

When an EPUB's NCX targets a single xhtml spine item with multiple `#anchor` navPoints, the splitter was collapsing all of them into one chapter. The canonical repro is Le Fantôme de l'Opéra (#62215): 36 navPoints, 5 xhtml files, splitter produced **4 chapters**. With this change, **30 chapters**.

## Measured impact (91 cached Gutenberg EPUBs)

| | before | after |
|---|---:|---:|
| 0-char books | 8 | **0** |
| Suspicious char/paragraph-ratio flags | 25 | **0** |

| Book | before | after |
|---|---:|---:|
| #62215 Le Fantôme de l'Opéra | 4 | 30 |
| #25575 Mémoires d'Outre-Tombe | 8 | 21 |
| #43759 Geflügelte Worte | 20 | 45 |

## What's new in the code

- `_epub_nav_anchors(book)` — ordered per-file anchor list, preserving NCX play-order.
- `_segment_body_by_anchors(body, anchors, book_title)` — one-pass DOM walk, slices top-level body children into per-anchor sub-bodies. Resolves `id=` and legacy `<a name="...">` alike. Returns [] on any missing-anchor error so segmentation falls back to whole-file instead of dropping content silently.
- `_extract_and_clean_chapter_text` — shared cleanup pipeline so slice path and fallback path match.
- `build_chapters_from_epub` gated on `len(anchors) >= 2 and any(…)`; single-anchor spine items keep current behaviour.

## Not in this PR

- `splitter_version` column on books + cache-invalidation gate. Design explicitly punted these to a follow-up — new imports use the new parser, existing books stay frozen until an explicit `resplit_book.py` CLI ships.
- `resplit_book.py` CLI — same follow-up.

## Test plan

Six new tests in `test_splitter.py`:
- multi-anchor single-file segmentation produces correct slice count
- slice content is partitioned correctly (no bleed)
- single-anchor files keep one-chapter behaviour (regression guard)
- missing DOM anchor falls back to single chapter (no silent drop)
- NCX order ≠ DOM order → output in DOM order
- Integration check against cached Le Fantôme EPUB: ≥20 chapters

**Full suite: 1528 passed.** Catalog-wide audit (`scripts/epub_split_audit`) shows 0 0-char books and 0 suspicious-ratio flags after the change.

Closes #964.
