### PR TITLE
fix: add exception logging to POST /vocabulary/export/obsidian 500 handler (closes #1085)

### DIFF
--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import logging
 from datetime import datetime, timezone
 
 import httpx
@@ -23,6 +24,7 @@ from services import vocab_tags
 from services.translate import translate_text
 
 router = APIRouter(prefix="/vocabulary", tags=["vocabulary"])
+logger = logging.getLogger(__name__)
 
 
 class WordSave(BaseModel):
@@ -482,5 +484,6 @@ async def export_obsidian(
             return {"urls": urls}
     except HTTPException:
         raise
-    except Exception:
+    except Exception as exc:
+        logger.warning("POST /vocabulary/export/obsidian failed: %s", exc, exc_info=True)
         raise HTTPException(status_code=500, detail="Export to GitHub failed")

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -837,3 +837,28 @@ async def test_save_word_returns_dict_when_row_is_none(tmp_db, test_user, monkey
     monkeypatch.setattr(_aio.Cursor, "fetchone", _fetchone_none_once)
     result = await save_word(test_user["id"], "hello", BOOK_ID, 0, "Hello world.")
     assert isinstance(result, dict), f"save_word must return a dict, got {type(result)}"
+
+
+# ── Issue #1085: Obsidian export missing exception logging ───────────────────
+
+
+async def test_obsidian_export_unexpected_error_logs_and_returns_500(client, test_user, caplog):
+    """Regression #1085: POST /vocabulary/export/obsidian must log a WARNING when
+    an unexpected exception escapes the GitHub put helper, not swallow it silently."""
+    import logging
+
+    await _setup_export(test_user)
+    with patch(
+        "routers.vocabulary._github_put",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("network blew up"),
+    ):
+        with caplog.at_level(logging.WARNING, logger="routers.vocabulary"):
+            resp = await client.post(
+                "/api/vocabulary/export/obsidian", json={"book_id": BOOK_ID}
+            )
+    assert resp.status_code == 500
+    assert any(
+        "obsidian" in r.message.lower() or "github" in r.message.lower()
+        for r in caplog.records
+    ), f"Expected a warning log for the failed export, got: {[r.message for r in caplog.records]}"


### PR DESCRIPTION
## What changed

`POST /vocabulary/export/obsidian` had a bare `except Exception: raise HTTPException(500, ...)` handler that swallowed the original error without logging it. When the GitHub PUT call fails, the 500 response gave no server-side trace to debug from.

Added `import logging` + `logger = logging.getLogger(__name__)` to `vocabulary.py` and changed the handler to:
```python
except Exception as exc:
    logger.warning("POST /vocabulary/export/obsidian failed: %s", exc, exc_info=True)
    raise HTTPException(status_code=500, detail="Export to GitHub failed")
```

## Why

Without the log, a failing export produces an opaque 500 with nothing in server logs to indicate whether the problem was network, auth, a bad repo name, etc.

## Test plan

- New regression test `test_obsidian_export_unexpected_error_logs_and_returns_500`:
  - Patches `_github_put` to raise `RuntimeError("network blew up")`
  - Asserts `resp.status_code == 500` (client detail is still suppressed)
  - Asserts a WARNING log was emitted for the failed export

[ ] Docs updated (if applicable)
