### PR TITLE
fix: add role=dialog and aria-modal to AnnotationToolbar panel (closes #1222)

### DIFF
--- a/frontend/src/__tests__/AnnotationToolbarDialogRole.test.tsx
+++ b/frontend/src/__tests__/AnnotationToolbarDialogRole.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * Regression test for #1222: AnnotationToolbar panel must have role="dialog",
+ * aria-modal="true", and aria-labelledby so screen readers announce it correctly.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("@/lib/api", () => ({
+  createAnnotation: jest.fn(),
+  updateAnnotation: jest.fn(),
+  deleteAnnotation: jest.fn(),
+}));
+
+import AnnotationToolbar from "@/components/AnnotationToolbar";
+
+const BASE_PROPS = {
+  sentenceText: "It is a truth universally acknowledged.",
+  chapterIndex: 0,
+  bookId: 1,
+  onClose: jest.fn(),
+  onSaved: jest.fn(),
+  onDeleted: jest.fn(),
+};
+
+test("panel has role=dialog and aria-modal=true", () => {
+  render(<AnnotationToolbar {...BASE_PROPS} />);
+  const dialog = screen.getByRole("dialog");
+  expect(dialog).toBeInTheDocument();
+  expect(dialog).toHaveAttribute("aria-modal", "true");
+});
+
+test("dialog is labelled by the visible title", () => {
+  render(<AnnotationToolbar {...BASE_PROPS} />);
+  const dialog = screen.getByRole("dialog");
+  const labelId = dialog.getAttribute("aria-labelledby");
+  expect(labelId).toBeTruthy();
+  const titleEl = document.getElementById(labelId!);
+  expect(titleEl).toBeInTheDocument();
+  expect(titleEl!.textContent).toMatch(/add note/i);
+});
+
+test("dialog title says 'Edit note' when editing an existing annotation", () => {
+  render(
+    <AnnotationToolbar
+      {...BASE_PROPS}
+      existingAnnotation={{ id: 1, note_text: "old", color: "yellow" }}
+    />,
+  );
+  const dialog = screen.getByRole("dialog");
+  const labelId = dialog.getAttribute("aria-labelledby");
+  const titleEl = document.getElementById(labelId!);
+  expect(titleEl!.textContent).toMatch(/edit note/i);
+});

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -104,6 +104,9 @@ export default function AnnotationToolbar({
       {/* Panel */}
       <div
         ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="annotation-toolbar-title"
         className="relative w-full max-w-sm bg-parchment border border-amber-200 rounded-2xl shadow-2xl animate-fade-in overflow-hidden"
         data-testid="annotation-toolbar"
       >
@@ -111,7 +114,7 @@ export default function AnnotationToolbar({
         <div className="flex items-center justify-between px-5 pt-4 pb-3 border-b border-amber-100">
           <div className="flex items-center gap-2 text-amber-800">
             <NoteIcon className="w-4 h-4" aria-hidden="true" />
-            <span className="font-serif font-semibold text-sm">
+            <span id="annotation-toolbar-title" className="font-serif font-semibold text-sm">
               {existingAnnotation ? "Edit note" : "Add note"}
             </span>
           </div>


### PR DESCRIPTION
Closes #1222.

## What changed

Added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby="annotation-toolbar-title"` to the `AnnotationToolbar` modal panel div. Added matching `id="annotation-toolbar-title"` to the visible title span ("Add note" / "Edit note").

## Why

Screen readers had no way to identify the annotation note panel as a dialog. All other modals in the codebase (`BookDetailModal`, `AuthPromptModal`, `WordActionDrawer`, `AnnotationsSidebar`) already carry these attributes — `AnnotationToolbar` was the only one missing them.

## Test plan

- New test file `AnnotationToolbarDialogRole.test.tsx` (3 tests):
  - Panel has `role="dialog"` and `aria-modal="true"`
  - `aria-labelledby` points to an element whose text matches "Add note"
  - Title text is "Edit note" when an existing annotation is supplied
- Full frontend suite: 2244/2244 passing
- Backend suite: all passing

## Docs follow-up

None — this is a one-element attribute fix with no user-visible behaviour change beyond correct AT announcement.
