### PR TITLE
fix: add role=alert to error displays in WordActionDrawer, WordLookup, TTSControls (closes #1234, #1236)

### DIFF
--- a/frontend/src/__tests__/WordErrorRoleAlert.test.tsx
+++ b/frontend/src/__tests__/WordErrorRoleAlert.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Regression test for #1234: error displays in WordActionDrawer and WordLookup
+ * must have role="alert" so screen readers announce them.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+
+beforeEach(() => {
+  global.fetch = jest.fn().mockRejectedValue(new Error("Network error"));
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// --- WordActionDrawer ---
+import WordActionDrawer from "@/components/WordActionDrawer";
+
+const ACTION = {
+  word: "ephemeral",
+  sentenceText: "It was an ephemeral moment.",
+  segmentStartTime: 0,
+  chapterIndex: 0,
+};
+
+test("WordActionDrawer error has role=alert when lookup fails", async () => {
+  render(
+    <WordActionDrawer
+      action={ACTION}
+      onClose={jest.fn()}
+    />,
+  );
+  await waitFor(() => {
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+});
+
+// --- WordLookup ---
+import WordLookup from "@/components/WordLookup";
+
+test("WordLookup error has role=alert when lookup fails", async () => {
+  render(
+    <WordLookup
+      word="ephemeral"
+      position={{ x: 100, y: 100 }}
+      onClose={jest.fn()}
+    />,
+  );
+  await waitFor(() => {
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/WordErrorRoleAlert.test.tsx
+++ b/frontend/src/__tests__/WordErrorRoleAlert.test.tsx
@@ -1,12 +1,29 @@
 /**
- * Regression test for #1234: error displays in WordActionDrawer and WordLookup
- * must have role="alert" so screen readers announce them.
+ * Regression tests for #1234 and #1236: error displays in WordActionDrawer,
+ * WordLookup, and TTSControls must have role="alert".
  */
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
 
 beforeEach(() => {
   global.fetch = jest.fn().mockRejectedValue(new Error("Network error"));
+  // @ts-ignore
+  global.Audio = jest.fn().mockImplementation(() => ({
+    src: "",
+    preload: "auto",
+    playbackRate: 1,
+    currentTime: 0,
+    duration: 10,
+    addEventListener: (event: string, handler: () => void) => {
+      if (event === "loadedmetadata") setTimeout(handler, 0);
+    },
+    removeEventListener: jest.fn(),
+    play: () => Promise.resolve(),
+    pause: jest.fn(),
+  }));
+  global.URL.createObjectURL = jest.fn(() => "blob:test-url");
+  global.URL.revokeObjectURL = jest.fn();
+  window.speechSynthesis = { cancel: jest.fn() } as unknown as SpeechSynthesis;
 });
 
 afterEach(() => {
@@ -46,6 +63,46 @@ test("WordLookup error has role=alert when lookup fails", async () => {
       onClose={jest.fn()}
     />,
   );
+  await waitFor(() => {
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+});
+
+// --- TTSControls ---
+jest.mock("@/lib/api", () => ({
+  synthesizeSpeech: jest.fn().mockRejectedValue(new Error("TTS failed")),
+  getTtsChunks: jest.fn().mockResolvedValue(["Hello world."]),
+}));
+jest.mock("@/lib/settings", () => ({
+  getSettings: jest.fn(() => ({ ttsGender: "female" })),
+  saveSettings: jest.fn(),
+}));
+jest.mock("@/lib/audio", () => ({
+  getAudioPosition: jest.fn(() => 0),
+  saveAudioPosition: jest.fn(),
+  clearAudioPosition: jest.fn(),
+}));
+
+import TTSControls from "@/components/TTSControls";
+
+const TTS_PROPS = {
+  text: "Hello world.",
+  language: "en",
+  bookId: 1,
+  chapterIndex: 0,
+};
+
+test("TTSControls error has role=alert when synthesis fails", async () => {
+  jest.useFakeTimers();
+  render(<TTSControls {...TTS_PROPS} />);
+
+  const buttons = screen.getAllByRole("button");
+  await act(async () => {
+    fireEvent.click(buttons[0]);
+    await jest.runAllTimersAsync();
+  });
+  jest.useRealTimers();
+
   await waitFor(() => {
     expect(screen.getByRole("alert")).toBeInTheDocument();
   });

--- a/frontend/src/components/TTSControls.tsx
+++ b/frontend/src/components/TTSControls.tsx
@@ -533,7 +533,7 @@ export default function TTSControls({
       )}
 
       {status === "error" && errorMsg && (
-        <p className="text-xs text-red-600 w-full">{errorMsg}</p>
+        <p role="alert" className="text-xs text-red-600 w-full">{errorMsg}</p>
       )}
     </div>
   );

--- a/frontend/src/components/WordActionDrawer.tsx
+++ b/frontend/src/components/WordActionDrawer.tsx
@@ -152,7 +152,7 @@ export default function WordActionDrawer({
           )}
 
           {error && (
-            <p className="text-sm text-amber-500 italic">{error}</p>
+            <p role="alert" className="text-sm text-amber-500 italic">{error}</p>
           )}
 
           {result && result.meanings.length > 0 && (

--- a/frontend/src/components/WordLookup.tsx
+++ b/frontend/src/components/WordLookup.tsx
@@ -92,7 +92,7 @@ export default function WordLookup({ word, position, language, onClose }: Props)
       )}
 
       {error && (
-        <p className="text-amber-600 italic">{error} for &ldquo;{word}&rdquo;</p>
+        <p role="alert" className="text-amber-600 italic">{error} for &ldquo;{word}&rdquo;</p>
       )}
 
       {result && (


### PR DESCRIPTION
Closes #1234. Closes #1236.

## What changed

Added `role="alert"` to three more error display elements that were rendering without it:

- `frontend/src/components/WordActionDrawer.tsx` line 155 — word lookup failure message
- `frontend/src/components/WordLookup.tsx` line 95 — inline word lookup failure message
- `frontend/src/components/TTSControls.tsx` line 536 — TTS synthesis failure message

## Why

Without `role="alert"`, these error messages are invisible to screen readers. All three are transient errors that appear dynamically after user actions — exactly the class of content that `role="alert"` is designed to announce. This continues the sweep from #1228 (PR #1233) that fixed the same pattern in upload, QueueTab, and SeedPopularButton.

## Test plan

- New test file `WordErrorRoleAlert.test.tsx` (3 tests):
  - `WordActionDrawer` error has `role="alert"` when dictionary lookup fails
  - `WordLookup` error has `role="alert"` when dictionary lookup fails
  - `TTSControls` error has `role="alert"` when synthesis fails
- Full frontend suite: 2253/2253 passing
- Backend suite: 1644/1644 passing

## Docs follow-up

None — attribute-only additions with no user-visible behaviour change.
