### PR TITLE
fix: include sentence text in SentenceReader note-dot button aria-label (closes #1325)

### DIFF
--- a/frontend/src/__tests__/SentenceReader.branches.test.tsx
+++ b/frontend/src/__tests__/SentenceReader.branches.test.tsx
@@ -340,7 +340,7 @@ describe("SentenceReader — note dot toggle expands/collapses (line 545)", () =
       />
     );
 
-    const noteBtn = container.querySelector("[aria-label='Toggle note']") as HTMLElement;
+    const noteBtn = container.querySelector("[aria-label^='Toggle note for:']") as HTMLElement;
     expect(noteBtn).not.toBeNull();
 
     // First click — note card should appear
@@ -375,7 +375,7 @@ describe("SentenceReader — note dot toggle expands/collapses (line 545)", () =
       />
     );
 
-    const noteBtn = container.querySelector("[aria-label='Toggle note']") as HTMLElement;
+    const noteBtn = container.querySelector("[aria-label^='Toggle note for:']") as HTMLElement;
     fireEvent.click(noteBtn);
 
     expect(screen.getByText("The expanded note content")).toBeInTheDocument();
@@ -410,7 +410,7 @@ describe("SentenceReader — expandedNoteFlatIdx with no matching segment (line 
     );
 
     // Click the note button on first paragraph
-    const noteBtn = container.querySelector("[aria-label='Toggle note']") as HTMLElement;
+    const noteBtn = container.querySelector("[aria-label^='Toggle note for:']") as HTMLElement;
     if (noteBtn) {
       fireEvent.click(noteBtn);
       // Note card should appear in the first paragraph

--- a/frontend/src/__tests__/SentenceReader.coverage.test.tsx
+++ b/frontend/src/__tests__/SentenceReader.coverage.test.tsx
@@ -348,7 +348,7 @@ describe("SentenceReader — showAnnotations=false (lines 401-409)", () => {
     );
 
     // Note toggle button should NOT be rendered
-    expect(screen.queryByRole("button", { name: "Toggle note" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Toggle note for:/i })).not.toBeInTheDocument();
   });
 
   it("shows annotation underline when showAnnotations defaults to true", () => {

--- a/frontend/src/__tests__/SentenceReader.extended.test.tsx
+++ b/frontend/src/__tests__/SentenceReader.extended.test.tsx
@@ -391,7 +391,7 @@ describe("SentenceReader annotations", () => {
     );
 
     // Note dot button should appear on the annotated segment
-    expect(screen.getByRole("button", { name: "Toggle note" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Toggle note for:/i })).toBeInTheDocument();
   });
 
   it("applies blue color class for blue annotation", () => {
@@ -803,6 +803,6 @@ describe("SentenceReader annotation substring matching", () => {
       />
     );
 
-    expect(screen.getByRole("button", { name: "Toggle note" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Toggle note for:/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/SentenceReaderNoteAriaExpanded.test.tsx
+++ b/frontend/src/__tests__/SentenceReaderNoteAriaExpanded.test.tsx
@@ -33,21 +33,21 @@ function renderWithAnnotation() {
 
 test("note toggle button has aria-expanded=false when note is closed", () => {
   const { container } = renderWithAnnotation();
-  const btn = container.querySelector("[aria-label='Toggle note']") as HTMLElement;
+  const btn = container.querySelector("[aria-label^='Toggle note for:']") as HTMLElement;
   expect(btn).not.toBeNull();
   expect(btn.getAttribute("aria-expanded")).toBe("false");
 });
 
 test("note toggle button has aria-expanded=true after clicking", () => {
   const { container } = renderWithAnnotation();
-  const btn = container.querySelector("[aria-label='Toggle note']") as HTMLElement;
+  const btn = container.querySelector("[aria-label^='Toggle note for:']") as HTMLElement;
   fireEvent.click(btn);
   expect(btn.getAttribute("aria-expanded")).toBe("true");
 });
 
 test("note toggle button returns to aria-expanded=false after second click", () => {
   const { container } = renderWithAnnotation();
-  const btn = container.querySelector("[aria-label='Toggle note']") as HTMLElement;
+  const btn = container.querySelector("[aria-label^='Toggle note for:']") as HTMLElement;
   fireEvent.click(btn);
   fireEvent.click(btn);
   expect(btn.getAttribute("aria-expanded")).toBe("false");

--- a/frontend/src/__tests__/SentenceReaderNoteDotTouchTarget.test.ts
+++ b/frontend/src/__tests__/SentenceReaderNoteDotTouchTarget.test.ts
@@ -9,7 +9,7 @@ const src = fs.readFileSync(
 describe("SentenceReader note-dot button touch target (closes #976)", () => {
   it("note-dot toggle button has min-h-[44px] touch target class", () => {
     // Find the note-dot button by its aria-label
-    const idx = src.indexOf('aria-label="Toggle note"');
+    const idx = src.indexOf("aria-label={`Toggle note for:");
     expect(idx).toBeGreaterThan(-1);
     // Look at the button element up to 300 chars before aria-label (className is set on the button tag)
     const window = src.slice(Math.max(0, idx - 300), idx + 50);
@@ -17,7 +17,7 @@ describe("SentenceReader note-dot button touch target (closes #976)", () => {
   });
 
   it("note-dot toggle button has min-w-[44px] touch target class", () => {
-    const idx = src.indexOf('aria-label="Toggle note"');
+    const idx = src.indexOf("aria-label={`Toggle note for:");
     expect(idx).toBeGreaterThan(-1);
     const window = src.slice(Math.max(0, idx - 300), idx + 50);
     expect(window).toContain("min-w-[44px]");

--- a/frontend/src/__tests__/SentenceReaderToggleNoteLabel.test.ts
+++ b/frontend/src/__tests__/SentenceReaderToggleNoteLabel.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Static assertion: SentenceReader note-dot button must have a unique
+ * aria-label including sentence text (closes #1325, WCAG 2.4.6).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/SentenceReader.tsx"),
+  "utf8"
+);
+
+describe("SentenceReader Toggle note button has unique aria-label (closes #1325)", () => {
+  it("note dot button aria-label includes seg.text", () => {
+    expect(src).toMatch(/aria-label=\{`Toggle note for: \$\{seg\.text\.slice/);
+  });
+
+  it("does not use generic static aria-label Toggle note", () => {
+    expect(src).not.toContain('aria-label="Toggle note"');
+  });
+});

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -712,7 +712,7 @@ export default function SentenceReader({
                 <button
                   onClick={(e) => { e.stopPropagation(); setExpandedNoteFlatIdx((prev) => prev === seg.flatIdx ? null : seg.flatIdx); }}
                   className="inline-flex items-center justify-center ml-0.5 align-middle cursor-pointer min-h-[44px] min-w-[44px] -m-[19px] p-[19px]"
-                  aria-label="Toggle note"
+                  aria-label={`Toggle note for: ${seg.text.slice(0, 60)}`}
                   aria-expanded={expandedNoteFlatIdx === seg.flatIdx}
                 >
                   <span className={`inline-block w-1.5 h-1.5 rounded-full ${NOTE_DOT_CLASS[annotation.color] ?? NOTE_DOT_CLASS.yellow}`} />


### PR DESCRIPTION
## What changed
- `SentenceReader.tsx`: Changed note-dot toggle button `aria-label` from the static `"Toggle note"` to a dynamic `"Toggle note for: ${seg.text.slice(0, 60)}"` so each button is uniquely identified by its sentence.

## Why
WCAG 2.4.6 (Headings and Labels): a chapter with multiple annotated sentences renders N identical "Toggle note" buttons. Screen readers cannot distinguish which note they are expanding. Fixes #1325.

## Test plan
- Added `SentenceReaderToggleNoteLabel.test.ts` (2 static assertions verifying the template-literal pattern and absence of the old generic label)
- Updated 5 existing test files to use the new accessible-name selectors:
  - `[aria-label='Toggle note']` → `[aria-label^='Toggle note for:']`
  - `getByRole("button", { name: "Toggle note" })` → `{ name: /^Toggle note for:/i }`
  - `SentenceReaderNoteDotTouchTarget.test.ts` indexOf updated to new pattern
- All 2381 frontend tests pass; all 1382 backend tests pass
