### PR TITLE
fix: add scope=col to QueueTab plan-preview table headers (closes #1264)

### DIFF
--- a/frontend/src/__tests__/QueueTabTableScope.test.ts
+++ b/frontend/src/__tests__/QueueTabTableScope.test.ts
@@ -1,0 +1,23 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "../components/QueueTab.tsx"),
+  "utf8"
+);
+
+describe("QueueTab plan-preview table headers have scope=col (closes #1264)", () => {
+  it("Book column header has scope=col", () => {
+    const idx = src.indexOf(">Book</th>");
+    expect(idx).toBeGreaterThan(-1);
+    const region = src.slice(Math.max(0, idx - 100), idx + 20);
+    expect(region).toContain('scope="col"');
+  });
+
+  it("Chapters column header has scope=col", () => {
+    const idx = src.indexOf(">Chapters</th>");
+    expect(idx).toBeGreaterThan(-1);
+    const region = src.slice(Math.max(0, idx - 100), idx + 20);
+    expect(region).toContain('scope="col"');
+  });
+});

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -720,8 +720,8 @@ export default function QueueTab({ adminFetch }: Props) {
                 <table className="w-full">
                   <thead className="bg-amber-50">
                     <tr>
-                      <th className="text-left px-2 py-1 text-stone-600">Book</th>
-                      <th className="text-right px-2 py-1 text-stone-600">Chapters</th>
+                      <th scope="col" className="text-left px-2 py-1 text-stone-600">Book</th>
+                      <th scope="col" className="text-right px-2 py-1 text-stone-600">Chapters</th>
                     </tr>
                   </thead>
                   <tbody>


### PR DESCRIPTION
## What changed
Added `scope="col"` to the two `<th>` elements in the QueueTab plan-preview table (Book and Chapters column headers).

## Why
WCAG 1.3.1 (Info and Relationships) requires data table column headers to carry `scope="col"` so screen readers can correctly associate cells with their headers. Without it, assistive technology announces the cells without context.

## Test plan
- New Jest test `QueueTabTableScope.test.ts` reads the source file and asserts both `<th>` elements have `scope="col"`.
- All 2320 frontend tests pass; 1644 backend tests pass.

Closes #1264
