### PR TITLE
fix: add missing tests for whitespace-only insight/annotation fields (closes #1355)

### DIFF
--- a/backend/tests/test_router_annotations.py
+++ b/backend/tests/test_router_annotations.py
@@ -602,3 +602,25 @@ async def test_patch_annotation_whitespace_note_text_is_stored_as_empty(client, 
     assert resp.json()["note_text"] == "", (
         f"Expected note_text to be stripped to empty, got: {resp.json()['note_text']!r}"
     )
+
+
+# ── Issue #1355: whitespace-only sentence_text ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_annotation_whitespace_only_sentence_text_returns_400(client, test_user, tmp_db):
+    """Regression #1355: POST /annotations with sentence_text='   ' must return 400.
+
+    Pydantic's min_length=1 passes whitespace-only strings; the router's strip()
+    guard at line 29 catches it and returns 400 (not 422).
+    """
+    from services.db import save_book
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    resp = await client.post(
+        "/api/annotations",
+        json={"book_id": BOOK_ID, "chapter_index": 0, "sentence_text": "   "},
+    )
+    assert resp.status_code == 400, (
+        f"Expected 400 for whitespace-only sentence_text, got {resp.status_code}: {resp.text}"
+    )
+    assert "sentence_text" in resp.json()["detail"].lower()

--- a/backend/tests/test_router_insights.py
+++ b/backend/tests/test_router_insights.py
@@ -198,6 +198,30 @@ async def test_post_insight_rejects_empty_answer(client: AsyncClient):
     assert resp.status_code == 422
 
 
+async def test_post_insight_rejects_whitespace_only_question(client: AsyncClient):
+    """Regression #1355: whitespace-only question passes Pydantic min_length=1 but
+    must return 400 via the router's strip() guard (not 422 from Pydantic)."""
+    await save_book(1, _META, "text")
+    resp = await client.post(
+        "/api/insights",
+        json={"book_id": 1, "question": "   ", "answer": "Some answer."},
+    )
+    assert resp.status_code == 400
+    assert "question" in resp.json()["detail"].lower()
+
+
+async def test_post_insight_rejects_whitespace_only_answer(client: AsyncClient):
+    """Regression #1355: whitespace-only answer passes Pydantic min_length=1 but
+    must return 400 via the router's strip() guard."""
+    await save_book(1, _META, "text")
+    resp = await client.post(
+        "/api/insights",
+        json={"book_id": 1, "question": "What is the theme?", "answer": "\t\n"},
+    )
+    assert resp.status_code == 400
+    assert "answer" in resp.json()["detail"].lower()
+
+
 async def test_post_insight_rejects_negative_chapter_index(client: AsyncClient):
     """POST /insights with chapter_index < 0 must return 422 (Pydantic ge=0).
     A negative chapter_index is not a valid position — rejected at validation layer."""


### PR DESCRIPTION
## What changed

Added regression tests for whitespace-only field values in `POST /insights` and `POST /annotations`.

Pydantic's `min_length=1` validator accepts strings like `"   "` (whitespace-only) because they have length ≥ 1. The routers already guard against this with `.strip()` checks that return HTTP 400, but there were no tests exercising the 400 path (only the Pydantic 422 path for empty strings `""`).

## Files changed

- `backend/tests/test_router_insights.py` — 2 new tests:
  - `test_post_insight_rejects_whitespace_only_question` — `"   "` → 400
  - `test_post_insight_rejects_whitespace_only_answer` — `"\t\n"` → 400
- `backend/tests/test_router_annotations.py` — 1 new test:
  - `test_create_annotation_whitespace_only_sentence_text_returns_400` — `"   "` → 400

## Why

The router-level strip() guard at lines 29 (annotations) and similar (insights) was untested. A refactor removing or weakening those guards would not be caught by the test suite.

## Test plan

- [x] All 3 new tests fail before the guard exists, pass after
- [x] Full backend suite: 1659 passed
- [x] Full frontend suite: 1750 passed

Closes #1355
