### PR TITLE
fix: fix WCAG 1.4.3 contrast failures on homepage (closes #1345)

### DIFF
--- a/frontend/src/__tests__/HomepageContrast.test.ts
+++ b/frontend/src/__tests__/HomepageContrast.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Regression test for #1345: homepage WCAG 1.4.3 contrast failures.
+ * text-stone-400 on white = 2.65:1 — fails AA. text-stone-500 = 4.86:1 — passes.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/page.tsx"),
+  "utf8",
+);
+
+describe("Homepage contrast (closes #1345)", () => {
+  it("section headers do not use text-stone-400 (2.65:1 contrast fail)", () => {
+    // h2 section labels "Continue Reading", "Your Progress", "Your Library"
+    expect(src).not.toMatch(/text-xs[^"]*text-stone-400/);
+  });
+
+  it("stat card labels do not use text-stone-400 (2.65:1 contrast fail)", () => {
+    // "day streak", "books started", "words saved", "annotations" at text-[10px]
+    expect(src).not.toMatch(/text-\[10px\][^"]*text-stone-400|text-stone-400[^"]*text-\[10px\]/);
+  });
+
+  it("book metadata does not use text-xs text-stone-400 (2.65:1 contrast fail)", () => {
+    // "Chapter N · 2h ago" metadata line
+    expect(src).not.toContain("text-xs text-stone-400");
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -282,7 +282,7 @@ export default function Home() {
             {/* Continue Reading */}
             {recentBooks.length > 0 && (
               <section>
-                <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-400 mb-2">
+                <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-500 mb-2">
                   Continue Reading
                 </h2>
                 <button
@@ -306,7 +306,7 @@ export default function Home() {
                   <div className="flex-1 min-w-0">
                     <p className="font-serif font-semibold text-sm text-ink line-clamp-1">{recentBooks[0].title}</p>
                     <p className="text-xs text-amber-700 mt-0.5 line-clamp-1">{recentBooks[0].authors?.join(", ")}</p>
-                    <p className="text-xs text-stone-400 mt-1">
+                    <p className="text-xs text-stone-500 mt-1">
                       Chapter {recentBooks[0].lastChapter + 1} · {timeAgo(recentBooks[0].lastRead)}
                     </p>
                   </div>
@@ -319,7 +319,7 @@ export default function Home() {
             {status === "authenticated" && userStats && (
               <section>
                 <div className="flex items-center gap-2 mb-3">
-                  <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-400 flex-1">
+                  <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-500 flex-1">
                     Your Progress
                   </h2>
                   <button
@@ -337,7 +337,7 @@ export default function Home() {
                       <FireIcon className="w-5 h-5 text-amber-600 shrink-0" />
                       <div>
                         <p className="text-lg font-bold text-amber-900 leading-none">{userStats.streak}</p>
-                        <p className="text-[10px] text-stone-400 mt-0.5">day streak</p>
+                        <p className="text-[10px] text-stone-500 mt-0.5">day streak</p>
                       </div>
                     </div>
                   )}
@@ -345,21 +345,21 @@ export default function Home() {
                     <BookOpenIcon className="w-5 h-5 text-amber-600 shrink-0" />
                     <div>
                       <p className="text-lg font-bold text-stone-800 leading-none">{userStats.totals.books_started}</p>
-                      <p className="text-[10px] text-stone-400 mt-0.5">books started</p>
+                      <p className="text-[10px] text-stone-500 mt-0.5">books started</p>
                     </div>
                   </div>
                   <div className="bg-white rounded-xl border border-amber-100 px-4 py-3 flex items-center gap-3">
                     <VocabIcon className="w-5 h-5 text-amber-600 shrink-0" />
                     <div>
                       <p className="text-lg font-bold text-stone-800 leading-none">{userStats.totals.vocabulary_words}</p>
-                      <p className="text-[10px] text-stone-400 mt-0.5">words saved</p>
+                      <p className="text-[10px] text-stone-500 mt-0.5">words saved</p>
                     </div>
                   </div>
                   <div className="bg-white rounded-xl border border-amber-100 px-4 py-3 flex items-center gap-3">
                     <NoteIcon className="w-5 h-5 text-amber-600 shrink-0" />
                     <div>
                       <p className="text-lg font-bold text-stone-800 leading-none">{userStats.totals.annotations}</p>
-                      <p className="text-[10px] text-stone-400 mt-0.5">annotations</p>
+                      <p className="text-[10px] text-stone-500 mt-0.5">annotations</p>
                     </div>
                   </div>
                 </div>
@@ -377,7 +377,7 @@ export default function Home() {
             {recentBooks.length > 0 ? (
               <section>
                 {recentBooks.length > 1 && (
-                  <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-400 mb-3">
+                  <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-500 mb-3">
                     Your Library
                   </h2>
                 )}


### PR DESCRIPTION
## What changed
Fixes eight WCAG 1.4.3 (Contrast Minimum, Level AA) failures on the homepage (`app/page.tsx`).

All affected elements used `text-stone-400` (#a8a29e) on white backgrounds — contrast ratio **2.65:1**, failing the 4.5:1 AA threshold for normal text at all sizes.

| Element | Fix |
|---|---|
| "Continue Reading" section header (`h2 text-xs`) | `text-stone-400` → `text-stone-500` |
| Book metadata "Chapter N · time ago" (`text-xs`) | `text-stone-400` → `text-stone-500` |
| "Your Progress" section header (`h2 text-xs`) | `text-stone-400` → `text-stone-500` |
| "day streak" stat label (`text-[10px]`) | `text-stone-400` → `text-stone-500` |
| "books started" stat label (`text-[10px]`) | `text-stone-400` → `text-stone-500` |
| "words saved" stat label (`text-[10px]`) | `text-stone-400` → `text-stone-500` |
| "annotations" stat label (`text-[10px]`) | `text-stone-400` → `text-stone-500` |
| "Your Library" section header (`h2 text-xs`) | `text-stone-400` → `text-stone-500` |

`text-stone-500` (#78716c) on white = **4.86:1** — passes AA.

## Why
WCAG AA requires 4.5:1 for normal text at any size, including `text-xs` (12 px) and `text-[10px]`. Stone-400 on white is below 3:1, failing even the large-text threshold.

## Test plan
New `HomepageContrast.test.ts` (3 assertions) verifies no `text-xs text-stone-400`, `text-[10px] text-stone-400`, or `text-xs text-stone-400` patterns remain in `page.tsx`. All 2411 frontend tests pass.

Closes #1345

- [ ] Docs updated (if applicable)
