### PR TITLE
fix: strip whitespace-only parsed title/author in upload_book fallback (closes #1123)

### DIFF
--- a/backend/routers/uploads.py
+++ b/backend/routers/uploads.py
@@ -129,8 +129,8 @@ async def upload_book(
             status_code=422,
             detail="No chapters could be detected. The file appears to be empty or contains no readable text.",
         )
-    title = (parsed["title"] or "Untitled")[:500]
-    author = (parsed["author"] or "Unknown")[:200]
+    title = ((parsed["title"] or "").strip() or "Untitled")[:500]
+    author = ((parsed["author"] or "").strip() or "Unknown")[:200]
     book_id = await _save_upload_book(
         user_id=user["id"],
         title=title,

--- a/backend/tests/test_router_uploads.py
+++ b/backend/tests/test_router_uploads.py
@@ -864,3 +864,34 @@ async def test_confirm_chapters_whitespace_title_falls_back_to_default(client, t
     assert first_title == "Chapter 1", (
         f"Expected fallback 'Chapter 1', got {first_title!r}"
     )
+
+
+# ── Issue #1123: whitespace-only parsed title/author bypass Untitled/Unknown fallback ──
+
+
+async def test_upload_whitespace_title_author_falls_back_to_defaults(client, test_user, tmp_db):
+    """Regression #1123: parser output with whitespace-only title/author must
+    fall back to 'Untitled'/'Unknown' (same as empty string), not be stored verbatim."""
+    with patch("services.book_parser.parse_txt") as mock_parse:
+        mock_parse.return_value = {
+            "title": "   ",
+            "author": "\t\n",
+            "chapters": [{"title": "Ch 1", "text": "Some content here."}],
+        }
+        resp = await client.post("/api/books/upload", files=_txt_upload())
+
+    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+    book_id = resp.json()["book_id"]
+
+    async with aiosqlite.connect(tmp_db) as db:
+        async with db.execute("SELECT title, authors FROM books WHERE id=?", (book_id,)) as cur:
+            row = await cur.fetchone()
+    assert row is not None
+    title_stored, authors_stored = row
+    assert title_stored == "Untitled", (
+        f"Expected fallback 'Untitled' for whitespace title, got {title_stored!r}"
+    )
+    authors_list = json.loads(authors_stored)
+    assert authors_list[0] == "Unknown", (
+        f"Expected fallback 'Unknown' for whitespace author, got {authors_list[0]!r}"
+    )


### PR DESCRIPTION
## What changed

`uploads.py:132-133` had the same Python-truthy fallback bug as #1119:
```python
title = (parsed["title"] or "Untitled")[:500]
author = (parsed["author"] or "Unknown")[:200]
```

`""` is falsy so the fallback worked, but `"   "` / `"\t\n"` (from malformed EPUB metadata) is truthy — so whitespace titles/authors were stored verbatim and the library rendered empty cards.

Fix: strip before the fallback.
```python
title = ((parsed["title"] or "").strip() or "Untitled")[:500]
author = ((parsed["author"] or "").strip() or "Unknown")[:200]
```

## Why

Issue #1123 — third instance of this pattern bug after #1119 (chapter titles) and #1116 (chat content). EPUB metadata is fully user-controlled via the upload, so this has a real (if narrow) exploit surface.

## Test plan

New regression test `test_upload_whitespace_title_author_falls_back_to_defaults` — patches `parse_txt` to return whitespace title/author and asserts the stored book row uses "Untitled" / "Unknown". Fails before the fix.

[ ] Docs updated (if applicable)
