### PR TITLE
fix: add aria-expanded to admin books expand/collapse toggle buttons (closes #1265)

### DIFF
--- a/frontend/src/__tests__/AdminBooksAriaExpanded.test.ts
+++ b/frontend/src/__tests__/AdminBooksAriaExpanded.test.ts
@@ -1,0 +1,17 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/admin/books/page.tsx"),
+  "utf8"
+);
+
+describe("admin books page aria-expanded on toggle buttons (closes #1265)", () => {
+  it("book row toggle has aria-expanded", () => {
+    expect(src).toMatch(/aria-expanded=\{isExpanded\}/);
+  });
+
+  it("language section toggle has aria-expanded", () => {
+    expect(src).toMatch(/aria-expanded=\{isLangExpanded\}/);
+  });
+});

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -287,6 +287,7 @@ export default function BooksPage() {
                   className="text-stone-400 hover:text-amber-700 flex items-center min-h-[44px] min-w-[44px] justify-center"
                   title={isExpanded ? "Collapse" : "Expand"}
                   aria-label={isExpanded ? "Collapse" : "Expand"}
+                  aria-expanded={isExpanded}
                 >
                   {isExpanded ? <ChevronDownIcon className="w-3.5 h-3.5" /> : <ChevronRightIcon className="w-3.5 h-3.5" />}
                 </button>
@@ -429,6 +430,7 @@ export default function BooksPage() {
                                 onClick={() => setExpandedLang(isLangExpanded ? null : bulkKey)}
                                 className="text-xs text-stone-400 hover:text-amber-700 flex items-center min-h-[44px] min-w-[44px] justify-center"
                                 aria-label={isLangExpanded ? "Collapse" : "Expand"}
+                                aria-expanded={isLangExpanded}
                               >
                                 {isLangExpanded ? <ChevronDownIcon className="w-3 h-3" /> : <ChevronRightIcon className="w-3 h-3" />}
                               </button>


### PR DESCRIPTION
## What

Adds `aria-expanded` to the expand/collapse toggle buttons on the admin books page:
- Book row toggle button (also keeps `title` + dynamic `aria-label` for tooltip/test compatibility)
- Language section toggle button (keeps dynamic `aria-label`, adds `aria-expanded`)

## Why

Disclosure buttons that show/hide additional content must expose their expanded state via `aria-expanded` (WCAG 4.1.2 Name, Role, Value). Without it, screen readers cannot tell users whether a section is open or closed.

## Test plan

- Static assertion test (`AdminBooksAriaExpanded.test.ts`) verifies `aria-expanded` is present on both toggle buttons.
- All existing `AdminBooksPage.*` RTL tests pass (they use `getByTitle("Expand")` / `aria-label` queries which are preserved).
- All 2333 frontend tests pass.
- All 1382 backend tests pass.

Closes #1265
