### PR TITLE
fix: reject whitespace-only content in POST /chat/{book_id}/messages (closes #1116)

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -6,7 +6,7 @@ carry across browsers / devices / cache clears. See the design doc
 """
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from services.auth import get_current_user, check_book_access
 from services.db import (
@@ -26,6 +26,13 @@ class ChatMessageCreate(BaseModel):
     # the 8 KB byte cap below so reject-with-413 is distinguishable from
     # reject-with-422 (schema violation).
     content: str = Field(..., min_length=1, max_length=64000)
+
+    @field_validator("content")
+    @classmethod
+    def content_not_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("content cannot be blank")
+        return v
 
 
 @router.get("/{book_id}/messages")

--- a/backend/tests/test_router_chat.py
+++ b/backend/tests/test_router_chat.py
@@ -240,3 +240,36 @@ async def test_router_user_isolation(client, test_user):
     res = await client.get(f"/api/chat/{TEST_BOOK_ID}/messages")
     assert res.status_code == 200
     assert res.json()["messages"] == []
+
+
+# ── Issue #1116: whitespace-only content bypasses validation ─────────────────
+
+
+async def test_router_rejects_whitespace_only_content(client, test_user):
+    """Regression #1116: POST /chat/{book_id}/messages with content="   " must
+    return 422, not store an empty whitespace message."""
+    await _seed_book(TEST_BOOK_ID)
+    res = await client.post(
+        f"/api/chat/{TEST_BOOK_ID}/messages",
+        json={"role": "user", "content": "   "},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for whitespace-only content, got {res.status_code}: {res.text}"
+    )
+
+    # Confirm nothing was persisted.
+    get_res = await client.get(f"/api/chat/{TEST_BOOK_ID}/messages")
+    assert get_res.status_code == 200
+    assert get_res.json()["messages"] == []
+
+
+async def test_router_rejects_tab_newline_only_content(client, test_user):
+    """Regression #1116: tabs and newlines also must not bypass validation."""
+    await _seed_book(TEST_BOOK_ID)
+    res = await client.post(
+        f"/api/chat/{TEST_BOOK_ID}/messages",
+        json={"role": "user", "content": "\t\n  "},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for tab/newline-only content, got {res.status_code}: {res.text}"
+    )


### PR DESCRIPTION
## What changed

`ChatMessageCreate.content` had `min_length=1` but no whitespace check, so `POST /chat/{book_id}/messages` accepted `content="   "` or `content="\t\n"` and stored a visually empty message.

Added a `field_validator` that strips and rejects blank — same pattern as the recent #1058 (annotations note_text) and #1060 (vocab target_language) fixes.

## Why

Issue #1116 — empty whitespace messages clutter the user's chat thread, and the InsightChat UI was newly wired to server history (#907 / PR #1114), so this gap has just gone live.

## Test plan

New regression tests:
- `test_router_rejects_whitespace_only_content` — `content="   "` returns 422 and is not persisted
- `test_router_rejects_tab_newline_only_content` — `content="\t\n  "` also returns 422

Both fail before the fix.

[ ] Docs updated (if applicable)
