### PR TITLE
fix: include annotation sentence text in AnnotationsSidebar edit button aria-label (closes #1320)

### DIFF
--- a/frontend/src/__tests__/AnnotationsSidebar.test.tsx
+++ b/frontend/src/__tests__/AnnotationsSidebar.test.tsx
@@ -153,8 +153,8 @@ test("edit button has aria-label so screen readers announce it correctly", async
   const ann = makeAnnotation({ sentence_text: "Some sentence." });
   render(<AnnotationsSidebar {...BASE_PROPS} annotations={[ann]} totalCount={1} />);
   await userEvent.click(screen.getByTestId("annotations-toggle"));
-  // getByRole with name relies on aria-label (not just title)
-  expect(screen.getByRole("button", { name: "Edit annotation" })).toBeInTheDocument();
+  // aria-label now includes sentence text for unique identification
+  expect(screen.getByRole("button", { name: `Edit annotation: ${ann.sentence_text.slice(0, 60)}` })).toBeInTheDocument();
 });
 
 test("annotation link button has aria-label when bookId is provided", async () => {

--- a/frontend/src/__tests__/AnnotationsSidebarEditLabel.test.ts
+++ b/frontend/src/__tests__/AnnotationsSidebarEditLabel.test.ts
@@ -1,0 +1,17 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/AnnotationsSidebar.tsx"),
+  "utf8"
+);
+
+describe("AnnotationsSidebar edit button has unique aria-label per annotation (closes #1320)", () => {
+  it("edit button aria-label includes sentence text", () => {
+    expect(src).toMatch(/aria-label=\{`Edit annotation: \$\{ann\.sentence_text\.slice/);
+  });
+
+  it("does not use generic static aria-label for edit button", () => {
+    expect(src).not.toContain('aria-label="Edit annotation"');
+  });
+});

--- a/frontend/src/__tests__/AnnotationsSidebarTouchTargets.test.ts
+++ b/frontend/src/__tests__/AnnotationsSidebarTouchTargets.test.ts
@@ -22,14 +22,14 @@ describe("AnnotationsSidebar touch targets (closes #806)", () => {
   });
 
   it("Edit annotation button has min-h-[44px]", () => {
-    const idx = src.indexOf('aria-label="Edit annotation"');
+    const idx = src.indexOf("aria-label={`Edit annotation: ${ann.sentence_text.slice");
     expect(idx).toBeGreaterThan(-1);
     const window = src.slice(Math.max(0, idx - 300), idx + 100);
     expect(window).toContain("min-h-[44px]");
   });
 
   it("Edit annotation button has min-w-[44px]", () => {
-    const idx = src.indexOf('aria-label="Edit annotation"');
+    const idx = src.indexOf("aria-label={`Edit annotation: ${ann.sentence_text.slice");
     expect(idx).toBeGreaterThan(-1);
     const window = src.slice(Math.max(0, idx - 300), idx + 100);
     expect(window).toContain("min-w-[44px]");

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -155,7 +155,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
                               onClick={(e) => { e.stopPropagation(); onEdit(ann); setOpen(false); }}
                               className="opacity-60 hover:opacity-100 min-h-[44px] min-w-[44px] flex items-center justify-center"
                               title="Edit annotation"
-                              aria-label="Edit annotation"
+                              aria-label={`Edit annotation: ${ann.sentence_text.slice(0, 60)}`}
                             >
                               <EditIcon className="w-3.5 h-3.5" />
                             </button>


### PR DESCRIPTION
## What changed

`AnnotationsSidebar`'s Edit button now uses a unique `aria-label` per annotation:
`Edit annotation: {sentence_text[:60]}` instead of the generic `Edit annotation`.

## Why

When multiple annotations are listed in the sidebar, every Edit button announced identical text to screen readers. Users had no way to tell which annotation they were editing. Violates WCAG 2.4.6 (Headings and Labels) — same class as #1312 (notes page).

## Test plan

- New `AnnotationsSidebarEditLabel.test.ts` asserts the template literal pattern is present and the generic static string is gone
- Updated `AnnotationsSidebar.test.tsx` regression test uses `Edit annotation: ${ann.sentence_text.slice(0, 60)}`
- Updated `AnnotationsSidebarTouchTargets.test.ts` static-string search uses new template literal fragment
- Full suite: 2378 tests pass, 1382 backend tests pass

Closes #1320
