### PR TITLE
ux: apply optimistic delete + UndoToast to decks page (closes #1135)

### DIFF
--- a/frontend/src/__tests__/DecksPage.test.tsx
+++ b/frontend/src/__tests__/DecksPage.test.tsx
@@ -84,7 +84,7 @@ test("'New deck' header button navigates to /decks/new", async () => {
   expect(mockPush).toHaveBeenCalledWith("/decks/new");
 });
 
-test("deleting a deck removes it from the list and calls the API", async () => {
+test("deleting a deck removes it from the list optimistically and shows UndoToast", async () => {
   mockListDecks.mockResolvedValue(SAMPLE_DECKS);
   mockDeleteDeck.mockResolvedValue(undefined);
   render(<DecksPage />);
@@ -93,13 +93,14 @@ test("deleting a deck removes it from the list and calls the API", async () => {
   const user = userEvent.setup();
   await user.click(screen.getByTestId("deck-delete-1"));
 
-  await waitFor(() => {
-    expect(mockDeleteDeck).toHaveBeenCalledWith(1);
-  });
+  // Optimistic: removed from list immediately
   await waitFor(() => {
     expect(screen.queryByText("German verbs")).not.toBeInTheDocument();
   });
   expect(screen.getByText("A1 Spanish")).toBeInTheDocument();
+
+  // UndoToast is shown
+  expect(screen.getByText(/"German verbs" deleted/)).toBeInTheDocument();
 });
 
 test("falls back to the empty state when the API errors", async () => {

--- a/frontend/src/__tests__/DecksUndoToast.test.ts
+++ b/frontend/src/__tests__/DecksUndoToast.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Static assertions: decks page uses UndoToast pattern for delete.
+ * Closes #1135
+ */
+import fs from "fs";
+import path from "path";
+
+const page = fs.readFileSync(
+  path.join(process.cwd(), "src/app/decks/page.tsx"),
+  "utf8",
+);
+
+describe("Decks page UndoToast", () => {
+  it("imports UndoToast component", () => {
+    expect(page).toContain('import UndoToast from "@/components/UndoToast"');
+  });
+
+  it("uses a toast state (removedDeckToast or similar)", () => {
+    expect(page).toMatch(/removedDeckToast|deletedDeckToast/);
+  });
+
+  it("renders UndoToast when a deck has been removed", () => {
+    expect(page).toMatch(/<UndoToast\b/);
+  });
+
+  it("UndoToast onDone calls deleteDeck (actual API delete deferred to toast expiry)", () => {
+    // The deleteDeck API call should be inside the UndoToast onDone, not in the click handler
+    const idx = page.indexOf("<UndoToast");
+    expect(idx).toBeGreaterThan(0);
+    const block = page.slice(idx, idx + 800);
+    expect(block).toContain("deleteDeck(");
+  });
+});

--- a/frontend/src/app/decks/page.tsx
+++ b/frontend/src/app/decks/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { DeckSummary, deleteDeck, listDecks } from "@/lib/api";
 import DeckCard from "@/components/DeckCard";
+import UndoToast from "@/components/UndoToast";
 import { ArrowLeftIcon, DeckIcon } from "@/components/Icons";
 
 export default function DecksPage() {
@@ -12,6 +13,7 @@ export default function DecksPage() {
   const [decks, setDecks] = useState<DeckSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  const [removedDeckToast, setRemovedDeckToast] = useState<DeckSummary | null>(null);
 
   useEffect(() => {
     let alive = true;
@@ -33,13 +35,20 @@ export default function DecksPage() {
     };
   }, [session?.backendToken]);
 
-  const handleDelete = useCallback(async (id: number) => {
-    try {
-      await deleteDeck(id);
-      setDecks((prev) => prev.filter((d) => d.id !== id));
-    } catch {
-      // leave the deck in place if the delete failed; a toast system isn't wired yet.
-    }
+  const handleDelete = useCallback((id: number) => {
+    setDecks((prev) => {
+      const removed = prev.find((d) => d.id === id);
+      if (removed) {
+        // If a previous toast is still showing, commit that delete immediately
+        setRemovedDeckToast((current) => {
+          if (current) {
+            deleteDeck(current.id).catch(() => {});
+          }
+          return removed;
+        });
+      }
+      return prev.filter((d) => d.id !== id);
+    });
   }, []);
 
   const isEmpty = !loading && (error || decks.length === 0);
@@ -113,6 +122,20 @@ export default function DecksPage() {
           </div>
         )}
       </div>
+
+      {removedDeckToast && (
+        <UndoToast
+          message={`"${removedDeckToast.name}" deleted`}
+          onUndo={() => {
+            setDecks((prev) => [...prev, removedDeckToast]);
+            setRemovedDeckToast(null);
+          }}
+          onDone={() => {
+            deleteDeck(removedDeckToast.id).catch(() => {});
+            setRemovedDeckToast(null);
+          }}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #1135

Previously, clicking the trash icon on a `DeckCard` immediately called `deleteDeck(id)` with no confirmation and no undo — a single misclick destroyed the deck. The code comment even admitted "a toast system isn't wired yet". Now that UndoToast is established elsewhere (PR #1084), wire it here.

## Changes
- `app/decks/page.tsx`:
  - `handleDelete` is now synchronous: optimistically removes the deck from state and queues an UndoToast. If a previous toast is still showing, commit that deck's delete immediately.
  - `<UndoToast>` renders at the page root. `onUndo` restores the deck to state with no API call. `onDone` (after 3s timer) fires the actual `deleteDeck` API call.
  - Stale comment about "toast system isn't wired yet" removed
- `DecksUndoToast.test.ts`: 4 static assertions that UndoToast is imported, state tracked, rendered, and `deleteDeck` moved into `onDone`
- `DecksPage.test.tsx`: existing delete test updated to match the new optimistic pattern (checks UI removal + UndoToast message instead of immediate API call)

## Test plan
- [x] `DecksUndoToast.test.ts` — 4 passing
- [x] `DecksPage.test.tsx` updated test — passing
- [x] Full frontend suite — 2116/2116 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
