### PR TITLE
fix: use per-stage aria-labels on import page progress bars (closes #1332)

### DIFF
--- a/frontend/src/__tests__/ImportPageProgressAriaLabel.test.ts
+++ b/frontend/src/__tests__/ImportPageProgressAriaLabel.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Regression test for #1332: import page stage progress bars must use unique,
+ * semantically accurate aria-labels (not the static "Chapter translation progress"
+ * which repeats for every stage and is wrong for the "fetching" stage).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/import/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe('Import page stage progress bar aria-labels (closes #1332)', () => {
+  it('does not use static aria-label="Chapter translation progress"', () => {
+    expect(src).not.toContain('aria-label="Chapter translation progress"');
+  });
+
+  it("uses STAGE_LABELS[stage] in the aria-label for unique per-stage labels", () => {
+    expect(src).toMatch(
+      /aria-label=\{`\$\{STAGE_LABELS\[stage\]\} progress`\}/,
+    );
+  });
+});

--- a/frontend/src/__tests__/ProgressBarAriaRoles.test.ts
+++ b/frontend/src/__tests__/ProgressBarAriaRoles.test.ts
@@ -13,14 +13,14 @@ describe("Import page chapter translation progress bar (closes #1251)", () => {
   const src = read("../app/import/[bookId]/page.tsx");
 
   it("has role=progressbar", () => {
-    const idx = src.indexOf("Chapter translation progress");
+    const idx = src.indexOf("STAGE_LABELS[stage]} progress`}");
     expect(idx).toBeGreaterThan(-1);
     const window = src.slice(Math.max(0, idx - 300), idx + 50);
     expect(window).toContain('role="progressbar"');
   });
 
   it("has aria-valuenow", () => {
-    const idx = src.indexOf("Chapter translation progress");
+    const idx = src.indexOf("STAGE_LABELS[stage]} progress`}");
     expect(idx).toBeGreaterThan(-1);
     const window = src.slice(Math.max(0, idx - 150), idx + 50);
     expect(window).toContain("aria-valuenow");

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -322,7 +322,7 @@ export default function BookImportPage() {
                           aria-valuemin={0}
                           aria-valuemax={100}
                           aria-valuenow={s.status === "done" ? 100 : Math.round(pct)}
-                          aria-label="Chapter translation progress"
+                          aria-label={`${STAGE_LABELS[stage]} progress`}
                         >
                           <div
                             className={`h-full rounded-full transition-all duration-150 ${


### PR DESCRIPTION
## What changed

The import page's stage progress bars all shared the static `aria-label="Chapter translation progress"`. This was wrong in two ways:
1. **Semantically inaccurate** — the "fetching" stage is downloading text, not translating chapters.
2. **Non-unique** — when multiple stages render simultaneously, screen readers encounter multiple identical progressbar labels with no way to distinguish them.

Changed to `aria-label={`${STAGE_LABELS[stage]} progress`}` which produces stage-specific labels:
- "Download text progress" (fetching stage)
- "Split chapters progress" (splitting stage)

## Why

WCAG 2.4.6 (Labels or Instructions) and 1.3.1 (Info and Relationships) — repeated controls in a list must have unique, accurate accessible names. Closes #1332.

## Test plan

- [x] New test `ImportPageProgressAriaLabel.test.ts`: asserts static label is gone and template literal is present
- [x] Updated `ProgressBarAriaRoles.test.ts`: fixed anchor string from old static label to new template literal pattern
- [x] All 2398 frontend tests pass
