### PR TITLE
fix: aria-hidden on upload confirm spinner; sr-only status text on import stage icons (closes #1235)

### DIFF
--- a/frontend/src/__tests__/UploadImportSpinnerAria.test.ts
+++ b/frontend/src/__tests__/UploadImportSpinnerAria.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Static assertions: upload confirm spinner has aria-hidden;
+ * import stage icons have aria-hidden and sr-only status text. Closes #1235.
+ */
+import fs from "fs";
+import path from "path";
+
+const uploadChaptersPage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/upload/[bookId]/chapters/page.tsx"),
+  "utf8",
+);
+
+const importPage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/import/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Upload chapters confirm button spinner", () => {
+  it("animate-spin span inside confirm button has aria-hidden=true", () => {
+    expect(uploadChaptersPage).toMatch(
+      /animate-spin[^>]*aria-hidden="true"|aria-hidden="true"[^>]*animate-spin/
+    );
+  });
+});
+
+describe("Import stage icon accessibility", () => {
+  it("icon wrapper span has aria-hidden=true", () => {
+    // The span wrapping CheckCircle/RetryIcon/AlertCircle/CircleDot is decorative
+    expect(importPage).toMatch(/aria-hidden="true"/);
+  });
+
+  it("stage has sr-only status text for screen readers", () => {
+    // Status (done/active/error/pending) must be announced, not just the label
+    expect(importPage).toMatch(/sr-only/);
+  });
+});

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -298,11 +298,15 @@ export default function BookImportPage() {
                     <div className="flex items-baseline gap-3 mb-1">
                       <span
                         className={`flex items-center justify-center w-4 h-4 shrink-0 ${iconColor}`}
+                        aria-hidden="true"
                       >
                         {icon}
                       </span>
                       <span className="flex-1 text-sm font-medium text-ink">
                         {STAGE_LABELS[stage]}
+                        <span className="sr-only">
+                          {s.status === "done" ? " — done" : s.status === "active" ? " — in progress" : s.status === "error" ? " — failed" : " — waiting"}
+                        </span>
                       </span>
                       {s.status === "active" && s.total > 1 && (
                         <span className="text-xs text-amber-600">

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -117,7 +117,7 @@ export default function ChapterEditorPage() {
             className="rounded-lg bg-amber-700 px-5 min-h-[44px] text-white text-sm font-medium hover:bg-amber-800 disabled:opacity-50 transition-colors flex items-center gap-2"
           >
             {confirming && (
-              <span className="w-3.5 h-3.5 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+              <span className="w-3.5 h-3.5 border-2 border-white/40 border-t-white rounded-full animate-spin" aria-hidden="true" />
             )}
             {confirming ? "Saving…" : "Confirm & Start Reading →"}
           </button>


### PR DESCRIPTION
## What changed

- `upload/[bookId]/chapters/page.tsx`: added `aria-hidden="true"` to the confirm-button spinner (button already shows "Saving…" text).
- `import/[bookId]/page.tsx`: added `aria-hidden="true"` to the stage icon wrapper span; added `sr-only` span with status text ("— done", "— in progress", "— failed", "— waiting") to each stage label so screen readers announce stage transitions.

## Why

The import page stage icons (spinner, check, alert, dot) had no accessible attributes — screen readers silently skipped them. The `sr-only` text fixes WCAG 4.1.2 Name, Role, Value by giving each stage a machine-readable state alongside the visible label.

## Test plan

- [x] 3 assertions in `UploadImportSpinnerAria.test.ts`
- [x] Full frontend suite: 2266 tests pass

Closes #1235
