### PR TITLE
fix: add aria-modal=true to AnnotationsSidebar dialog (closes #1223)

### DIFF
--- a/frontend/src/__tests__/AnnotationsSidebarDialog.test.ts
+++ b/frontend/src/__tests__/AnnotationsSidebarDialog.test.ts
@@ -27,4 +27,8 @@ describe("AnnotationsSidebar drawer dialog semantics", () => {
   it("focuses the drawer when opened (useEffect with focus call)", () => {
     expect(sidebar).toMatch(/drawerRef\.current\?\.focus\(\)|drawerRef\.current\.focus\(\)/);
   });
+
+  it("drawer has aria-modal=true to trap screen reader virtual cursor", () => {
+    expect(sidebar).toContain('aria-modal="true"');
+  });
 });

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -73,6 +73,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
           ref={drawerRef}
           tabIndex={-1}
           role="dialog"
+          aria-modal="true"
           aria-labelledby="annotations-heading"
           className="fixed right-0 top-0 h-full w-full sm:w-80 bg-white border-l border-amber-200 shadow-2xl z-50 flex flex-col focus:outline-none"
           data-testid="annotations-sidebar"


### PR DESCRIPTION
Closes #1223.

`AnnotationsSidebar` rendered its drawer with `role="dialog"` but omitted `aria-modal="true"`. Without this attribute, screen readers (NVDA, JAWS, VoiceOver) do not restrict virtual cursor navigation to the drawer — users can tab through background content while the modal is open, violating WCAG 2.1 SC 1.3.1 and the ARIA authoring practices for dialog widgets.

## Change

Added `aria-modal="true"` to the drawer `div` in `AnnotationsSidebar.tsx`.

## Test plan

- [x] New static assertion in `AnnotationsSidebarDialog.test.ts` — confirms `aria-modal="true"` is present (was failing before this fix)
- [x] All 5 dialog-semantics tests pass (role, aria-labelledby, tabIndex, focus, aria-modal)
- [x] Full frontend suite — 2242/2242 passing
- [x] Full backend suite — 1382/1382 passing
