### PR TITLE
fix: add aria-current=page to admin nav tabs (closes #1215)

### DIFF
--- a/frontend/src/__tests__/AdminNavAriaCurrent.test.ts
+++ b/frontend/src/__tests__/AdminNavAriaCurrent.test.ts
@@ -1,0 +1,17 @@
+/**
+ * Static assertion: admin layout nav tabs set aria-current=page on the active tab.
+ * Closes #1215
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("Admin nav aria-current", () => {
+  it("active tab Link sets aria-current=page", () => {
+    const src = read("src/app/admin/layout.tsx");
+    expect(src).toMatch(/aria-current=\{current === key \? ["']page["'] : undefined\}/);
+  });
+});

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -92,6 +92,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
               key={key}
               href={href}
               prefetch
+              aria-current={current === key ? "page" : undefined}
               className={`px-3 md:px-4 py-2.5 md:py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap min-h-[44px] md:min-h-0 flex items-center ${
                 current === key
                   ? "border-amber-700 text-amber-900"


### PR DESCRIPTION
Closes #1215.

Admin layout's five tab Links (Users / Books / Audio Cache / Queue / Uploads) visually highlight the active tab via border + text-color but did not expose that state to assistive tech. `aria-current="page"` mirrors the pattern from `app/page.tsx` tabs.

## WCAG
- 4.1.2 Name/Role/Value (current state of an element must be programmatically determinable)

## Test plan
- [x] `AdminNavAriaCurrent.test.ts` — 1 static assertion
- [x] Full frontend suite — 2238/2238 passing

Label: `ux`

Generated with Claude Code
