### PR TITLE
fix: aria-hidden on QueueTab Spinner component, button spinners, and search button (closes #1242)

### DIFF
--- a/frontend/src/__tests__/QueueTabSpinnerAria.test.ts
+++ b/frontend/src/__tests__/QueueTabSpinnerAria.test.ts
@@ -1,0 +1,55 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const queueTabSrc = fs.readFileSync(
+  path.join(__dirname, "../components/QueueTab.tsx"),
+  "utf-8",
+);
+
+const pageSrc = fs.readFileSync(
+  path.join(__dirname, "../app/page.tsx"),
+  "utf-8",
+);
+
+describe("QueueTab Spinner and button spinner aria attributes", () => {
+  it("Spinner component uses aria-hidden instead of aria-label", () => {
+    expect(queueTabSrc).toContain('aria-hidden="true"');
+    expect(queueTabSrc).not.toContain('aria-label="loading"');
+  });
+
+  it("stop-worker button spinner is aria-hidden", () => {
+    expect(queueTabSrc).not.toContain('aria-label="stopping"');
+  });
+
+  it("start-worker button spinner is aria-hidden", () => {
+    expect(queueTabSrc).not.toContain('aria-label="starting"');
+  });
+
+  it("save-chain button spinner is aria-hidden", () => {
+    expect(queueTabSrc).not.toContain('aria-label="saving"');
+  });
+
+  it("status dot is aria-hidden", () => {
+    expect(queueTabSrc).toMatch(/aria-hidden="true"[\s\S]{0,200}bg-emerald-500 animate-pulse/);
+  });
+
+  it("startup banner loading container has role=status", () => {
+    expect(queueTabSrc).toMatch(/role="status"[\s\S]{0,300}text-sky-700/);
+  });
+
+  it("cost estimate loading container has role=status", () => {
+    expect(queueTabSrc).toMatch(/role="status"[\s\S]{0,300}Computing cost estimate/);
+  });
+
+  it("items loading container has role=status", () => {
+    expect(queueTabSrc).toMatch(/role="status"[\s\S]{0,400}Loading items/);
+  });
+});
+
+describe("page.tsx search button spinner aria attribute", () => {
+  it("search button spinner is aria-hidden", () => {
+    expect(pageSrc).toMatch(
+      /animate-spin"[^/]*aria-hidden="true"/,
+    );
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -573,7 +573,7 @@ export default function Home() {
                     disabled={searching}
                   >
                     {searching && (
-                      <span className="w-3.5 h-3.5 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+                      <span className="w-3.5 h-3.5 border-2 border-white/40 border-t-white rounded-full animate-spin" aria-hidden="true" />
                     )}
                     {searching ? "Searching" : "Search"}
                   </button>

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -101,7 +101,7 @@ function Spinner({ size = 12 }: { size?: number }) {
     <span
       className="inline-block border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin align-middle"
       style={{ width: size, height: size }}
-      aria-label="loading"
+      aria-hidden="true"
     />
   );
 }
@@ -482,6 +482,7 @@ export default function QueueTab({ adminFetch }: Props) {
       <div className="bg-white rounded-xl border border-amber-200 p-4 space-y-3">
         <div className="flex items-center gap-3">
           <div
+            aria-hidden="true"
             className={`w-2.5 h-2.5 rounded-full ${
               status?.running
                 ? s?.idle
@@ -515,7 +516,7 @@ export default function QueueTab({ adminFetch }: Props) {
                 <span
                   className="inline-block border-2 border-red-300 border-t-red-600 rounded-full animate-spin"
                   style={{ width: 10, height: 10 }}
-                  aria-label="stopping"
+                  aria-hidden="true"
                 />
               )}
               {togglingWorker === "stop" ? "Stopping…" : "Stop"}
@@ -530,7 +531,7 @@ export default function QueueTab({ adminFetch }: Props) {
                 <span
                   className="inline-block border-2 border-emerald-300 border-t-emerald-700 rounded-full animate-spin"
                   style={{ width: 10, height: 10 }}
-                  aria-label="starting"
+                  aria-hidden="true"
                 />
               )}
               {togglingWorker === "start" ? "Starting…" : "Start"}
@@ -543,7 +544,7 @@ export default function QueueTab({ adminFetch }: Props) {
             concrete feedback instead of a silent "Starting…" while the
             splitter chews through 100+ books. */}
         {s?.startup_phase && s.startup_phase !== "ready" ? (
-          <div className="text-xs text-sky-700 bg-sky-50 border border-sky-200 rounded px-2 py-1 flex items-center gap-2">
+          <div role="status" className="text-xs text-sky-700 bg-sky-50 border border-sky-200 rounded px-2 py-1 flex items-center gap-2">
             <Spinner />
             <span>
               <span className="font-medium">
@@ -879,7 +880,7 @@ export default function QueueTab({ adminFetch }: Props) {
                     <span
                       className="inline-block border-2 border-white/60 border-t-white rounded-full animate-spin"
                       style={{ width: 10, height: 10 }}
-                      aria-label="saving"
+                      aria-hidden="true"
                     />
                   )}
                   {saving ? "Saving…" : "Save chain"}
@@ -1100,7 +1101,7 @@ export default function QueueTab({ adminFetch }: Props) {
           across each model. Helps decide whether to route through pro vs flash.
           Shows its own spinner (not full-tab) because this is the slowest fetch. */}
       {loadingCost && !cost && (
-        <div className="bg-white rounded-xl border border-amber-200 p-4 flex items-center gap-2 text-sm text-stone-500">
+        <div role="status" className="bg-white rounded-xl border border-amber-200 p-4 flex items-center gap-2 text-sm text-stone-500">
           <Spinner />
           Computing cost estimate…
         </div>
@@ -1252,7 +1253,7 @@ export default function QueueTab({ adminFetch }: Props) {
           </button>
         </div>
         {items.length === 0 ? (
-          <div className="px-4 py-8 text-center text-stone-400 text-sm flex items-center justify-center gap-2">
+          <div role="status" className="px-4 py-8 text-center text-stone-400 text-sm flex items-center justify-center gap-2">
             {loadingItems && <Spinner />}
             <span>{loadingItems ? "Loading items…" : "No items in this view."}</span>
           </div>


### PR DESCRIPTION
## What changed

- `QueueTab.tsx` `Spinner` component: replaced `aria-label="loading"` (ignored on `<span>` without `role`) with `aria-hidden="true"`. Added `role="status"` to parent loading containers at startup banner, cost estimate, and items loading states so screen readers announce the loading text.
- `QueueTab.tsx` button spinners (stop/start/save): replaced ineffective `aria-label="stopping|starting|saving"` with `aria-hidden="true"` — the parent buttons already have visible text describing the state.
- `QueueTab.tsx` worker status dot: added `aria-hidden="true"` to the decorative `animate-pulse` dot.
- `page.tsx` search button: added `aria-hidden="true"` to the inline spinner — button text "Searching" already describes the state.

## Why

`aria-label` on a plain `<span>` without a semantic `role` is ignored by all screen readers (WCAG 4.1.2 Name, Role, Value). The spinners were providing no accessible information while potentially confusing assistive technology.

## Test plan

- [x] 9 static assertions in `QueueTabSpinnerAria.test.ts` covering all fixed elements
- [x] Full frontend suite: 2266 tests pass
- [x] Full backend suite: 1382 tests pass

Closes #1242
