### PR TITLE
fix: convert flashcards page wrapper to <main id=main-content> (closes #1209)

### DIFF
--- a/frontend/src/__tests__/FlashcardsSkipLink.test.ts
+++ b/frontend/src/__tests__/FlashcardsSkipLink.test.ts
@@ -1,0 +1,18 @@
+/**
+ * Static assertion: vocabulary/flashcards page <main> has id=main-content.
+ * Closes #1209
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("Flashcards page skip-link target", () => {
+  it("vocabulary/flashcards/page.tsx <main> has id=main-content", () => {
+    const src = read("src/app/vocabulary/flashcards/page.tsx");
+    expect(src).toContain('id="main-content"');
+    expect(src).toMatch(/<main\b[^>]*id=["']main-content["']/);
+  });
+});

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -130,7 +130,7 @@ export default function FlashcardsPage() {
   const progress = total > 0 ? (reviewed / total) * 100 : 0;
 
   return (
-    <div className="min-h-screen bg-parchment">
+    <main id="main-content" className="min-h-screen bg-parchment">
       <div className="max-w-lg mx-auto px-4 py-6 space-y-6">
         {/* Header */}
         <div className="flex items-center gap-3">
@@ -272,6 +272,6 @@ export default function FlashcardsPage() {
           </div>
         ) : null}
       </div>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
Closes #1209.

Last remaining skip-link gap: `/vocabulary/flashcards` used a top-level `<div>` with no main landmark or skip-link target. Now matches the rest of the route tree (#1180 / #1182 / #1186 / #1188 / #1206 / #1208).

With this merged, every top-level Next.js route + the admin layout wrapper has `<main id="main-content">`.

## WCAG
- 1.3.1 Info and Relationships
- 2.4.1 Bypass Blocks

## Test plan
- [x] `FlashcardsSkipLink.test.ts` — 1 static assertion
- [x] Full frontend suite — 2232/2232 passing

Label: `ux`

Generated with Claude Code
