### PR TITLE
docs: add per-PR docs-check rule + PM nightly journal + weekly-editorial wiring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -394,15 +394,27 @@ The label-driven gates (`pm-approved`, `user-approved`, `needs-pm-review`, `bloc
 
 ## Documentation policy
 
-**Every role contributes to keeping the docs-site source content fresh.** The docs site proposed in #864 builds directly from files in this repo; it rots the instant any source file drifts from the code. The rules below are source-content invariants and hold independently of how the site eventually renders them — they apply **now**, before the site ships.
+**Every role contributes to keeping the docs-site source content fresh.** The docs site at `alfmunny.github.io/book-reader-ai/` builds directly from files in this repo; it rots the instant any source file drifts from the code. The rules below are source-content invariants and hold independently of how the site renders them.
+
+### Per-PR docs check (applies to every role)
+
+**After finishing an issue or PR, before moving to the next task, scan the diff and ask: does any file under `docs/` need updating to reflect this change?**
+
+- If yes **and the doc update is small**: include it in the same PR.
+- If yes **but the doc update would materially grow the PR** (e.g., a new tutorial, a full FEATURES.md rewrite): file a `documentation` issue immediately, link it in the PR body under a `## Docs follow-up` heading, and claim it on the next cycle.
+- If no: no action.
+
+The default is "yes, something needs updating." Merging code without at least *checking* is the rot source.
 
 ### Dev
 - When adding, modifying, or removing a script in `backend/scripts/`, update the module docstring at the top of the file. Docstring must describe: (1) what the script does, (2) when to use it, (3) one concrete example invocation. The docs site auto-generates the scripts reference from these.
 - When a bug fix changes user-visible behaviour documented in `docs/FEATURES.md`, update the feature page in the same PR. When a fix changes API request/response shape, update the API reference section (out-of-scope placeholder today; add a TODO line so it's caught later).
+- **Per-PR check** — after every merge, confirm: (a) touched script has fresh docstring, (b) user-visible behaviour change is reflected in `docs/FEATURES.md`, (c) new migration has a matching line in `docs/reference/migrations.md` if it exists.
 
 ### UI/UX
-- Existing rule, restated here for visibility: when adding a new component pattern (modal, toolbar, sidebar type) or a significant design change, append a row to the Change Log table in `docs/design-improvement-plan.md`.
+- When adding a new component pattern (modal, toolbar, sidebar type) or a significant design change, append a row to the Change Log table in `docs/design-improvement-plan.md`.
 - When shipping a user-visible UX flow that a new reader would not discover on their own (e.g. focus mode, typography panel, flashcards), add a short tutorial stub to `docs/tutorials/<flow>.md` — a few sentences is enough; the docs site renders it.
+- **Per-PR check** — after every merge, confirm: (a) design Change Log updated if the change is user-visible, (b) if a new interaction pattern, `docs/reader-interaction-design.md` notes it, (c) screenshot-bearing pages still match the current UI.
 
 ### Architect
 - Every design doc in `docs/design/*.md` must start with this frontmatter block:
@@ -415,14 +427,18 @@ The label-driven gates (`pm-approved`, `user-approved`, `needs-pm-review`, `bloc
   ```
   The docs site's Architecture → Design Docs index renders this frontmatter. `#821` (declared-fks-schema.md) is the exemplar.
 - When a design doc's series ships, change its `Status` line to `Shipped (PR #<N>, YYYY-MM-DD)` in a one-line follow-up commit. Do not leave stale `Draft` / `PM-approved` statuses on merged-and-implemented design docs.
+- **Per-PR check** — after every merge, confirm: (a) if the shipped PR was the last of a design-doc series, the design doc's `Status` is bumped to `Shipped`, (b) `docs/FEATURES.md` status line reflects the new feature, (c) if the change adds a new service/table/router, `docs/architecture/` has a matching section.
 
 ### PM
-- The development journal in the docs site is auto-summarized from `product/review-state.md` cycle entries. Keep each cycle entry one paragraph: start with the headline (a merged PR or a decision), cover what changed and why. Avoid blow-by-blow tool output or internal deliberation.
-- When a CLAUDE.md rule changes, flag the change in the PR body under a `## Process change` heading so the development-process page in the docs site surfaces the edit. This PR (adding the user-approval gate + documentation policy) is an example.
+- The development journal lives at `docs/journal/daily/YYYY-MM-DD.md`. A nightly workflow (`.github/workflows/docs-journal.yml` at 01:07 UTC) creates an empty stub with the 7-section template; PM **fills the hand-written sections (3 — pipeline/workflow lessons, 5 — incidents/near-misses, 6 — decisions and abandoned paths) in the evening of each working day.** Sections 1, 2, 4, 7 are auto-populated — do not duplicate that content.
+- **Nightly journal cadence** — at the end of each working day, open `docs/journal/daily/YYYY-MM-DD.md` and fill sections 3/5/6 based on the day's `product/review-state.md` cycle entries. One short paragraph per section is enough; the goal is the *why*, not a second copy of the cycle log. If there were no pipeline lessons / incidents / abandoned paths that day, write `None.` — don't invent.
+- **Weekly editorial rollup** — every Sunday, produce `docs/journal/weekly/YYYY-WW.md` by distilling the week's seven daily entries into themes (shipped wins, recurring incidents, process drift, upcoming priorities). Use the `/weekly-editorial` skill — it does the aggregation and writes the file; PM reviews and commits. Can also be scheduled via `/schedule every sunday /weekly-editorial`.
+- **Full-docs sweep on material change** — when a CLAUDE.md rule changes, a new service/feature ships, or a significant UX flow lands, walk through the docs site top-to-bottom and fix any page that now contradicts reality. Flag the sweep in the PR body under a `## Process change` heading so the development-process page surfaces the edit.
+- Keep each `product/review-state.md` cycle entry to one paragraph: headline (merged PR or decision) + what changed + why. Avoid blow-by-blow tool output.
 
 ### Freshness enforcement
 - PR body checkbox: `[ ] Docs updated (if applicable)`. Reviewers flag unchecked PRs whose diff touches `backend/scripts/`, `docs/`, or user-visible frontend behaviour.
-- Until #864's docs site exists, these rules still apply to the source files; they just don't render anywhere yet. This avoids source rot during the site's build-out.
+- Weekly editorial rollup acts as a secondary freshness check — themes that appear two weeks in a row without a linked docs update signal drift and should open a `documentation` issue.
 
 ## Migration policy
 

--- a/docs/journal/daily/2026-04-24.md
+++ b/docs/journal/daily/2026-04-24.md
@@ -13,7 +13,11 @@ _Auto-populated from changes in the `reports/` folder._
 
 ## 3. Pipeline / workflow lessons
 
-_PM to fill._
+- **Path B user-approval gate bypasses reached 8 today** (#790, #866, #901, #902, #968, #990, #992, #1059). In every case `auto-merge.yml`'s label-gate logic behaved correctly — the `auto_merge_disabled` workflow event fires when a gate label is present. The rot is upstream: Architect sessions reading a pre-rule CLAUDE.md do not apply `needs-user-approval` at PR creation. `#908` (session restart) is the structural fix. Until then, PM either hand-labels at triage or lives with the bypasses.
+- **Duplicate-work detection needs a softer framing.** Cycle 599 closed #1022 as a duplicate of #951 and blocked PR #1025; the user manually Squash-merged #1025 four minutes later. Lesson: when two PRs partially overlap, "ship first-wins and scope-reduce the loser" beats "close as dup." Applied on #952's rebase — it landed cleanly adding only the `aria-expanded` additions on top of #1025's aria-labels.
+- **CI paths-filter fix (#891) paid for itself in one day.** Docs-only PRs (#996, #1059, this journal PR) now skip the four heavy CI jobs, shaving roughly 6 minutes each.
+- **Quiet CI failures are easy to ignore.** The `coverage-comment` job had been silently failing on every backend-only PR for several days (first noticed on PR #988); #1047 finally fixed it. Red post-merge jobs that aren't required-checks deserve a periodic scan — they save bisect time later.
+
 
 ## 4. Next things
 
@@ -21,11 +25,17 @@ _Auto-populated from open architecture / feat / bug issues ranked by priority._
 
 ## 5. Incidents / near-misses
 
-_PM to fill._
+- **Production AI outage (#1051, P1, unresolved at day-end).** User reported all AI endpoints failing on `reader/2229?chapter=6` — `/api/ai/insight` and `/api/ai/summary` returning 500, translation cache calls 404ing, Obsidian export 400ing. Primary suspect is #1016 (`asyncio.get_event_loop()` → `get_running_loop()`), because `get_running_loop` raises `RuntimeError` if no loop is running, whereas the old API silently created one. Both `translate.py` and the shared `rate_limiter.py` were touched, which explains the symptom spanning Insight + Summary + Translate. Dev session hadn't claimed the issue by end of day — five cycles of PM nudges went unanswered. Same root cause as the Path B bypasses: stale CLAUDE.md in the code-role sessions.
+- **Near-miss on `blocked` label vs. manual merge.** PR #1025 merged manually despite `blocked` being applied 4 minutes earlier. Workflow-level gate worked (`auto_merge_disabled` event fired), but GitHub's manual Squash UI ignores it. Not a regression — expected behaviour — but worth knowing: `blocked` protects against *automation*, not against human action.
+- **P1 JWT fix shipped before any user-visible failure.** #1026 caught a class of 500-on-every-authenticated-endpoint bug (non-integer JWT `sub` → `int()` ValueError → unhandled 500). Idle-mode grep-scan found it; no incident, no production regression — pure defensive win.
+
 
 ## 6. Decisions and abandoned paths
 
-_PM to fill._
+- **Reverted #992 (Chapter Comprehension Quiz design doc).** Architect filed a full Path B design in idle mode without checking that parent feat #557 carried `wontfix` and an explicit "Don't do it for now" comment. User reverted via #994 within a few minutes of merge. Root-cause fix landed as #996 (FEATURES.md status sync — three features were mis-marked `FUTURE` when they were either shipped or declined). Takeaway: idle-mode invariant added — before filing a new architecture issue against a `docs/FEATURES.md` feat, check the parent feat issue labels and comment thread first.
+- **Chose not to retroactively block #1059** (InsightChat history persistence design doc, 8th Path B bypass of the day). Parent #907 already carried `user-approved`, so the content direction was pre-approved; only the design-doc specifics were unreviewed. Rather than reverting, the lighter-weight path is: user skims the design doc in follow-up and either approves the implementation series or asks for a revert — we spend one decision-round either way, but only revert if the doc content is actually off.
+- **Abandoned path — "close PR #1025 as duplicate."** Cycle 599's initial call was to close #1025 and keep #952; user overrode by manually merging #1025. Rescoped #952 to only the `aria-expanded` additions — both PRs shipped value, neither got lost. Lesson captured in section 3.
+
 
 ## 7. User-facing changelog
 

--- a/docs/journal/index.md
+++ b/docs/journal/index.md
@@ -32,7 +32,7 @@ Seeded for validation of the generator; the nightly workflow commits new stubs f
 
 ## Weekly editorial rollup
 
-Not wired yet — planned as a hand-written Sunday post pulling themes from the week's seven daily entries. Tracked under a future follow-up issue.
+Every Sunday, PM produces a themed rollup at `docs/journal/weekly/YYYY-WW.md` aggregating the week's seven daily entries into shipped wins, recurring incidents, process lessons, and next-week priorities. The rollup is driven by the `/weekly-editorial` skill — it reads the daily entries, extracts themes, and drafts the weekly file; PM reviews the draft, hand-edits, and submits via `/submit-pr`. Can be run on demand (`/weekly-editorial`) or scheduled (`/schedule every sunday 22:00 /weekly-editorial`).
 
 ## Related
 


### PR DESCRIPTION
## Summary

Adds a **per-PR documentation-check rule** that applies to every role plus a PM-specific nightly-journal + weekly-editorial cadence, and fills today's journal hand-sections.

## What changed

### `CLAUDE.md` — Documentation policy

- **New per-PR rule for every role**: after finishing any issue or PR, scan the diff and ask whether any file under `docs/` needs updating. Small updates go in the same PR; material ones become a follow-up `documentation` issue. The default is "yes, something needs updating" — merging without checking is the rot source.
- **Per-role check-lists** spell out what to confirm after each PR:
  - **Dev** — script docstring refresh, `FEATURES.md` bump on user-visible behaviour change, migration index line.
  - **UI/UX** — design Change Log, `reader-interaction-design.md` for new interaction patterns, screenshot pages still match the UI.
  - **Architect** — design-doc `Status:` bump on ship, `FEATURES.md` status, `docs/architecture/` sections on new services/tables/routers.
  - **PM** — nightly journal fill + weekly editorial + full-docs sweep (see below).
- **PM nightly journal cadence**: end of each working day, open `docs/journal/daily/YYYY-MM-DD.md` and fill sections 3 (pipeline lessons), 5 (incidents), 6 (decisions). Auto-populated sections 1/2/4/7 are left alone. One short paragraph per section; write `None.` if nothing that day rather than invent.
- **Weekly editorial rollup**: every Sunday, produce `docs/journal/weekly/YYYY-WW.md` by distilling the week's seven daily entries into themes. Driven by the new `/weekly-editorial` skill (user-scope at `~/.claude/skills/weekly-editorial/`); can be run on demand or scheduled.
- **Full-docs sweep**: when a CLAUDE.md rule changes, a new service/feature ships, or a significant UX flow lands, PM walks through the docs top-to-bottom and fixes anything that now contradicts reality.

### `docs/journal/daily/2026-04-24.md`

PM-hand sections 3, 5, 6 filled from today's `product/review-state.md` cycle entries. Covers: 8 Path B gate bypasses (structural #908 fix still blocking), duplicate-detection lesson from #1025/#1022, CI paths-filter payoff, quiet CI failure on `coverage-comment`, production P1 #1051 still unresolved at end of day, #992 revert + root-cause #996.

### `docs/journal/index.md`

"Weekly editorial rollup" section updated from "Not wired yet" to the new `/weekly-editorial` skill wiring.

## Why

Two gaps in the existing Documentation policy:

1. Rules said *what* to update but never framed it as a per-PR habit, so the check got skipped in practice.
2. PM had no explicit journal/weekly cadence — the journal stubs were being auto-generated but no one was filling the hand sections.

This PR closes both gaps.

## Test plan

- Docs-only diff; CI paths-filter (#891) correctly skips the heavy jobs.
- No code touched; no test regressions possible.

## Process change

New per-PR docs-check rule applies to future PRs. Next cycle's PRs across all roles should start including docs updates inline where relevant, or filing `documentation` follow-ups explicitly.
