### PR TITLE
ux: add role=alert to error states across notes, vocabulary, ChapterSummary, AnnotationToolbar (closes #1112)

### DIFF
--- a/frontend/src/__tests__/ErrorRoleAlert.test.ts
+++ b/frontend/src/__tests__/ErrorRoleAlert.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Static assertions: error messages have role=alert.
+ * Closes #1112
+ */
+import fs from "fs";
+import path from "path";
+
+const annotationToolbar = fs.readFileSync(
+  path.join(process.cwd(), "src/components/AnnotationToolbar.tsx"),
+  "utf8",
+);
+const chapterSummary = fs.readFileSync(
+  path.join(process.cwd(), "src/components/ChapterSummary.tsx"),
+  "utf8",
+);
+const notesPage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/notes/page.tsx"),
+  "utf8",
+);
+const notesBookPage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/notes/[bookId]/page.tsx"),
+  "utf8",
+);
+const vocabPage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/vocabulary/page.tsx"),
+  "utf8",
+);
+
+describe("Error role=alert", () => {
+  it("AnnotationToolbar error block has role=alert", () => {
+    // Locate the {error && ...} render block and check it includes role=alert
+    const errorBlockIdx = annotationToolbar.indexOf("{/* Error */}");
+    expect(errorBlockIdx).toBeGreaterThan(0);
+    const after = annotationToolbar.slice(errorBlockIdx, errorBlockIdx + 400);
+    expect(after).toContain('role="alert"');
+  });
+
+  it("ChapterSummary error block has role=alert", () => {
+    const idx = chapterSummary.indexOf("Could not generate summary");
+    expect(idx).toBeGreaterThan(0);
+    const block = chapterSummary.slice(Math.max(0, idx - 300), idx + 100);
+    expect(block).toContain('role="alert"');
+  });
+
+  it("notes overview Failed-to-load block has role=alert", () => {
+    const idx = notesPage.indexOf("Failed to load notes");
+    expect(idx).toBeGreaterThan(0);
+    const block = notesPage.slice(Math.max(0, idx - 400), idx + 100);
+    expect(block).toContain('role="alert"');
+  });
+
+  it("notes/[bookId] Failed-to-load block has role=alert", () => {
+    const idx = notesBookPage.indexOf("Failed to load notes");
+    expect(idx).toBeGreaterThan(0);
+    const block = notesBookPage.slice(Math.max(0, idx - 400), idx + 100);
+    expect(block).toContain('role="alert"');
+  });
+
+  it("vocabulary Failed-to-load block has role=alert", () => {
+    const idx = vocabPage.indexOf("Failed to load vocabulary");
+    expect(idx).toBeGreaterThan(0);
+    const block = vocabPage.slice(Math.max(0, idx - 400), idx + 100);
+    expect(block).toContain('role="alert"');
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -693,7 +693,7 @@ export default function BookNotesPage() {
             <span className="w-6 h-6 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
           </div>
         ) : fetchError ? (
-          <div className="text-center text-stone-400 mt-20 flex flex-col items-center gap-2">
+          <div role="alert" className="text-center text-stone-400 mt-20 flex flex-col items-center gap-2">
             <p className="font-serif text-lg text-red-500 mt-1">Failed to load notes.</p>
             <p className="text-sm">Please refresh the page to try again.</p>
           </div>

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -142,7 +142,7 @@ export default function NotesOverviewPage() {
             <span className="w-6 h-6 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
           </div>
         ) : fetchError ? (
-          <div className="text-center text-stone-400 mt-20 flex flex-col items-center gap-2">
+          <div role="alert" className="text-center text-stone-400 mt-20 flex flex-col items-center gap-2">
             <p className="font-serif text-lg text-red-500 mt-1">Failed to load notes.</p>
             <p className="text-sm">Please refresh the page to try again.</p>
           </div>

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -556,7 +556,7 @@ function VocabularyPageContent() {
             ))}
           </div>
         ) : fetchError ? (
-          <div className="text-center text-stone-400 mt-20 flex flex-col items-center gap-2">
+          <div role="alert" className="text-center text-stone-400 mt-20 flex flex-col items-center gap-2">
             <p className="font-serif text-lg text-red-500 mt-1">Failed to load vocabulary.</p>
             <p className="text-sm">Please refresh the page to try again.</p>
           </div>

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -171,7 +171,7 @@ export default function AnnotationToolbar({
 
           {/* Error */}
           {error && (
-            <p className="text-xs text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">{error}</p>
+            <p role="alert" className="text-xs text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">{error}</p>
           )}
 
           {/* Actions */}

--- a/frontend/src/components/ChapterSummary.tsx
+++ b/frontend/src/components/ChapterSummary.tsx
@@ -112,7 +112,7 @@ export default function ChapterSummary({
         )}
 
         {error && !loading && (
-          <div className="rounded-lg bg-red-50 border border-red-200 p-4 text-sm text-red-700">
+          <div role="alert" className="rounded-lg bg-red-50 border border-red-200 p-4 text-sm text-red-700">
             <p className="font-medium mb-1">Could not generate summary</p>
             <p className="text-xs text-red-500">{error}</p>
             <button


### PR DESCRIPTION
Closes #1112

Multiple user-facing error states across the app rendered without `role="alert"`, so screen readers were not announced when errors appeared after an action (e.g. failed save, failed fetch).

## Changes
- `components/AnnotationToolbar.tsx` line ~174: error `<p>` shown after save/delete failure → `role="alert"`
- `components/ChapterSummary.tsx` line ~115: "Could not generate summary" error block → `role="alert"`
- `app/notes/page.tsx` line ~145: "Failed to load notes" error state → `role="alert"`
- `app/notes/[bookId]/page.tsx` line ~696: "Failed to load notes" error state → `role="alert"`
- `app/vocabulary/page.tsx` line ~559: "Failed to load vocabulary" error state → `role="alert"`
- `ErrorRoleAlert.test.ts`: 5 static assertions verifying each error block now has `role="alert"`

## WCAG
- 4.1.3 Status Messages

## Test plan
- [x] `ErrorRoleAlert.test.ts` — 5 passing
- [x] Full frontend suite — 2098/2098 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
