### PR TITLE
fix: include word in flashcard aria-label so screen readers can announce it (closes #1261)

### DIFF
--- a/frontend/src/__tests__/FlashcardAriaWord.test.ts
+++ b/frontend/src/__tests__/FlashcardAriaWord.test.ts
@@ -1,0 +1,25 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/flashcards/page.tsx"),
+  "utf8",
+);
+
+describe("flashcard card aria-label includes the word (closes #1261)", () => {
+  it("aria-label for front side includes the word", () => {
+    expect(src).toMatch(/aria-label=\{.*Word:.*currentCard\.word/);
+  });
+
+  it("aria-label for back side includes the word", () => {
+    expect(src).toMatch(/aria-label=\{.*currentCard\.word.*definition side/i);
+  });
+
+  it("does not use the old static 'Card front — click to reveal' label", () => {
+    expect(src).not.toMatch(/Card front — click to reveal/);
+  });
+
+  it("does not use the old static 'Card back — click to flip' label", () => {
+    expect(src).not.toMatch(/Card back — click to flip/);
+  });
+});

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -219,7 +219,7 @@ export default function FlashcardsPage() {
             <div
               role="button"
               tabIndex={0}
-              aria-label={flipped ? "Card back — click to flip" : "Card front — click to reveal"}
+              aria-label={flipped ? `${currentCard.word} — definition side, press to flip back` : `Word: ${currentCard.word}. Press to reveal definition.`}
               onClick={() => setFlipped(f => !f)}
               onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setFlipped(f => !f); }}
               className="cursor-pointer rounded-2xl border border-amber-200 bg-white p-8 min-h-[200px] flex flex-col items-center justify-center gap-3 hover:-translate-y-0.5 transition-all duration-200 select-none"


### PR DESCRIPTION
## What changed

Fixed the flashcard card `aria-label` in `vocabulary/flashcards/page.tsx` to include the word being reviewed.

**Before (front side):** `"Card front — click to reveal"` — screen readers announced only a generic label, never the word itself.

**Before (back side):** `"Card back — click to flip"` — same problem; the word was not spoken.

**After (front side):** `"Word: {word}. Press to reveal definition."` — screen readers announce the word immediately when the card is focused.

**After (back side):** `"{word} — definition side, press to flip back"` — the word is still present for context after revealing.

## Why

The `aria-label` attribute on a `role="button"` element overrides ALL text content for screen readers, so the `{currentCard.word}` rendered inside the card was silently swallowed. A screen reader user navigating via keyboard had no way to hear what word they were being tested on — defeating the purpose of the exercise.

**WCAG 4.1.2** (Name, Role, Value, Level A): interactive controls must expose a meaningful accessible name that includes the content necessary to complete the interaction.

## Test plan

- New static assertion test in `FlashcardAriaWord.test.ts` verifies:
  1. Front-side `aria-label` includes `Word:` + `currentCard.word`
  2. Back-side `aria-label` includes `currentCard.word` + `definition side`
  3. Old static labels `"Card front — click to reveal"` and `"Card back — click to flip"` are gone
- 2310 frontend tests pass
