### PR TITLE
ux: associate AnnotationToolbar Note textarea with a <label htmlFor> (closes #1100)

### DIFF
--- a/frontend/src/__tests__/AnnotationTextareaLabel.test.ts
+++ b/frontend/src/__tests__/AnnotationTextareaLabel.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Static assertions: AnnotationToolbar textarea has accessible label
+ * Closes #1100
+ */
+import fs from "fs";
+import path from "path";
+
+const toolbar = fs.readFileSync(
+  path.join(process.cwd(), "src/components/AnnotationToolbar.tsx"),
+  "utf8",
+);
+
+describe("AnnotationToolbar Note textarea label", () => {
+  it("textarea has id=annotation-note", () => {
+    expect(toolbar).toMatch(/<textarea[^>]*id="annotation-note"|id="annotation-note"[\s\S]*<textarea/);
+    expect(toolbar).toContain('id="annotation-note"');
+  });
+
+  it("has a <label> with htmlFor pointing to the textarea", () => {
+    expect(toolbar).toMatch(/<label[^>]*htmlFor="annotation-note"/);
+  });
+
+  it("removed the bare <p>Note</p> in favor of the label", () => {
+    // The old pattern was <p>Note <span>(optional)</span></p>
+    // After fix: <label htmlFor="annotation-note">Note <span>(optional)</span></label>
+    expect(toolbar).not.toMatch(/<p[^>]*>Note <span/);
+  });
+});

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -157,9 +157,10 @@ export default function AnnotationToolbar({
 
           {/* Note textarea */}
           <div>
-            <p className="text-xs text-stone-500 mb-1.5">Note <span className="text-stone-400">(optional)</span></p>
+            <label htmlFor="annotation-note" className="block text-xs text-stone-500 mb-1.5">Note <span className="text-stone-400">(optional)</span></label>
             <textarea
               ref={textareaRef}
+              id="annotation-note"
               value={note}
               onChange={(e) => setNote(e.target.value)}
               placeholder="Your thoughts on this passage…"


### PR DESCRIPTION
Closes #1100

The Note textarea in `AnnotationToolbar` had only a visual `<p>Note (optional)</p>` heading and a placeholder — no semantic label. Screen readers announced the textarea as 'edit text' with no name.

## Changes
- `components/AnnotationToolbar.tsx`: replaced the visual `<p>` with a `<label htmlFor="annotation-note">` and added matching `id="annotation-note"` to the textarea. Visual styling preserved (same Tailwind classes).
- `AnnotationTextareaLabel.test.ts`: 3 static assertions verifying the label/id association is in place.

## WCAG
- 1.3.1 Info and Relationships
- 4.1.2 Name, Role, Value

## Test plan
- [x] `AnnotationTextareaLabel.test.ts` — 3 passing
- [x] Full frontend suite — 2079/2079 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
