### PR TITLE
fix: log WARNING when POST /admin/books/import Gutenberg fetch fails (closes #1094)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -218,7 +218,8 @@ async def import_book(req: ImportBookRequest, _admin: dict = Depends(_require_ad
         text = await get_book_text(req.book_id)
         await save_book(req.book_id, meta, text)
         return {"ok": True, "status": "imported", "title": meta.get("title", ""), "text_length": len(text)}
-    except Exception:
+    except Exception as exc:
+        logger.warning("admin import book %d failed: %s", req.book_id, exc, exc_info=True)
         raise HTTPException(status_code=400, detail=f"Failed to import book {req.book_id}")
 
 

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -2969,6 +2969,22 @@ async def test_import_book_error_does_not_leak_exception_detail(admin_client):
 
 
 @pytest.mark.asyncio
+async def test_import_book_error_logs_warning(admin_client, caplog):
+    """Regression #1094: POST /admin/books/import must log a WARNING when get_book_meta
+    raises, not silently swallow the exception."""
+    import logging
+    with patch("routers.admin.get_book_meta", new_callable=AsyncMock,
+               side_effect=RuntimeError("gutenberg-timeout")):
+        with caplog.at_level(logging.WARNING, logger="routers.admin"):
+            res = await admin_client.post("/api/admin/books/import", json={"book_id": 42})
+    assert res.status_code == 400
+    assert any(
+        "import" in r.message.lower() or "book" in r.message.lower() or "42" in r.message
+        for r in caplog.records
+    ), f"Expected a WARNING log for failed import, got: {[r.message for r in caplog.records]}"
+
+
+@pytest.mark.asyncio
 async def test_queue_dry_run_error_does_not_leak_exception_detail(admin_client):
     """Regression #756: queue_dry_run must not expose raw exception text in 500 response."""
     with patch("routers.admin.get_setting", new_callable=AsyncMock, return_value="encrypted-key"), \


### PR DESCRIPTION
## What changed

`POST /admin/books/import` previously had a bare `except Exception:` that mapped Gutenberg fetch failures to 400 without logging:
```python
try:
    meta = await get_book_meta(req.book_id)
    text = await get_book_text(req.book_id)
    await save_book(req.book_id, meta, text)
    return {...}
except Exception:
    raise HTTPException(status_code=400, detail=f"Failed to import book {req.book_id}")
```

Now logs a WARNING with `exc_info=True` before raising. Same pattern as #1083, #1085, #1086, #1078, #1091.

## Why

Issue #1094 — when an admin import fails, no server-side trace exists to determine whether the problem is "book ID doesn't exist on Gutenberg", "network timeout", or "parse error".

## Test plan

New regression test: `test_import_book_error_logs_warning` — patches `get_book_meta` to raise `RuntimeError("gutenberg-timeout")` and asserts a WARNING is emitted.

[ ] Docs updated (if applicable)
