### PR TITLE
fix: whitespace-only lang and target_language bypass validation in vocabulary router (closes #1060)

### DIFF
--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from services.auth import get_current_user, encrypt_api_key, decrypt_api_key, check_book_access
 from services.db import (
@@ -37,6 +37,14 @@ class WordSave(BaseModel):
 class ExportRequest(BaseModel):
     book_id: int | None = Field(default=None, ge=1)
     target_language: str = Field(default="zh", min_length=1, max_length=20)
+
+    @field_validator("target_language")
+    @classmethod
+    def target_language_not_blank(cls, v: str) -> str:
+        s = v.strip().lower().split("-")[0]
+        if not s:
+            raise ValueError("target_language cannot be blank")
+        return s
 
 
 @router.post("")
@@ -76,6 +84,9 @@ async def get_definition(
     lang: str = Query(default="en", min_length=1, max_length=20),
     user: dict = Depends(get_current_user),
 ):
+    lang = lang.strip().lower().split("-")[0]
+    if not lang:
+        raise HTTPException(status_code=422, detail="lang cannot be blank")
     from services import wiktionary
     result = await wiktionary.lookup(word, lang)
     if not result["definitions"]:

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -862,3 +862,27 @@ async def test_obsidian_export_unexpected_error_logs_and_returns_500(client, tes
         "obsidian" in r.message.lower() or "github" in r.message.lower()
         for r in caplog.records
     ), f"Expected a warning log for the failed export, got: {[r.message for r in caplog.records]}"
+
+
+# ── Issue #1060: whitespace-only lang / target_language in vocabulary router ──
+
+
+@pytest.mark.asyncio
+async def test_definition_whitespace_lang_returns_422(client, test_user):
+    """Regression #1060: GET /vocabulary/definition/{word}?lang=" " must return 422."""
+    resp = await client.get("/api/vocabulary/definition/hello?lang=%20")
+    assert resp.status_code == 422, (
+        f"Expected 422 for whitespace lang in /vocabulary/definition, got {resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_export_obsidian_whitespace_target_language_returns_422(client, test_user):
+    """Regression #1060: POST /vocabulary/export/obsidian with target_language="   " must return 422."""
+    resp = await client.post(
+        "/api/vocabulary/export/obsidian",
+        json={"target_language": "   "},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for whitespace target_language in /vocabulary/export/obsidian, got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## What changed

`GET /vocabulary/definition/{word}` and `POST /vocabulary/export/obsidian` previously accepted whitespace-only `lang` / `target_language` values:
- `lang=" "` (URL-encoded `%20`) passed Pydantic's `min_length=1` and reached the wiktionary lookup with a blank language code
- `target_language="   "` on the export request similarly passed through

Both now reject whitespace-only inputs with 422:
- `lang` query param: `.strip()` then check + raise `HTTPException(422)` in the route handler
- `ExportRequest.target_language`: added a `field_validator` that strips, lowercases, splits on `-`, and rejects blank

## Why

Issue #1060 — same pattern as #1048 (books router) and #1058 (annotations note_text). Whitespace-only inputs that bypass `min_length=1` cause downstream operations to silently produce wrong results.

## Test plan

New regression tests:
- `test_definition_whitespace_lang_returns_422`
- `test_export_obsidian_whitespace_target_language_returns_422`

Both fail before the fix.

[ ] Docs updated (if applicable)
