### PR TITLE
feat: add flashcards deck selector to /vocabulary/flashcards (closes #1195)

### DIFF
--- a/frontend/src/__tests__/FlashcardsDeckSelector.test.ts
+++ b/frontend/src/__tests__/FlashcardsDeckSelector.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Static assertion: /vocabulary/flashcards page exposes a deck selector
+ * that filters the review session via the backend's deck_id query param.
+ * Closes #1195
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("Flashcards deck selector", () => {
+  const page = read("src/app/vocabulary/flashcards/page.tsx");
+  const api = read("src/lib/api.ts");
+
+  it("getDueFlashcards accepts an optional deckId and forwards it as deck_id", () => {
+    expect(api).toMatch(/getDueFlashcards\s*\(\s*deckId\?:\s*number/);
+    expect(api).toMatch(/deck_id=/);
+  });
+
+  it("getFlashcardStats accepts an optional deckId and forwards it as deck_id", () => {
+    expect(api).toMatch(/getFlashcardStats\s*\(\s*deckId\?:\s*number/);
+  });
+
+  it("page imports listDecks and DeckSummary", () => {
+    expect(page).toMatch(/listDecks/);
+    expect(page).toMatch(/DeckSummary/);
+  });
+
+  it("page renders a labelled <select> deck selector with All decks default", () => {
+    expect(page).toMatch(/<label\b[^>]*htmlFor=["']flashcards-deck-select["']/);
+    expect(page).toMatch(/<select\b[^>]*id=["']flashcards-deck-select["']/);
+    expect(page).toMatch(/All decks/i);
+  });
+
+  it("selector option for 'all decks' has empty value", () => {
+    expect(page).toMatch(/<option\s+value=["']{2}/);
+  });
+
+  it("loadData passes the selected deck id to the flashcards APIs", () => {
+    expect(page).toMatch(/getDueFlashcards\s*\(\s*selectedDeckId/);
+    expect(page).toMatch(/getFlashcardStats\s*\(\s*selectedDeckId/);
+  });
+
+  it("selector control meets 44px touch target", () => {
+    // The <select> wrapper or the select itself must include min-h-[44px]
+    const idx = page.indexOf('id="flashcards-deck-select"');
+    expect(idx).toBeGreaterThan(0);
+    const window = page.slice(Math.max(0, idx - 400), idx + 400);
+    expect(window).toMatch(/min-h-\[44px\]/);
+  });
+});

--- a/frontend/src/__tests__/FlashcardsPage.test.tsx
+++ b/frontend/src/__tests__/FlashcardsPage.test.tsx
@@ -18,6 +18,7 @@ jest.mock("@/lib/api", () => ({
   getDueFlashcards: jest.fn(),
   reviewFlashcard: jest.fn(),
   getFlashcardStats: jest.fn(),
+  listDecks: jest.fn(() => Promise.resolve([])),
 }));
 
 import * as api from "@/lib/api";

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -6,6 +6,8 @@ import {
   getDueFlashcards,
   reviewFlashcard,
   getFlashcardStats,
+  listDecks,
+  DeckSummary,
   Flashcard,
   FlashcardStats,
 } from "@/lib/api";
@@ -29,11 +31,16 @@ export default function FlashcardsPage() {
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [done, setDone] = useState(false);
+  const [decks, setDecks] = useState<DeckSummary[]>([]);
+  const [selectedDeckId, setSelectedDeckId] = useState<number | undefined>(undefined);
 
   const loadData = useCallback(async () => {
     setLoading(true);
     try {
-      const [due, statsData] = await Promise.all([getDueFlashcards(), getFlashcardStats()]);
+      const [due, statsData] = await Promise.all([
+        getDueFlashcards(selectedDeckId),
+        getFlashcardStats(selectedDeckId),
+      ]);
       setCards(due);
       setStats(statsData);
       setCurrentIndex(0);
@@ -42,11 +49,24 @@ export default function FlashcardsPage() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [selectedDeckId]);
 
   useEffect(() => {
     if (status === "authenticated") loadData();
   }, [status, loadData]);
+
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    let alive = true;
+    listDecks()
+      .then((d) => {
+        if (alive) setDecks(d);
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, [status]);
 
   const currentCard = cards[currentIndex] ?? null;
 
@@ -104,6 +124,33 @@ export default function FlashcardsPage() {
           )}
         </div>
 
+        {/* Deck selector */}
+        {decks.length > 0 && (
+          <div className="flex items-center gap-2">
+            <label
+              htmlFor="flashcards-deck-select"
+              className="text-sm text-stone-600 shrink-0"
+            >
+              Deck:
+            </label>
+            <select
+              id="flashcards-deck-select"
+              value={selectedDeckId ?? ""}
+              onChange={(e) =>
+                setSelectedDeckId(e.target.value ? Number(e.target.value) : undefined)
+              }
+              className="flex-1 min-h-[44px] rounded-lg border border-amber-200 bg-white px-3 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-amber-300"
+            >
+              <option value="">All decks</option>
+              {decks.map((d) => (
+                <option key={d.id} value={d.id}>
+                  {d.name} ({d.due_today} due)
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
         {/* Progress bar */}
         <div className="h-2 bg-amber-100 rounded-full overflow-hidden">
           <div
@@ -118,8 +165,9 @@ export default function FlashcardsPage() {
             <CheckIcon className="w-12 h-12 text-green-500" />
             <h2 className="font-serif text-2xl text-ink">All done for today!</h2>
             <p className="text-sm text-stone-500">
-              You reviewed {stats?.reviewed_today ?? 0} card{(stats?.reviewed_today ?? 0) !== 1 ? "s" : ""}.
-              Come back tomorrow for more.
+              {selectedDeckId
+                ? `No more cards due in "${decks.find((d) => d.id === selectedDeckId)?.name ?? "this deck"}".`
+                : `You reviewed ${stats?.reviewed_today ?? 0} card${(stats?.reviewed_today ?? 0) !== 1 ? "s" : ""}. Come back tomorrow for more.`}
             </p>
             <button
               onClick={() => router.push("/vocabulary")}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -906,8 +906,9 @@ export interface FlashcardStats {
   reviewed_today: number;
 }
 
-export function getDueFlashcards() {
-  return request<Flashcard[]>("/vocabulary/flashcards/due");
+export function getDueFlashcards(deckId?: number) {
+  const qs = deckId ? `?deck_id=${deckId}` : "";
+  return request<Flashcard[]>(`/vocabulary/flashcards/due${qs}`);
 }
 
 export function reviewFlashcard(vocabularyId: number, grade: number) {
@@ -918,8 +919,9 @@ export function reviewFlashcard(vocabularyId: number, grade: number) {
   });
 }
 
-export function getFlashcardStats() {
-  return request<FlashcardStats>("/vocabulary/flashcards/stats");
+export function getFlashcardStats(deckId?: number) {
+  const qs = deckId ? `?deck_id=${deckId}` : "";
+  return request<FlashcardStats>(`/vocabulary/flashcards/stats${qs}`);
 }
 
 // ── Chat history (server-side persistence, issue #907) ────────────────────────


### PR DESCRIPTION
Closes #1195 — slice 3a/3 of #819 (follow-up to #1189, #1193).

## Summary
Lets users limit a flashcards review session to a single deck. Backend already supports the `deck_id` query param on `/vocabulary/flashcards/due` and `/stats`.

## Changes
- `lib/api.ts`: `getDueFlashcards` and `getFlashcardStats` accept an optional `deckId` and forward it as `?deck_id=N`
- `/vocabulary/flashcards` page:
  - Header gains a `<label htmlFor>` + `<select id>` deck selector — `All decks` default plus one entry per user-owned deck with due-count
  - Selecting reloads cards + stats via the new query param
  - Selector hidden when user has no decks
  - Done-state copy mentions the deck name when a deck is selected
- `FlashcardsPage.test.tsx`: mock extended with `listDecks` (no behaviour change to existing assertions)

## a11y
- `<label htmlFor>` + `<select id>` association
- 44px touch target on the select
- Existing keyboard / grade-button behaviour unchanged

## WCAG
- 1.3.1 Info and Relationships (label/control association)
- 4.1.2 Name/Role/Value (native select)

## Out of scope
- Slice 3b: smart-rule builder UI for editing `rules_json` on smart decks

## Test plan
- [x] `FlashcardsDeckSelector.test.ts` — 7 static assertions
- [x] `FlashcardsPage.test.tsx` — 7 still pass after mock extension
- [x] Full frontend suite — 2210/2210 passing

Label: `ui` `feat`

Generated with Claude Code
