### PR TITLE
fix: override iOS default tap-highlight to amber palette (closes #1219)

### DIFF
--- a/frontend/src/__tests__/IosTapHighlight.test.ts
+++ b/frontend/src/__tests__/IosTapHighlight.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Static assertion: globals.css overrides iOS default tap-highlight color
+ * with a semi-transparent amber that matches the design palette.
+ * Closes #1219
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("iOS tap-highlight palette override", () => {
+  const css = read("src/app/globals.css");
+
+  it("declares -webkit-tap-highlight-color globally", () => {
+    expect(css).toMatch(/-webkit-tap-highlight-color:/);
+  });
+
+  it("uses an amber-tinted rgba (matches design palette)", () => {
+    // amber-300 is rgb(252, 211, 77); accept any semi-transparent amber tint
+    expect(css).toMatch(/-webkit-tap-highlight-color:\s*rgba\(\s*25[0-2],\s*21[0-2],\s*7[5-9],\s*0?\.[0-9]+\s*\)/);
+  });
+});

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -148,6 +148,12 @@ body, [data-theme="light"] {
   animation: vocab-flash 1.8s ease-out forwards;
 }
 
+/* iOS Safari / Chrome default tap-highlight is gray-blue and clashes with the amber palette.
+   Amber-300 (rgb 252 211 77) at 35% opacity matches the design tokens. */
+* {
+  -webkit-tap-highlight-color: rgba(252, 211, 77, 0.35);
+}
+
 /* Honour user's reduced-motion preference (WCAG 2.3.3, vestibular accessibility) */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {


### PR DESCRIPTION
Closes #1219.

iOS Safari / Chrome on iOS show a default gray-blue `-webkit-tap-highlight-color` flash on every tappable element. Against the amber/parchment palette this looks out of place. Overriding to a semi-transparent amber-300 (`rgb(252, 211, 77, 0.35)`) produces a tap-feedback flash that fits the design tokens and fades coherently into existing `hover:bg-amber-*` states.

One `*` selector in `globals.css`; covers every interactive element with no per-component edits.

## Test plan
- [x] `IosTapHighlight.test.ts` — 2 static assertions (declared globally, amber rgba)
- [x] Full frontend suite — 2241/2241 passing

Label: `ui`

Generated with Claude Code
