### PR TITLE
ux: bring search page in line with rest of app — back button, skeletons, role=alert, focus-visible, empty CTA (closes #1150)

### DIFF
--- a/frontend/src/__tests__/SearchPageUx.test.ts
+++ b/frontend/src/__tests__/SearchPageUx.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Static assertions: search page parity fixes.
+ * Closes #1150
+ */
+import fs from "fs";
+import path from "path";
+
+const page = fs.readFileSync(
+  path.join(process.cwd(), "src/app/search/page.tsx"),
+  "utf8",
+);
+
+describe("Search page UX parity", () => {
+  it("imports ArrowLeftIcon for the back button", () => {
+    expect(page).toMatch(/ArrowLeftIcon/);
+  });
+
+  it("loading state has role=status with aria-label", () => {
+    expect(page).toMatch(/role="status"[^>]*aria-label="Searching"/);
+  });
+
+  it("error state has role=alert", () => {
+    // The error JSX should have role="alert"
+    const idx = page.indexOf("Error:");
+    expect(idx).toBeGreaterThan(0);
+    const block = page.slice(Math.max(0, idx - 300), idx + 100);
+    expect(block).toContain('role="alert"');
+  });
+
+  it("no-results state has a Browse books CTA navigating to /", () => {
+    const idx = page.indexOf("No matches for");
+    expect(idx).toBeGreaterThan(0);
+    const block = page.slice(idx, idx + 1000);
+    expect(block).toMatch(/Browse books|Discover books/);
+    expect(block).toMatch(/href="\/"|router\.push\("\/"\)|Link[^>]*href="\/"/);
+  });
+
+  it("result cards use focus-visible ring (BookCard/ContinueReading pattern)", () => {
+    expect(page).toMatch(/focus-visible:-translate-y-0\.5/);
+    expect(page).toMatch(/focus-visible:ring-2/);
+  });
+});

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
 
-import { SearchIcon } from "@/components/Icons";
+import { SearchIcon, ArrowLeftIcon, ArrowRightIcon } from "@/components/Icons";
 import { InAppSearchResponse, InAppSearchResult, searchInAppContent } from "@/lib/api";
 
 function SnippetHtml({ snippet }: { snippet: string }) {
@@ -25,7 +25,7 @@ function AnnotationCard({ r }: { r: Extract<InAppSearchResult, { type: "annotati
   return (
     <Link
       href={href}
-      className="block p-4 rounded-md border border-amber-200 bg-parchment hover:-translate-y-0.5 transition-all duration-200"
+      className="block p-4 rounded-md border border-amber-200 bg-parchment hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 transition-all duration-200"
       style={{ boxShadow: "var(--shadow-card)" }}
     >
       <div className="flex items-baseline justify-between gap-2 mb-1">
@@ -45,7 +45,7 @@ function VocabularyCard({ r }: { r: Extract<InAppSearchResult, { type: "vocabula
   return (
     <Link
       href={href}
-      className="block p-4 rounded-md border border-amber-200 bg-parchment hover:-translate-y-0.5 transition-all duration-200"
+      className="block p-4 rounded-md border border-amber-200 bg-parchment hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 transition-all duration-200"
       style={{ boxShadow: "var(--shadow-card)" }}
     >
       <div className="flex items-baseline justify-between gap-2 mb-1">
@@ -63,7 +63,7 @@ function ChapterCard({ r }: { r: Extract<InAppSearchResult, { type: "chapter" }>
   return (
     <Link
       href={href}
-      className="block p-4 rounded-md border border-amber-200 bg-parchment hover:-translate-y-0.5 transition-all duration-200"
+      className="block p-4 rounded-md border border-amber-200 bg-parchment hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 transition-all duration-200"
       style={{ boxShadow: "var(--shadow-card)" }}
     >
       <div className="flex items-baseline justify-between gap-2 mb-1">
@@ -136,16 +136,32 @@ function SearchResultsInner() {
   }
 
   if (loading) {
-    return <div className="text-sm text-stone-500 py-8">Searching…</div>;
+    return (
+      <div role="status" aria-label="Searching" className="space-y-3 animate-pulse py-2">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-20 bg-amber-100 rounded-md" />
+        ))}
+      </div>
+    );
   }
   if (error) {
-    return <div className="text-sm text-red-700 py-8">Error: {error}</div>;
+    return (
+      <div role="alert" className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
+        Error: {error}
+      </div>
+    );
   }
   if (!data || data.total === 0) {
     return (
       <div className="text-center text-stone-500 py-12">
-        <p className="font-serif text-lg text-ink">No matches for “{q}”.</p>
+        <p className="font-serif text-lg text-ink">No matches for &ldquo;{q}&rdquo;.</p>
         <p className="text-sm mt-2">Try a shorter or different word.</p>
+        <Link
+          href="/"
+          className="mt-5 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px]"
+        >
+          Browse books <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
+        </Link>
       </div>
     );
   }
@@ -166,8 +182,22 @@ function SearchResultsInner() {
 export default function SearchPage() {
   return (
     <main className="max-w-3xl mx-auto p-4 md:p-8">
-      <h1 className="font-serif text-2xl text-ink mb-6">Search</h1>
-      <Suspense fallback={<div className="text-sm text-stone-500 py-8">Loading…</div>}>
+      <div className="flex items-center gap-4 mb-6">
+        <Link
+          href="/"
+          className="text-amber-700 hover:text-amber-900 text-sm font-medium shrink-0 min-h-[44px] flex items-center"
+        >
+          <ArrowLeftIcon className="w-3.5 h-3.5 mr-1 inline" aria-hidden="true" />Library
+        </Link>
+        <h1 className="font-serif text-2xl text-ink">Search</h1>
+      </div>
+      <Suspense fallback={
+        <div role="status" aria-label="Loading search" className="space-y-3 animate-pulse py-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-20 bg-amber-100 rounded-md" />
+          ))}
+        </div>
+      }>
         <SearchResultsInner />
       </Suspense>
     </main>


### PR DESCRIPTION
Closes #1150

The in-app search page (`/search`) was a UX outlier — bare h1, plain-text loading/error states, no back button, no empty-state CTA, hover-translate result cards without focus-visible. This brings it in line with notes, vocabulary, decks, and reader pages.

## Changes (`app/search/page.tsx`)
- **Header**: added `<ArrowLeftIcon /> Library` back-link mirroring notes/vocabulary headers
- **Loading state**: plain text → 3-row skeleton with `role="status" aria-label="Searching"`
- **Error state**: plain text → red-50/red-200 styled block with `role="alert"`
- **No-results state**: added "Browse books" CTA `<Link href="/">` matching #1090's empty-state pattern
- **Suspense fallback**: plain text → matching skeleton
- **Result cards (Annotation/Vocabulary/Chapter)**: added `focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1` matching #1143/#1145
- `SearchPageUx.test.ts`: 5 static assertions

## WCAG
- 4.1.3 Status Messages (loading + error)
- 2.4.7 Focus Visible (result cards)

## Test plan
- [x] `SearchPageUx.test.ts` — 5 passing
- [x] Full frontend suite — 2135/2135 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
