### PR TITLE
ux: add aria-pressed and role=group to TypographyPanel SegmentedControl (closes #1115)

### DIFF
--- a/frontend/src/__tests__/SegmentedControlAria.test.ts
+++ b/frontend/src/__tests__/SegmentedControlAria.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Static assertions: SegmentedControl in TypographyPanel exposes selection via aria-pressed
+ * and groups buttons via role=group.
+ * Closes #1115
+ */
+import fs from "fs";
+import path from "path";
+
+const panel = fs.readFileSync(
+  path.join(process.cwd(), "src/components/TypographyPanel.tsx"),
+  "utf8",
+);
+
+describe("TypographyPanel SegmentedControl ARIA", () => {
+  it("wrapper div has role=group", () => {
+    // Find the SegmentedControl function body and verify role=group
+    expect(panel).toContain('role="group"');
+  });
+
+  it("segmented buttons expose aria-pressed for selection state", () => {
+    expect(panel).toMatch(/aria-pressed=\{value === opt\.value\}/);
+  });
+
+  it("SegmentedControl accepts a label prop and forwards it as aria-label", () => {
+    // Group should have aria-label so screen readers know what the group controls
+    expect(panel).toMatch(/aria-label=\{label\}/);
+  });
+});

--- a/frontend/src/components/TypographyPanel.tsx
+++ b/frontend/src/components/TypographyPanel.tsx
@@ -48,17 +48,20 @@ function SegmentedControl<T extends string>({
   options,
   value,
   onChange,
+  label,
 }: {
   options: Option<T>[];
   value: T;
   onChange: (v: T) => void;
+  label: string;
 }) {
   return (
-    <div className="flex rounded-lg border border-amber-200 overflow-hidden">
+    <div role="group" aria-label={label} className="flex rounded-lg border border-amber-200 overflow-hidden">
       {options.map((opt) => (
         <button
           key={opt.value}
           onClick={() => onChange(opt.value)}
+          aria-pressed={value === opt.value}
           className={`flex-1 px-2 py-1.5 min-h-[44px] text-xs font-medium transition-colors flex items-center justify-center ${
             value === opt.value
               ? "bg-amber-700 text-white"
@@ -124,6 +127,7 @@ export default function TypographyPanel({
       <div className="space-y-4">
         <Row label="Font size">
           <SegmentedControl
+            label="Font size"
             options={FONT_SIZES}
             value={fontSize}
             onChange={set(onFontSize, "fontSize")}
@@ -131,6 +135,7 @@ export default function TypographyPanel({
         </Row>
         <Row label="Font">
           <SegmentedControl
+            label="Font family"
             options={FONT_FAMILIES}
             value={fontFamily}
             onChange={set(onFontFamily, "fontFamily")}
@@ -138,6 +143,7 @@ export default function TypographyPanel({
         </Row>
         <Row label="Spacing">
           <SegmentedControl
+            label="Line spacing"
             options={LINE_HEIGHTS}
             value={lineHeight}
             onChange={set(onLineHeight, "lineHeight")}
@@ -145,6 +151,7 @@ export default function TypographyPanel({
         </Row>
         <Row label="Width">
           <SegmentedControl
+            label="Content width"
             options={CONTENT_WIDTHS}
             value={contentWidth}
             onChange={set(onContentWidth, "contentWidth")}


### PR DESCRIPTION
Closes #1115

`SegmentedControl` (used inside `TypographyPanel` for font size, font family, line spacing, and content width settings) signaled its selection state visually only — no `aria-pressed` on each segment button and no `role="group"` on the wrapper. Screen-reader users could not tell which segment was selected.

## Changes
- `components/TypographyPanel.tsx`:
  - `SegmentedControl` now requires a `label: string` prop
  - Wrapper div gets `role="group" aria-label={label}`
  - Each segment button gets `aria-pressed={value === opt.value}`
  - All 4 call sites pass an appropriate label ("Font size", "Font family", "Line spacing", "Content width")
- `SegmentedControlAria.test.ts`: 3 static assertions

## WCAG
- 4.1.2 Name, Role, Value (toggle state exposed)
- 1.3.1 Info and Relationships (related controls grouped)

## Test plan
- [x] `SegmentedControlAria.test.ts` — 3 passing
- [x] Full frontend suite — 2101/2101 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
