### PR TITLE
ux: add role="status" and aria-label to AnnotationsSidebar loading spinners (closes #1057)

### DIFF
--- a/frontend/src/__tests__/AnnotationsSpinnerAria.test.ts
+++ b/frontend/src/__tests__/AnnotationsSpinnerAria.test.ts
@@ -1,0 +1,17 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/AnnotationsSidebar.tsx"),
+  "utf8",
+);
+
+describe("AnnotationsSidebar loading spinners have accessible labels (closes #1057)", () => {
+  it("has role=\"status\" on at least one loading container", () => {
+    expect(src).toMatch(/role="status"/);
+  });
+
+  it("has sr-only or aria-label text for loading state", () => {
+    expect(src).toMatch(/sr-only|aria-label="[^"]*[Ll]oad/);
+  });
+});

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -75,8 +75,8 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
 
           <div className="flex-1 overflow-y-auto p-4 space-y-6 pb-0">
             {loading && annotations.length === 0 ? (
-              <div className="flex justify-center mt-10">
-                <span className="w-5 h-5 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+              <div role="status" aria-label="Loading annotations" className="flex justify-center mt-10">
+                <span className="w-5 h-5 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
               </div>
             ) : annotations.length === 0 ? (
               <div className="text-center text-stone-400 mt-10 text-sm">
@@ -87,8 +87,8 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
             ) : (
               <>
                 {loading && (
-                  <div className="flex justify-center py-1">
-                    <span className="w-4 h-4 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+                  <div role="status" aria-label="Refreshing annotations" className="flex justify-center py-1">
+                    <span className="w-4 h-4 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
                   </div>
                 )}
               {chapters.map((ch) => (


### PR DESCRIPTION
Closes #1057

The two loading spinners in `AnnotationsSidebar` had no accessible text alternative, violating WCAG 4.1.3 (Status Messages, Level AA). Screen readers received no indication that annotations were loading.

## Changes
- `AnnotationsSidebar.tsx`: wrapped both spinner `<span>` elements in `<div role="status" aria-label="...">` containers; added `aria-hidden="true"` to the decorative spinner spans
- `AnnotationsSpinnerAria.test.ts`: 2 static assertions confirming `role="status"` and accessible label are present

## Test plan
- [x] 2 new tests pass
- [x] Full frontend suite — 2026/2026 passing
- [x] Full backend suite — 1382/1382 passing

🤖 Generated with Claude Code
