### PR TITLE
ux: convert upload + chapters page section labels from <p> to <h2> (closes #1165)

### DIFF
--- a/frontend/src/__tests__/UploadChaptersHeading.test.ts
+++ b/frontend/src/__tests__/UploadChaptersHeading.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Static assertion: upload + chapters page section labels use <h2>.
+ * Closes #1165
+ */
+import fs from "fs";
+import path from "path";
+
+const uploadPage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/upload/page.tsx"),
+  "utf8",
+);
+const chaptersPage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/upload/[bookId]/chapters/page.tsx"),
+  "utf8",
+);
+
+describe("Upload + chapters section heading hierarchy", () => {
+  it('upload page uses <h2> for "Tips" label', () => {
+    expect(uploadPage).toMatch(/<h2[^>]*>Tips<\/h2>/);
+    expect(uploadPage).not.toMatch(/<p[^>]*>Tips<\/p>/);
+  });
+
+  it('chapters page uses <h2> for "Preview" label', () => {
+    expect(chaptersPage).toMatch(/<h2[^>]*>Preview<\/h2>/);
+    expect(chaptersPage).not.toMatch(/<p[^>]*>Preview<\/p>/);
+  });
+});

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -187,7 +187,7 @@ export default function ChapterEditorPage() {
         <div className="bg-white rounded-xl border border-amber-100 p-5 overflow-y-auto">
           {selectedChapter ? (
             <>
-              <p className="text-xs font-semibold uppercase tracking-widest text-stone-400 mb-3">Preview</p>
+              <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-400 mb-3">Preview</h2>
               <p className="font-serif font-semibold text-ink mb-3">{selectedChapter.title}</p>
               <p className="text-sm text-stone-600 leading-relaxed whitespace-pre-wrap font-serif">
                 {selectedChapter.preview}

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -179,7 +179,7 @@ export default function UploadPage() {
 
         {/* Format hints */}
         <div className="rounded-xl border border-amber-100 bg-white/60 p-4 space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-widest text-stone-400">Tips</p>
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-400">Tips</h2>
           <ul className="text-sm text-amber-800 space-y-1 list-disc list-inside">
             <li>Plain text (.txt) files work best when chapters start with &quot;Chapter I&quot;, &quot;CHAPTER 1&quot;, etc.</li>
             <li>EPUB files are parsed automatically using the book&apos;s built-in structure.</li>


### PR DESCRIPTION
Closes #1165

Follow-up to #1158/#1162. Two more `<p>` section labels in the upload flow.

## Changes
- `app/upload/page.tsx` line 182: `<p>Tips</p>` → `<h2>Tips</h2>`
- `app/upload/[bookId]/chapters/page.tsx` line 190: `<p>Preview</p>` → `<h2>Preview</h2>`

Visual styling preserved.
- `UploadChaptersHeading.test.ts`: 2 static assertions

## WCAG
- 1.3.1 Info and Relationships
- 2.4.6 Headings and Labels

## Test plan
- [x] `UploadChaptersHeading.test.ts` — 2 passing
- [x] Full frontend suite — 2145/2145 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
