### PR TITLE
ux: add role="status" and aria-label to remaining spinner/skeleton loading states (closes #1075)

### DIFF
--- a/frontend/src/__tests__/SecondarySkeletonAria.test.ts
+++ b/frontend/src/__tests__/SecondarySkeletonAria.test.ts
@@ -1,0 +1,55 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const root = path.resolve(__dirname, "../../src");
+
+function readSrc(rel: string) {
+  return fs.readFileSync(path.join(root, rel), "utf8");
+}
+
+describe("Secondary skeleton/spinner role=status aria accessibility (WCAG 4.1.3)", () => {
+  it("admin/users SpinnerRow has role=status", () => {
+    const src = readSrc("app/admin/users/page.tsx");
+    expect(src).toMatch(/role="status"/);
+  });
+
+  it("admin/users SpinnerRow has aria-label for loading", () => {
+    const src = readSrc("app/admin/users/page.tsx");
+    expect(src).toMatch(/aria-label="[^"]*[Ll]oad[^"]*"/);
+  });
+
+  it("vocabulary/flashcards page has role=status on loading spinner", () => {
+    const src = readSrc("app/vocabulary/flashcards/page.tsx");
+    expect(src).toMatch(/role="status"/);
+  });
+
+  it("vocabulary/flashcards page has aria-label on loading spinner", () => {
+    const src = readSrc("app/vocabulary/flashcards/page.tsx");
+    expect(src).toMatch(/aria-label="[^"]*[Ll]oad[^"]*"/);
+  });
+
+  it("upload/[bookId]/chapters page has role=status on loading spinner", () => {
+    const src = readSrc("app/upload/[bookId]/chapters/page.tsx");
+    expect(src).toMatch(/role="status"/);
+  });
+
+  it("upload/[bookId]/chapters page has aria-label on loading spinner", () => {
+    const src = readSrc("app/upload/[bookId]/chapters/page.tsx");
+    expect(src).toMatch(/aria-label="[^"]*[Ll]oad[^"]*"/);
+  });
+
+  it("notes/[bookId] page has role=status on content spinner", () => {
+    const src = readSrc("app/notes/[bookId]/page.tsx");
+    expect(src).toMatch(/role="status"/);
+  });
+
+  it("ReadingStats component has role=status on skeleton", () => {
+    const src = readSrc("components/ReadingStats.tsx");
+    expect(src).toMatch(/role="status"/);
+  });
+
+  it("vocabulary page word-list skeleton has role=status and aria-label", () => {
+    const src = readSrc("app/vocabulary/page.tsx");
+    expect(src).toMatch(/aria-label="Loading vocabulary"/);
+  });
+});

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -109,8 +109,8 @@ export default function UsersPage() {
 
 function SpinnerRow() {
   return (
-    <div className="flex items-center justify-center py-16">
-      <div className="w-6 h-6 border-4 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+    <div role="status" aria-label="Loading users" className="flex items-center justify-center py-16">
+      <div className="w-6 h-6 border-4 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
     </div>
   );
 }

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -680,8 +680,8 @@ export default function BookNotesPage() {
       {/* Content */}
       <div className="max-w-3xl mx-auto px-4 md:px-8 py-8">
         {loading ? (
-          <div className="flex justify-center py-24">
-            <span className="w-6 h-6 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+          <div role="status" aria-label="Loading notes" className="flex justify-center py-24">
+            <span className="w-6 h-6 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
           </div>
         ) : fetchError ? (
           <div className="text-center text-stone-400 mt-20 flex flex-col items-center gap-2">

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -69,8 +69,8 @@ export default function ChapterEditorPage() {
 
   if (loading) {
     return (
-      <main className="min-h-screen bg-parchment flex items-center justify-center">
-        <div className="w-6 h-6 border-2 border-amber-400 border-t-amber-700 rounded-full animate-spin" />
+      <main role="status" aria-label="Loading chapters" className="min-h-screen bg-parchment flex items-center justify-center">
+        <div className="w-6 h-6 border-2 border-amber-400 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
       </main>
     );
   }

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -71,8 +71,8 @@ export default function FlashcardsPage() {
 
   if (status === "loading" || loading) {
     return (
-      <div className="min-h-screen bg-parchment flex items-center justify-center">
-        <div className="w-6 h-6 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+      <div role="status" aria-label="Loading flashcards" className="min-h-screen bg-parchment flex items-center justify-center">
+        <div className="w-6 h-6 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
       </div>
     );
   }

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -538,7 +538,7 @@ function VocabularyPageContent() {
         )}
 
         {loading ? (
-          <div className="space-y-3 animate-pulse">
+          <div role="status" aria-label="Loading vocabulary" className="space-y-3 animate-pulse">
             {Array.from({ length: 8 }).map((_, i) => (
               <div key={i} className="h-5 bg-amber-100 rounded w-full" />
             ))}

--- a/frontend/src/components/ReadingStats.tsx
+++ b/frontend/src/components/ReadingStats.tsx
@@ -96,7 +96,7 @@ export default function ReadingStats({ active, heatmapOnly = false }: Props) {
 
   if (!active || (loading && !stats)) {
     return (
-      <div className="space-y-4 animate-pulse">
+      <div role="status" aria-label="Loading reading stats" className="space-y-4 animate-pulse">
         {!heatmapOnly && (
           <div className="grid grid-cols-2 gap-3">
             {[...Array(4)].map((_, i) => (


### PR DESCRIPTION
Closes #1075

Six more pages/components had `animate-spin`/`animate-pulse` loading states without `role="status"` or `aria-label`, violating WCAG 4.1.3 (Status Messages, Level AA). Screen readers had no way to announce that content was loading.

## Changes
- `app/admin/users/page.tsx`: `SpinnerRow` component gets `role="status" aria-label="Loading users"` + `aria-hidden` on the spinner div
- `app/vocabulary/flashcards/page.tsx`: page-level spinner wrapped with `role="status" aria-label="Loading flashcards"`
- `app/upload/[bookId]/chapters/page.tsx`: `<main>` gets `role="status" aria-label="Loading chapters"`
- `app/notes/[bookId]/page.tsx`: content-area spinner wrapped with `role="status" aria-label="Loading notes"`
- `components/ReadingStats.tsx`: skeleton wrapped with `role="status" aria-label="Loading reading stats"`
- `app/vocabulary/page.tsx`: word-list skeleton gets `role="status" aria-label="Loading vocabulary"`
- `frontend/src/__tests__/SecondarySkeletonAria.test.ts`: 9 static assertions, one per fix

## Test plan
- [x] 9 new tests pass
- [x] Full frontend suite — 2043/2043 passing
- [x] Full backend suite — 1382/1382 passing

🤖 Generated with Claude Code
