### PR TITLE
ux: add role=dialog/aria-modal to vocabulary DefinitionSheet and aria-hidden to modal backdrops (closes #1087)

### DIFF
--- a/frontend/src/__tests__/DialogAria.test.ts
+++ b/frontend/src/__tests__/DialogAria.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Static assertions: dialog ARIA attributes on DefinitionSheet and AuthPromptModal
+ * Closes #1087
+ */
+import fs from "fs";
+import path from "path";
+
+const vocabPage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/vocabulary/page.tsx"),
+  "utf8",
+);
+
+const authModal = fs.readFileSync(
+  path.join(process.cwd(), "src/components/AuthPromptModal.tsx"),
+  "utf8",
+);
+
+describe("DialogAria", () => {
+  it("vocabulary DefinitionSheet panel has role=dialog", () => {
+    expect(vocabPage).toContain('role="dialog"');
+  });
+
+  it("vocabulary DefinitionSheet panel has aria-modal=true", () => {
+    expect(vocabPage).toContain('aria-modal="true"');
+  });
+
+  it("vocabulary DefinitionSheet panel has aria-label for word definition", () => {
+    expect(vocabPage).toContain('aria-label="Word definition"');
+  });
+
+  it("vocabulary DefinitionSheet backdrop has aria-hidden=true", () => {
+    expect(vocabPage).toContain('"fixed inset-0 z-40 bg-black/10"');
+    // The backdrop div should have aria-hidden
+    expect(vocabPage).toMatch(/"fixed inset-0 z-40 bg-black\/10"[^>]*aria-hidden="true"|aria-hidden="true"[^>]*"fixed inset-0 z-40 bg-black\/10"/);
+  });
+
+  it("AuthPromptModal backdrop has aria-hidden=true", () => {
+    // The backdrop div (absolute inset-0 bg-black/40) should have aria-hidden
+    expect(authModal).toMatch(/aria-hidden="true"[^>]*"absolute inset-0 bg-black\/40"|"absolute inset-0 bg-black\/40"[^>]*aria-hidden="true"/);
+  });
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -142,9 +142,12 @@ function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
 
   return (
     <>
-      <div className="fixed inset-0 z-40 bg-black/10" onClick={onClose} />
+      <div className="fixed inset-0 z-40 bg-black/10" aria-hidden="true" onClick={onClose} />
       <div
         ref={ref}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Word definition"
         className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl border-t border-amber-200 max-h-[60vh] overflow-y-auto animate-slide-up"
       >
         <div className="flex justify-center py-2">

--- a/frontend/src/components/AuthPromptModal.tsx
+++ b/frontend/src/components/AuthPromptModal.tsx
@@ -19,7 +19,7 @@ export default function AuthPromptModal({ open, feature, onClose }: Props) {
 
   return (
     <div className="fixed inset-0 z-[200] flex items-end md:items-center justify-center">
-      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="absolute inset-0 bg-black/40" aria-hidden="true" onClick={onClose} />
       <div role="dialog" aria-modal="true" aria-label="Sign in required" className="relative bg-white rounded-t-2xl md:rounded-2xl shadow-xl p-6 w-full max-w-sm animate-slide-up">
         <p className="font-serif text-lg text-ink mb-1">Sign in to {feature}</p>
         <p className="text-sm text-stone-500 mb-5">


### PR DESCRIPTION
Closes #1087

The vocabulary `DefinitionSheet` bottom sheet was not announced as a dialog by screen readers (missing `role="dialog"`, `aria-modal`, `aria-label`). Two modal backdrop overlay divs were also unnamed interactive elements visible to AT.

## Changes
- `vocabulary/page.tsx`: Added `role="dialog" aria-modal="true" aria-label="Word definition"` to the DefinitionSheet panel div; added `aria-hidden="true"` to its backdrop div
- `AuthPromptModal.tsx`: Added `aria-hidden="true"` to the backdrop div (the dialog panel already had `role="dialog"` and `aria-modal`)
- `DialogAria.test.ts`: 5 static assertions for all 5 new attributes

## Test plan
- [x] `DialogAria.test.ts` — 5 passing
- [x] Full frontend suite — 2063/2063 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
