### PR TITLE
ux: add focus-visible ring + lift to BookCard mirroring hover state (closes #1143)

### DIFF
--- a/frontend/src/__tests__/BookCardFocusVisible.test.ts
+++ b/frontend/src/__tests__/BookCardFocusVisible.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Static assertion: BookCard has focus-visible ring + lift to mirror hover.
+ * Closes #1143
+ */
+import fs from "fs";
+import path from "path";
+
+const card = fs.readFileSync(
+  path.join(process.cwd(), "src/components/BookCard.tsx"),
+  "utf8",
+);
+
+describe("BookCard focus-visible styles", () => {
+  it("primary book button has focus-visible ring", () => {
+    expect(card).toMatch(/focus-visible:ring-2/);
+  });
+
+  it("primary book button has focus-visible translate (mirroring hover lift)", () => {
+    expect(card).toMatch(/focus-visible:-translate-y-0\.5/);
+  });
+
+  it("focus-visible:outline-none disables default outline in favor of ring", () => {
+    expect(card).toContain("focus-visible:outline-none");
+  });
+});

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -31,10 +31,12 @@ export default function BookCard({ book, onClick, badge, onRemove }: Props) {
       <button
         data-testid="book-card"
         onClick={onClick}
-        className="text-left rounded-xl border border-amber-200 bg-white p-3 flex flex-col w-full transition-all duration-200 hover:-translate-y-0.5"
+        className="text-left rounded-xl border border-amber-200 bg-white p-3 flex flex-col w-full transition-all duration-200 hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
         style={{ boxShadow: "var(--shadow-card)" }}
         onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card-hover)"; }}
         onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card)"; }}
+        onFocus={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card-hover)"; }}
+        onBlur={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card)"; }}
       >
         {book.cover ? (
           <img


### PR DESCRIPTION
Closes #1143

`BookCard` had a `hover:-translate-y-0.5` lift and JS-driven box-shadow swap on hover but no equivalent for keyboard focus — tabbing onto a book card produced no visual feedback.

## Changes
- `components/BookCard.tsx`:
  - Added `focus-visible:-translate-y-0.5` (matches the hover lift)
  - Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1` (visible amber ring, replaces browser default)
  - Added `onFocus` / `onBlur` handlers that mirror the existing `onMouseEnter` / `onMouseLeave` shadow swap, so keyboard focus also gets the hover-card shadow
- `BookCardFocusVisible.test.ts`: 3 static assertions

## WCAG
- 2.4.7 Focus Visible (visible keyboard focus indicator)
- 1.3.3 Sensory Characteristics (info conveyed visually only must be perceivable in non-mouse modes)

## Test plan
- [x] `BookCardFocusVisible.test.ts` — 3 passing
- [x] Full frontend suite — 2124/2124 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
