### PR TITLE
fix: strip leading chapter-title headings at any depth in EPUB body (closes #1157)

### DIFF
--- a/backend/services/splitter.py
+++ b/backend/services/splitter.py
@@ -811,13 +811,48 @@ def _extract_and_clean_chapter_text(body, title: str, book_title: str) -> str:
     heading if it repeats as body prose, strip the book title prefix if it
     leaks in, and split dramatic speaker cues.
     """
-    text = _html_body_text(body, skip_first_heading=True)
+    # Drop leading chapter-title heading(s) at any depth before extracting
+    # text. _html_body_text's skip_first_heading only handles direct children
+    # of body, so a heading wrapped in <div class="chapter">…</div> would
+    # otherwise leak into the body and shift the paragraph index — breaking
+    # translation alignment (#1157).
+    _strip_leading_headings(body)
+    text = _html_body_text(body, skip_first_heading=False)
     if not text.strip():
         return ""
     text = _strip_title_from_body_prefix(text, title)
     text = _strip_title_from_body_prefix(text, book_title)
     text = _split_dramatic_speakers(text)
     return text
+
+
+def _strip_leading_headings(body) -> None:
+    """Remove h1/h2/h3 elements that appear in document order BEFORE the
+    first paragraph-class block. Mutates `body` in place.
+
+    This catches:
+      • a single chapter heading wrapped in any depth of <div>s
+      • multi-line chapter headings split across <h2>+<h3> (book number +
+        chapter name)
+
+    Stops at the first <p>/<blockquote>/<pre> so mid-chapter section
+    headings inside the body are preserved.
+    """
+    HEADING = {"h1", "h2", "h3"}
+    REAL_BODY_BLOCK = {"p", "blockquote", "pre"}
+
+    headings_to_remove: list = []
+    for elem in body.iter():
+        tag = elem.tag if isinstance(elem.tag, str) else ""
+        if tag in HEADING:
+            headings_to_remove.append(elem)
+        elif tag in REAL_BODY_BLOCK:
+            break
+
+    for heading in headings_to_remove:
+        parent = heading.getparent()
+        if parent is not None:
+            parent.remove(heading)
 
 
 def _epub_nav_titles(book) -> dict[str, str]:

--- a/backend/tests/test_splitter.py
+++ b/backend/tests/test_splitter.py
@@ -2170,3 +2170,93 @@ def test_build_chapters_from_epub_ncx_fragment_anchors_real_file_62215():
     assert len(chapters) >= 20, (
         f"Expected ≥20 chapters from #62215 after fragment-anchor split, got {len(chapters)}"
     )
+
+
+# ── Issue #1157: chapter title must not leak into chapter body ──────────────
+
+
+def _make_epub_with_chapters(book_title: str, items: list[tuple[str, str, str]]) -> bytes:
+    """Helper: build an in-memory EPUB. items = [(ncx_title, file_basename, html_body)]."""
+    import io
+    from ebooklib import epub
+
+    epub_book = epub.EpubBook()
+    epub_book.set_title(book_title)
+    epub_book.set_language("en")
+    epub_book.add_author("Test Author")
+
+    spine: list = ["nav"]
+    toc: list = []
+    for ncx_title, basename, body_html in items:
+        item = epub.EpubHtml(title=ncx_title, file_name=basename, lang="en")
+        item.content = (
+            f'<?xml version="1.0" encoding="utf-8"?>'
+            f'<html xmlns="http://www.w3.org/1999/xhtml">'
+            f'<head><title>{ncx_title}</title></head>'
+            f'<body>{body_html}</body></html>'
+        ).encode("utf-8")
+        epub_book.add_item(item)
+        spine.append(item)
+        toc.append(epub.Link(basename, ncx_title, basename.split(".")[0]))
+
+    epub_book.toc = toc
+    epub_book.add_item(epub.EpubNcx())
+    epub_book.add_item(epub.EpubNav())
+    epub_book.spine = spine
+
+    buf = io.BytesIO()
+    epub.write_epub(buf, epub_book)
+    return buf.getvalue()
+
+
+def test_build_chapters_from_epub_strips_heading_nested_in_wrapper_div():
+    """Regression #1157: when the chapter heading is wrapped in a <div>
+    (depth-2 in body), skip_first_heading must still drop it. Common in
+    Gutenberg EPUBs that use <div class="chapter"> / <div class="section">."""
+    body_a = (
+        '<div class="section">'
+        '<h1>Chapter I — The Beginning</h1>'
+        '<p>It was a dark and stormy night that began the long story to come for our weary travellers and their loyal hounds.</p>'
+        '<p>The wind howled through the trees and the leaves rustled in the night air as the moon shone down on the silent road.</p>'
+        '</div>'
+    )
+    data = _make_epub_with_chapters("Big Book", [("I", "ch1.xhtml", body_a)])
+    chapters = build_chapters_from_epub(data)
+    assert len(chapters) == 1, f"Expected 1 chapter, got {len(chapters)}"
+    body = chapters[0].text
+    assert "Chapter I — The Beginning" not in body, (
+        f"Heading text leaked into body verbatim: {body[:200]!r}"
+    )
+    assert body.lstrip().startswith("It was a dark"), (
+        f"Body should start with the actual prose, got: {body[:100]!r}"
+    )
+
+
+def test_build_chapters_from_epub_strips_heading_when_ncx_title_is_substring():
+    """Regression #1157: NCX title 'Chapter 1: The Awakening' vs body
+    rendering '<h2>Chapter 1</h2><h3>The Awakening</h3>'. The two halves of
+    the heading must both be stripped, not exact-matched."""
+    body_a = (
+        '<div>'
+        '<h2>Chapter 1</h2>'
+        '<h3>The Awakening</h3>'
+        '<p>It was a dark and stormy night and the storm raged through the long valley below the cliffs.</p>'
+        '<p>The wind howled through the trees and the leaves rustled in the night air as the storm passed over.</p>'
+        '</div>'
+    )
+    data = _make_epub_with_chapters(
+        "Big Book", [("Chapter 1: The Awakening", "ch1.xhtml", body_a)]
+    )
+    chapters = build_chapters_from_epub(data)
+    assert len(chapters) == 1, f"Expected 1 chapter, got {len(chapters)}"
+    body = chapters[0].text
+    first_para = body.split("\n\n")[0] if body else ""
+    assert first_para.strip() != "Chapter 1", (
+        f"First paragraph is the chapter-number heading: {body[:200]!r}"
+    )
+    assert first_para.strip() != "The Awakening", (
+        f"First paragraph is the chapter-name heading: {body[:200]!r}"
+    )
+    assert body.lstrip().startswith("It was a dark"), (
+        f"Body should start with the actual prose, got: {body[:120]!r}"
+    )


### PR DESCRIPTION
## What changed

`build_chapters_from_epub` now strips leading chapter-title headings at any depth in the chapter body, not just direct children. Previously `_html_body_text(body, skip_first_heading=True)` only checked depth-1 children, so any EPUB that wrapped its heading inside `<div class="chapter">` (very common — modern Gutenberg, Kafka, plus most non-Gutenberg EPUBs) leaked the chapter title into the chapter body.

New helper `_strip_leading_headings(body)` walks the etree in document order and removes every `h1/h2/h3` that appears **before** the first `<p>/<blockquote>/<pre>`. Stops at the first paragraph-class block, so mid-chapter section headings are preserved.

This also handles multi-line chapter titles split across `<h2>chapter number</h2>` + `<h3>chapter name</h3>` — both pieces are stripped because both come before any paragraph.

## Why

User-reported bug. When the title leaks into the body:
1. Reader UI renders the title twice (chapter header + first paragraph)
2. **Translation alignment shifts permanently** — paragraph 0 of the source is no longer paragraph 0 in the cached translation, so cross-language paragraph-by-paragraph display goes off-by-one or worse
3. Annotations / vocabulary saved with `chapter_index + sentence_text` lose their referent when the body shifts

This affected every EPUB whose heading was wrapped in any depth of div, plus every EPUB whose NCX title differed from its `<h*>` rendering (substring match — the existing `_strip_title_from_body_prefix` is exact-match only).

## Test plan

Two new regression tests in `test_splitter.py`:
- `test_build_chapters_from_epub_strips_heading_nested_in_wrapper_div` — single `<h1>` inside `<div class="section">`, NCX title is just "I"
- `test_build_chapters_from_epub_strips_heading_when_ncx_title_is_substring` — `<h2>Chapter 1</h2><h3>The Awakening</h3>` with NCX title "Chapter 1: The Awakening"

Both fail before the fix.

Full splitter suite: 117/117 pass.
Full backend suite: 1585/1585 pass.

## Related

Companion concern (separate fix): when a Gutenberg book is freshly added, the text-based chapter list is used until the EPUB lands in DB (background task). On the next process restart the EPUB-based split takes over — chapter indices can shift, breaking annotations / cached translations made before restart. This is a separate alignment race; tracking for a follow-up.

[ ] Docs updated (if applicable)
