### PR TITLE
feat: add manual-deck member management UI on /decks/[deckId] (closes #1191)

### DIFF
--- a/frontend/src/__tests__/DeckMemberMgmt.test.ts
+++ b/frontend/src/__tests__/DeckMemberMgmt.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Static assertion: /decks/[deckId] page supports manual-deck member management
+ * (add/remove words) with proper a11y; smart decks remain read-only.
+ * Closes #1191
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("Deck detail member management UI", () => {
+  const src = read("src/app/decks/[deckId]/page.tsx");
+
+  it("imports addDeckMember and removeDeckMember", () => {
+    expect(src).toMatch(/addDeckMember/);
+    expect(src).toMatch(/removeDeckMember/);
+  });
+
+  it("gates add/remove UI on manual mode", () => {
+    expect(src).toMatch(/mode\s*===\s*["']manual["']/);
+  });
+
+  it("remove button has aria-label", () => {
+    expect(src).toMatch(/aria-label=\{?["'`]Remove [^"'`]+/);
+  });
+
+  it("remove button uses 44px touch target", () => {
+    expect(src).toMatch(/min-h-\[44px\]/);
+  });
+
+  it("add-word button is rendered with PlusIcon", () => {
+    expect(src).toMatch(/PlusIcon/);
+    expect(src).toMatch(/Add word/i);
+  });
+
+  it("picker modal uses role=dialog with aria-modal", () => {
+    expect(src).toMatch(/role=["']dialog["']/);
+    expect(src).toMatch(/aria-modal=\{?["']?true/);
+  });
+
+  it("uses UndoToast for remove flow", () => {
+    expect(src).toMatch(/UndoToast/);
+  });
+});

--- a/frontend/src/app/decks/[deckId]/page.tsx
+++ b/frontend/src/app/decks/[deckId]/page.tsx
@@ -1,14 +1,23 @@
 "use client";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import {
   DeckDetail,
   VocabularyWord,
+  addDeckMember,
   getDeck,
   getVocabulary,
+  removeDeckMember,
 } from "@/lib/api";
-import { ArrowLeftIcon, DeckIcon } from "@/components/Icons";
+import {
+  ArrowLeftIcon,
+  CloseIcon,
+  DeckIcon,
+  PlusIcon,
+  TrashIcon,
+} from "@/components/Icons";
+import UndoToast from "@/components/UndoToast";
 
 export default function DeckDetailPage() {
   const { data: session } = useSession();
@@ -20,6 +29,8 @@ export default function DeckDetailPage() {
   const [vocab, setVocab] = useState<VocabularyWord[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  const [removedToast, setRemovedToast] = useState<VocabularyWord | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   useEffect(() => {
     document.title = "Deck — Book Reader AI";
@@ -52,11 +63,57 @@ export default function DeckDetailPage() {
     };
   }, [deckId, session?.backendToken]);
 
-  const memberWords = useMemo(() => {
-    if (!deck) return [];
-    const memberIds = new Set(deck.members);
-    return vocab.filter((w) => memberIds.has(w.id));
-  }, [deck, vocab]);
+  const memberIds = useMemo(
+    () => new Set(deck?.members ?? []),
+    [deck?.members],
+  );
+
+  const memberWords = useMemo(
+    () => vocab.filter((w) => memberIds.has(w.id)),
+    [vocab, memberIds],
+  );
+
+  const candidateWords = useMemo(
+    () => vocab.filter((w) => !memberIds.has(w.id)),
+    [vocab, memberIds],
+  );
+
+  const isManual = deck?.mode === "manual";
+
+  const handleRemove = useCallback(
+    (vocabularyId: number) => {
+      setDeck((prev) => {
+        if (!prev) return prev;
+        const removed = vocab.find((w) => w.id === vocabularyId) ?? null;
+        if (removed) {
+          setRemovedToast((current) => {
+            if (current) {
+              removeDeckMember(deckId, current.id).catch(() => {});
+            }
+            return removed;
+          });
+        }
+        return { ...prev, members: prev.members.filter((id) => id !== vocabularyId) };
+      });
+    },
+    [deckId, vocab],
+  );
+
+  const handleAdd = useCallback(
+    (vocabularyId: number) => {
+      setDeck((prev) =>
+        prev ? { ...prev, members: [...prev.members, vocabularyId] } : prev,
+      );
+      addDeckMember(deckId, vocabularyId).catch(() => {
+        setDeck((prev) =>
+          prev
+            ? { ...prev, members: prev.members.filter((id) => id !== vocabularyId) }
+            : prev,
+        );
+      });
+    },
+    [deckId],
+  );
 
   return (
     <main id="main-content" className="min-h-screen bg-parchment">
@@ -78,6 +135,18 @@ export default function DeckDetailPage() {
             </p>
           )}
         </div>
+        {deck && isManual && (
+          <button
+            type="button"
+            onClick={() => setPickerOpen(true)}
+            aria-label="Add word to deck"
+            disabled={candidateWords.length === 0}
+            className="flex items-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium transition-colors min-h-[44px] md:min-h-0 shrink-0"
+          >
+            <PlusIcon className="w-4 h-4" />
+            <span className="hidden sm:inline">Add word</span>
+          </button>
+        )}
       </header>
 
       <div className="max-w-2xl mx-auto px-4 md:px-6 py-6 md:py-8">
@@ -127,16 +196,30 @@ export default function DeckDetailPage() {
                   No words in this deck yet.
                 </p>
                 <p className="text-sm text-stone-400 max-w-xs">
-                  Add words from your vocabulary to study them as a focused set.
+                  {isManual
+                    ? "Add words from your vocabulary to study them as a focused set."
+                    : "This smart deck has no matching words yet — saved vocabulary that matches the rules will appear here."}
                 </p>
-                <button
-                  type="button"
-                  onClick={() => router.push("/decks")}
-                  className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px]"
-                >
-                  <ArrowLeftIcon className="w-4 h-4" />
-                  Back to decks
-                </button>
+                {isManual ? (
+                  <button
+                    type="button"
+                    onClick={() => setPickerOpen(true)}
+                    disabled={candidateWords.length === 0}
+                    className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium transition-colors min-h-[44px]"
+                  >
+                    <PlusIcon className="w-4 h-4" />
+                    Add word
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => router.push("/decks")}
+                    className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px]"
+                  >
+                    <ArrowLeftIcon className="w-4 h-4" />
+                    Back to decks
+                  </button>
+                )}
               </div>
             ) : (
               <ul
@@ -147,15 +230,25 @@ export default function DeckDetailPage() {
                 {memberWords.map((w) => (
                   <li
                     key={w.id}
-                    className="rounded-xl border border-amber-200 bg-white px-4 py-3 flex items-baseline justify-between gap-3"
+                    className="rounded-xl border border-amber-200 bg-white px-4 py-3 flex items-center justify-between gap-3"
                   >
-                    <span className="font-serif text-ink truncate">
+                    <span className="font-serif text-ink truncate flex-1 min-w-0">
                       {w.word}
                     </span>
                     {w.language && (
                       <span className="text-xs uppercase tracking-wide text-stone-400 shrink-0">
                         {w.language}
                       </span>
+                    )}
+                    {isManual && (
+                      <button
+                        type="button"
+                        onClick={() => handleRemove(w.id)}
+                        aria-label={`Remove ${w.word} from deck`}
+                        className="shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg text-stone-400 hover:text-red-600 hover:bg-red-50 transition-colors"
+                      >
+                        <TrashIcon className="w-4 h-4" />
+                      </button>
                     )}
                   </li>
                 ))}
@@ -164,6 +257,149 @@ export default function DeckDetailPage() {
           </>
         )}
       </div>
+
+      {pickerOpen && deck && isManual && (
+        <AddWordPicker
+          candidates={candidateWords}
+          onClose={() => setPickerOpen(false)}
+          onAdd={(id) => {
+            handleAdd(id);
+          }}
+        />
+      )}
+
+      {removedToast && (
+        <UndoToast
+          message={`"${removedToast.word}" removed`}
+          onUndo={() => {
+            setDeck((prev) =>
+              prev && removedToast
+                ? { ...prev, members: [...prev.members, removedToast.id] }
+                : prev,
+            );
+            setRemovedToast(null);
+          }}
+          onDone={() => {
+            removeDeckMember(deckId, removedToast.id).catch(() => {});
+            setRemovedToast(null);
+          }}
+        />
+      )}
     </main>
+  );
+}
+
+interface AddWordPickerProps {
+  candidates: VocabularyWord[];
+  onClose: () => void;
+  onAdd: (vocabularyId: number) => void;
+}
+
+function AddWordPicker({ candidates, onClose, onAdd }: AddWordPickerProps) {
+  const [query, setQuery] = useState("");
+  const closeRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    closeRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const q = query.trim().toLowerCase();
+  const filtered = q
+    ? candidates.filter((w) => w.word.toLowerCase().includes(q))
+    : candidates;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end md:items-center justify-center bg-stone-900/40"
+      onClick={onClose}
+      aria-hidden="true"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-word-picker-title"
+        onClick={(e) => e.stopPropagation()}
+        className="w-full md:max-w-md bg-parchment rounded-t-2xl md:rounded-2xl shadow-xl flex flex-col max-h-[80vh] animate-slide-up"
+      >
+        <div className="flex items-center gap-3 border-b border-amber-200 px-4 py-3">
+          <h2
+            id="add-word-picker-title"
+            className="flex-1 font-serif text-lg text-ink"
+          >
+            Add word
+          </h2>
+          <button
+            ref={closeRef}
+            type="button"
+            onClick={onClose}
+            aria-label="Close add-word picker"
+            className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg text-stone-500 hover:text-ink hover:bg-amber-100 transition-colors"
+          >
+            <CloseIcon className="w-4 h-4" />
+          </button>
+        </div>
+
+        {candidates.length > 0 && (
+          <div className="px-4 pt-3">
+            <label htmlFor="add-word-picker-search" className="sr-only">
+              Filter words
+            </label>
+            <input
+              id="add-word-picker-search"
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Filter your vocabulary…"
+              className="w-full rounded-lg border border-amber-200 bg-white px-3 py-2 text-sm text-ink placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-amber-300"
+            />
+          </div>
+        )}
+
+        <div className="flex-1 overflow-y-auto px-4 py-3">
+          {candidates.length === 0 ? (
+            <p className="text-sm text-stone-500 text-center py-6">
+              All your saved words are already in this deck.
+            </p>
+          ) : filtered.length === 0 ? (
+            <p className="text-sm text-stone-500 text-center py-6">
+              No matches.
+            </p>
+          ) : (
+            <ul className="space-y-1.5" aria-label="Available words">
+              {filtered.map((w) => (
+                <li key={w.id}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onAdd(w.id);
+                    }}
+                    aria-label={`Add ${w.word} to deck`}
+                    className="w-full flex items-center justify-between gap-3 rounded-lg border border-amber-200 bg-white px-3 py-2 text-left hover:border-amber-400 hover:bg-amber-50 transition-colors min-h-[44px]"
+                  >
+                    <span className="font-serif text-ink truncate flex-1 min-w-0">
+                      {w.word}
+                    </span>
+                    {w.language && (
+                      <span className="text-xs uppercase tracking-wide text-stone-400 shrink-0">
+                        {w.language}
+                      </span>
+                    )}
+                    <PlusIcon className="w-4 h-4 text-amber-700 shrink-0" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -465,3 +465,11 @@ export function ArrowUpIcon({ className = "w-4 h-4" }: IconProps) {
     </svg>
   );
 }
+
+export function PlusIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M12 5v14m-7-7h14" />
+    </svg>
+  );
+}


### PR DESCRIPTION
Closes #1191 — slice 2/3 of #819 (follow-up to #1189).

## Summary
Adds add/remove member UI to the deck detail page for manual-mode decks. Smart decks remain read-only.

## Changes
- `Icons.tsx`: new `PlusIcon`
- `/decks/[deckId]` page:
  - Header `Add word` button (manual only) opens a modal picker listing user's vocabulary not already in the deck, with filter input
  - Per-row Trash remove button (manual only) — optimistic update + `UndoToast` (3s undo before commit), reusing the established pattern from `/decks` and `/notes`
  - Smart-deck empty-state copy clarifies rules-driven membership

Backend endpoints and client functions already existed.

## a11y
- Picker: role=dialog, aria-modal, aria-labelledby, focus on close on open, Escape to close, sr-only label on filter input
- Remove: aria-label=`Remove <word> from deck`, 44x44 target
- Add buttons in picker: aria-label=`Add <word> to deck`, 44px target
- All trigger buttons meet 44px touch target on mobile

## WCAG
- 1.3.1 Info and Relationships
- 4.1.2 Name/Role/Value (aria-labels on icon-only buttons, dialog role)
- 4.1.3 Status Messages (UndoToast role=status, aria-live)

## Out of scope
- Slice 3/3: smart-rule builder + flashcards deck selector

## Test plan
- [x] `DeckMemberMgmt.test.ts` — 7 static assertions
- [x] Existing `DeckDetailPage.test.ts` — 7 still pass
- [x] Full frontend suite — 2203/2203 passing

Label: `ui` `feat`

Generated with Claude Code
