### PR TITLE
ux: WordActionDrawer focus + backdrop aria-hidden + loading role=status; DefinitionSheet focus (closes #1098)

### DIFF
--- a/frontend/src/__tests__/WordDrawerAria.test.ts
+++ b/frontend/src/__tests__/WordDrawerAria.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Static assertions: WordActionDrawer focus management + aria-hidden + role=status
+ * and DefinitionSheet focus management.
+ * Closes #1098
+ */
+import fs from "fs";
+import path from "path";
+
+const wordDrawer = fs.readFileSync(
+  path.join(process.cwd(), "src/components/WordActionDrawer.tsx"),
+  "utf8",
+);
+
+const vocabPage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/vocabulary/page.tsx"),
+  "utf8",
+);
+
+describe("WordActionDrawer aria + focus", () => {
+  it("backdrop div has aria-hidden=true", () => {
+    expect(wordDrawer).toMatch(/"fixed inset-0 z-40 bg-black\/10"[^>]*aria-hidden="true"|aria-hidden="true"[^>]*"fixed inset-0 z-40 bg-black\/10"/);
+  });
+
+  it("has tabIndex={-1} on dialog div for focus management", () => {
+    expect(wordDrawer).toContain("tabIndex={-1}");
+  });
+
+  it("focuses dialog on mount via useEffect", () => {
+    // Look for a useEffect that calls dialogRef.current?.focus()
+    expect(wordDrawer).toMatch(/drawerRef\.current\?\.focus\(\)|drawerRef\.current\.focus\(\)/);
+  });
+
+  it("loading state has role=status with aria-label", () => {
+    // Loading block should have role=status
+    expect(wordDrawer).toMatch(/role="status"[^>]*aria-label="Looking up word"|aria-label="Looking up word"[^>]*role="status"/);
+  });
+});
+
+describe("DefinitionSheet (vocabulary/page.tsx) focus", () => {
+  it("focuses dialog on mount", () => {
+    // ref.current?.focus() should appear in a useEffect
+    expect(vocabPage).toMatch(/ref\.current\?\.focus\(\)/);
+  });
+
+  it("has tabIndex={-1} on the dialog div", () => {
+    expect(vocabPage).toContain("tabIndex={-1}");
+  });
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -140,15 +140,24 @@ function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
     };
   }, [onClose]);
 
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    ref.current?.focus();
+    return () => {
+      previouslyFocused?.focus?.();
+    };
+  }, []);
+
   return (
     <>
       <div className="fixed inset-0 z-40 bg-black/10" aria-hidden="true" onClick={onClose} />
       <div
         ref={ref}
+        tabIndex={-1}
         role="dialog"
         aria-modal="true"
         aria-label="Word definition"
-        className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl border-t border-amber-200 max-h-[60vh] overflow-y-auto animate-slide-up"
+        className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl border-t border-amber-200 max-h-[60vh] overflow-y-auto animate-slide-up focus:outline-none"
       >
         <div className="flex justify-center py-2">
           <div className="w-10 h-1 bg-amber-200 rounded-full" />

--- a/frontend/src/components/WordActionDrawer.tsx
+++ b/frontend/src/components/WordActionDrawer.tsx
@@ -99,6 +99,16 @@ export default function WordActionDrawer({
     };
   }, [action, onClose]);
 
+  // Move focus to drawer on open; restore on unmount
+  useEffect(() => {
+    if (!action) return;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    drawerRef.current?.focus();
+    return () => {
+      previouslyFocused?.focus?.();
+    };
+  }, [action]);
+
   if (!action) return null;
 
   return (
@@ -106,16 +116,18 @@ export default function WordActionDrawer({
       {/* Backdrop */}
       <div
         className="fixed inset-0 z-40 bg-black/10"
+        aria-hidden="true"
         onClick={onClose}
       />
 
       {/* Drawer */}
       <div
         ref={drawerRef}
+        tabIndex={-1}
         role="dialog"
         aria-modal="true"
         aria-label={`Word lookup: ${word}`}
-        className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl border-t border-amber-200 max-h-[60vh] overflow-y-auto safe-bottom animate-slide-up"
+        className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl border-t border-amber-200 max-h-[60vh] overflow-y-auto safe-bottom animate-slide-up focus:outline-none"
       >
         {/* Drag handle */}
         <div className="flex justify-center py-2">
@@ -133,8 +145,8 @@ export default function WordActionDrawer({
 
           {/* Dictionary definitions */}
           {loading && (
-            <div className="flex items-center gap-2 text-amber-600 text-sm">
-              <span className="w-3 h-3 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+            <div role="status" aria-label="Looking up word" className="flex items-center gap-2 text-amber-600 text-sm">
+              <span className="w-3 h-3 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
               Looking up...
             </div>
           )}


### PR DESCRIPTION
Closes #1098

Follow-up to #1095 (BookDetailModal/AuthPromptModal focus management). Two more dialog/drawer components had similar accessibility gaps.

## Changes
- `components/WordActionDrawer.tsx`:
  - Focus moves to drawer on open, restored to trigger on unmount (`useEffect`, `tabIndex={-1}`, `focus:outline-none`)
  - Backdrop div now has `aria-hidden="true"`
  - Loading state wrapper now has `role="status"` + `aria-label="Looking up word"`; spinner span gets `aria-hidden="true"`
- `app/vocabulary/page.tsx` (`DefinitionSheet`): Focus moves to dialog on open, restored on unmount; `tabIndex={-1}` + `focus:outline-none` on dialog div
- `WordDrawerAria.test.ts`: 6 static assertions covering all 6 changes

## WCAG
- 2.4.3 Focus Order (focus management)
- 4.1.3 Status Messages (loading announcement)
- 4.1.2 Name, Role, Value (backdrop hidden from AT)

## Test plan
- [x] `WordDrawerAria.test.ts` — 6 passing
- [x] Full frontend suite — 2082/2082 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
