### PR TITLE
fix: aria-hidden on decorative pulse dots; role=status on chat typing indicator (closes #1226)

### DIFF
--- a/frontend/src/__tests__/AnimatePulseAria.test.ts
+++ b/frontend/src/__tests__/AnimatePulseAria.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Static assertions: animate-pulse/bounce decorative indicators have aria-hidden="true";
+ * InsightChat typing indicator container has role="status" + aria-label. Closes #1226.
+ */
+import fs from "fs";
+import path from "path";
+
+const readerPage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+const insightChat = fs.readFileSync(
+  path.join(process.cwd(), "src/components/InsightChat.tsx"),
+  "utf8",
+);
+
+describe("Decorative animate-pulse dots in reader page", () => {
+  it("translation queued banner dot has aria-hidden=true", () => {
+    // The sky-blue pulse dot beside the 'Translation queued' text is decorative
+    expect(readerPage).toMatch(
+      /bg-sky-500[^>]*animate-pulse[^>]*aria-hidden="true"|animate-pulse[^>]*bg-sky-500[^>]*aria-hidden="true"|aria-hidden="true"[^>]*bg-sky-500[^>]*animate-pulse/
+    );
+  });
+
+  it("translation progress dot has aria-hidden=true", () => {
+    // The amber pulse dot beside 'X / Y chapters translated' text is decorative
+    expect(readerPage).toMatch(
+      /bg-amber-500[^>]*animate-pulse[^>]*aria-hidden="true"|animate-pulse[^>]*bg-amber-500[^>]*aria-hidden="true"|animate-pulse[^>]*shrink-0[^>]*aria-hidden="true"|aria-hidden="true"[^>]*animate-pulse[^>]*shrink-0/
+    );
+  });
+});
+
+describe("InsightChat typing indicator accessibility", () => {
+  it("typing indicator container has role=status", () => {
+    expect(insightChat).toMatch(/role="status"/);
+  });
+
+  it("typing indicator container has aria-label for AI typing", () => {
+    expect(insightChat).toMatch(/aria-label="AI is typing"/);
+  });
+
+  it("typing indicator bounce dots have aria-hidden=true", () => {
+    // The three animate-bounce dots are purely visual — aria-hidden keeps them silent
+    expect(insightChat).toMatch(/animate-bounce[^>]*aria-hidden="true"|aria-hidden="true"[^>]*animate-bounce/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1255,7 +1255,7 @@ export default function ReaderPage() {
         translationUsedProvider &&
         translationUsedProvider.startsWith("queue") && (
           <div className="bg-sky-50 border-b border-sky-200 px-4 py-2 text-xs text-sky-800 flex items-center gap-2">
-            <span className="inline-block w-1.5 h-1.5 bg-sky-500 rounded-full animate-pulse" />
+            <span className="inline-block w-1.5 h-1.5 bg-sky-500 rounded-full animate-pulse" aria-hidden="true" />
             <span>
               <strong>Translation queued</strong> — {translationUsedProvider}.
               The background worker is processing this chapter; translated
@@ -1996,7 +1996,7 @@ export default function ReaderPage() {
                       return (
                         <div className="mt-3 pt-3 border-t border-amber-200">
                           <div className="flex items-center gap-1.5 text-xs text-amber-700">
-                            {queued > 0 && <span className="inline-block w-1.5 h-1.5 bg-amber-500 rounded-full animate-pulse shrink-0" />}
+                            {queued > 0 && <span className="inline-block w-1.5 h-1.5 bg-amber-500 rounded-full animate-pulse shrink-0" aria-hidden="true" />}
                             <span>
                               <strong>{ready} / {total}</strong> chapters translated
                               {queued > 0 && (<> · <strong>{queued}</strong> processing</>)}

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -550,14 +550,14 @@ export default function InsightChat({
 
         {/* Typing indicator */}
         {chatLoading && messages.length > 0 && (
-          <div className="flex gap-2">
-            <div className="w-5 h-5 rounded-full bg-amber-100 border border-amber-200 flex items-center justify-center shrink-0 mt-0.5">
+          <div className="flex gap-2" role="status" aria-label="AI is typing" aria-live="polite">
+            <div className="w-5 h-5 rounded-full bg-amber-100 border border-amber-200 flex items-center justify-center shrink-0 mt-0.5" aria-hidden="true">
               <div className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
             </div>
             <div className="flex items-center gap-1 py-2">
-              <span className="w-1.5 h-1.5 rounded-full bg-gray-300 animate-bounce" style={{ animationDelay: "0ms" }} />
-              <span className="w-1.5 h-1.5 rounded-full bg-gray-300 animate-bounce" style={{ animationDelay: "150ms" }} />
-              <span className="w-1.5 h-1.5 rounded-full bg-gray-300 animate-bounce" style={{ animationDelay: "300ms" }} />
+              <span className="w-1.5 h-1.5 rounded-full bg-gray-300 animate-bounce" aria-hidden="true" style={{ animationDelay: "0ms" }} />
+              <span className="w-1.5 h-1.5 rounded-full bg-gray-300 animate-bounce" aria-hidden="true" style={{ animationDelay: "150ms" }} />
+              <span className="w-1.5 h-1.5 rounded-full bg-gray-300 animate-bounce" aria-hidden="true" style={{ animationDelay: "300ms" }} />
             </div>
           </div>
         )}


### PR DESCRIPTION
Closes #1226.

Two decorative `animate-pulse` dots in the reader page and three `animate-bounce` dots in the InsightChat typing indicator were missing accessibility attributes, causing unnecessary noise or silence for screen reader users.

## Changes

**`reader/[bookId]/page.tsx`**
- Translation queued banner dot (`bg-sky-500 animate-pulse`) → added `aria-hidden="true"`. The adjacent text already conveys the queued status; the dot is purely decorative.
- Chapter translation progress dot (`bg-amber-500 animate-pulse`) → added `aria-hidden="true"`. Same reasoning — the sibling text "X / Y chapters translated · Z processing" is the live information.

**`InsightChat.tsx`**
- Typing indicator container → added `role="status"` `aria-label="AI is typing"` `aria-live="polite"` so screen readers announce when the AI is responding.
- Avatar inner dot and the three bounce dots → added `aria-hidden="true"` to suppress the visual-only elements from the accessibility tree.

## Test plan
- [x] New `AnimatePulseAria.test.ts` — 5 static assertions covering all three fixes (was failing before this PR)
- [x] Full frontend suite — 2246/2246 passing (279 suites)
- [x] Full backend suite — 1382/1382 passing
