### PR TITLE
feat: persist last-selected deck on /vocabulary/flashcards (closes #1199)

### DIFF
--- a/frontend/src/__tests__/FlashcardsLastDeck.test.ts
+++ b/frontend/src/__tests__/FlashcardsLastDeck.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Static assertion: /vocabulary/flashcards persists the selected deck id
+ * via localStorage("flashcards.lastDeckId") wrapped in try/catch.
+ * Closes #1199
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("Flashcards lastDeckId persistence", () => {
+  const src = read("src/app/vocabulary/flashcards/page.tsx");
+
+  it("reads lastDeckId from localStorage on mount", () => {
+    expect(src).toMatch(/localStorage\.getItem\(\s*["']flashcards\.lastDeckId["']/);
+  });
+
+  it("writes lastDeckId to localStorage on change", () => {
+    expect(src).toMatch(/localStorage\.setItem\(\s*["']flashcards\.lastDeckId["']/);
+  });
+
+  it("removes the key when 'All decks' is selected (no deck id)", () => {
+    expect(src).toMatch(/localStorage\.removeItem\(\s*["']flashcards\.lastDeckId["']/);
+  });
+
+  it("wraps storage access in try/catch (SSR + private-mode safety)", () => {
+    // At least one try block in proximity to a localStorage call
+    const idx = src.indexOf("localStorage");
+    expect(idx).toBeGreaterThan(0);
+    const window = src.slice(Math.max(0, idx - 200), idx + 400);
+    expect(window).toMatch(/try\s*\{/);
+    expect(window).toMatch(/catch\s*[\(\{]/);
+  });
+
+  it("only restores the saved id if it matches one of the user's decks", () => {
+    // Confidence that the restore path checks against the loaded decks list
+    expect(src).toMatch(/decks\.(some|find)\b/);
+  });
+});

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -20,6 +20,29 @@ const GRADES = [
   { label: "Easy", value: 5, className: "bg-blue-100 text-blue-700 hover:bg-blue-200 border-blue-200" },
 ];
 
+function readLastDeckId(): number | undefined {
+  try {
+    const raw = localStorage.getItem("flashcards.lastDeckId");
+    if (!raw) return undefined;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? n : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function persistLastDeckId(id: number | undefined): void {
+  try {
+    if (id === undefined) {
+      localStorage.removeItem("flashcards.lastDeckId");
+    } else {
+      localStorage.setItem("flashcards.lastDeckId", String(id));
+    }
+  } catch {
+    /* SSR / private-mode safe */
+  }
+}
+
 export default function FlashcardsPage() {
   const router = useRouter();
   const { status } = useSession();
@@ -60,7 +83,12 @@ export default function FlashcardsPage() {
     let alive = true;
     listDecks()
       .then((d) => {
-        if (alive) setDecks(d);
+        if (!alive) return;
+        setDecks(d);
+        const saved = readLastDeckId();
+        if (saved && d.some((deck) => deck.id === saved)) {
+          setSelectedDeckId(saved);
+        }
       })
       .catch(() => {});
     return () => {
@@ -136,9 +164,11 @@ export default function FlashcardsPage() {
             <select
               id="flashcards-deck-select"
               value={selectedDeckId ?? ""}
-              onChange={(e) =>
-                setSelectedDeckId(e.target.value ? Number(e.target.value) : undefined)
-              }
+              onChange={(e) => {
+                const next = e.target.value ? Number(e.target.value) : undefined;
+                setSelectedDeckId(next);
+                persistLastDeckId(next);
+              }}
               className="flex-1 min-h-[44px] rounded-lg border border-amber-200 bg-white px-3 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-amber-300"
             >
               <option value="">All decks</option>


### PR DESCRIPTION
Closes #1199 — slice of #746 (follow-up to #1196).

## Summary
Adds the localStorage persistence behaviour the original #746 spec called for. The flashcards deck selector shipped in #1196 without persistence; this restores it.

## Changes
- Read `flashcards.lastDeckId` after `listDecks()` resolves; only restore the selection when the saved id matches one of the user's decks (handles deleted/renamed decks gracefully — no broken default)
- Write on selector change; remove the key when `All decks` is chosen
- All `localStorage` access wrapped in `try/catch` for SSR + private-mode safety

## a11y / WCAG
No new visible patterns — selector already meets WCAG via #1196's label/control association. Persistence is invisible to screen readers.

## Test plan
- [x] `FlashcardsLastDeck.test.ts` — 5 static assertions (read, write, remove, try/catch, decks gate)
- [x] `FlashcardsDeckSelector.test.ts` — 7 still pass
- [x] `FlashcardsPage.test.tsx` — 7 still pass
- [x] Full frontend suite — 2222/2222 passing

Label: `ui` `feat`

Generated with Claude Code
