### PR TITLE
chore: bump design-doc Status lines to reflect shipped work

### DIFF
--- a/docs/design/ci-speedup-phase-2.md
+++ b/docs/design/ci-speedup-phase-2.md
@@ -1,8 +1,10 @@
 # CI Speedup Phase 2 — Closing the 318s → 180s Gap
 
-Issue: #971
-Prior work: #885 (phase 1, merged). Phase 1 design: `docs/design/ci-speedup.md`.
-Baseline: `reports/ci_baseline_2026_04_24.md`.
+**Status:** Merged — design only (PR #990, 2026-04-24); staged implementation per design (slow-test fixes → pytest-xdist → Playwright smoke → deferred sharding)
+**Author:** Architect
+**Date:** 2026-04-24
+**Priority:** P2
+**Prior work:** #971 (issue), #885 (phase 1, merged), `docs/design/ci-speedup.md`, `reports/ci_baseline_2026_04_24.md`
 
 ## Problem
 

--- a/docs/design/ci-speedup.md
+++ b/docs/design/ci-speedup.md
@@ -1,6 +1,6 @@
 # Design: Accelerate CI pipeline — Issue #885
 
-**Status:** Draft — awaiting PM review, then user approval
+**Status:** Shipped — Phase 1 (PRs #914 baseline, #919 path-scoping, #922 docker cache, #973 measurement, 2026-04-24); Phase 2 design follow-up: see `ci-speedup-phase-2.md` (PR #990)
 **Author:** Architect
 **Date:** 2026-04-24
 **Priority:** P2 — engineering-time drag, not user-visible. Pipeline is functional.

--- a/docs/design/declared-fks-schema.md
+++ b/docs/design/declared-fks-schema.md
@@ -1,6 +1,6 @@
 # Design: Declared FKs on Soft `user_id` / `book_id` Columns (Issue #754)
 
-**Status:** Draft — awaiting PM review
+**Status:** Shipped (PRs #851, #858, #975, #986, 2026-04-24)
 **Author:** Architect
 **Date:** 2026-04-24
 **Priority:** P3 — quality-of-life hardening; no user-visible bug today.

--- a/docs/design/epub-ncx-fragment-anchors.md
+++ b/docs/design/epub-ncx-fragment-anchors.md
@@ -1,6 +1,10 @@
 # EPUB NCX Fragment-Anchor Chapter Boundaries
 
-Issue: #964
+**Status:** Shipped (design PR #968; impl PR #1055, 2026-04-24)
+**Author:** Architect
+**Date:** 2026-04-24
+**Priority:** P2
+**Prior work:** #964 (issue), #780 / #783 (prior cache-misalignment incidents), `reports/epub_parser_investigation_2026_04_24.md`
 
 ## Problem
 

--- a/docs/design/epub-nested-ncx-titles.md
+++ b/docs/design/epub-nested-ncx-titles.md
@@ -1,4 +1,4 @@
-**Status:** Draft
+**Status:** Shipped (design PR #1190; impl PR #1204, 2026-04-25)
 **Author:** Architect
 **Date:** 2026-04-25
 **Priority:** P3

--- a/docs/design/epub-speaker-cue-fix.md
+++ b/docs/design/epub-speaker-cue-fix.md
@@ -1,6 +1,6 @@
 # Design: EPUB speaker-cue / verse paragraph collapse fix — Issue #888
 
-**Status:** Draft — awaiting PM review, then user approval
+**Status:** Merged (design PR #902, 2026-04-24); related follow-up fix PR #982 (closes #967)
 **Author:** Architect
 **Date:** 2026-04-24
 **Priority:** P2 — user-visible on dramatic and verse books (Faust, Dumas, etc.); not app-wide.

--- a/docs/design/fk-enforcement.md
+++ b/docs/design/fk-enforcement.md
@@ -1,6 +1,6 @@
 # Design: Enable `PRAGMA foreign_keys` per connection (Issue #700)
 
-**Status:** Draft — awaiting PM review
+**Status:** Shipped (design PR #742; impl PR #751, 2026-04-23)
 **Author:** Architect
 **Date:** 2026-04-23
 **Priority:** P3 — quality-of-life hardening; no user-visible bug today.

--- a/docs/design/fts5-in-app-search.md
+++ b/docs/design/fts5-in-app-search.md
@@ -1,6 +1,6 @@
 # Design: In-App Full-Text Search via FTS5 (Issue #592)
 
-**Status:** PM approved 2026-04-23 ✅ — revised per review notes  
+**Status:** Shipped (PR #733, 2026-04-23)  
 **Author:** Architect  
 **Date:** 2026-04-23  
 **Depends on:** #357 (user_book_chapters) implementation must merge before the implementation PR for this design is opened.

--- a/docs/design/insightchat-history-persistence.md
+++ b/docs/design/insightchat-history-persistence.md
@@ -1,6 +1,10 @@
 # InsightChat History Persistence
 
-Issue: #907
+**Status:** Shipped (design PR #1059, 2026-04-24; backend PR #1061, 2026-04-24; frontend PR #1114)
+**Author:** Architect
+**Date:** 2026-04-24
+**Priority:** P2
+**Prior work:** #907 (issue)
 
 ## Problem
 

--- a/docs/design/translation-alignment-checker.md
+++ b/docs/design/translation-alignment-checker.md
@@ -1,4 +1,4 @@
-**Status:** Draft
+**Status:** Shipped (design PR #1194; impl PR #1203, 2026-04-25)
 **Author:** Architect
 **Date:** 2026-04-25
 **Priority:** P3

--- a/docs/design/user-book-chapters.md
+++ b/docs/design/user-book-chapters.md
@@ -1,6 +1,6 @@
 # Design: user_book_chapters Table (Issue #357)
 
-**Status:** PM approved 2026-04-23 ✅ — revised to resolve migration-runner question  
+**Status:** Shipped (PR #649, 2026-04-23)  
 **Author:** Architect  
 **Date:** 2026-04-23
 

--- a/docs/design/vocab-tags-decks.md
+++ b/docs/design/vocab-tags-decks.md
@@ -1,6 +1,6 @@
 # Design: Vocabulary Tags & Custom Study Decks (Issue #645)
 
-**Status:** Awaiting PM approval
+**Status:** Shipped (design PR #646; backend PR #745, 2026-04-23; frontend PRs #1189, #1193, #1196, #1198, #1200, #1202)
 **Author:** Architect
 **Date:** 2026-04-23
 


### PR DESCRIPTION
## Summary

Bumps stale `Status:` lines on 12 design docs in `docs/design/` to reflect what has actually shipped. Per CLAUDE.md Architect duty:

> When a design doc's series ships, change its `Status` line to `Shipped (PR #<N>, YYYY-MM-DD)` in a one-line follow-up commit. Do not leave stale `Draft` / `PM-approved` statuses on merged-and-implemented design docs.

The docs site at `alfmunny.github.io/book-reader-ai/` renders this frontmatter on the Architecture → Design Docs index, so stale statuses mislead anyone scanning for what's done vs. in-flight.

### Status updates (10 docs)

| Doc | Before | After |
|---|---|---|
| `ci-speedup.md` | Draft — awaiting PM review | Shipped — Phase 1 (PRs #914/#919/#922/#973, 2026-04-24) |
| `declared-fks-schema.md` | Draft — awaiting PM review | Shipped (PRs #851/#858/#975/#986, 2026-04-24) |
| `epub-nested-ncx-titles.md` | Draft | Shipped (design PR #1190; impl PR #1204, 2026-04-25) |
| `epub-speaker-cue-fix.md` | Draft — awaiting PM review | Merged (design PR #902, 2026-04-24); related fix PR #982 |
| `fk-enforcement.md` | Draft — awaiting PM review | Shipped (design PR #742; impl PR #751, 2026-04-23) |
| `fts5-in-app-search.md` | PM-approved 2026-04-23 | Shipped (PR #733, 2026-04-23) |
| `insightchat-history-persistence.md` | (no frontmatter) | Shipped (design #1059; backend #1061; frontend #1114) |
| `translation-alignment-checker.md` | Draft | Shipped (design PR #1194; impl PR #1203, 2026-04-25) |
| `user-book-chapters.md` | PM-approved 2026-04-23 | Shipped (PR #649, 2026-04-23) |
| `vocab-tags-decks.md` | Awaiting PM approval | Shipped (design #646; backend #745; frontend #1189/#1193/#1196/#1198/#1200/#1202) |

### Frontmatter added to 3 docs that had none

`ci-speedup-phase-2.md`, `epub-ncx-fragment-anchors.md`, and `insightchat-history-persistence.md` now all carry the full `Status / Author / Date / Priority / Prior work` block per the CLAUDE.md frontmatter spec; `declared-fks-schema.md` (#821) is the exemplar.

## Test plan

- [x] `git diff --stat` confirms the diff is `docs/design/*.md`-only (12 files, 24 insertions / 14 deletions).
- [x] PR numbers cross-checked against `gh pr view <N>` for each citation.
- [x] No source code touched; CI path-scoping (Phase 1 — `ci-speedup.md`, in this same diff) skips the full backend + frontend suite for `docs/`-only diffs, so the local test run was skipped per CLAUDE.md spirit ("aim to maintain coverage" — no code coverage to lose).
- [ ] CI must be green before merge.

## Docs follow-up

None — this *is* the docs follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
