### PR TITLE
ux: add role=status to TranslationView skeleton loaders (closes #1109)

### DIFF
--- a/frontend/src/__tests__/TranslationViewStatus.test.ts
+++ b/frontend/src/__tests__/TranslationViewStatus.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Static assertions: TranslationView skeleton loaders have role=status with aria-label.
+ * Closes #1109
+ */
+import fs from "fs";
+import path from "path";
+
+const view = fs.readFileSync(
+  path.join(process.cwd(), "src/components/TranslationView.tsx"),
+  "utf8",
+);
+
+describe("TranslationView skeleton loaders", () => {
+  it("contains role=status with aria-label for translation loading", () => {
+    expect(view).toMatch(/role="status"[^>]*aria-label="Loading translation"|aria-label="Loading translation"[^>]*role="status"/);
+  });
+
+  it("has at least 2 role=status occurrences (parallel + inline mode)", () => {
+    const matches = view.match(/role="status"/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/frontend/src/components/TranslationView.tsx
+++ b/frontend/src/components/TranslationView.tsx
@@ -48,7 +48,7 @@ export default function TranslationView({ paragraphs, translations, displayMode,
                   {translations[i]}
                 </p>
               ) : loading ? (
-                <div className="space-y-2 animate-pulse">
+                <div role="status" aria-label="Loading translation" className="space-y-2 animate-pulse">
                   {Array.from({ length: 3 }).map((_, j) => (
                     <div key={j} className={`h-3 bg-amber-100 rounded ${j === 2 ? "w-2/3" : "w-full"}`} />
                   ))}
@@ -70,7 +70,7 @@ export default function TranslationView({ paragraphs, translations, displayMode,
             {renderSource(para)}
           </p>
           {loading && i === 0 && !translations.length && (
-            <div className="mt-1 space-y-1 animate-pulse">
+            <div role="status" aria-label="Loading translation" className="mt-1 space-y-1 animate-pulse">
               <div className="h-3 bg-amber-100 rounded w-full" />
               <div className="h-3 bg-amber-100 rounded w-5/6" />
             </div>


### PR DESCRIPTION
Closes #1109

The `TranslationView` component had two `animate-pulse` skeleton loaders (parallel mode + inline mode) for streaming translations. Both lacked `role="status"` and an accessible label, so screen-reader users were not informed when translations were loading.

## Changes
- `components/TranslationView.tsx`: added `role="status" aria-label="Loading translation"` to both skeleton blocks (line ~51 parallel, line ~73 inline)
- `TranslationViewStatus.test.ts`: 2 static assertions verifying the role/aria-label are present and there are at least 2 occurrences

## WCAG
- 4.1.3 Status Messages

## Test plan
- [x] `TranslationViewStatus.test.ts` — 2 passing
- [x] Full frontend suite — 2091/2091 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
