### PR TITLE
fix: add role=alert to error displays in upload, QueueTab, SeedPopularButton (closes #1228)

### DIFF
--- a/frontend/src/__tests__/ErrorRoleAlert.test.tsx
+++ b/frontend/src/__tests__/ErrorRoleAlert.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Regression test for #1228: error display elements in upload/page,
+ * QueueTab, and SeedPopularButton must have role="alert".
+ */
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+
+// Hoisted mocks
+jest.mock("next/navigation", () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ status: "authenticated", data: { user: {} } }),
+}));
+jest.mock("@/lib/api", () => ({
+  uploadBook: jest.fn().mockRejectedValue(new Error("Upload failed")),
+  getUploadQuota: jest.fn().mockResolvedValue({ used: 0, max: 5, remaining: 5 }),
+  ApiError: class ApiError extends Error {},
+}));
+
+// --- QueueTab: adminFetch failure on initial load ---
+import QueueTab from "@/components/QueueTab";
+
+test("QueueTab error has role=alert", async () => {
+  const adminFetch = jest.fn().mockRejectedValue(new Error("Network error"));
+  render(<QueueTab adminFetch={adminFetch} />);
+  await waitFor(() => {
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+  expect(screen.getByRole("alert").textContent).toMatch(/network error/i);
+});
+
+// --- SeedPopularButton: start() failure when fetch for start call rejects ---
+import SeedPopularButton from "@/components/SeedPopularButton";
+
+const IDLE_STATE = {
+  status: "idle",
+  total: 0,
+  current: 0,
+  downloaded: 0,
+  failed: 0,
+  already_cached: 0,
+  current_book_id: null,
+  current_book_title: "",
+  last_error: "",
+  started_at: null,
+  ended_at: null,
+  log: [],
+};
+
+const RUNNING_STATE = {
+  ...IDLE_STATE,
+  status: "running",
+  total: 5,
+  current: 1,
+  started_at: "2026-01-01T00:00:00Z",
+};
+
+test("SeedPopularButton error has role=alert when start fails", async () => {
+  // First call (refresh on mount) succeeds so state is populated
+  // Second call (start) rejects to trigger setError
+  const adminFetch = jest.fn()
+    .mockResolvedValueOnce({ running: false, state: RUNNING_STATE })
+    .mockRejectedValueOnce(new Error("Start failed"));
+
+  window.confirm = jest.fn().mockReturnValue(true);
+
+  render(<SeedPopularButton adminFetch={adminFetch} />);
+
+  // Wait for initial status load (makes Start button not disabled and state non-null)
+  await waitFor(() => {
+    expect(adminFetch).toHaveBeenCalledWith("/admin/books/seed-popular/status");
+  });
+
+  const startBtn = screen.getByRole("button", { name: /seed all popular books/i });
+  fireEvent.click(startBtn);
+
+  await waitFor(() => {
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+});
+
+// --- upload/page: unsupported file type triggers error ---
+import UploadPage from "@/app/upload/page";
+
+test("upload/page error has role=alert when unsupported file type chosen", async () => {
+  render(<UploadPage />);
+
+  const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+  expect(input).toBeTruthy();
+
+  const file = new File(["content"], "test.pdf", { type: "application/pdf" });
+  fireEvent.change(input, { target: { files: [file] } });
+
+  await waitFor(() => {
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+  expect(screen.getByRole("alert").textContent).toMatch(/only.*\.txt.*\.epub/i);
+});

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -172,7 +172,7 @@ export default function UploadPage() {
 
         {/* Error */}
         {error && (
-          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          <div role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
             {error}
           </div>
         )}

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -473,7 +473,7 @@ export default function QueueTab({ adminFetch }: Props) {
   return (
     <div className="space-y-4">
       {error && (
-        <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-2 text-sm">
+        <div role="alert" className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-2 text-sm">
           {error}
         </div>
       )}

--- a/frontend/src/components/SeedPopularButton.tsx
+++ b/frontend/src/components/SeedPopularButton.tsx
@@ -159,7 +159,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
           </div>
 
           {error && (
-            <div className="bg-red-50 border border-red-200 text-red-700 rounded px-2 py-1 text-xs">
+            <div role="alert" className="bg-red-50 border border-red-200 text-red-700 rounded px-2 py-1 text-xs">
               {error}
             </div>
           )}


### PR DESCRIPTION
Closes #1228.

## What changed

Added `role="alert"` to three error display `<div>` elements that were rendering error messages without it:

- `frontend/src/app/upload/page.tsx` — file upload validation/API error
- `frontend/src/components/QueueTab.tsx` — translation queue load error
- `frontend/src/components/SeedPopularButton.tsx` — seed job start error

## Why

Without `role="alert"`, screen readers have no signal to announce these error messages when they appear. Every other dynamic error display in the codebase already carries `role="alert"` (or `role="alert"` via `AnnotationToolbar`, etc.) — these three were the remaining gaps.

## Test plan

- New test file `ErrorRoleAlert.test.tsx` (3 tests):
  - `QueueTab` error div has `role="alert"` when `adminFetch` fails on load
  - `SeedPopularButton` error div has `role="alert"` when start call rejects
  - `upload/page` error div has `role="alert"` when unsupported file type chosen
- Full frontend suite: 2245/2245 passing
- Backend suite: all passing

## Docs follow-up

None — pure attribute additions with no user-visible behaviour change beyond correct AT announcement.
