### PR TITLE
ux: add role="status" and aria-label to page-level skeleton and spinner loading states (closes #1066)

### DIFF
--- a/frontend/src/__tests__/PageSkeletonAria.test.ts
+++ b/frontend/src/__tests__/PageSkeletonAria.test.ts
@@ -1,0 +1,52 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const appDir = path.join(__dirname, "../app");
+
+const homeSrc = fs.readFileSync(path.join(appDir, "page.tsx"), "utf8");
+const vocabSrc = fs.readFileSync(path.join(appDir, "vocabulary/page.tsx"), "utf8");
+const notesSrc = fs.readFileSync(path.join(appDir, "notes/page.tsx"), "utf8");
+const decksSrc = fs.readFileSync(path.join(appDir, "decks/page.tsx"), "utf8");
+const uploadSrc = fs.readFileSync(path.join(appDir, "upload/page.tsx"), "utf8");
+const adminLayoutSrc = fs.readFileSync(path.join(appDir, "admin/layout.tsx"), "utf8");
+const adminUploadsSrc = fs.readFileSync(path.join(appDir, "admin/uploads/page.tsx"), "utf8");
+const adminBooksSrc = fs.readFileSync(path.join(appDir, "admin/books/page.tsx"), "utf8");
+const adminAudioSrc = fs.readFileSync(path.join(appDir, "admin/audio/page.tsx"), "utf8");
+
+describe("Page-level loading states have accessible role=\"status\" (closes #1066)", () => {
+  it("home page (page.tsx) has role=\"status\" on loading states", () => {
+    expect(homeSrc).toMatch(/role="status"/);
+  });
+
+  it("vocabulary page has role=\"status\" on loading state", () => {
+    expect(vocabSrc).toMatch(/role="status"/);
+  });
+
+  it("notes page has role=\"status\" on loading spinner", () => {
+    expect(notesSrc).toMatch(/role="status"/);
+  });
+
+  it("decks page has role=\"status\" on loading skeleton", () => {
+    expect(decksSrc).toMatch(/role="status"/);
+  });
+
+  it("upload page has role=\"status\" on loading states", () => {
+    expect(uploadSrc).toMatch(/role="status"/);
+  });
+
+  it("admin layout has role=\"status\" on auth-check spinner", () => {
+    expect(adminLayoutSrc).toMatch(/role="status"/);
+  });
+
+  it("admin/uploads page has role=\"status\" on loading spinner", () => {
+    expect(adminUploadsSrc).toMatch(/role="status"/);
+  });
+
+  it("admin/books page has role=\"status\" on loading spinner", () => {
+    expect(adminBooksSrc).toMatch(/role="status"/);
+  });
+
+  it("admin/audio page has role=\"status\" on loading spinner", () => {
+    expect(adminAudioSrc).toMatch(/role="status"/);
+  });
+});

--- a/frontend/src/app/admin/audio/page.tsx
+++ b/frontend/src/app/admin/audio/page.tsx
@@ -44,8 +44,8 @@ export default function AudioPage() {
 
   if (loading)
     return (
-      <div className="flex items-center justify-center py-16">
-        <div className="w-6 h-6 border-4 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+      <div role="status" aria-label="Loading audio jobs" className="flex items-center justify-center py-16">
+        <div className="w-6 h-6 border-4 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
       </div>
     );
   if (error)

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -214,8 +214,8 @@ export default function BooksPage() {
 
   if (loading)
     return (
-      <div className="flex items-center justify-center py-16">
-        <div className="w-6 h-6 border-4 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+      <div role="status" aria-label="Loading books" className="flex items-center justify-center py-16">
+        <div className="w-6 h-6 border-4 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
       </div>
     );
 

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -65,8 +65,8 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
 
   if (!authed) {
     return (
-      <div className="min-h-screen bg-parchment flex items-center justify-center">
-        <div className="w-8 h-8 border-4 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+      <div role="status" aria-label="Loading admin panel" className="min-h-screen bg-parchment flex items-center justify-center">
+        <div className="w-8 h-8 border-4 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
       </div>
     );
   }

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -71,9 +71,8 @@ export default function UploadsPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-16">
-        <div className="w-6 h-6 border-4 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
-        <span className="sr-only">Loading…</span>
+      <div role="status" aria-label="Loading uploads" className="flex items-center justify-center py-16">
+        <div className="w-6 h-6 border-4 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
       </div>
     );
   }

--- a/frontend/src/app/decks/page.tsx
+++ b/frontend/src/app/decks/page.tsx
@@ -77,10 +77,12 @@ export default function DecksPage() {
 
       <div className="max-w-2xl mx-auto px-4 md:px-6 py-6 md:py-8">
         {loading ? (
-          <div className="space-y-3 animate-pulse">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <div key={i} className="h-24 bg-amber-100 rounded-xl" />
-            ))}
+          <div role="status" aria-label="Loading decks">
+            <div className="space-y-3 animate-pulse">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="h-24 bg-amber-100 rounded-xl" />
+              ))}
+            </div>
           </div>
         ) : isEmpty ? (
           <div

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -138,8 +138,8 @@ export default function NotesOverviewPage() {
         />
 
         {loading ? (
-          <div className="flex justify-center py-20">
-            <span className="w-6 h-6 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+          <div role="status" aria-label="Loading notes" className="flex justify-center py-20">
+            <span className="w-6 h-6 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
           </div>
         ) : fetchError ? (
           <div className="text-center text-stone-400 mt-20 flex flex-col items-center gap-2">

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -593,14 +593,16 @@ export default function Home() {
               )}
 
               {searching && (
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 mb-4">
-                  {Array.from({ length: 10 }).map((_, i) => (
-                    <div key={i} className="rounded-xl border border-amber-200 bg-white p-3 animate-pulse">
-                      <div className="w-full h-40 bg-amber-100 rounded-lg mb-2" />
-                      <div className="h-3 bg-amber-100 rounded w-3/4 mb-1.5" />
-                      <div className="h-3 bg-amber-100 rounded w-1/2" />
-                    </div>
-                  ))}
+                <div role="status" aria-label="Loading search results">
+                  <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 mb-4">
+                    {Array.from({ length: 10 }).map((_, i) => (
+                      <div key={i} className="rounded-xl border border-amber-200 bg-white p-3 animate-pulse">
+                        <div className="w-full h-40 bg-amber-100 rounded-lg mb-2" />
+                        <div className="h-3 bg-amber-100 rounded w-3/4 mb-1.5" />
+                        <div className="h-3 bg-amber-100 rounded w-1/2" />
+                      </div>
+                    ))}
+                  </div>
                 </div>
               )}
 
@@ -662,30 +664,32 @@ export default function Home() {
               </div>
 
               {popularLoading && (
-                popularView === "grid" ? (
-                  <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-                    {Array.from({ length: 10 }).map((_, i) => (
-                      <div key={i} className="rounded-xl border border-amber-200 bg-white p-3 animate-pulse">
-                        <div className="w-full h-40 bg-amber-100 rounded-lg mb-2" />
-                        <div className="h-3 bg-amber-100 rounded w-3/4 mb-1.5" />
-                        <div className="h-3 bg-amber-100 rounded w-1/2" />
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <div className="divide-y divide-amber-100 border border-amber-200 rounded-xl overflow-hidden bg-white">
-                    {Array.from({ length: 10 }).map((_, i) => (
-                      <div key={i} className="flex items-center gap-3 px-4 py-3 animate-pulse">
-                        <div className="w-8 h-3 bg-amber-100 rounded shrink-0" />
-                        <div className="w-8 h-12 bg-amber-100 rounded shrink-0" />
-                        <div className="flex-1 space-y-1.5">
-                          <div className="h-3 bg-amber-100 rounded w-2/3" />
-                          <div className="h-3 bg-amber-100 rounded w-1/3" />
+                <div role="status" aria-label="Loading popular books">
+                  {popularView === "grid" ? (
+                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+                      {Array.from({ length: 10 }).map((_, i) => (
+                        <div key={i} className="rounded-xl border border-amber-200 bg-white p-3 animate-pulse">
+                          <div className="w-full h-40 bg-amber-100 rounded-lg mb-2" />
+                          <div className="h-3 bg-amber-100 rounded w-3/4 mb-1.5" />
+                          <div className="h-3 bg-amber-100 rounded w-1/2" />
                         </div>
-                      </div>
-                    ))}
-                  </div>
-                )
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="divide-y divide-amber-100 border border-amber-200 rounded-xl overflow-hidden bg-white">
+                      {Array.from({ length: 10 }).map((_, i) => (
+                        <div key={i} className="flex items-center gap-3 px-4 py-3 animate-pulse">
+                          <div className="w-8 h-3 bg-amber-100 rounded shrink-0" />
+                          <div className="w-8 h-12 bg-amber-100 rounded shrink-0" />
+                          <div className="flex-1 space-y-1.5">
+                            <div className="h-3 bg-amber-100 rounded w-2/3" />
+                            <div className="h-3 bg-amber-100 rounded w-1/3" />
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
               )}
 
               {!popularLoading && popularBooks.length > 0 && (

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -84,8 +84,8 @@ export default function UploadPage() {
 
   if (status === "loading") {
     return (
-      <main className="min-h-screen bg-parchment flex items-center justify-center">
-        <div className="w-6 h-6 border-2 border-amber-400 border-t-amber-700 rounded-full animate-spin" />
+      <main role="status" aria-label="Loading upload page" className="min-h-screen bg-parchment flex items-center justify-center">
+        <div className="w-6 h-6 border-2 border-amber-400 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
       </main>
     );
   }
@@ -145,11 +145,11 @@ export default function UploadPage() {
           `}
         >
           {uploading ? (
-            <>
-              <div className="w-10 h-10 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin mb-4" />
+            <div role="status" aria-label="Uploading file" className="flex flex-col items-center">
+              <div className="w-10 h-10 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin mb-4" aria-hidden="true" />
               <p className="font-serif text-lg text-ink">Uploading and parsing…</p>
               <p className="text-sm text-amber-700 mt-1">This may take a moment for large files.</p>
-            </>
+            </div>
           ) : (
             <>
               <UploadIcon className="w-10 h-10 text-amber-400 mb-4" />


### PR DESCRIPTION
Closes #1066

Eight page files rendered skeleton/spinner loading states without `role="status"` or accessible labels, violating WCAG 4.1.3 (Status Messages, Level AA). Screen readers had no way to announce that content was loading.

## Changes
- `app/page.tsx`: two skeletons (search results, popular books) wrapped in `role="status"` containers
- `app/notes/page.tsx`: spinner div gets `role="status" aria-label="Loading notes"` + `aria-hidden` on the spinner
- `app/decks/page.tsx`: skeleton div wrapped in `role="status" aria-label="Loading decks"`
- `app/upload/page.tsx`: auth-check spinner and upload-progress state each get `role="status"`
- `app/admin/layout.tsx`: auth-check spinner gets `role="status" aria-label="Loading admin panel"`
- `app/admin/uploads/page.tsx`, `admin/books/page.tsx`, `admin/audio/page.tsx`: each spinner gets `role="status"` with appropriate label
- `PageSkeletonAria.test.ts`: 9 static assertions, one per affected file

## Test plan
- [x] 9 new tests pass
- [x] Full frontend suite — 2037/2037 passing
- [x] Full backend suite — 1382/1382 passing

🤖 Generated with Claude Code
