### PR TITLE
fix: await EPUB fetch synchronously in _fetch_and_cache (closes #1161)

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -517,8 +517,14 @@ async def _fetch_and_cache(book_id: int) -> tuple[dict, str]:
     meta = await get_book_meta(book_id)
     text = await get_book_text(book_id)
     await save_book(book_id, meta, text)
-    # Fetch EPUB in background so book-add stays snappy.
-    asyncio.create_task(_fetch_and_store_epub(book_id))
+    # Fetch the EPUB synchronously so the very first /chapters request
+    # uses the EPUB-based split — otherwise it falls back to text-based,
+    # and the next process restart switches to EPUB-based, shifting
+    # chapter indices and breaking translations / annotations made
+    # before restart (#1161). _fetch_and_store_epub already swallows
+    # exceptions (logs at DEBUG), so a missing-EPUB book continues to
+    # work via text-based split forever — consistently.
+    await _fetch_and_store_epub(book_id)
     return meta, text
 
 

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -1341,3 +1341,77 @@ async def test_book_chapters_404_logs_warning_on_exception(client, caplog):
         "99999" in r.message or "chapter" in r.message.lower() or "fetch" in r.message.lower()
         for r in caplog.records
     ), f"Expected a WARNING log for failed chapters fetch, got: {[r.message for r in caplog.records]}"
+
+
+# ── Issue #1161: synchronous EPUB fetch on first book add ───────────────────
+
+
+async def test_fetch_and_cache_awaits_epub_fetch_before_returning(client):
+    """Regression #1161: _fetch_and_cache must await the EPUB fetch
+    synchronously, not fire it as a background task. Otherwise the first
+    chapters request falls back to text-based split, then the next process
+    restart switches to EPUB-based — chapter indices shift and break
+    cached translations / annotations made before restart."""
+    fake_meta = {
+        "id": 99001,
+        "title": "T",
+        "authors": ["A"],
+        "languages": ["en"],
+        "subjects": [],
+        "download_count": 1,
+        "cover": "",
+    }
+    fake_text = "Chapter 1\n\nSome content."
+    fake_epub_bytes = b"PK\x03\x04fake_epub_data"
+
+    save_calls: list[str] = []
+
+    async def fake_save_book_epub(book_id, epub_bytes, epub_url):
+        save_calls.append("epub")
+
+    async def fake_save_book(book_id, meta, text, *args, **kwargs):
+        save_calls.append("book")
+
+    with (
+        patch("routers.books.get_book_meta", new_callable=AsyncMock, return_value=fake_meta),
+        patch("routers.books.get_book_text", new_callable=AsyncMock, return_value=fake_text),
+        patch("routers.books.get_book_epub", new_callable=AsyncMock,
+              return_value=(fake_epub_bytes, "http://example.com/book.epub")),
+        patch("routers.books.save_book", side_effect=fake_save_book),
+        patch("routers.books.save_book_epub", side_effect=fake_save_book_epub),
+    ):
+        from routers.books import _fetch_and_cache
+        await _fetch_and_cache(99001)
+
+    # Both saves must have completed before _fetch_and_cache returned.
+    # Without the fix, save_book_epub fires in a background task and may
+    # not have run yet, so split_with_html_preference falls back to text.
+    assert "book" in save_calls, f"save_book never called: {save_calls}"
+    assert "epub" in save_calls, (
+        f"save_book_epub did not run synchronously — chapters request "
+        f"would fall back to text-based split. Calls: {save_calls}"
+    )
+
+
+async def test_fetch_and_cache_continues_when_epub_fetch_fails(client):
+    """Regression #1161: when the EPUB doesn't exist on Gutenberg
+    (or fetch fails), _fetch_and_cache must still return text + meta
+    successfully — book-add does not depend on EPUB availability."""
+    fake_meta = {"id": 99002, "title": "T", "authors": ["A"], "languages": ["en"],
+                 "subjects": [], "download_count": 1, "cover": ""}
+    fake_text = "Chapter 1\n\nSome content."
+
+    async def fake_save_book(*args, **kwargs):
+        pass
+
+    with (
+        patch("routers.books.get_book_meta", new_callable=AsyncMock, return_value=fake_meta),
+        patch("routers.books.get_book_text", new_callable=AsyncMock, return_value=fake_text),
+        patch("routers.books.get_book_epub", new_callable=AsyncMock,
+              side_effect=RuntimeError("Gutenberg has no EPUB for this book")),
+        patch("routers.books.save_book", side_effect=fake_save_book),
+    ):
+        from routers.books import _fetch_and_cache
+        meta, text = await _fetch_and_cache(99002)
+    assert meta == fake_meta
+    assert text == fake_text


### PR DESCRIPTION
## What changed

`_fetch_and_cache` previously fired `_fetch_and_store_epub` as a background task with `asyncio.create_task`. The first `/chapters` request for the new book then ran while the EPUB fetch was still in flight, saw no stored EPUB, and fell back to the **text-based regex split** — which got cached for the process lifetime.

On the next process restart the EPUB was now in the DB, so `split_with_html_preference` switched to the **EPUB-based split**. Different chapter boundaries → different paragraph counts → cached translations and saved annotations pointed at the wrong chapters.

Switch to a synchronous `await`:
```python
async def _fetch_and_cache(book_id: int) -> tuple[dict, str]:
    meta = await get_book_meta(book_id)
    text = await get_book_text(book_id)
    await save_book(book_id, meta, text)
    await _fetch_and_store_epub(book_id)  # was: asyncio.create_task(...)
    return meta, text
```

## Why

User-reported bug. Chapter indices have to be stable across restarts; otherwise every translation cached today might point at a different chapter tomorrow. `_fetch_and_store_epub` already catches all exceptions (logs at DEBUG), so books without a Gutenberg EPUB still succeed — they just stay text-based forever, which is exactly what we want for stability.

Tradeoff: book-add latency goes up by one Gutenberg HTTP fetch (typically 1-3s). Worth it.

## Test plan

Two new regression tests in `test_router_books.py`:
- `test_fetch_and_cache_awaits_epub_fetch_before_returning` — patches `get_book_epub`/`save_book_epub` and verifies `save_book_epub` was called **before** `_fetch_and_cache` returned. Fails before the fix.
- `test_fetch_and_cache_continues_when_epub_fetch_fails` — patches `get_book_epub` to raise, verifies `_fetch_and_cache` still returns text + meta successfully.

Full backend suite: 1585 → 1587 passing.

## Companion

PR #1160 (already merged, closes #1157) — strips the chapter title from EPUB body. Both fixes need to be in place for translation alignment to be reliable.

[ ] Docs updated (if applicable)
