### PR TITLE
ux: move focus to dialog on open and restore on close in BookDetailModal and AuthPromptModal (closes #1095)

### DIFF
--- a/frontend/src/__tests__/ModalFocus.test.tsx
+++ b/frontend/src/__tests__/ModalFocus.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Modal focus management — focus moves to dialog on open, restored on close.
+ * Closes #1095
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import AuthPromptModal from "@/components/AuthPromptModal";
+import BookDetailModal from "@/components/BookDetailModal";
+import type { BookMeta } from "@/lib/api";
+
+jest.mock("@/lib/api", () => ({
+  getBookTranslationStatus: jest.fn().mockResolvedValue(null),
+}));
+jest.mock("@/lib/settings", () => ({
+  getSettings: () => ({ translationLang: "en" }),
+}));
+
+const BOOK: BookMeta = {
+  id: 1,
+  title: "Test Book",
+  authors: ["Author"],
+  languages: ["en"],
+  subjects: [],
+  download_count: 0,
+  cover: null,
+};
+
+describe("AuthPromptModal focus management", () => {
+  it("moves focus to the dialog when opened", () => {
+    const trigger = document.createElement("button");
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    render(<AuthPromptModal open feature="translate" onClose={jest.fn()} />);
+
+    const dialog = screen.getByRole("dialog");
+    expect(document.activeElement).toBe(dialog);
+    document.body.removeChild(trigger);
+  });
+
+  it("restores focus to previously focused element on unmount", () => {
+    const trigger = document.createElement("button");
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const { unmount } = render(<AuthPromptModal open feature="translate" onClose={jest.fn()} />);
+    unmount();
+
+    expect(document.activeElement).toBe(trigger);
+    document.body.removeChild(trigger);
+  });
+});
+
+describe("BookDetailModal focus management", () => {
+  it("moves focus to the dialog when opened", () => {
+    const trigger = document.createElement("button");
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    render(<BookDetailModal book={BOOK} recentBook={null} onClose={jest.fn()} onRead={jest.fn()} />);
+
+    const dialog = screen.getByRole("dialog");
+    expect(document.activeElement).toBe(dialog);
+    document.body.removeChild(trigger);
+  });
+
+  it("restores focus to previously focused element on unmount", () => {
+    const trigger = document.createElement("button");
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const { unmount } = render(
+      <BookDetailModal book={BOOK} recentBook={null} onClose={jest.fn()} onRead={jest.fn()} />,
+    );
+    unmount();
+
+    expect(document.activeElement).toBe(trigger);
+    document.body.removeChild(trigger);
+  });
+});

--- a/frontend/src/components/AuthPromptModal.tsx
+++ b/frontend/src/components/AuthPromptModal.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 interface Props {
   open: boolean;
@@ -8,6 +8,8 @@ interface Props {
 }
 
 export default function AuthPromptModal({ open, feature, onClose }: Props) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     if (!open) return;
     function onKey(e: KeyboardEvent) { if (e.key === "Escape") onClose(); }
@@ -15,12 +17,21 @@ export default function AuthPromptModal({ open, feature, onClose }: Props) {
     return () => document.removeEventListener("keydown", onKey);
   }, [open, onClose]);
 
+  useEffect(() => {
+    if (!open) return;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    dialogRef.current?.focus();
+    return () => {
+      previouslyFocused?.focus?.();
+    };
+  }, [open]);
+
   if (!open) return null;
 
   return (
     <div className="fixed inset-0 z-[200] flex items-end md:items-center justify-center">
       <div className="absolute inset-0 bg-black/40" aria-hidden="true" onClick={onClose} />
-      <div role="dialog" aria-modal="true" aria-label="Sign in required" className="relative bg-white rounded-t-2xl md:rounded-2xl shadow-xl p-6 w-full max-w-sm animate-slide-up">
+      <div ref={dialogRef} tabIndex={-1} role="dialog" aria-modal="true" aria-label="Sign in required" className="relative bg-white rounded-t-2xl md:rounded-2xl shadow-xl p-6 w-full max-w-sm animate-slide-up focus:outline-none">
         <p className="font-serif text-lg text-ink mb-1">Sign in to {feature}</p>
         <p className="text-sm text-stone-500 mb-5">
           Create a free account or sign in to unlock this feature.

--- a/frontend/src/components/BookDetailModal.tsx
+++ b/frontend/src/components/BookDetailModal.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { BookMeta, getBookTranslationStatus, TranslationStatus } from "@/lib/api";
 import { RecentBook } from "@/lib/recentBooks";
 import { getSettings } from "@/lib/settings";
@@ -22,6 +22,7 @@ interface Props {
 export default function BookDetailModal({ book, recentBook, onClose, onRead }: Props) {
   const [translationStatus, setTranslationStatus] = useState<TranslationStatus | null>(null);
   const translationLang = getSettings().translationLang;
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     getBookTranslationStatus(book.id, translationLang)
@@ -37,6 +38,14 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
     return () => document.removeEventListener("keydown", onKey);
   }, [onClose]);
 
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    dialogRef.current?.focus();
+    return () => {
+      previouslyFocused?.focus?.();
+    };
+  }, []);
+
   const hasTranslation =
     translationStatus !== null && translationStatus.translated_chapters > 0;
   const fullTranslation =
@@ -50,10 +59,12 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
       onClick={onClose}
     >
       <div
+        ref={dialogRef}
+        tabIndex={-1}
         role="dialog"
         aria-modal="true"
         aria-labelledby="book-detail-title"
-        className="w-full sm:max-w-md bg-white rounded-t-2xl sm:rounded-2xl shadow-xl p-6 max-h-[85vh] overflow-y-auto"
+        className="w-full sm:max-w-md bg-white rounded-t-2xl sm:rounded-2xl shadow-xl p-6 max-h-[85vh] overflow-y-auto focus:outline-none"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header: cover + metadata + close */}


### PR DESCRIPTION
Closes #1095

When `BookDetailModal` or `AuthPromptModal` opened, keyboard focus stayed on the trigger button. Screen-reader users got no audible signal that a dialog opened, and tabbing continued from the underlying page. On close, focus was not restored to the trigger.

## Changes
- `BookDetailModal.tsx`: added `useRef` + `useEffect` to focus the dialog div on mount and restore focus on unmount. Added `tabIndex={-1}` and `focus:outline-none` to the dialog div so it is programmatically focusable without showing a focus ring.
- `AuthPromptModal.tsx`: same pattern, gated on `open === true` so focus management only runs while the modal is rendered.
- `ModalFocus.test.tsx`: 4 RTL tests verifying focus moves to dialog on open and restores to the trigger on unmount, for both modals.

## Out of scope

Full focus trap (Tab/Shift-Tab cycling within the modal) is a larger change and intentionally not included — the open-focus + close-restore pattern is the minimum viable WCAG 2.4.3 fix.

## Test plan
- [x] `ModalFocus.test.tsx` — 4 passing
- [x] Full frontend suite — 2076/2076 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
