### PR TITLE
ux: add role=log and aria-live=polite to InsightChat message container (closes #1125)

### DIFF
--- a/frontend/src/__tests__/InsightChatLogRole.test.ts
+++ b/frontend/src/__tests__/InsightChatLogRole.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Static assertion: InsightChat message container has role=log with aria-live.
+ * Closes #1125
+ */
+import fs from "fs";
+import path from "path";
+
+const chat = fs.readFileSync(
+  path.join(process.cwd(), "src/components/InsightChat.tsx"),
+  "utf8",
+);
+
+describe("InsightChat message container", () => {
+  it("has role=log on the scroll container (messagesBoxRef)", () => {
+    // Look for the messagesBoxRef div and verify it has role=log
+    const idx = chat.indexOf("ref={messagesBoxRef}");
+    expect(idx).toBeGreaterThan(0);
+    const block = chat.slice(Math.max(0, idx - 200), idx + 400);
+    expect(block).toContain('role="log"');
+  });
+
+  it("has aria-live=polite on the scroll container", () => {
+    const idx = chat.indexOf("ref={messagesBoxRef}");
+    const block = chat.slice(Math.max(0, idx - 200), idx + 400);
+    expect(block).toContain('aria-live="polite"');
+  });
+
+  it("has aria-label on the scroll container", () => {
+    const idx = chat.indexOf("ref={messagesBoxRef}");
+    const block = chat.slice(Math.max(0, idx - 200), idx + 400);
+    expect(block).toMatch(/aria-label="Conversation"/);
+  });
+});

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -421,6 +421,9 @@ export default function InsightChat({
       {/* ── Messages ──────────────────────────────────────────────────── */}
       <div
         ref={messagesBoxRef}
+        role="log"
+        aria-live="polite"
+        aria-label="Conversation"
         className="flex-1 overflow-y-auto px-3 py-3 space-y-3"
         style={{ fontSize }}
       >


### PR DESCRIPTION
Closes #1125

The chat message container in `InsightChat` was a plain scrollable `<div>` with no ARIA role. New messages arriving after a user asks a question were not announced to screen readers. `role="log"` + `aria-live="polite"` on the container turns it into a live region so screen readers pick up new messages as they appear.

## Changes
- `components/InsightChat.tsx` (line ~422): added `role="log" aria-live="polite" aria-label="Conversation"` to the scroll container wrapping the message list
- `InsightChatLogRole.test.ts`: 3 static assertions

## WCAG
- 4.1.3 Status Messages (new messages announced)

## Test plan
- [x] `InsightChatLogRole.test.ts` — 3 passing
- [x] Full frontend suite — 2109/2109 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
