### PR TITLE
fix: add aria-pressed to QueueTab item filter pills (closes #1299)

### DIFF
--- a/frontend/src/__tests__/QueueTabFilterAriaPressed.test.ts
+++ b/frontend/src/__tests__/QueueTabFilterAriaPressed.test.ts
@@ -1,0 +1,13 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/QueueTab.tsx"),
+  "utf8"
+);
+
+describe("QueueTab item filter pills aria-pressed (closes #1299)", () => {
+  it("filter button has aria-pressed={itemFilter === f}", () => {
+    expect(src).toContain("aria-pressed={itemFilter === f}");
+  });
+});

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -1236,6 +1236,7 @@ export default function QueueTab({ adminFetch }: Props) {
             <button
               key={f}
               onClick={() => setItemFilter(f)}
+              aria-pressed={itemFilter === f}
               className={`text-xs px-2 py-0.5 min-h-[44px] flex items-center rounded ${
                 itemFilter === f ? "bg-amber-700 text-white" : "text-amber-700 hover:bg-amber-50"
               }`}


### PR DESCRIPTION
## What changed
Added `aria-pressed` to the three item-filter pill buttons in QueueTab ("All", "Queued", "Done"). Each pill now correctly announces its toggled state to screen readers via `aria-pressed={itemFilter === f}`.

## Why
Filter pill buttons are stateful toggles — without `aria-pressed`, screen readers announce them as plain buttons with no indication of which filter is currently active (closes #1299).

## Test plan
- `QueueTabFilterAriaPressed.test.ts`: static assertion verifies `aria-pressed={itemFilter === f}` is present in `QueueTab.tsx`
- Full frontend suite: 2347 tests pass
- [ ] Docs updated (if applicable)
