### PR TITLE
fix: add aria-expanded to reader disclosure buttons; role=dialog to mobile chat (closes #1245)

### DIFF
--- a/frontend/src/__tests__/ReaderAriaExpandedDialog.test.ts
+++ b/frontend/src/__tests__/ReaderAriaExpandedDialog.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Regression tests for #1245: reader page disclosure buttons must have
+ * aria-expanded, and the mobile chat sheet must have role="dialog".
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Reader page disclosure button aria-expanded (closes #1245)", () => {
+  it("Typography settings button has aria-expanded", () => {
+    const idx = src.indexOf('aria-label="Typography settings"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 200);
+    expect(window).toContain("aria-expanded");
+  });
+
+  it("Notes button has aria-expanded", () => {
+    const idx = src.indexOf('aria-label="Notes"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 100);
+    expect(window).toContain("aria-expanded");
+  });
+
+  it("Insight chat button has aria-expanded", () => {
+    const idx = src.indexOf('aria-label="Insight chat"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 100);
+    expect(window).toContain("aria-expanded");
+  });
+});
+
+describe("Mobile chat sheet role=dialog (closes #1245)", () => {
+  it("chat sheet inner div has role=dialog", () => {
+    const idx = src.indexOf("Chat sheet (bottom half)");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 200);
+    expect(window).toContain('role="dialog"');
+  });
+
+  it("chat sheet inner div has aria-modal", () => {
+    const idx = src.indexOf("Chat sheet (bottom half)");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 200);
+    expect(window).toContain('aria-modal="true"');
+  });
+
+  it("chat sheet inner div has aria-label", () => {
+    const idx = src.indexOf("Chat sheet (bottom half)");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 200);
+    expect(window).toContain('aria-label="Chat"');
+  });
+});

--- a/frontend/src/__tests__/ReaderPage.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.test.tsx
@@ -1367,13 +1367,8 @@ describe("ReaderPage — mobile bottom bar interactions", () => {
     render(<ReaderPage />);
     await flushPromises();
 
-    // Find the mobile Notes button: aria-label="Notes" but no aria-expanded (the desktop header toggle has aria-expanded)
-    let mobileNotesBtn: HTMLElement | undefined;
-    await waitFor(() => {
-      const allBtns = screen.queryAllByRole("button");
-      mobileNotesBtn = allBtns.find((b) => b.getAttribute("aria-label") === "Notes" && b.getAttribute("aria-expanded") === null);
-      expect(mobileNotesBtn).toBeDefined();
-    });
+    // Find the mobile Notes button by its exact aria-label (desktop uses "Annotations & notes")
+    const mobileNotesBtn = await screen.findByRole("button", { name: "Notes" });
 
     await userEvent.click(mobileNotesBtn!);
     // Mobile expand panel appears — "No annotations yet." in it

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -997,6 +997,7 @@ export default function ReaderPage() {
               }}
               title="Typography settings"
               aria-label="Typography settings"
+              aria-expanded={showTypographyPanel}
               className={`flex shrink-0 items-center gap-1 px-2 py-1 min-h-[44px] md:min-h-0 rounded-lg border text-xs font-bold transition-colors ${
                 showTypographyPanel || paragraphFocus
                   ? "bg-amber-100 border-amber-400 text-amber-800"
@@ -2074,7 +2075,7 @@ export default function ReaderPage() {
             onClick={() => { setSidebarOpen(false); setChatSheetText(null); }}
           />
           {/* Chat sheet (bottom half) */}
-          <div className="h-[55vh] bg-parchment border-t border-amber-200 rounded-t-2xl shadow-2xl flex flex-col animate-slide-up safe-bottom">
+          <div role="dialog" aria-modal="true" aria-label="Chat" className="h-[55vh] bg-parchment border-t border-amber-200 rounded-t-2xl shadow-2xl flex flex-col animate-slide-up safe-bottom">
             {/* Drag handle + close */}
             <div className="flex items-center justify-between px-4 py-2 border-b border-amber-200 shrink-0">
               <div className="w-10 h-1 bg-amber-200 rounded-full" />
@@ -2241,6 +2242,7 @@ export default function ReaderPage() {
                   : "text-amber-700 bg-amber-50 border-amber-200"
               }`}
               aria-label="Notes"
+              aria-expanded={notesExpanded}
             >
               <NoteIcon className="w-5 h-5" />
               {annotations.length > 0 && (
@@ -2258,6 +2260,7 @@ export default function ReaderPage() {
                   : "text-amber-700 bg-amber-50 border-amber-200"
               }`}
               aria-label="Insight chat"
+              aria-expanded={sidebarOpen}
             ><ChatIcon className="w-5 h-5" /></button>
           </div>
         </div>


### PR DESCRIPTION
## What

Adds missing ARIA attributes to three reader disclosure buttons and the mobile chat sheet:

1. **Typography settings button** — added `aria-expanded={showTypographyPanel}`
2. **Notes button** (mobile bottom bar) — added `aria-expanded={notesExpanded}`
3. **Insight chat button** (mobile bottom bar) — added `aria-expanded={sidebarOpen}`
4. **Mobile chat sheet inner div** — added `role="dialog" aria-modal="true" aria-label="Chat"`

Also updates `ReaderPage.test.tsx` to find the mobile Notes button by its unique `aria-label="Notes"` (distinct from desktop's `"Annotations & notes"`) instead of the absence of `aria-expanded`.

## Why

WCAG 4.1.2 (Name, Role, Value): buttons that control the visibility of panels must expose `aria-expanded` so screen readers know whether the controlled content is open or closed. The mobile chat sheet is a non-native dialog and must declare `role="dialog"` and `aria-modal`.

Closes #1245

## Test plan

- Added `ReaderAriaExpandedDialog.test.ts` with 6 static-analysis tests.
- All 2291 frontend tests pass.
