### PR TITLE
fix: aria-hidden on TTS preparing spinner; role=progressbar on audio loading bar (closes #1237)

### DIFF
--- a/frontend/src/__tests__/TTSControlsAria.test.ts
+++ b/frontend/src/__tests__/TTSControlsAria.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Static assertions: TTSControls preparing spinner has aria-hidden;
+ * TTS loading progress bar has role=progressbar with value attrs. Closes #1237.
+ */
+import fs from "fs";
+import path from "path";
+
+const ttsControls = fs.readFileSync(
+  path.join(process.cwd(), "src/components/TTSControls.tsx"),
+  "utf8",
+);
+
+describe("TTSControls preparing button spinner", () => {
+  it("animate-spin span in preparing button has aria-hidden=true", () => {
+    // The spinner alongside 'Preparing…' text is decorative
+    expect(ttsControls).toMatch(
+      /animate-spin[^>]*aria-hidden="true"|aria-hidden="true"[^>]*animate-spin/
+    );
+  });
+});
+
+describe("TTSControls loading progress bar", () => {
+  it("progress bar outer container has role=progressbar", () => {
+    expect(ttsControls).toMatch(/role="progressbar"/);
+  });
+
+  it("progress bar has aria-valuenow attribute", () => {
+    expect(ttsControls).toMatch(/aria-valuenow/);
+  });
+
+  it("progress bar inner visual divs have aria-hidden=true", () => {
+    // The filled and pulsing divs are decorative — text already says 'X of Y'
+    expect(ttsControls).toMatch(/animate-pulse[^>]*aria-hidden="true"|aria-hidden="true"[^>]*animate-pulse/);
+  });
+});

--- a/frontend/src/components/TTSControls.tsx
+++ b/frontend/src/components/TTSControls.tsx
@@ -413,7 +413,7 @@ export default function TTSControls({
             className="rounded-lg bg-amber-300 text-amber-900 px-4 py-2.5 md:py-1.5 text-sm flex items-center gap-2 hover:bg-amber-400 min-h-[44px] md:min-h-0"
             title="Click to cancel"
           >
-            <span className="w-3 h-3 border-2 border-amber-700/40 border-t-amber-800 rounded-full animate-spin" />
+            <span className="w-3 h-3 border-2 border-amber-700/40 border-t-amber-800 rounded-full animate-spin" aria-hidden="true" />
             Preparing…
             <CloseIcon className="w-3.5 h-3.5" />
           </button>
@@ -513,10 +513,18 @@ export default function TTSControls({
               {Math.round(((loadingState.index) / loadingState.total) * 100)}%
             </span>
           </div>
-          <div className="h-2 w-full bg-amber-100 rounded-full overflow-hidden relative">
+          <div
+            className="h-2 w-full bg-amber-100 rounded-full overflow-hidden relative"
+            role="progressbar"
+            aria-valuenow={Math.round((loadingState.index / loadingState.total) * 100)}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label="TTS audio loading progress"
+          >
             <div
               className="absolute inset-y-0 left-0 bg-amber-600 transition-all duration-300"
               style={{ width: `${(loadingState.index / loadingState.total) * 100}%` }}
+              aria-hidden="true"
             />
             <div
               className="absolute inset-y-0 bg-amber-400/60 animate-pulse"
@@ -524,6 +532,7 @@ export default function TTSControls({
                 left: `${(loadingState.index / loadingState.total) * 100}%`,
                 width: `${(1 / loadingState.total) * 100}%`,
               }}
+              aria-hidden="true"
             />
           </div>
           <p className="text-xs text-stone-500 mt-1 italic truncate">


### PR DESCRIPTION
## What changed

- `TTSControls.tsx` preparing button spinner: added `aria-hidden="true"` — button text "Preparing…" already describes the state.
- `TTSControls.tsx` audio loading progress bar: added `role="progressbar"` with `aria-valuenow`, `aria-valuemin={0}`, `aria-valuemax={100}`, and `aria-label="TTS audio loading progress"`. The inner fill div and the pulse overlay div get `aria-hidden="true"`.

## Why

The TTS loading progress bar was visual-only with no semantic role — screen readers could not determine loading progress. WCAG 4.1.2 requires UI component state to be programmatically determinable.

## Test plan

- [x] 4 assertions in `TTSControlsAria.test.ts`: preparing spinner aria-hidden, progressbar role, aria-valuenow, pulse div aria-hidden
- [x] Full frontend suite: 2279 tests pass

Closes #1237
