### PR TITLE
ux: convert home page section labels from <p> to <h2> for heading nav (closes #1158)

### DIFF
--- a/frontend/src/__tests__/HomeHeadingHierarchy.test.ts
+++ b/frontend/src/__tests__/HomeHeadingHierarchy.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Static assertion: home page section labels use <h2> instead of <p>.
+ * Closes #1158
+ */
+import fs from "fs";
+import path from "path";
+
+const homePage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/page.tsx"),
+  "utf8",
+);
+
+describe("Home page heading hierarchy", () => {
+  it('uses <h2> for "Continue Reading" section label', () => {
+    expect(homePage).toMatch(/<h2[^>]*>\s*Continue Reading/);
+  });
+
+  it('uses <h2> for "Your Progress" section label', () => {
+    expect(homePage).toMatch(/<h2[^>]*>\s*Your Progress/);
+  });
+
+  it('uses <h2> for "Your Library" section label', () => {
+    expect(homePage).toMatch(/<h2[^>]*>\s*Your Library/);
+  });
+
+  it("does not use <p> for any of the three section labels", () => {
+    expect(homePage).not.toMatch(/<p[^>]*>\s*Continue Reading/);
+    expect(homePage).not.toMatch(/<p[^>]*>\s*Your Progress/);
+    expect(homePage).not.toMatch(/<p[^>]*>\s*Your Library/);
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -282,9 +282,9 @@ export default function Home() {
             {/* Continue Reading */}
             {recentBooks.length > 0 && (
               <section>
-                <p className="text-xs font-semibold uppercase tracking-widest text-stone-400 mb-2">
+                <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-400 mb-2">
                   Continue Reading
-                </p>
+                </h2>
                 <button
                   aria-label="Continue reading"
                   onClick={() => router.push(`/reader/${recentBooks[0].id}`)}
@@ -319,9 +319,9 @@ export default function Home() {
             {status === "authenticated" && userStats && (
               <section>
                 <div className="flex items-center gap-2 mb-3">
-                  <p className="text-xs font-semibold uppercase tracking-widest text-stone-400 flex-1">
+                  <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-400 flex-1">
                     Your Progress
-                  </p>
+                  </h2>
                   <button
                     onClick={() => setStatsExpanded((v) => !v)}
                     className="text-xs text-amber-600 hover:text-amber-800 transition-colors min-h-[44px] px-2 flex items-center"
@@ -376,9 +376,9 @@ export default function Home() {
             {recentBooks.length > 0 ? (
               <section>
                 {recentBooks.length > 1 && (
-                  <p className="text-xs font-semibold uppercase tracking-widest text-stone-400 mb-3">
+                  <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-400 mb-3">
                     Your Library
-                  </p>
+                  </h2>
                 )}
                 <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
                   {recentBooks.map((book) => (


### PR DESCRIPTION
Closes #1158

Three section labels on the home page were styled-as-headings but rendered as `<p>` elements. Screen-reader users who navigate by heading hierarchy (a primary AT navigation method) skipped these sections entirely.

## Changes (`app/page.tsx`)
- Line 285: `<p>Continue Reading</p>` → `<h2>Continue Reading</h2>`
- Line 322: `<p>Your Progress</p>` → `<h2>Your Progress</h2>`
- Line 379: `<p>Your Library</p>` → `<h2>Your Library</h2>`

Visual styling preserved (Tailwind classes are tag-agnostic).
- `HomeHeadingHierarchy.test.ts`: 4 static assertions (3 positive on h2, 1 negative on p)

## WCAG
- 1.3.1 Info and Relationships (heading hierarchy reflects document structure)
- 2.4.6 Headings and Labels

## Test plan
- [x] `HomeHeadingHierarchy.test.ts` — 4 passing
- [x] Full frontend suite — 2139/2139 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
