### PR TITLE
fix: unique aria-label on reader sidebar Edit annotation buttons (closes #1327)

### DIFF
--- a/frontend/src/__tests__/ReaderAnnotationEditAriaLabel.test.ts
+++ b/frontend/src/__tests__/ReaderAnnotationEditAriaLabel.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Regression test for #1327: the Edit annotation button in the reader sidebar
+ * must have a unique aria-label that includes the sentence text, not the static
+ * string "Edit annotation" which repeats identically for every card.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe('Reader sidebar "Edit annotation" button aria-label (closes #1327)', () => {
+  it('does not use static aria-label="Edit annotation"', () => {
+    expect(src).not.toContain('aria-label="Edit annotation"');
+  });
+
+  it("uses a dynamic aria-label that includes ann.sentence_text", () => {
+    expect(src).toMatch(
+      /aria-label=\{`Edit annotation for: \$\{ann\.sentence_text\.slice/,
+    );
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1738,7 +1738,7 @@ export default function ReaderPage() {
                           });
                         }}
                         className="shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center opacity-60 hover:opacity-100"
-                        aria-label="Edit annotation"
+                        aria-label={`Edit annotation for: ${ann.sentence_text.slice(0, 60)}`}
                       >
                         <EditIcon className="w-3.5 h-3.5" />
                       </button>


### PR DESCRIPTION
## What changed

In `app/reader/[bookId]/page.tsx`, the `renderCard` function renders an Edit button for each annotation card in the sidebar. Every button had the same static `aria-label="Edit annotation"`, making them indistinguishable for screen readers — a WCAG 2.4.6 (Labels or Instructions) violation.

Changed to a dynamic label that includes the first 60 characters of the annotation's sentence text:

```tsx
// Before
aria-label="Edit annotation"

// After
aria-label={`Edit annotation for: ${ann.sentence_text.slice(0, 60)}`}
```

This matches the pattern already used on the card's parent element (`aria-label={`Jump to annotation: ${ann.sentence_text.slice(0, 60)}`}`).

## Why

Screen readers announce all Edit buttons identically when multiple annotations exist in the sidebar, making it impossible to distinguish which annotation you're editing.

## Test plan

- [x] New static assertion test `ReaderAnnotationEditAriaLabel.test.ts` confirms the old static label is gone and the new dynamic pattern is present
- [x] Full frontend suite: 2390 tests pass

Closes #1327
