### PR TITLE
ux: add role="status" and aria-label to InsightChat, SentenceReader, ChapterSummary skeleton loaders (closes #1064)

### DIFF
--- a/frontend/src/__tests__/SkeletonLoaderAria.test.ts
+++ b/frontend/src/__tests__/SkeletonLoaderAria.test.ts
@@ -1,0 +1,41 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const insightSrc = fs.readFileSync(
+  path.join(__dirname, "../components/InsightChat.tsx"),
+  "utf8",
+);
+const sentenceSrc = fs.readFileSync(
+  path.join(__dirname, "../components/SentenceReader.tsx"),
+  "utf8",
+);
+const chapterSrc = fs.readFileSync(
+  path.join(__dirname, "../components/ChapterSummary.tsx"),
+  "utf8",
+);
+
+describe("Skeleton loaders have accessible role=\"status\" (closes #1064)", () => {
+  it("InsightChat skeleton has role=\"status\"", () => {
+    expect(insightSrc).toMatch(/role="status"/);
+  });
+
+  it("InsightChat skeleton has aria-label for loading state", () => {
+    expect(insightSrc).toMatch(/aria-label="[^"]*[Ll]oad/);
+  });
+
+  it("SentenceReader translation skeleton has role=\"status\"", () => {
+    expect(sentenceSrc).toMatch(/role="status"/);
+  });
+
+  it("SentenceReader translation skeleton has aria-label for loading state", () => {
+    expect(sentenceSrc).toMatch(/aria-label="[^"]*[Ll]oad/);
+  });
+
+  it("ChapterSummary skeleton has role=\"status\"", () => {
+    expect(chapterSrc).toMatch(/role="status"/);
+  });
+
+  it("ChapterSummary skeleton has aria-label for loading state", () => {
+    expect(chapterSrc).toMatch(/aria-label="[^"]*[Ll]oad/);
+  });
+});

--- a/frontend/src/components/ChapterSummary.tsx
+++ b/frontend/src/components/ChapterSummary.tsx
@@ -98,14 +98,16 @@ export default function ChapterSummary({
 
       <div className="flex-1 overflow-y-auto p-4">
         {loading && (
-          <div className="space-y-3 animate-pulse">
-            <div className="h-4 bg-amber-100 rounded w-3/4" />
-            <div className="h-4 bg-amber-100 rounded w-full" />
-            <div className="h-4 bg-amber-100 rounded w-5/6" />
-            <div className="h-3 bg-amber-50 rounded w-1/2 mt-4" />
-            <div className="h-3 bg-amber-50 rounded w-full" />
-            <div className="h-3 bg-amber-50 rounded w-4/5" />
-            <div className="h-3 bg-amber-50 rounded w-3/4" />
+          <div role="status" aria-label="Loading summary">
+            <div className="space-y-3 animate-pulse">
+              <div className="h-4 bg-amber-100 rounded w-3/4" />
+              <div className="h-4 bg-amber-100 rounded w-full" />
+              <div className="h-4 bg-amber-100 rounded w-5/6" />
+              <div className="h-3 bg-amber-50 rounded w-1/2 mt-4" />
+              <div className="h-3 bg-amber-50 rounded w-full" />
+              <div className="h-3 bg-amber-50 rounded w-4/5" />
+              <div className="h-3 bg-amber-50 rounded w-3/4" />
+            </div>
           </div>
         )}
 

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -359,10 +359,12 @@ export default function InsightChat({
 
         {/* Initial loading skeleton */}
         {chatLoading && messages.length === 0 && (
-          <div className="space-y-2 animate-pulse pt-1 px-1">
-            {[1, 0.85, 1, 0.7, 1, 0.8].map((w, i) => (
-              <div key={i} className="h-3 bg-gray-100 rounded" style={{ width: `${w * 100}%` }} />
-            ))}
+          <div role="status" aria-label="Loading messages">
+            <div className="space-y-2 animate-pulse pt-1 px-1">
+              {[1, 0.85, 1, 0.7, 1, 0.8].map((w, i) => (
+                <div key={i} className="h-3 bg-gray-100 rounded" style={{ width: `${w * 100}%` }} />
+              ))}
+            </div>
           </div>
         )}
 

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -783,10 +783,12 @@ export default function SentenceReader({
                       {translationText}
                     </p>
                   ) : translationLoading ? (
-                    <div className="space-y-2 animate-pulse">
-                      {Array.from({ length: 3 }).map((_, j) => (
-                        <div key={j} className={`h-3 bg-amber-100 rounded ${j === 2 ? "w-2/3" : "w-full"}`} />
-                      ))}
+                    <div role="status" aria-label="Loading translation">
+                      <div className="space-y-2 animate-pulse">
+                        {Array.from({ length: 3 }).map((_, j) => (
+                          <div key={j} className={`h-3 bg-amber-100 rounded ${j === 2 ? "w-2/3" : "w-full"}`} />
+                        ))}
+                      </div>
                     </div>
                   ) : null}
                 </div>
@@ -801,9 +803,11 @@ export default function SentenceReader({
             {originalContent}
             {noteCard}
             {translationLoading && textParaIdx === 0 && !translationText && (
-              <div className="mt-1 space-y-1 animate-pulse">
-                <div className="h-3 bg-amber-100 rounded w-full" />
-                <div className="h-3 bg-amber-100 rounded w-5/6" />
+              <div role="status" aria-label="Loading translation">
+                <div className="mt-1 space-y-1 animate-pulse">
+                  <div className="h-3 bg-amber-100 rounded w-full" />
+                  <div className="h-3 bg-amber-100 rounded w-5/6" />
+                </div>
               </div>
             )}
             {translationText && (


### PR DESCRIPTION
Closes #1064

Three components rendered skeleton loading states without `role="status"` or accessible text alternatives, violating WCAG 4.1.3 (Status Messages, Level AA). Screen readers had no way to announce that content was loading.

## Changes
- `InsightChat.tsx`: wrapped initial chat loading skeleton in `<div role="status" aria-label="Loading messages">`
- `SentenceReader.tsx`: wrapped both translation loading skeletons (inline and sidebar modes) in `<div role="status" aria-label="Loading translation">`
- `ChapterSummary.tsx`: wrapped chapter summary loading skeleton in `<div role="status" aria-label="Loading summary">`
- `SkeletonLoaderAria.test.ts`: 6 static assertions confirming `role="status"` and `aria-label` on all three components

## Test plan
- [x] 6 new tests pass
- [x] Full frontend suite — 2030/2030 passing
- [x] Full backend suite — 1382/1382 passing

🤖 Generated with Claude Code
