### PR TITLE
ux: add role=alert to import + chapters page error states (closes #1155)

### DIFF
--- a/frontend/src/__tests__/ImportChaptersRoleAlert.test.ts
+++ b/frontend/src/__tests__/ImportChaptersRoleAlert.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Static assertions: import + chapters error states have role=alert.
+ * Closes #1155
+ */
+import fs from "fs";
+import path from "path";
+
+const importPage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/import/[bookId]/page.tsx"),
+  "utf8",
+);
+const chaptersPage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/upload/[bookId]/chapters/page.tsx"),
+  "utf8",
+);
+
+describe("Import + chapters error states", () => {
+  it("import translateError block has role=alert", () => {
+    const idx = importPage.indexOf("{translateError &&");
+    expect(idx).toBeGreaterThan(0);
+    const block = importPage.slice(idx, idx + 500);
+    expect(block).toContain('role="alert"');
+  });
+
+  it("import error block has role=alert", () => {
+    // The 'error' state block (different from translateError)
+    const idx = importPage.indexOf("bg-red-50 border border-red-200 text-red-700 rounded-lg");
+    expect(idx).toBeGreaterThan(0);
+    const block = importPage.slice(Math.max(0, idx - 300), idx + 100);
+    expect(block).toContain('role="alert"');
+  });
+
+  it("chapters Could-not-load block has role=alert", () => {
+    const idx = chaptersPage.indexOf("Could not load chapters");
+    expect(idx).toBeGreaterThan(0);
+    const block = chaptersPage.slice(Math.max(0, idx - 300), idx + 100);
+    expect(block).toContain('role="alert"');
+  });
+
+  it("chapters in-page error banner has role=alert", () => {
+    const idx = chaptersPage.indexOf("rounded-lg border border-red-200 bg-red-50");
+    expect(idx).toBeGreaterThan(0);
+    // role=alert is on the same div, just before className
+    const block = chaptersPage.slice(Math.max(0, idx - 200), idx + 200);
+    expect(block).toContain('role="alert"');
+  });
+});

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -370,7 +370,7 @@ export default function BookImportPage() {
               </div>
 
               {translateError && (
-                <p className="text-xs text-red-600 mb-2">{translateError}</p>
+                <p role="alert" className="text-xs text-red-700 bg-red-50 border border-red-200 rounded-lg px-3 py-2 mb-2">{translateError}</p>
               )}
 
               <div className="flex gap-2">
@@ -416,7 +416,7 @@ export default function BookImportPage() {
           )}
 
           {error && (
-            <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-3 py-2 text-sm mb-4">
+            <div role="alert" className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-3 py-2 text-sm mb-4">
               {error}
             </div>
           )}

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -78,7 +78,7 @@ export default function ChapterEditorPage() {
   if (error && chapters.length === 0) {
     return (
       <main className="min-h-screen bg-parchment flex items-center justify-center px-4">
-        <div className="text-center max-w-sm">
+        <div role="alert" className="text-center max-w-sm">
           <p className="font-serif text-lg text-ink mb-2">Could not load chapters</p>
           <p className="text-sm text-red-600 mb-6">{error}</p>
           <button
@@ -126,7 +126,7 @@ export default function ChapterEditorPage() {
 
       {error && (
         <div className="max-w-5xl mx-auto w-full px-4 md:px-6 pt-4">
-          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          <div role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
             {error}
           </div>
         </div>


### PR DESCRIPTION
Closes #1155

Follow-up to #1112. Four more error states across the import + chapters wizard lacked `role="alert"`. When a translation enqueue fails, an import fails mid-stage, or chapter loading/confirm fails, screen-reader users were not announced.

## Changes
- `app/import/[bookId]/page.tsx`:
  - `translateError` block (line ~372): bare `<p>` upgraded to styled red-50/red-200 block with `role="alert"`
  - `error` block (line ~418): added `role="alert"` (already styled)
- `app/upload/[bookId]/chapters/page.tsx`:
  - "Could not load chapters" full-page error (line ~78): wrapping `<div>` gets `role="alert"`
  - In-page error banner (line ~127): added `role="alert"`
- `ImportChaptersRoleAlert.test.ts`: 4 static assertions

## WCAG
- 4.1.3 Status Messages

## Test plan
- [x] `ImportChaptersRoleAlert.test.ts` — 4 passing
- [x] Full frontend suite — 2134/2134 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
