### PR TITLE
test: remove duplicate test function in test_router_vocabulary.py (closes #1335)

### DIFF
--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -752,15 +752,6 @@ async def test_save_word_negative_book_id_returns_422(client, test_user):
 # ── Issue #734: ge=1 on ExportRequest.book_id ─────────────────────────────────
 
 
-async def test_save_word_negative_book_id_returns_422(client, test_user):
-    """Regression #731: POST /vocabulary with book_id < 1 must return 422."""
-    resp = await client.post("/api/vocabulary", json={
-        "word": "hello", "book_id": -1, "chapter_index": 0,
-        "sentence_text": "Hello world.",
-    })
-    assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.text}"
-
-
 async def test_export_obsidian_negative_book_id_returns_422(client, test_user):
     """Regression #734: POST /vocabulary/export/obsidian with book_id < 1 must return 422."""
     resp = await client.post("/api/vocabulary/export/obsidian", json={"book_id": -1})


### PR DESCRIPTION
## What changed

Removed a duplicate definition of `test_save_word_negative_book_id_returns_422` in `backend/tests/test_router_vocabulary.py` (the second copy at line 755 was identical to the first at line 743).

## Why

Python silently overwrites the first function with the second when two functions share the same name in a module, making the first definition dead code. The issue #731 regression test was never actually executing. Coverage confirmed this: lines 745–749 of the test file were always uncovered.

The duplicate was introduced when the `#734` section header was copy-pasted — the body wasn't updated to a new test. The actual #734 test (`test_export_obsidian_negative_book_id_returns_422`) already exists correctly below.

## Test plan

- [x] `pytest tests/test_router_vocabulary.py` — 48 passed (same count; the duplicate ran but was identical so no net change in pass/fail)
- [x] Full backend suite: 1649 passed, 0 failed
- [x] No source code changed — pure test-file cleanup

Closes #1335
