### PR TITLE
fix: add unique aria-labels to admin/books Expand/Collapse and action buttons (closes #1322)

### DIFF
--- a/frontend/src/__tests__/AdminBooksPage.branches.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.branches.test.tsx
@@ -87,14 +87,14 @@ async function renderWithLangExpanded() {
   await flushPromises();
 
   // Expand book row
-  const expandBtns = await screen.findAllByTitle("Expand");
+  const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
   await userEvent.click(expandBtns[0]);
 
   // Expand the zh language row
   await waitFor(() => screen.getByText("zh"));
   const allBtns = screen.getAllByRole("button");
   const langArrow = allBtns.find(
-    (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
+    (b) => (b.getAttribute("aria-label")?.startsWith("Expand") || b.getAttribute("aria-label")?.startsWith("Collapse")) && !b.title,
   );
   if (langArrow) await userEvent.click(langArrow);
 
@@ -325,7 +325,7 @@ describe("AdminBooksPage — expanded book with no translations cached", () => {
     await flushPromises();
 
     // Expand book row
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     await waitFor(() =>
@@ -345,7 +345,7 @@ describe("AdminBooksPage — Open button navigates to reader", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const openBtn = await screen.findByRole("button", { name: /^Open reader$/i });
+    const openBtn = await screen.findByRole("button", { name: /^Open reader for/i });
     await userEvent.click(openBtn);
 
     expect(mockPush).toHaveBeenCalledWith("/reader/1");

--- a/frontend/src/__tests__/AdminBooksPage.branches2.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.branches2.test.tsx
@@ -203,13 +203,13 @@ describe("AdminBooksPage — handleMove non-Error catch (line 190)", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     await waitFor(() => screen.getByText("zh"));
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
+      (b) => (b.getAttribute("aria-label")?.startsWith("Expand") || b.getAttribute("aria-label")?.startsWith("Collapse")) && !b.title,
     );
     if (langArrow) await userEvent.click(langArrow);
     await waitFor(() => screen.getByText("Ch. 1"));
@@ -377,7 +377,7 @@ describe("AdminBooksPage — language row expand/collapse toggle (line 423)", ()
     await flushPromises();
 
     // Expand book
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     await waitFor(() => screen.getByText("zh"));
@@ -385,7 +385,7 @@ describe("AdminBooksPage — language row expand/collapse toggle (line 423)", ()
     // Find the lang arrow and click it to expand
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
+      (b) => (b.getAttribute("aria-label")?.startsWith("Expand") || b.getAttribute("aria-label")?.startsWith("Collapse")) && !b.title,
     );
     if (langArrow) {
       await userEvent.click(langArrow);
@@ -394,7 +394,7 @@ describe("AdminBooksPage — language row expand/collapse toggle (line 423)", ()
 
       // Click again to collapse
       const collapsedArrow = screen.getAllByRole("button").find(
-        (b) => b.getAttribute("aria-label") === "Collapse" && !b.title,
+        (b) => b.getAttribute("aria-label")?.startsWith("Collapse") && !b.title,
       );
       if (collapsedArrow) {
         await userEvent.click(collapsedArrow);
@@ -441,7 +441,7 @@ describe("AdminBooksPage — singular chapter count (line 430)", () => {
     await flushPromises();
 
     // Expand book
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     await waitFor(() =>
@@ -463,7 +463,7 @@ describe("AdminBooksPage — bulk retranslate non-Error catch (line 453)", () =>
     render(<BooksPage />);
     await flushPromises();
 
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     const retranslateAllBtn = await screen.findByRole("button", {
@@ -513,13 +513,13 @@ describe("AdminBooksPage — empty chapter rows message (line 480)", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     await waitFor(() => screen.getByText("zh"));
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
+      (b) => (b.getAttribute("aria-label")?.startsWith("Expand") || b.getAttribute("aria-label")?.startsWith("Collapse")) && !b.title,
     );
     if (langArrow) await userEvent.click(langArrow);
 
@@ -542,13 +542,13 @@ describe("AdminBooksPage — moveInput onChange (lines 512-518)", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     await waitFor(() => screen.getByText("zh"));
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
+      (b) => (b.getAttribute("aria-label")?.startsWith("Expand") || b.getAttribute("aria-label")?.startsWith("Collapse")) && !b.title,
     );
     if (langArrow) await userEvent.click(langArrow);
     await waitFor(() => screen.getByText("Ch. 1"));

--- a/frontend/src/__tests__/AdminBooksPage.branches3.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.branches3.test.tsx
@@ -162,7 +162,7 @@ describe("AdminBooksPage — null translations and queue fallback (lines 273, 27
 
     await screen.findByText("Null Fields Book");
     // no translations → allLangs=[] → "no translations" shown
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     await waitFor(() =>
@@ -275,13 +275,13 @@ describe("AdminBooksPage — moveInput ?? '' false branch (lines 512, 518)", () 
     render(<BooksPage />);
     await flushPromises();
 
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     await waitFor(() => screen.getByText("zh"));
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
+      (b) => (b.getAttribute("aria-label")?.startsWith("Expand") || b.getAttribute("aria-label")?.startsWith("Collapse")) && !b.title,
     );
     if (langArrow) await userEvent.click(langArrow);
     await waitFor(() => screen.getByText("Ch. 1"));

--- a/frontend/src/__tests__/AdminBooksPage.coverage.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.coverage.test.tsx
@@ -112,7 +112,7 @@ describe("AdminBooksPage — act() error path (line 90)", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const deleteBtns = await screen.findAllByRole("button", { name: /^Delete$/i });
+    const deleteBtns = await screen.findAllByRole("button", { name: (n) => n.startsWith("Delete ") && !n.startsWith("Delete all") });
     await userEvent.click(deleteBtns[0]);
 
     await waitFor(() =>
@@ -130,7 +130,7 @@ describe("AdminBooksPage — act() error path (line 90)", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const deleteBtns = await screen.findAllByRole("button", { name: /^Delete$/i });
+    const deleteBtns = await screen.findAllByRole("button", { name: (n) => n.startsWith("Delete ") && !n.startsWith("Delete all") });
     await userEvent.click(deleteBtns[0]);
 
     await waitFor(() =>
@@ -196,13 +196,13 @@ describe("AdminBooksPage — handleRetranslate (lines 118-136)", () => {
     await flushPromises();
 
     // Expand book 1
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     // Expand zh language row
     await waitFor(() => screen.getByText("zh"));
     const langExpandBtns = screen.getAllByRole("button", {
-      name: (name) => name === "Expand" || name === "Collapse",
+      name: (name) => name.startsWith("Expand") || name.startsWith("Collapse"),
     });
     // The language expand chevron is inside the expanded book section
     const innerExpand = langExpandBtns.find(
@@ -220,7 +220,7 @@ describe("AdminBooksPage — handleRetranslate (lines 118-136)", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     // Expand the zh language row
@@ -228,7 +228,7 @@ describe("AdminBooksPage — handleRetranslate (lines 118-136)", () => {
     // Click the small arrow to expand the language
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
+      (b) => (b.getAttribute("aria-label")?.startsWith("Expand") || b.getAttribute("aria-label")?.startsWith("Collapse")) && !b.title,
     );
     if (langArrow) await userEvent.click(langArrow);
 
@@ -265,13 +265,13 @@ describe("AdminBooksPage — handleRetranslate (lines 118-136)", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     await waitFor(() => screen.getByText("zh"));
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
+      (b) => (b.getAttribute("aria-label")?.startsWith("Expand") || b.getAttribute("aria-label")?.startsWith("Collapse")) && !b.title,
     );
     if (langArrow) await userEvent.click(langArrow);
 
@@ -320,7 +320,7 @@ describe("AdminBooksPage — book expansion and metadata (lines 161-210)", () =>
     render(<BooksPage />);
     await flushPromises();
 
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     // "3 chapters cached" should appear
@@ -336,13 +336,13 @@ describe("AdminBooksPage — book expansion and metadata (lines 161-210)", () =>
     render(<BooksPage />);
     await flushPromises();
 
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
-    const collapseBtn = await screen.findByTitle("Collapse");
+    const collapseBtn = await screen.findByRole("button", { name: /^Collapse / });
     await userEvent.click(collapseBtn);
 
     await waitFor(() =>
-      expect(screen.queryByTitle("Collapse")).not.toBeInTheDocument(),
+      expect(screen.queryByRole("button", { name: /^Collapse / })).not.toBeInTheDocument(),
     );
   });
 
@@ -353,13 +353,13 @@ describe("AdminBooksPage — book expansion and metadata (lines 161-210)", () =>
     render(<BooksPage />);
     await flushPromises();
 
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     await waitFor(() => screen.getByText("zh"));
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
+      (b) => (b.getAttribute("aria-label")?.startsWith("Expand") || b.getAttribute("aria-label")?.startsWith("Collapse")) && !b.title,
     );
     if (langArrow) await userEvent.click(langArrow);
 
@@ -510,7 +510,7 @@ describe("AdminBooksPage — Delete all translations per-lang (line 373)", () =>
     await flushPromises();
 
     // Expand book 1
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     // "Delete all" button inside expanded section
@@ -534,7 +534,7 @@ describe("AdminBooksPage — Delete all translations per-lang (line 373)", () =>
     render(<BooksPage />);
     await flushPromises();
 
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     const deleteAllBtn = await screen.findByRole("button", { name: /delete all/i });
@@ -560,7 +560,7 @@ describe("AdminBooksPage — bulk retranslate (lines 423-460)", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     const retranslateAllBtn = await screen.findByRole("button", {
@@ -588,7 +588,7 @@ describe("AdminBooksPage — bulk retranslate (lines 423-460)", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     const retranslateAllBtn = await screen.findByRole("button", {
@@ -609,7 +609,7 @@ describe("AdminBooksPage — bulk retranslate (lines 423-460)", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     const retranslateAllBtn = await screen.findByRole("button", {
@@ -633,13 +633,13 @@ describe("AdminBooksPage — chapter-level delete (lines 530-543)", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     await waitFor(() => screen.getByText("zh"));
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
+      (b) => (b.getAttribute("aria-label")?.startsWith("Expand") || b.getAttribute("aria-label")?.startsWith("Collapse")) && !b.title,
     );
     if (langArrow) await userEvent.click(langArrow);
     await waitFor(() => screen.getByText("Ch. 1"));
@@ -683,13 +683,13 @@ describe("AdminBooksPage — chapter move (lines 496-519)", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     await waitFor(() => screen.getByText("zh"));
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
-      (b) => (b.getAttribute("aria-label") === "Expand" || b.getAttribute("aria-label") === "Collapse") && !b.title,
+      (b) => (b.getAttribute("aria-label")?.startsWith("Expand") || b.getAttribute("aria-label")?.startsWith("Collapse")) && !b.title,
     );
     if (langArrow) await userEvent.click(langArrow);
     await waitFor(() => screen.getByText("Ch. 1"));

--- a/frontend/src/__tests__/AdminBooksPage.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.test.tsx
@@ -266,9 +266,9 @@ describe("AdminBooksPage — expand/collapse", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
-    expect(await screen.findByTitle("Collapse")).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /^Collapse / })).toBeInTheDocument();
   });
 
   it("shows 'No translations cached yet' when expanded book has no translations", async () => {
@@ -279,7 +279,7 @@ describe("AdminBooksPage — expand/collapse", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const expandBtns = await screen.findAllByTitle("Expand");
+    const expandBtns = await screen.findAllByRole("button", { name: /^Expand / });
     await userEvent.click(expandBtns[0]);
 
     expect(await screen.findByText(/no translations cached yet/i)).toBeInTheDocument();

--- a/frontend/src/__tests__/AdminBooksUniqueAriaLabels.test.ts
+++ b/frontend/src/__tests__/AdminBooksUniqueAriaLabels.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Static assertions: admin/books/page.tsx must have unique aria-labels on
+ * all repeated interactive controls (closes #1322, WCAG 2.4.6).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/admin/books/page.tsx"),
+  "utf8"
+);
+
+describe("AdminBooks aria-labels are unique per book/language (closes #1322)", () => {
+  it("book expand/collapse button includes b.title in aria-label", () => {
+    expect(src).toMatch(/aria-label=\{isExpanded \? `Collapse \$\{b\.title\}`/);
+  });
+
+  it("language expand/collapse button includes lang in aria-label", () => {
+    expect(src).toMatch(/aria-label=\{isLangExpanded \? `Collapse \$\{lang\}/);
+  });
+
+  it("Open reader button includes book title", () => {
+    expect(src).toMatch(/aria-label=\{`Open reader for \$\{b\.title\}`\}/);
+  });
+
+  it("Delete book button includes book title", () => {
+    expect(src).toMatch(/aria-label=\{`Delete \$\{b\.title\}`\}/);
+  });
+
+  it("Retranslate all button includes lang in aria-label", () => {
+    expect(src).toMatch(/aria-label=\{`Retranslate all \$\{lang\}/);
+  });
+
+  it("Delete all translations button includes lang in aria-label", () => {
+    expect(src).toMatch(/aria-label=\{`Delete all \$\{lang\}/);
+  });
+
+  it("does not use generic static aria-label Collapse/Expand for book expand button", () => {
+    expect(src).not.toContain('aria-label={isExpanded ? "Collapse" : "Expand"}');
+  });
+
+  it("does not use generic static aria-label Collapse/Expand for language expand button", () => {
+    expect(src).not.toContain('aria-label={isLangExpanded ? "Collapse" : "Expand"}');
+  });
+
+  it("does not use generic static aria-label Open reader", () => {
+    expect(src).not.toContain('aria-label="Open reader"');
+  });
+});

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -285,8 +285,8 @@ export default function BooksPage() {
                     setExpandedLang(null);
                   }}
                   className="text-stone-400 hover:text-amber-700 flex items-center min-h-[44px] min-w-[44px] justify-center"
-                  title={isExpanded ? "Collapse" : "Expand"}
-                  aria-label={isExpanded ? "Collapse" : "Expand"}
+                  title={isExpanded ? `Collapse ${b.title}` : `Expand ${b.title}`}
+                  aria-label={isExpanded ? `Collapse ${b.title}` : `Expand ${b.title}`}
                   aria-expanded={isExpanded}
                 >
                   {isExpanded ? <ChevronDownIcon className="w-3.5 h-3.5" /> : <ChevronRightIcon className="w-3.5 h-3.5" />}
@@ -368,7 +368,7 @@ export default function BooksPage() {
 
                 <button
                   onClick={() => router.push(`/reader/${b.id}`)}
-                  aria-label="Open reader"
+                  aria-label={`Open reader for ${b.title}`}
                   className="text-xs text-amber-600 hover:text-amber-800 shrink-0 min-h-[44px] flex items-center"
                 >
                   Open
@@ -401,6 +401,7 @@ export default function BooksPage() {
                     if (confirm(`Delete "${b.title}" and all its audio/translations?`))
                       act(() => adminFetch(`/admin/books/${b.id}`, { method: "DELETE" }));
                   }}
+                  aria-label={`Delete ${b.title}`}
                   className="text-xs px-2 py-1 rounded border border-red-200 text-red-500 shrink-0 min-h-[44px]"
                 >
                   Delete
@@ -429,7 +430,7 @@ export default function BooksPage() {
                               <button
                                 onClick={() => setExpandedLang(isLangExpanded ? null : bulkKey)}
                                 className="text-xs text-stone-400 hover:text-amber-700 flex items-center min-h-[44px] min-w-[44px] justify-center"
-                                aria-label={isLangExpanded ? "Collapse" : "Expand"}
+                                aria-label={isLangExpanded ? `Collapse ${lang} translations` : `Expand ${lang} translations`}
                                 aria-expanded={isLangExpanded}
                               >
                                 {isLangExpanded ? <ChevronDownIcon className="w-3 h-3" /> : <ChevronRightIcon className="w-3 h-3" />}
@@ -464,6 +465,7 @@ export default function BooksPage() {
                                     setBulkRetranslating(null);
                                   }
                                 }}
+                                aria-label={`Retranslate all ${lang} chapters of ${b.title}`}
                                 className="ml-auto text-xs px-2 py-1 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-50 min-h-[44px]"
                               >
                                 {bulkRetranslating === bulkKey ? "Retranslating…" : "Retranslate all"}
@@ -478,6 +480,7 @@ export default function BooksPage() {
                                     }),
                                   );
                                 }}
+                                aria-label={`Delete all ${lang} translations for ${b.title}`}
                                 className="text-xs px-2 py-1 rounded border border-red-200 text-red-500 min-h-[44px]"
                               >
                                 Delete all


### PR DESCRIPTION
## What changed
- `admin/books/page.tsx`: Added unique aria-labels to all repeated interactive controls:
  - Book-level expand/collapse: `"Expand Moby Dick"` / `"Collapse Moby Dick"`
  - Language-level expand/collapse: `"Expand zh translations"` / `"Collapse zh translations"`
  - Open reader button: `"Open reader for Moby Dick"`
  - Delete book button: `"Delete Moby Dick"`
  - Retranslate all button: `"Retranslate all zh chapters of Moby Dick"`
  - Delete all translations button: `"Delete all zh translations for Moby Dick"`

## Why
WCAG 2.4.6 (Headings and Labels): all six button types appear once per book (or per book×language), giving screen readers identical labels with no context. Fixes #1322.

## Test plan
- Added `AdminBooksUniqueAriaLabels.test.ts` (9 static assertions verifying the template-literal patterns)
- Updated 5 existing AdminBooksPage test files to use new accessible-name selectors:
  - `findAllByTitle("Expand")` → `findAllByRole("button", { name: /^Expand / })`
  - `aria-label === "Expand"` → `aria-label?.startsWith("Expand")`
  - `findByTitle("Collapse")` → `findByRole("button", { name: /^Collapse / })`
  - `name: /^Open reader$/` → `name: /^Open reader for/`
  - Book-level `findAllByRole("button", { name: /^Delete$/ })` → name filter excluding "Delete all"
- All 2387 frontend tests pass; all 1382 backend tests pass
