### PR TITLE
fix: fix WCAG 1.4.3 contrast failures in vocabulary and profile pages (closes #1349)

### DIFF
--- a/frontend/src/__tests__/VocabProfileContrast.test.ts
+++ b/frontend/src/__tests__/VocabProfileContrast.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Regression test for #1349: vocabulary and profile pages WCAG 1.4.3 contrast failures.
+ * text-stone-400 on white = 2.65:1 (fail). text-stone-400 on stone-100 = 2.24:1 (fail).
+ * text-stone-500 = 4.86:1 on white (pass). text-stone-600 on stone-100 = 6.26:1 (pass).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const vocabSrc = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8",
+);
+const profileSrc = fs.readFileSync(
+  path.join(__dirname, "../app/profile/page.tsx"),
+  "utf8",
+);
+
+describe("Vocabulary and profile pages contrast (closes #1349)", () => {
+  it("vocabulary/page.tsx has no text-sm text-stone-400 (2.65:1 fail)", () => {
+    expect(vocabSrc).not.toContain('"text-sm text-stone-400');
+    expect(vocabSrc).not.toContain('"text-center text-stone-400');
+  });
+
+  it("vocabulary/page.tsx has no text-xs text-stone-400 (2.65:1 fail)", () => {
+    expect(vocabSrc).not.toMatch(/text-xs[^"]*text-stone-400|text-stone-400[^"]*text-xs/);
+  });
+
+  it("vocabulary/page.tsx occurrence-count badge uses text-stone-600 (6.26:1 on stone-100)", () => {
+    // bg-stone-100 badge requires stone-600 since stone-500 = 4.1:1 (fails AA on stone-100)
+    expect(vocabSrc).not.toContain("text-stone-400 bg-stone-100");
+    expect(vocabSrc).toContain("text-stone-600 bg-stone-100");
+  });
+
+  it("profile/page.tsx has no text-xs text-stone-400 (2.65:1 fail)", () => {
+    expect(profileSrc).not.toMatch(/text-xs[^"]*text-stone-400|text-stone-400[^"]*text-xs/);
+  });
+});

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -281,7 +281,7 @@ export default function ProfilePage() {
         ) : null}
 
         {/* Section label */}
-        <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-400 px-1">AI &amp; Integrations</h2>
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-500 px-1">AI &amp; Integrations</h2>
 
         {/* ── Gemini API key ──────────────────────────────────────────────── */}
         <section className="bg-white rounded-2xl border border-amber-100 p-6">
@@ -354,7 +354,7 @@ export default function ProfilePage() {
           >
             <div>
               <h2 className="font-serif text-lg font-semibold text-ink">Obsidian Export</h2>
-              <p className="text-xs text-stone-400 mt-0.5">
+              <p className="text-xs text-stone-500 mt-0.5">
                 {hasObsidianToken
                   ? "GitHub token configured — vault sync ready"
                   : "Configure GitHub integration to push vocab to Obsidian"}
@@ -398,7 +398,7 @@ export default function ProfilePage() {
                   onChange={(e) => setObsidianToken(e.target.value)}
                   className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-amber-400"
                 />
-                <p className="text-xs text-stone-400 mt-1">
+                <p className="text-xs text-stone-500 mt-1">
                   Requires <code>contents:write</code> permission on your vault repo.
                 </p>
               </div>
@@ -449,7 +449,7 @@ export default function ProfilePage() {
         </section>
 
         {/* Section label */}
-        <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-400 px-1">Reader Preferences</h2>
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-500 px-1">Reader Preferences</h2>
 
         {/* ── Preferences ─────────────────────────────────────────────────── */}
         <section className="bg-white rounded-2xl border border-amber-100 p-6 space-y-6">

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -178,7 +178,7 @@ function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
           )}
 
           {!loading && (!def || def.definitions.length === 0) && (
-            <p className="text-sm text-stone-400 italic">No definition found.</p>
+            <p className="text-sm text-stone-500 italic">No definition found.</p>
           )}
 
           {def && def.definitions.length > 0 && (
@@ -368,7 +368,7 @@ function VocabularyPageContent() {
               {group.lemma}
             </button>
             {alternateForms.length > 0 && (
-              <span className="text-xs text-stone-400">
+              <span className="text-xs text-stone-500">
                 ({alternateForms.map((f) => f.word).join(", ")})
               </span>
             )}
@@ -377,7 +377,7 @@ function VocabularyPageContent() {
                 {group.language}
               </span>
             )}
-            <span className="text-xs text-stone-400 bg-stone-100 rounded-full px-2 py-0.5">
+            <span className="text-xs text-stone-600 bg-stone-100 rounded-full px-2 py-0.5">
               {occurrenceCount}×
             </span>
           </div>
@@ -411,9 +411,9 @@ function VocabularyPageContent() {
                     {occ.book_title}
                   </a>
                 ) : (
-                  <span className="text-stone-400 font-medium">(deleted book)</span>
+                  <span className="text-stone-500 font-medium">(deleted book)</span>
                 )}{" "}
-                <span className="text-stone-400">{`Ch.${occ.chapter_index + 1}`}</span>
+                <span className="text-stone-500">{`Ch.${occ.chapter_index + 1}`}</span>
                 {" — "}
                 <span className="italic">&ldquo;{occ.sentence_text}&rdquo;</span>
               </div>
@@ -443,7 +443,7 @@ function VocabularyPageContent() {
         <div className="flex-1 min-w-0">
           <h1 className="font-serif font-bold text-ink truncate">Vocabulary</h1>
           {!loading && (
-            <p className="text-xs text-stone-400 mt-0.5">
+            <p className="text-xs text-stone-500 mt-0.5">
               {words.length} word{words.length !== 1 ? "s" : ""} · {totalOccurrences} occurrence{totalOccurrences !== 1 ? "s" : ""}
             </p>
           )}
@@ -546,7 +546,7 @@ function VocabularyPageContent() {
                   }`}
                 >
                   {tag}
-                  <span className={`ml-1 ${active ? "opacity-80" : "text-stone-400"}`}>
+                  <span className={`ml-1 ${active ? "opacity-80" : "text-stone-500"}`}>
                     · {word_count}
                   </span>
                 </button>
@@ -562,12 +562,12 @@ function VocabularyPageContent() {
             ))}
           </div>
         ) : fetchError ? (
-          <div role="alert" className="text-center text-stone-400 mt-20 flex flex-col items-center gap-2">
+          <div role="alert" className="text-center text-stone-500 mt-20 flex flex-col items-center gap-2">
             <p className="font-serif text-lg text-red-500 mt-1">Failed to load vocabulary.</p>
             <p className="text-sm">Please refresh the page to try again.</p>
           </div>
         ) : words.length === 0 ? (
-          <div className="text-center text-stone-400 mt-20 flex flex-col items-center gap-2">
+          <div className="text-center text-stone-500 mt-20 flex flex-col items-center gap-2">
             <EmptyVocabIcon className="w-14 h-14 text-amber-300" />
             <p className="font-serif text-lg text-stone-500 mt-1">No saved words yet.</p>
             <p className="text-sm">Double-click any word while reading to save it here.</p>
@@ -581,11 +581,11 @@ function VocabularyPageContent() {
           </div>
         ) : filtered.length === 0 ? (
           selectedTag ? (
-            <p className="text-center text-stone-400 mt-12 text-sm">
+            <p className="text-center text-stone-500 mt-12 text-sm">
               No words tagged with &ldquo;<span className="font-medium text-ink">{selectedTag}</span>&rdquo;
             </p>
           ) : (
-            <p className="text-center text-stone-400 mt-12 text-sm">No words match &ldquo;{search}&rdquo;</p>
+            <p className="text-center text-stone-500 mt-12 text-sm">No words match &ldquo;{search}&rdquo;</p>
           )
         ) : (
           <div className="space-y-8">


### PR DESCRIPTION
## What

Fixes WCAG 1.4.3 (Contrast Minimum, Level AA) failures in the vocabulary and profile pages. `text-stone-400` (#a8a29e) on white (#ffffff) = **2.65:1** — below the required **4.5:1** for normal-size text.

## Files changed

- `frontend/src/app/vocabulary/page.tsx` — 8 instances: "No definition found." label, alternate forms list, occurrence-count badge (on `bg-stone-100` needs `text-stone-600`, not stone-500), "(deleted book)" and "Ch.N" labels, word/tag count spans, error/empty state containers
- `frontend/src/app/profile/page.tsx` — 4 instances: "AI & Integrations" section header, Obsidian subtitle, permissions hint, "Reader Preferences" header

## Key detail

The occurrence-count badge sits on `bg-stone-100` background. `stone-500`/`stone-100` = 4.1:1 (still fails). Changed to `text-stone-600 bg-stone-100` = **6.26:1** ✓

## Test plan

- [x] `VocabProfileContrast.test.ts` — 4 static assertions confirm no failing color patterns
- [x] All 2418 frontend tests pass (`npm test -- --no-coverage --ci`)
- [x] Vocabulary backend tests pass (48/48)

Closes #1349

## Docs follow-up
- [ ] Design Change Log updated in `docs/design-improvement-plan.md`
