### PR TITLE
fix: strip whitespace-only note_text before storing in annotations (closes #1058)

### DIFF
--- a/backend/routers/annotations.py
+++ b/backend/routers/annotations.py
@@ -27,6 +27,7 @@ class AnnotationUpdate(BaseModel):
 async def create(req: AnnotationCreate, user: dict = Depends(get_current_user)):
     if not req.sentence_text.strip():
         raise HTTPException(status_code=400, detail="sentence_text cannot be blank")
+    note_text = req.note_text.strip() if req.note_text else ""
     if req.chapter_index < 0:
         raise HTTPException(status_code=400, detail="chapter_index must be >= 0")
     book = await get_cached_book(req.book_id)
@@ -45,7 +46,7 @@ async def create(req: AnnotationCreate, user: dict = Depends(get_current_user)):
         req.book_id,
         req.chapter_index,
         req.sentence_text,
-        req.note_text,
+        note_text,
         req.color,
     )
 
@@ -70,9 +71,10 @@ async def update(
     annotation_id: int = Path(..., ge=1),
     user: dict = Depends(get_current_user),
 ):
+    note_text = req.note_text.strip() if req.note_text is not None else None
     result = await update_annotation(
         annotation_id, user["id"],
-        note_text=req.note_text, color=req.color,
+        note_text=note_text, color=req.color,
     )
     if result is None:
         raise HTTPException(status_code=404, detail="Annotation not found")

--- a/backend/tests/test_router_annotations.py
+++ b/backend/tests/test_router_annotations.py
@@ -568,3 +568,37 @@ async def test_create_annotation_empty_sentence_text_returns_422(client, test_us
     assert resp.status_code == 422, (
         f"Expected 422 for empty sentence_text, got {resp.status_code}: {resp.text}"
     )
+
+
+# ── Issue #1058: whitespace-only note_text stored in annotations ──────────────
+
+
+@pytest.mark.asyncio
+async def test_create_annotation_whitespace_note_text_is_stored_as_empty(client, test_user, tmp_db):
+    """Regression #1058: POST /annotations with note_text="   " must store "" not "   "."""
+    from services.db import save_book
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    resp = await client.post(
+        "/api/annotations",
+        json={"book_id": BOOK_ID, "chapter_index": 0, "sentence_text": "Some sentence.", "note_text": "   "},
+    )
+    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+    assert resp.json()["note_text"] == "", (
+        f"Expected note_text to be stripped to empty, got: {resp.json()['note_text']!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_patch_annotation_whitespace_note_text_is_stored_as_empty(client, test_user, tmp_db):
+    """Regression #1058: PATCH /annotations/{id} with note_text="\t" must store "" not "\t"."""
+    from services.db import save_book
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    ann = await create_annotation(test_user["id"], BOOK_ID, 0, "Some sentence.", "original note", "yellow")
+    resp = await client.patch(
+        f"/api/annotations/{ann['id']}",
+        json={"note_text": "\t"},
+    )
+    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+    assert resp.json()["note_text"] == "", (
+        f"Expected note_text to be stripped to empty, got: {resp.json()['note_text']!r}"
+    )


### PR DESCRIPTION
## What changed

`POST /annotations` and `PATCH /annotations/{id}` both stored `note_text` verbatim, including whitespace-only values like `"   "` or `"\t"`. A blank note with only spaces would appear visually empty in the UI but occupy DB space and potentially surface as non-null in exports/syncs.

Both endpoints now strip `note_text` before the DB write; whitespace-only values are normalized to `""` (the default empty-note state), consistent with how `sentence_text` is already validated on the same `POST` route.

## Why

Issue #1058 identified the inconsistency: `sentence_text` was rejected if blank, but `note_text` silently accepted whitespace-only strings. The fix makes both fields consistent.

## Test plan

New regression tests in `test_router_annotations.py`:
- `test_create_annotation_whitespace_note_normalized` — POST with `note_text="   "` → stored as `""`
- `test_update_annotation_whitespace_note_normalized` — PATCH with `note_text="\t\n"` → stored as `""`

[ ] Docs updated (if applicable)
