### PR TITLE
ux: add role="status" to reader chapter skeleton and QueueTab initial skeleton (closes #1077)

### DIFF
--- a/frontend/src/__tests__/ReaderQueueTabAria.test.ts
+++ b/frontend/src/__tests__/ReaderQueueTabAria.test.ts
@@ -1,0 +1,30 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const root = path.resolve(__dirname, "../../src");
+
+function readSrc(rel: string) {
+  return fs.readFileSync(path.join(root, rel), "utf8");
+}
+
+describe("Reader and QueueTab role=status aria accessibility (WCAG 4.1.3)", () => {
+  it("reader page chapter skeleton has role=status", () => {
+    const src = readSrc("app/reader/[bookId]/page.tsx");
+    expect(src).toMatch(/role="status"/);
+  });
+
+  it("reader page chapter skeleton has aria-label for loading", () => {
+    const src = readSrc("app/reader/[bookId]/page.tsx");
+    expect(src).toMatch(/aria-label="[^"]*[Ll]oad[^"]*"/);
+  });
+
+  it("QueueTab initial skeleton has role=status", () => {
+    const src = readSrc("components/QueueTab.tsx");
+    expect(src).toMatch(/role="status"/);
+  });
+
+  it("QueueTab initial skeleton has aria-label for loading", () => {
+    const src = readSrc("components/QueueTab.tsx");
+    expect(src).toMatch(/aria-label="[^"]*[Ll]oad[^"]*"/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1317,7 +1317,7 @@ export default function ReaderPage() {
             onMouseUp={handleSelection}
           >
             {loading ? (
-              <div className="max-w-prose mx-auto space-y-3 animate-pulse">
+              <div role="status" aria-label="Loading chapter" className="max-w-prose mx-auto space-y-3 animate-pulse">
                 {Array.from({ length: 14 }).map((_, i) => (
                   <div key={i} className={`h-4 bg-amber-200 rounded ${i % 5 === 4 ? "w-2/3" : "w-full"}`} />
                 ))}

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -436,7 +436,7 @@ export default function QueueTab({ adminFetch }: Props) {
   // rendered panels that used to pop in incrementally over a few seconds.
   if (!initialLoaded && !error) {
     return (
-      <div className="space-y-3 animate-pulse">
+      <div role="status" aria-label="Loading queue" className="space-y-3 animate-pulse">
         <div className="bg-white rounded-xl border border-amber-200 p-4">
           <div className="flex items-center gap-3">
             <div className="w-2.5 h-2.5 rounded-full bg-stone-300" />


### PR DESCRIPTION
Closes #1077

Two more WCAG 4.1.3 violations fixed — major loading states in the reader and admin queue lacked `role="status"` so screen readers couldn't announce content loading.

## Changes
- `app/reader/[bookId]/page.tsx`: chapter text skeleton (14-row animate-pulse) gets `role="status" aria-label="Loading chapter"`
- `components/QueueTab.tsx`: initial full-tab skeleton (`!initialLoaded && !error` guard) gets `role="status" aria-label="Loading queue"`
- `frontend/src/__tests__/ReaderQueueTabAria.test.ts`: 4 static assertions

## Test plan
- [x] 4 new tests pass
- [x] Full frontend suite — 2047/2047 passing
- [x] Full backend suite — 1382/1382 passing

🤖 Generated with Claude Code
