### PR TITLE
feat: compose nested-NCX titles for multi-part EPUB books (closes #1151)

### DIFF
--- a/backend/services/splitter.py
+++ b/backend/services/splitter.py
@@ -855,8 +855,108 @@ def _strip_leading_headings(body) -> None:
             parent.remove(heading)
 
 
+# --- Nested-NCX title composition (issue #1151, design doc
+# `docs/design/epub-nested-ncx-titles.md`) -----------------------------------
+
+_WEAK_LEAF_ROMAN_RE = re.compile(r"^[IVXLCDM]+\.?$")
+
+
+def _is_weak_leaf_title(title: str) -> bool:
+    """A leaf navPoint title is "weak" iff it doesn't carry enough chapter
+    context on its own and benefits from `<Parent> — <Leaf>` composition.
+    Calibrated for Bovary-shaped multi-part NCX (bare roman numerals)
+    without affecting Faust-shape descriptive leaves.
+    """
+    s = title.strip()
+    if not s:
+        return False
+    if _WEAK_LEAF_ROMAN_RE.match(s):
+        return True
+    words = s.split()
+    if len(words) <= 2 and len(s) < 5:
+        return True
+    return False
+
+
+def _compose_title(ancestor_titles: list[str], leaf_title: str) -> str:
+    """Compose `<Parent> — <Leaf>` only when leaf is weak AND the immediate
+    ancestor has a non-empty title distinct from the leaf's.
+    """
+    if not _is_weak_leaf_title(leaf_title):
+        return leaf_title
+    parent = next(
+        (a for a in reversed(ancestor_titles) if a and a.strip() != leaf_title.strip()),
+        None,
+    )
+    if not parent:
+        return leaf_title
+    composed = f"{parent} — {leaf_title}"
+    if len(composed) > 100:
+        return leaf_title
+    return composed
+
+
+_STANDALONE_ROMAN_RE = re.compile(r"\b[IVXLCDM]+\b")
+
+
+def _is_bloated_root_title(title: str) -> bool:
+    """Detect the chapter-0 case where the root navPoint title is a
+    concatenation of every leaf navLabel (Madame Bovary repro: a 213-char
+    string `"PREMIÈRE PARTIE I II III ..."`). Reject such titles so the
+    spine item falls back to a saner placeholder.
+
+    Two signals (either fires):
+        - title length > 120 chars (catches the production Bovary case)
+        - title contains ≥3 standalone roman-numeral tokens (catches shorter
+          but still over-concatenated TOCs without needing the full-length
+          threshold)
+    """
+    if len(title) > 120:
+        return True
+    if len(_STANDALONE_ROMAN_RE.findall(title)) >= 3:
+        return True
+    return False
+
+
+def _walk_toc_with_path(toc_items, on_entry) -> None:
+    """Depth-first walk of `book.toc` that maintains an ancestor-title stack
+    and invokes `on_entry(href, title, ancestor_titles)` for every navPoint.
+
+    `ancestor_titles` is a list of *parent* titles (the path from root to
+    the entry's parent, EXCLUSIVE of the entry itself). Children are walked
+    after `on_entry` for the parent runs, so callers using `setdefault`
+    semantics get parent-first ordering — but children's `_compose_title`
+    sees the parent in their `ancestor_titles` list.
+    """
+    def _walk(items, path: list[str]) -> None:
+        for entry in items:
+            if isinstance(entry, tuple):
+                section, children = entry
+                href = getattr(section, "href", None)
+                title = getattr(section, "title", None)
+                if href and title:
+                    on_entry(href, title, path)
+                _walk(children, path + ([title] if title else []))
+            else:
+                href = getattr(entry, "href", None)
+                title = getattr(entry, "title", None)
+                if href and title:
+                    on_entry(href, title, path)
+    _walk(toc_items, [])
+
+
 def _epub_nav_titles(book) -> dict[str, str]:
-    """Return {item_id: chapter_title} from the EPUB TOC (NCX or EPUB3 nav)."""
+    """Return {item_id: chapter_title} from the EPUB TOC (NCX or EPUB3 nav).
+
+    Composes `<Parent> — <Leaf>` titles for nested-NCX hierarchies where
+    leaf navPoints are "weak" (bare roman numerals, single-char/short
+    strings). Issue #1151, design doc `docs/design/epub-nested-ncx-titles.md`.
+
+    Bloated root titles (the entire TOC concatenated into one string —
+    the Madame Bovary `"PREMIÈRE PARTIE I II III ..."` repro) are rejected;
+    the affected item_id is left out of the dict, so callers fall back to
+    spine-level metadata.
+    """
     import ebooklib
 
     name_to_id: dict[str, str] = {
@@ -875,23 +975,28 @@ def _epub_nav_titles(book) -> dict[str, str]:
                 return item_id
         return None
 
-    def _walk(toc_items) -> None:
-        for entry in toc_items:
-            if isinstance(entry, tuple):
-                section, children = entry
-                # Walk children first so leaf chapter titles take priority over
-                # the enclosing section header when both point to the same file.
-                _walk(children)
-                if getattr(section, "href", None):
-                    item_id = _resolve(section.href)
-                    if item_id and getattr(section, "title", None):
-                        titles.setdefault(item_id, section.title)
-            elif getattr(entry, "href", None):
-                item_id = _resolve(entry.href)
-                if item_id and getattr(entry, "title", None):
-                    titles.setdefault(item_id, entry.title)
+    # Two-pass: collect, then prefer the deepest (most-composed) title for each
+    # item_id. We can't use simple setdefault because children should override
+    # parent-only assignments when both target the same href.
+    collected: dict[str, list[tuple[int, str]]] = {}
 
-    _walk(book.toc)
+    def on_entry(href: str, title: str, ancestors: list[str]) -> None:
+        item_id = _resolve(href)
+        if not item_id:
+            return
+        if _is_bloated_root_title(title):
+            return
+        composed = _compose_title(ancestors, title)
+        depth = len(ancestors)
+        collected.setdefault(item_id, []).append((depth, composed))
+
+    _walk_toc_with_path(book.toc, on_entry)
+
+    for item_id, candidates in collected.items():
+        # Prefer the deepest entry (most specific). On tie, first wins.
+        candidates.sort(key=lambda x: -x[0])
+        titles[item_id] = candidates[0][1]
+
     return titles
 
 
@@ -908,6 +1013,9 @@ def _epub_nav_anchors(book) -> dict[str, list[tuple[str | None, str]]]:
     The list order matches the NCX playOrder (depth-first walk of the
     navMap). Length-1 lists reproduce the current behaviour (one chapter
     per spine item); length-≥2 lists trigger DOM segmentation.
+
+    Titles are composed for weak leaves (issue #1151, see `_compose_title`).
+    Bloated root titles are dropped.
     """
     import ebooklib
 
@@ -917,7 +1025,6 @@ def _epub_nav_anchors(book) -> dict[str, list[tuple[str | None, str]]]:
     }
 
     def _resolve(href: str) -> tuple[str | None, str | None]:
-        # Split on '#' into (bare_path, anchor_or_None).
         if "#" in href:
             bare, anchor = href.split("#", 1)
             anchor = anchor or None
@@ -933,23 +1040,16 @@ def _epub_nav_anchors(book) -> dict[str, list[tuple[str | None, str]]]:
 
     result: dict[str, list[tuple[str | None, str]]] = {}
 
-    def _walk(toc_items) -> None:
-        for entry in toc_items:
-            if isinstance(entry, tuple):
-                section, children = entry
-                if getattr(section, "href", None):
-                    item_id, anchor = _resolve(section.href)
-                    title = getattr(section, "title", None)
-                    if item_id and title:
-                        result.setdefault(item_id, []).append((anchor, title))
-                _walk(children)
-            elif getattr(entry, "href", None):
-                item_id, anchor = _resolve(entry.href)
-                title = getattr(entry, "title", None)
-                if item_id and title:
-                    result.setdefault(item_id, []).append((anchor, title))
+    def on_entry(href: str, title: str, ancestors: list[str]) -> None:
+        item_id, anchor = _resolve(href)
+        if not item_id:
+            return
+        if _is_bloated_root_title(title):
+            return
+        composed = _compose_title(ancestors, title)
+        result.setdefault(item_id, []).append((anchor, composed))
 
-    _walk(book.toc)
+    _walk_toc_with_path(book.toc, on_entry)
     return result
 
 

--- a/backend/tests/test_splitter_ncx_compose.py
+++ b/backend/tests/test_splitter_ncx_compose.py
@@ -1,0 +1,317 @@
+"""Tests for nested-NCX title composition (#1151).
+
+Per the design doc `docs/design/epub-nested-ncx-titles.md`, the splitter
+must compose `<Parent> — <Leaf>` titles when nested-NCX leaf navPoints are
+"weak" (bare roman numerals, very short strings) — fixes Madame Bovary's
+flattened titles ("PREMIÈRE PARTIE", "II", "II", …) and the chapter-0
+TOC-concatenation defect.
+
+These tests exercise the helpers (_is_weak_leaf_title, _compose_title,
+_is_bloated_root_title, _walk_toc_with_path) directly with synthetic
+inputs so we don't need a real EPUB fixture for the logic tests.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from services.splitter import (
+    _compose_title,
+    _is_bloated_root_title,
+    _is_weak_leaf_title,
+    _walk_toc_with_path,
+)
+
+
+# ---------------- _is_weak_leaf_title ---------------------------------------
+
+
+@pytest.mark.parametrize("title", ["I", "II", "III", "IV", "X.", "XII.", "L"])
+def test_weak_leaf_roman_numerals(title):
+    assert _is_weak_leaf_title(title)
+
+
+@pytest.mark.parametrize("title", ["1.", "2", "A", "I.", "i."])
+def test_weak_leaf_short_strings(title):
+    assert _is_weak_leaf_title(title)
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "Prolog im Himmel",
+        "Loomings",
+        "CHAPTER 1. Loomings.",
+        "Erstes Buch",
+        "ETYMOLOGY (Supplied by a Late Consumptive Usher to a Grammar School).",
+    ],
+)
+def test_strong_leaf_descriptive_titles(title):
+    assert not _is_weak_leaf_title(title)
+
+
+def test_weak_leaf_empty_or_whitespace():
+    assert not _is_weak_leaf_title("")
+    assert not _is_weak_leaf_title("   ")
+
+
+# ---------------- _compose_title --------------------------------------------
+
+
+def test_compose_with_strong_leaf_returns_leaf():
+    out = _compose_title(["PREMIÈRE PARTIE"], "Loomings")
+    assert out == "Loomings"
+
+
+def test_compose_weak_leaf_with_parent():
+    assert _compose_title(["PREMIÈRE PARTIE"], "I") == "PREMIÈRE PARTIE — I"
+    assert _compose_title(["PREMIÈRE PARTIE"], "II") == "PREMIÈRE PARTIE — II"
+    assert _compose_title(["TROISIÈME PARTIE"], "XI") == "TROISIÈME PARTIE — XI"
+
+
+def test_compose_skips_when_parent_equals_leaf():
+    # If parent and leaf are textually identical (some malformed NCXes),
+    # composition would produce duplicate; fall back to leaf alone.
+    assert _compose_title(["I"], "I") == "I"
+
+
+def test_compose_skips_when_no_parent():
+    assert _compose_title([], "I") == "I"
+
+
+def test_compose_uses_immediate_parent_only():
+    # Three-level deep: root > Section > Subsection > leaf "I".
+    # Should compose with immediate parent ("Subsection"), not full path.
+    out = _compose_title(["Root", "Section", "Subsection"], "I")
+    assert out == "Subsection — I"
+
+
+def test_compose_drops_empty_ancestor():
+    out = _compose_title(["", "PREMIÈRE PARTIE", ""], "I")
+    assert out == "PREMIÈRE PARTIE — I"
+
+
+def test_compose_rejects_too_long_composition():
+    parent = "A " * 60  # 120 chars
+    leaf = "I"
+    out = _compose_title([parent], leaf)
+    assert out == leaf  # composed > 100 chars, fall back
+
+
+# ---------------- _is_bloated_root_title ------------------------------------
+
+
+def test_bloated_root_long_string():
+    title = (
+        "PREMIÈRE PARTIE I II III IV V VI VII VIII IX "
+        "DEUXIÈME PARTIE I II III IV V VI VII VIII IX X XI XII XIII XIV XV "
+        "TROISIÈME PARTIE I II III IV V VI VII VIII IX X XI"
+    )
+    assert _is_bloated_root_title(title)
+
+
+def test_bloated_root_many_roman_numerals():
+    # ≥3 standalone roman numeral tokens — the TOC-concatenation signature
+    title = "Part I II III IV V"
+    assert _is_bloated_root_title(title)
+
+
+def test_normal_chapter_title_not_bloated():
+    assert not _is_bloated_root_title("PREMIÈRE PARTIE")
+    assert not _is_bloated_root_title("Loomings")
+    assert not _is_bloated_root_title("CHAPTER 1. Loomings.")
+
+
+# ---------------- _walk_toc_with_path ---------------------------------------
+
+
+def _make_entry(title: str, href: str):
+    """Build a minimal stand-in for an ebooklib.epub.Link / Section."""
+    return SimpleNamespace(title=title, href=href)
+
+
+def test_walk_flat_toc():
+    toc = [
+        _make_entry("Chapter 1", "ch1.xhtml"),
+        _make_entry("Chapter 2", "ch2.xhtml"),
+    ]
+    visited: list = []
+    _walk_toc_with_path(toc, lambda h, t, a: visited.append((h, t, list(a))))
+    assert visited == [
+        ("ch1.xhtml", "Chapter 1", []),
+        ("ch2.xhtml", "Chapter 2", []),
+    ]
+
+
+def test_walk_nested_toc_tracks_path():
+    # Bovary-shape: PREMIÈRE PARTIE > [I, II, III]
+    toc = [
+        (
+            _make_entry("PREMIÈRE PARTIE", "p1c1.xhtml"),
+            [
+                _make_entry("I", "p1c1.xhtml"),
+                _make_entry("II", "p1c2.xhtml"),
+                _make_entry("III", "p1c3.xhtml"),
+            ],
+        ),
+    ]
+    visited: list = []
+    _walk_toc_with_path(toc, lambda h, t, a: visited.append((h, t, list(a))))
+    assert visited == [
+        ("p1c1.xhtml", "PREMIÈRE PARTIE", []),
+        ("p1c1.xhtml", "I", ["PREMIÈRE PARTIE"]),
+        ("p1c2.xhtml", "II", ["PREMIÈRE PARTIE"]),
+        ("p1c3.xhtml", "III", ["PREMIÈRE PARTIE"]),
+    ]
+
+
+def test_walk_three_level_deep():
+    toc = [
+        (
+            _make_entry("Volume One", "v1.xhtml"),
+            [
+                (
+                    _make_entry("Part 1", "p1.xhtml"),
+                    [_make_entry("I", "p1.xhtml")],
+                ),
+            ],
+        ),
+    ]
+    visited: list = []
+    _walk_toc_with_path(toc, lambda h, t, a: visited.append((h, t, list(a))))
+    assert ("p1.xhtml", "I", ["Volume One", "Part 1"]) in visited
+
+
+# ---------------- End-to-end via _epub_nav_titles ---------------------------
+
+
+class _FakeItem:
+    def __init__(self, name: str, item_id: str):
+        self._name = name
+        self._id = item_id
+
+    def get_name(self):
+        return self._name
+
+    def get_id(self):
+        return self._id
+
+
+class _FakeBook:
+    def __init__(self, toc, items):
+        self.toc = toc
+        self._items = items
+
+    def get_items_of_type(self, _t):
+        return self._items
+
+
+def test_epub_nav_titles_composes_bovary_shape():
+    from services.splitter import _epub_nav_titles
+
+    items = [
+        _FakeItem("p1c1.xhtml", "id_p1c1"),
+        _FakeItem("p1c2.xhtml", "id_p1c2"),
+        _FakeItem("p1c3.xhtml", "id_p1c3"),
+        _FakeItem("p2c1.xhtml", "id_p2c1"),
+        _FakeItem("p2c2.xhtml", "id_p2c2"),
+    ]
+    toc = [
+        (
+            _make_entry("PREMIÈRE PARTIE", "p1c1.xhtml"),
+            [
+                _make_entry("I", "p1c1.xhtml"),
+                _make_entry("II", "p1c2.xhtml"),
+                _make_entry("III", "p1c3.xhtml"),
+            ],
+        ),
+        (
+            _make_entry("DEUXIÈME PARTIE", "p2c1.xhtml"),
+            [
+                _make_entry("I", "p2c1.xhtml"),
+                _make_entry("II", "p2c2.xhtml"),
+            ],
+        ),
+    ]
+
+    result = _epub_nav_titles(_FakeBook(toc, items))
+
+    assert result["id_p1c1"] == "PREMIÈRE PARTIE — I"
+    assert result["id_p1c2"] == "PREMIÈRE PARTIE — II"
+    assert result["id_p1c3"] == "PREMIÈRE PARTIE — III"
+    assert result["id_p2c1"] == "DEUXIÈME PARTIE — I"
+    assert result["id_p2c2"] == "DEUXIÈME PARTIE — II"
+
+
+def test_epub_nav_titles_keeps_strong_leaves_verbatim():
+    """Faust shape: descriptive leaves, no composition."""
+    from services.splitter import _epub_nav_titles
+
+    items = [
+        _FakeItem("ch01.xhtml", "id_ch01"),
+        _FakeItem("ch02.xhtml", "id_ch02"),
+    ]
+    toc = [
+        (
+            _make_entry("Erster Teil", "ch01.xhtml"),
+            [
+                _make_entry("Prolog im Himmel", "ch01.xhtml"),
+                _make_entry("Vor dem Tor", "ch02.xhtml"),
+            ],
+        ),
+    ]
+
+    result = _epub_nav_titles(_FakeBook(toc, items))
+
+    assert result["id_ch01"] == "Prolog im Himmel"
+    assert result["id_ch02"] == "Vor dem Tor"
+
+
+def test_epub_nav_titles_drops_bloated_root():
+    """Chapter 0 TOC-concatenation defect: the root navPoint title equals
+    every leaf navLabel concatenated. Must be dropped, not surfaced."""
+    from services.splitter import _epub_nav_titles
+
+    items = [
+        _FakeItem("title.xhtml", "id_title"),
+        _FakeItem("p1c1.xhtml", "id_p1c1"),
+    ]
+    toc = [
+        _make_entry(
+            "PREMIÈRE PARTIE I II III IV V VI VII VIII IX "
+            "DEUXIÈME PARTIE I II III TROISIÈME PARTIE I II",
+            "title.xhtml",
+        ),
+        (
+            _make_entry("PREMIÈRE PARTIE", "p1c1.xhtml"),
+            [_make_entry("I", "p1c1.xhtml")],
+        ),
+    ]
+
+    result = _epub_nav_titles(_FakeBook(toc, items))
+
+    assert "id_title" not in result  # bloated root rejected
+    assert result["id_p1c1"] == "PREMIÈRE PARTIE — I"
+
+
+def test_epub_nav_anchors_composes_titles():
+    from services.splitter import _epub_nav_anchors
+
+    items = [
+        _FakeItem("p1c1.xhtml", "id_p1c1"),
+    ]
+    toc = [
+        (
+            _make_entry("PREMIÈRE PARTIE", "p1c1.xhtml"),
+            [_make_entry("I", "p1c1.xhtml#anchor1")],
+        ),
+    ]
+
+    result = _epub_nav_anchors(_FakeBook(toc, items))
+
+    assert "id_p1c1" in result
+    titles_out = [t for _, t in result["id_p1c1"]]
+    assert "PREMIÈRE PARTIE" in titles_out
+    assert "PREMIÈRE PARTIE — I" in titles_out


### PR DESCRIPTION
Implementation of #1151 per the merged design doc (#1190 / `docs/design/epub-nested-ncx-titles.md`).

## Summary

Fixes Madame Bovary's flattened EPUB titles (chapter 0 absorbing the entire TOC into a 213-char title; first chapter of each part rendered as bare "PREMIÈRE PARTIE"; all other chapters as bare roman numerals like "II", "II", "II" across three parts).

## Approach

Extracted `_walk_toc_with_path` shared walker that maintains an ancestor-title stack across the depth-first NCX walk. Both `_epub_nav_titles` and `_epub_nav_anchors` use it now. Three small helpers do the work:

- `_is_weak_leaf_title` — leaf is "weak" iff roman numeral OR ≤2 words AND <5 chars. Used to gate composition so that descriptive leaves (Faust's "Prolog im Himmel", Moby Dick's "CHAPTER 1. Loomings.") stay verbatim.
- `_compose_title` — emits `<Parent> — <Leaf>` only when leaf is weak AND has a non-empty distinct ancestor. Bounded to 100 chars total; falls back to leaf alone when composition would be redundant/oversized.
- `_is_bloated_root_title` — detects the chapter-0 TOC-concatenation defect via length>120 chars OR ≥3 standalone roman numerals. Rejected entries leave the spine item unmapped so the splitter falls back to spine-level metadata.

## Result on the Bovary repro

Before:
| Chapter | Title (before) |
|---|---|
| 0 | "PREMIÈRE PARTIE I II III IV V VI VII VIII IX DEUXIÈME PARTIE …" (213 chars) |
| 1 | "PREMIÈRE PARTIE" |
| 2 | "II" |
| 11 | "DEUXIÈME PARTIE" |
| 12 | "II" |

After:
| Chapter | Title (after) |
|---|---|
| 0 | (dropped — falls back to spine metadata) |
| 1 | "PREMIÈRE PARTIE — I" |
| 2 | "PREMIÈRE PARTIE — II" |
| 11 | "DEUXIÈME PARTIE — I" |
| 12 | "DEUXIÈME PARTIE — II" |

## Test plan

- [x] 35 new tests in `test_splitter_ncx_compose.py` covering the helpers individually plus end-to-end via fake EPUB books (Bovary shape, Faust shape, bloated root, fragment-anchor case).
- [x] All 117 existing splitter tests still pass (no regressions in `_epub_nav_titles` semantics for the strong-leaf cases — Faust, Moby Dick, Stundenbuch).
- [ ] CI runs the full backend + frontend suite as the authoritative gate.

## Out of scope (per design doc)

- Re-splitting existing books in DB. Admin action — user triggers manually via the existing re-split flow for books they care about. The Bovary translation in #1192 has per-row `title_translation` workarounds that already display correct Chinese titles in the reader; those are unaffected by this change.
- pageList walking for per-poem splits (Stundenbuch §1 of audit).
- Three-or-more-level NCX composition. Spec is parent-only; tested explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
