### PR TITLE
fix: role=status and aria-hidden on WordLookup, VocabWordTooltip, vocabulary page spinners (closes #1232)

### DIFF
--- a/frontend/src/__tests__/LookupSpinnerAria.test.ts
+++ b/frontend/src/__tests__/LookupSpinnerAria.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Static assertions: "Looking up" spinner containers have role=status and
+ * spinner spans have aria-hidden=true in WordLookup, VocabWordTooltip, and
+ * vocabulary page. Closes #1232.
+ */
+import fs from "fs";
+import path from "path";
+
+const wordLookup = fs.readFileSync(
+  path.join(process.cwd(), "src/components/WordLookup.tsx"),
+  "utf8",
+);
+
+const vocabTooltip = fs.readFileSync(
+  path.join(process.cwd(), "src/components/VocabWordTooltip.tsx"),
+  "utf8",
+);
+
+const vocabPage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/vocabulary/page.tsx"),
+  "utf8",
+);
+
+describe("WordLookup loading spinner", () => {
+  it("spinner container has role=status", () => {
+    expect(wordLookup).toMatch(/role="status"/);
+  });
+
+  it("spinner span has aria-hidden=true", () => {
+    expect(wordLookup).toMatch(/animate-spin[^>]*aria-hidden="true"|aria-hidden="true"[^>]*animate-spin/);
+  });
+});
+
+describe("VocabWordTooltip loading spinner", () => {
+  it("spinner container has role=status", () => {
+    expect(vocabTooltip).toMatch(/role="status"/);
+  });
+
+  it("spinner span has aria-hidden=true", () => {
+    expect(vocabTooltip).toMatch(/animate-spin[^>]*aria-hidden="true"|aria-hidden="true"[^>]*animate-spin/);
+  });
+});
+
+describe("Vocabulary page loading spinner", () => {
+  it("spinner container has role=status", () => {
+    // The "Looking up…" div in the word-detail panel
+    expect(vocabPage).toMatch(/role="status"/);
+  });
+
+  it("spinner span has aria-hidden=true", () => {
+    expect(vocabPage).toMatch(/animate-spin[^>]*aria-hidden="true"|aria-hidden="true"[^>]*animate-spin/);
+  });
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -171,8 +171,8 @@ function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
           </div>
 
           {loading && (
-            <div className="flex items-center gap-2 text-amber-600 text-sm">
-              <span className="w-3 h-3 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+            <div className="flex items-center gap-2 text-amber-600 text-sm" role="status">
+              <span className="w-3 h-3 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
               Looking up…
             </div>
           )}

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -75,8 +75,8 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
       {/* Body */}
       <div className="px-3 py-2.5 max-h-40 overflow-y-auto">
         {loading && (
-          <div className="flex items-center gap-2 text-amber-600 text-xs py-1">
-            <span className="w-3 h-3 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin shrink-0" />
+          <div className="flex items-center gap-2 text-amber-600 text-xs py-1" role="status">
+            <span className="w-3 h-3 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin shrink-0" aria-hidden="true" />
             Looking up definition…
           </div>
         )}

--- a/frontend/src/components/WordLookup.tsx
+++ b/frontend/src/components/WordLookup.tsx
@@ -85,8 +85,8 @@ export default function WordLookup({ word, position, language, onClose }: Props)
   return (
     <div ref={ref} style={style} className="sm:w-72 max-h-64 overflow-y-auto rounded-xl border border-amber-300 bg-white shadow-lg p-3 text-sm">
       {loading && (
-        <div className="flex items-center gap-2 text-amber-600">
-          <span className="w-3 h-3 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" />
+        <div className="flex items-center gap-2 text-amber-600" role="status">
+          <span className="w-3 h-3 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
           Looking up &ldquo;{word}&rdquo;...
         </div>
       )}


### PR DESCRIPTION
Closes #1232.

Three "Looking up…" loading states in `WordLookup`, `VocabWordTooltip`, and the vocabulary page shared the same accessibility gap: a bare `animate-spin` spinner sat alongside visible "Looking up…" text, but the container div lacked `role="status"` and the spinner span lacked `aria-hidden="true"`.

## Changes

**`components/WordLookup.tsx`**
- Container div `→` added `role="status"`
- Spinner span `→` added `aria-hidden="true"`

**`components/VocabWordTooltip.tsx`**
- Container div `→` added `role="status"`
- Spinner span `→` added `aria-hidden="true"`

**`app/vocabulary/page.tsx`**
- Container div `→` added `role="status"`
- Spinner span `→` added `aria-hidden="true"`

## Why

Without `role="status"`, there is no guaranteed live-region announcement when the lookup state appears. The spinner span was also read as a nameless empty element rather than being silenced. The adjacent visible text already conveys the full state; the spinner is purely decorative.

## Test plan
- [x] New `LookupSpinnerAria.test.ts` — 6 static assertions (role=status + aria-hidden for all three components; all failing before this PR)
- [x] Full frontend suite — 2256/2256 passing (281 suites)
- [x] Full backend suite — 1382/1382 passing
