### PR TITLE
ux: add aria-current=page to active home tab button (closes #1121)

### DIFF
--- a/frontend/src/__tests__/HomeTabAriaCurrent.test.ts
+++ b/frontend/src/__tests__/HomeTabAriaCurrent.test.ts
@@ -1,0 +1,17 @@
+/**
+ * Static assertion: home page tab buttons set aria-current=page when active.
+ * Closes #1121
+ */
+import fs from "fs";
+import path from "path";
+
+const homePage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/page.tsx"),
+  "utf8",
+);
+
+describe("Home page tab aria-current", () => {
+  it("tab buttons include aria-current bound to active tab", () => {
+    expect(homePage).toMatch(/aria-current=\{tab === key \? "page" : undefined\}/);
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -215,6 +215,7 @@ export default function Home() {
             <button
               key={key}
               onClick={() => setTab(key)}
+              aria-current={tab === key ? "page" : undefined}
               className={`px-5 py-3 min-h-[44px] text-sm font-medium border-b-2 transition-colors ${
                 tab === key
                   ? "border-amber-700 text-amber-900"


### PR DESCRIPTION
Closes #1121

The home page Home/Discover tab buttons signaled the active tab visually only (border colour + text colour) — no `aria-current="page"` was set, so screen-reader users could not tell which tab was active.

## Changes
- `app/page.tsx` line ~215: added `aria-current={tab === key ? "page" : undefined}` to the tab `<button>` (Upload/Admin tabs navigate away via router.push so they don't need aria-current)
- `HomeTabAriaCurrent.test.ts`: 1 static assertion

## WCAG
- 4.1.2 Name, Role, Value (state of active tab exposed to AT)

## Test plan
- [x] `HomeTabAriaCurrent.test.ts` — 1 passing
- [x] Full frontend suite — 2104/2104 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
