### PR TITLE
fix: add aria-pressed to reader display mode toggle buttons (closes #1278)

### DIFF
--- a/frontend/src/__tests__/ReaderDisplayModeAriaPressed.test.ts
+++ b/frontend/src/__tests__/ReaderDisplayModeAriaPressed.test.ts
@@ -1,0 +1,27 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("reader display mode buttons aria-pressed (issue #1278)", () => {
+  it("sets aria-pressed for inline button in settings panel", () => {
+    expect(src).toMatch(/aria-pressed=\{displayMode === "inline"\}/);
+  });
+
+  it("sets aria-pressed for parallel button in settings panel", () => {
+    expect(src).toMatch(/aria-pressed=\{displayMode === "parallel"\}/);
+  });
+
+  it("has aria-pressed on both occurrences of inline button", () => {
+    const matches = [...src.matchAll(/aria-pressed=\{displayMode === "inline"\}/g)];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("has aria-pressed on both occurrences of parallel button", () => {
+    const matches = [...src.matchAll(/aria-pressed=\{displayMode === "parallel"\}/g)];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1934,12 +1934,14 @@ export default function ReaderPage() {
                       <div className="flex rounded-lg border border-amber-300 overflow-hidden">
                         <button
                           onClick={() => setDisplayMode("inline")}
+                          aria-pressed={displayMode === "inline"}
                           className={`flex-1 px-3 py-2 min-h-[44px] text-sm transition-colors ${
                             displayMode === "inline" ? "bg-amber-700 text-white" : "text-amber-700 hover:bg-amber-50"
                           }`}
                         >Inline</button>
                         <button
                           onClick={() => setDisplayMode("parallel")}
+                          aria-pressed={displayMode === "parallel"}
                           className={`flex-1 px-3 py-2 min-h-[44px] text-sm border-l border-amber-300 transition-colors ${
                             displayMode === "parallel" ? "bg-amber-700 text-white" : "text-amber-700 hover:bg-amber-50"
                           }`}
@@ -2130,12 +2132,14 @@ export default function ReaderPage() {
               <div className="flex rounded border border-amber-300 overflow-hidden text-xs">
                 <button
                   onClick={() => setDisplayMode("inline")}
+                  aria-pressed={displayMode === "inline"}
                   className={`px-3 py-2 min-h-[44px] transition-colors ${
                     displayMode === "inline" ? "bg-amber-700 text-white" : "text-amber-700 hover:bg-amber-50"
                   }`}
                 >Inline</button>
                 <button
                   onClick={() => setDisplayMode("parallel")}
+                  aria-pressed={displayMode === "parallel"}
                   className={`px-3 py-2 min-h-[44px] border-l border-amber-300 transition-colors ${
                     displayMode === "parallel" ? "bg-amber-700 text-white" : "text-amber-700 hover:bg-amber-50"
                   }`}


### PR DESCRIPTION
## What

Adds `aria-pressed` to the "Inline" / "Side by side" display mode toggle buttons in the reader. Both occurrences are patched — the settings panel (line ~1935) and the translation bar (line ~2131).

## Why

Toggle buttons exposing a binary choice must use `aria-pressed` to convey the current selection to screen readers (WCAG 4.1.2 Name, Role, Value). Without it, users navigating by keyboard/AT cannot determine which mode is active.

## Test plan

- `ReaderDisplayModeAriaPressed.test.ts`: 4 static assertions verify `aria-pressed={displayMode === "inline"}` and `aria-pressed={displayMode === "parallel"}` appear at least twice each in the source.
- All 2336 frontend tests pass.
- All 1382 backend tests pass.

Closes #1278
