### PR TITLE
ux: add role="toolbar" and aria-label to SelectionToolbar and SentenceActionPopup (closes #1050)

### DIFF
--- a/frontend/src/__tests__/ToolbarRoleAria.test.ts
+++ b/frontend/src/__tests__/ToolbarRoleAria.test.ts
@@ -1,0 +1,36 @@
+import * as fs from "fs";
+import * as path from "path";
+
+describe("Floating action bars have role=\"toolbar\" (closes #1050)", () => {
+  it("SelectionToolbar container has role=\"toolbar\"", () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, "../components/SelectionToolbar.tsx"),
+      "utf8",
+    );
+    expect(src).toMatch(/role="toolbar"/);
+  });
+
+  it("SelectionToolbar container has aria-label", () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, "../components/SelectionToolbar.tsx"),
+      "utf8",
+    );
+    expect(src).toMatch(/aria-label="[^"]+"/);
+  });
+
+  it("SentenceActionPopup container has role=\"toolbar\"", () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, "../components/SentenceActionPopup.tsx"),
+      "utf8",
+    );
+    expect(src).toMatch(/role="toolbar"/);
+  });
+
+  it("SentenceActionPopup container has aria-label", () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, "../components/SentenceActionPopup.tsx"),
+      "utf8",
+    );
+    expect(src).toMatch(/aria-label="[^"]+"/);
+  });
+});

--- a/frontend/src/components/SelectionToolbar.tsx
+++ b/frontend/src/components/SelectionToolbar.tsx
@@ -116,6 +116,8 @@ export default function SelectionToolbar({ onRead, onHighlight, onNote, onChat, 
   return (
     <div
       ref={toolbarRef}
+      role="toolbar"
+      aria-label="Text selection actions"
       className="fixed z-50 flex items-center gap-0.5 bg-stone-800/95 backdrop-blur rounded-xl shadow-xl border border-white/10 px-1 py-1 animate-fade-in"
       style={{ left, top }}
     >

--- a/frontend/src/components/SentenceActionPopup.tsx
+++ b/frontend/src/components/SentenceActionPopup.tsx
@@ -44,6 +44,8 @@ export default function SentenceActionPopup({ sentenceText: _sentenceText, posit
   return (
     <div
       ref={ref}
+      role="toolbar"
+      aria-label="Sentence actions"
       style={{ left, top }}
       className="fixed z-50 flex items-center gap-0.5 bg-stone-800 rounded-xl shadow-xl px-1 py-1 animate-fade-in"
     >


### PR DESCRIPTION
Closes #1050

Two floating action bars had no ARIA role on their container divs, violating WCAG 4.1.2 (Name, Role, Value, Level A): screen readers could not identify them as toolbars.

- **`SelectionToolbar`**: appears on text selection; container lacked `role` attribute
- **`SentenceActionPopup`**: appears on sentence tap; container lacked `role` and `aria-label`

## Changes
- `SelectionToolbar.tsx`: added `role="toolbar"` and `aria-label="Text selection actions"` to the container div
- `SentenceActionPopup.tsx`: added `role="toolbar"` and `aria-label="Sentence actions"` to the container div
- `ToolbarRoleAria.test.ts`: 4 static assertions confirming both containers have the required attributes

## Test plan
- [x] 4 new tests pass
- [x] Full frontend suite — 2028/2028 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
