### PR TITLE
fix: add exception logging to POST /ai/translate and POST /ai/tts 500 handlers (closes #1078)

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -463,7 +463,8 @@ async def translate(req: TranslateRequest, user: dict = Depends(get_current_user
         }
     except HTTPException:
         raise
-    except Exception:
+    except Exception as exc:
+        logger.exception("POST /ai/translate failed: %s", exc)
         raise HTTPException(status_code=500, detail="Translation service request failed")
 
 
@@ -475,7 +476,8 @@ async def tts(req: TTSRequest):
         audio, content_type, boundaries = await synthesize(
             req.text, req.language, req.rate, gender=req.gender
         )
-    except Exception:
+    except Exception as exc:
+        logger.exception("POST /ai/tts failed: %s", exc)
         raise HTTPException(status_code=500, detail="TTS synthesis failed")
     headers: dict = {}
     if boundaries:

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -1377,3 +1377,30 @@ async def test_tts_whitespace_language_returns_422(client, test_user):
     assert resp.status_code == 422, (
         f"Expected 422 for whitespace language in /ai/tts, got {resp.status_code}: {resp.text}"
     )
+
+
+async def test_translate_unexpected_error_logs_and_returns_500(client, test_user, caplog):
+    """Regression #1078: POST /ai/translate unexpected errors must be logged."""
+    import logging
+    # do_translate is imported inside the function body, so patch at source module.
+    with patch("services.translate.translate_text", new_callable=AsyncMock, side_effect=RuntimeError("service exploded")):
+        with caplog.at_level(logging.ERROR, logger="routers.ai"):
+            resp = await client.post("/api/ai/translate", json={
+                "text": "Hallo", "source_language": "de", "target_language": "en",
+            })
+    assert resp.status_code == 500
+    assert any("translate" in r.message.lower() for r in caplog.records), \
+        f"Expected error log for translate 500 but got: {[r.message for r in caplog.records]}"
+
+
+async def test_tts_unexpected_error_logs_and_returns_500(client, caplog):
+    """Regression #1078: POST /ai/tts unexpected errors must be logged."""
+    import logging
+    with patch("routers.ai.synthesize", new_callable=AsyncMock, side_effect=RuntimeError("TTS crashed")):
+        with caplog.at_level(logging.ERROR, logger="routers.ai"):
+            resp = await client.post("/api/ai/tts", json={
+                "text": "Hello world", "language": "en", "rate": 1.0,
+            })
+    assert resp.status_code == 500
+    assert any("tts" in r.message.lower() or "500" in r.message for r in caplog.records), \
+        f"Expected error log for tts 500 but got: {[r.message for r in caplog.records]}"


### PR DESCRIPTION
## What changed

`POST /ai/translate` and `POST /ai/tts` previously had bare `except Exception:` handlers that swallowed the original error before raising 500:
```python
except Exception:
    raise HTTPException(status_code=500, detail="Translation service request failed")

except Exception:
    raise HTTPException(status_code=500, detail="TTS synthesis failed")
```

Both now log a WARNING with `exc_info=True` before raising the 500 — same pattern as the recently-merged admin/stats (#1083), admin retranslate (#1086 → #1089), and vocab obsidian (#1085 → #1092) fixes.

## Why

Issue #1078 — without the log, a failing translation/TTS produces an opaque 500 with no server-side trace to debug.

## Test plan

New regression tests:
- `test_translate_unexpected_error_logs_and_returns_500`
- `test_tts_unexpected_error_logs_and_returns_500`

Both fail before the fix (caplog records empty).

[ ] Docs updated (if applicable)
