### PR TITLE
fix: whitespace-only language fields bypass validation in books and ai routers

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -4,7 +4,7 @@ from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from services.auth import get_current_user, decrypt_api_key, check_book_access
 from services.db import (
     get_cached_translation,
@@ -242,11 +242,13 @@ async def translate_cache(
     _user: dict = Depends(get_current_user),
 ):
     """Check if a translation is cached. Returns paragraphs + provider/model if yes, 404 if not."""
+    target_language = target_language.strip().lower().split("-")[0]
+    if not target_language:
+        raise HTTPException(status_code=422, detail="target_language cannot be blank")
     book = await get_cached_book(book_id)
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
     check_book_access(book, _user)
-    target_language = target_language.lower().split("-")[0]
     from services.book_chapters import split_with_html_preference as _split
     _chapters = await _split(book_id, book.get("text") or "")
     if chapter_index < 0 or chapter_index >= len(_chapters):
@@ -273,6 +275,14 @@ class SaveTranslationRequest(BaseModel):
     paragraphs: list[Annotated[str, Field(min_length=1, max_length=50000)]] = Field(..., max_length=2000)
     provider: str | None = Field(default=None, max_length=100)
     model: str | None = Field(default=None, max_length=200)
+
+    @field_validator("target_language")
+    @classmethod
+    def target_language_not_blank(cls, v: str) -> str:
+        s = v.strip().lower().split("-")[0]
+        if not s:
+            raise ValueError("target_language cannot be blank")
+        return s
 
 
 @router.put("/translate/cache")
@@ -315,8 +325,10 @@ async def save_translate_cache(req: SaveTranslationRequest, _user: dict = Depend
 @router.post("/translate")
 async def translate(req: TranslateRequest, user: dict = Depends(get_current_user)):
     """Translate text with auto-fallback: Gemini if key available, else Google Translate (free)."""
-    src = req.source_language.lower().split("-")[0]
-    tgt = req.target_language.lower().split("-")[0]
+    src = req.source_language.strip().lower().split("-")[0]
+    tgt = req.target_language.strip().lower().split("-")[0]
+    if not src or not tgt:
+        raise HTTPException(status_code=422, detail="source_language and target_language cannot be blank")
     if src == tgt:
         raise HTTPException(status_code=400, detail="Source and target language are the same.")
     try:

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -45,11 +45,24 @@ def _require_gemini_key(user: dict) -> str:
 
 # ── Request models ────────────────────────────────────────────────────────────
 
+def _validate_language_code(v: str) -> str:
+    """Strip, lowercase, and take the primary subtag. Raises ValueError if blank."""
+    s = v.strip().lower().split("-")[0]
+    if not s:
+        raise ValueError("language code cannot be blank")
+    return s
+
+
 class InsightRequest(BaseModel):
     chapter_text: str = Field(..., min_length=1, max_length=50_000)
     book_title: str = Field(..., min_length=1, max_length=500)
     author: str = Field(..., min_length=1, max_length=500)
     response_language: str = Field(default="en", min_length=1, max_length=20)
+
+    @field_validator("response_language")
+    @classmethod
+    def response_language_not_blank(cls, v: str) -> str:
+        return _validate_language_code(v)
 
 
 class QARequest(BaseModel):
@@ -59,6 +72,11 @@ class QARequest(BaseModel):
     author: str = Field(..., min_length=1, max_length=500)
     response_language: str = Field(default="en", min_length=1, max_length=20)
 
+    @field_validator("response_language")
+    @classmethod
+    def response_language_not_blank(cls, v: str) -> str:
+        return _validate_language_code(v)
+
 
 class ReferencesRequest(BaseModel):
     book_title: str = Field(..., min_length=1, max_length=500)
@@ -66,6 +84,11 @@ class ReferencesRequest(BaseModel):
     chapter_title: str = Field(default="", max_length=500)
     chapter_excerpt: str = Field(default="", max_length=10_000)
     response_language: str = Field(default="en", min_length=1, max_length=20)
+
+    @field_validator("response_language")
+    @classmethod
+    def response_language_not_blank(cls, v: str) -> str:
+        return _validate_language_code(v)
 
 
 class SummaryRequest(BaseModel):
@@ -92,6 +115,11 @@ class TTSRequest(BaseModel):
     language: str = Field(default="en", min_length=1, max_length=20)
     rate: float = Field(default=1.0, ge=0.25, le=4.0)
     gender: Literal["female", "male"] = "female"
+
+    @field_validator("language")
+    @classmethod
+    def language_not_blank(cls, v: str) -> str:
+        return _validate_language_code(v)
 
 
 class ChunkTextRequest(BaseModel):
@@ -279,10 +307,7 @@ class SaveTranslationRequest(BaseModel):
     @field_validator("target_language")
     @classmethod
     def target_language_not_blank(cls, v: str) -> str:
-        s = v.strip().lower().split("-")[0]
-        if not s:
-            raise ValueError("target_language cannot be blank")
-        return s
+        return _validate_language_code(v)
 
 
 @router.put("/translate/cache")

--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -6,7 +6,7 @@ from typing import AsyncIterator
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from services.gutenberg import search_books, get_book_meta, get_book_text, get_book_epub
 from services.db import (
     get_cached_book,
@@ -104,7 +104,9 @@ async def translation_status(book_id: int = Path(..., ge=1), target_language: st
     import aiosqlite
     from services.db import count_translations_for_book, DB_PATH
 
-    target_language = target_language.lower().split("-")[0]
+    target_language = target_language.strip().lower().split("-")[0]
+    if not target_language:
+        raise HTTPException(status_code=422, detail="target_language cannot be blank")
     cached = await get_cached_book(book_id)
     if not cached:
         raise HTTPException(status_code=404, detail="Book not found")
@@ -157,7 +159,9 @@ async def chapter_queue_status(
     on-demand translate to avoid duplicating work the background worker is
     already scheduled to do.
     """
-    target_language = target_language.lower().split("-")[0]
+    target_language = target_language.strip().lower().split("-")[0]
+    if not target_language:
+        raise HTTPException(status_code=422, detail="target_language cannot be blank")
     book = await get_cached_book(book_id)
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
@@ -181,7 +185,9 @@ async def get_chapter_translation(
     user: dict | None = Depends(get_optional_user),
 ):
     """Return the cached translation if available, 404 otherwise. Never enqueues."""
-    target_language = target_language.lower().split("-")[0]
+    target_language = target_language.strip().lower().split("-")[0]
+    if not target_language:
+        raise HTTPException(status_code=422, detail="target_language cannot be blank")
     book = await get_cached_book(book_id)
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
@@ -206,8 +212,20 @@ async def get_chapter_translation(
     }
 
 
+def _validate_target_language(v: str) -> str:
+    stripped = v.strip().lower().split("-")[0]
+    if not stripped:
+        raise ValueError("target_language cannot be blank")
+    return stripped
+
+
 class RequestTranslationBody(BaseModel):
     target_language: str = Field(..., min_length=1, max_length=20)
+
+    @field_validator("target_language")
+    @classmethod
+    def target_language_not_blank(cls, v: str) -> str:
+        return _validate_target_language(v)
 
 
 @router.post("/{book_id}/chapters/{chapter_index}/translation")

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -1330,3 +1330,50 @@ async def test_tts_empty_text_returns_422(client, test_user):
     """Regression #813: POST /ai/tts with text="" must return 422."""
     resp = await client.post("/api/ai/tts", json={"text": ""})
     assert resp.status_code == 422, f"Expected 422 for empty text in /ai/tts, got {resp.status_code}: {resp.text}"
+
+
+# ── Issue #1054: whitespace-only response_language / language ─────────────────
+
+
+async def test_insight_whitespace_response_language_returns_422(client, test_user):
+    """Regression #1054: POST /ai/insight with response_language="   " must return 422."""
+    resp = await client.post("/api/ai/insight", json={
+        "chapter_text": "Some text.", "book_title": "Faust", "author": "Goethe",
+        "response_language": "   ",
+    })
+    assert resp.status_code == 422, (
+        f"Expected 422 for whitespace response_language in /ai/insight, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_qa_whitespace_response_language_returns_422(client, test_user):
+    """Regression #1054: POST /ai/qa with response_language=" " must return 422."""
+    resp = await client.post("/api/ai/qa", json={
+        "question": "What?", "passage": "Some text.", "book_title": "Faust", "author": "Goethe",
+        "response_language": " ",
+    })
+    assert resp.status_code == 422, (
+        f"Expected 422 for whitespace response_language in /ai/qa, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_references_whitespace_response_language_returns_422(client, test_user):
+    """Regression #1054: POST /ai/references with response_language="\t" must return 422."""
+    resp = await client.post("/api/ai/references", json={
+        "book_title": "Faust", "author": "Goethe",
+        "response_language": "\t",
+    })
+    assert resp.status_code == 422, (
+        f"Expected 422 for whitespace response_language in /ai/references, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_tts_whitespace_language_returns_422(client, test_user):
+    """Regression #1054: POST /ai/tts with language=" " must return 422."""
+    resp = await client.post("/api/ai/tts", json={
+        "text": "Hello world",
+        "language": " ",
+    })
+    assert resp.status_code == 422, (
+        f"Expected 422 for whitespace language in /ai/tts, got {resp.status_code}: {resp.text}"
+    )

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -1265,6 +1265,42 @@ async def test_chapter_translation_get_empty_target_language_returns_422(client,
     )
 
 
+# ── Issue #1048: whitespace-only target_language must be rejected (422) ───────
+
+
+async def test_request_translation_whitespace_target_language_returns_422(client, test_user):
+    """Regression #1048: POST /books/{id}/chapters/{i}/translation with target_language=" " must return 422."""
+    resp = await client.post(
+        "/api/books/1/chapters/0/translation",
+        json={"target_language": "   "},
+    )
+    assert resp.status_code == 422, f"Expected 422 for whitespace target_language, got {resp.status_code}: {resp.text}"
+
+
+async def test_translation_status_whitespace_target_language_returns_422(client, test_user):
+    """Regression #1048: GET /books/{id}/translation-status?target_language=" " must return 422."""
+    resp = await client.get("/api/books/1/translation-status?target_language=%20")
+    assert resp.status_code == 422, (
+        f"Expected 422 for whitespace target_language in translation-status, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_chapter_queue_status_whitespace_target_language_returns_422(client, test_user):
+    """Regression #1048: GET /books/{id}/chapters/{i}/queue-status?target_language=" " must return 422."""
+    resp = await client.get("/api/books/1/chapters/0/queue-status?target_language=%20")
+    assert resp.status_code == 422, (
+        f"Expected 422 for whitespace target_language in queue-status, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_chapter_translation_get_whitespace_target_language_returns_422(client, test_user):
+    """Regression #1048: GET /books/{id}/chapters/{i}/translation?target_language=" " must return 422."""
+    resp = await client.get("/api/books/1/chapters/0/translation?target_language=%20")
+    assert resp.status_code == 422, (
+        f"Expected 422 for whitespace target_language in GET translation, got {resp.status_code}: {resp.text}"
+    )
+
+
 # ── Issue #794: min_length=1 on q in GET /books/search ───────────────────────
 
 


### PR DESCRIPTION
## What changed

Whitespace-only strings (e.g. `"   "`, `"\t"`) pass Pydantic's `min_length=1` check because length is counted before stripping. Passing such values downstream reaches Gemini/TTS APIs with a blank language code.

**`routers/books.py`** (closes #1048)
- Added `_validate_target_language()` helper used in a `field_validator` on `RequestTranslationBody`
- Added `.strip()` + blank-check to `target_language` query params in `translation_status`, `chapter_queue_status`, `get_chapter_translation`

**`routers/ai.py`** (closes #1048, closes #1054)
- Added `_validate_language_code()` shared helper (strip → lowercase → split `-` → reject blank)
- Added `field_validator` for `target_language` on `SaveTranslationRequest` (now uses shared helper)
- Added `field_validator` for `response_language` on `InsightRequest`, `QARequest`, `ReferencesRequest`
- Added `field_validator` for `language` on `TTSRequest`
- Added `.strip()` + blank-check to `target_language` query param in `GET /translate/cache`
- Added `.strip()` + blank-check to both language fields in `POST /translate`

## Why

A blank normalized language code (`v.strip().lower().split("-")[0]` → `""`) is not rejected by `min_length=1`. This allows blank codes to reach external APIs.

## Test plan

- 4 new tests in `test_router_books.py` asserting 422 for whitespace `target_language` in each affected endpoint
- 4 new tests in `test_router_ai.py` asserting 422 for whitespace `response_language`/`language` in each affected endpoint
- Full suite: 1531 backend + 1750 frontend tests passing
