### PR TITLE
fix: add role=status to reader loading and translation status spans (closes #1241)

### DIFF
--- a/frontend/src/__tests__/ReaderStatusLiveRegions.test.ts
+++ b/frontend/src/__tests__/ReaderStatusLiveRegions.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression tests for #1241: reader page status/loading spans must have
+ * role="status" so screen readers announce them as live regions.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Reader page status live regions (closes #1241)", () => {
+  it("chapter loading span has role=status", () => {
+    const idx = src.indexOf("Loading…");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 100), idx + 50);
+    expect(window).toContain('role="status"');
+  });
+
+  it("translation status container has role=status", () => {
+    const idx = src.indexOf("Checking for translation…");
+    expect(idx).toBeGreaterThan(-1);
+    // The role="status" wrapper should be within 250 chars before the first span
+    const window = src.slice(Math.max(0, idx - 250), idx + 50);
+    expect(window).toContain('role="status"');
+  });
+
+  it("translating-now span is inside the role=status container", () => {
+    const idx = src.indexOf("Translating now…");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 600), idx + 50);
+    expect(window).toContain('role="status"');
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -949,7 +949,7 @@ export default function ReaderPage() {
           {/* Chapter navigation — desktop only (mobile uses bottom bar) */}
           <div className="hidden md:flex items-center gap-1 shrink-0">
             {loading ? (
-              <span className="text-xs text-amber-500 animate-pulse">Loading…</span>
+              <span role="status" className="text-xs text-amber-500 animate-pulse">Loading…</span>
             ) : (
               <>
                 <button
@@ -1957,7 +1957,7 @@ export default function ReaderPage() {
 
                     {/* Status */}
                     {translationEnabled && (
-                      <div className="text-xs">
+                      <div role="status" className="text-xs">
                         {translationLoading && !translationUsedProvider && (
                           <span className="animate-pulse text-amber-600">Checking for translation…</span>
                         )}


### PR DESCRIPTION
Closes #1241.

## What changed

Added `role="status"` to two dynamically-rendered text spans in the reader page (`frontend/src/app/reader/[bookId]/page.tsx`):

1. **Chapter loading indicator** (line 952) — `<span>Loading…</span>` that appears during chapter fetch
2. **Translation status container** (line 1960) — the `<div>` wrapping the animate-pulse spans "Checking for translation…", "Translating now…", "Worker offline — translation queued", "In queue · position N"

## Why

Without `role="status"`, these elements render dynamically but screen readers never announce them — they're invisible to assistive technology. WCAG 4.1.3 requires live regions for any status change that a sighted user can perceive visually. `role="status"` creates a polite live region that announces the content change without interrupting the user.

## Test plan

- New test file `ReaderStatusLiveRegions.test.ts` (3 tests):
  - "Loading…" span has `role="status"`
  - Translation status container has `role="status"`
  - "Translating now…" text is inside the `role="status"` container
- Full frontend suite: 2278/2278 passing

## Docs follow-up

None — attribute-only addition with no user-visible behaviour change.
