### PR TITLE
fix: add aria-pressed to reader Focus mode and Translation toggle buttons (closes #1248)

### DIFF
--- a/frontend/src/__tests__/ReaderAriaPressedToggles.test.ts
+++ b/frontend/src/__tests__/ReaderAriaPressedToggles.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Regression tests for #1248: Focus mode and Translation mobile buttons
+ * must have aria-pressed to expose their on/off state to screen readers.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Reader page toggle button aria-pressed (closes #1248)", () => {
+  it("Focus mode button has aria-pressed", () => {
+    const idx = src.indexOf('aria-label="Focus mode"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 150);
+    expect(window).toContain("aria-pressed");
+  });
+
+  it("Focus mode aria-pressed references focusMode state", () => {
+    const idx = src.indexOf('aria-label="Focus mode"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 150);
+    expect(window).toContain("focusMode");
+  });
+
+  it("Translation mobile button has aria-pressed", () => {
+    const idx = src.indexOf('aria-label="Translation"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 100);
+    expect(window).toContain("aria-pressed");
+  });
+
+  it("Translation aria-pressed references translationEnabled state", () => {
+    const idx = src.indexOf('aria-label="Translation"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 100);
+    expect(window).toContain("translationEnabled");
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1163,6 +1163,7 @@ export default function ReaderPage() {
             }}
             title="Focus mode (F)"
             aria-label="Focus mode"
+            aria-pressed={focusMode}
             className={`hidden md:flex shrink-0 items-center gap-1.5 px-2 lg:px-3 py-1.5 min-h-[44px] md:min-h-0 rounded-lg border text-xs font-medium transition-colors ${
               focusMode
                 ? "bg-amber-700 text-white border-amber-700"
@@ -2197,6 +2198,7 @@ export default function ReaderPage() {
                   : "text-amber-700 bg-amber-50 border-amber-200"
               }`}
               aria-label="Translation"
+              aria-pressed={translationEnabled}
             ><GlobeIcon className="w-5 h-5" /></button>
 
             <button


### PR DESCRIPTION
## What

Adds `aria-pressed` to two toggle buttons in the reader mobile bottom bar:

1. **Focus mode button** — added `aria-pressed={focusMode}`
2. **Translation mobile button** — added `aria-pressed={translationEnabled}`

## Why

WCAG 4.1.2 (Name, Role, Value): toggle buttons that activate/deactivate a mode must expose `aria-pressed` so screen readers can announce whether the feature is currently on or off.

Closes #1248

## Test plan

- Added `ReaderAriaPressedToggles.test.ts` with 4 static-analysis tests checking that both buttons have `aria-pressed` referencing the correct state variables.
- All 2302 frontend tests pass.
