### PR TITLE
fix: add aria-pressed/aria-expanded to reader annotation toggle, typography button, and homepage stats toggle

### DIFF
--- a/frontend/src/__tests__/HomepageStatsAriaExpanded.test.ts
+++ b/frontend/src/__tests__/HomepageStatsAriaExpanded.test.ts
@@ -1,0 +1,13 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/page.tsx"),
+  "utf8",
+);
+
+describe("homepage stats expand/collapse button aria-expanded (issue #1282)", () => {
+  it("adds aria-expanded to stats expand toggle", () => {
+    expect(src).toMatch(/aria-expanded=\{statsExpanded\}/);
+  });
+});

--- a/frontend/src/__tests__/ReaderAnnotationAriaPressed.test.ts
+++ b/frontend/src/__tests__/ReaderAnnotationAriaPressed.test.ts
@@ -1,0 +1,23 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("reader annotation toggle aria-pressed (issue #1281)", () => {
+  it("adds aria-pressed to annotation marks toggle", () => {
+    expect(src).toMatch(/aria-pressed=\{showAnnotations\}/);
+  });
+});
+
+describe("reader typography button aria-label and aria-expanded (issue #1283)", () => {
+  it("has aria-label on typography button", () => {
+    expect(src).toMatch(/aria-label="Typography settings"/);
+  });
+
+  it("has aria-expanded on typography button", () => {
+    expect(src).toMatch(/aria-expanded=\{showTypographyPanel\}/);
+  });
+});

--- a/frontend/src/__tests__/ReaderToolbarTouchTargets.test.ts
+++ b/frontend/src/__tests__/ReaderToolbarTouchTargets.test.ts
@@ -37,7 +37,7 @@ describe("reader desktop toolbar touch targets (closes #871)", () => {
 
   it("Show/hide annotation marks button has min-h-[44px]", () => {
     // setItem anchor is inside the button's onClick (only 1 occurrence)
-    checkForward('setItem("reader-show-annotations"', 320);
+    checkForward('setItem("reader-show-annotations"', 400);
   });
 
   it("Vocabulary toggle has min-h-[44px]", () => {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -324,6 +324,7 @@ export default function Home() {
                   </h2>
                   <button
                     onClick={() => setStatsExpanded((v) => !v)}
+                    aria-expanded={statsExpanded}
                     className="text-xs text-amber-600 hover:text-amber-800 transition-colors min-h-[44px] px-2 flex items-center"
                   >
                     {statsExpanded ? "Hide activity" : "Show activity"}

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -873,6 +873,8 @@ export default function ReaderPage() {
                 setTypographyAnchorPos({ x: rect.right, y: rect.bottom });
                 setShowTypographyPanel((v) => !v);
               }}
+              aria-label="Typography settings"
+              aria-expanded={showTypographyPanel}
               className="px-2 py-1 rounded-full hover:bg-amber-50 transition-colors font-bold min-h-[44px]"
               title="Typography"
             >Aa</button>
@@ -1105,6 +1107,7 @@ export default function ReaderPage() {
                   return next;
                 });
               }}
+              aria-pressed={showAnnotations}
               title={showAnnotations ? "Hide annotation marks" : "Show annotation marks"}
               className={`hidden lg:flex shrink-0 items-center gap-1.5 px-3 py-1.5 min-h-[44px] lg:min-h-0 rounded-lg border text-xs font-medium transition-colors ${
                 showAnnotations


### PR DESCRIPTION
## What changed

- `reader/[bookId]/page.tsx`: added `aria-pressed={showAnnotations}` to the annotation marks toggle button (closes #1281)
- `reader/[bookId]/page.tsx`: added `aria-label="Typography settings"` and `aria-expanded={showTypographyPanel}` to the focus mode "Aa" typography button (closes #1282)
- `app/page.tsx`: added `aria-expanded={statsExpanded}` to the "Show/Hide activity" stats section toggle button (closes #1283)
- `ReaderToolbarTouchTargets.test.ts`: bumped search radius from 320→400 chars to accommodate the newly added `aria-pressed` attribute

## Why

Toggle buttons for annotation marks, typography panel, and stats section lacked `aria-pressed`/`aria-expanded` semantics. Screen readers could not convey button state to users with visual impairments.

## Test plan

- `ReaderAnnotationAriaPressed.test.ts`: static assertions verify `aria-pressed={showAnnotations}` and `aria-label`/`aria-expanded` on the Aa typography button
- `HomepageStatsAriaExpanded.test.ts`: static assertion verifies `aria-expanded={statsExpanded}`
- Full frontend suite: 2342 tests passing

Closes #1281, #1282, #1283
