### PR TITLE
fix: reject whitespace target_language on admin retranslate-all / import (closes #1137)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -10,7 +10,7 @@ import aiosqlite
 logger = logging.getLogger(__name__)
 from typing import Annotated
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from services.auth import get_current_user, decrypt_api_key, encrypt_api_key
 from services.db import (
     DB_PATH,
@@ -604,6 +604,14 @@ async def retranslate(
 class BulkRetranslateRequest(BaseModel):
     target_language: str = Field(..., min_length=1, max_length=20)
 
+    @field_validator("target_language")
+    @classmethod
+    def target_language_not_blank(cls, v: str) -> str:
+        s = v.strip().lower().split("-")[0]
+        if not s:
+            raise ValueError("target_language cannot be blank")
+        return s
+
 
 class ImportTranslationEntry(BaseModel):
     book_id: int = Field(..., ge=1)
@@ -613,6 +621,14 @@ class ImportTranslationEntry(BaseModel):
     provider: str | None = Field(default=None, max_length=100)
     model: str | None = Field(default=None, max_length=200)
     title_translation: str | None = Field(default=None, max_length=500)
+
+    @field_validator("target_language")
+    @classmethod
+    def target_language_not_blank(cls, v: str) -> str:
+        s = v.strip().lower().split("-")[0]
+        if not s:
+            raise ValueError("target_language cannot be blank")
+        return s
 
 
 class ImportTranslationsRequest(BaseModel):

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -3236,3 +3236,37 @@ async def test_queue_dry_run_translation_failure_logs_warning(admin_client, admi
         "dry" in r.message.lower() or "preview" in r.message.lower() or "translat" in r.message.lower()
         for r in caplog.records
     ), f"Expected warning log for dry-run failure, got: {[r.message for r in caplog.records]}"
+
+
+# ── Issue #1137: whitespace-only target_language on admin retranslate/import ──
+
+
+@pytest.mark.asyncio
+async def test_retranslate_all_whitespace_target_language_returns_422(admin_client):
+    """Regression #1137: POST /admin/translations/{id}/retranslate-all with
+    target_language="   " must return 422, not proceed with a whitespace language."""
+    res = await admin_client.post(
+        "/api/admin/translations/42/retranslate-all",
+        json={"target_language": "   "},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for whitespace target_language in retranslate-all, got {res.status_code}: {res.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_import_translations_whitespace_target_language_returns_422(admin_client):
+    """Regression #1137: POST /admin/translations/import with an entry
+    target_language="   " must return 422 (pydantic validation)."""
+    res = await admin_client.post(
+        "/api/admin/translations/import",
+        json={"entries": [{
+            "book_id": 1,
+            "chapter_index": 0,
+            "target_language": "   ",
+            "paragraphs": ["p"],
+        }]},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for whitespace target_language in import, got {res.status_code}: {res.text}"
+    )


### PR DESCRIPTION
## What changed

Final two admin router models with the whitespace-bypass pattern:
- `BulkRetranslateRequest.target_language` — POST `/admin/translations/{book_id}/retranslate-all`
- `ImportTranslationEntry.target_language` — POST `/admin/translations/import`

Both now have a `field_validator` that strips, lowercases, splits on `-`, and rejects blanks — same pattern as `SaveTranslationRequest`, `ExportRequest`, `QueueSettingsRequest` already use.

## Why

Issue #1137 — mop-up of the `target_language` whitespace family (#1060, #1127). These admin endpoints would previously have saved `target_language=" "` into translation_queue rows which never match any real query.

## Test plan

Two new regression tests:
- `test_retranslate_all_whitespace_target_language_returns_422`
- `test_import_translations_whitespace_target_language_returns_422`

Full backend suite: 1583 / 1583 pass.

[ ] Docs updated (if applicable)
