### PR TITLE
fix: make annotation cards keyboard-accessible in reader and sidebar (closes #1310)

### DIFF
--- a/frontend/src/__tests__/ReaderAnnotationCardKeyboard.test.ts
+++ b/frontend/src/__tests__/ReaderAnnotationCardKeyboard.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Regression test for #1310: annotation cards in the reader notes sidebar
+ * must be keyboard-accessible (role=button, tabIndex, onKeyDown).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Reader annotation card keyboard accessibility (closes #1310)", () => {
+  it("annotation card has role=button", () => {
+    expect(src).toContain('role="button"');
+  });
+
+  it("annotation card has tabIndex for keyboard focus", () => {
+    expect(src).toContain("tabIndex={0}");
+  });
+
+  it("annotation card handles Enter/Space keydown", () => {
+    expect(src).toContain('e.key === "Enter" || e.key === " "');
+  });
+
+  it("annotation card has aria-label", () => {
+    expect(src).toContain("Jump to annotation");
+  });
+});

--- a/frontend/src/__tests__/ReaderAnnotationCardKeyboard.test.ts
+++ b/frontend/src/__tests__/ReaderAnnotationCardKeyboard.test.ts
@@ -1,29 +1,52 @@
 /**
  * Regression test for #1310: annotation cards in the reader notes sidebar
- * must be keyboard-accessible (role=button, tabIndex, onKeyDown).
+ * and AnnotationsSidebar drawer must be keyboard-accessible.
  */
 import * as fs from "fs";
 import * as path from "path";
 
-const src = fs.readFileSync(
+const readerSrc = fs.readFileSync(
   path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
   "utf8"
 );
 
+const sidebarSrc = fs.readFileSync(
+  path.join(__dirname, "../components/AnnotationsSidebar.tsx"),
+  "utf8"
+);
+
 describe("Reader annotation card keyboard accessibility (closes #1310)", () => {
-  it("annotation card has role=button", () => {
-    expect(src).toContain('role="button"');
+  it("reader annotation card has role=button", () => {
+    expect(readerSrc).toContain('role="button"');
   });
 
-  it("annotation card has tabIndex for keyboard focus", () => {
-    expect(src).toContain("tabIndex={0}");
+  it("reader annotation card has tabIndex for keyboard focus", () => {
+    expect(readerSrc).toContain("tabIndex={0}");
   });
 
-  it("annotation card handles Enter/Space keydown", () => {
-    expect(src).toContain('e.key === "Enter" || e.key === " "');
+  it("reader annotation card handles Enter/Space keydown", () => {
+    expect(readerSrc).toContain('e.key === "Enter" || e.key === " "');
   });
 
-  it("annotation card has aria-label", () => {
-    expect(src).toContain("Jump to annotation");
+  it("reader annotation card has aria-label", () => {
+    expect(readerSrc).toContain("Jump to annotation");
+  });
+});
+
+describe("AnnotationsSidebar annotation card keyboard accessibility (closes #1310)", () => {
+  it("sidebar annotation card has role=button", () => {
+    expect(sidebarSrc).toContain('role="button"');
+  });
+
+  it("sidebar annotation card has tabIndex for keyboard focus", () => {
+    expect(sidebarSrc).toContain("tabIndex={0}");
+  });
+
+  it("sidebar annotation card handles Enter/Space keydown", () => {
+    expect(sidebarSrc).toContain('e.key === "Enter" || e.key === " "');
+  });
+
+  it("sidebar annotation card has aria-label", () => {
+    expect(sidebarSrc).toContain("Jump to annotation");
   });
 });

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1697,6 +1697,9 @@ export default function ReaderPage() {
                 const renderCard = (ann: (typeof annotations)[0]) => (
                   <div
                     key={ann.id}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`Jump to annotation: ${ann.sentence_text.slice(0, 60)}`}
                     className={`rounded-lg border px-3 py-2.5 cursor-pointer hover:opacity-80 transition-opacity ${colorBadge[ann.color] ?? colorBadge.yellow}`}
                     onClick={() => {
                       if (ann.chapter_index !== chapterIndex) {
@@ -1707,6 +1710,19 @@ export default function ReaderPage() {
                         setTimeout(() => setScrollTargetSentence(ann.sentence_text), 10);
                       }
                       setSidebarOpen(false);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        if (ann.chapter_index !== chapterIndex) {
+                          goToChapter(ann.chapter_index);
+                          setTimeout(() => setScrollTargetSentence(ann.sentence_text), 400);
+                        } else {
+                          setScrollTargetSentence(undefined);
+                          setTimeout(() => setScrollTargetSentence(ann.sentence_text), 10);
+                        }
+                        setSidebarOpen(false);
+                      }
                     }}
                   >
                     <div className="flex items-start justify-between gap-2">

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -128,8 +128,12 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
                     {byChapter[ch].map((ann) => (
                       <div
                         key={ann.id}
+                        role="button"
+                        tabIndex={0}
+                        aria-label={`Jump to annotation: ${ann.sentence_text.slice(0, 60)}`}
                         className={`rounded-lg border px-3 py-2.5 cursor-pointer hover:opacity-80 transition-opacity ${COLOR_BADGE[ann.color] ?? COLOR_BADGE.yellow}`}
                         onClick={() => { onJump(ann); setOpen(false); }}
+                        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onJump(ann); setOpen(false); } }}
                       >
                         <div className="flex items-start justify-between gap-2">
                           <p className="text-xs italic leading-relaxed line-clamp-3 flex-1">


### PR DESCRIPTION
## What

Makes annotation cards in two locations keyboard-accessible (closes #1310):

1. **Reader notes sidebar** (`frontend/src/app/reader/[bookId]/page.tsx`) — the inline annotation card list in the reader's sidebar panel
2. **AnnotationsSidebar drawer** (`frontend/src/components/AnnotationsSidebar.tsx`) — the slide-in annotations drawer

## Why

Both locations render annotation cards as `<div onClick>` elements without `role="button"`, `tabIndex`, or `onKeyDown`. Keyboard users cannot activate them — they can Tab to the "Edit" button inside, but cannot trigger the jump-to-annotation action without a mouse.

WCAG 4.1.2 requires all interactive UI components to have a name, role, and value, and to be operable via keyboard. The fix follows the same pattern already used in the flashcard flip widget (same repo).

## Changes

- `reader/[bookId]/page.tsx` — `renderCard` div: added `role="button"`, `tabIndex={0}`, `aria-label`, `onKeyDown` (Enter/Space)
- `AnnotationsSidebar.tsx` — annotation card div: same additions
- `__tests__/ReaderAnnotationCardKeyboard.test.ts` — 8 static assertions verifying both fixes

## Test plan

- [x] 2364 frontend Jest tests pass
- [x] 8 new static assertions all pass
- [x] Keyboard: Tab to annotation card → Enter/Space jumps to the annotation
- [x] Mouse: click behavior unchanged
