### PR TITLE
fix: add aria-expanded to SentenceReader note toggle button (closes #1240)

### DIFF
--- a/frontend/src/__tests__/SentenceReaderNoteAriaExpanded.test.tsx
+++ b/frontend/src/__tests__/SentenceReaderNoteAriaExpanded.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * Regression test for #1240: SentenceReader note toggle button must expose
+ * aria-expanded so screen readers announce the expanded/collapsed state.
+ */
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import SentenceReader from "@/components/SentenceReader";
+import type { Annotation } from "@/lib/api";
+
+const noop = () => {};
+
+const ANNOTATION: Annotation = {
+  id: 1,
+  book_id: 1,
+  chapter_index: 0,
+  sentence_text: "It was a bright cold day in April.",
+  note_text: "A memorable opening.",
+  color: "yellow",
+};
+
+function renderWithAnnotation() {
+  return render(
+    <SentenceReader
+      text="It was a bright cold day in April."
+      duration={0}
+      currentTime={0}
+      isPlaying={false}
+      onSegmentClick={noop}
+      annotations={[ANNOTATION]}
+    />,
+  );
+}
+
+test("note toggle button has aria-expanded=false when note is closed", () => {
+  const { container } = renderWithAnnotation();
+  const btn = container.querySelector("[aria-label='Toggle note']") as HTMLElement;
+  expect(btn).not.toBeNull();
+  expect(btn.getAttribute("aria-expanded")).toBe("false");
+});
+
+test("note toggle button has aria-expanded=true after clicking", () => {
+  const { container } = renderWithAnnotation();
+  const btn = container.querySelector("[aria-label='Toggle note']") as HTMLElement;
+  fireEvent.click(btn);
+  expect(btn.getAttribute("aria-expanded")).toBe("true");
+});
+
+test("note toggle button returns to aria-expanded=false after second click", () => {
+  const { container } = renderWithAnnotation();
+  const btn = container.querySelector("[aria-label='Toggle note']") as HTMLElement;
+  fireEvent.click(btn);
+  fireEvent.click(btn);
+  expect(btn.getAttribute("aria-expanded")).toBe("false");
+});

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -713,6 +713,7 @@ export default function SentenceReader({
                   onClick={(e) => { e.stopPropagation(); setExpandedNoteFlatIdx((prev) => prev === seg.flatIdx ? null : seg.flatIdx); }}
                   className="inline-flex items-center justify-center ml-0.5 align-middle cursor-pointer min-h-[44px] min-w-[44px] -m-[19px] p-[19px]"
                   aria-label="Toggle note"
+                  aria-expanded={expandedNoteFlatIdx === seg.flatIdx}
                 >
                   <span className={`inline-block w-1.5 h-1.5 rounded-full ${NOTE_DOT_CLASS[annotation.color] ?? NOTE_DOT_CLASS.yellow}`} />
                 </button>


### PR DESCRIPTION
Closes #1240.

## What changed

Added `aria-expanded` to the note-toggle button inside `SentenceReader` (`frontend/src/components/SentenceReader.tsx`).

The button at line 714 lets readers expand/collapse inline notes attached to word segments. It had an `aria-label="Toggle note"` but no `aria-expanded` attribute, so keyboard and screen-reader users had no programmatic signal about the open/closed state — a WCAG 4.1.2 (Name, Role, Value) violation.

**Change:**
```tsx
<button
  ...
  aria-label="Toggle note"
  aria-expanded={expandedNoteFlatIdx === seg.flatIdx}
>
```

## Why

WCAG 4.1.2 requires that all user-interface components (including disclosure/toggle controls) expose their current state through ARIA attributes. Without `aria-expanded`, a screen reader announces "Toggle note button" with no indication of whether the note is open or closed — the user cannot tell what the button will do when activated.

## Test plan

- New test file `SentenceReaderNoteAriaExpanded.test.tsx` (3 tests):
  - button starts with `aria-expanded="false"`
  - button has `aria-expanded="true"` after first click
  - button reverts to `aria-expanded="false"` after second click
- Full frontend suite: 2260/2260 passing

## Docs follow-up

None — attribute-only addition with no user-visible behaviour change.
