### PR TITLE
fix: add role=dialog and aria-controls to TypographyPanel (closes #1340)

### DIFF
--- a/frontend/src/__tests__/ReaderMiscSmallButtonsTouchTargets.test.ts
+++ b/frontend/src/__tests__/ReaderMiscSmallButtonsTouchTargets.test.ts
@@ -20,7 +20,7 @@ describe("reader miscellaneous small button touch targets (closes #882)", () => 
   });
 
   it("Typography Aa panel toggle has min-h-[44px]", () => {
-    checkForward('"Typography settings"');
+    checkForward('"Typography settings"', 260);
   });
 
   it("Notes sidebar chapter-section collapse button has min-h-[44px]", () => {

--- a/frontend/src/__tests__/TypographyPanelRole.test.ts
+++ b/frontend/src/__tests__/TypographyPanelRole.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression test for #1340: TypographyPanel must have role="dialog" and
+ * aria-label so screen readers announce the floating settings panel, and
+ * the reader trigger buttons must have aria-controls pointing to the panel.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const panelSrc = fs.readFileSync(
+  path.join(__dirname, "../components/TypographyPanel.tsx"),
+  "utf8",
+);
+
+const readerSrc = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("TypographyPanel accessible panel semantics (closes #1340)", () => {
+  it('panel root has role="dialog"', () => {
+    expect(panelSrc).toContain('role="dialog"');
+  });
+
+  it("panel root has aria-label", () => {
+    expect(panelSrc).toContain('aria-label="Typography settings"');
+  });
+
+  it('panel root has id="typography-panel"', () => {
+    expect(panelSrc).toContain('id="typography-panel"');
+  });
+
+  it('reader trigger buttons have aria-controls="typography-panel"', () => {
+    expect(readerSrc).toContain('aria-controls="typography-panel"');
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -878,6 +878,7 @@ export default function ReaderPage() {
               }}
               aria-label="Typography settings"
               aria-expanded={showTypographyPanel}
+              aria-controls="typography-panel"
               className="px-2 py-1 rounded-full hover:bg-amber-50 transition-colors font-bold min-h-[44px]"
               title="Typography"
             >Aa</button>
@@ -1004,6 +1005,7 @@ export default function ReaderPage() {
               title="Typography settings"
               aria-label="Typography settings"
               aria-expanded={showTypographyPanel}
+              aria-controls="typography-panel"
               className={`flex shrink-0 items-center gap-1 px-2 py-1 min-h-[44px] md:min-h-0 rounded-lg border text-xs font-bold transition-colors ${
                 showTypographyPanel || paragraphFocus
                   ? "bg-amber-100 border-amber-400 text-amber-800"

--- a/frontend/src/components/TypographyPanel.tsx
+++ b/frontend/src/components/TypographyPanel.tsx
@@ -128,6 +128,9 @@ export default function TypographyPanel({
   return (
     <div
       ref={panelRef}
+      id="typography-panel"
+      role="dialog"
+      aria-label="Typography settings"
       style={fixedStyle}
       className={`${anchorPos ? "" : "absolute top-full right-0 mt-1 z-50 "}bg-white border border-amber-200 rounded-xl shadow-lg p-4 w-64 animate-fade-in`}
       data-testid="typography-panel"


### PR DESCRIPTION
## What changed

- `TypographyPanel.tsx`: Added `id="typography-panel"`, `role="dialog"`, and `aria-label="Typography settings"` to the floating panel root `<div>`.
- `reader/[bookId]/page.tsx`: Added `aria-controls="typography-panel"` to both Aa trigger buttons (focus-mode header and normal header).
- `ReaderMiscSmallButtonsTouchTargets.test.ts`: Widened the forward-scan radius from 200→260 chars for the Typography button test to accommodate the new `aria-controls` attribute.
- Added `TypographyPanelRole.test.ts` with 4 assertions covering `role`, `aria-label`, `id`, and `aria-controls`.

## Why

The floating settings panel had no ARIA role or accessible name. Screen readers could not identify it as a discrete interactive region. The trigger buttons had `aria-expanded` but lacked `aria-controls`, so assistive technology could not programmatically navigate from button to panel. WCAG 4.1.2 (Name, Role, Value, Level A).

## Test plan

- [x] 4 new static assertions in `TypographyPanelRole.test.ts` all pass
- [x] Existing `ReaderMiscSmallButtonsTouchTargets.test.ts` continues to pass (radius widened)
- [x] Full frontend suite: 2406 tests pass
- [x] Full backend suite: 1382 tests pass

Closes #1340
