### PR TITLE
fix: add aria-label to admin uploads Open button with book title (closes #1275)

### DIFF
--- a/frontend/src/__tests__/AdminUploadsOpenAriaLabel.test.ts
+++ b/frontend/src/__tests__/AdminUploadsOpenAriaLabel.test.ts
@@ -1,0 +1,13 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/admin/uploads/page.tsx"),
+  "utf8"
+);
+
+describe("admin uploads Open button aria-label (issue #1275)", () => {
+  it("open button has aria-label with book title context", () => {
+    expect(src).toMatch(/aria-label=\{`Open \$\{u\.title\}`\}/);
+  });
+});

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -166,6 +166,7 @@ export default function UploadsPage() {
                     <td className="px-4 py-2.5">
                       <button
                         onClick={() => router.push(`/reader/${u.book_id}`)}
+                        aria-label={`Open ${u.title}`}
                         className="text-xs text-amber-600 hover:text-amber-800 min-h-[44px] flex items-center"
                       >
                         Open


### PR DESCRIPTION
## What changed
Added `aria-label={`Open ${u.title}`}` to the per-row Open button in `admin/uploads/page.tsx`.

## Why
Multiple upload table rows each had an "Open" button with no context. Screen readers navigating by button announced identical "Open" labels. Closes #1275.

## Test plan
- [x] `AdminUploadsOpenAriaLabel.test.ts` — 1 new test
- [x] Full Jest suite: 2325 tests pass