### PR TITLE
feat: maintained translation alignment checker (closes #1073)

### DIFF
--- a/backend/scripts/check_translation_alignment.py
+++ b/backend/scripts/check_translation_alignment.py
@@ -1,0 +1,399 @@
+"""Verify source-vs-translation structural alignment for any cached book.
+
+Generalised from `/tmp/check_faust_alignment.py` per the design doc at
+`docs/design/translation-alignment-checker.md` (issue #1073).
+
+What it checks per chapter:
+
+    1. Row existence       — one translations row per splitter chapter.
+    2. Paragraph count     — src paragraph count == translated paragraph count.
+    3. Paragraph line drift — for paragraphs with ≥4 lines, |src_lines − tr_lines|
+                              must be 0. Catches Opus's typical off-by-one drop
+                              on chunked input (the 18 drifts in Rilke/zh that
+                              the original Faust-only checker found).
+    4. Stanza line count   — for paragraphs flagged as VERSE by the classifier,
+                              src and translated lines must match exactly.
+    5. Speaker cues        — per-source-language detector (de/fr/en/ru) flags
+                              source cues; checker requires a translated cue at
+                              the same line position.
+    6. Title (informational) — null `title_translation` is reported but does
+                              not fail the check.
+
+Usage:
+    python -m scripts.check_translation_alignment --book-id 24288 --target-lang zh
+    python -m scripts.check_translation_alignment --all-books --target-lang zh
+    python -m scripts.check_translation_alignment --book-id 24288 --target-lang zh \
+        --format json --severity-threshold error
+
+Exit code 0 when no issues at the requested severity threshold; non-zero
+otherwise. Output is markdown by default (issue-body friendly), JSON via
+`--format json` for CI gating.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+import statistics
+import sys
+from typing import Iterable
+
+from services.db import DB_PATH
+from services.splitter import build_chapters_from_epub
+from scripts.translation_alignment_detectors import (
+    get_detector,
+    is_translated_cue,
+)
+from scripts.translation_alignment_overrides import get_override
+
+
+# ---------- Severity ---------------------------------------------------------
+
+SEVERITY_RANK = {"info": 0, "warning": 1, "error": 2}
+
+SEVERITY_BY_KIND = {
+    "missing_translation":         "error",
+    "paragraph_count_drift":       "error",
+    "paragraph_line_count_drift":  "error",
+    "stanza_line_drift":           "error",
+    "speaker_cue_missing":         "warning",
+    "speaker_cue_not_translated":  "warning",
+    "title_translation_missing":   "info",
+}
+
+
+# ---------- Verse classifier -------------------------------------------------
+
+
+def is_verse_paragraph(text: str) -> bool:
+    """Heuristic: paragraph is verse iff
+        - ≥3 non-empty lines AND
+        - line lengths are roughly even (stddev/mean < 0.5) AND
+        - at least 2 lines do NOT end with sentence-final punctuation.
+
+    Calibrated against the audited books in `reports/translation_audits_2026_04_25.md`:
+    Faust (verse), Stundenbuch (verse), Bovary (prose), Moby Dick (prose).
+    """
+    lines = [l for l in text.split("\n") if l.strip()]
+    if len(lines) < 3:
+        return False
+    lengths = [len(l) for l in lines]
+    mean = sum(lengths) / len(lengths)
+    if mean == 0:
+        return False
+    if len(lengths) >= 2:
+        stddev = statistics.stdev(lengths)
+        if stddev / mean >= 0.5:
+            return False
+    sentence_final = (".", "?", "!", "。", "？", "！")
+    non_terminal = sum(1 for l in lines if not l.rstrip().endswith(sentence_final))
+    return non_terminal >= 2
+
+
+def classify_paragraph(
+    book_id: int, chapter_index: int, paragraph_index: int, text: str
+) -> bool:
+    """Return True iff the paragraph should be treated as verse, applying
+    per-book overrides when present."""
+    ov = get_override(book_id)
+    verse_chapters = ov.get("verse_chapters")
+    if verse_chapters == "all":
+        return True
+    if isinstance(verse_chapters, list) and verse_chapters:
+        if chapter_index in verse_chapters:
+            return True
+    explicit = ov.get("verse_paragraph_indices")
+    if explicit and chapter_index in explicit:
+        return paragraph_index in explicit[chapter_index]
+    if verse_chapters == []:
+        return False
+    return is_verse_paragraph(text)
+
+
+# ---------- DB I/O -----------------------------------------------------------
+
+
+def _conn() -> sqlite3.Connection:
+    return sqlite3.connect(DB_PATH)
+
+
+def chapters_from_db(book_id: int):
+    conn = _conn()
+    row = conn.execute(
+        "SELECT epub_bytes FROM book_epubs WHERE book_id=?", (book_id,)
+    ).fetchone()
+    conn.close()
+    if not row:
+        raise SystemExit(f"No EPUB cached for book {book_id}")
+    return build_chapters_from_epub(row[0])
+
+
+def translations_for_book(
+    book_id: int, target_language: str
+) -> dict[int, tuple[list[str], str | None]]:
+    conn = _conn()
+    rows = conn.execute(
+        "SELECT chapter_index, paragraphs, title_translation "
+        "FROM translations WHERE book_id=? AND target_language=? "
+        "ORDER BY chapter_index",
+        (book_id, target_language),
+    ).fetchall()
+    conn.close()
+    return {ci: (json.loads(p), tt) for ci, p, tt in rows}
+
+
+def list_books_with_translations(target_language: str) -> list[int]:
+    conn = _conn()
+    rows = conn.execute(
+        "SELECT DISTINCT book_id FROM translations "
+        "WHERE target_language=? ORDER BY book_id",
+        (target_language,),
+    ).fetchall()
+    conn.close()
+    return [r[0] for r in rows]
+
+
+def book_source_language(book_id: int, ov: dict) -> str:
+    if ov.get("source_language"):
+        return ov["source_language"]
+    conn = _conn()
+    row = conn.execute(
+        "SELECT languages FROM books WHERE id=?", (book_id,)
+    ).fetchone()
+    conn.close()
+    if row and row[0]:
+        try:
+            langs = json.loads(row[0])
+            if langs:
+                return langs[0].lower()
+        except (json.JSONDecodeError, AttributeError):
+            pass
+    return ""
+
+
+# ---------- Core check -------------------------------------------------------
+
+
+def paragraphs(text: str) -> list[str]:
+    return [p for p in text.split("\n\n") if p.strip()]
+
+
+def check_alignment(book_id: int, target_language: str) -> list[dict]:
+    chapters = chapters_from_db(book_id)
+    trans = translations_for_book(book_id, target_language)
+    ov = get_override(book_id)
+    src_lang = book_source_language(book_id, ov)
+    is_cue = get_detector(src_lang)
+    issues: list[dict] = []
+
+    def add(kind: str, chapter: int, title: str, **detail) -> None:
+        issues.append(
+            {
+                "kind": kind,
+                "severity": SEVERITY_BY_KIND.get(kind, "warning"),
+                "chapter": chapter,
+                "title": title,
+                **detail,
+            }
+        )
+
+    for idx, chap in enumerate(chapters):
+        src_paras = paragraphs(chap.text)
+        if idx not in trans:
+            add(
+                "missing_translation",
+                idx,
+                chap.title,
+                detail=f"no translations row for chapter_index={idx}",
+            )
+            continue
+
+        tr_paras, title_tr = trans[idx]
+
+        if title_tr is None:
+            add("title_translation_missing", idx, chap.title, detail="title_translation is NULL")
+
+        if len(src_paras) != len(tr_paras):
+            add(
+                "paragraph_count_drift",
+                idx,
+                chap.title,
+                detail=f"src={len(src_paras)} paragraphs, translated={len(tr_paras)}",
+            )
+
+        for pi, (sp, tp) in enumerate(zip(src_paras, tr_paras)):
+            src_lines = [l for l in sp.split("\n") if l.strip()]
+            tr_lines = [l for l in tp.split("\n") if l.strip()]
+            verse = classify_paragraph(book_id, idx, pi, sp)
+
+            if verse and len(src_lines) != len(tr_lines):
+                add(
+                    "stanza_line_drift",
+                    idx,
+                    chap.title,
+                    paragraph=pi,
+                    detail=f"src={len(src_lines)} lines, translated={len(tr_lines)}",
+                )
+            elif (
+                (not verse)
+                and len(src_lines) >= 4
+                and len(tr_lines) >= 2  # skip reflowed prose where translator merged to 1 line
+                and abs(len(src_lines) - len(tr_lines)) >= 1
+            ):
+                add(
+                    "paragraph_line_count_drift",
+                    idx,
+                    chap.title,
+                    paragraph=pi,
+                    detail=f"src={len(src_lines)} lines, translated={len(tr_lines)} "
+                           f"(possible Opus line drop)",
+                )
+
+            sp_lines_raw = sp.split("\n")
+            tp_lines_raw = tp.split("\n")
+            for li, src_line in enumerate(sp_lines_raw):
+                if not is_cue(src_line):
+                    continue
+                if li >= len(tp_lines_raw):
+                    add(
+                        "speaker_cue_missing",
+                        idx,
+                        chap.title,
+                        paragraph=pi,
+                        line=li,
+                        detail=f"src cue {src_line.strip()!r} has no translated line",
+                    )
+                    continue
+                if not is_translated_cue(tp_lines_raw[li], target_language):
+                    add(
+                        "speaker_cue_not_translated",
+                        idx,
+                        chap.title,
+                        paragraph=pi,
+                        line=li,
+                        detail=f"src {src_line.strip()!r} → tr {tp_lines_raw[li].strip()!r}",
+                    )
+
+    return issues
+
+
+# ---------- Output formats ---------------------------------------------------
+
+
+def filter_by_severity(issues: list[dict], threshold: str) -> list[dict]:
+    rank = SEVERITY_RANK[threshold]
+    return [i for i in issues if SEVERITY_RANK.get(i.get("severity", "warning"), 1) >= rank]
+
+
+def format_markdown(book_id: int, target_language: str, issues: list[dict]) -> str:
+    lines = [f"# Alignment check: book #{book_id}, target={target_language}", ""]
+    if not issues:
+        lines.append("No alignment issues detected.")
+        return "\n".join(lines)
+
+    lines.append(f"**{len(issues)} issues across chapters.**")
+    lines.append("")
+
+    by_kind: dict[str, int] = {}
+    for i in issues:
+        by_kind[i["kind"]] = by_kind.get(i["kind"], 0) + 1
+    lines.append("## Summary by kind")
+    for k, n in sorted(by_kind.items(), key=lambda x: -x[1]):
+        sev = SEVERITY_BY_KIND.get(k, "?")
+        lines.append(f"- **{k}** [{sev}]: {n}")
+    lines.append("")
+
+    lines.append("## Details (first 30)")
+    lines.append("")
+    for issue in issues[:30]:
+        title = (issue.get("title") or "")[:40]
+        para = f" p{issue['paragraph']}" if "paragraph" in issue else ""
+        line = f" l{issue['line']}" if "line" in issue else ""
+        lines.append(
+            f"- ch{issue['chapter']:2d} {title!r:44s}{para}{line} "
+            f"[{issue['kind']}]  {issue.get('detail', '')}"
+        )
+    if len(issues) > 30:
+        lines.append(f"...and {len(issues) - 30} more.")
+    return "\n".join(lines)
+
+
+def format_json(book_id: int, target_language: str, issues: list[dict]) -> str:
+    return json.dumps(
+        {"book_id": book_id, "target_language": target_language, "issues": issues},
+        ensure_ascii=False,
+        indent=2,
+    )
+
+
+# ---------- CLI --------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Check translation alignment against splitter source paragraphs."
+    )
+    g = p.add_mutually_exclusive_group(required=False)
+    g.add_argument("--book-id", type=int, help="Single book id")
+    g.add_argument("--all-books", action="store_true", help="Check all books with translations in the target language")
+    p.add_argument("--target-lang", default="zh", help="Target language code (default: zh)")
+    p.add_argument("--format", choices=("markdown", "json"), default="markdown")
+    p.add_argument(
+        "--severity-threshold",
+        choices=("info", "warning", "error"),
+        default="error",
+        help="Issues at or above this severity affect the exit code (default: error)",
+    )
+    p.add_argument(
+        "book_id_pos",
+        nargs="?",
+        type=int,
+        help="Deprecated: positional book id alias for --book-id",
+    )
+    p.add_argument(
+        "target_lang_pos",
+        nargs="?",
+        help="Deprecated: positional target language alias for --target-lang",
+    )
+    args = p.parse_args(argv)
+
+    book_ids: list[int]
+    target_language = args.target_lang
+    if args.all_books:
+        book_ids = list_books_with_translations(target_language)
+        if not book_ids:
+            print(f"No books with translations in target_language={target_language}")
+            return 0
+    elif args.book_id is not None:
+        book_ids = [args.book_id]
+    elif args.book_id_pos is not None:
+        book_ids = [args.book_id_pos]
+        if args.target_lang_pos:
+            target_language = args.target_lang_pos
+    else:
+        p.error("must pass --book-id N or --all-books")
+
+    overall_exit = 0
+    for book_id in book_ids:
+        try:
+            issues = check_alignment(book_id, target_language)
+        except SystemExit as e:
+            print(f"# {e}", file=sys.stderr)
+            overall_exit = max(overall_exit, 2)
+            continue
+        gating = filter_by_severity(issues, args.severity_threshold)
+        if args.format == "json":
+            print(format_json(book_id, target_language, issues))
+        else:
+            print(format_markdown(book_id, target_language, issues))
+            print()
+        if gating:
+            overall_exit = max(overall_exit, 1)
+
+    return overall_exit
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/translation_alignment_detectors.py
+++ b/backend/scripts/translation_alignment_detectors.py
@@ -1,0 +1,141 @@
+"""Per-source-language speaker-cue detectors for the translation alignment
+checker (issue #1073, design doc `docs/design/translation-alignment-checker.md`).
+
+Each detector is a pair of pure functions:
+
+    is_cue(line: str) -> bool
+        True iff the source-language line is a speaker cue (a stage-play line
+        like "FAUST." in Goethe, "Le Roi." in classical French theatre).
+
+    is_translated_cue(line: str, target_language: str) -> bool
+        True iff the translated line preserves the speaker-cue typography
+        for the given target language. Currently only zh is wired up
+        (heuristic: ≤20 chars, ends with "。"), but the signature leaves
+        room for future targets.
+
+Detectors are looked up by source-language ISO code (`de`, `fr`, `en`, `ru`).
+Languages without a registered detector fall through to `no_cue_detector`,
+which makes the cue check a no-op (every line passes).
+
+Adding a language: implement the two functions and register in DETECTORS.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Callable
+
+CueDetector = Callable[[str], bool]
+TranslatedCueDetector = Callable[[str, str], bool]
+
+
+# ----- Generic translated-cue check (target-language aware) ------------------
+# Heuristic shared across detectors: a translated cue is a short standalone
+# line that ends with the target language's sentence-final punctuation.
+_TRANSLATED_CUE_TERMINATORS = {
+    "zh": ("。", "："),  # full stop or colon (some translators use colon)
+    "ja": ("。", "："),
+    "en": (".", ":"),
+    "fr": (".", ":"),
+    "de": (".", ":"),
+    "ru": (".", ":"),
+    "es": (".", ":"),
+}
+
+
+def _is_translated_cue_default(line: str, target_language: str) -> bool:
+    line = line.strip()
+    if not line:
+        return False
+    if len(line) > 20:
+        return False
+    terminators = _TRANSLATED_CUE_TERMINATORS.get(target_language, (".",))
+    return any(line.endswith(t) for t in terminators)
+
+
+# ----- DE: Goethe-style ALL-CAPS cues ---------------------------------------
+# "FAUST.", "MEPHISTOPHELES.", "DER KAISER.", "FAUST (abgewendet)."
+_DE_CUE_RE = re.compile(
+    r"^[A-ZÄÖÜ][A-ZÄÖÜß\s,]{1,}(?:\s*\([^)]{0,60}\))?\.$"
+)
+
+
+def _is_cue_de(line: str) -> bool:
+    return bool(_DE_CUE_RE.match(line.strip()))
+
+
+# ----- FR: classical theatre cues (mixed case + period) ----------------------
+# "Le Roi.", "LE ROI.", "Don Juan.", "Sganarelle, à part."
+# Either fully uppercase, OR Capitalized + ending in period AND ≤30 chars.
+_FR_CUE_FULLCAP_RE = re.compile(
+    r"^[A-ZÉÈÊÀÂÔ][A-ZÉÈÊÀÂÔ\s,]{1,}(?:\s*\([^)]{0,60}\))?\.$"
+)
+_FR_CUE_TITLECASE_RE = re.compile(
+    r"^[A-ZÉÈÊÀÂÔ][a-zéèêàâôç]+(?:\s+[A-Z][a-zéèêàâôç]+)*"
+    r"(?:,\s*[a-zéèêàâôç ]{1,30})?\.$"
+)
+
+
+def _is_cue_fr(line: str) -> bool:
+    line = line.strip()
+    if len(line) > 40:
+        return False
+    return bool(_FR_CUE_FULLCAP_RE.match(line) or _FR_CUE_TITLECASE_RE.match(line))
+
+
+# ----- EN: Shakespearean / English-drama cues -------------------------------
+# "HAMLET.", "Hamlet.", "OPHELIA, aside."
+# Same shape as FR but with ASCII-only letters.
+_EN_CUE_FULLCAP_RE = re.compile(
+    r"^[A-Z][A-Z\s,]{1,}"
+    r"(?:,\s*[a-z ]{1,30})?"           # optional ", aside" lowercase tail
+    r"(?:\s*\([^)]{0,60}\))?\.$"
+)
+_EN_CUE_TITLECASE_RE = re.compile(
+    r"^[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*(?:,\s*[a-z ]{1,30})?\.$"
+)
+
+
+def _is_cue_en(line: str) -> bool:
+    line = line.strip()
+    if len(line) > 40:
+        return False
+    return bool(_EN_CUE_FULLCAP_RE.match(line) or _EN_CUE_TITLECASE_RE.match(line))
+
+
+# ----- RU: Cyrillic ALL-CAPS + period ----------------------------------------
+# "ГАМЛЕТ.", "ОФЕЛИЯ."
+_RU_CUE_RE = re.compile(
+    r"^[А-ЯЁ][А-ЯЁ\s,]{1,}(?:\s*\([^)]{0,60}\))?\.$"
+)
+
+
+def _is_cue_ru(line: str) -> bool:
+    return bool(_RU_CUE_RE.match(line.strip()))
+
+
+# ----- No-op default ---------------------------------------------------------
+
+
+def _is_cue_none(line: str) -> bool:
+    """Default detector for languages with no registered cue typography.
+    Returns False for every line so the cue check is a no-op."""
+    return False
+
+
+# ----- Registry -------------------------------------------------------------
+
+DETECTORS: dict[str, CueDetector] = {
+    "de": _is_cue_de,
+    "fr": _is_cue_fr,
+    "en": _is_cue_en,
+    "ru": _is_cue_ru,
+}
+
+
+def get_detector(source_language: str) -> CueDetector:
+    return DETECTORS.get(source_language.lower(), _is_cue_none)
+
+
+def is_translated_cue(line: str, target_language: str) -> bool:
+    return _is_translated_cue_default(line, target_language)

--- a/backend/scripts/translation_alignment_overrides.py
+++ b/backend/scripts/translation_alignment_overrides.py
@@ -1,0 +1,63 @@
+"""Per-book overrides for the translation alignment checker (#1073).
+
+The checker's verse-vs-prose classifier is heuristic. Some books legitimately
+need explicit per-book pinning — Faust is verse-and-prose mixed, Moby Dick
+has occasional inset hymns inside prose chapters, etc. This registry lets us
+encode that knowledge as code without bloating the heuristic.
+
+Books not in the registry fall through to the heuristic (zero-config for new
+books).
+
+Schema:
+    OVERRIDES[book_id] = {
+        'source_language': 'de' | 'fr' | 'en' | 'ru' | …,
+        'verse_chapters': 'all' | list[int] | None,
+            # 'all'   = every chapter is verse
+            # [3, 8] = chapter indices 3 and 8 are verse, others heuristic
+            # None  = pure heuristic (default)
+        'verse_paragraph_indices': dict[int, list[int]] | None,
+            # per-chapter verse paragraph index list. Wins over `verse_chapters`
+            # for those chapters. e.g. {42: [3, 7]} means in chapter 42,
+            # paragraphs 3 and 7 are verse, the rest is prose.
+    }
+
+Adding a book: append an entry. Keep entries minimal — only override what
+the heuristic gets wrong.
+"""
+
+from __future__ import annotations
+
+OVERRIDES: dict[int, dict] = {
+    2229: {  # Goethe — Faust I & II
+        "source_language": "de",
+        "verse_chapters": "all",
+    },
+    24288: {  # Rilke — Das Stunden-Buch
+        "source_language": "de",
+        "verse_chapters": "all",
+    },
+    14155: {  # Flaubert — Madame Bovary
+        "source_language": "fr",
+        "verse_chapters": [],
+    },
+    2701: {  # Melville — Moby Dick
+        "source_language": "en",
+        "verse_chapters": [],
+    },
+    1342: {  # Austen — Pride and Prejudice
+        "source_language": "en",
+        "verse_chapters": [],
+    },
+    1513: {  # Shakespeare — Romeo and Juliet
+        "source_language": "en",
+        "verse_chapters": "all",
+    },
+    84: {  # Shelley — Frankenstein
+        "source_language": "en",
+        "verse_chapters": [],
+    },
+}
+
+
+def get_override(book_id: int) -> dict:
+    return OVERRIDES.get(book_id, {})

--- a/backend/tests/test_translation_alignment_checker.py
+++ b/backend/tests/test_translation_alignment_checker.py
@@ -1,0 +1,241 @@
+"""Tests for the translation alignment checker (#1073).
+
+Each `kind` documented in the design doc gets at least one positive test.
+We mock chapters_from_db / translations_for_book so tests don't depend on
+the live DB or any cached EPUBs — pure logic tests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from scripts import check_translation_alignment as cta
+from scripts.translation_alignment_detectors import (
+    _is_cue_de,
+    _is_cue_en,
+    _is_cue_fr,
+    _is_cue_ru,
+    _is_translated_cue_default,
+    get_detector,
+    is_translated_cue,
+)
+
+
+class _Chapter:
+    """Minimal stand-in for services.splitter.Chapter."""
+
+    def __init__(self, title: str, text: str):
+        self.title = title
+        self.text = text
+
+
+def _run(book_id, target_lang, src_chapters, translations_dict, *, source_lang="de"):
+    """Helper: patch the DB-touching functions and run the checker."""
+    with patch.object(cta, "chapters_from_db", return_value=src_chapters), \
+         patch.object(cta, "translations_for_book", return_value=translations_dict), \
+         patch.object(cta, "book_source_language", return_value=source_lang):
+        return cta.check_alignment(book_id, target_lang)
+
+
+# ---------------- Detector unit tests ----------------------------------------
+
+
+def test_de_cue_detects_classic_goethe_cues():
+    assert _is_cue_de("FAUST.")
+    assert _is_cue_de("MEPHISTOPHELES.")
+    assert _is_cue_de("DER KAISER.")
+    assert _is_cue_de("FAUST (abgewendet).")
+    assert not _is_cue_de("Margarete denkt nach.")
+    assert not _is_cue_de("ein langer Satz hier.")
+
+
+def test_fr_cue_detects_titlecase_and_fullcap():
+    assert _is_cue_fr("Le Roi.")
+    assert _is_cue_fr("LE ROI.")
+    assert _is_cue_fr("Don Juan.")
+    assert _is_cue_fr("Sganarelle, à part.")
+    assert not _is_cue_fr("Un long passage de prose française se termine ainsi.")
+
+
+def test_en_cue_detects_shakespearean_cues():
+    assert _is_cue_en("HAMLET.")
+    assert _is_cue_en("Hamlet.")
+    assert _is_cue_en("OPHELIA, aside.")
+    assert not _is_cue_en("This is a long English sentence ending with a period.")
+
+
+def test_ru_cue_detects_cyrillic_caps():
+    assert _is_cue_ru("ГАМЛЕТ.")
+    assert _is_cue_ru("ОФЕЛИЯ.")
+    assert not _is_cue_ru("Гамлет говорит долго.")
+
+
+def test_no_cue_default_for_unknown_language():
+    detector = get_detector("ja")
+    assert detector("Some line") is False
+    assert detector("FAUST.") is False  # registered no-op
+
+
+def test_translated_cue_zh():
+    assert _is_translated_cue_default("浮士德。", "zh")
+    assert _is_translated_cue_default("梅菲斯特：", "zh")
+    assert not _is_translated_cue_default(
+        "这是一个非常长的句子，根本不可能是一个说话人提示。" * 2, "zh"
+    )
+
+
+def test_translated_cue_target_aware():
+    assert is_translated_cue("Hamlet.", "en")
+    assert is_translated_cue("梅菲斯特。", "zh")
+
+
+# ---------------- Verse classifier ------------------------------------------
+
+
+def test_verse_classifier_recognises_short_even_lines():
+    verse = (
+        "Ich bete wieder, du Erlauchter,\n"
+        "du hörst mich wieder durch den Wind,\n"
+        "weil meine Tiefen nie gebrauchter\n"
+        "rauschender Worte mächtig sind."
+    )
+    assert cta.is_verse_paragraph(verse)
+
+
+def test_verse_classifier_rejects_uneven_prose():
+    prose = (
+        "It was a wide and roomy chamber, with floor of stone and walls of beaten earth.\n"
+        "Short.\n"
+        "Then a much longer descriptive sentence that goes on and on with detail."
+    )
+    assert not cta.is_verse_paragraph(prose)
+
+
+def test_verse_classifier_rejects_short():
+    assert not cta.is_verse_paragraph("a single line")
+    assert not cta.is_verse_paragraph("two\nlines")
+
+
+# ---------------- check_alignment integration tests --------------------------
+
+
+def test_missing_translation_reported():
+    chapters = [_Chapter("ch0", "p0\n\np1")]
+    issues = _run(1, "zh", chapters, translations_dict={})
+    assert any(i["kind"] == "missing_translation" for i in issues)
+
+
+def test_paragraph_count_drift_flagged():
+    chapters = [_Chapter("ch0", "para A\n\npara B\n\npara C")]
+    translations = {0: (["译A", "译B"], None)}
+    issues = _run(1, "zh", chapters, translations)
+    assert any(i["kind"] == "paragraph_count_drift" for i in issues)
+
+
+def test_stanza_line_drift_flagged_for_verse():
+    src = "line1\nline2\nline3\nline4"
+    tr = "译1\n译2\n译3"
+    chapters = [_Chapter("verse", src)]
+    translations = {0: ([tr], "标题")}
+    with patch.object(cta, "is_verse_paragraph", return_value=True):
+        issues = _run(1, "zh", chapters, translations)
+    assert any(i["kind"] == "stanza_line_drift" for i in issues)
+
+
+def test_paragraph_line_count_drift_for_prose():
+    src = "Line one short.\nLine two short.\nLine three short.\nLine four short."
+    tr = "译一\n译二\n译三"
+    chapters = [_Chapter("prose", src)]
+    translations = {0: ([tr], "标题")}
+    with patch.object(cta, "is_verse_paragraph", return_value=False):
+        issues = _run(1, "zh", chapters, translations, source_lang="en")
+    assert any(i["kind"] == "paragraph_line_count_drift" for i in issues)
+
+
+def test_prose_reflow_to_single_line_does_not_trigger_drift():
+    # Source has 4 wrapped-prose lines; translator produced one Chinese line.
+    # This is legitimate reflow, not an Opus line drop. Should NOT flag.
+    src = "Line one short.\nLine two short.\nLine three short.\nLine four short."
+    tr = "翻译者把全部四行散文合并成一句中文。"
+    chapters = [_Chapter("prose", src)]
+    translations = {0: ([tr], "标题")}
+    with patch.object(cta, "is_verse_paragraph", return_value=False):
+        issues = _run(1, "zh", chapters, translations, source_lang="en")
+    assert not any(i["kind"] == "paragraph_line_count_drift" for i in issues)
+
+
+def test_speaker_cue_missing_flagged():
+    src = "FAUST.\nIch bin der Geist."
+    tr = "FAUST.\n我是那灵."
+    chapters = [_Chapter("verse", src)]
+    translations = {0: ([tr], None)}
+    issues = _run(1, "zh", chapters, translations, source_lang="de")
+    cue_missing = [i for i in issues if i["kind"] == "speaker_cue_not_translated"]
+    assert cue_missing, f"Expected cue-not-translated issue, got: {issues}"
+
+
+def test_speaker_cue_correctly_translated_passes():
+    src = "FAUST.\nIch bin der Geist."
+    tr = "浮士德。\n我是那灵。"
+    chapters = [_Chapter("verse", src)]
+    translations = {0: ([tr], "标题")}
+    issues = _run(1, "zh", chapters, translations, source_lang="de")
+    assert not any(
+        i["kind"] in ("speaker_cue_missing", "speaker_cue_not_translated")
+        for i in issues
+    )
+
+
+def test_no_cue_detector_skips_cue_check_entirely():
+    # Source language with no detector => cue check is no-op even with
+    # all-caps lines that LOOK like cues.
+    src = "FAUST.\nThis would be a cue in DE but EN-treated-as-no-cue."
+    tr = "Some long Chinese translation that doesn't end with a period as a cue."
+    chapters = [_Chapter("test", src)]
+    translations = {0: ([tr], "标题")}
+    issues = _run(1, "zh", chapters, translations, source_lang="ja")
+    assert not any(
+        i["kind"] in ("speaker_cue_missing", "speaker_cue_not_translated")
+        for i in issues
+    )
+
+
+def test_severity_filtering():
+    # title_translation_missing is "info" — should be excluded by error threshold
+    chapters = [_Chapter("ch0", "p0")]
+    translations = {0: (["t0"], None)}  # title_translation is None
+    issues = _run(1, "zh", chapters, translations)
+    info_issues = [i for i in issues if i["severity"] == "info"]
+    assert info_issues
+    gated = cta.filter_by_severity(issues, "error")
+    assert all(i["severity"] == "error" for i in gated)
+
+
+def test_clean_run_returns_no_issues():
+    src = "First paragraph of prose.\n\nSecond paragraph."
+    chapters = [_Chapter("clean", src)]
+    translations = {
+        0: (["第一段散文。", "第二段。"], "标题"),
+    }
+    issues = _run(1, "zh", chapters, translations, source_lang="en")
+    assert issues == []
+
+
+# ---------------- Output formatters -----------------------------------------
+
+
+def test_format_markdown_clean():
+    md = cta.format_markdown(2229, "zh", [])
+    assert "No alignment issues" in md
+    assert "book #2229" in md
+
+
+def test_format_json_structure():
+    issue = {"kind": "stanza_line_drift", "severity": "error", "chapter": 1, "title": "t", "paragraph": 0, "detail": "x"}
+    out = cta.format_json(2229, "zh", [issue])
+    import json as _json
+    parsed = _json.loads(out)
+    assert parsed["book_id"] == 2229
+    assert parsed["issues"][0]["kind"] == "stanza_line_drift"


### PR DESCRIPTION
Implementation of #1073 per the merged design doc (#1194 / `docs/design/translation-alignment-checker.md`).

## Summary

Promotes the throwaway `/tmp/check_faust_alignment.py` to a canonical, maintained tool at `backend/scripts/check_translation_alignment.py` with the four generalisations from the design doc: pluggable per-source-language speaker-cue detectors, verse/prose classifier with per-book overrides, off-by-one line-drop detection, and structured JSON output.

## Files added

- `backend/scripts/check_translation_alignment.py` — main CLI script (~330 LOC).
- `backend/scripts/translation_alignment_detectors.py` — de/fr/en/ru cue detectors + no-op fallback (~140 LOC).
- `backend/scripts/translation_alignment_overrides.py` — per-book registry pinning verse vs. prose for known cases (~60 LOC).
- `backend/tests/test_translation_alignment_checker.py` — 22 unit tests covering each issue `kind`, each detector, classifier behaviour, and output formatters.

## Smoke runs against tracked books

| Book | Issues | Notes |
|---|---|---|
| Rilke #24288 | 0 | Clean (the audit pass already fixed all 18 line drifts) |
| Bovary #14155 | 24 | 21 `missing_translation` (chapters 15–35 not yet translated, expected) + 3 cue warnings (legitimate FR detector hits) |
| Moby Dick #2701 | 63 | Real `paragraph_count_drift` (35) + cue findings — surfaced for downstream review |

After tightening the prose-reflow guard (skip `paragraph_line_count_drift` when `tr_lines == 1`, since that's the legitimate "translator merged multi-line src into one Chinese line" case), Bovary went from 344 false positives to 24 legitimate issues.

## Test plan

- [x] 22 new unit tests pass (`tests/test_translation_alignment_checker.py`).
- [x] Smoke runs on three real books produce expected output (Rilke clean, Bovary issues all true positives, Moby Dick surfaces real misalignments).
- [x] No imports broken: existing scripts module pattern preserved (`from services.db import DB_PATH`, `from services.splitter import build_chapters_from_epub`).
- [ ] CI runs the full backend + frontend suite (full local suite was killed at 49% complete with all dots passing; CI is the authoritative gate).

## Out of scope (per design doc)

- CI integration (`.github/workflows/ci.yml` step) — deferred to a follow-up PR per the design doc's rollout plan: ship the script first, observe noise patterns over a week, then add the gating step.
- Auto-fix mode.
- Per-paragraph retry in the translation pipeline.
- Deletion of `/tmp/check_faust_alignment.py` — outside the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
