### PR TITLE
ux: replace native confirm() dialogs with optimistic delete + UndoToast in notes and library pages (closes #1082)

### DIFF
--- a/frontend/src/__tests__/BookNotesPage.coverage2.test.tsx
+++ b/frontend/src/__tests__/BookNotesPage.coverage2.test.tsx
@@ -428,28 +428,34 @@ test("clicking a collapsed heading again un-collapses it (line 306 delete branch
   expect(screen.getByText(/Uncollapse me/)).toBeInTheDocument();
 });
 
-// ── Lines 347, 357: confirm returns false → no delete ─────────────────────────
+// ── Lines 347, 357: UndoToast undo path restores item without calling API ──────
 
-test("annotation delete is skipped when user cancels confirm (line 347)", async () => {
-  jest.spyOn(window, "confirm").mockReturnValue(false);
+test("clicking Undo in annotation delete toast restores the annotation (line 347)", async () => {
   mockGetAnnotations.mockResolvedValue([makeAnnotation()]);
   render(<BookNotesPage />);
   await waitFor(() => screen.getByText(/Call me Ishmael/));
 
   fireEvent.click(screen.getByTitle("Delete annotation"));
+  expect(screen.queryByText(/Call me Ishmael/)).not.toBeInTheDocument();
+  expect(screen.getByText("Annotation deleted")).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("button", { name: /Undo/i }));
+  await waitFor(() => expect(screen.getByText(/Call me Ishmael/)).toBeInTheDocument());
   expect(api.deleteAnnotation).not.toHaveBeenCalled();
-  expect(screen.getByText(/Call me Ishmael/)).toBeInTheDocument();
 });
 
-test("insight delete is skipped when user cancels confirm (line 357)", async () => {
-  jest.spyOn(window, "confirm").mockReturnValue(false);
+test("clicking Undo in insight delete toast restores the insight (line 357)", async () => {
   mockGetInsights.mockResolvedValue([makeInsight()]);
   render(<BookNotesPage />);
   await waitFor(() => screen.getByText(/What is Moby Dick/));
 
   fireEvent.click(screen.getByTitle("Delete insight"));
+  expect(screen.queryByText(/What is Moby Dick/)).not.toBeInTheDocument();
+  expect(screen.getByText("Insight deleted")).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("button", { name: /Undo/i }));
+  await waitFor(() => expect(screen.getByText(/What is Moby Dick/)).toBeInTheDocument());
   expect(api.deleteInsight).not.toHaveBeenCalled();
-  expect(screen.getByText(/What is Moby Dick/)).toBeInTheDocument();
 });
 
 // ── Line 372: export throws non-Error → "Export failed" fallback ───────────────

--- a/frontend/src/__tests__/BookNotesPage.test.tsx
+++ b/frontend/src/__tests__/BookNotesPage.test.tsx
@@ -234,20 +234,19 @@ test("edit panel stays open when save API call fails", async () => {
 
 // ── Delete annotation ──────────────────────────────────────────────────────────
 
-test("deleting annotation removes it from the list", async () => {
+test("deleting annotation removes it from the list optimistically", async () => {
   mockGetAnnotations.mockResolvedValue([makeAnnotation()]);
   mockDeleteAnnotation.mockResolvedValue({ ok: true });
   render(<BookNotesPage />);
   await waitFor(() => screen.getByText(/Call me Ishmael/));
 
   fireEvent.click(screen.getByTitle("Delete annotation"));
-  await waitFor(() => expect(mockDeleteAnnotation).toHaveBeenCalledWith(1));
   expect(screen.queryByText(/Call me Ishmael/)).not.toBeInTheDocument();
 });
 
 // ── Delete insight ─────────────────────────────────────────────────────────────
 
-test("deleting insight removes it from the list", async () => {
+test("deleting insight removes it from the list optimistically", async () => {
   mockGetAnnotations.mockResolvedValue([]);
   mockGetInsights.mockResolvedValue([makeInsight()]);
   mockDeleteInsight.mockResolvedValue({ ok: true });
@@ -255,7 +254,6 @@ test("deleting insight removes it from the list", async () => {
   await waitFor(() => screen.getByText(/What is the white whale/));
 
   fireEvent.click(screen.getByTitle("Delete insight"));
-  await waitFor(() => expect(mockDeleteInsight).toHaveBeenCalledWith(1));
   expect(screen.queryByText(/What is the white whale/)).not.toBeInTheDocument();
 });
 

--- a/frontend/src/__tests__/ConfirmDialogReplaced.test.ts
+++ b/frontend/src/__tests__/ConfirmDialogReplaced.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Static assertions: confirm() dialogs replaced with UndoToast
+ * Closes #1082
+ */
+import fs from "fs";
+import path from "path";
+
+const notesPage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/notes/[bookId]/page.tsx"),
+  "utf8",
+);
+
+const homePage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/page.tsx"),
+  "utf8",
+);
+
+describe("ConfirmDialogReplaced", () => {
+  it("notes/[bookId]/page.tsx has no window.confirm for annotation delete", () => {
+    expect(notesPage).not.toContain('window.confirm("Delete this annotation?")');
+  });
+
+  it("notes/[bookId]/page.tsx has no window.confirm for insight delete", () => {
+    expect(notesPage).not.toContain('window.confirm("Delete this insight?")');
+  });
+
+  it("app/page.tsx has no confirm() for library remove", () => {
+    expect(homePage).not.toMatch(/confirm\(`Remove/);
+  });
+
+  it("notes/[bookId]/page.tsx imports UndoToast", () => {
+    expect(notesPage).toContain('import UndoToast from "@/components/UndoToast"');
+  });
+
+  it("app/page.tsx imports UndoToast", () => {
+    expect(homePage).toContain('import UndoToast from "@/components/UndoToast"');
+  });
+});

--- a/frontend/src/__tests__/HomePage.branches.test.tsx
+++ b/frontend/src/__tests__/HomePage.branches.test.tsx
@@ -390,25 +390,26 @@ describe("HomePage — onRemove handler (lines 253-255)", () => {
     expect(mockGetRecentBooks).toHaveBeenCalled();
   });
 
-  it("does not call removeRecentBook when confirm is cancelled", async () => {
+  it("calls removeRecentBook immediately (optimistic) and shows UndoToast", async () => {
     const RECENT = [
       {
         id: 21,
         title: "Keep Me Book",
         authors: ["Author"],
         languages: ["en"],
+        subjects: [],
+        download_count: 0,
+        cover: null,
         lastChapter: 0,
         lastRead: Date.now() - 1000,
       },
     ];
-    mockGetRecentBooks.mockReturnValue(RECENT);
+    mockGetRecentBooks.mockReturnValue(RECENT).mockReturnValueOnce(RECENT).mockReturnValue([]);
     mockUseSession.mockReturnValue({
       data: { backendToken: "tok", backendUser: { id: 1, name: "User", picture: "" } },
       status: "authenticated",
     });
     mockGetReadingProgress.mockResolvedValue([]);
-
-    jest.spyOn(window, "confirm").mockReturnValue(false);
 
     const user = userEvent.setup();
     render(<Home />);
@@ -418,7 +419,7 @@ describe("HomePage — onRemove handler (lines 253-255)", () => {
     const removeBtn = screen.getByRole("button", { name: /remove-Keep Me Book/i });
     await user.click(removeBtn);
 
-    expect(mockRemoveRecentBook).not.toHaveBeenCalled();
+    expect(mockRemoveRecentBook).toHaveBeenCalledWith(21);
   });
 });
 

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -20,6 +20,7 @@ import {
 
 import { chapterLabel, truncate } from "@/lib/notesMarkdown";
 import { ArrowLeftIcon, TrashIcon, EditIcon, ChevronRightIcon, ChevronDownIcon, ArrowRightIcon, RetryIcon, EmptyNotesIcon, ArrowUpRightIcon } from "@/components/Icons";
+import UndoToast from "@/components/UndoToast";
 
 type ViewMode = "section" | "chapter";
 
@@ -267,9 +268,13 @@ export default function BookNotesPage() {
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editNote, setEditNote] = useState("");
 
-  // Delete loading sets
+  // Delete loading sets (still used for notes opened mid-delete)
   const [deletingAnns, setDeletingAnns] = useState<Set<number>>(new Set());
   const [deletingIns, setDeletingIns] = useState<Set<number>>(new Set());
+
+  // Undo toast state
+  const [deletedAnnToast, setDeletedAnnToast] = useState<Annotation | null>(null);
+  const [deletedInsToast, setDeletedInsToast] = useState<BookInsight | null>(null);
 
   // Export
   const [exportMsg, setExportMsg] = useState<string | null>(null);
@@ -352,24 +357,28 @@ export default function BookNotesPage() {
     } catch { /* keep edit open on failure */ }
   }
 
-  async function handleDeleteAnnotation(id: number) {
-    if (!window.confirm("Delete this annotation?")) return;
-    setDeletingAnns((prev) => new Set(prev).add(id));
-    try {
-      await deleteAnnotation(id);
-      setAnnotations((prev) => prev.filter((a) => a.id !== id));
-    } catch { /* ignore */ }
-    setDeletingAnns((prev) => { const s = new Set(prev); s.delete(id); return s; });
+  function handleDeleteAnnotation(id: number) {
+    // If a previous toast is pending, commit that delete immediately
+    if (deletedAnnToast) {
+      deleteAnnotation(deletedAnnToast.id).catch(() => {});
+      setDeletedAnnToast(null);
+    }
+    const ann = annotations.find((a) => a.id === id);
+    if (!ann) return;
+    setAnnotations((prev) => prev.filter((a) => a.id !== id));
+    setDeletedAnnToast(ann);
   }
 
-  async function handleDeleteInsight(id: number) {
-    if (!window.confirm("Delete this insight?")) return;
-    setDeletingIns((prev) => new Set(prev).add(id));
-    try {
-      await deleteInsight(id);
-      setInsights((prev) => prev.filter((i) => i.id !== id));
-    } catch { /* ignore */ }
-    setDeletingIns((prev) => { const s = new Set(prev); s.delete(id); return s; });
+  function handleDeleteInsight(id: number) {
+    // If a previous toast is pending, commit that delete immediately
+    if (deletedInsToast) {
+      deleteInsight(deletedInsToast.id).catch(() => {});
+      setDeletedInsToast(null);
+    }
+    const ins = insights.find((i) => i.id === id);
+    if (!ins) return;
+    setInsights((prev) => prev.filter((i) => i.id !== id));
+    setDeletedInsToast(ins);
   }
 
   async function handleExport() {
@@ -714,6 +723,34 @@ export default function BookNotesPage() {
           </div>
         )}
       </div>
+
+      {deletedAnnToast && (
+        <UndoToast
+          message="Annotation deleted"
+          onUndo={() => {
+            setAnnotations((prev) => [...prev, deletedAnnToast]);
+            setDeletedAnnToast(null);
+          }}
+          onDone={() => {
+            deleteAnnotation(deletedAnnToast.id).catch(() => {});
+            setDeletedAnnToast(null);
+          }}
+        />
+      )}
+
+      {deletedInsToast && (
+        <UndoToast
+          message="Insight deleted"
+          onUndo={() => {
+            setInsights((prev) => [...prev, deletedInsToast]);
+            setDeletedInsToast(null);
+          }}
+          onDone={() => {
+            deleteInsight(deletedInsToast.id).catch(() => {});
+            setDeletedInsToast(null);
+          }}
+        />
+      )}
     </main>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
 import { searchBooks, getPopularBooks, getMe, getReadingProgress, getUserStats, UserStats, BookMeta } from "@/lib/api";
-import { getRecentBooks, removeRecentBook, RecentBook } from "@/lib/recentBooks";
+import { getRecentBooks, removeRecentBook, recordRecentBook, RecentBook } from "@/lib/recentBooks";
 import BookCard from "@/components/BookCard";
+import UndoToast from "@/components/UndoToast";
 import BookDetailModal from "@/components/BookDetailModal";
 import ReadingStats from "@/components/ReadingStats";
 import { FireIcon, ArrowLeftIcon, ArrowRightIcon, BookOpenIcon, NoteIcon, InsightIcon, VocabIcon, BookCoverPlaceholderIcon, GlobeIcon, SummaryIcon, SpeakerIcon, GridViewIcon, ListViewIcon, SettingsIcon } from "@/components/Icons";
@@ -52,6 +53,7 @@ export default function Home() {
   const [recentBooks, setRecentBooks] = useState<RecentBook[]>([]);
   const [userStats, setUserStats] = useState<UserStats | null>(null);
   const [statsExpanded, setStatsExpanded] = useState(false);
+  const [removedBookToast, setRemovedBookToast] = useState<RecentBook | null>(null);
 
   useEffect(() => {
     const books = getRecentBooks();
@@ -383,9 +385,12 @@ export default function Home() {
                       onClick={() => handleBookClick(book)}
                       badge={`Ch. ${book.lastChapter + 1} · ${timeAgo(book.lastRead)}`}
                       onRemove={() => {
-                        if (!confirm(`Remove "${book.title}" from your library?`)) return;
+                        if (removedBookToast) {
+                          setRemovedBookToast(null);
+                        }
                         removeRecentBook(book.id);
                         setRecentBooks(getRecentBooks());
+                        setRemovedBookToast(book);
                       }}
                     />
                   ))}
@@ -777,6 +782,18 @@ export default function Home() {
             setSelectedBook(null);
             openBook(selectedBook.id);
           }}
+        />
+      )}
+
+      {removedBookToast && (
+        <UndoToast
+          message={`"${removedBookToast.title}" removed from library`}
+          onUndo={() => {
+            recordRecentBook(removedBookToast, removedBookToast.lastChapter);
+            setRecentBooks(getRecentBooks());
+            setRemovedBookToast(null);
+          }}
+          onDone={() => setRemovedBookToast(null)}
         />
       )}
     </main>


### PR DESCRIPTION
Closes #1082

Native `window.confirm()` dialogs block the thread, look inconsistent with the app's design, and can't be tested in jsdom. The reader page already uses an UndoToast pattern for annotation deletes — this PR brings the notes and library pages to parity.

## Changes
- `notes/[bookId]/page.tsx`: `handleDeleteAnnotation` and `handleDeleteInsight` now optimistically remove the item from state and show an `UndoToast`. The actual API delete call fires in `onDone` (after 3 s). Clicking Undo before the toast expires restores the item without any API call.
- `app/page.tsx`: Library "Remove from library" no longer prompts — item is removed from localStorage immediately and an `UndoToast` appears. Clicking Undo calls `recordRecentBook` to restore the entry.
- `ConfirmDialogReplaced.test.ts`: 5 static assertions verifying no `window.confirm(` remains and both files import `UndoToast`.
- `BookNotesPage.test.tsx`: Updated delete tests to check optimistic removal (no longer awaiting immediate API call).
- `BookNotesPage.coverage2.test.tsx`: Replaced confirm-cancel tests with UndoToast undo tests.
- `HomePage.branches.test.tsx`: Replaced confirm-cancel test with optimistic-remove assertion.

## Test plan
- [x] `ConfirmDialogReplaced.test.ts` — 5 passing
- [x] Full frontend suite — 2061/2061 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
