### PR TITLE
ux: add sr-only sender prefix to InsightChat user/assistant bubbles (closes #1141)

### DIFF
--- a/frontend/src/__tests__/ChatSenderSrLabel.test.ts
+++ b/frontend/src/__tests__/ChatSenderSrLabel.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Static assertions: InsightChat message bubbles include screen-reader-only sender prefix.
+ * Closes #1141
+ */
+import fs from "fs";
+import path from "path";
+
+const chat = fs.readFileSync(
+  path.join(process.cwd(), "src/components/InsightChat.tsx"),
+  "utf8",
+);
+
+describe("InsightChat message sender labels", () => {
+  it("user message bubble has sr-only You: prefix", () => {
+    expect(chat).toMatch(/className="sr-only">You: /);
+  });
+
+  it("assistant message bubble has sr-only Assistant: prefix", () => {
+    expect(chat).toMatch(/className="sr-only">Assistant: /);
+  });
+});

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -468,7 +468,7 @@ export default function InsightChat({
             return (
               <div key={i} className="flex flex-col items-end gap-1.5">
                 <div className="bg-amber-600 text-white rounded-2xl rounded-tr-sm px-3.5 py-2 max-w-[88%] leading-relaxed shadow-sm break-words">
-                  {msg.content}
+                  <span className="sr-only">You: </span>{msg.content}
                 </div>
                 {msg.context && (
                   <div className="max-w-[88%] w-full">
@@ -514,6 +514,7 @@ export default function InsightChat({
                     "text-gray-700",
                   ].join(" ")}
                 >
+                  <span className="sr-only">Assistant: </span>
                   <ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.content}</ReactMarkdown>
                 </div>
                 {onSaveInsight && prevUserMsg && (() => {


### PR DESCRIPTION
Closes #1141

`InsightChat` distinguished user vs. assistant messages visually only — different bubble position, colour, and avatar. Screen-reader users heard message content with no "You:" / "Assistant:" prefix, so the role of each message was lost.

## Changes
- `components/InsightChat.tsx`:
  - User bubble (line ~471): added `<span className="sr-only">You: </span>` prefix
  - Assistant bubble (line ~516, before the ReactMarkdown render): added `<span className="sr-only">Assistant: </span>` prefix
- `ChatSenderSrLabel.test.ts`: 2 static assertions

Matches the existing export logic (line 348) which already prefixes by sender for the conversation export.

## WCAG
- 1.3.3 Sensory Characteristics (info conveyed visually only must also be available textually)
- 4.1.2 Name, Role, Value (sender role exposed)

## Test plan
- [x] `ChatSenderSrLabel.test.ts` — 2 passing
- [x] Full frontend suite — 2121/2121 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
