### PR TITLE
ux: convert AnnotationToolbar color picker to role=radiogroup pattern (closes #1147)

### DIFF
--- a/frontend/src/__tests__/AnnotationToolbar.branches.test.tsx
+++ b/frontend/src/__tests__/AnnotationToolbar.branches.test.tsx
@@ -202,8 +202,8 @@ describe("AnnotationToolbar — color picker", () => {
   it("selects yellow by default", () => {
     render(<AnnotationToolbar {...BASE_PROPS} />);
 
-    expect(screen.getByLabelText("Yellow")).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByLabelText("Blue")).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByLabelText("Yellow")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByLabelText("Blue")).toHaveAttribute("aria-checked", "false");
   });
 
   it("switches selected color when a different color is clicked", async () => {
@@ -212,7 +212,7 @@ describe("AnnotationToolbar — color picker", () => {
 
     await user.click(screen.getByLabelText("Pink"));
 
-    expect(screen.getByLabelText("Pink")).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByLabelText("Yellow")).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByLabelText("Pink")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByLabelText("Yellow")).toHaveAttribute("aria-checked", "false");
   });
 });

--- a/frontend/src/__tests__/AnnotationToolbarColorTouchTargets.test.ts
+++ b/frontend/src/__tests__/AnnotationToolbarColorTouchTargets.test.ts
@@ -24,7 +24,7 @@ describe("AnnotationToolbar color picker touch targets (closes #826)", () => {
   it("visual circle swatch stays w-8 h-8", () => {
     const idx = src.indexOf("Highlight colour");
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(idx, idx + 600);
+    const window = src.slice(idx, idx + 1000);
     expect(window).toContain("w-8 h-8");
   });
 });

--- a/frontend/src/__tests__/ColorPickerRadiogroup.test.ts
+++ b/frontend/src/__tests__/ColorPickerRadiogroup.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Static assertion: AnnotationToolbar color picker uses radiogroup pattern.
+ * Closes #1147
+ */
+import fs from "fs";
+import path from "path";
+
+const toolbar = fs.readFileSync(
+  path.join(process.cwd(), "src/components/AnnotationToolbar.tsx"),
+  "utf8",
+);
+
+describe("AnnotationToolbar color picker radiogroup", () => {
+  it("color picker wrapper has role=radiogroup", () => {
+    expect(toolbar).toContain('role="radiogroup"');
+  });
+
+  it("color picker wrapper has aria-label", () => {
+    expect(toolbar).toMatch(/aria-label="Highlight colour"/);
+  });
+
+  it("each color button has role=radio", () => {
+    expect(toolbar).toContain('role="radio"');
+  });
+
+  it("each color button uses aria-checked instead of aria-pressed", () => {
+    expect(toolbar).toContain("aria-checked={color === c.key}");
+    // Old aria-pressed should be removed
+    expect(toolbar).not.toContain("aria-pressed={color === c.key}");
+  });
+});

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -132,15 +132,17 @@ export default function AnnotationToolbar({
 
           {/* Color picker */}
           <div>
-            <p className="text-xs text-stone-500 mb-2">Highlight colour</p>
-            <div className="flex items-center gap-0.5">
+            <p className="text-xs text-stone-500 mb-2" aria-hidden="true">Highlight colour</p>
+            <div role="radiogroup" aria-label="Highlight colour" className="flex items-center gap-0.5">
               {COLORS.map((c) => (
                 <button
                   key={c.key}
+                  type="button"
+                  role="radio"
                   title={c.label}
                   onClick={() => setColor(c.key)}
                   aria-label={c.label}
-                  aria-pressed={color === c.key}
+                  aria-checked={color === c.key}
                   className="min-h-[44px] min-w-[44px] flex items-center justify-center"
                 >
                   <span


### PR DESCRIPTION
Closes #1147

The highlight color picker in `AnnotationToolbar` previously used `aria-pressed` toggle-button semantics. For mutually-exclusive selection (pick one of N), the canonical WAI-ARIA pattern is `role="radiogroup"` + `role="radio"` + `aria-checked`. This communicates the "pick one" affordance to screen readers explicitly.

## Changes
- `components/AnnotationToolbar.tsx`:
  - Wrapper `<div>` becomes `role="radiogroup" aria-label="Highlight colour"`
  - The visual `<p>Highlight colour</p>` heading gets `aria-hidden="true"` (the radiogroup's aria-label provides the accessible name)
  - Each color button: `role="radio"`, `aria-checked={color === c.key}` (replaces `aria-pressed`); `type="button"` added for safety
- `ColorPickerRadiogroup.test.ts`: 4 static assertions covering the role/aria-label/aria-checked transitions
- `AnnotationToolbar.branches.test.tsx`: 2 existing color-picker tests updated to use `aria-checked` instead of `aria-pressed`
- `AnnotationToolbarColorTouchTargets.test.ts`: search window expanded from 600→1000 chars (the new wrapper+aria-label shifted the `w-8 h-8` swatch class slightly past the old window)

## WCAG
- 4.1.2 Name, Role, Value (correct role for mutually-exclusive selection)

## Test plan
- [x] `ColorPickerRadiogroup.test.ts` — 4 passing
- [x] Existing color-picker tests adapted — passing
- [x] Full frontend suite — 2130/2130 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
