### PR TITLE
fix: honour prefers-reduced-motion in globals.css (closes #1213)

### DIFF
--- a/frontend/src/__tests__/ReducedMotion.test.ts
+++ b/frontend/src/__tests__/ReducedMotion.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Static assertion: globals.css honours prefers-reduced-motion: reduce.
+ * Closes #1213
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("Reduced-motion CSS support", () => {
+  const css = read("src/app/globals.css");
+
+  it("declares a prefers-reduced-motion media block", () => {
+    expect(css).toMatch(/@media[^{]*prefers-reduced-motion:\s*reduce/);
+  });
+
+  it("nullifies animation duration under reduced motion", () => {
+    expect(css).toMatch(/animation-duration:\s*0\.01ms\s*!important/);
+  });
+
+  it("nullifies transition duration under reduced motion", () => {
+    expect(css).toMatch(/transition-duration:\s*0\.01ms\s*!important/);
+  });
+
+  it("forces auto scroll-behavior under reduced motion", () => {
+    expect(css).toMatch(/scroll-behavior:\s*auto\s*!important/);
+  });
+});

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -147,3 +147,13 @@ body, [data-theme="light"] {
 .animate-vocab-flash {
   animation: vocab-flash 1.8s ease-out forwards;
 }
+
+/* Honour user's reduced-motion preference (WCAG 2.3.3, vestibular accessibility) */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
Closes #1213.

## Summary
Adds a single media-query block to `globals.css` that disables / accelerates animations and transitions for users with `prefers-reduced-motion: reduce`.

## Coverage
All Tailwind `animate-*` classes (pulse, spin, fade-in, slide-up), custom `@keyframes` (slide-up, fade-in, vocab-flash), all `transition-*` properties (para-dim, theme-toggle, etc.), and `scroll-behavior: smooth → auto`.

Standard WAI-ARIA pattern. One CSS block; reduces motion globally without per-component edits. Spinners stay structurally correct (still rotate, just instantly).

## WCAG
- 2.3.3 Animation from Interactions (AAA)
- Best practice for vestibular accessibility

## Test plan
- [x] `ReducedMotion.test.ts` — 4 static assertions (media block, animation-duration, transition-duration, scroll-behavior)
- [x] Full frontend suite — 2237/2237 passing

Label: `ux`

Generated with Claude Code
