### PR TITLE
fix: add aria-pressed to vocabulary sort-mode buttons (closes #1279)

### DIFF
--- a/frontend/src/__tests__/VocabSortAriaPressed.test.ts
+++ b/frontend/src/__tests__/VocabSortAriaPressed.test.ts
@@ -1,0 +1,17 @@
+/**
+ * Regression test for #1279 — vocabulary sort-mode buttons must carry aria-pressed.
+ * Uses static source analysis (no component mount needed).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8"
+);
+
+describe("Vocabulary sort-mode buttons have aria-pressed (closes #1279)", () => {
+  it("aria-pressed is bound dynamically on sort buttons", () => {
+    expect(src).toContain('aria-pressed={sortMode === value}');
+  });
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -495,6 +495,7 @@ function VocabularyPageContent() {
                   key={value}
                   onClick={() => setSortMode(value)}
                   data-testid={`sort-${value}`}
+                  aria-pressed={sortMode === value}
                   className={`flex-1 px-2 py-2 text-xs font-medium transition-colors min-h-[44px] ${
                     sortMode === value
                       ? "bg-amber-700 text-white"


### PR DESCRIPTION
## What changed
Added `aria-pressed={sortMode === value}` to each vocabulary sort-mode toggle button (A–Z, Language, Book, Recent).

## Why
WCAG 4.1.2 (Name, Role, Value) requires toggle buttons to expose their pressed state to assistive technology. Without `aria-pressed`, screen readers announce the buttons as ordinary buttons with no indication of which sort mode is currently active.

## Test plan
- New test `VocabSortAriaPressed.test.ts` asserts the `aria-pressed` binding is present in source.
- All 2337 frontend tests pass; 1644 backend tests pass.

Closes #1279
