### PR TITLE
fix: add aria-label to home page tab bar nav (closes #1308)

### DIFF
--- a/frontend/src/__tests__/HomeNavAriaLabel.test.ts
+++ b/frontend/src/__tests__/HomeNavAriaLabel.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Regression test for #1308: home page tab bar <nav> must have aria-label.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/page.tsx"),
+  "utf8"
+);
+
+describe("Home page nav landmark (closes #1308)", () => {
+  it("tab bar nav has aria-label", () => {
+    expect(src).toContain('aria-label="Main navigation"');
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -206,7 +206,7 @@ export default function Home() {
       </header>
 
       {/* Tab bar */}
-      <nav className="border-b border-amber-200 bg-white/40 backdrop-blur">
+      <nav aria-label="Main navigation" className="border-b border-amber-200 bg-white/40 backdrop-blur">
         <div className="max-w-5xl mx-auto px-4 md:px-6 flex gap-1 items-center overflow-x-auto scrollbar-none" style={{ scrollbarWidth: "none" }}>
           {([
             { key: "library" as Tab, label: "Home", count: recentBooks.length || undefined },


### PR DESCRIPTION
## What

Adds `aria-label="Main navigation"` to the home page tab bar `<nav>` element (closes #1308).

## Why

WCAG 2.4.6 (Headings and Labels) and the ARIA landmark pattern recommend labeling all `<nav>` elements so screen readers can identify them by purpose. The admin tab strip already has `aria-label="Admin sections"` (PR #1218); this brings the home page into the same standard. Without the label, screen readers announce the landmark as just "navigation" with no context.

## Changes

- `frontend/src/app/page.tsx` — `<nav aria-label="Main navigation">`
- `frontend/src/__tests__/HomeNavAriaLabel.test.ts` — static assertion verifying the attribute is present

## Test plan

- [x] 2356 frontend Jest tests pass
- [x] Static test `HomeNavAriaLabel.test.ts` confirms `aria-label="Main navigation"` is present
