### PR TITLE
ux: add OpenGraph and Twitter card metadata to layout (closes #1175)

### DIFF
--- a/frontend/src/__tests__/OpenGraphTags.test.ts
+++ b/frontend/src/__tests__/OpenGraphTags.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Static assertions: app/layout.tsx exports OpenGraph + Twitter card metadata.
+ * Closes #1175
+ */
+import fs from "fs";
+import path from "path";
+
+const layout = fs.readFileSync(
+  path.join(process.cwd(), "src/app/layout.tsx"),
+  "utf8",
+);
+
+describe("OpenGraph + Twitter metadata", () => {
+  it("metadata includes openGraph block", () => {
+    expect(layout).toMatch(/openGraph:\s*\{/);
+  });
+
+  it("openGraph references the icon image", () => {
+    const idx = layout.indexOf("openGraph");
+    expect(idx).toBeGreaterThan(0);
+    const block = layout.slice(idx, idx + 500);
+    expect(block).toContain("/icon.svg");
+  });
+
+  it("metadata includes twitter card block", () => {
+    expect(layout).toMatch(/twitter:\s*\{/);
+  });
+
+  it("twitter card uses summary", () => {
+    const idx = layout.indexOf("twitter:");
+    expect(idx).toBeGreaterThan(0);
+    const block = layout.slice(idx, idx + 500);
+    expect(block).toMatch(/card:\s*"summary"/);
+  });
+});

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -6,6 +6,18 @@ export const metadata: Metadata = {
   title: "Book Reader AI",
   description: "Read public domain classics with AI assistance",
   manifest: "/manifest.json",
+  openGraph: {
+    title: "Book Reader AI",
+    description: "Read public domain classics with AI assistance",
+    type: "website",
+    images: ["/icon.svg"],
+  },
+  twitter: {
+    card: "summary",
+    title: "Book Reader AI",
+    description: "Read public domain classics with AI assistance",
+    images: ["/icon.svg"],
+  },
 };
 
 export const viewport: Viewport = {


### PR DESCRIPTION
Closes #1175

`app/layout.tsx` declared only `title`, `description`, and `manifest`. Shared links (Slack, Discord, Twitter, Mastodon) had no preview image or rich title.

## Changes
- `app/layout.tsx`:
  - Added `openGraph` block (title, description, type=website, image=/icon.svg)
  - Added `twitter` block (card=summary, title, description, image=/icon.svg)
- `OpenGraphTags.test.ts`: 4 static assertions

Future enhancement: a richer 1200×630 OG image. Current /icon.svg works as a small social card.

## Test plan
- [x] `OpenGraphTags.test.ts` — 4 passing
- [x] Full frontend suite — 2172/2172 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
