### PR TITLE
fix: add aria-pressed to reader vocabulary sidebar view toggle (closes #1300)

### DIFF
--- a/frontend/src/__tests__/ReaderVocabViewToggleAriaPressed.test.ts
+++ b/frontend/src/__tests__/ReaderVocabViewToggleAriaPressed.test.ts
@@ -1,0 +1,13 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("reader vocabulary sidebar view toggle aria-pressed (closes #1300)", () => {
+  it("vocab view toggle button has aria-pressed={vocabView === v}", () => {
+    expect(src).toContain("aria-pressed={vocabView === v}");
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1827,6 +1827,7 @@ export default function ReaderPage() {
                         <button
                           key={v}
                           onClick={() => setVocabView(v)}
+                          aria-pressed={vocabView === v}
                           className={`flex-1 text-xs py-1 min-h-[44px] rounded-md font-medium transition-colors ${
                             vocabView === v ? "bg-white text-amber-700 shadow-sm" : "text-stone-400 hover:text-stone-600"
                           }`}


### PR DESCRIPTION
## What changed
Added `aria-pressed={vocabView === v}` to the "This chapter" / "All chapters" view-toggle buttons in the reader vocabulary sidebar.

## Why
The two filter pills are stateful toggle buttons — without `aria-pressed`, screen readers announce them as plain buttons with no indication of which view is currently active (closes #1300).

## Test plan
- `ReaderVocabViewToggleAriaPressed.test.ts`: static assertion verifies `aria-pressed={vocabView === v}` is present in `page.tsx`
- Full frontend suite: 2352 tests pass
- [ ] Docs updated (if applicable)
