### PR TITLE
ux: add themed app/not-found.tsx for typo'd URLs (closes #1167)

### DIFF
--- a/frontend/src/__tests__/NotFoundPage.test.ts
+++ b/frontend/src/__tests__/NotFoundPage.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Static assertions: app/not-found.tsx renders themed 404 with CTA to library.
+ * Closes #1167
+ */
+import fs from "fs";
+import path from "path";
+
+const notFoundPath = path.join(process.cwd(), "src/app/not-found.tsx");
+
+describe("Custom 404 page", () => {
+  it("file exists at app/not-found.tsx", () => {
+    expect(fs.existsSync(notFoundPath)).toBe(true);
+  });
+
+  it("uses bg-parchment for theme consistency", () => {
+    const src = fs.readFileSync(notFoundPath, "utf8");
+    expect(src).toContain("bg-parchment");
+  });
+
+  it("has Page not found heading", () => {
+    const src = fs.readFileSync(notFoundPath, "utf8");
+    expect(src).toMatch(/<h1[^>]*>\s*Page not found/);
+  });
+
+  it("links back to library", () => {
+    const src = fs.readFileSync(notFoundPath, "utf8");
+    expect(src).toMatch(/href="\/"/);
+    expect(src).toMatch(/Browse books|Back to library|Library/);
+  });
+});

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import { BookOpenIcon, ArrowRightIcon } from "@/components/Icons";
+
+export default function NotFound() {
+  return (
+    <main className="min-h-screen bg-parchment flex items-center justify-center px-4">
+      <div className="text-center max-w-sm">
+        <BookOpenIcon className="w-14 h-14 mx-auto mb-4 text-amber-300" aria-hidden="true" />
+        <h1 className="font-serif text-2xl font-bold text-ink mb-2">Page not found</h1>
+        <p className="text-sm text-stone-500 mb-6">
+          The page you&rsquo;re looking for doesn&rsquo;t exist or has been moved.
+        </p>
+        <Link
+          href="/"
+          className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px]"
+        >
+          Browse books <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
+        </Link>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
Closes #1167

The app had no `app/not-found.tsx`. Users hitting a typo'd URL or stale link saw Next.js's default unstyled 404 — a jarring break from the parchment/amber theme.

## Changes
- New `app/not-found.tsx`:
  - Centered card on `bg-parchment`
  - `BookOpenIcon` (decorative, `aria-hidden="true"`)
  - `<h1>Page not found</h1>` (`font-serif`)
  - Sub-text explanation
  - "Browse books" CTA `<Link href="/">` matching #1090's empty-state pattern
- `NotFoundPage.test.ts`: 4 static assertions

## Test plan
- [x] `NotFoundPage.test.ts` — 4 passing
- [x] Full frontend suite — 2152/2152 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
