### PR TITLE
fix: fix WCAG 1.4.3 contrast failures in decks and notes pages (closes #1347)

### DIFF
--- a/frontend/src/__tests__/DecksNotesContrast.test.ts
+++ b/frontend/src/__tests__/DecksNotesContrast.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression test for #1347: decks and notes pages WCAG 1.4.3 contrast failures.
+ * text-stone-400 on white = 2.65:1 — fails AA. text-stone-500 = 4.86:1 — passes.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const decksPage = fs.readFileSync(
+  path.join(__dirname, "../app/decks/page.tsx"),
+  "utf8",
+);
+const deckDetailPage = fs.readFileSync(
+  path.join(__dirname, "../app/decks/[deckId]/page.tsx"),
+  "utf8",
+);
+const notesPage = fs.readFileSync(
+  path.join(__dirname, "../app/notes/page.tsx"),
+  "utf8",
+);
+const notesDetailPage = fs.readFileSync(
+  path.join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Decks and notes pages contrast (closes #1347)", () => {
+  it("decks/page.tsx has no text-xs text-stone-400 (2.65:1 fail)", () => {
+    expect(decksPage).not.toMatch(/text-xs[^"]*text-stone-400|text-stone-400[^"]*text-xs/);
+  });
+
+  it("decks/page.tsx has no text-sm text-stone-400 (2.65:1 fail)", () => {
+    expect(decksPage).not.toMatch(/text-sm[^"]*text-stone-400|text-stone-400[^"]*text-sm/);
+  });
+
+  it("decks/[deckId]/page.tsx has no text-xs text-stone-400 (2.65:1 fail)", () => {
+    expect(deckDetailPage).not.toMatch(/text-xs[^"]*text-stone-400|text-stone-400[^"]*text-xs/);
+  });
+
+  it("decks/[deckId]/page.tsx has no text-sm text-stone-400 (2.65:1 fail)", () => {
+    // Use word-boundary check to avoid matching placeholder:text-stone-400 in the same className
+    expect(deckDetailPage).not.toContain('"text-sm text-stone-400');
+    expect(deckDetailPage).not.toContain('"text-stone-400 text-sm');
+  });
+
+  it("notes/page.tsx has no text-xs text-stone-400 (2.65:1 fail)", () => {
+    expect(notesPage).not.toMatch(/text-xs[^"]*text-stone-400|text-stone-400[^"]*text-xs/);
+  });
+
+  it("notes/[bookId]/page.tsx has no text-xs text-stone-400 (2.65:1 fail)", () => {
+    expect(notesDetailPage).not.toMatch(/text-xs[^"]*text-stone-400|text-stone-400[^"]*text-xs/);
+  });
+});

--- a/frontend/src/app/decks/[deckId]/page.tsx
+++ b/frontend/src/app/decks/[deckId]/page.tsx
@@ -129,7 +129,7 @@ export default function DeckDetailPage() {
             {deck?.name ?? "Deck"}
           </h1>
           {deck && (
-            <p className="text-xs text-stone-400 mt-0.5">
+            <p className="text-xs text-stone-500 mt-0.5">
               {deck.members.length} word{deck.members.length !== 1 ? "s" : ""}
               {deck.mode === "smart" ? " · smart" : ""}
             </p>
@@ -195,7 +195,7 @@ export default function DeckDetailPage() {
                 <p className="font-serif text-lg text-stone-500 mt-1">
                   No words in this deck yet.
                 </p>
-                <p className="text-sm text-stone-400 max-w-xs">
+                <p className="text-sm text-stone-500 max-w-xs">
                   {isManual
                     ? "Add words from your vocabulary to study them as a focused set."
                     : "This smart deck has no matching words yet — saved vocabulary that matches the rules will appear here."}
@@ -236,7 +236,7 @@ export default function DeckDetailPage() {
                       {w.word}
                     </span>
                     {w.language && (
-                      <span className="text-xs uppercase tracking-wide text-stone-400 shrink-0">
+                      <span className="text-xs uppercase tracking-wide text-stone-500 shrink-0">
                         {w.language}
                       </span>
                     )}
@@ -388,7 +388,7 @@ function AddWordPicker({ candidates, onClose, onAdd }: AddWordPickerProps) {
                       {w.word}
                     </span>
                     {w.language && (
-                      <span className="text-xs uppercase tracking-wide text-stone-400 shrink-0">
+                      <span className="text-xs uppercase tracking-wide text-stone-500 shrink-0">
                         {w.language}
                       </span>
                     )}

--- a/frontend/src/app/decks/page.tsx
+++ b/frontend/src/app/decks/page.tsx
@@ -69,7 +69,7 @@ export default function DecksPage() {
         <div className="flex-1 min-w-0">
           <h1 className="font-serif font-bold text-ink truncate">Decks</h1>
           {!loading && !error && (
-            <p className="text-xs text-stone-400 mt-0.5">
+            <p className="text-xs text-stone-500 mt-0.5">
               {decks.length} deck{decks.length !== 1 ? "s" : ""}
             </p>
           )}
@@ -104,7 +104,7 @@ export default function DecksPage() {
           >
             <DeckIcon className="w-14 h-14 text-amber-300" />
             <p className="font-serif text-lg text-stone-500 mt-1">No study decks yet.</p>
-            <p className="text-sm text-stone-400 max-w-xs">
+            <p className="text-sm text-stone-500 max-w-xs">
               Build focused review lists from your saved vocabulary. Start with a manual
               deck — pick a few words and study just them.
             </p>

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -232,7 +232,7 @@ function VocabRow({
         >
           {word}
         </a>{" "}
-        <span className="text-stone-400 text-xs">({chapterLabel(chapters, occurrence.chapter_index)})</span>
+        <span className="text-stone-500 text-xs">({chapterLabel(chapters, occurrence.chapter_index)})</span>
         {" — "}
         <a
           href={readerHref}
@@ -636,7 +636,7 @@ export default function BookNotesPage() {
           </button>
 
           <div className="flex-1 min-w-0">
-            <p className="text-xs text-stone-400 truncate">
+            <p className="text-xs text-stone-500 truncate">
               {annCount} annotations · {insCount} insights · {vocCount} words
             </p>
           </div>
@@ -645,7 +645,7 @@ export default function BookNotesPage() {
           {(annCount + insCount + vocCount) > 0 && !loading && (
             <button
               onClick={toggleCollapseAll}
-              className="text-xs text-stone-400 hover:text-stone-600 shrink-0 transition-colors min-h-[44px]"
+              className="text-xs text-stone-500 hover:text-stone-600 shrink-0 transition-colors min-h-[44px]"
             >
               {isAllCollapsed ? "Expand all" : "Collapse all"}
             </button>
@@ -695,12 +695,12 @@ export default function BookNotesPage() {
             <span className="w-6 h-6 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
           </div>
         ) : fetchError ? (
-          <div role="alert" className="text-center text-stone-400 mt-20 flex flex-col items-center gap-2">
+          <div role="alert" className="text-center text-stone-500 mt-20 flex flex-col items-center gap-2">
             <p className="font-serif text-lg text-red-500 mt-1">Failed to load notes.</p>
             <p className="text-sm">Please refresh the page to try again.</p>
           </div>
         ) : annCount + insCount + vocCount === 0 ? (
-          <div className="text-center py-24 text-stone-400">
+          <div className="text-center py-24 text-stone-500">
             <EmptyNotesIcon className="w-16 h-16 mx-auto mb-3 text-amber-300" aria-hidden="true" />
             <p className="font-serif text-lg text-ink mb-1">No notes yet</p>
             <p className="text-sm">Annotate sentences, save AI insights, or add words to vocabulary while reading.</p>

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -146,12 +146,12 @@ export default function NotesOverviewPage() {
             <span className="w-6 h-6 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
           </div>
         ) : fetchError ? (
-          <div role="alert" className="text-center text-stone-400 mt-20 flex flex-col items-center gap-2">
+          <div role="alert" className="text-center text-stone-500 mt-20 flex flex-col items-center gap-2">
             <p className="font-serif text-lg text-red-500 mt-1">Failed to load notes.</p>
             <p className="text-sm">Please refresh the page to try again.</p>
           </div>
         ) : filtered.length === 0 ? (
-          <div className="text-center py-20 text-stone-400">
+          <div className="text-center py-20 text-stone-500">
             <EmptyNotesIcon className="w-14 h-14 mx-auto mb-4 text-amber-400/60" />
             {books.length === 0 ? (
               <>
@@ -204,7 +204,7 @@ export default function NotesOverviewPage() {
                     </div>
                   </div>
                   <div className="shrink-0 text-right">
-                    <span className="text-xs text-stone-400">{timeAgo(book.lastActivity)}</span>
+                    <span className="text-xs text-stone-500">{timeAgo(book.lastActivity)}</span>
                     <p className="text-amber-600 group-hover:text-amber-800 mt-0.5"><ArrowRightIcon className="w-5 h-5" aria-hidden="true" /></p>
                   </div>
                 </div>


### PR DESCRIPTION
## What changed
Fixes WCAG 1.4.3 (Contrast Minimum, Level AA) failures across the decks and notes pages. All changes replace `text-stone-400` (#a8a29e, 2.65:1 on white) with `text-stone-500` (#78716c, 4.86:1 — passes AA).

### `decks/page.tsx`
- Count label ("N decks") — `text-xs`
- Empty-state description — `text-sm`

### `decks/[deckId]/page.tsx`
- Word-count subtitle ("N words · smart") — `text-xs`
- Empty-state description — `text-sm`
- Language tag labels — `text-xs uppercase`

### `notes/page.tsx`
- Error state container (inherits stone-400 to child text)
- Empty state container
- "time ago" label — `text-xs`

### `notes/[bookId]/page.tsx`
- Chapter location label — `text-xs`
- Stats summary ("N annotations · N insights · N words") — `text-xs`
- "Collapse all / Expand all" button — `text-xs`
- Error state and empty state containers

## Why
WCAG AA requires 4.5:1 contrast for normal text at any size. Stone-400 on white (2.65:1) fails even the 3:1 large-text threshold. Affects all users in bright environments and users with low-contrast vision.

## Test plan
New `DecksNotesContrast.test.ts` (6 assertions) verifies no `text-xs text-stone-400` or `text-sm text-stone-400` patterns remain in any of the four affected files. All 2414 frontend tests pass.

Closes #1347

- [ ] Docs updated (if applicable)
