### PR TITLE
ux: add aria-expanded to shortcuts toggle and role=region to popover (closes #1131)

### DIFF
--- a/frontend/src/__tests__/ShortcutsPopoverAria.test.ts
+++ b/frontend/src/__tests__/ShortcutsPopoverAria.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Static assertion: keyboard shortcuts popover has role=region + aria-label
+ * and the toggle button has aria-expanded.
+ * Closes #1131
+ */
+import fs from "fs";
+import path from "path";
+
+const readerPage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Keyboard shortcuts popover ARIA", () => {
+  it("toggle button has aria-expanded bound to showShortcuts", () => {
+    // Locate the Keyboard shortcuts toggle button and verify aria-expanded
+    const idx = readerPage.indexOf('aria-label="Keyboard shortcuts"');
+    expect(idx).toBeGreaterThan(0);
+    const block = readerPage.slice(Math.max(0, idx - 400), idx + 200);
+    expect(block).toContain("aria-expanded={showShortcuts}");
+  });
+
+  it("popover div has role=region", () => {
+    // The popover contains "Keyboard Shortcuts" heading text
+    const idx = readerPage.indexOf("Keyboard Shortcuts");
+    expect(idx).toBeGreaterThan(0);
+    const block = readerPage.slice(Math.max(0, idx - 400), idx + 100);
+    expect(block).toContain('role="region"');
+  });
+
+  it("popover div has aria-label Keyboard shortcuts", () => {
+    const idx = readerPage.indexOf("Keyboard Shortcuts");
+    const block = readerPage.slice(Math.max(0, idx - 400), idx + 100);
+    expect(block).toContain('aria-label="Keyboard shortcuts"');
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1179,6 +1179,7 @@ export default function ReaderPage() {
               onClick={() => setShowShortcuts((v) => !v)}
               title="Keyboard shortcuts (?)"
               aria-label="Keyboard shortcuts"
+              aria-expanded={showShortcuts}
               className={`flex shrink-0 items-center justify-center w-7 h-7 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 rounded-lg border text-xs font-medium transition-colors ${
                 showShortcuts
                   ? "bg-amber-100 border-amber-400 text-amber-800"
@@ -1188,7 +1189,7 @@ export default function ReaderPage() {
               <KeyboardIcon className="w-3.5 h-3.5" />
             </button>
             {showShortcuts && (
-              <div className="absolute right-0 top-full mt-2 w-56 bg-white border border-amber-200 rounded-xl shadow-lg z-50 p-3 animate-fade-in">
+              <div role="region" aria-label="Keyboard shortcuts" className="absolute right-0 top-full mt-2 w-56 bg-white border border-amber-200 rounded-xl shadow-lg z-50 p-3 animate-fade-in">
                 <p className="text-[10px] font-semibold uppercase tracking-widest text-stone-400 mb-2">Keyboard Shortcuts</p>
                 <div className="space-y-1.5">
                   {[


### PR DESCRIPTION
Closes #1131

The keyboard shortcuts toggle button in the reader header opened a small popover with a list of shortcuts. The toggle button did not communicate its expanded state and the popover had no semantic role.

## Changes
- `app/reader/[bookId]/page.tsx`:
  - Shortcuts toggle button gets `aria-expanded={showShortcuts}`
  - Popover div gets `role="region" aria-label="Keyboard shortcuts"`
- `ShortcutsPopoverAria.test.ts`: 3 static assertions

## WCAG
- 4.1.2 Name, Role, Value (toggle state + region identification)

## Test plan
- [x] `ShortcutsPopoverAria.test.ts` — 3 passing
- [x] Full frontend suite — 2112/2112 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
