### PR TITLE
feat: add Study decks panel to /profile (closes #1201)

### DIFF
--- a/frontend/src/__tests__/CheckmarkIconA11y.test.tsx
+++ b/frontend/src/__tests__/CheckmarkIconA11y.test.tsx
@@ -15,6 +15,7 @@ jest.mock("@/lib/api", () => ({
   saveGeminiKey: jest.fn(),
   deleteGeminiKey: jest.fn(),
   saveObsidianSettings: jest.fn(),
+  listDecks: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock("@/lib/settings", () => ({

--- a/frontend/src/__tests__/ProfileDecksDuePanel.test.ts
+++ b/frontend/src/__tests__/ProfileDecksDuePanel.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Static assertion: /profile surfaces a "Study decks" section listing
+ * decks with due_today > 0, with rows that pre-select the deck via the
+ * flashcards.lastDeckId localStorage key (#1199) before navigating.
+ * Closes #1201
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("Profile decks-due-today panel", () => {
+  const src = read("src/app/profile/page.tsx");
+
+  it("imports listDecks and DeckSummary", () => {
+    expect(src).toMatch(/listDecks/);
+    expect(src).toMatch(/DeckSummary/);
+  });
+
+  it("filters to decks with due_today > 0", () => {
+    expect(src).toMatch(/due_today\s*>\s*0/);
+  });
+
+  it("renders a Study decks heading", () => {
+    expect(src).toMatch(/Study decks/);
+  });
+
+  it("each row has aria-label describing the action", () => {
+    expect(src).toMatch(/aria-label=\{[^}]*Review\b/);
+  });
+
+  it("row navigates to /vocabulary/flashcards after persisting lastDeckId", () => {
+    expect(src).toMatch(/flashcards\.lastDeckId/);
+    expect(src).toMatch(/router\.push\(\s*["']\/vocabulary\/flashcards["']/);
+  });
+
+  it("row meets 44px touch target", () => {
+    const idx = src.indexOf(">Study decks<");
+    expect(idx).toBeGreaterThan(0);
+    const window = src.slice(idx, idx + 1500);
+    expect(window).toMatch(/min-h-\[44px\]/);
+  });
+
+  it("loading state on the panel uses role=status with aria-label", () => {
+    // Loading skeleton must use role=status; appears in the decksLoading branch
+    expect(src).toMatch(/role=["']status["']\s+aria-label=["']Loading study decks["']/);
+  });
+});

--- a/frontend/src/__tests__/ProfilePage.coverage.test.tsx
+++ b/frontend/src/__tests__/ProfilePage.coverage.test.tsx
@@ -42,6 +42,7 @@ jest.mock("@/lib/api", () => ({
   }),
   saveObsidianSettings: jest.fn().mockResolvedValue({}),
   getUserStats: jest.fn().mockResolvedValue({ totals: { books_started: 0, vocabulary_words: 0, annotations: 0, insights: 0 }, streak: 0, longest_streak: 0, activity: [] }),
+  listDecks: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock("@/lib/settings", () => ({

--- a/frontend/src/__tests__/ProfilePage.coverage2.test.tsx
+++ b/frontend/src/__tests__/ProfilePage.coverage2.test.tsx
@@ -35,6 +35,7 @@ jest.mock("@/lib/api", () => ({
   getObsidianSettings: jest.fn().mockResolvedValue({ obsidian_repo: "u/v", obsidian_path: "Notes" }),
   saveObsidianSettings: jest.fn().mockResolvedValue({}),
   getUserStats: jest.fn().mockResolvedValue({ totals: { books_started: 0, vocabulary_words: 0, annotations: 0, insights: 0 }, streak: 0, longest_streak: 0, activity: [] }),
+  listDecks: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock("@/lib/settings", () => ({

--- a/frontend/src/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/__tests__/ProfilePage.test.tsx
@@ -26,6 +26,7 @@ jest.mock("@/lib/api", () => ({
     obsidian_path: "Notes/Books",
   }),
   saveObsidianSettings: jest.fn().mockResolvedValue({}),
+  listDecks: jest.fn().mockResolvedValue([]),
   getUserStats: jest.fn().mockResolvedValue({ totals: { books_started: 0, vocabulary_words: 0, annotations: 0, insights: 0 }, streak: 0, longest_streak: 0, activity: [] }),
 }));
 

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -2,8 +2,8 @@
 import { useSession, signOut } from "next-auth/react";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { saveGeminiKey, deleteGeminiKey, getMe, getObsidianSettings, saveObsidianSettings } from "@/lib/api";
-import { ArrowLeftIcon, CheckIcon, ChevronRightIcon } from "@/components/Icons";
+import { saveGeminiKey, deleteGeminiKey, getMe, getObsidianSettings, saveObsidianSettings, listDecks, DeckSummary } from "@/lib/api";
+import { ArrowLeftIcon, CheckIcon, ChevronRightIcon, DeckIcon } from "@/components/Icons";
 import { getSettings, saveSettings, AppSettings } from "@/lib/settings";
 
 const LANGUAGES = [
@@ -55,9 +55,41 @@ export default function ProfilePage() {
   });
   const [prefsSaved, setPrefsSaved] = useState(false);
 
+  // ── Study decks (decks with due cards today) ───────────────────────────────
+  const [decks, setDecks] = useState<DeckSummary[]>([]);
+  const [decksLoading, setDecksLoading] = useState(true);
+
   useEffect(() => {
     document.title = "Profile — Book Reader AI";
   }, []);
+
+  useEffect(() => {
+    let alive = true;
+    listDecks()
+      .then((d) => {
+        if (alive) setDecks(d);
+      })
+      .catch(() => {
+        // Swallow — section just hides
+      })
+      .finally(() => {
+        if (alive) setDecksLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  function gotoFlashcardsForDeck(deckId: number) {
+    try {
+      localStorage.setItem("flashcards.lastDeckId", String(deckId));
+    } catch {
+      /* ignore */
+    }
+    router.push("/vocabulary/flashcards");
+  }
+
+  const dueDecks = decks.filter((d) => d.due_today > 0);
 
   // Fetch live key status from backend (session JWT can be stale after key changes)
   useEffect(() => {
@@ -207,6 +239,46 @@ export default function ProfilePage() {
             )}
           </div>
         </section>
+
+        {/* ── Study decks (due today) ──────────────────────────────────── */}
+        {decksLoading ? (
+          <section
+            role="status"
+            aria-label="Loading study decks"
+            className="bg-white rounded-2xl border border-amber-100 p-6"
+          >
+            <div className="animate-pulse space-y-3" aria-hidden="true">
+              <div className="h-5 w-32 bg-amber-100 rounded" />
+              <div className="h-12 bg-amber-100 rounded-xl min-h-[44px]" />
+              <div className="h-12 bg-amber-100 rounded-xl min-h-[44px]" />
+            </div>
+          </section>
+        ) : dueDecks.length > 0 ? (
+          <section className="bg-white rounded-2xl border border-amber-100 p-6">
+            <h2 className="font-serif text-lg font-semibold text-ink mb-4">Study decks</h2>
+            <ul className="space-y-2">
+              {dueDecks.map((d) => (
+                <li key={d.id}>
+                  <button
+                    type="button"
+                    onClick={() => gotoFlashcardsForDeck(d.id)}
+                    aria-label={`Review ${d.due_today} due card${d.due_today !== 1 ? "s" : ""} in ${d.name}`}
+                    className="w-full flex items-center gap-3 rounded-xl border border-amber-200 bg-white px-4 py-2 hover:border-amber-400 hover:bg-amber-50 transition-colors min-h-[44px]"
+                  >
+                    <DeckIcon className="w-4 h-4 text-amber-700 shrink-0" />
+                    <span className="font-serif text-ink truncate flex-1 min-w-0 text-left">
+                      {d.name}
+                    </span>
+                    <span className="text-xs font-medium text-amber-700 shrink-0">
+                      {d.due_today} due
+                    </span>
+                    <ChevronRightIcon className="w-4 h-4 text-stone-400 shrink-0" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
 
         {/* Section label */}
         <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-400 px-1">AI &amp; Integrations</h2>


### PR DESCRIPTION
Closes #1201 — final spec item of #746 (follow-up to #1189, #1193, #1196, #1198, #1200).

## Summary
Surfaces decks with `due_today > 0` on the profile page so users can see at a glance which review queues are waiting and jump straight in.

## Changes
- `/profile` page calls `listDecks()` on mount; filters to `due_today > 0`
- New section between Account and AI & Integrations: `<h2>Study decks</h2>` with one row per due deck
- Each row: `DeckIcon` + name + `{N} due` + `ChevronRightIcon`, `aria-label="Review {N} due card(s) in {name}"`, 44px touch target
- Click writes `flashcards.lastDeckId` then navigates to `/vocabulary/flashcards` — pairs with #1200 so the flashcards selector lands on the right deck
- Section hidden when no decks are due (no empty state — profile already has plenty of structure)
- Loading skeleton uses `role="status" aria-label="Loading study decks"`
- Errors swallowed silently (consistent with other profile sections; surfacing them would be noisy on login flicker)

## Mock plumbing
Four existing test files mock `@/lib/api` and need `listDecks` stubbed: `ProfilePage.test.tsx`, `ProfilePage.coverage.test.tsx`, `ProfilePage.coverage2.test.tsx`, `CheckmarkIconA11y.test.tsx`. Each gets `listDecks: jest.fn().mockResolvedValue([])`. No behaviour change to existing assertions.

## a11y / WCAG
- 1.3.1 Info and Relationships (`<h2>` for section, `<ul>` for rows)
- 4.1.2 Name/Role/Value (aria-label on each row)
- 4.1.3 Status Messages (loading skeleton role=status)
- 44px touch targets

## Test plan
- [x] `ProfileDecksDuePanel.test.ts` — 7 static assertions
- [x] All four updated profile-related test files — 33+ existing assertions still pass
- [x] Full frontend suite — 2229/2229 passing

This closes the final remaining spec item of #746. After merge, all of vocab tags & decks frontend work is shipped end-to-end.

Label: `ui` `feat`

Generated with Claude Code
