### PR TITLE
fix: guard retranslate-all against empty chapter list to avoid SQLite IN () error (closes #1323)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -712,6 +712,8 @@ async def retranslate_all(
 
     from services.book_chapters import split_with_html_preference
     chapters = await split_with_html_preference(book_id, book.get("text") or "")
+    if not chapters:
+        return {"ok": True, "chapters": 0, "results": []}
     source_language = (book.get("languages") or ["en"])[0]
 
     # Pre-check: reject before translating any chapter if any have a running

--- a/backend/tests/test_router_admin_extended.py
+++ b/backend/tests/test_router_admin_extended.py
@@ -911,3 +911,25 @@ async def test_queue_retry_failed_oversized_language_returns_422(admin_client, a
     assert res.status_code == 422, (
         f"Expected 422 for oversized target_language in /queue/retry-failed, got {res.status_code}: {res.text}"
     )
+
+
+# ── Issue #1323: retranslate-all crashes on books with no chapters ────────────
+
+@pytest.mark.asyncio
+async def test_retranslate_all_empty_book_returns_200_empty(admin_client, admin_db):
+    """Regression #1323: retranslate-all on a book with no chapters must return 200
+    with empty results, not a 500 SQLite syntax error from an empty IN () clause."""
+    # Save a book with empty text — split_with_html_preference returns no chapters.
+    await save_book(200, BOOK_META, "")
+
+    res = await admin_client.post(
+        "/api/admin/translations/200/retranslate-all",
+        json={"target_language": "zh"},
+    )
+    assert res.status_code == 200, (
+        f"Expected 200 for a book with no chapters, got {res.status_code}: {res.text}"
+    )
+    data = res.json()
+    assert data["ok"] is True
+    assert data["chapters"] == 0
+    assert data["results"] == []


### PR DESCRIPTION
## What changed

Added an early-return guard in `retranslate_all` (`routers/admin.py`) when `split_with_html_preference` returns zero chapters. Previously the code fell through to build `chapter_index IN ()` — invalid SQLite syntax — causing a 500 OperationalError.

Now the endpoint returns `{"ok": true, "chapters": 0, "results": []}` immediately, consistent with the normal success response shape.

## Why

SQLite does not allow an empty `IN ()` clause. When a book has no confirmed chapters (e.g. empty text field), the query was malformed and crashed the worker. Issue #1323 / original crash first covered by #715.

## Test plan

- Added `test_retranslate_all_empty_book_returns_200_empty` in `test_router_admin_extended.py` — seeds a book with empty text, calls the endpoint, asserts 200 with `{ok: true, chapters: 0, results: []}`.
- Existing `test_retranslate_all_empty_chapters_returns_ok` (issue #715) still passes — both cover the same path via different setup methods.
- Full test suite: 1649 passed.

Closes #1323

## Docs follow-up

None — internal behaviour change only, no user-visible API shape change.
