### PR TITLE
ux: add aria-controls + panel id/role=region to Profile Obsidian accordion (closes #1139)

### DIFF
--- a/frontend/src/__tests__/ProfileAccordionAria.test.ts
+++ b/frontend/src/__tests__/ProfileAccordionAria.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Static assertions: Profile Obsidian accordion has aria-controls + panel id + region role.
+ * Closes #1139
+ */
+import fs from "fs";
+import path from "path";
+
+const page = fs.readFileSync(
+  path.join(process.cwd(), "src/app/profile/page.tsx"),
+  "utf8",
+);
+
+describe("Profile accordion ARIA", () => {
+  it("toggle button has aria-controls pointing to the panel id", () => {
+    expect(page).toContain('aria-controls="obsidian-export-panel"');
+  });
+
+  it("collapsible body has id=obsidian-export-panel", () => {
+    expect(page).toContain('id="obsidian-export-panel"');
+  });
+
+  it("collapsible body has role=region", () => {
+    // Scope to the Obsidian section
+    const idx = page.indexOf('id="obsidian-export-panel"');
+    expect(idx).toBeGreaterThan(0);
+    const block = page.slice(Math.max(0, idx - 200), idx + 200);
+    expect(block).toContain('role="region"');
+  });
+});

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -274,6 +274,7 @@ export default function ProfilePage() {
             onClick={() => setObsidianOpen((o) => !o)}
             className="w-full flex items-center justify-between px-6 py-4 text-left hover:bg-amber-50/50 transition-colors"
             aria-expanded={obsidianOpen}
+            aria-controls="obsidian-export-panel"
           >
             <div>
               <h2 className="font-serif text-lg font-semibold text-ink">Obsidian Export</h2>
@@ -291,7 +292,7 @@ export default function ProfilePage() {
 
           {/* Collapsible body */}
           {obsidianOpen && (
-            <div className="px-6 pb-6 space-y-4 border-t border-amber-100">
+            <div id="obsidian-export-panel" role="region" aria-label="Obsidian export settings" className="px-6 pb-6 space-y-4 border-t border-amber-100">
               <div className="pt-4">
                 <div className="flex items-center justify-between mb-1">
                   <label htmlFor="obsidian-token" className="block text-sm font-medium text-ink">


### PR DESCRIPTION
Closes #1139

The Obsidian Export accordion in `app/profile/page.tsx` used `aria-expanded` on the toggle button but was missing `aria-controls` linking it to its panel, and the panel had no `id` or region role. Completes the standard WAI-ARIA accordion pattern.

## Changes
- `app/profile/page.tsx`:
  - Toggle button gets `aria-controls="obsidian-export-panel"`
  - Collapsible body div gets `id="obsidian-export-panel"`, `role="region"`, `aria-label="Obsidian export settings"`
- `ProfileAccordionAria.test.ts`: 3 static assertions

## WCAG
- 4.1.2 Name, Role, Value (complete accordion ARIA pattern)

## Test plan
- [x] `ProfileAccordionAria.test.ts` — 3 passing
- [x] Full frontend suite — 2119/2119 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
