### PR TITLE
ux: add themed app/loading.tsx for route navigation (closes #1171)

### DIFF
--- a/frontend/src/__tests__/LoadingPage.test.ts
+++ b/frontend/src/__tests__/LoadingPage.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Static assertion: app/loading.tsx renders themed loading state.
+ * Closes #1171
+ */
+import fs from "fs";
+import path from "path";
+
+const loadingPath = path.join(process.cwd(), "src/app/loading.tsx");
+
+describe("Custom loading page", () => {
+  it("file exists at app/loading.tsx", () => {
+    expect(fs.existsSync(loadingPath)).toBe(true);
+  });
+
+  it("uses bg-parchment for theme consistency", () => {
+    const src = fs.readFileSync(loadingPath, "utf8");
+    expect(src).toContain("bg-parchment");
+  });
+
+  it("has role=status with aria-label", () => {
+    const src = fs.readFileSync(loadingPath, "utf8");
+    expect(src).toContain('role="status"');
+    expect(src).toMatch(/aria-label="Loading page"/);
+  });
+
+  it("uses an aria-hidden spinner (decorative)", () => {
+    const src = fs.readFileSync(loadingPath, "utf8");
+    expect(src).toContain('aria-hidden="true"');
+  });
+});

--- a/frontend/src/app/loading.tsx
+++ b/frontend/src/app/loading.tsx
@@ -1,0 +1,14 @@
+export default function Loading() {
+  return (
+    <div
+      role="status"
+      aria-label="Loading page"
+      className="min-h-screen bg-parchment flex items-center justify-center"
+    >
+      <span
+        className="w-8 h-8 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin"
+        aria-hidden="true"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #1171

Completes the trio with #1167 (404) and #1169 (error). The app had no `app/loading.tsx`, so users saw a blank screen during route navigation while async data was being fetched.

## Changes
- New `app/loading.tsx`:
  - `min-h-screen bg-parchment` matching the rest of the app
  - Centered amber spinner
  - `role="status" aria-label="Loading page"` so screen readers announce the loading state
  - Spinner span has `aria-hidden="true"` (decorative)
- `LoadingPage.test.ts`: 4 static assertions

This is a global default. Pages that already have their own loading state in subdirectories continue to work as-is.

## WCAG
- 4.1.3 Status Messages

## Test plan
- [x] `LoadingPage.test.ts` — 4 passing
- [x] Full frontend suite — 2163/2163 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
