### PR TITLE
fix: reject whitespace-only text in /ai/tts and /ai/tts/chunks (closes #1132)

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -147,6 +147,11 @@ class TTSRequest(BaseModel):
     rate: float = Field(default=1.0, ge=0.25, le=4.0)
     gender: Literal["female", "male"] = "female"
 
+    @field_validator("text")
+    @classmethod
+    def text_not_blank(cls, v: str) -> str:
+        return _not_blank(v)
+
     @field_validator("language")
     @classmethod
     def language_not_blank(cls, v: str) -> str:
@@ -155,6 +160,11 @@ class TTSRequest(BaseModel):
 
 class ChunkTextRequest(BaseModel):
     text: str = Field(..., min_length=1, max_length=50_000)
+
+    @field_validator("text")
+    @classmethod
+    def text_not_blank(cls, v: str) -> str:
+        return _not_blank(v)
 
 
 # ── Endpoints ─────────────────────────────────────────────────────────────────

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -1464,3 +1464,20 @@ async def test_translate_rejects_whitespace_text(client, test_user):
         "target_language": "en",
     })
     assert resp.status_code == 422, f"Expected 422 for whitespace text in translate, got {resp.status_code}"
+
+
+# ── Issue #1132: whitespace-only text on /tts and /tts/chunks ───────────────
+
+
+async def test_tts_rejects_whitespace_text(anon_client):
+    resp = await anon_client.post("/api/ai/tts", json={
+        "text": "   ",
+        "language": "en",
+        "rate": 1.0,
+    })
+    assert resp.status_code == 422, f"Expected 422 for whitespace text in /ai/tts, got {resp.status_code}"
+
+
+async def test_tts_chunks_rejects_whitespace_text(anon_client):
+    resp = await anon_client.post("/api/ai/tts/chunks", json={"text": "\t\n  "})
+    assert resp.status_code == 422, f"Expected 422 for whitespace text in /ai/tts/chunks, got {resp.status_code}"


### PR DESCRIPTION
## What changed

Follow-up to #1127 — TTS endpoints had the same whitespace-bypass:
- `POST /ai/tts` — `TTSRequest.text`
- `POST /ai/tts/chunks` — `ChunkTextRequest.text`

Both now use the existing `_not_blank` validator from ai.py.

## Why

Issue #1132. A `text="   "` POST to `/ai/tts` would forward to Edge TTS and return 500; the same POST to `/ai/tts/chunks` produced a single-whitespace chunk. 422 at the request boundary is the right answer either way.

## Test plan

Two new regression tests — both fail before the fix:
- `test_tts_rejects_whitespace_text`
- `test_tts_chunks_rejects_whitespace_text`

Full backend suite: 1581 / 1581 pass.

[ ] Docs updated (if applicable)
