### PR TITLE
fix: fix WCAG 1.4.3 contrast failures on flashcards page (closes #1342)

### DIFF
--- a/frontend/src/__tests__/FlashcardContrast.test.ts
+++ b/frontend/src/__tests__/FlashcardContrast.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Regression test for #1342: flashcards page WCAG 1.4.3 contrast failures.
+ * White on amber-500 (2.09:1) and stone-400 on white (2.45:1) both fail AA.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/flashcards/page.tsx"),
+  "utf8",
+);
+
+describe("Flashcard page contrast (closes #1342)", () => {
+  it("Show Answer button does not use bg-amber-500 (2.09:1 contrast fail)", () => {
+    // bg-amber-500 with text-white fails WCAG AA (white on amber-500 = ~2.09:1)
+    expect(src).not.toContain("bg-amber-500 text-white");
+  });
+
+  it("Show Answer button uses bg-amber-700 (5.07:1 contrast pass)", () => {
+    expect(src).toContain("bg-amber-700");
+  });
+
+  it("card type labels and counters do not use text-stone-400 (2.45:1 contrast fail)", () => {
+    // No text-xs text-stone-400 used for informational card text
+    expect(src).not.toMatch(/text-xs text-stone-400/);
+  });
+});

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -208,7 +208,7 @@ export default function FlashcardsPage() {
             </p>
             <button
               onClick={() => router.push("/vocabulary")}
-              className="mt-2 px-5 py-2.5 bg-amber-500 text-white rounded-lg font-medium hover:bg-amber-600 transition-colors min-h-[44px]"
+              className="mt-2 px-5 py-2.5 bg-amber-700 text-white rounded-lg font-medium hover:bg-amber-800 transition-colors min-h-[44px]"
             >
               Back to Vocabulary
             </button>
@@ -225,7 +225,7 @@ export default function FlashcardsPage() {
               className="cursor-pointer rounded-2xl border border-amber-200 bg-white p-8 min-h-[200px] flex flex-col items-center justify-center gap-3 hover:-translate-y-0.5 transition-all duration-200 select-none"
               style={{ boxShadow: "var(--shadow-card)" }}
             >
-              <span className="text-xs text-stone-400 uppercase tracking-wide">
+              <span className="text-xs text-stone-500 uppercase tracking-wide">
                 {flipped ? "Definition" : "Word"}
               </span>
               {!flipped ? (
@@ -240,7 +240,7 @@ export default function FlashcardsPage() {
                 </div>
               )}
               {!flipped && (
-                <span className="text-xs text-stone-400 mt-2">tap to reveal</span>
+                <span className="text-xs text-stone-500 mt-2">tap to reveal</span>
               )}
             </div>
 
@@ -265,7 +265,7 @@ export default function FlashcardsPage() {
               <div className="flex justify-center">
                 <button
                   onClick={() => setFlipped(true)}
-                  className="px-6 py-3 bg-amber-500 text-white rounded-xl font-medium hover:bg-amber-600 transition-colors min-h-[44px]"
+                  className="px-6 py-3 bg-amber-700 text-white rounded-xl font-medium hover:bg-amber-800 transition-colors min-h-[44px]"
                 >
                   Show answer
                 </button>
@@ -273,7 +273,7 @@ export default function FlashcardsPage() {
             )}
 
             {/* Card counter */}
-            <p className="text-center text-xs text-stone-400">
+            <p className="text-center text-xs text-stone-500">
               {currentIndex + 1} of {cards.length} remaining
             </p>
           </div>


### PR DESCRIPTION
## What changed
Fixes five WCAG 1.4.3 (Contrast Minimum, Level AA) failures on the flashcards page.

| Element | Before | After | Old ratio | New ratio |
|---|---|---|---|---|
| "Show answer" button | `bg-amber-500 text-white` | `bg-amber-700 text-white` | 2.09:1 ❌ | 5.07:1 ✅ |
| "Back to Vocabulary" button | `bg-amber-500 text-white` | `bg-amber-700 text-white` | 2.09:1 ❌ | 5.07:1 ✅ |
| Card type label ("Word" / "Definition") | `text-stone-400` | `text-stone-500` | 2.45:1 ❌ | 4.86:1 ✅ |
| "tap to reveal" hint | `text-stone-400` | `text-stone-500` | 2.45:1 ❌ | 4.86:1 ✅ |
| Card counter ("1 of N remaining") | `text-stone-400` | `text-stone-500` | 2.45:1 ❌ | 4.86:1 ✅ |

## Why
WCAG AA requires 4.5:1 contrast for normal text (including 12 px / `text-xs`). White on `amber-500` and `stone-400` on white both fall below that threshold, making these labels and buttons inaccessible to low-vision users.

## Test plan
- New `FlashcardContrast.test.ts` (3 assertions): verifies no `bg-amber-500 text-white` remains, `bg-amber-700` is present, and no `text-xs text-stone-400` is used for informational text.
- All 2407 frontend tests pass.

Closes #1342

[ ] Docs updated (if applicable)
