### PR TITLE
fix: mark decorative AI-circle SVG in InsightChat aria-hidden (closes #1211)

### DIFF
--- a/frontend/src/__tests__/InsightChatAiIconAria.test.ts
+++ b/frontend/src/__tests__/InsightChatAiIconAria.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Static assertion: decorative AI-circle SVG in InsightChat has aria-hidden=true.
+ * Closes #1211
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("InsightChat AI icon a11y", () => {
+  it("decorative AI-circle SVG sets aria-hidden=true", () => {
+    const src = read("src/components/InsightChat.tsx");
+    // Look for the specific SVG by its viewBox 0 0 20 20 (info-style circle icon)
+    const idx = src.indexOf('viewBox="0 0 20 20"');
+    expect(idx).toBeGreaterThan(0);
+    // Within the surrounding 200 chars, aria-hidden=true must be present on the svg
+    const window = src.slice(Math.max(0, idx - 200), idx + 200);
+    expect(window).toMatch(/<svg[^>]*aria-hidden=["']?true["']?/);
+  });
+});

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -495,7 +495,7 @@ export default function InsightChat({
             <div key={i} className="flex gap-2 max-w-full">
               {/* AI icon */}
               <div className="w-5 h-5 rounded-full bg-amber-100 border border-amber-200 flex items-center justify-center shrink-0 mt-0.5">
-                <svg className="w-3 h-3 text-amber-600" viewBox="0 0 20 20" fill="currentColor">
+                <svg className="w-3 h-3 text-amber-600" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                   <path d="M10 2a8 8 0 100 16A8 8 0 0010 2zm0 14.5a6.5 6.5 0 110-13 6.5 6.5 0 010 13zm-.75-8.25a.75.75 0 011.5 0v3.5a.75.75 0 01-1.5 0v-3.5zm.75 6a.875.875 0 110-1.75.875.875 0 010 1.75z"/>
                 </svg>
               </div>


### PR DESCRIPTION
Closes #1211.

The AI-circle decoration on each assistant message in InsightChat was missing `aria-hidden="true"`. Without it, screen readers may announce a phantom graphic on every assistant turn — and the speaker is already disambiguated by the sr-only `Assistant:` prefix from the Wave 9 sweep.

## WCAG
- 1.1.1 Non-text Content (decorative graphics excluded from a11y tree)
- 4.1.2 Name/Role/Value

## Test plan
- [x] `InsightChatAiIconAria.test.ts` — 1 static assertion
- [x] Full frontend suite — 2233/2233 passing

Label: `ux`

Generated with Claude Code
