### PR TITLE
ux: extend skip-link main-content anchor to remaining pages (closes #1181)

### DIFF
--- a/frontend/src/__tests__/SkipLinkExtend.test.ts
+++ b/frontend/src/__tests__/SkipLinkExtend.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Static assertion: remaining pages have id=main-content for the skip link.
+ * Closes #1181
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+const pages = [
+  "src/app/decks/page.tsx",
+  "src/app/profile/page.tsx",
+  "src/app/search/page.tsx",
+  "src/app/upload/page.tsx",
+  "src/app/upload/[bookId]/chapters/page.tsx",
+  "src/app/decks/new/page.tsx",
+];
+
+describe("Skip-link main-content anchor on remaining pages", () => {
+  for (const page of pages) {
+    it(`${page} has id=main-content somewhere`, () => {
+      const src = read(page);
+      expect(src).toContain('id="main-content"');
+    });
+  }
+});

--- a/frontend/src/app/decks/new/page.tsx
+++ b/frontend/src/app/decks/new/page.tsx
@@ -40,7 +40,7 @@ export default function DecksNewPage() {
   }
 
   return (
-    <div className="min-h-screen bg-parchment">
+    <main id="main-content" className="min-h-screen bg-parchment">
       <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
         <button
           onClick={() => router.push("/decks")}
@@ -162,6 +162,6 @@ export default function DecksNewPage() {
           </div>
         </form>
       </div>
-    </div>
+    </main>
   );
 }

--- a/frontend/src/app/decks/page.tsx
+++ b/frontend/src/app/decks/page.tsx
@@ -58,7 +58,7 @@ export default function DecksPage() {
   const isEmpty = !loading && (error || decks.length === 0);
 
   return (
-    <div className="min-h-screen bg-parchment">
+    <main id="main-content" className="min-h-screen bg-parchment">
       <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
         <button
           onClick={() => router.push("/")}
@@ -140,6 +140,6 @@ export default function DecksPage() {
           }}
         />
       )}
-    </div>
+    </main>
   );
 }

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -160,7 +160,7 @@ export default function ProfilePage() {
   }
 
   return (
-    <div className="min-h-screen bg-parchment">
+    <main id="main-content" className="min-h-screen bg-parchment">
       {/* Header */}
       <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-6 py-4 flex items-center gap-4">
         <button
@@ -510,6 +510,6 @@ export default function ProfilePage() {
         </section>
 
       </div>
-    </div>
+    </main>
   );
 }

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -187,7 +187,7 @@ function SearchResultsInner() {
 
 export default function SearchPage() {
   return (
-    <main className="max-w-3xl mx-auto p-4 md:p-8">
+    <main id="main-content" className="max-w-3xl mx-auto p-4 md:p-8">
       <div className="flex items-center gap-4 mb-6">
         <Link
           href="/"

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -95,7 +95,7 @@ export default function ChapterEditorPage() {
   const selectedChapter = chapters[selected];
 
   return (
-    <main className="min-h-screen bg-parchment flex flex-col">
+    <main id="main-content" className="min-h-screen bg-parchment flex flex-col">
       {/* Header */}
       <header className="border-b border-amber-200 bg-white/60 backdrop-blur px-4 md:px-6 py-3 shrink-0">
         <div className="max-w-5xl mx-auto flex items-center justify-between gap-4">

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -93,7 +93,7 @@ export default function UploadPage() {
   const quotaFull = quota !== null && quota.used >= quota.max;
 
   return (
-    <main className="min-h-screen bg-parchment">
+    <main id="main-content" className="min-h-screen bg-parchment">
       <header className="border-b border-amber-200 bg-white/60 backdrop-blur px-4 md:px-6 py-3">
         <div className="max-w-2xl mx-auto flex items-center gap-3">
           <button


### PR DESCRIPTION
Closes #1181

Follow-up to #1179. Adds `id="main-content"` to the remaining six top-level pages so the skip-to-content link from layout.tsx lands at the right place. Also converts three top-level `<div>` wrappers to proper `<main>` landmarks.

## Changes
- `app/decks/page.tsx`: `<div>` → `<main id="main-content">`
- `app/profile/page.tsx`: `<div>` → `<main id="main-content">`
- `app/search/page.tsx`: existing `<main>` gets `id="main-content"`
- `app/upload/page.tsx`: regular content `<main>` gets `id="main-content"` (loading state untouched)
- `app/upload/[bookId]/chapters/page.tsx`: regular content `<main>` gets `id="main-content"` (loading/error states untouched)
- `app/decks/new/page.tsx`: `<div>` → `<main id="main-content">`
- `SkipLinkExtend.test.ts`: 6 static assertions

Reader page (`app/reader/[bookId]/page.tsx`) intentionally not updated in this PR — its layout structure is more complex with sidebar resizing and would benefit from a dedicated review.

## WCAG
- 2.4.1 Bypass Blocks (Level A — completes coverage from #1179)

## Test plan
- [x] `SkipLinkExtend.test.ts` — 6 passing
- [x] Full frontend suite — 2184/2184 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
