### PR TITLE
ux: set per-page document.title for browser tabs across top-level pages (closes #1173)

### DIFF
--- a/frontend/src/__tests__/PageTitles.test.ts
+++ b/frontend/src/__tests__/PageTitles.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Static assertions: top-level pages set document.title for browser tabs.
+ * Closes #1173
+ */
+import fs from "fs";
+import path from "path";
+
+function readPage(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("Per-page document.title", () => {
+  it("notes overview sets a Notes title", () => {
+    const src = readPage("src/app/notes/page.tsx");
+    expect(src).toMatch(/document\.title\s*=\s*["'`]Notes.*Book Reader AI/);
+  });
+
+  it("vocabulary page sets a Vocabulary title", () => {
+    const src = readPage("src/app/vocabulary/page.tsx");
+    expect(src).toMatch(/document\.title\s*=\s*["'`]Vocabulary.*Book Reader AI/);
+  });
+
+  it("profile page sets a Profile title", () => {
+    const src = readPage("src/app/profile/page.tsx");
+    expect(src).toMatch(/document\.title\s*=\s*["'`]Profile.*Book Reader AI/);
+  });
+
+  it("decks page sets a Decks title", () => {
+    const src = readPage("src/app/decks/page.tsx");
+    expect(src).toMatch(/document\.title\s*=\s*["'`]Decks.*Book Reader AI/);
+  });
+
+  it("search page sets a Search title", () => {
+    const src = readPage("src/app/search/page.tsx");
+    // Search uses a conditional title to include the query — match either branch
+    expect(src).toMatch(/document\.title/);
+    expect(src).toMatch(/Search.*Book Reader AI/);
+  });
+});

--- a/frontend/src/app/decks/page.tsx
+++ b/frontend/src/app/decks/page.tsx
@@ -16,6 +16,10 @@ export default function DecksPage() {
   const [removedDeckToast, setRemovedDeckToast] = useState<DeckSummary | null>(null);
 
   useEffect(() => {
+    document.title = "Decks — Book Reader AI";
+  }, []);
+
+  useEffect(() => {
     let alive = true;
     listDecks()
       .then((d) => {

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -36,6 +36,10 @@ export default function NotesOverviewPage() {
   const [search, setSearch] = useState("");
 
   useEffect(() => {
+    document.title = "Notes — Book Reader AI";
+  }, []);
+
+  useEffect(() => {
     if (status === "unauthenticated") { router.replace("/login"); return; }
     if (status !== "authenticated") return;
     setFetchError(false);

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -55,6 +55,10 @@ export default function ProfilePage() {
   });
   const [prefsSaved, setPrefsSaved] = useState(false);
 
+  useEffect(() => {
+    document.title = "Profile — Book Reader AI";
+  }, []);
+
   // Fetch live key status from backend (session JWT can be stale after key changes)
   useEffect(() => {
     getMe().then((me) => {

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -107,6 +107,12 @@ function SearchResultsInner() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    document.title = q.trim()
+      ? `Search: ${q.trim()} — Book Reader AI`
+      : "Search — Book Reader AI";
+  }, [q]);
+
+  useEffect(() => {
     if (!q.trim()) {
       setData(null);
       setError(null);

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -229,6 +229,10 @@ function VocabularyPageContent() {
   const highlightRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    document.title = "Vocabulary — Book Reader AI";
+  }, []);
+
+  useEffect(() => {
     setFetchError(false);
     getVocabulary()
       .then(setWords)


### PR DESCRIPTION
Closes #1173

Every page in the app showed "Book Reader AI" as the browser tab title (set in the root `app/layout.tsx`). Users with multiple tabs open couldn't tell pages apart — Profile, Vocabulary, Notes, Decks, Search all read the same. WCAG 2.4.2 (Page Titled, Level A) requires unique descriptive titles per page.

Most pages are client components, so `export const metadata` (server-only) doesn't apply. Standard workaround: set `document.title` in a `useEffect`.

## Changes
- `app/notes/page.tsx`: "Notes — Book Reader AI"
- `app/vocabulary/page.tsx`: "Vocabulary — Book Reader AI"
- `app/profile/page.tsx`: "Profile — Book Reader AI"
- `app/decks/page.tsx`: "Decks — Book Reader AI"
- `app/search/page.tsx`: dynamic — `"Search: {query} — Book Reader AI"` when there's an active query, falls back to `"Search — Book Reader AI"`
- `PageTitles.test.ts`: 5 static assertions

## WCAG
- 2.4.2 Page Titled (Level A)

## Test plan
- [x] `PageTitles.test.ts` — 5 passing
- [x] Full frontend suite — 2164/2164 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
