### PR TITLE
ux: add themeColor to Viewport so mobile browser chrome matches app theme (closes #1177)

### DIFF
--- a/frontend/src/__tests__/ViewportThemeColor.test.ts
+++ b/frontend/src/__tests__/ViewportThemeColor.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Static assertion: app/layout.tsx Viewport sets themeColor matching manifest.
+ * Closes #1177
+ */
+import fs from "fs";
+import path from "path";
+
+const layout = fs.readFileSync(
+  path.join(process.cwd(), "src/app/layout.tsx"),
+  "utf8",
+);
+const manifest = JSON.parse(
+  fs.readFileSync(path.join(process.cwd(), "public/manifest.json"), "utf8"),
+);
+
+describe("Viewport themeColor", () => {
+  it("Viewport export includes themeColor", () => {
+    expect(layout).toMatch(/themeColor:/);
+  });
+
+  it("themeColor matches manifest theme_color", () => {
+    // Pull the value from the layout TS source
+    const match = layout.match(/themeColor:\s*"([^"]+)"/);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe(manifest.theme_color);
+  });
+});

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -24,6 +24,7 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
+  themeColor: "#F59E0B",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
Closes #1177

`app/layout.tsx` exports a `Viewport` config but did not set `themeColor`. On mobile (Chrome/Safari/etc.), the browser chrome (URL bar, status bar) was the OS default colour, breaking visual continuity with the parchment/amber theme.

The PWA `manifest.json` already declared `theme_color: "#F59E0B"`, but that only applies after install — not in regular browser tabs.

## Changes
- `app/layout.tsx`: added `themeColor: "#F59E0B"` to the `Viewport` export (matches manifest)
- `ViewportThemeColor.test.ts`: 2 static assertions, including a check that the layout value matches `manifest.json` so they can't drift

## Test plan
- [x] `ViewportThemeColor.test.ts` — 2 passing
- [x] Full frontend suite — 2170/2170 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
