### PR TITLE
fix: add role=img and aria-label to ReadingStats activity heatmap (closes #1334)

### DIFF
--- a/frontend/src/__tests__/ReadingStatsHeatmapAria.test.ts
+++ b/frontend/src/__tests__/ReadingStatsHeatmapAria.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Regression test for #1334: ReadingStats heatmap must have role="img"
+ * and a descriptive aria-label so screen readers announce the visualization.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/ReadingStats.tsx"),
+  "utf8",
+);
+
+describe("ReadingStats heatmap accessible text alternative (closes #1334)", () => {
+  it('heatmap container has role="img"', () => {
+    const idx = src.indexOf("Activity — last year");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 500), idx + 50);
+    expect(window).toContain('role="img"');
+  });
+
+  it("heatmap container has aria-label referencing activeDays", () => {
+    const idx = src.indexOf("Activity — last year");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 500), idx + 50);
+    expect(window).toContain("aria-label");
+    expect(window).toContain("activeDays");
+  });
+});

--- a/frontend/src/components/ReadingStats.tsx
+++ b/frontend/src/components/ReadingStats.tsx
@@ -144,7 +144,11 @@ export default function ReadingStats({ active, heatmapOnly = false }: Props) {
       )}
 
       {/* Activity heatmap */}
-      <div className="bg-white border border-amber-100 rounded-xl p-4">
+      <div
+        role="img"
+        aria-label={`Reading activity heatmap: ${activeDays} active ${activeDays === 1 ? "day" : "days"} in the last year`}
+        className="bg-white border border-amber-100 rounded-xl p-4"
+      >
         <div className="flex items-center justify-between mb-3">
           <p className="text-sm font-medium text-stone-700">Activity — last year</p>
           <p className="text-xs text-stone-400">


### PR DESCRIPTION
## What changed

Added `role="img"` and a descriptive `aria-label` to the reading activity heatmap container in `ReadingStats.tsx`.

**Before:** the heatmap was an unlabelled grid of `<div>` cells — screen readers received no meaningful description of the visualization.

**After:** the container announces: *"Reading activity heatmap: N active days in the last year"*.

## Why

WCAG 1.1.1 (Non-text Content) requires non-text content to have a text alternative. The `title` attributes on individual cells are not reliably announced by screen readers (especially on mobile/touch) and provide no high-level description of what the chart represents. `role="img"` with `aria-label` gives screen readers a concise, accurate summary. Closes #1334.

## Test plan

- [x] New test `ReadingStatsHeatmapAria.test.ts`: asserts `role="img"` and `aria-label` referencing `activeDays` exist within the heatmap region
- [x] All 2400 frontend tests pass
