### PR TITLE
fix: add missing 404 tests for deck member ops on non-existent deck (closes #1351)

### DIFF
--- a/backend/tests/test_router_decks.py
+++ b/backend/tests/test_router_decks.py
@@ -221,6 +221,14 @@ async def test_add_member_404_for_foreign_word(client, test_user):
     assert resp.status_code == 404
 
 
+async def test_add_member_404_for_nonexistent_deck(client, test_user):
+    """Regression #1351: add member to a deck that doesn't exist must return 404."""
+    await _book()
+    vid = await _save("orphan", test_user["id"])
+    resp = await client.post("/api/decks/9999/members", json={"vocabulary_id": vid})
+    assert resp.status_code == 404
+
+
 async def test_remove_member(client, test_user):
     await _book()
     vid = await _save("removable", test_user["id"])
@@ -232,6 +240,14 @@ async def test_remove_member(client, test_user):
 
     refreshed = (await client.get(f"/api/decks/{deck['id']}")).json()
     assert refreshed["members"] == []
+
+
+async def test_remove_member_404_for_nonexistent_deck(client, test_user):
+    """Regression #1351: remove member from a deck that doesn't exist must return 404."""
+    await _book()
+    vid = await _save("ghost", test_user["id"])
+    resp = await client.delete(f"/api/decks/9999/members/{vid}")
+    assert resp.status_code == 404
 
 
 # ── Smart deck rule resolution ──────────────────────────────────────────────


### PR DESCRIPTION
## What changed

Added two missing regression tests in `backend/tests/test_router_decks.py`:

1. `test_add_member_404_for_nonexistent_deck` — `POST /api/decks/9999/members` with a valid `vocabulary_id` but a deck that doesn't exist must return 404.
2. `test_remove_member_404_for_nonexistent_deck` — `DELETE /api/decks/9999/members/{vid}` when the deck doesn't exist must return 404.

## Why

`add_manual_member` (line 194) and `remove_manual_member` (line 219) in `services/decks.py` both have `return False` branches for the non-existent-deck case, but neither was exercised by the test suite. The existing `test_add_member_404_for_foreign_word` only hit the vocabulary-not-owned path (line 202), leaving the deck-not-found path uncovered.

## Test plan

- Both new tests pass locally.
- All 36 deck tests pass (including `test_router_decks_blank_name`).
- Full backend suite: 1651 passed.

Closes #1351
