### PR TITLE
ux: add skip-to-main-content link (WCAG 2.4.1 Level A) (closes #1179)

### DIFF
--- a/frontend/src/__tests__/SkipToContent.test.ts
+++ b/frontend/src/__tests__/SkipToContent.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Static assertions: skip-to-main-content link exists in layout and a few
+ * top-level pages add the matching anchor id.
+ * Closes #1179
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("Skip-to-main-content", () => {
+  it("layout includes a skip-to-content anchor", () => {
+    const src = read("src/app/layout.tsx");
+    expect(src).toMatch(/href="#main-content"/);
+    expect(src).toMatch(/Skip to main content/);
+  });
+
+  it("home page <main> has id=main-content", () => {
+    const src = read("src/app/page.tsx");
+    expect(src).toMatch(/<main[^>]*id="main-content"/);
+  });
+
+  it("notes page <main> has id=main-content", () => {
+    const src = read("src/app/notes/page.tsx");
+    expect(src).toMatch(/<main[^>]*id="main-content"/);
+  });
+
+  it("vocabulary page <main> has id=main-content", () => {
+    const src = read("src/app/vocabulary/page.tsx");
+    expect(src).toMatch(/<main[^>]*id="main-content"/);
+  });
+});

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -35,6 +35,12 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[1000] focus:bg-amber-700 focus:text-white focus:px-4 focus:py-2 focus:rounded-lg focus:shadow-xl focus:outline-none"
+        >
+          Skip to main content
+        </a>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -103,7 +103,7 @@ export default function NotesOverviewPage() {
   const totalVoc = new Set(vocab.map((v) => v.word)).size;
 
   return (
-    <main className="min-h-screen bg-parchment">
+    <main id="main-content" className="min-h-screen bg-parchment">
       <header className="border-b border-amber-200 bg-white/60 backdrop-blur px-4 md:px-6 py-3 md:py-4 sticky top-0 z-10">
         <div className="max-w-3xl mx-auto flex items-center gap-4">
           <button

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -163,7 +163,7 @@ export default function Home() {
   }
 
   return (
-    <main className="min-h-screen bg-parchment">
+    <main id="main-content" className="min-h-screen bg-parchment">
       {/* Header */}
       <header className="border-b border-amber-200 bg-white/60 backdrop-blur px-4 md:px-6 py-3 md:py-4">
         <div className="max-w-5xl mx-auto flex items-center justify-between">

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -431,7 +431,7 @@ function VocabularyPageContent() {
   }
 
   return (
-    <div className="min-h-screen bg-parchment">
+    <main id="main-content" className="min-h-screen bg-parchment">
       <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
         <button
           onClick={() => router.push("/")}
@@ -610,7 +610,7 @@ function VocabularyPageContent() {
           onClose={closeSheet}
         />
       )}
-    </div>
+    </main>
   );
 }
 


### PR DESCRIPTION
Closes #1179

The app had no "Skip to main content" link. WCAG 2.4.1 (Bypass Blocks, Level A — mandatory) requires a mechanism for keyboard users to skip past repeated header/nav blocks and jump to main content.

## Changes
- `app/layout.tsx`: added a `<a href="#main-content">Skip to main content</a>` as the first focusable element in `<body>`. Visually hidden until focused (`sr-only focus:not-sr-only` + amber styled focus state).
- `app/page.tsx`, `app/notes/page.tsx`: added `id="main-content"` to the `<main>` so the skip-link anchor lands somewhere sensible
- `app/vocabulary/page.tsx`: changed top-level `<div>` to `<main id="main-content">` (also a small landmark improvement — vocabulary was using a div instead of a main landmark)
- `SkipToContent.test.ts`: 4 static assertions

Remaining pages can be picked up incrementally as a follow-up. The skip link works regardless — it just won't reach the right anchor on those pages.

## WCAG
- 2.4.1 Bypass Blocks (Level A — mandatory)

## Test plan
- [x] `SkipToContent.test.ts` — 4 passing
- [x] Full frontend suite — 2178/2178 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
