### PR TITLE
fix: add contextual aria-labels to admin users and audio delete buttons (closes #1270, #1273)

### DIFF
--- a/frontend/src/__tests__/AdminAudioAriaLabel.test.ts
+++ b/frontend/src/__tests__/AdminAudioAriaLabel.test.ts
@@ -1,0 +1,13 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/admin/audio/page.tsx"),
+  "utf8"
+);
+
+describe("admin audio delete button aria-label (issue #1273)", () => {
+  it("delete button has aria-label with book and chapter context", () => {
+    expect(src).toMatch(/aria-label=\{`Delete audio for Book \$\{a\.book_id\}, Chapter \$\{a\.chapter_index \+ 1\}`\}/);
+  });
+});

--- a/frontend/src/__tests__/AdminUsersAriaLabels.test.ts
+++ b/frontend/src/__tests__/AdminUsersAriaLabels.test.ts
@@ -1,0 +1,22 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/admin/users/page.tsx"),
+  "utf8"
+);
+
+describe("admin users button aria-labels (issue #1270)", () => {
+  it("approve/revoke button has aria-label with user name", () => {
+    expect(src).toMatch(/aria-label=\{u\.approved \? `Revoke \$\{u\.name\}` : `Approve \$\{u\.name\}`\}/);
+  });
+
+  it("delete button has aria-label with user name", () => {
+    expect(src).toMatch(/aria-label=\{`Delete \$\{u\.name\}`\}/);
+  });
+
+  it("delete button text is 'Delete' not 'Del'", () => {
+    expect(src).toMatch(/>\s*Delete\s*<\/button>/);
+    expect(src).not.toMatch(/>\s*Del\s*<\/button>/);
+  });
+});

--- a/frontend/src/app/admin/audio/page.tsx
+++ b/frontend/src/app/admin/audio/page.tsx
@@ -67,6 +67,7 @@ export default function AudioPage() {
             onClick={() =>
               act(() => adminFetch(`/admin/audio/${a.book_id}/${a.chapter_index}`, { method: "DELETE" }))
             }
+            aria-label={`Delete audio for Book ${a.book_id}, Chapter ${a.chapter_index + 1}`}
             className="text-xs px-2 py-1 rounded border border-red-200 text-red-500 min-h-[44px]"
           >
             Delete

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -83,6 +83,7 @@ export default function UsersPage() {
                     }),
                   )
                 }
+                aria-label={u.approved ? `Revoke ${u.name}` : `Approve ${u.name}`}
                 className={`text-xs px-3 py-2 md:px-2 md:py-1 rounded border min-h-[44px] md:min-h-0 flex items-center ${
                   u.approved ? "border-orange-200 text-orange-600" : "border-emerald-200 text-emerald-600"
                 }`}
@@ -94,9 +95,10 @@ export default function UsersPage() {
                   if (confirm(`Delete "${u.name}"?`))
                     act(() => adminFetch(`/admin/users/${u.id}`, { method: "DELETE" }));
                 }}
+                aria-label={`Delete ${u.name}`}
                 className="text-xs px-3 py-2 md:px-2 md:py-1 rounded border min-h-[44px] md:min-h-0 flex items-center border-red-200 text-red-500"
               >
-                Del
+                Delete
               </button>
             </div>
           )}


### PR DESCRIPTION
## What changed
- `admin/users/page.tsx`: Added `aria-label` to Approve/Revoke and Delete buttons so each is uniquely named per user. Also renamed "Del" button text to "Delete" for clarity.
- `admin/audio/page.tsx`: Added `aria-label` to each audio entry's Delete button including book ID and chapter number for context.

## Why
Multiple admin list rows produced identical button labels ("Approve", "Revoke", "Delete") with no user/entry context, failing WCAG 2.4.6 (Descriptive Labels). Screen readers navigating by button list couldn't tell which user or audio entry each button acted on. Closes #1270, closes #1273.

## Test plan
- [x] `AdminUsersAriaLabels.test.ts` — 3 new tests
- [x] `AdminAudioAriaLabel.test.ts` — 1 new test
- [x] Full Jest suite: 2322 tests pass, 0 failures
