### PR TITLE
fix: add id=main-content to admin layout <main> (closes #1205)

### DIFF
--- a/frontend/src/__tests__/AdminSkipLink.test.ts
+++ b/frontend/src/__tests__/AdminSkipLink.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Static assertion: admin layout's <main> has id=main-content so the
+ * skip-link from app/layout.tsx works on /admin/* routes.
+ * Closes #1205
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("Admin layout skip-link target", () => {
+  it("admin/layout.tsx <main> has id=main-content", () => {
+    const src = read("src/app/admin/layout.tsx");
+    expect(src).toContain('id="main-content"');
+    expect(src).toMatch(/<main\b[^>]*id=["']main-content["']/);
+  });
+});

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -72,7 +72,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   }
 
   return (
-    <main className="min-h-screen bg-parchment">
+    <main id="main-content" className="min-h-screen bg-parchment">
       <header className="border-b border-amber-200 bg-white/60 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
         <button onClick={() => router.push("/")} className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] flex items-center gap-1">
           <ArrowLeftIcon className="w-4 h-4" aria-hidden="true" /> Library


### PR DESCRIPTION
Closes #1205.

Extends the skip-link series (#1180 / #1182 / #1186 / #1188) to admin sub-routes. The admin layout wraps every `/admin/*` page in `<main>`, so adding `id="main-content"` here gives every admin route a working skip-link target in one minimal change.

## WCAG
- 1.3.1 Info and Relationships
- 2.4.1 Bypass Blocks

## Test plan
- [x] `AdminSkipLink.test.ts` — 1 static assertion
- [x] Full frontend suite — 2230/2230 passing

Label: `ux`

Generated with Claude Code
