### PR TITLE
ux: convert profile page section group labels from <p> to <h2> (closes #1162)

### DIFF
--- a/frontend/src/__tests__/ProfileHeadingHierarchy.test.ts
+++ b/frontend/src/__tests__/ProfileHeadingHierarchy.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Static assertion: profile page section group labels use <h2>.
+ * Closes #1162
+ */
+import fs from "fs";
+import path from "path";
+
+const page = fs.readFileSync(
+  path.join(process.cwd(), "src/app/profile/page.tsx"),
+  "utf8",
+);
+
+describe("Profile page section group labels", () => {
+  it('uses <h2> for "AI & Integrations" group label', () => {
+    expect(page).toMatch(/<h2[^>]*>AI &amp; Integrations<\/h2>/);
+  });
+
+  it('uses <h2> for "Reader Preferences" group label', () => {
+    expect(page).toMatch(/<h2[^>]*>Reader Preferences<\/h2>/);
+  });
+
+  it("does not use <p> for these group labels", () => {
+    expect(page).not.toMatch(/<p[^>]*>AI &amp; Integrations<\/p>/);
+    expect(page).not.toMatch(/<p[^>]*>Reader Preferences<\/p>/);
+  });
+});

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -205,7 +205,7 @@ export default function ProfilePage() {
         </section>
 
         {/* Section label */}
-        <p className="text-xs font-semibold uppercase tracking-widest text-stone-400 px-1">AI &amp; Integrations</p>
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-400 px-1">AI &amp; Integrations</h2>
 
         {/* ── Gemini API key ──────────────────────────────────────────────── */}
         <section className="bg-white rounded-2xl border border-amber-100 p-6">
@@ -373,7 +373,7 @@ export default function ProfilePage() {
         </section>
 
         {/* Section label */}
-        <p className="text-xs font-semibold uppercase tracking-widest text-stone-400 px-1">Reader Preferences</p>
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-400 px-1">Reader Preferences</h2>
 
         {/* ── Preferences ─────────────────────────────────────────────────── */}
         <section className="bg-white rounded-2xl border border-amber-100 p-6 space-y-6">


### PR DESCRIPTION
Closes #1162

Follow-up to #1158 (home page heading hierarchy). Two section group labels on the profile page were `<p>` elements where they should be `<h2>` for screen-reader heading navigation.

## Changes (`app/profile/page.tsx`)
- Line 208: `<p>AI & Integrations</p>` → `<h2>AI & Integrations</h2>`
- Line 376: `<p>Reader Preferences</p>` → `<h2>Reader Preferences</h2>`

Visual styling preserved (Tailwind classes are tag-agnostic).
- `ProfileHeadingHierarchy.test.ts`: 3 static assertions

## WCAG
- 1.3.1 Info and Relationships
- 2.4.6 Headings and Labels

## Test plan
- [x] `ProfileHeadingHierarchy.test.ts` — 3 passing
- [x] Full frontend suite — 2146/2146 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
