### PR TITLE
fix: add exception logging to admin retranslate, retranslate-all, and queue dry-run 500 handlers (closes #1086)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -566,19 +566,25 @@ async def retranslate(
             provider=provider,
             gemini_key=decrypted_key,
         )
-    except Exception:
+    except Exception as _exc:
         if provider == "gemini":
             try:
                 paragraphs = await do_translate(
                     chapter_text, source_language, target_language, provider="google",
                 )
                 provider = "google"
-            except Exception:
+            except Exception as exc:
+                logger.warning(
+                    "admin retranslate ch %d: both providers failed: %s", chapter_index, exc, exc_info=True
+                )
                 raise HTTPException(
                     status_code=502,
                     detail="Translation failed: both Gemini and Google Translate could not process this chapter.",
                 )
         else:
+            logger.warning(
+                "admin retranslate ch %d: Google Translate failed: %s", chapter_index, _exc, exc_info=True
+            )
             raise HTTPException(
                 status_code=502,
                 detail="Translation failed: Google Translate could not process this chapter.",
@@ -726,16 +732,22 @@ async def retranslate_all(
                 ch.text, source_language, target_language,
                 provider=provider, gemini_key=decrypted_key,
             )
-        except Exception:
+        except Exception as _exc:
             if provider == "gemini":
                 try:
                     paragraphs = await do_translate(
                         ch.text, source_language, target_language, provider="google",
                     )
-                except Exception:
+                except Exception as exc:
+                    logger.warning(
+                        "admin retranslate-all ch %d: both providers failed: %s", i, exc, exc_info=True
+                    )
                     results.append({"chapter": i, "status": "failed"})
                     continue
             else:
+                logger.warning(
+                    "admin retranslate-all ch %d: Google Translate failed: %s", i, _exc, exc_info=True
+                )
                 results.append({"chapter": i, "status": "failed"})
                 continue
         await save_translation(book_id, i, target_language, paragraphs)
@@ -1028,7 +1040,8 @@ async def queue_dry_run(req: QueuePlanRequest, _admin: dict = Depends(_require_a
             model=chain[0] or TRANSLATOR_MODEL,
             max_output_tokens=max_output_tokens,
         )
-    except Exception:
+    except Exception as exc:
+        logger.warning("admin queue dry-run translation failed: %s", exc, exc_info=True)
         raise HTTPException(status_code=500, detail="Translation service request failed")
 
     return {

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -3141,3 +3141,82 @@ async def test_retranslate_all_continues_after_per_chapter_translation_failure(a
     results = {r["chapter"]: r["status"] for r in body["results"]}
     assert results.get(0) == "failed", "chapter 0 must be recorded as failed"
     assert results.get(1) == "ok", "chapter 1 must succeed after chapter 0 failed"
+
+
+# ── Issue #1086: admin translate/retranslate missing exception logging ────────
+
+
+@pytest.mark.asyncio
+async def test_retranslate_both_fail_logs_warning(admin_user, admin_client, admin_db, caplog):
+    """Regression #1086: POST .../retranslate must log a WARNING when both providers fail."""
+    import logging
+    from services.auth import encrypt_api_key
+    from services.db import set_user_gemini_key
+    await set_user_gemini_key(admin_user["id"], encrypt_api_key("fake-api-key"))
+    await save_book(100, BOOK_META, BOOK_TEXT)
+
+    async def _always_fail(text, src, tgt, *, provider="google", gemini_key=None):
+        raise RuntimeError("both providers broken")
+
+    with patch("routers.admin.do_translate", side_effect=_always_fail):
+        with caplog.at_level(logging.WARNING, logger="routers.admin"):
+            res = await admin_client.post("/api/admin/translations/100/0/de/retranslate")
+
+    assert res.status_code == 502
+    assert any(
+        "retranslate" in r.message.lower() or "translat" in r.message.lower()
+        for r in caplog.records
+    ), f"Expected warning log for retranslate failure, got: {[r.message for r in caplog.records]}"
+
+
+@pytest.mark.asyncio
+async def test_retranslate_all_chapter_failure_logs_warning(admin_user, admin_client, admin_db, caplog):
+    """Regression #1086: retranslate-all per-chapter failure must log a WARNING, not swallow silently."""
+    import logging
+    from services.auth import encrypt_api_key
+    from services.db import set_user_gemini_key
+    await set_user_gemini_key(admin_user["id"], encrypt_api_key("fake-api-key"))
+    await save_book(100, BOOK_META, MOVE_BOOK_TEXT)
+
+    async def _always_fail(text, src, tgt, *, provider="google", gemini_key=None):
+        raise RuntimeError("chapter translation broken")
+
+    with patch("routers.admin.do_translate", side_effect=_always_fail):
+        with caplog.at_level(logging.WARNING, logger="routers.admin"):
+            res = await admin_client.post(
+                "/api/admin/translations/100/retranslate-all",
+                json={"target_language": "zh"},
+            )
+
+    assert res.status_code == 200
+    results = {r["chapter"]: r["status"] for r in res.json()["results"]}
+    assert results.get(0) == "failed"
+    assert any(
+        "retranslate" in r.message.lower() or "translat" in r.message.lower() or "ch " in r.message.lower()
+        for r in caplog.records
+    ), f"Expected warning log for chapter failure, got: {[r.message for r in caplog.records]}"
+
+
+@pytest.mark.asyncio
+async def test_queue_dry_run_translation_failure_logs_warning(admin_client, admin_db, caplog):
+    """Regression #1086: POST /admin/queue/dry-run translation failure must log a WARNING."""
+    import logging
+
+    with patch("routers.admin.get_setting", new_callable=AsyncMock, return_value="encrypted-key"), \
+         patch("routers.admin.decrypt_api_key", return_value="sk-fake"), \
+         patch("routers.admin.plan_work_for_queue", new_callable=AsyncMock,
+               return_value=[{"book_id": 100, "book_title": "T", "source_language": "de",
+                              "chapters": [type("C", (), {"chapter_index": 0, "chapter_text": "hello"})()]}]), \
+         patch("routers.admin.group_chapters_for_batch",
+               return_value=[[type("C", (), {"chapter_index": 0, "chapter_text": "hello"})()]]), \
+         patch("routers.admin.get_model_chain", new_callable=AsyncMock, return_value=["gemini-pro"]), \
+         patch("routers.admin.translate_chapters_batch", new_callable=AsyncMock,
+               side_effect=RuntimeError("dry-run broken")):
+        with caplog.at_level(logging.WARNING, logger="routers.admin"):
+            res = await admin_client.post("/api/admin/queue/dry-run", json={"target_language": "zh"})
+
+    assert res.status_code == 500
+    assert any(
+        "dry" in r.message.lower() or "preview" in r.message.lower() or "translat" in r.message.lower()
+        for r in caplog.records
+    ), f"Expected warning log for dry-run failure, got: {[r.message for r in caplog.records]}"


### PR DESCRIPTION
## What

Three admin translation endpoints swallowed provider failures with bare
`except Exception:` and no `logger.` call — impossible to diagnose from logs:

1. `PUT /admin/translations/{book_id}/{chapter_index}/{lang}/retranslate` — both Gemini
   and Google fail → 502 with no traceback.
2. `POST /admin/translations/{book_id}/retranslate-all` — per-chapter failure recorded
   as `"status": "failed"` with no trace.
3. `POST /admin/queue/dry-run` — batch translation fails → 500 with no traceback.

`routers/admin.py` already defines `logger = logging.getLogger(__name__)`
(added in #1083). This PR adds `logger.warning(..., exc_info=True)` to each handler.

## Why

Same logging-gap pattern as #1067 (admin /stats), #1078 (POST /ai/translate and
POST /ai/tts), and #1085 (POST /vocabulary/export/obsidian). Silent 500s / 502s in
admin ops are the hardest to diagnose without log context (#1086).

## Test plan

Three new regression tests in `test_router_admin.py`:
- `test_retranslate_both_fail_logs_warning` — patches `do_translate` to always raise,
  asserts 502 and a WARNING in `caplog`.
- `test_retranslate_all_chapter_failure_logs_warning` — patches both providers to fail,
  asserts per-chapter `"failed"` record and a WARNING.
- `test_queue_dry_run_translation_failure_logs_warning` — patches
  `translate_chapters_batch` to raise, asserts 500 and a WARNING.

Full backend suite: 1557 passed ✓  
Full frontend suite: 2058 passed ✓

Closes #1086
