### PR TITLE
fix: include book title in BookCard remove button aria-label (closes #1317)

### DIFF
--- a/frontend/src/__tests__/BookCard.test.tsx
+++ b/frontend/src/__tests__/BookCard.test.tsx
@@ -63,14 +63,16 @@ test("renders multiple authors joined by comma", () => {
 
 // ── onRemove branch ────────────────────────────────────────────────────────────
 
+const REMOVE_LABEL = `Remove ${BOOK.title} from library`;
+
 test("does not render remove button when onRemove is not provided", () => {
   render(<BookCard book={BOOK} onClick={jest.fn()} />);
-  expect(screen.queryByRole("button", { name: /remove from library/i })).not.toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: REMOVE_LABEL })).not.toBeInTheDocument();
 });
 
 test("renders remove button when onRemove is provided", () => {
   render(<BookCard book={BOOK} onClick={jest.fn()} onRemove={jest.fn()} />);
-  expect(screen.getByRole("button", { name: /remove from library/i })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: REMOVE_LABEL })).toBeInTheDocument();
 });
 
 test("calls onRemove when remove button is clicked", async () => {
@@ -78,7 +80,7 @@ test("calls onRemove when remove button is clicked", async () => {
   const onClick = jest.fn();
   render(<BookCard book={BOOK} onClick={onClick} onRemove={onRemove} />);
 
-  const removeBtn = screen.getByRole("button", { name: /remove from library/i });
+  const removeBtn = screen.getByRole("button", { name: REMOVE_LABEL });
   await userEvent.click(removeBtn);
 
   expect(onRemove).toHaveBeenCalledTimes(1);
@@ -88,7 +90,7 @@ test("calls onRemove when remove button is clicked", async () => {
 
 test("remove button meets 44px minimum touch target size", () => {
   render(<BookCard book={BOOK} onClick={jest.fn()} onRemove={jest.fn()} />);
-  const removeBtn = screen.getByRole("button", { name: /remove from library/i });
+  const removeBtn = screen.getByRole("button", { name: REMOVE_LABEL });
   expect(removeBtn.className).toContain("min-w-[44px]");
   expect(removeBtn.className).toContain("min-h-[44px]");
 });

--- a/frontend/src/__tests__/BookCardRemoveLabel.test.ts
+++ b/frontend/src/__tests__/BookCardRemoveLabel.test.ts
@@ -1,0 +1,16 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(path.join(__dirname, "../components/BookCard.tsx"), "utf8");
+
+describe("BookCard remove button has unique aria-label per book (closes #1317)", () => {
+  it("remove button aria-label includes book.title", () => {
+    expect(src).toContain("book.title");
+    // The label must be a template literal containing the title, not a static string
+    expect(src).toMatch(/aria-label=\{`Remove \$\{book\.title\}/);
+  });
+
+  it("does not use generic static aria-label for remove button", () => {
+    expect(src).not.toContain('aria-label="Remove from library"');
+  });
+});

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -21,8 +21,8 @@ export default function BookCard({ book, onClick, badge, onRemove }: Props) {
             e.stopPropagation();
             onRemove();
           }}
-          title="Remove from library"
-          aria-label="Remove from library"
+          title={`Remove ${book.title} from library`}
+          aria-label={`Remove ${book.title} from library`}
           className="absolute top-0 right-0 z-10 min-w-[44px] min-h-[44px] inline-flex items-center justify-center rounded-full bg-white/80 text-stone-500 border border-amber-200 text-sm hover:bg-red-50 hover:text-red-600 hover:border-red-200 transition-colors"
         >
           <CloseIcon className="w-3.5 h-3.5" />


### PR DESCRIPTION
## What changed

`BookCard`'s "Remove from library" corner button now includes the book title in its `aria-label`: `Remove {title} from library` instead of the generic `Remove from library`.

## Why

When multiple book cards are shown (Your Library tab), every removal button announced the same text to screen readers. Users had no way to tell which book they were about to remove. Violates WCAG 2.4.6 (Headings and Labels).

## Test plan

- New `BookCardRemoveLabel.test.ts` asserts the label is a template containing `book.title`
- Existing `BookCard.test.tsx` updated to use `REMOVE_LABEL` constant (`Remove Pride and Prejudice from library`) — all 4 onRemove tests still pass
- Full suite: 2376 tests pass, 1382 backend tests pass

Closes #1317
