### PR TITLE
fix: add aria-label to vocabulary delete buttons for unique screen reader names (closes #1269)

### DIFF
--- a/frontend/e2e/vocab-definition.spec.ts
+++ b/frontend/e2e/vocab-definition.spec.ts
@@ -12,9 +12,9 @@ test("clicking a lemma button opens the definition sheet", async ({ page }) => {
   await page.goto("/vocabulary");
 
   // Wait for vocab list to render (lemma "universal" from mock fixture)
-  await expect(page.getByRole("button", { name: "universal" })).toBeVisible({ timeout: 10000 });
+  await expect(page.getByRole("button", { name: "universal", exact: true })).toBeVisible({ timeout: 10000 });
 
-  await page.getByRole("button", { name: "universal" }).click();
+  await page.getByRole("button", { name: "universal", exact: true }).click();
 
   // Slide-up sheet appears with the word title
   await expect(page.locator(".animate-slide-up")).toBeVisible();
@@ -23,8 +23,8 @@ test("clicking a lemma button opens the definition sheet", async ({ page }) => {
 
 test("definition sheet shows part-of-speech, definition text, and Wiktionary link", async ({ page }) => {
   await page.goto("/vocabulary");
-  await expect(page.getByRole("button", { name: "universal" })).toBeVisible({ timeout: 10000 });
-  await page.getByRole("button", { name: "universal" }).click();
+  await expect(page.getByRole("button", { name: "universal", exact: true })).toBeVisible({ timeout: 10000 });
+  await page.getByRole("button", { name: "universal", exact: true }).click();
 
   // POS label and definition from fixture mock
   await expect(page.getByText("adjective")).toBeVisible();
@@ -36,8 +36,8 @@ test("definition sheet shows part-of-speech, definition text, and Wiktionary lin
 
 test("Escape key closes the definition sheet", async ({ page }) => {
   await page.goto("/vocabulary");
-  await expect(page.getByRole("button", { name: "universal" })).toBeVisible({ timeout: 10000 });
-  await page.getByRole("button", { name: "universal" }).click();
+  await expect(page.getByRole("button", { name: "universal", exact: true })).toBeVisible({ timeout: 10000 });
+  await page.getByRole("button", { name: "universal", exact: true }).click();
   await expect(page.locator(".animate-slide-up")).toBeVisible();
 
   await page.keyboard.press("Escape");
@@ -47,8 +47,8 @@ test("Escape key closes the definition sheet", async ({ page }) => {
 
 test("clicking the backdrop closes the definition sheet", async ({ page }) => {
   await page.goto("/vocabulary");
-  await expect(page.getByRole("button", { name: "universal" })).toBeVisible({ timeout: 10000 });
-  await page.getByRole("button", { name: "universal" }).click();
+  await expect(page.getByRole("button", { name: "universal", exact: true })).toBeVisible({ timeout: 10000 });
+  await page.getByRole("button", { name: "universal", exact: true }).click();
   await expect(page.locator(".animate-slide-up")).toBeVisible();
 
   // Click at the top of the screen, well away from the bottom sheet

--- a/frontend/src/__tests__/VocabDeleteAriaLabel.test.ts
+++ b/frontend/src/__tests__/VocabDeleteAriaLabel.test.ts
@@ -1,0 +1,13 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8"
+);
+
+describe("vocabulary delete button aria-label (issue #1269)", () => {
+  it("delete button has aria-label including the word", () => {
+    expect(src).toMatch(/aria-label=\{`Delete \$\{f\.word\}`\}/);
+  });
+});

--- a/frontend/src/__tests__/VocabularyPage.coverage2.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.coverage2.test.tsx
@@ -115,7 +115,7 @@ describe("VocabularyPage — DefinitionSheet mousedown outside (lines 59-62)", (
     await act(async () => await flushPromises());
     await screen.findByText("ephemeral");
 
-    await userEvent.click(screen.getByRole("button", { name: /ephemeral/i }));
+    await userEvent.click(screen.getByRole("button", { name: "ephemeral" }));
     await waitFor(() => expect(screen.getByText("short-lived")).toBeInTheDocument());
 
     // Wait 110ms for the setTimeout(100) mousedown listener to register
@@ -136,7 +136,7 @@ describe("VocabularyPage — DefinitionSheet mousedown outside (lines 59-62)", (
     await act(async () => await flushPromises());
     await screen.findByText("ephemeral");
 
-    await userEvent.click(screen.getByRole("button", { name: /ephemeral/i }));
+    await userEvent.click(screen.getByRole("button", { name: "ephemeral" }));
     await waitFor(() => expect(screen.getByText("short-lived")).toBeInTheDocument());
 
     await act(async () => {
@@ -162,7 +162,7 @@ describe("VocabularyPage — DefinitionSheet getWordDefinition error (line 46)",
     await act(async () => await flushPromises());
     await screen.findByText("ephemeral");
 
-    await userEvent.click(screen.getByRole("button", { name: /ephemeral/i }));
+    await userEvent.click(screen.getByRole("button", { name: "ephemeral" }));
 
     // After rejection, loading stops and "No definition found" shows
     await waitFor(() =>
@@ -207,7 +207,7 @@ describe("VocabularyPage — DefinitionSheet non-Escape keydown (line 51)", () =
     await act(async () => await flushPromises());
     await screen.findByText("ephemeral");
 
-    await userEvent.click(screen.getByRole("button", { name: /ephemeral/i }));
+    await userEvent.click(screen.getByRole("button", { name: "ephemeral" }));
     await waitFor(() => expect(screen.getByText("short-lived")).toBeInTheDocument());
 
     // Press a non-Escape key → sheet stays open

--- a/frontend/src/__tests__/VocabularyPage.definition.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.definition.test.tsx
@@ -61,7 +61,7 @@ test("clicking a word lemma button opens DefinitionSheet with spinner then defin
   await screen.findByText("ephemeral");
 
   // Click the word lemma button (shows the definition sheet)
-  await userEvent.click(screen.getByRole("button", { name: /ephemeral/i }));
+  await userEvent.click(screen.getByRole("button", { name: "ephemeral" }));
 
   // Spinner visible while loading
   await waitFor(() => expect(screen.getByText(/Looking up/i)).toBeInTheDocument());
@@ -94,7 +94,7 @@ test("DefinitionSheet shows 'No definition found' when API returns no definition
   await flushPromises();
   await screen.findByText("ephemeral");
 
-  await userEvent.click(screen.getByRole("button", { name: /ephemeral/i }));
+  await userEvent.click(screen.getByRole("button", { name: "ephemeral" }));
 
   await waitFor(() => expect(screen.getByText(/No definition found/i)).toBeInTheDocument());
 });
@@ -111,7 +111,7 @@ test("DefinitionSheet closes on Escape key", async () => {
   await flushPromises();
   await screen.findByText("ephemeral");
 
-  await userEvent.click(screen.getByRole("button", { name: /ephemeral/i }));
+  await userEvent.click(screen.getByRole("button", { name: "ephemeral" }));
   await waitFor(() => expect(screen.getByText("short-lived")).toBeInTheDocument());
 
   fireEvent.keyDown(document, { key: "Escape" });
@@ -135,13 +135,13 @@ test("DefinitionSheet can be opened a second time after Escape-close (no stale e
   await screen.findByText("ephemeral");
 
   // First open → close via Escape
-  await userEvent.click(screen.getByRole("button", { name: /ephemeral/i }));
+  await userEvent.click(screen.getByRole("button", { name: "ephemeral" }));
   await waitFor(() => expect(screen.getByText("short-lived")).toBeInTheDocument());
   fireEvent.keyDown(document, { key: "Escape" });
   await waitFor(() => expect(screen.queryByText("short-lived")).not.toBeInTheDocument());
 
   // Second open — sheet must appear again without instantly closing
-  await userEvent.click(screen.getByRole("button", { name: /ephemeral/i }));
+  await userEvent.click(screen.getByRole("button", { name: "ephemeral" }));
   await waitFor(() => expect(screen.getByText("short-lived")).toBeInTheDocument());
   // Give stale mousedown listeners a chance to fire (they wouldn't normally — but
   // if they accumulate they would close the sheet immediately)
@@ -170,6 +170,6 @@ test("DefinitionSheet shows lemma redirect arrow when lemma differs from word", 
   await flushPromises();
   await screen.findByText("running");
 
-  await userEvent.click(screen.getByRole("button", { name: /running/i }));
+  await userEvent.click(screen.getByRole("button", { name: "running" }));
   await waitFor(() => expect(screen.getByText(/← run/)).toBeInTheDocument());
 });

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -387,6 +387,7 @@ function VocabularyPageContent() {
                 key={f.word}
                 onClick={() => handleDelete(f.word)}
                 disabled={deleting === f.word}
+                aria-label={`Delete ${f.word}`}
                 className="text-xs text-red-400 hover:text-red-600 disabled:opacity-50 transition-colors min-h-[44px] md:min-h-0 flex items-center px-2"
                 data-testid={`delete-${f.word}`}
               >


### PR DESCRIPTION
## What changed
- Added `aria-label={`Delete ${f.word}`}` to each per-form delete button in `vocabulary/page.tsx` so screen readers announce "Delete ephemeral", "Delete running", etc. instead of multiple identical "Delete" labels
- Updated two existing vocabulary page test files to use exact name matches (`"ephemeral"`) instead of regex (`/ephemeral/i`) — the regex now matches both the lemma button and the delete button
- Added `VocabDeleteAriaLabel.test.ts` asserting the aria-label pattern is present

## Why
Multiple forms under the same lemma produce several identical "Delete" buttons. Screen readers navigating by button list announced them all as "Delete" with no context, violating WCAG 2.4.6 (Descriptive Labels). Closes #1269.

## Test plan
- [x] New test `VocabDeleteAriaLabel.test.ts` — verifies aria-label pattern
- [x] Updated existing vocabulary tests to use exact matches to avoid ambiguity
- [x] Full Jest suite: 2319 tests pass, 0 failures
