### PR TITLE
fix: add role=dialog and focus management to VocabWordTooltip (closes #1315)

### DIFF
--- a/frontend/src/__tests__/VocabWordTooltipDialog.test.ts
+++ b/frontend/src/__tests__/VocabWordTooltipDialog.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Regression test for #1315: VocabWordTooltip must be announced to screen
+ * readers as a dialog with an accessible name and receive focus on mount.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/VocabWordTooltip.tsx"),
+  "utf8"
+);
+
+describe("VocabWordTooltip dialog accessibility (closes #1315)", () => {
+  it("has role=dialog", () => {
+    expect(src).toContain('role="dialog"');
+  });
+
+  it("has aria-modal=true", () => {
+    expect(src).toContain('aria-modal="true"');
+  });
+
+  it("has aria-labelledby pointing to a heading id", () => {
+    expect(src).toContain("aria-labelledby");
+    expect(src).toContain("vocab-tooltip-title");
+  });
+
+  it("has tabIndex={-1} on dialog container for focus management", () => {
+    expect(src).toContain("tabIndex={-1}");
+  });
+
+  it("moves focus into dialog on mount via useEffect", () => {
+    expect(src).toContain(".focus()");
+  });
+});

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -45,6 +45,11 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
     return () => document.removeEventListener("keydown", handleKey);
   }, [onClose]);
 
+  // Move focus into the dialog on mount so screen readers announce it
+  useEffect(() => {
+    ref.current?.focus();
+  }, []);
+
   // Position near the selection, keep within viewport
   const tooltipW = 288;
   const tooltipH = 220;
@@ -63,12 +68,16 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
   return (
     <div
       ref={ref}
-      className="fixed z-50 w-72 rounded-xl border border-amber-200 bg-white shadow-xl overflow-hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="vocab-tooltip-title"
+      tabIndex={-1}
+      className="fixed z-50 w-72 rounded-xl border border-amber-200 bg-white shadow-xl overflow-hidden focus:outline-none"
       style={{ left, top }}
     >
       {/* Header */}
       <div className="flex items-center justify-between px-3 pt-2.5 pb-1.5 border-b border-amber-100">
-        <span className="font-semibold text-ink text-sm">{word}</span>
+        <span id="vocab-tooltip-title" className="font-semibold text-ink text-sm">{word}</span>
         <button onClick={onClose} aria-label="Close" className="text-stone-400 hover:text-stone-600 p-0.5 rounded transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"><CloseIcon className="w-3.5 h-3.5" /></button>
       </div>
 


### PR DESCRIPTION
## What changed

`VocabWordTooltip` — the word-definition popup triggered by "Word" in the selection toolbar — was rendered as a bare `<div>` with no ARIA semantics. Screen readers had no way to know the popup appeared when a user clicked "Word" on selected text.

Changes to `frontend/src/components/VocabWordTooltip.tsx`:

- Added `role="dialog"`, `aria-modal="true"`, `aria-labelledby="vocab-tooltip-title"` to the outer container
- Added `id="vocab-tooltip-title"` to the word heading span so the dialog name resolves to the looked-up word
- Added `tabIndex={-1}` and a `useEffect(() => ref.current?.focus(), [])` to move focus into the dialog on mount — screen readers announce dialogs when focus enters them

## Why

WCAG 4.1.2 (Name, Role, Value) — custom UI components must communicate their purpose via ARIA. A dynamically appearing popup with interactive controls (Close, Save to vocab) is a dialog; without `role="dialog"` and focus management it is invisible to assistive technology.

## Test plan

- [x] New static test `VocabWordTooltipDialog.test.ts` (5 assertions) verifies `role="dialog"`, `aria-modal`, `aria-labelledby`, `vocab-tooltip-title`, `tabIndex={-1}`, and `.focus()` are present
- [x] Full frontend suite: 2370 tests passed
- [x] Full backend suite: 1382 tests passed

Closes #1315

[ ] Docs updated (if applicable) — N/A
