### PR TITLE
fix: add aria-label to admin uploads table actions column header (closes #1337)

### DIFF
--- a/frontend/src/__tests__/AdminUploadsTableTh.test.ts
+++ b/frontend/src/__tests__/AdminUploadsTableTh.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Regression test for #1337: admin uploads table actions column header
+ * must have an accessible name so screen readers can identify the column.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/admin/uploads/page.tsx"),
+  "utf8",
+);
+
+describe("Admin uploads table actions column header (closes #1337)", () => {
+  it("has no <th> with empty body and no accessible name", () => {
+    // A th with no aria-label AND no visible text is inaccessible.
+    // The pattern captures: <th ...> </th> where the tag has no aria-label.
+    expect(src).not.toMatch(/<th(?![^>]*aria-label)[^>]*>\s*<\/th>/);
+  });
+
+  it("actions column th has aria-label=\"Actions\"", () => {
+    expect(src).toContain('aria-label="Actions"');
+  });
+});

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -145,7 +145,7 @@ export default function UploadsPage() {
                   <th scope="col" className="px-4 py-2.5 text-left font-medium text-amber-800">Size</th>
                   <th scope="col" className="px-4 py-2.5 text-left font-medium text-amber-800">Uploader</th>
                   <th scope="col" className="px-4 py-2.5 text-left font-medium text-amber-800">Date</th>
-                  <th scope="col" className="px-4 py-2.5 text-left font-medium text-amber-800"></th>
+                  <th scope="col" className="px-4 py-2.5 text-left font-medium text-amber-800" aria-label="Actions"></th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-amber-100">


### PR DESCRIPTION
## What changed

Added `aria-label="Actions"` to the empty seventh `<th>` in the admin uploads table.

## Why

The actions column header had no accessible name — screen readers would announce an unnamed column, breaking the table's data relationship for blind users (WCAG 1.3.1 Info and Relationships). Adding `aria-label="Actions"` gives the column a machine-readable name without cluttering the visual UI. Closes #1337.

## Test plan

- [x] New test `AdminUploadsTableTh.test.ts`: asserts no `<th>` exists with empty body and no `aria-label`, and that `aria-label="Actions"` is present
- [x] All 2400 frontend tests pass
