### PR TITLE
ux: complete skip-link main-content coverage on login/pending/notes-bookid (closes #1187)

### DIFF
--- a/frontend/src/__tests__/SkipLinkFinal.test.ts
+++ b/frontend/src/__tests__/SkipLinkFinal.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Static assertion: login, pending, notes/[bookId] now have main#main-content.
+ * Closes #1187
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("Skip-link final coverage", () => {
+  it("login page uses <main id=main-content>", () => {
+    const src = read("src/app/login/page.tsx");
+    expect(src).toContain('id="main-content"');
+  });
+
+  it("pending page uses <main id=main-content>", () => {
+    const src = read("src/app/pending/page.tsx");
+    expect(src).toContain('id="main-content"');
+  });
+
+  it("notes/[bookId] page <main> has id=main-content", () => {
+    const src = read("src/app/notes/[bookId]/page.tsx");
+    expect(src).toContain('id="main-content"');
+  });
+});

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -8,7 +8,7 @@ function LoginForm() {
   const callbackUrl = params.get("callbackUrl") || "/";
 
   return (
-    <div className="min-h-screen bg-parchment flex items-center justify-center px-4">
+    <main id="main-content" className="min-h-screen bg-parchment flex items-center justify-center px-4">
       <div className="w-full max-w-sm">
         {/* Logo / branding */}
         <div className="text-center mb-10">
@@ -66,7 +66,7 @@ function LoginForm() {
           Your reading data stays on your own device.
         </p>
       </div>
-    </div>
+    </main>
   );
 }
 

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -623,7 +623,7 @@ export default function BookNotesPage() {
   }
 
   return (
-    <main className="min-h-screen bg-parchment">
+    <main id="main-content" className="min-h-screen bg-parchment">
       {/* Sticky header */}
       <header className="sticky top-0 z-10 border-b border-amber-200 bg-white/80 backdrop-blur px-4 md:px-6 py-3">
         <div className="max-w-3xl mx-auto flex items-center gap-3 flex-wrap">

--- a/frontend/src/app/pending/page.tsx
+++ b/frontend/src/app/pending/page.tsx
@@ -4,7 +4,7 @@ import { ClockIcon } from "@/components/Icons";
 
 export default function PendingApprovalPage() {
   return (
-    <div className="min-h-screen bg-parchment flex items-center justify-center px-4">
+    <main id="main-content" className="min-h-screen bg-parchment flex items-center justify-center px-4">
       <div className="w-full max-w-sm text-center">
         <ClockIcon className="w-16 h-16 text-amber-400 mx-auto mb-4" />
         <h1 className="font-serif text-2xl font-bold text-ink mb-2">Account Pending</h1>
@@ -19,6 +19,6 @@ export default function PendingApprovalPage() {
           Sign out
         </button>
       </div>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
Closes #1187

Final cleanup after #1179 / #1181 / #1184. Every top-level page route now has `<main id="main-content">`.

## Changes
- `app/login/page.tsx`: `<div>` → `<main id="main-content">`
- `app/pending/page.tsx`: `<div>` → `<main id="main-content">`
- `app/notes/[bookId]/page.tsx`: existing `<main>` gets `id="main-content"`
- `SkipLinkFinal.test.ts`: 3 static assertions

## WCAG
- 1.3.1 Info and Relationships
- 2.4.1 Bypass Blocks (skip-link coverage now complete across the entire app)

## Test plan
- [x] `SkipLinkFinal.test.ts` — 3 passing
- [x] Full frontend suite — 2189/2189 passing
- [x] Backend suite — 1382/1382 passing

🤖 Generated with Claude Code
