### PR TITLE
fix: give notes-page annotation action buttons unique aria-labels (closes #1312)

### DIFF
--- a/frontend/src/__tests__/NotesAnnotationButtonLabels.test.ts
+++ b/frontend/src/__tests__/NotesAnnotationButtonLabels.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Regression test for #1312: annotation action buttons on the notes page
+ * must have unique aria-labels that identify which annotation they act on.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Notes page annotation button unique aria-labels (closes #1312)", () => {
+  it("Edit button label includes annotation sentence text", () => {
+    expect(src).toContain("Edit annotation:");
+  });
+
+  it("Delete annotation button label includes annotation sentence text", () => {
+    expect(src).toContain("Delete annotation:");
+  });
+
+  it("Delete insight button label includes insight question text", () => {
+    expect(src).toContain("Delete insight:");
+  });
+
+  it("Labels use slice(0, 60) to truncate long text", () => {
+    expect(src).toContain(".slice(0, 60)");
+  });
+});

--- a/frontend/src/__tests__/NotesAnnotationTouchTargets.test.tsx
+++ b/frontend/src/__tests__/NotesAnnotationTouchTargets.test.tsx
@@ -53,26 +53,28 @@ beforeEach(() => {
 
 afterEach(() => jest.clearAllMocks());
 
+const EDIT_LABEL = `Edit annotation: ${ANNOTATION.sentence_text.slice(0, 60)}`;
+const DELETE_LABEL = `Delete annotation: ${ANNOTATION.sentence_text.slice(0, 60)}`;
+
 test("Edit note button has min-h-[44px] touch target", async () => {
   render(<BookNotesPage />);
-  await waitFor(() => screen.getByLabelText("Edit note"));
-  const btn = screen.getByLabelText("Edit note");
+  await waitFor(() => screen.getByLabelText(EDIT_LABEL));
+  const btn = screen.getByLabelText(EDIT_LABEL);
   expect(btn.className).toContain("min-h-[44px]");
 });
 
 test("Delete annotation button has min-h-[44px] touch target", async () => {
   render(<BookNotesPage />);
-  await waitFor(() => screen.getByLabelText("Delete annotation"));
-  const btn = screen.getByLabelText("Delete annotation");
+  await waitFor(() => screen.getByLabelText(DELETE_LABEL));
+  const btn = screen.getByLabelText(DELETE_LABEL);
   expect(btn.className).toContain("min-h-[44px]");
 });
 
 test("Save button in edit mode has min-h-[44px] touch target", async () => {
   render(<BookNotesPage />);
-  await waitFor(() => screen.getByLabelText("Edit note"));
+  await waitFor(() => screen.getByLabelText(EDIT_LABEL));
 
-  // click edit to enter editing mode
-  const editBtn = screen.getByLabelText("Edit note");
+  const editBtn = screen.getByLabelText(EDIT_LABEL);
   editBtn.click();
 
   await waitFor(() => screen.getByRole("button", { name: "Save" }));
@@ -82,9 +84,9 @@ test("Save button in edit mode has min-h-[44px] touch target", async () => {
 
 test("Cancel button in edit mode has min-h-[44px] touch target", async () => {
   render(<BookNotesPage />);
-  await waitFor(() => screen.getByLabelText("Edit note"));
+  await waitFor(() => screen.getByLabelText(EDIT_LABEL));
 
-  const editBtn = screen.getByLabelText("Edit note");
+  const editBtn = screen.getByLabelText(EDIT_LABEL);
   editBtn.click();
 
   await waitFor(() => screen.getByRole("button", { name: "Cancel" }));

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -143,7 +143,7 @@ function AnnotationCard({
             onClick={onEdit}
             className="text-stone-400 hover:text-stone-600 transition-colors p-1 min-h-[44px] flex items-center justify-center"
             title="Edit note"
-            aria-label="Edit note"
+            aria-label={`Edit annotation: ${ann.sentence_text.slice(0, 60)}`}
           >
             <EditIcon className="w-3.5 h-3.5" />
           </button>
@@ -152,7 +152,7 @@ function AnnotationCard({
             disabled={isDeleting}
             className="text-red-400 hover:text-red-600 disabled:opacity-40 transition-colors p-1 min-h-[44px] flex items-center justify-center"
             title="Delete annotation"
-            aria-label="Delete annotation"
+            aria-label={`Delete annotation: ${ann.sentence_text.slice(0, 60)}`}
           >
             {isDeleting ? <RetryIcon className="w-3.5 h-3.5 animate-spin" /> : <TrashIcon className="w-3.5 h-3.5" />}
           </button>
@@ -204,7 +204,7 @@ function InsightCard({
           disabled={isDeleting}
           className="text-red-400 hover:text-red-600 disabled:opacity-40 transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
           title="Delete insight"
-          aria-label="Delete insight"
+          aria-label={`Delete insight: ${ins.question.slice(0, 60)}`}
         >
           {isDeleting ? <RetryIcon className="w-3.5 h-3.5 animate-spin" /> : <TrashIcon className="w-3.5 h-3.5" />}
         </button>


### PR DESCRIPTION
## What changed

In `notes/[bookId]/page.tsx`, the Edit and Delete action buttons inside `AnnotationCard` and `InsightCard` had generic aria-labels (`"Edit note"`, `"Delete annotation"`, `"Delete insight"`). When a page has multiple annotations, a screen reader user navigating with Tab heard the same label repeated with no way to distinguish which annotation each button acts on.

Fixed by appending the first 60 chars of the annotation sentence text (or insight question) to each button's aria-label, matching the pattern already used for vocabulary delete buttons (PR #1271):

```tsx
aria-label={`Edit annotation: ${ann.sentence_text.slice(0, 60)}`}
aria-label={`Delete annotation: ${ann.sentence_text.slice(0, 60)}`}
aria-label={`Delete insight: ${ins.question.slice(0, 60)}`}
```

## Why

WCAG 2.4.6 (Headings and Labels) — every interactive control must have a label that is descriptive in context. Repeated identical labels on a page fail this criterion.

## Test plan

- [x] New static test `NotesAnnotationButtonLabels.test.ts` (4 assertions) verifies the label patterns exist in the source
- [x] Updated existing `NotesAnnotationTouchTargets.test.tsx` to use new label format — all 4 tests still pass
- [x] Full frontend suite: 2368 tests passed
- [x] Full backend suite: 1382 tests passed

Closes #1312

[ ] Docs updated (if applicable) — N/A, no user-visible doc change needed
