### PR TITLE
fix: log WARNING when Gutenberg meta/chapter fetch raises in books.py (closes #1091)

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -460,7 +460,8 @@ async def book_meta(book_id: int = Path(..., ge=1), user: dict | None = Depends(
         return {k: v for k, v in cached.items() if k not in ("text", "cached_at", "images")}
     try:
         return await get_book_meta(book_id)
-    except Exception:
+    except Exception as exc:
+        logger.warning("GET /books/%d meta fetch failed: %s", book_id, exc, exc_info=True)
         raise HTTPException(status_code=404, detail="Book not found")
 
 
@@ -498,7 +499,8 @@ async def book_chapters(book_id: int = Path(..., ge=1), user: dict | None = Depe
     else:
         try:
             meta, text = await _fetch_and_cache(book_id)
-        except Exception:
+        except Exception as exc:
+            logger.warning("GET /books/%d chapters fetch failed: %s", book_id, exc, exc_info=True)
             raise HTTPException(status_code=404, detail="Could not load book")
 
     from services.book_chapters import split_with_html_preference, get_chapter_source

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -1310,3 +1310,34 @@ async def test_search_empty_q_returns_422(client):
     assert resp.status_code == 422, (
         f"Expected 422 for empty q in /books/search, got {resp.status_code}: {resp.text}"
     )
+
+
+# ── Issue #1091: books.py Gutenberg fetch must log WARNING on unexpected exception ──────
+
+
+async def test_book_meta_404_logs_warning_on_exception(client, caplog):
+    """Regression #1091: GET /books/{id} must emit a WARNING when get_book_meta raises,
+    not silently swallow the exception."""
+    import logging
+    with patch("routers.books.get_book_meta", side_effect=RuntimeError("network timeout")):
+        with caplog.at_level(logging.WARNING, logger="routers.books"):
+            resp = await client.get("/api/books/99999")
+    assert resp.status_code == 404
+    assert any(
+        "99999" in r.message or "meta" in r.message.lower() or "fetch" in r.message.lower()
+        for r in caplog.records
+    ), f"Expected a WARNING log for failed meta fetch, got: {[r.message for r in caplog.records]}"
+
+
+async def test_book_chapters_404_logs_warning_on_exception(client, caplog):
+    """Regression #1091: GET /books/{id}/chapters must emit a WARNING when _fetch_and_cache
+    raises, not silently swallow the exception."""
+    import logging
+    with patch("routers.books._fetch_and_cache", side_effect=RuntimeError("connection refused")):
+        with caplog.at_level(logging.WARNING, logger="routers.books"):
+            resp = await client.get("/api/books/99999/chapters")
+    assert resp.status_code == 404
+    assert any(
+        "99999" in r.message or "chapter" in r.message.lower() or "fetch" in r.message.lower()
+        for r in caplog.records
+    ), f"Expected a WARNING log for failed chapters fetch, got: {[r.message for r in caplog.records]}"


### PR DESCRIPTION
## What changed

`GET /books/{id}` and `GET /books/{id}/chapters` previously had bare `except Exception:` handlers that mapped Gutenberg fetch failures to 404 without logging:
```python
try:
    return await get_book_meta(book_id)
except Exception:
    raise HTTPException(status_code=404, detail="Book not found")

try:
    meta, text = await _fetch_and_cache(book_id)
except Exception:
    raise HTTPException(status_code=404, detail="Could not load book")
```

Both now log a WARNING with `exc_info=True` before raising the 404.

## Why

Issue #1091 — without the log, you cannot distinguish "book ID doesn't exist on Gutenberg" from "network timeout" or "parse error" in production.

## Test plan

New regression tests:
- `test_book_meta_404_logs_warning_on_exception`
- `test_book_chapters_404_logs_warning_on_exception`

Both fail before the fix.

[ ] Docs updated (if applicable)
