### PR TITLE
fix: add id=main-content to import/[bookId] <main> (closes #1207)

### DIFF
--- a/frontend/src/__tests__/ImportSkipLink.test.ts
+++ b/frontend/src/__tests__/ImportSkipLink.test.ts
@@ -1,0 +1,18 @@
+/**
+ * Static assertion: import/[bookId] page <main> has id=main-content.
+ * Closes #1207
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("Import page skip-link target", () => {
+  it("import/[bookId]/page.tsx <main> has id=main-content", () => {
+    const src = read("src/app/import/[bookId]/page.tsx");
+    expect(src).toContain('id="main-content"');
+    expect(src).toMatch(/<main\b[^>]*id=["']main-content["']/);
+  });
+});

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -235,7 +235,7 @@ export default function BookImportPage() {
   const cost = estimateCost(chapterCount, totalWords);
 
   return (
-    <main className="min-h-screen bg-parchment flex items-center justify-center px-4 py-8">
+    <main id="main-content" className="min-h-screen bg-parchment flex items-center justify-center px-4 py-8">
       <div className="w-full max-w-xl">
         <div className="bg-white border border-amber-200 rounded-2xl shadow-sm p-8">
           <h1 className="font-serif text-2xl font-bold text-ink mb-1">


### PR DESCRIPTION
Closes #1207.

Extends the skip-link series (#1180 / #1182 / #1186 / #1188 / #1206) to `/import/{bookId}`. Same one-liner pattern.

## WCAG
- 1.3.1 Info and Relationships
- 2.4.1 Bypass Blocks

## Test plan
- [x] `ImportSkipLink.test.ts` — 1 static assertion
- [x] Full frontend suite — 2231/2231 passing

Label: `ux`

Generated with Claude Code
