### PR TITLE
ux: add focus-visible ring + lift to home Continue Reading button (closes #1145)

### DIFF
--- a/frontend/src/__tests__/ContinueReadingFocusVisible.test.ts
+++ b/frontend/src/__tests__/ContinueReadingFocusVisible.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Static assertion: home page Continue Reading button has focus-visible ring + lift.
+ * Closes #1145
+ */
+import fs from "fs";
+import path from "path";
+
+const homePage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/page.tsx"),
+  "utf8",
+);
+
+describe("Home page Continue Reading focus-visible", () => {
+  it("Continue Reading button has focus-visible ring + lift", () => {
+    const idx = homePage.indexOf('aria-label="Continue reading"');
+    expect(idx).toBeGreaterThan(0);
+    const block = homePage.slice(idx, idx + 800);
+    expect(block).toContain("focus-visible:-translate-y-0.5");
+    expect(block).toContain("focus-visible:ring-2");
+    expect(block).toContain("focus-visible:outline-none");
+  });
+
+  it("Continue Reading button has onFocus/onBlur handlers", () => {
+    const idx = homePage.indexOf('aria-label="Continue reading"');
+    const block = homePage.slice(idx, idx + 1500);
+    expect(block).toMatch(/onFocus=/);
+    expect(block).toMatch(/onBlur=/);
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -288,10 +288,12 @@ export default function Home() {
                 <button
                   aria-label="Continue reading"
                   onClick={() => router.push(`/reader/${recentBooks[0].id}`)}
-                  className="w-full text-left rounded-xl border border-amber-200 bg-white p-3 flex items-center gap-3 hover:-translate-y-0.5 transition-all duration-200"
+                  className="w-full text-left rounded-xl border border-amber-200 bg-white p-3 flex items-center gap-3 hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 transition-all duration-200"
                   style={{ boxShadow: "var(--shadow-card)" }}
                   onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card-hover)"; }}
                   onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card)"; }}
+                  onFocus={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card-hover)"; }}
+                  onBlur={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card)"; }}
                 >
                   {recentBooks[0].cover ? (
                     // eslint-disable-next-line @next/next/no-img-element


### PR DESCRIPTION
Closes #1145

Follow-up to #1143 / PR #1144 (BookCard focus-visible). The home page Continue Reading button used the same hover-translate + JS-driven box-shadow pattern as `BookCard` did, but had no `focus-visible` equivalent.

## Changes
- `app/page.tsx` Continue Reading button (line ~290):
  - Added `focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1`
  - Added `onFocus` / `onBlur` handlers mirroring the existing mouse handlers for the box-shadow swap
- `ContinueReadingFocusVisible.test.ts`: 2 static assertions

## WCAG
- 2.4.7 Focus Visible
- 1.3.3 Sensory Characteristics

## Test plan
- [x] `ContinueReadingFocusVisible.test.ts` — 2 passing
- [x] Full frontend suite — 2126/2126 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
