### PR TITLE
fix: add aria-pressed to QueueTab chain preset buttons

### DIFF
--- a/frontend/src/__tests__/QueueTabPresetAriaPressed.test.ts
+++ b/frontend/src/__tests__/QueueTabPresetAriaPressed.test.ts
@@ -1,0 +1,13 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/QueueTab.tsx"),
+  "utf8"
+);
+
+describe("QueueTab chain preset buttons aria-pressed (closes #1292)", () => {
+  it("preset button has aria-pressed={active}", () => {
+    expect(src).toContain("aria-pressed={active}");
+  });
+});

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -917,6 +917,7 @@ export default function QueueTab({ adminFetch }: Props) {
                     <button
                       key={p.id}
                       onClick={() => setChain([...p.chain])}
+                      aria-pressed={active}
                       className={`text-left p-2 min-h-[44px] rounded-lg border transition-colors ${
                         active
                           ? "border-amber-500 bg-amber-100/60"


### PR DESCRIPTION
## What changed

- `components/QueueTab.tsx`: added `aria-pressed={active}` to each chain preset button in the "Quick presets" section (closes #1292)

## Why

The preset buttons show a visual active state (amber border + background + "selected" text) when they match the current model chain, but had no `aria-pressed` attribute. Screen readers could not tell users which preset was currently loaded.

## Test plan

- `QueueTabPresetAriaPressed.test.ts`: static assertion verifies `aria-pressed={active}` is present
- Full frontend suite: 2346 tests passing
- Full backend suite: 1382 tests passing

Closes #1292
