### PR TITLE
fix: add aria-pressed to notes page view-mode toggle buttons (closes #1276)

### DIFF
--- a/frontend/src/__tests__/NotesViewModeAriaPressed.test.ts
+++ b/frontend/src/__tests__/NotesViewModeAriaPressed.test.ts
@@ -1,0 +1,13 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("notes view mode toggle aria-pressed (issue #1276)", () => {
+  it("view mode toggle buttons have aria-pressed", () => {
+    expect(src).toMatch(/aria-pressed=\{viewMode === m\}/);
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -657,6 +657,7 @@ export default function BookNotesPage() {
               <button
                 key={m}
                 onClick={() => setViewMode(m)}
+                aria-pressed={viewMode === m}
                 className={`px-3 py-1.5 min-h-[44px] transition-colors ${
                   viewMode === m
                     ? "bg-amber-700 text-white"


### PR DESCRIPTION
## What

Adds `aria-pressed` to the "By section" / "By chapter" view-mode toggle buttons on the notes page.

## Why

Toggle buttons must expose their pressed state via `aria-pressed` so screen readers can announce whether the button is active (WCAG 4.1.2 Name, Role, Value).

## Test plan

- Static assertion test (`NotesViewModeAriaPressed.test.ts`) verifies `aria-pressed={viewMode === m}` is present in the source.
- All 2331 frontend tests pass.
- All 1382 backend tests pass.

Closes #1276
