### PR TITLE
ux: add role=toolbar and aria-label to QuickHighlightPanel popover (closes #1102)

### DIFF
--- a/frontend/src/__tests__/QuickHighlightToolbar.test.ts
+++ b/frontend/src/__tests__/QuickHighlightToolbar.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Static assertions: QuickHighlightPanel exposed as a toolbar.
+ * Closes #1102
+ */
+import fs from "fs";
+import path from "path";
+
+const panel = fs.readFileSync(
+  path.join(process.cwd(), "src/components/QuickHighlightPanel.tsx"),
+  "utf8",
+);
+
+describe("QuickHighlightPanel toolbar role", () => {
+  it("root panel div has role=toolbar", () => {
+    expect(panel).toContain('role="toolbar"');
+  });
+
+  it("root panel div has aria-label", () => {
+    expect(panel).toMatch(/aria-label="Highlight (options|actions)"/);
+  });
+});

--- a/frontend/src/components/QuickHighlightPanel.tsx
+++ b/frontend/src/components/QuickHighlightPanel.tsx
@@ -100,6 +100,8 @@ export default function QuickHighlightPanel({
   return (
     <div
       ref={panelRef}
+      role="toolbar"
+      aria-label="Highlight options"
       style={{ position: "fixed", top, left, zIndex: 1000 }}
       className="flex items-center gap-2 bg-white border border-amber-200 rounded-xl shadow-xl px-3 py-2.5 animate-fade-in"
       data-testid="quick-highlight-panel"


### PR DESCRIPTION
Closes #1102

`QuickHighlightPanel` is the small popover that appears when tapping a highlighted sentence — color swatches plus Add Note / Delete buttons. It is functionally a toolbar, but the root div lacked the ARIA role and accessible name. Brings it in line with `SelectionToolbar` which already uses `role="toolbar"` + `aria-label`.

## Changes
- `components/QuickHighlightPanel.tsx`: added `role="toolbar"` and `aria-label="Highlight options"` to the panel root div
- `QuickHighlightToolbar.test.ts`: 2 static assertions

## WCAG
- 4.1.2 Name, Role, Value

## Test plan
- [x] `QuickHighlightToolbar.test.ts` — 2 passing
- [x] Full frontend suite — 2082/2082 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
