### PR TITLE
fix: unique aria-labels on QueueTab chain reorder buttons (closes #1329)

### DIFF
--- a/frontend/src/__tests__/QueueTab.branches.test.tsx
+++ b/frontend/src/__tests__/QueueTab.branches.test.tsx
@@ -405,7 +405,7 @@ describe("QueueTab.branches — chain reorder edge cases", () => {
     });
     await renderAndWait(adminFetch);
 
-    const upBtns = screen.getAllByTitle(/move up/i);
+    const upBtns = screen.getAllByTitle(/move .+ up/i);
     expect(upBtns.length).toBeGreaterThan(0);
 
     // The first ↑ button is disabled (idx=0), clicking it does nothing
@@ -418,7 +418,7 @@ describe("QueueTab.branches — chain reorder edge cases", () => {
     fe.click(firstUpBtn);
 
     // No reorder should have happened — chain order unchanged
-    expect(screen.getAllByTitle(/move up/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByTitle(/move .+ up/i).length).toBeGreaterThan(0);
   });
 
   it("clicking ↓ on last chain item (idx=last) does nothing", async () => {
@@ -431,7 +431,7 @@ describe("QueueTab.branches — chain reorder edge cases", () => {
     });
     await renderAndWait(adminFetch);
 
-    const downBtns = screen.getAllByTitle(/move down/i);
+    const downBtns = screen.getAllByTitle(/move .+ down/i);
     expect(downBtns.length).toBeGreaterThan(0);
 
     // The last ↓ button is disabled
@@ -441,7 +441,7 @@ describe("QueueTab.branches — chain reorder edge cases", () => {
     const { fireEvent: fe } = await import("@testing-library/react");
     fe.click(lastDownBtn);
 
-    expect(screen.getAllByTitle(/move down/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByTitle(/move .+ down/i).length).toBeGreaterThan(0);
   });
 
   it("clicking ↑ on second chain item moves it up", async () => {
@@ -454,13 +454,13 @@ describe("QueueTab.branches — chain reorder edge cases", () => {
     });
     await renderAndWait(adminFetch);
 
-    const upBtns = screen.getAllByTitle(/move up/i);
+    const upBtns = screen.getAllByTitle(/move .+ up/i);
     // Second ↑ button (idx=1) should be enabled
     if (upBtns.length > 1) {
       expect(upBtns[1]).not.toBeDisabled();
       await userEvent.click(upBtns[1]);
       // After click, items should reorder — no crash
-      expect(screen.getAllByTitle(/move up/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByTitle(/move .+ up/i).length).toBeGreaterThan(0);
     }
   });
 
@@ -474,11 +474,11 @@ describe("QueueTab.branches — chain reorder edge cases", () => {
     });
     await renderAndWait(adminFetch);
 
-    const downBtns = screen.getAllByTitle(/move down/i);
+    const downBtns = screen.getAllByTitle(/move .+ down/i);
     if (downBtns.length > 0) {
       expect(downBtns[0]).not.toBeDisabled();
       await userEvent.click(downBtns[0]);
-      expect(screen.getAllByTitle(/move down/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByTitle(/move .+ down/i).length).toBeGreaterThan(0);
     }
   });
 });
@@ -694,7 +694,7 @@ describe("QueueTab.branches — refreshCore langs initialization", () => {
     await renderAndWait(adminFetch);
 
     // Chain should be initialized from the model field
-    const chainItems = screen.queryAllByTitle(/remove from chain/i);
+    const chainItems = screen.queryAllByTitle(/remove .+ from chain/i);
     expect(chainItems.length).toBeGreaterThanOrEqual(1);
   });
 
@@ -919,7 +919,7 @@ describe("QueueTab.branches — chain initialization from DEFAULT_CHAIN", () => 
     await renderAndWait(adminFetch);
 
     // Chain items should be rendered from DEFAULT_CHAIN
-    const chainItems = document.querySelectorAll("[title='Remove from chain']");
+    const chainItems = document.querySelectorAll("[title*='from chain']");
     // DEFAULT_CHAIN is non-empty so there should be items
     expect(chainItems.length).toBeGreaterThanOrEqual(0);
   });

--- a/frontend/src/__tests__/QueueTab.branches2.test.tsx
+++ b/frontend/src/__tests__/QueueTab.branches2.test.tsx
@@ -486,7 +486,7 @@ describe("QueueTab.branches2 — save chain (line 643)", () => {
     await renderAndWait(adminFetch);
 
     // Remove all chain items using the × button
-    const removeButtons = screen.getAllByTitle(/remove from chain/i);
+    const removeButtons = screen.getAllByTitle(/remove .+ from chain/i);
     for (const btn of removeButtons) {
       await userEvent.click(btn);
     }

--- a/frontend/src/__tests__/QueueTab.coverage.test.tsx
+++ b/frontend/src/__tests__/QueueTab.coverage.test.tsx
@@ -879,13 +879,13 @@ describe("model chain management in settings (lines 826-964 / settings panel)", 
     await renderAndWait(adminFetch);
 
     // Find all ↓ buttons (move down); click the first one
-    const downBtns = screen.getAllByTitle(/move down/i);
+    const downBtns = screen.getAllByTitle(/move .+ down/i);
     if (downBtns.length > 0) {
       await userEvent.click(downBtns[0]);
     }
 
     // The ↑ on the second item should now be enabled — just verify no crash
-    expect(screen.getAllByTitle(/move up/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByTitle(/move .+ up/i).length).toBeGreaterThan(0);
   });
 
   it("× button removes model from chain", async () => {
@@ -898,7 +898,7 @@ describe("model chain management in settings (lines 826-964 / settings panel)", 
     });
     await renderAndWait(adminFetch);
 
-    const removeButtons = screen.getAllByTitle(/remove from chain/i);
+    const removeButtons = screen.getAllByTitle(/remove .+ from chain/i);
     // Remove the last model
     await userEvent.click(removeButtons[removeButtons.length - 1]);
 
@@ -934,10 +934,10 @@ describe("model chain management in settings (lines 826-964 / settings panel)", 
     await renderAndWait(adminFetch);
 
     // Remove all × buttons to empty the chain
-    let removeBtns = screen.queryAllByTitle(/remove from chain/i);
+    let removeBtns = screen.queryAllByTitle(/remove .+ from chain/i);
     while (removeBtns.length > 0) {
       await userEvent.click(removeBtns[0]);
-      removeBtns = screen.queryAllByTitle(/remove from chain/i);
+      removeBtns = screen.queryAllByTitle(/remove .+ from chain/i);
     }
 
     expect(screen.getByText(/chain is empty/i)).toBeInTheDocument();

--- a/frontend/src/__tests__/QueueTabChainAria.test.tsx
+++ b/frontend/src/__tests__/QueueTabChainAria.test.tsx
@@ -78,28 +78,28 @@ describe("QueueTab chain buttons accessibility (#595)", () => {
 
   it("move-up buttons have aria-label", async () => {
     await renderAndWait(makeAdminFetch());
-    const upBtns = screen.getAllByTitle(/move up/i);
+    const upBtns = screen.getAllByTitle(/move .+ up/i);
     expect(upBtns.length).toBeGreaterThan(0);
     upBtns.forEach((btn) => {
-      expect(btn.getAttribute("aria-label")).toBe("Move up");
+      expect(btn.getAttribute("aria-label")).toMatch(/^Move .+ up$/);
     });
   });
 
   it("move-down buttons have aria-label", async () => {
     await renderAndWait(makeAdminFetch());
-    const downBtns = screen.getAllByTitle(/move down/i);
+    const downBtns = screen.getAllByTitle(/move .+ down/i);
     expect(downBtns.length).toBeGreaterThan(0);
     downBtns.forEach((btn) => {
-      expect(btn.getAttribute("aria-label")).toBe("Move down");
+      expect(btn.getAttribute("aria-label")).toMatch(/^Move .+ down$/);
     });
   });
 
   it("remove-from-chain buttons have aria-label", async () => {
     await renderAndWait(makeAdminFetch());
-    const removeBtns = screen.getAllByTitle(/remove from chain/i);
+    const removeBtns = screen.getAllByTitle(/remove .+ from chain/i);
     expect(removeBtns.length).toBeGreaterThan(0);
     removeBtns.forEach((btn) => {
-      expect(btn.getAttribute("aria-label")).toBe("Remove from chain");
+      expect(btn.getAttribute("aria-label")).toMatch(/^Remove .+ from chain$/);
     });
   });
 

--- a/frontend/src/__tests__/QueueTabChainAriaLabels.test.ts
+++ b/frontend/src/__tests__/QueueTabChainAriaLabels.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Regression test for #1329: QueueTab chain reorder buttons must use unique
+ * aria-labels that include the model name, not static "Move up" / "Move down"
+ * / "Remove from chain" which repeat identically for every chain item.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/QueueTab.tsx"),
+  "utf8",
+);
+
+describe("QueueTab chain button unique aria-labels (closes #1329)", () => {
+  it('does not use static aria-label="Move up"', () => {
+    expect(src).not.toContain('aria-label="Move up"');
+  });
+
+  it('does not use static aria-label="Move down"', () => {
+    expect(src).not.toContain('aria-label="Move down"');
+  });
+
+  it('does not use static aria-label="Remove from chain"', () => {
+    expect(src).not.toContain('aria-label="Remove from chain"');
+  });
+
+  it("Move up button uses labelForModel(m) in its aria-label", () => {
+    expect(src).toMatch(
+      /aria-label=\{`Move \$\{labelForModel\(m\)\} up`\}/,
+    );
+  });
+
+  it("Move down button uses labelForModel(m) in its aria-label", () => {
+    expect(src).toMatch(
+      /aria-label=\{`Move \$\{labelForModel\(m\)\} down`\}/,
+    );
+  });
+
+  it("Remove button uses labelForModel(m) in its aria-label", () => {
+    expect(src).toMatch(
+      /aria-label=\{`Remove \$\{labelForModel\(m\)\} from chain`\}/,
+    );
+  });
+});

--- a/frontend/src/__tests__/QueueTabChainTouchTargets.test.ts
+++ b/frontend/src/__tests__/QueueTabChainTouchTargets.test.ts
@@ -23,14 +23,14 @@ describe("QueueTab model-chain button touch targets (closes #850)", () => {
   });
 
   it("Move up button has min-h-[44px]", () => {
-    checkAround('"Move up"');
+    checkAround("} up`}");
   });
 
   it("Move down button has min-h-[44px]", () => {
-    checkAround('"Move down"');
+    checkAround("} down`}");
   });
 
   it("Remove from chain button has min-h-[44px]", () => {
-    checkAround("Remove from chain");
+    checkAround("from chain`}");
   });
 });

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -1000,8 +1000,8 @@ export default function QueueTab({ adminFetch }: Props) {
                         }}
                         disabled={idx === 0}
                         className="text-xs min-h-[44px] min-w-[44px] flex items-center justify-center text-stone-500 hover:text-amber-700 disabled:opacity-30"
-                        title="Move up"
-                        aria-label="Move up"
+                        title={`Move ${labelForModel(m)} up`}
+                        aria-label={`Move ${labelForModel(m)} up`}
                       >
                         ↑
                       </button>
@@ -1014,8 +1014,8 @@ export default function QueueTab({ adminFetch }: Props) {
                         }}
                         disabled={idx === chain.length - 1}
                         className="text-xs min-h-[44px] min-w-[44px] flex items-center justify-center text-stone-500 hover:text-amber-700 disabled:opacity-30"
-                        title="Move down"
-                        aria-label="Move down"
+                        title={`Move ${labelForModel(m)} down`}
+                        aria-label={`Move ${labelForModel(m)} down`}
                       >
                         ↓
                       </button>
@@ -1023,8 +1023,8 @@ export default function QueueTab({ adminFetch }: Props) {
                     <button
                       onClick={() => setChain(chain.filter((_, i) => i !== idx))}
                       className="text-xs min-h-[44px] min-w-[44px] flex items-center justify-center rounded border border-red-200 text-red-500 shrink-0"
-                      title="Remove from chain"
-                      aria-label="Remove from chain"
+                      title={`Remove ${labelForModel(m)} from chain`}
+                      aria-label={`Remove ${labelForModel(m)} from chain`}
                     >
                       <CloseIcon aria-hidden="true" className="w-3 h-3" />
                     </button>


### PR DESCRIPTION
## What changed

In `components/QueueTab.tsx`, the model chain list renders three action buttons for each chain entry. All had static labels that repeated identically for every model in the chain — violating WCAG 2.4.6 (Labels or Instructions):

```tsx
// Before — every chain item shows these identical labels
aria-label="Move up"
aria-label="Move down"
aria-label="Remove from chain"

// After — includes model name via labelForModel(m)
aria-label={`Move ${labelForModel(m)} up`}
aria-label={`Move ${labelForModel(m)} down`}
aria-label={`Remove ${labelForModel(m)} from chain`}
```

The `title` attribute was updated to match in each case.

## Why

Screen readers announce all "Move up" buttons identically when 2+ models are in the chain, making reordering impossible for keyboard/screen-reader users. `labelForModel(m)` is already imported and used inline in this component.

## Test plan

- [x] New static assertion test `QueueTabChainAriaLabels.test.ts` confirms old static labels are gone and new dynamic pattern is present
- [x] Updated 5 existing test files to use `/move .+ up/i` / `/move .+ down/i` / `/remove .+ from chain/i` regex selectors
- [x] Full frontend suite: 2396 tests pass

Closes #1329
