### PR TITLE
fix: add aria-expanded to AnnotationsSidebar and InsightChat toggle buttons (closes #1247)

### DIFF
--- a/frontend/src/__tests__/InsightChat.coverage2.test.tsx
+++ b/frontend/src/__tests__/InsightChat.coverage2.test.tsx
@@ -62,28 +62,29 @@ describe("InsightChat — ContextChip expand/collapse (L78)", () => {
     render(<InsightChat {...BASE} selectedText={LONG_TEXT} />);
     await act(async () => await flushPromises());
 
-    // Initially shows "more"
-    const moreBtn = screen.getByRole("button", { name: "Expand context" });
-    expect(moreBtn).toBeInTheDocument();
+    // Initially collapsed (aria-expanded=false)
+    const toggleBtn = screen.getByRole("button", { name: "Toggle context" });
+    expect(toggleBtn).toHaveAttribute("aria-expanded", "false");
 
-    fireEvent.click(moreBtn);
+    fireEvent.click(toggleBtn);
     await act(async () => await flushPromises());
 
-    // After expanding, shows "less"
-    expect(screen.getByRole("button", { name: "Collapse context" })).toBeInTheDocument();
+    // After expanding, aria-expanded=true
+    expect(screen.getByRole("button", { name: "Toggle context" })).toHaveAttribute("aria-expanded", "true");
   });
 
   it("toggles ContextChip back from 'less' to 'more' on second click", async () => {
     render(<InsightChat {...BASE} selectedText={LONG_TEXT} />);
     await act(async () => await flushPromises());
 
-    fireEvent.click(screen.getByRole("button", { name: "Expand context" }));
+    const toggleBtn2 = screen.getByRole("button", { name: "Toggle context" });
+    fireEvent.click(toggleBtn2);
     await act(async () => await flushPromises());
 
-    fireEvent.click(screen.getByRole("button", { name: "Collapse context" }));
+    fireEvent.click(screen.getByRole("button", { name: "Toggle context" }));
     await act(async () => await flushPromises());
 
-    expect(screen.getByRole("button", { name: "Expand context" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Toggle context" })).toHaveAttribute("aria-expanded", "false");
   });
 });
 
@@ -273,19 +274,17 @@ describe("InsightChat — MsgContextBlock onToggle (L389-L390)", () => {
     // Wait for the assistant reply
     await waitFor(() => expect(screen.getByText("Answer.")).toBeInTheDocument());
 
-    // The user message's MsgContextBlock shows "more" (context > 160 chars, collapsed)
-    // There may be multiple "more" buttons (ContextChip in input area is gone after send,
-    // but MsgContextBlock in the user bubble should now be present)
-    const moreBtns = screen.getAllByRole("button", { name: "Expand context" });
+    // The user message's MsgContextBlock shows collapsed toggle (aria-expanded=false)
+    const moreBtns = screen.getAllByRole("button", { name: "Toggle context" });
     expect(moreBtns.length).toBeGreaterThanOrEqual(1);
 
-    // Click the MsgContextBlock's "more" button (last one, as ContextChip was cleared on send)
+    // Click the MsgContextBlock's toggle button (last one)
     fireEvent.click(moreBtns[moreBtns.length - 1]);
     await act(async () => await flushPromises());
 
-    // After expanding, the MsgContextBlock shows "less"
-    const lessBtns = screen.getAllByRole("button", { name: "Collapse context" });
-    expect(lessBtns.length).toBeGreaterThanOrEqual(1);
+    // After expanding, the last toggle button should be aria-expanded=true
+    const lessBtns = screen.getAllByRole("button", { name: "Toggle context" });
+    expect(lessBtns[lessBtns.length - 1]).toHaveAttribute("aria-expanded", "true");
   });
 
   it("toggles MsgContextBlock back from 'less' to 'more' on second click", async () => {
@@ -298,15 +297,16 @@ describe("InsightChat — MsgContextBlock onToggle (L389-L390)", () => {
 
     await waitFor(() => expect(screen.getByText("Answer.")).toBeInTheDocument());
 
-    const moreBtns = screen.getAllByRole("button", { name: "Expand context" });
-    fireEvent.click(moreBtns[moreBtns.length - 1]);
+    const moreBtns2 = screen.getAllByRole("button", { name: "Toggle context" });
+    fireEvent.click(moreBtns2[moreBtns2.length - 1]);
     await act(async () => await flushPromises());
 
-    const lessBtns = screen.getAllByRole("button", { name: "Collapse context" });
-    fireEvent.click(lessBtns[lessBtns.length - 1]);
+    const lessBtns2 = screen.getAllByRole("button", { name: "Toggle context" });
+    fireEvent.click(lessBtns2[lessBtns2.length - 1]);
     await act(async () => await flushPromises());
 
-    // Back to "more"
-    expect(screen.getAllByRole("button", { name: "Expand context" }).length).toBeGreaterThanOrEqual(1);
+    // Back to collapsed
+    const finalBtns = screen.getAllByRole("button", { name: "Toggle context" });
+    expect(finalBtns[finalBtns.length - 1]).toHaveAttribute("aria-expanded", "false");
   });
 });

--- a/frontend/src/__tests__/ToggleAriaExpanded.test.ts
+++ b/frontend/src/__tests__/ToggleAriaExpanded.test.ts
@@ -1,0 +1,34 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const annotationsSrc = fs.readFileSync(
+  path.join(__dirname, "../components/AnnotationsSidebar.tsx"),
+  "utf-8",
+);
+
+const insightChatSrc = fs.readFileSync(
+  path.join(__dirname, "../components/InsightChat.tsx"),
+  "utf-8",
+);
+
+describe("AnnotationsSidebar toggle button aria-expanded", () => {
+  it("toggle button has aria-expanded attribute", () => {
+    expect(annotationsSrc).toContain("aria-expanded={open}");
+  });
+
+  it("toggle button has a stable aria-label", () => {
+    expect(annotationsSrc).toContain('aria-label="Toggle notes panel"');
+  });
+});
+
+describe("InsightChat context toggle button aria-expanded", () => {
+  it("primary context toggle has aria-expanded", () => {
+    expect(insightChatSrc).toContain("aria-expanded={expanded}");
+  });
+
+  it("context toggle uses stable aria-label instead of dynamic one", () => {
+    expect(insightChatSrc).toContain('aria-label="Toggle context"');
+    expect(insightChatSrc).not.toContain('"Collapse context"');
+    expect(insightChatSrc).not.toContain('"Expand context"');
+  });
+});

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -55,6 +55,8 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
       {/* Toggle button — always visible */}
       <button
         onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-label="Toggle notes panel"
         title="Annotations"
         className="relative shrink-0 flex items-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-xs font-medium transition-colors min-h-[44px] md:min-h-0"
         data-testid="annotations-toggle"

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -77,7 +77,8 @@ function ContextChip({
             <button
               onClick={() => setExpanded((v) => !v)}
               className="ml-1.5 text-amber-500 hover:text-amber-700 font-medium not-italic min-h-[44px] inline-flex items-center"
-              aria-label={expanded ? "Collapse context" : "Expand context"}
+              aria-label="Toggle context"
+              aria-expanded={expanded}
             >
               {expanded ? "less" : "more"}
             </button>
@@ -634,7 +635,8 @@ function MsgContextBlock({
           <button
             onClick={onToggle}
             className="ml-1.5 text-amber-500 hover:text-amber-700 font-medium not-italic min-h-[44px] inline-flex items-center"
-            aria-label={expanded ? "Collapse context" : "Expand context"}
+            aria-label="Toggle context"
+            aria-expanded={expanded}
           >
             {expanded ? "less" : "more"}
           </button>


### PR DESCRIPTION
## What changed

- `AnnotationsSidebar.tsx`: The "Notes" toggle button now carries `aria-expanded={open}` and a stable `aria-label="Toggle notes panel"` (replaces the title-only labelling). Screen readers can now report whether the panel is open or closed without requiring focus changes.
- `InsightChat.tsx`: Two context-toggle buttons (`ContextChip` expand/collapse and `MsgContextBlock` expand/collapse) updated from a dynamic `aria-label` (`"Expand context"` / `"Collapse context"`) to a stable `aria-label="Toggle context"` + `aria-expanded={expanded}`. This is the WCAG-correct pattern — a changing accessible name confuses some assistive technologies.

## Why

Dynamic `aria-label` changes on toggle buttons cause AT to re-announce the element name on every focus, which is disorienting. The correct pattern is a stable label + `aria-expanded` state attribute (ARIA 1.1 §5.3.3).

## Test plan

- Static assertions in `ToggleAriaExpanded.test.ts`: verifies `aria-expanded` attribute, stable labels, and absence of the old "Expand context"/"Collapse context" strings.
- Updated `InsightChat.coverage2.test.tsx`: queries now use `{ name: "Toggle context" }` and assert `aria-expanded` changes correctly.

Closes #1247
