### PR TITLE
feat: add smart-rule builder UI on /decks/new (closes #1197)

### DIFF
--- a/frontend/src/__tests__/DecksNewPage.test.tsx
+++ b/frontend/src/__tests__/DecksNewPage.test.tsx
@@ -66,6 +66,7 @@ test("submitting a valid form creates a manual deck and navigates to /decks", as
       name: "German verbs",
       description: "Top-frequency verbs",
       mode: "manual",
+      rules_json: null,
     });
   });
   expect(mockPush).toHaveBeenCalledWith("/decks");
@@ -96,8 +97,15 @@ test("surfaces the API error instead of navigating on failure", async () => {
   expect(mockPush).not.toHaveBeenCalledWith("/decks");
 });
 
-test("notes that smart decks are coming in a later slice (disabled mode)", () => {
+test("smart mode radio is enabled and reveals the rules sub-form when selected", async () => {
   render(<DecksNewPage />);
   const smartRadio = screen.getByTestId("deck-mode-smart") as HTMLInputElement;
-  expect(smartRadio.disabled).toBe(true);
+  expect(smartRadio.disabled).toBe(false);
+
+  // Rules sub-form is hidden in manual mode by default
+  expect(screen.queryByTestId("deck-rules-fieldset")).toBeNull();
+
+  const user = userEvent.setup();
+  await user.click(smartRadio);
+  expect(screen.getByTestId("deck-rules-fieldset")).toBeInTheDocument();
 });

--- a/frontend/src/__tests__/DecksNewSmartRules.test.ts
+++ b/frontend/src/__tests__/DecksNewSmartRules.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Static assertion: /decks/new enables Smart mode and exposes a rules
+ * sub-form (language, tags_any, tags_all, saved_after, saved_before)
+ * that builds rules_json on submit.
+ * Closes #1197
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("Smart-rule builder on /decks/new", () => {
+  const src = read("src/app/decks/new/page.tsx");
+
+  it("smart radio is no longer disabled", () => {
+    // Look for the smart radio block; it must NOT contain `disabled`
+    const idx = src.indexOf('value="smart"');
+    expect(idx).toBeGreaterThan(0);
+    const block = src.slice(idx, idx + 400);
+    expect(block).not.toMatch(/disabled\b/);
+  });
+
+  it("mode state setter is wired (allows switching modes)", () => {
+    expect(src).toMatch(/setMode\s*\(/);
+  });
+
+  it("renders all five rule fields with htmlFor/id associations", () => {
+    expect(src).toMatch(/htmlFor=["']deck-rule-language["']/);
+    expect(src).toMatch(/id=["']deck-rule-language["']/);
+    expect(src).toMatch(/htmlFor=["']deck-rule-tags-any["']/);
+    expect(src).toMatch(/id=["']deck-rule-tags-any["']/);
+    expect(src).toMatch(/htmlFor=["']deck-rule-tags-all["']/);
+    expect(src).toMatch(/id=["']deck-rule-tags-all["']/);
+    expect(src).toMatch(/htmlFor=["']deck-rule-saved-after["']/);
+    expect(src).toMatch(/id=["']deck-rule-saved-after["']/);
+    expect(src).toMatch(/htmlFor=["']deck-rule-saved-before["']/);
+    expect(src).toMatch(/id=["']deck-rule-saved-before["']/);
+  });
+
+  it("date fields use type=date", () => {
+    const afterIdx = src.indexOf('id="deck-rule-saved-after"');
+    expect(afterIdx).toBeGreaterThan(0);
+    const window = src.slice(Math.max(0, afterIdx - 200), afterIdx + 200);
+    expect(window).toMatch(/type=["']date["']/);
+  });
+
+  it("submit builds rules_json only for smart mode", () => {
+    expect(src).toMatch(/rules_json/);
+    expect(src).toMatch(/mode\s*===?\s*["']smart["']/);
+  });
+
+  it("rule fields are hidden in manual mode (conditional render)", () => {
+    expect(src).toMatch(/mode\s*===?\s*["']smart["']\s*&&/);
+  });
+
+  it("comma-separated tag input is split into string array", () => {
+    // implementation detail tolerated: a `.split(",")` somewhere near tags
+    expect(src).toMatch(/\.split\(/);
+  });
+});

--- a/frontend/src/app/decks/new/page.tsx
+++ b/frontend/src/app/decks/new/page.tsx
@@ -4,13 +4,39 @@ import { useRouter } from "next/navigation";
 import { ApiError, createDeck, DeckMode } from "@/lib/api";
 import { ArrowLeftIcon, DeckIcon } from "@/components/Icons";
 
+function splitTags(input: string): string[] {
+  return input
+    .split(",")
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+}
+
 export default function DecksNewPage() {
   const router = useRouter();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
-  const [mode] = useState<DeckMode>("manual");
+  const [mode, setMode] = useState<DeckMode>("manual");
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+
+  // Smart-rule fields
+  const [ruleLanguage, setRuleLanguage] = useState("");
+  const [ruleTagsAny, setRuleTagsAny] = useState("");
+  const [ruleTagsAll, setRuleTagsAll] = useState("");
+  const [ruleSavedAfter, setRuleSavedAfter] = useState("");
+  const [ruleSavedBefore, setRuleSavedBefore] = useState("");
+
+  function buildRulesJson(): Record<string, unknown> | null {
+    const rules: Record<string, unknown> = {};
+    if (ruleLanguage.trim()) rules.language = ruleLanguage.trim();
+    const tagsAny = splitTags(ruleTagsAny);
+    if (tagsAny.length > 0) rules.tags_any = tagsAny;
+    const tagsAll = splitTags(ruleTagsAll);
+    if (tagsAll.length > 0) rules.tags_all = tagsAll;
+    if (ruleSavedAfter) rules.saved_after = ruleSavedAfter;
+    if (ruleSavedBefore) rules.saved_before = ruleSavedBefore;
+    return Object.keys(rules).length > 0 ? rules : null;
+  }
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -26,6 +52,7 @@ export default function DecksNewPage() {
         name: trimmedName,
         description: description.trim(),
         mode,
+        rules_json: mode === "smart" ? buildRulesJson() : null,
       });
       router.push("/decks");
     } catch (e) {
@@ -102,7 +129,7 @@ export default function DecksNewPage() {
                   name="mode"
                   value="manual"
                   checked={mode === "manual"}
-                  onChange={() => {}}
+                  onChange={() => setMode("manual")}
                   data-testid="deck-mode-manual"
                   className="mt-1"
                 />
@@ -113,24 +140,121 @@ export default function DecksNewPage() {
                   </span>
                 </span>
               </label>
-              <label className="flex items-start gap-3 rounded-lg border border-amber-100 bg-stone-50 p-3 opacity-60 cursor-not-allowed">
+              <label className="flex items-start gap-3 rounded-lg border border-amber-200 bg-white p-3 cursor-pointer has-[:checked]:border-amber-500 has-[:checked]:bg-amber-50">
                 <input
                   type="radio"
                   name="mode"
                   value="smart"
-                  disabled
+                  checked={mode === "smart"}
+                  onChange={() => setMode("smart")}
                   data-testid="deck-mode-smart"
                   className="mt-1"
                 />
                 <span className="text-sm">
                   <span className="font-medium text-ink block">Smart</span>
                   <span className="text-stone-500">
-                    Rule-based — membership recomputed at query time. Coming in a later slice.
+                    Rule-based — membership recomputed at query time from your saved vocabulary.
                   </span>
                 </span>
               </label>
             </div>
           </fieldset>
+
+          {mode === "smart" && (
+            <fieldset
+              data-testid="deck-rules-fieldset"
+              className="rounded-xl border border-amber-200 bg-amber-50/40 p-4 space-y-4"
+            >
+              <legend className="px-2 text-sm font-medium text-ink">
+                Rules <span className="text-stone-400 font-normal">(leave blank to match everything)</span>
+              </legend>
+
+              <div>
+                <label
+                  htmlFor="deck-rule-language"
+                  className="block text-sm font-medium text-ink mb-1"
+                >
+                  Language <span className="text-stone-400 font-normal">(e.g. de, en, zh)</span>
+                </label>
+                <input
+                  id="deck-rule-language"
+                  type="text"
+                  value={ruleLanguage}
+                  onChange={(e) => setRuleLanguage(e.target.value)}
+                  maxLength={10}
+                  className="w-full rounded-lg border border-amber-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+                  placeholder="de"
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="deck-rule-tags-any"
+                  className="block text-sm font-medium text-ink mb-1"
+                >
+                  Tags any of <span className="text-stone-400 font-normal">(comma-separated)</span>
+                </label>
+                <input
+                  id="deck-rule-tags-any"
+                  type="text"
+                  value={ruleTagsAny}
+                  onChange={(e) => setRuleTagsAny(e.target.value)}
+                  className="w-full rounded-lg border border-amber-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+                  placeholder="grammar, verbs"
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="deck-rule-tags-all"
+                  className="block text-sm font-medium text-ink mb-1"
+                >
+                  Tags all of <span className="text-stone-400 font-normal">(comma-separated)</span>
+                </label>
+                <input
+                  id="deck-rule-tags-all"
+                  type="text"
+                  value={ruleTagsAll}
+                  onChange={(e) => setRuleTagsAll(e.target.value)}
+                  className="w-full rounded-lg border border-amber-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+                  placeholder="advanced"
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label
+                    htmlFor="deck-rule-saved-after"
+                    className="block text-sm font-medium text-ink mb-1"
+                  >
+                    Saved after
+                  </label>
+                  <input
+                    id="deck-rule-saved-after"
+                    type="date"
+                    value={ruleSavedAfter}
+                    onChange={(e) => setRuleSavedAfter(e.target.value)}
+                    className="w-full rounded-lg border border-amber-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor="deck-rule-saved-before"
+                    className="block text-sm font-medium text-ink mb-1"
+                  >
+                    Saved before
+                  </label>
+                  <input
+                    id="deck-rule-saved-before"
+                    type="date"
+                    value={ruleSavedBefore}
+                    onChange={(e) => setRuleSavedBefore(e.target.value)}
+                    className="w-full rounded-lg border border-amber-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+                  />
+                </div>
+              </div>
+            </fieldset>
+          )}
 
           {error && (
             <p


### PR DESCRIPTION
Closes #1197 — final slice 3b/3 of #819 (follow-up to #1189, #1193, #1196).

## Summary
Enables Smart-mode deck creation. Backend already validates `rules_json` schema (`_validate_rules` in `services/decks.py`); the radio was just disabled pending this UI.

## Changes
- `/decks/new` page:
  - Smart radio is now enabled (was disabled with `Coming in a later slice.` copy)
  - When mode=smart, a fieldset reveals five rule fields:
    - `language` — text input (e.g. `de`, `en`, `zh`)
    - `tags_any` — comma-separated → `string[]`
    - `tags_all` — comma-separated → `string[]`
    - `saved_after` — native `<input type="date">`
    - `saved_before` — native `<input type="date">`
  - Submit builds `rules_json` from non-empty fields, only when smart; manual decks pass `rules_json: null`
- `DecksNewPage.test.tsx`: smart radio now enabled + reveals fieldset on click; createDeck payload includes `rules_json` (`null` in manual mode)

## Out of scope (future micro-slices if requested)
- `book_ids` picker (would need a book multi-select)
- Edit-existing-rules flow (PATCH UI)
- Live `matches X words` preview

## a11y
- Every rule input has `<label htmlFor>` / `id` pairing
- Date pickers use native `<input type="date">`
- Existing form-error `role=alert` preserved
- Mode radios use native `<input type="radio">`

## WCAG
- 1.3.1 Info and Relationships (label/control association, fieldset+legend)
- 4.1.2 Name/Role/Value (native form controls)

## Test plan
- [x] `DecksNewSmartRules.test.ts` — 7 static assertions
- [x] `DecksNewPage.test.tsx` — 5 still pass after updating the smart-radio assertion + createDeck payload
- [x] Full frontend suite — 2217/2217 passing

This closes the final UX surface of #819 (vocab decks slice 3b).

Label: `ui` `feat`

Generated with Claude Code
