### PR TITLE
fix: fix WCAG 1.4.3 contrast failures in shared components and admin pages (closes #1353)

### DIFF
--- a/frontend/src/__tests__/ComponentsAdminContrast.test.ts
+++ b/frontend/src/__tests__/ComponentsAdminContrast.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression test for #1353: shared components and admin pages WCAG 1.4.3 contrast failures.
+ * text-stone-400 on white = 2.65:1 — fails AA. text-stone-500 = 4.86:1 — passes.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+function read(rel: string) {
+  return fs.readFileSync(path.join(__dirname, rel), "utf8");
+}
+
+const readingStats = read("../components/ReadingStats.tsx");
+const queueTab = read("../components/QueueTab.tsx");
+const annotationsSidebar = read("../components/AnnotationsSidebar.tsx");
+const bookDetailModal = read("../components/BookDetailModal.tsx");
+const vocabTooltip = read("../components/VocabWordTooltip.tsx");
+const adminBooks = read("../app/admin/books/page.tsx");
+const adminUploads = read("../app/admin/uploads/page.tsx");
+const adminAudio = read("../app/admin/audio/page.tsx");
+const adminUsers = read("../app/admin/users/page.tsx");
+
+function noSmallStone400(src: string, label: string) {
+  it(`${label} has no text-xs text-stone-400 (2.65:1 fail)`, () => {
+    expect(src).not.toMatch(/text-xs[^"]*text-stone-400|text-stone-400[^"]*text-xs/);
+  });
+}
+
+describe("Shared components and admin pages contrast (closes #1353)", () => {
+  noSmallStone400(readingStats, "ReadingStats.tsx");
+  noSmallStone400(queueTab, "QueueTab.tsx");
+  noSmallStone400(annotationsSidebar, "AnnotationsSidebar.tsx");
+  noSmallStone400(bookDetailModal, "BookDetailModal.tsx");
+  noSmallStone400(vocabTooltip, "VocabWordTooltip.tsx");
+  noSmallStone400(adminBooks, "admin/books/page.tsx");
+  noSmallStone400(adminUploads, "admin/uploads/page.tsx");
+  noSmallStone400(adminAudio, "admin/audio/page.tsx");
+  noSmallStone400(adminUsers, "admin/users/page.tsx");
+
+  it("QueueTab.tsx has no text-sm text-stone-400 (2.65:1 fail)", () => {
+    expect(queueTab).not.toContain('"text-center text-stone-400');
+    expect(queueTab).not.toContain('"text-sm text-stone-400');
+  });
+
+  it("admin/uploads/page.tsx has no text-sm text-stone-400 (2.65:1 fail)", () => {
+    expect(adminUploads).not.toContain('"text-sm text-stone-400');
+  });
+});

--- a/frontend/src/app/admin/audio/page.tsx
+++ b/frontend/src/app/admin/audio/page.tsx
@@ -59,7 +59,7 @@ export default function AudioPage() {
             <div className="text-sm text-ink">
               Book {a.book_id}, Ch. {a.chapter_index + 1}
             </div>
-            <div className="text-xs text-stone-400">
+            <div className="text-xs text-stone-500">
               {a.provider}/{a.voice} · {a.chunks} chunks · {a.size_mb} MB
             </div>
           </div>

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -301,7 +301,7 @@ export default function BooksPage() {
                       </span>
                     )}
                   </div>
-                  <div className="text-xs text-stone-400">
+                  <div className="text-xs text-stone-500">
                     ID: {b.id} · {b.languages?.join(", ")}
                     {" · "}
                     {((b.text_length || 0) / 1000).toFixed(0)}K chars
@@ -429,7 +429,7 @@ export default function BooksPage() {
                             <div className="px-3 py-2 flex items-center gap-2">
                               <button
                                 onClick={() => setExpandedLang(isLangExpanded ? null : bulkKey)}
-                                className="text-xs text-stone-400 hover:text-amber-700 flex items-center min-h-[44px] min-w-[44px] justify-center"
+                                className="text-xs text-stone-500 hover:text-amber-700 flex items-center min-h-[44px] min-w-[44px] justify-center"
                                 aria-label={isLangExpanded ? `Collapse ${lang} translations` : `Expand ${lang} translations`}
                                 aria-expanded={isLangExpanded}
                               >
@@ -490,7 +490,7 @@ export default function BooksPage() {
                             {isLangExpanded && (
                               <div className="border-t border-amber-100 divide-y divide-amber-50 max-h-80 overflow-y-auto">
                                 {chapterRows.length === 0 ? (
-                                  <p className="text-xs text-stone-400 px-3 py-2">
+                                  <p className="text-xs text-stone-500 px-3 py-2">
                                     (Chapter-level details load from the translations list — reload if empty.)
                                   </p>
                                 ) : (

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -109,7 +109,7 @@ export default function UploadsPage() {
             <CloseIcon className="w-3.5 h-3.5 inline" aria-hidden="true" /> Clear filter (user {activeFilter})
           </button>
         )}
-        <span className="ml-auto text-xs text-stone-400">{uploads.length} upload{uploads.length !== 1 ? "s" : ""}</span>
+        <span className="ml-auto text-xs text-stone-500">{uploads.length} upload{uploads.length !== 1 ? "s" : ""}</span>
       </div>
 
       {uploads.length === 0 ? (
@@ -129,7 +129,7 @@ export default function UploadsPage() {
             />
           </svg>
           <p className="font-serif text-ink mb-1">No uploads yet</p>
-          <p className="text-sm text-stone-400">
+          <p className="text-sm text-stone-500">
             {activeFilter ? `No uploads found for user ${activeFilter}.` : "No books have been uploaded by users."}
           </p>
         </div>

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -70,7 +70,7 @@ export default function UsersPage() {
                 <span className="text-xs bg-orange-100 text-orange-800 px-1.5 py-0.5 rounded">pending</span>
               )}
             </div>
-            <p className="text-xs text-stone-400 truncate">{u.email}</p>
+            <p className="text-xs text-stone-500 truncate">{u.email}</p>
           </div>
           {u.id !== myId && (
             <div className="flex gap-1">

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -107,7 +107,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
                 <span className="w-5 h-5 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
               </div>
             ) : annotations.length === 0 ? (
-              <div className="text-center text-stone-400 mt-10 text-sm">
+              <div className="text-center text-stone-500 mt-10 text-sm">
                 <EmptyNotesIcon className="w-10 h-10 text-stone-300 mx-auto mb-2" />
                 <p>No annotations yet.</p>
                 <p className="mt-1 text-xs">Click a sentence and choose Note to add one.</p>
@@ -121,7 +121,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
                 )}
               {chapters.map((ch) => (
                 <div key={ch}>
-                  <h3 className="text-xs font-semibold text-stone-400 uppercase tracking-wide mb-2">
+                  <h3 className="text-xs font-semibold text-stone-500 uppercase tracking-wide mb-2">
                     Chapter {ch + 1}
                   </h3>
                   <div className="space-y-2">
@@ -187,7 +187,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
             <a
               href="/notes"
               onClick={() => setOpen(false)}
-              className="text-xs text-stone-400 hover:text-stone-600 transition-colors"
+              className="text-xs text-stone-500 hover:text-stone-600 transition-colors"
             >
               All books
             </a>

--- a/frontend/src/components/BookDetailModal.tsx
+++ b/frontend/src/components/BookDetailModal.tsx
@@ -142,7 +142,7 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
 
         <div className="flex items-center justify-between mt-3">
           {book.download_count > 0 && (
-            <p className="text-xs text-stone-400">
+            <p className="text-xs text-stone-500">
               {book.download_count.toLocaleString()} downloads
             </p>
           )}

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -463,7 +463,7 @@ export default function QueueTab({ adminFetch }: Props) {
           <div className="h-4 w-3/4 bg-stone-100 rounded" />
           <div className="h-4 w-5/6 bg-stone-100 rounded" />
         </div>
-        <div className="text-center text-xs text-stone-400">
+        <div className="text-center text-xs text-stone-500">
           Loading queue…
         </div>
       </div>
@@ -650,7 +650,7 @@ export default function QueueTab({ adminFetch }: Props) {
             )}
           </div>
           {s.ended_at && (
-            <p className="text-xs text-stone-400 mt-2">Last completed {relTime(s.ended_at)}</p>
+            <p className="text-xs text-stone-500 mt-2">Last completed {relTime(s.ended_at)}</p>
           )}
         </div>
       )}
@@ -936,7 +936,7 @@ export default function QueueTab({ adminFetch }: Props) {
                       <div className="text-[11px] text-stone-500 mt-1 leading-snug">
                         {p.description}
                       </div>
-                      <div className="text-xs font-mono text-stone-400 mt-1 truncate">
+                      <div className="text-xs font-mono text-stone-500 mt-1 truncate">
                         {p.chain.join(" → ")}
                       </div>
                     </button>
@@ -981,7 +981,7 @@ export default function QueueTab({ adminFetch }: Props) {
                             {opt.maxOutputTokens.toLocaleString()} tok
                           </span>
                         ) : (
-                          <span className="text-[11px] text-stone-400">
+                          <span className="text-[11px] text-stone-500">
                             custom — conservative defaults
                           </span>
                         )}
@@ -1032,7 +1032,7 @@ export default function QueueTab({ adminFetch }: Props) {
                 );
               })}
               {chain.length === 0 && (
-                <div className="text-xs text-stone-400 italic">
+                <div className="text-xs text-stone-500 italic">
                   Chain is empty — add a model below.
                 </div>
               )}
@@ -1201,7 +1201,7 @@ export default function QueueTab({ adminFetch }: Props) {
                       <div className="text-sm font-semibold text-ink">
                         ${row.usd.toFixed(2)}
                       </div>
-                      <div className="text-xs text-stone-400">
+                      <div className="text-xs text-stone-500">
                         ${(row.usd / books).toFixed(3)}/book
                       </div>
                     </div>
@@ -1210,7 +1210,7 @@ export default function QueueTab({ adminFetch }: Props) {
               </div>
             </div>
 
-            <p className="text-[11px] text-stone-400">
+            <p className="text-[11px] text-stone-500">
               Rough estimate — assumes ~3 chars/token and 1:1 input-to-output ratio.
               Actual cost depends on tokenizer, chapter lengths, and batching.
               Chain advance on 429/quota means multiple models may contribute — the
@@ -1255,7 +1255,7 @@ export default function QueueTab({ adminFetch }: Props) {
           </button>
         </div>
         {items.length === 0 ? (
-          <div role="status" className="px-4 py-8 text-center text-stone-400 text-sm flex items-center justify-center gap-2">
+          <div role="status" className="px-4 py-8 text-center text-stone-500 text-sm flex items-center justify-center gap-2">
             {loadingItems && <Spinner />}
             <span>{loadingItems ? "Loading items…" : "No items in this view."}</span>
           </div>
@@ -1288,7 +1288,7 @@ export default function QueueTab({ adminFetch }: Props) {
                   · ch {it.chapter_index + 1} → {it.target_language}
                 </span>
                 <span
-                  className="text-stone-400 shrink-0"
+                  className="text-stone-500 shrink-0"
                   title={`Queued ${it.created_at} by ${it.queued_by || "auto (save_book)"}`}
                 >
                   · {relTime(it.created_at)}
@@ -1298,7 +1298,7 @@ export default function QueueTab({ adminFetch }: Props) {
                   </span>
                 </span>
                 {it.attempts > 0 && (
-                  <span className="text-stone-400 shrink-0">· {it.attempts} attempts</span>
+                  <span className="text-stone-500 shrink-0">· {it.attempts} attempts</span>
                 )}
                 {it.last_error && (
                   <span

--- a/frontend/src/components/ReadingStats.tsx
+++ b/frontend/src/components/ReadingStats.tsx
@@ -151,7 +151,7 @@ export default function ReadingStats({ active, heatmapOnly = false }: Props) {
       >
         <div className="flex items-center justify-between mb-3">
           <p className="text-sm font-medium text-stone-700">Activity — last year</p>
-          <p className="text-xs text-stone-400">
+          <p className="text-xs text-stone-500">
             {activeDays} active {activeDays === 1 ? "day" : "days"}
           </p>
         </div>

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -90,7 +90,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
           </div>
         )}
         {!loading && (!def || def.definitions.length === 0) && (
-          <p className="text-xs text-stone-400 italic">No definition found.</p>
+          <p className="text-xs text-stone-500 italic">No definition found.</p>
         )}
         {!loading && def && def.definitions.length > 0 && (
           <div className="space-y-2">


### PR DESCRIPTION
## What

Fixes WCAG 1.4.3 (Contrast Minimum AA) failures across 5 shared components and 4 admin pages. `text-stone-400` (#a8a29e) on white (#ffffff) = **2.65:1** — below the required **4.5:1** for normal-size text. All instances replaced with `text-stone-500` (4.86:1 ✓).

## Files changed

**Shared components:**
- `ReadingStats.tsx` — "N active days" label
- `QueueTab.tsx` — 8 instances: empty states, metadata labels, secondary text
- `AnnotationsSidebar.tsx` — empty state, chapter headings, "All books" link
- `BookDetailModal.tsx` — download count label
- `VocabWordTooltip.tsx` — "No definition found." label

**Admin pages:**
- `admin/books/page.tsx` — book metadata, expand link, empty message
- `admin/uploads/page.tsx` — upload count, empty-state description
- `admin/audio/page.tsx` — audio metadata label
- `admin/users/page.tsx` — user email truncated label

## Test plan

- [x] `ComponentsAdminContrast.test.ts` — 11 static assertions across all 9 files
- [x] All 2425 frontend tests pass (`npm test -- --no-coverage --ci`)

Closes #1353

## Docs follow-up
- [ ] Design Change Log updated in `docs/design-improvement-plan.md`
