### PR TITLE
fix: add role=status to profile feedback messages and reader obsidian toast (closes #1255)

### DIFF
--- a/frontend/src/__tests__/ProfileObsidianFeedbackRole.test.ts
+++ b/frontend/src/__tests__/ProfileObsidianFeedbackRole.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression tests for #1255: profile page feedback messages and reader
+ * obsidian toast must have live-region roles so screen readers announce them.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const profile = fs.readFileSync(
+  path.join(__dirname, "../app/profile/page.tsx"),
+  "utf8"
+);
+const reader = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Profile page feedback messages have live-region roles (closes #1255)", () => {
+  it("keyMessage paragraph has role=status or role=alert", () => {
+    const idx = profile.indexOf("keyMessage &&");
+    expect(idx).toBeGreaterThan(-1);
+    const region = profile.slice(idx, idx + 300);
+    expect(region).toMatch(/role="status"|role="alert"/);
+  });
+
+  it("obsidianMsg paragraph has role=status or role=alert", () => {
+    const idx = profile.indexOf("obsidianMsg &&");
+    expect(idx).toBeGreaterThan(-1);
+    const region = profile.slice(idx, idx + 300);
+    expect(region).toMatch(/role="status"|role="alert"/);
+  });
+});
+
+describe("Reader obsidian toast has live-region role (closes #1255)", () => {
+  it("obsidianToast container has role=status", () => {
+    const idx = reader.indexOf("obsidianToast &&");
+    expect(idx).toBeGreaterThan(-1);
+    const region = reader.slice(idx, idx + 300);
+    expect(region).toContain('role="status"');
+  });
+});

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -337,7 +337,7 @@ export default function ProfilePage() {
           )}
 
           {keyMessage && (
-            <p className={`mt-3 text-sm ${keyMessage.ok ? "text-emerald-700" : "text-red-600"}`}>
+            <p role="status" className={`mt-3 text-sm ${keyMessage.ok ? "text-emerald-700" : "text-red-600"}`}>
               {keyMessage.text}
             </p>
           )}
@@ -440,7 +440,7 @@ export default function ProfilePage() {
               </button>
 
               {obsidianMsg && (
-                <p className={`text-sm ${obsidianMsg.ok ? "text-emerald-700" : "text-red-600"}`}>
+                <p role="status" className={`text-sm ${obsidianMsg.ok ? "text-emerald-700" : "text-red-600"}`}>
                   {obsidianMsg.text}
                 </p>
               )}

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1583,7 +1583,7 @@ export default function ReaderPage() {
 
           {/* Obsidian export toast */}
           {obsidianToast && (
-            <div className="fixed bottom-6 right-6 z-50 bg-white border border-amber-300 shadow-lg rounded-xl px-5 py-3 text-sm text-ink max-w-xs">
+            <div role="status" className="fixed bottom-6 right-6 z-50 bg-white border border-amber-300 shadow-lg rounded-xl px-5 py-3 text-sm text-ink max-w-xs">
               {obsidianToast.startsWith("http") ? (
                 <>
                   Exported!{" "}


### PR DESCRIPTION
## What changed
- Added `role="status"` to the API key and Obsidian feedback messages in `profile/page.tsx` so screen readers announce success/error results live
- Added `role="status"` to the Obsidian export toast in `reader/[bookId]/page.tsx`
- Added 3 static-assertion tests in `ProfileObsidianFeedbackRole.test.ts` verifying all three elements carry the attribute

## Why
These feedback messages are dynamically injected into the DOM. Without a live-region role, screen readers cannot announce them to users who cannot see the visual change. Closes #1255.

## Test plan
- [x] `ProfileObsidianFeedbackRole.test.ts` — 3 new tests all pass
- [x] Full Jest suite: 2315 tests pass, 0 failures

## Docs follow-up
None required — internal accessibility attribute, no user-visible text or API change.
