### PR TITLE
ux: convert reader page wrapper to <main id=main-content> (closes #1184)

### DIFF
--- a/frontend/src/__tests__/ReaderMainLandmark.test.ts
+++ b/frontend/src/__tests__/ReaderMainLandmark.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Static assertion: reader page wrapper is <main id="main-content">.
+ * Closes #1184
+ */
+import fs from "fs";
+import path from "path";
+
+const reader = fs.readFileSync(
+  path.join(process.cwd(), "src/app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Reader page main landmark", () => {
+  it("uses <main> with id=main-content for the page wrapper", () => {
+    expect(reader).toMatch(/<main[^>]*id="main-content"[^>]*className="h-screen bg-parchment/);
+  });
+
+  it("does not use <div> for the page wrapper", () => {
+    expect(reader).not.toMatch(/<div className="h-screen bg-parchment flex flex-col overflow-hidden">/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -811,7 +811,7 @@ export default function ReaderPage() {
   }
 
   return (
-    <div className="h-screen bg-parchment flex flex-col overflow-hidden">
+    <main id="main-content" className="h-screen bg-parchment flex flex-col overflow-hidden">
       {/* ── Gemini key reminder banner ───────────────────────────────────── */}
       {geminiReminderVisible && (
         <div className="shrink-0 bg-amber-50 border-b border-amber-300 px-4 py-2 flex items-center justify-between gap-4 text-sm text-amber-800">
@@ -2277,6 +2277,6 @@ export default function ReaderPage() {
         feature={authPrompt ?? ""}
         onClose={() => setAuthPrompt(null)}
       />
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
Closes #1184

The reader page — the app's flagship — used a top-level `<div>` with no `<main>` landmark and no `id="main-content"` for the skip link. This completes the skip-link/landmark coverage from #1179/#1181.

## Changes
- `app/reader/[bookId]/page.tsx`: top-level `<div className="h-screen bg-parchment flex flex-col overflow-hidden">` → `<main id="main-content" className="...">`. Closing `</div>` → `</main>`.
- `ReaderMainLandmark.test.ts`: 2 static assertions

## WCAG
- 1.3.1 Info and Relationships (main landmark)
- 2.4.1 Bypass Blocks (skip link target)

## Test plan
- [x] `ReaderMainLandmark.test.ts` — 2 passing
- [x] Full frontend suite — 2186/2186 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
