### PR TITLE
fix: aria-hidden on reader header skeleton; role=status on annotations spinner (closes #1229)

### DIFF
--- a/frontend/src/__tests__/ReaderLoadingAria.test.ts
+++ b/frontend/src/__tests__/ReaderLoadingAria.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Static assertions: reader page loading indicators have correct aria attributes.
+ * Closes #1229.
+ */
+import fs from "fs";
+import path from "path";
+
+const readerPage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Reader header skeleton aria-hidden", () => {
+  it("title skeleton pulse div has aria-hidden=true", () => {
+    // The h-4 w-48 animate-pulse placeholder is decorative while the title loads
+    expect(readerPage).toMatch(
+      /h-4 w-48 bg-amber-200 animate-pulse rounded"[^>]*aria-hidden="true"|aria-hidden="true"[^>]*h-4 w-48 bg-amber-200 animate-pulse/
+    );
+  });
+});
+
+describe("Reader annotations loading spinner accessibility", () => {
+  it("annotations spinner container has role=status", () => {
+    // The spinner shown while annotationsLoading && annotations.length === 0
+    expect(readerPage).toMatch(/annotationsLoading[\s\S]{0,300}role="status"/);
+  });
+
+  it("annotations spinner container has aria-label", () => {
+    expect(readerPage).toMatch(/aria-label="Loading annotations"/);
+  });
+
+  it("annotations spinner span has aria-hidden=true", () => {
+    // The visual spin element is decorative once role=status is on the container
+    expect(readerPage).toMatch(
+      /border-t-amber-700 rounded-full animate-spin"[^/]*aria-hidden="true"|animate-spin[^>]*aria-hidden="true"/
+    );
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -942,7 +942,7 @@ export default function ReaderPage() {
                 <p className="text-xs text-amber-700 truncate">{meta.authors.join(", ")}</p>
               </>
             ) : (
-              <div className="h-4 w-48 bg-amber-200 animate-pulse rounded" />
+              <div className="h-4 w-48 bg-amber-200 animate-pulse rounded" aria-hidden="true" />
             )}
           </div>
 
@@ -1734,8 +1734,8 @@ export default function ReaderPage() {
                       ))}
                     </div>
                     {annotationsLoading && annotations.length === 0 ? (
-                      <div className="flex justify-center mt-10">
-                        <span className="w-5 h-5 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+                      <div className="flex justify-center mt-10" role="status" aria-label="Loading annotations">
+                        <span className="w-5 h-5 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
                       </div>
                     ) : filteredNotes.length === 0 ? (
                       <div className="text-center text-stone-400 mt-10 text-sm">


### PR DESCRIPTION
Closes #1229.

Two loading indicators in `reader/[bookId]/page.tsx` were missing accessibility attributes.

## Changes

**Header title skeleton (line ~945)**
Added `aria-hidden="true"` to the `animate-pulse` placeholder div that renders while book metadata loads. The element is purely decorative — screen readers were encountering a silent, animated element with no meaning.

**Annotations panel spinner (line ~1737)**
Added `role="status"` and `aria-label="Loading annotations"` to the spinner's container div, and `aria-hidden="true"` to the spinner span itself. Screen readers can now announce that annotations are loading without reading the visual-only spin element directly.

## Test plan
- [x] New `ReaderLoadingAria.test.ts` — 4 static assertions covering both fixes (all failing before this PR)
- [x] Full frontend suite — 2251/2251 passing (280 suites)
- [x] Full backend suite — 1382/1382 passing
