### PR TITLE
ux: add Browse books CTA to vocabulary and notes overview empty states (closes #1090)

### DIFF
--- a/frontend/src/__tests__/EmptyStateCta.test.ts
+++ b/frontend/src/__tests__/EmptyStateCta.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Static assertions: empty states in vocabulary and notes overview pages have CTA buttons.
+ * Closes #1090
+ */
+import fs from "fs";
+import path from "path";
+
+const vocabPage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/vocabulary/page.tsx"),
+  "utf8",
+);
+
+const notesOverviewPage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/notes/page.tsx"),
+  "utf8",
+);
+
+describe("EmptyStateCta", () => {
+  it("vocabulary empty state has a Browse books CTA button", () => {
+    // Look for the empty state block + a button that navigates to library
+    expect(vocabPage).toContain('No saved words yet');
+    expect(vocabPage).toMatch(/Browse books|Discover books/);
+  });
+
+  it("vocabulary empty state CTA navigates to home/library", () => {
+    // Empty state CTA should call router.push("/")
+    const idx = vocabPage.indexOf('No saved words yet');
+    expect(idx).toBeGreaterThan(0);
+    const after = vocabPage.slice(idx, idx + 1500);
+    expect(after).toMatch(/router\.push\("\/"\)/);
+  });
+
+  it("notes overview empty state has a Browse books CTA button", () => {
+    expect(notesOverviewPage).toContain('No notes yet');
+    expect(notesOverviewPage).toMatch(/Browse books|Discover books/);
+  });
+
+  it("notes overview empty state CTA navigates to home/library", () => {
+    const idx = notesOverviewPage.indexOf('No notes yet');
+    expect(idx).toBeGreaterThan(0);
+    const after = notesOverviewPage.slice(idx, idx + 1500);
+    expect(after).toMatch(/router\.push\("\/"\)/);
+  });
+});

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -153,6 +153,13 @@ export default function NotesOverviewPage() {
               <>
                 <p className="font-serif text-lg text-ink mb-1">No notes yet</p>
                 <p className="text-sm">Annotate sentences or save AI insights while reading.</p>
+                <button
+                  type="button"
+                  onClick={() => router.push("/")}
+                  className="mt-5 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px]"
+                >
+                  Browse books <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
+                </button>
               </>
             ) : (
               <p className="text-sm">No books match your search.</p>

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -13,7 +13,7 @@ import {
   VocabularyWord,
   WordDefinition,
 } from "@/lib/api";
-import { EmptyVocabIcon, ArrowLeftIcon, FlashcardIcon, ArrowUpRightIcon } from "@/components/Icons";
+import { EmptyVocabIcon, ArrowLeftIcon, ArrowRightIcon, FlashcardIcon, ArrowUpRightIcon } from "@/components/Icons";
 import TagEditor from "@/components/TagEditor";
 
 type SortMode = "alpha" | "language" | "book" | "recent";
@@ -556,6 +556,13 @@ function VocabularyPageContent() {
             <EmptyVocabIcon className="w-14 h-14 text-amber-300" />
             <p className="font-serif text-lg text-stone-500 mt-1">No saved words yet.</p>
             <p className="text-sm">Double-click any word while reading to save it here.</p>
+            <button
+              type="button"
+              onClick={() => router.push("/")}
+              className="mt-4 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px]"
+            >
+              Browse books <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
+            </button>
           </div>
         ) : filtered.length === 0 ? (
           selectedTag ? (


### PR DESCRIPTION
Closes #1090

CLAUDE.md's graphic design rules require every empty state to include a primary CTA button. Two user-facing pages were missing one — when users land on `/vocabulary` or `/notes` with no content, they got told *how* to create content ("while reading") but had no button to go start reading.

## Changes
- `app/vocabulary/page.tsx`: "No saved words yet" empty state now has a "Browse books" CTA that navigates to `/`. Imported `ArrowRightIcon`.
- `app/notes/page.tsx`: "No notes yet" empty state (when there are no books at all) now has a matching "Browse books" CTA.
- Both buttons use the same amber-700 / 44px-min-height pattern as the existing CTAs in `app/decks/page.tsx` and `app/notes/[bookId]/page.tsx`.
- `EmptyStateCta.test.ts`: 4 static assertions verifying CTAs exist on both pages and navigate to `/`.

## Test plan
- [x] `EmptyStateCta.test.ts` — 4 passing
- [x] Full frontend suite — 2066/2066 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
