### PR TITLE
ux: add role=dialog, aria-labelledby, and focus management to AnnotationsSidebar drawer (closes #1106)

### DIFF
--- a/frontend/src/__tests__/AnnotationsSidebarDialog.test.ts
+++ b/frontend/src/__tests__/AnnotationsSidebarDialog.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Static assertions: AnnotationsSidebar drawer has dialog role + accessible name + focus management.
+ * Closes #1106
+ */
+import fs from "fs";
+import path from "path";
+
+const sidebar = fs.readFileSync(
+  path.join(process.cwd(), "src/components/AnnotationsSidebar.tsx"),
+  "utf8",
+);
+
+describe("AnnotationsSidebar drawer dialog semantics", () => {
+  it("drawer root has role=dialog", () => {
+    expect(sidebar).toContain('role="dialog"');
+  });
+
+  it("drawer is labelled by the Annotations heading", () => {
+    expect(sidebar).toContain('aria-labelledby="annotations-heading"');
+    expect(sidebar).toContain('id="annotations-heading"');
+  });
+
+  it("drawer div has tabIndex={-1} for programmatic focus", () => {
+    expect(sidebar).toContain("tabIndex={-1}");
+  });
+
+  it("focuses the drawer when opened (useEffect with focus call)", () => {
+    expect(sidebar).toMatch(/drawerRef\.current\?\.focus\(\)|drawerRef\.current\.focus\(\)/);
+  });
+});

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Annotation } from "@/lib/api";
 import { ArrowRightIcon, NoteIcon, EditIcon, CloseIcon, EmptyNotesIcon } from "@/components/Icons";
 
@@ -31,6 +31,7 @@ interface Props {
 
 export default function AnnotationsSidebar({ annotations, totalCount, onJump, onEdit, loading, bookId }: Props) {
   const [open, setOpen] = useState(false);
+  const drawerRef = useRef<HTMLDivElement>(null);
 
   // Group by chapter
   const byChapter = annotations.reduce<Record<number, Annotation[]>>((acc, a) => {
@@ -38,6 +39,16 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
     return acc;
   }, {});
   const chapters = Object.keys(byChapter).map(Number).sort((a, b) => a - b);
+
+  // Move focus to drawer on open; restore on close
+  useEffect(() => {
+    if (!open) return;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    drawerRef.current?.focus();
+    return () => {
+      previouslyFocused?.focus?.();
+    };
+  }, [open]);
 
   return (
     <>
@@ -59,11 +70,15 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
       {/* Drawer */}
       {open && (
         <div
-          className="fixed right-0 top-0 h-full w-full sm:w-80 bg-white border-l border-amber-200 shadow-2xl z-50 flex flex-col"
+          ref={drawerRef}
+          tabIndex={-1}
+          role="dialog"
+          aria-labelledby="annotations-heading"
+          className="fixed right-0 top-0 h-full w-full sm:w-80 bg-white border-l border-amber-200 shadow-2xl z-50 flex flex-col focus:outline-none"
           data-testid="annotations-sidebar"
         >
           <div className="flex items-center justify-between px-4 py-3 border-b border-amber-100">
-            <h2 className="font-serif font-semibold text-ink text-sm">Annotations</h2>
+            <h2 id="annotations-heading" className="font-serif font-semibold text-ink text-sm">Annotations</h2>
             <button
               onClick={() => setOpen(false)}
               className="text-stone-400 hover:text-stone-600 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg transition-colors"


### PR DESCRIPTION
Closes #1106

`AnnotationsSidebar` is a slide-out drawer in the reader. Its root div had no semantic role and no focus management — screen-reader users got no signal a panel opened, and keyboard focus stayed on the toggle button when the drawer appeared.

## Changes
- `components/AnnotationsSidebar.tsx`:
  - Added `role="dialog"` and `aria-labelledby="annotations-heading"` to the drawer root div
  - Added matching `id="annotations-heading"` to the existing h2
  - Added `tabIndex={-1}` and `focus:outline-none` so the drawer is programmatically focusable
  - Added `useEffect` keyed to `open` that focuses the drawer on open and restores focus to the toggle on close
- `AnnotationsSidebarDialog.test.ts`: 4 static assertions

## WCAG
- 4.1.2 Name, Role, Value (drawer exposed as a dialog with a name)
- 2.4.3 Focus Order (focus moves into drawer on open, restored on close)

## Test plan
- [x] `AnnotationsSidebarDialog.test.ts` — 4 passing
- [x] Full frontend suite — 2093/2093 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
