### PR TITLE
fix: add aria-pressed to vocabulary sort mode buttons (closes #1279)

### DIFF
--- a/frontend/src/__tests__/VocabSortModeAriaPressed.test.ts
+++ b/frontend/src/__tests__/VocabSortModeAriaPressed.test.ts
@@ -1,0 +1,13 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8",
+);
+
+describe("vocabulary sort mode buttons aria-pressed (issue #1279)", () => {
+  it("sets aria-pressed on sort mode button", () => {
+    expect(src).toMatch(/aria-pressed=\{sortMode === value\}/);
+  });
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -494,6 +494,7 @@ function VocabularyPageContent() {
                 <button
                   key={value}
                   onClick={() => setSortMode(value)}
+                  aria-pressed={sortMode === value}
                   data-testid={`sort-${value}`}
                   className={`flex-1 px-2 py-2 text-xs font-medium transition-colors min-h-[44px] ${
                     sortMode === value


### PR DESCRIPTION
## What

Adds `aria-pressed={sortMode === value}` to the A–Z / Language / Book / Recent sort mode buttons on the vocabulary page.

## Why

Toggle buttons in a segmented control must expose the currently-selected option via `aria-pressed` (WCAG 4.1.2 Name, Role, Value). Without it, screen readers cannot determine which sort mode is active.

## Test plan

- `VocabSortModeAriaPressed.test.ts`: static assertion verifies `aria-pressed={sortMode === value}` is present.
- All 2337 frontend tests pass.
- All 1382 backend tests pass.

Closes #1279
