### PR TITLE
fix: add aria-label to annotation note editing textarea (closes #1249)

### DIFF
--- a/frontend/src/__tests__/NotesTextareaAriaLabel.test.ts
+++ b/frontend/src/__tests__/NotesTextareaAriaLabel.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Regression test for #1249: annotation note editing textarea must have
+ * an accessible label so screen readers announce it on focus.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Notes page annotation textarea aria-label (closes #1249)", () => {
+  it("editing textarea has aria-label", () => {
+    const idx = src.indexOf("Edit note");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 50), idx + 100);
+    expect(window).toContain('aria-label');
+  });
+
+  it("editing textarea aria-label describes the purpose", () => {
+    expect(src).toContain('aria-label="Edit note"');
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -103,6 +103,7 @@ function AnnotationCard({
       {isEditing ? (
         <div className="mt-2 space-y-2">
           <textarea
+            aria-label="Edit note"
             value={editNote}
             onChange={(e) => onEditChange(e.target.value)}
             className="w-full text-sm border border-amber-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-amber-400 resize-none"


### PR DESCRIPTION
## What changed

Added `aria-label="Edit note"` to the annotation editing `<textarea>` in `notes/[bookId]/page.tsx` (line 105). The textarea had no accessible label, failing WCAG 4.1.2 (Name, Role, Value) — screen readers could not announce its purpose.

## Why

The annotation edit form shows an inline textarea when the user clicks "Edit" on a note. Without an accessible label, assistive technologies announce it as an unlabelled input, making keyboard-only and screen-reader workflows inaccessible.

## Test plan

- New static-analysis test `NotesTextareaAriaLabel.test.ts` asserts `aria-label="Edit note"` is present on the textarea element
- All 294 frontend test suites pass
- Backend suite unaffected (frontend-only change)

## Docs follow-up

N/A — internal accessibility attribute, no user-visible docs change needed.
