### PR TITLE
fix: add aria-pressed to reader notes sidebar view toggle buttons

### DIFF
--- a/frontend/src/__tests__/ReaderNotesViewToggleAriaPressed.test.ts
+++ b/frontend/src/__tests__/ReaderNotesViewToggleAriaPressed.test.ts
@@ -1,0 +1,13 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("reader notes sidebar view toggle aria-pressed (issue #1289)", () => {
+  it("adds aria-pressed to notes chapter/all toggle buttons", () => {
+    expect(src).toMatch(/aria-pressed=\{notesView === v\}/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1738,6 +1738,7 @@ export default function ReaderPage() {
                         <button
                           key={v}
                           onClick={() => setNotesView(v)}
+                          aria-pressed={notesView === v}
                           className={`flex-1 text-xs py-1 min-h-[44px] rounded-md font-medium transition-colors ${
                             notesView === v ? "bg-white text-amber-700 shadow-sm" : "text-stone-400 hover:text-stone-600"
                           }`}


### PR DESCRIPTION
## What changed

- `reader/[bookId]/page.tsx`: added `aria-pressed={notesView === v}` to the "This chapter" / "All chapters" notes sidebar view toggle buttons (closes #1289)

## Why

The notes sidebar view toggle buttons had visual active state (amber background on selected option) but no `aria-pressed` attribute. Screen readers could not convey which view was currently active to users with visual impairments.

## Test plan

- `ReaderNotesViewToggleAriaPressed.test.ts`: static assertion verifies `aria-pressed={notesView === v}`
- Full frontend suite: 2344 tests passing
- Full backend suite: 1382 tests passing

Closes #1289
