### PR TITLE
fix: wrap admin tab strip in <nav> landmark (closes #1217)

### DIFF
--- a/frontend/src/__tests__/AdminNavLandmark.test.ts
+++ b/frontend/src/__tests__/AdminNavLandmark.test.ts
@@ -1,0 +1,18 @@
+/**
+ * Static assertion: admin layout wraps its tab strip in a <nav> landmark
+ * with an accessible name.
+ * Closes #1217
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("Admin tab strip landmark", () => {
+  it("admin/layout.tsx wraps tabs in <nav aria-label=...>", () => {
+    const src = read("src/app/admin/layout.tsx");
+    expect(src).toMatch(/<nav\b[^>]*aria-label=["']Admin sections["']/);
+  });
+});

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -86,7 +86,10 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
       <div className="max-w-5xl mx-auto px-4 md:px-6 py-4 md:py-6">
         <ContextualStats tab={current} stats={stats} />
 
-        <div className="flex gap-1 border-b border-amber-200 mb-4 overflow-x-auto -mx-4 px-4 md:mx-0 md:px-0">
+        <nav
+          aria-label="Admin sections"
+          className="flex gap-1 border-b border-amber-200 mb-4 overflow-x-auto -mx-4 px-4 md:mx-0 md:px-0"
+        >
           {TABS.map(({ key, label, href }) => (
             <Link
               key={key}
@@ -102,7 +105,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
               {label}
             </Link>
           ))}
-        </div>
+        </nav>
 
         {children}
       </div>


### PR DESCRIPTION
Closes #1217.

Admin tabs were rendered in a plain `<div>`. Promoting to a `<nav aria-label="Admin sections">` landmark exposes them to screen-reader landmark navigation (NVDA, VoiceOver rotor) and adds another bypass-block for keyboard users.

Follows the same pattern as the home-page tabs.

## WCAG
- 1.3.1 Info and Relationships
- 2.4.1 Bypass Blocks

## Test plan
- [x] `AdminNavLandmark.test.ts` — 1 static assertion
- [x] Full frontend suite — 2239/2239 passing

Label: `ux`

Generated with Claude Code
