### PR TITLE
chore: extract duplicated auto-admin logic into _new_user_role_approved helper (closes #1343)

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -119,6 +119,18 @@ async def init_db() -> None:
         )
 
 
+async def _new_user_role_approved(db) -> tuple[str, int]:
+    """Return (role, approved) for a brand-new user registration.
+
+    The very first user ever registered automatically becomes admin and is
+    pre-approved so the app is usable out of the box.  All subsequent users
+    start as role='user', approved=0 (pending manual approval by an admin).
+    """
+    async with db.execute("SELECT COUNT(*) FROM users") as cursor:
+        count = (await cursor.fetchone())[0]
+    return ("admin", 1) if count == 0 else ("user", 0)
+
+
 async def get_or_create_user(google_id: str, email: str, name: str, picture: str) -> dict:
     """Return existing user or create a new one.
 
@@ -143,16 +155,10 @@ async def get_or_create_user(google_id: str, email: str, name: str, picture: str
                 row = await cur.fetchone()
             return dict(row)
 
-        # New user — check if this is the very first user (auto-admin)
-        async with db.execute("SELECT COUNT(*) FROM users") as cursor:
-            count = (await cursor.fetchone())[0]
-        is_first = count == 0
-
+        role, approved = await _new_user_role_approved(db)
         await db.execute(
             "INSERT INTO users (google_id, email, name, picture, role, approved) VALUES (?,?,?,?,?,?)",
-            (google_id, email, name, picture,
-             "admin" if is_first else "user",
-             1 if is_first else 0),
+            (google_id, email, name, picture, role, approved),
         )
         async with db.execute(
             "SELECT * FROM users WHERE google_id = ?", (google_id,)
@@ -198,16 +204,10 @@ async def get_or_create_user_github(github_id: str, email: str, name: str, pictu
                     row = await cur.fetchone()
                 return dict(row)
 
-        # New user
-        async with db.execute("SELECT COUNT(*) FROM users") as cursor:
-            count = (await cursor.fetchone())[0]
-        is_first = count == 0
-
+        role, approved = await _new_user_role_approved(db)
         await db.execute(
             "INSERT INTO users (google_id, github_id, email, name, picture, role, approved) VALUES (?,?,?,?,?,?,?)",
-            (f"github:{github_id}", github_id, email, name, picture,
-             "admin" if is_first else "user",
-             1 if is_first else 0),
+            (f"github:{github_id}", github_id, email, name, picture, role, approved),
         )
         async with db.execute("SELECT * FROM users WHERE github_id = ?", (github_id,)) as cursor:
             row = await cursor.fetchone()
@@ -252,16 +252,10 @@ async def get_or_create_user_apple(apple_id: str, email: str, name: str) -> dict
                 updated["apple_id"] = apple_id
                 return updated
 
-        # New user
-        async with db.execute("SELECT COUNT(*) FROM users") as cursor:
-            count = (await cursor.fetchone())[0]
-        is_first = count == 0
-
+        role, approved = await _new_user_role_approved(db)
         await db.execute(
             "INSERT INTO users (google_id, apple_id, email, name, role, approved) VALUES (?,?,?,?,?,?)",
-            (f"apple:{apple_id}", apple_id, email, name,
-             "admin" if is_first else "user",
-             1 if is_first else 0),
+            (f"apple:{apple_id}", apple_id, email, name, role, approved),
         )
         async with db.execute("SELECT * FROM users WHERE apple_id = ?", (apple_id,)) as cursor:
             row = await cursor.fetchone()

--- a/backend/tests/test_db_extended.py
+++ b/backend/tests/test_db_extended.py
@@ -8,6 +8,7 @@ import pytest
 import services.db as db_module
 from services.db import (
     init_db,
+    _new_user_role_approved,
     get_or_create_user,
     get_or_create_user_github,
     get_or_create_user_apple,
@@ -159,6 +160,29 @@ async def test_apple_no_email_skips_linking():
     # Should create a new user, not link
     existing = await get_or_create_user("g201", "existing@example.com", "Existing", "")
     assert new_user["id"] != existing["id"]
+
+
+# ── _new_user_role_approved helper ────────────────────────────────────────────
+
+async def test_new_user_role_approved_first_user_gets_admin():
+    """Regression #1343: first user ever must get role=admin, approved=1."""
+    import aiosqlite
+    import services.db as db_module
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        role, approved = await _new_user_role_approved(db)
+    assert role == "admin"
+    assert approved == 1
+
+
+async def test_new_user_role_approved_subsequent_user_gets_user():
+    """Regression #1343: second+ user must get role=user, approved=0."""
+    await get_or_create_user("seed-g1", "seed@example.com", "Seed", "")
+    import aiosqlite
+    import services.db as db_module
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        role, approved = await _new_user_role_approved(db)
+    assert role == "user"
+    assert approved == 0
 
 
 # ── User management ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## What changed

Extracted the duplicated "is this the first-ever user?" auto-admin logic from three `get_or_create_user*` functions in `backend/services/db.py` into a single private helper `_new_user_role_approved(db)`.

Before this change, the following block was copy-pasted verbatim in `get_or_create_user` (Google), `get_or_create_user_github`, and `get_or_create_user_apple`:

```python
async with db.execute("SELECT COUNT(*) FROM users") as cursor:
    count = (await cursor.fetchone())[0]
is_first = count == 0
# ...
"admin" if is_first else "user",
1 if is_first else 0,
```

## Why

Single source of truth for the first-user invariant. Any future change to the rule (e.g. seeding an initial admin differently) only needs to happen in one place.

## Test plan

- `test_new_user_role_approved_first_user_gets_admin`: calls the helper directly on an empty DB; asserts role=admin, approved=1.
- `test_new_user_role_approved_subsequent_user_gets_user`: seeds one user first; asserts role=user, approved=0.
- All 50 existing `test_db_extended.py` tests continue to pass (GitHub/Apple auth, user management).
- Full backend suite: 1651 passed.

Closes #1343
