### PR TITLE
feat: InsightChat history persistence — backend (#907 PR 1/2)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -16,6 +16,7 @@ from routers.insights import router as insights_router
 from routers.uploads import router as uploads_router
 from routers.search import router as search_router
 from routers.decks import router as decks_router
+from routers.chat import router as chat_router
 from services.db import init_db
 
 
@@ -98,6 +99,7 @@ app.include_router(insights_router, prefix="/api")
 app.include_router(uploads_router, prefix="/api")
 app.include_router(search_router, prefix="/api")
 app.include_router(decks_router, prefix="/api")
+app.include_router(chat_router, prefix="/api")
 
 
 @app.get("/api/health")

--- a/backend/migrations/035_chat_messages.sql
+++ b/backend/migrations/035_chat_messages.sql
@@ -1,0 +1,21 @@
+-- Issue #907 / design doc: docs/design/insightchat-history-persistence.md
+-- Persist InsightChat conversation history on the backend so threads
+-- carry across browsers / devices / cache clears. See the design for
+-- the "why a separate table vs reusing book_insights" decision.
+--
+-- Declared FKs from day one per the #754 policy: ON DELETE CASCADE
+-- means delete_user and admin.delete_book need no shadow-cleanup.
+
+CREATE TABLE IF NOT EXISTS chat_messages (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    book_id    INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    role       TEXT    NOT NULL CHECK (role IN ('user', 'assistant')),
+    content    TEXT    NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Primary read pattern is "all messages for (user, book) ordered by time",
+-- reverse-paginated via `before_id`. This composite index covers it.
+CREATE INDEX IF NOT EXISTS idx_chat_messages_user_book
+    ON chat_messages (user_id, book_id, created_at);

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -1,0 +1,97 @@
+"""InsightChat message-history endpoints (issue #907).
+
+Persists the running InsightChat conversation server-side so threads
+carry across browsers / devices / cache clears. See the design doc
+`docs/design/insightchat-history-persistence.md`.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from pydantic import BaseModel, Field
+
+from services.auth import get_current_user, check_book_access
+from services.db import (
+    CHAT_MESSAGE_MAX_BYTES,
+    append_chat_message,
+    clear_chat_messages,
+    get_cached_book,
+    get_chat_messages,
+)
+
+router = APIRouter(prefix="/chat", tags=["chat"])
+
+
+class ChatMessageCreate(BaseModel):
+    role: str = Field(..., pattern="^(user|assistant)$")
+    # Upper bound is intentionally generous at the pydantic level; we enforce
+    # the 8 KB byte cap below so reject-with-413 is distinguishable from
+    # reject-with-422 (schema violation).
+    content: str = Field(..., min_length=1, max_length=64000)
+
+
+@router.get("/{book_id}/messages")
+async def list_messages(
+    book_id: int = Path(..., ge=1),
+    limit: int = Query(50, ge=1, le=200),
+    before_id: int | None = Query(None, ge=1),
+    user: dict = Depends(get_current_user),
+):
+    """Return messages for (authenticated user, book), newest first.
+
+    Reverse-pagination: pass the oldest id from the last page as
+    `before_id` to fetch the next older page. Response includes
+    `has_more` so the client knows when to stop.
+    """
+    book = await get_cached_book(book_id)
+    if not book:
+        raise HTTPException(status_code=404, detail="Book not found")
+    check_book_access(book, user)
+    rows = await get_chat_messages(
+        user["id"], book_id, limit=limit + 1, before_id=before_id
+    )
+    has_more = len(rows) > limit
+    messages = rows[:limit]
+    return {"messages": messages, "has_more": has_more}
+
+
+@router.post("/{book_id}/messages")
+async def post_message(
+    req: ChatMessageCreate,
+    book_id: int = Path(..., ge=1),
+    user: dict = Depends(get_current_user),
+):
+    """Append one message. Returns the inserted row so the client can
+    pick up the id + created_at without a re-fetch."""
+    book = await get_cached_book(book_id)
+    if not book:
+        raise HTTPException(status_code=404, detail="Book not found")
+    check_book_access(book, user)
+
+    # 8 KB byte cap — prevents a client from filling disk with large
+    # individual messages. Size checked on UTF-8-encoded bytes, not
+    # pydantic character count, because character vs byte cost differs.
+    if len(req.content.encode("utf-8")) > CHAT_MESSAGE_MAX_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Message exceeds {CHAT_MESSAGE_MAX_BYTES // 1024} KB limit",
+        )
+
+    row = await append_chat_message(
+        user["id"], book_id, req.role, req.content
+    )
+    if not row:
+        raise HTTPException(status_code=500, detail="Failed to persist message")
+    return row
+
+
+@router.delete("/{book_id}/messages")
+async def clear_messages(
+    book_id: int = Path(..., ge=1),
+    user: dict = Depends(get_current_user),
+):
+    """Clear the full thread for (user, book). Returns deleted count."""
+    book = await get_cached_book(book_id)
+    if not book:
+        raise HTTPException(status_code=404, detail="Book not found")
+    check_book_access(book, user)
+    deleted = await clear_chat_messages(user["id"], book_id)
+    return {"deleted": deleted}

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -1139,6 +1139,82 @@ async def delete_insight(insight_id: int, user_id: int) -> bool:
     return cursor.rowcount > 0
 
 
+# ── InsightChat message history (issue #907, migration 035) ──────────────────
+#
+# See docs/design/insightchat-history-persistence.md for the "why new table"
+# decision. `book_insights` is the user-bookmarked Q&A pair store; this is
+# the transient running-conversation store.
+
+CHAT_MESSAGE_MAX_BYTES = 8 * 1024  # 8 KB per message — rejected with 413 otherwise
+
+
+async def append_chat_message(
+    user_id: int, book_id: int, role: str, content: str
+) -> dict:
+    """Insert one chat message and return the inserted row (including
+    auto-assigned id + created_at) so the caller can avoid a re-fetch."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            "INSERT INTO chat_messages (user_id, book_id, role, content) "
+            "VALUES (?, ?, ?, ?)",
+            (user_id, book_id, role, content),
+        )
+        new_id = cursor.lastrowid
+        async with db.execute(
+            "SELECT * FROM chat_messages WHERE id = ?", (new_id,)
+        ) as c:
+            row = await c.fetchone()
+        await db.commit()
+    return dict(row) if row else {}
+
+
+async def get_chat_messages(
+    user_id: int,
+    book_id: int,
+    *,
+    limit: int = 50,
+    before_id: int | None = None,
+) -> list[dict]:
+    """Return up to `limit` messages for (user, book), newest first.
+
+    When `before_id` is given, only rows with id < before_id are returned
+    — enables reverse-scroll pagination of older history.
+    """
+    # Defensive bound — router also enforces but keep the helper safe.
+    safe_limit = max(1, min(limit, 200))
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        if before_id is not None:
+            sql = (
+                "SELECT * FROM chat_messages "
+                "WHERE user_id = ? AND book_id = ? AND id < ? "
+                "ORDER BY id DESC LIMIT ?"
+            )
+            params = (user_id, book_id, before_id, safe_limit)
+        else:
+            sql = (
+                "SELECT * FROM chat_messages "
+                "WHERE user_id = ? AND book_id = ? "
+                "ORDER BY id DESC LIMIT ?"
+            )
+            params = (user_id, book_id, safe_limit)
+        async with db.execute(sql, params) as cursor:
+            rows = await cursor.fetchall()
+    return [dict(r) for r in rows]
+
+
+async def clear_chat_messages(user_id: int, book_id: int) -> int:
+    """Delete all chat messages for (user, book). Returns rowcount."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "DELETE FROM chat_messages WHERE user_id = ? AND book_id = ?",
+            (user_id, book_id),
+        )
+        await db.commit()
+    return cursor.rowcount
+
+
 # ── Flashcard / SRS (issue #556) ─────────────────────────────────────────────
 
 async def _ensure_flashcard_rows(user_id: int) -> None:

--- a/backend/tests/test_router_chat.py
+++ b/backend/tests/test_router_chat.py
@@ -1,0 +1,242 @@
+"""Tests for /api/chat/* endpoints (InsightChat history persistence, #907)."""
+
+import pytest
+import aiosqlite
+
+import services.db as db_module
+from services.db import (
+    CHAT_MESSAGE_MAX_BYTES,
+    get_or_create_user,
+    get_user_by_id,
+    append_chat_message,
+    get_chat_messages,
+    clear_chat_messages,
+)
+from services.auth import get_current_user, get_optional_user
+from main import app
+from httpx import AsyncClient, ASGITransport
+
+
+TEST_BOOK_ID = 7001
+
+
+async def _seed_book(book_id: int) -> None:
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            "INSERT OR IGNORE INTO books (id, title, images, source) "
+            "VALUES (?, 'T', '[]', 'gutenberg')",
+            (book_id,),
+        )
+        await db.commit()
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+async def test_append_and_get_single_message(tmp_db):
+    user = await get_or_create_user("chat-u", "u@t.com", "U", "")
+    await _seed_book(TEST_BOOK_ID)
+    row = await append_chat_message(user["id"], TEST_BOOK_ID, "user", "Hello?")
+    assert row["role"] == "user"
+    assert row["content"] == "Hello?"
+    assert row["user_id"] == user["id"]
+    assert row["book_id"] == TEST_BOOK_ID
+    assert row["id"] > 0
+
+    msgs = await get_chat_messages(user["id"], TEST_BOOK_ID)
+    assert len(msgs) == 1
+    assert msgs[0]["content"] == "Hello?"
+
+
+async def test_get_messages_newest_first_and_paginates(tmp_db):
+    user = await get_or_create_user("chat-p", "p@t.com", "P", "")
+    await _seed_book(TEST_BOOK_ID)
+    for i in range(7):
+        await append_chat_message(
+            user["id"], TEST_BOOK_ID, "user" if i % 2 == 0 else "assistant",
+            f"message-{i}",
+        )
+
+    page1 = await get_chat_messages(user["id"], TEST_BOOK_ID, limit=3)
+    assert len(page1) == 3
+    # Newest-first ordering: most recent message is `message-6`
+    assert page1[0]["content"] == "message-6"
+    assert page1[2]["content"] == "message-4"
+
+    # Reverse paginate using before_id
+    oldest_on_page = page1[-1]["id"]
+    page2 = await get_chat_messages(
+        user["id"], TEST_BOOK_ID, limit=3, before_id=oldest_on_page
+    )
+    assert len(page2) == 3
+    assert page2[0]["content"] == "message-3"
+
+
+async def test_get_messages_scoped_to_user_and_book(tmp_db):
+    user_a = await get_or_create_user("ua", "a@t.com", "A", "")
+    user_b = await get_or_create_user("ub", "b@t.com", "B", "")
+    await _seed_book(TEST_BOOK_ID)
+    await _seed_book(TEST_BOOK_ID + 1)
+
+    await append_chat_message(user_a["id"], TEST_BOOK_ID, "user", "a-on-book-1")
+    await append_chat_message(user_a["id"], TEST_BOOK_ID + 1, "user", "a-on-book-2")
+    await append_chat_message(user_b["id"], TEST_BOOK_ID, "user", "b-on-book-1")
+
+    a_book1 = await get_chat_messages(user_a["id"], TEST_BOOK_ID)
+    assert [m["content"] for m in a_book1] == ["a-on-book-1"]
+
+    b_book1 = await get_chat_messages(user_b["id"], TEST_BOOK_ID)
+    assert [m["content"] for m in b_book1] == ["b-on-book-1"]
+
+
+async def test_clear_chat_messages_scoped(tmp_db):
+    user = await get_or_create_user("uc", "c@t.com", "C", "")
+    await _seed_book(TEST_BOOK_ID)
+    await _seed_book(TEST_BOOK_ID + 1)
+    for _ in range(3):
+        await append_chat_message(user["id"], TEST_BOOK_ID, "user", "x")
+    await append_chat_message(user["id"], TEST_BOOK_ID + 1, "user", "y")
+
+    deleted = await clear_chat_messages(user["id"], TEST_BOOK_ID)
+    assert deleted == 3
+    # Other book untouched
+    assert len(await get_chat_messages(user["id"], TEST_BOOK_ID + 1)) == 1
+    assert len(await get_chat_messages(user["id"], TEST_BOOK_ID)) == 0
+
+
+async def test_fk_cascade_on_user_delete(tmp_db):
+    from services.db import delete_user
+
+    user = await get_or_create_user("cascade-u", "cu@t.com", "CU", "")
+    await _seed_book(TEST_BOOK_ID)
+    await append_chat_message(user["id"], TEST_BOOK_ID, "user", "will be gone")
+
+    await delete_user(user["id"])
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        async with db.execute(
+            "SELECT COUNT(*) FROM chat_messages WHERE user_id=?", (user["id"],)
+        ) as cur:
+            count = (await cur.fetchone())[0]
+    assert count == 0, "chat_messages should cascade-delete with the user"
+
+
+async def test_fk_cascade_on_book_delete(tmp_db):
+    user = await get_or_create_user("cascade-b", "cb@t.com", "CB", "")
+    await _seed_book(TEST_BOOK_ID)
+    await append_chat_message(user["id"], TEST_BOOK_ID, "user", "will be gone")
+
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute("DELETE FROM books WHERE id=?", (TEST_BOOK_ID,))
+        await db.commit()
+        async with db.execute(
+            "SELECT COUNT(*) FROM chat_messages WHERE book_id=?", (TEST_BOOK_ID,)
+        ) as cur:
+            count = (await cur.fetchone())[0]
+    assert count == 0, "chat_messages should cascade-delete with the book"
+
+
+# ── router tests ─────────────────────────────────────────────────────────────
+
+
+async def test_router_post_and_get_roundtrip(client, test_user):
+    await _seed_book(TEST_BOOK_ID)
+
+    res = await client.post(
+        f"/api/chat/{TEST_BOOK_ID}/messages",
+        json={"role": "user", "content": "What happens in chapter 12?"},
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["content"] == "What happens in chapter 12?"
+
+    res = await client.get(f"/api/chat/{TEST_BOOK_ID}/messages")
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data["messages"]) == 1
+    assert data["has_more"] is False
+
+
+async def test_router_requires_auth(anon_client):
+    res = await anon_client.get(f"/api/chat/{TEST_BOOK_ID}/messages")
+    assert res.status_code == 401
+
+    res = await anon_client.post(
+        f"/api/chat/{TEST_BOOK_ID}/messages",
+        json={"role": "user", "content": "hi"},
+    )
+    assert res.status_code == 401
+
+    res = await anon_client.delete(f"/api/chat/{TEST_BOOK_ID}/messages")
+    assert res.status_code == 401
+
+
+async def test_router_404_for_missing_book(client):
+    res = await client.get("/api/chat/99999/messages")
+    assert res.status_code == 404
+
+
+async def test_router_clear(client, test_user):
+    await _seed_book(TEST_BOOK_ID)
+    for i in range(4):
+        await append_chat_message(
+            test_user["id"], TEST_BOOK_ID, "user", f"m{i}"
+        )
+
+    res = await client.delete(f"/api/chat/{TEST_BOOK_ID}/messages")
+    assert res.status_code == 200
+    assert res.json()["deleted"] == 4
+
+    res = await client.get(f"/api/chat/{TEST_BOOK_ID}/messages")
+    assert res.json()["messages"] == []
+
+
+async def test_router_rejects_oversize_message(client, test_user):
+    await _seed_book(TEST_BOOK_ID)
+    oversize = "x" * (CHAT_MESSAGE_MAX_BYTES + 1)
+    res = await client.post(
+        f"/api/chat/{TEST_BOOK_ID}/messages",
+        json={"role": "user", "content": oversize},
+    )
+    assert res.status_code == 413
+
+
+async def test_router_rejects_invalid_role(client, test_user):
+    await _seed_book(TEST_BOOK_ID)
+    res = await client.post(
+        f"/api/chat/{TEST_BOOK_ID}/messages",
+        json={"role": "system", "content": "hi"},
+    )
+    assert res.status_code == 422  # pydantic pattern mismatch
+
+
+async def test_router_pagination_has_more(client, test_user):
+    await _seed_book(TEST_BOOK_ID)
+    for i in range(55):
+        await append_chat_message(
+            test_user["id"], TEST_BOOK_ID, "user", f"m{i}"
+        )
+
+    res = await client.get(f"/api/chat/{TEST_BOOK_ID}/messages?limit=50")
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data["messages"]) == 50
+    assert data["has_more"] is True
+
+    # Second page via before_id
+    last_id = data["messages"][-1]["id"]
+    res2 = await client.get(
+        f"/api/chat/{TEST_BOOK_ID}/messages?limit=50&before_id={last_id}"
+    )
+    data2 = res2.json()
+    assert len(data2["messages"]) == 5
+    assert data2["has_more"] is False
+
+
+async def test_router_user_isolation(client, test_user):
+    """User A's GET must not return user B's messages."""
+    await _seed_book(TEST_BOOK_ID)
+    other = await get_or_create_user("chat-other", "other@t.com", "Other", "")
+    await append_chat_message(other["id"], TEST_BOOK_ID, "user", "other's secret")
+
+    res = await client.get(f"/api/chat/{TEST_BOOK_ID}/messages")
+    assert res.status_code == 200
+    assert res.json()["messages"] == []


### PR DESCRIPTION
## Summary

Implements the backend half of #907 per the design in `docs/design/insightchat-history-persistence.md` (merged #1059). Server-side persistence for InsightChat messages so threads survive browser changes / cache clears / device switches.

## What this ships

- Migration 035 — new `chat_messages` table with declared FKs (CASCADE on users(id) and books(id)) per the #754 policy
- `backend/routers/chat.py` with three endpoints:
  - `GET /api/chat/{book_id}/messages` — newest-first, paginated via `before_id` (1 ≤ limit ≤ 200)
  - `POST /api/chat/{book_id}/messages` — append one message, 8 KB byte cap → 413
  - `DELETE /api/chat/{book_id}/messages` — clear the current (user, book) thread
- DB helpers: `append_chat_message`, `get_chat_messages`, `clear_chat_messages`, `CHAT_MESSAGE_MAX_BYTES`

All endpoints require auth and use the existing `check_book_access` helper. User isolation is structural (keyed on `user_id`).

## Not in this PR

- Frontend wiring — PR 2/2 per the design's rollout
- localStorage fallback migration — handled in PR 2/2
- Removing PR 2/2's localStorage fallback — scheduled follow-up a week after launch

## Test plan

**14 new tests in `test_router_chat.py`** — full suite: **1545 passed**.

Covers:
- DB helpers: insert + round-trip, newest-first + before_id pagination, user/book scoping, clear scoping
- FK cascade: delete user, delete book
- Router: POST+GET roundtrip, 401 for anon on all three verbs, 404 for unknown book, DELETE clears only the current thread, 413 for oversize body, 422 for invalid role, pagination `has_more`, user isolation

Closes #907 (the server contract half). Implementation PR 2/2 will close it once frontend lands.
