### PR TITLE
fix: add role=alert to homepage searchError and QueueTab error displays (closes #1256, #1254, #1260)

### DIFF
--- a/frontend/src/__tests__/ErrorRoleAlert1256.test.ts
+++ b/frontend/src/__tests__/ErrorRoleAlert1256.test.ts
@@ -1,0 +1,32 @@
+import * as fs from "fs";
+import * as path from "path";
+
+function read(rel: string) {
+  return fs.readFileSync(path.join(__dirname, rel), "utf8");
+}
+
+describe("role=alert on dynamic error containers (closes #1256)", () => {
+  it("homepage searchError div has role=alert", () => {
+    const src = read("../app/page.tsx");
+    const idx = src.indexOf("searchError &&");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 150);
+    expect(window).toMatch(/role="alert"/);
+  });
+
+  it("QueueTab last_error div has role=alert", () => {
+    const src = read("../components/QueueTab.tsx");
+    const idx = src.indexOf("Last error:");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 100), idx + 50);
+    expect(window).toMatch(/role="alert"/);
+  });
+
+  it("QueueTab dryRunError div has role=alert", () => {
+    const src = read("../components/QueueTab.tsx");
+    const idx = src.indexOf("dryRunError &&");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 150);
+    expect(window).toMatch(/role="alert"/);
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -595,7 +595,7 @@ export default function Home() {
               </div>
 
               {searchError && (
-                <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 mb-4 text-sm">
+                <div role="alert" className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 mb-4 text-sm">
                   {searchError}
                 </div>
               )}

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -580,7 +580,7 @@ export default function QueueTab({ adminFetch }: Props) {
 
         {/* Hard error — only shown once retries are exhausted. */}
         {s?.last_error && !(s.retry_attempt && s.retry_attempt > 0) && (
-          <div className="text-xs text-red-600 bg-red-50 rounded px-2 py-1 truncate">
+          <div role="alert" className="text-xs text-red-600 bg-red-50 rounded px-2 py-1 truncate">
             Last error: {s.last_error}
           </div>
         )}
@@ -693,7 +693,7 @@ export default function QueueTab({ adminFetch }: Props) {
         </div>
 
         {dryRunError && (
-          <div className="text-xs text-red-600 bg-red-50 rounded px-2 py-1">{dryRunError}</div>
+          <div role="alert" className="text-xs text-red-600 bg-red-50 rounded px-2 py-1">{dryRunError}</div>
         )}
 
         {planResult && (


### PR DESCRIPTION
## What changed

Added `role="alert"` to three dynamically-rendered error message containers that were missing the ARIA live-region attribute:

- **Homepage** (`page.tsx`): `searchError` div — shown when a book search returns an error
- **QueueTab** (`QueueTab.tsx`): `s.last_error` per-chapter error display (line ~583)
- **QueueTab** (`QueueTab.tsx`): `dryRunError` from failed plan dry-run (line ~696)

Also closes #1254 (homepage `searchError` missing `role="alert"`) and #1260 (QueueTab errors missing `role="alert"`) which are narrower scopes of the same bug.

## Why

Without `role="alert"`, dynamically injected error text is not announced by screen readers — violating WCAG 4.1.3 (Status Messages, Level AA). The `role="alert"` designation implies `aria-live="assertive"` and `aria-atomic="true"`, ensuring the message interrupts screen reader output immediately when it appears.

## Test plan

- New static assertion test in `ErrorRoleAlert1256.test.ts` confirms `role="alert"` is present on all three containers
- 2301 frontend tests pass
