### PR TITLE
fix: fix WCAG 1.4.3/1.4.11 contrast failures in components wave 6 (closes #1362)

### DIFF
--- a/frontend/src/__tests__/ComponentsContrastWave6.test.ts
+++ b/frontend/src/__tests__/ComponentsContrastWave6.test.ts
@@ -1,0 +1,48 @@
+import fs from "fs";
+import path from "path";
+
+const readSrc = (name: string) =>
+  fs.readFileSync(path.resolve(__dirname, `../components/${name}`), "utf8");
+
+const readingStats    = readSrc("ReadingStats.tsx");
+const annotationTb    = readSrc("AnnotationToolbar.tsx");
+const vocabTooltip    = readSrc("VocabWordTooltip.tsx");
+const deckCard        = readSrc("DeckCard.tsx");
+const chapterSummary  = readSrc("ChapterSummary.tsx");
+
+describe("Component contrast wave 6 (closes #1362)", () => {
+  it("ReadingStats heatmap month labels use text-stone-500 not text-stone-400", () => {
+    expect(readingStats).not.toContain("text-[9px] text-stone-400");
+    expect(readingStats).toContain("text-[9px] text-stone-500");
+  });
+
+  it("ReadingStats legend Less/More use text-stone-500 not text-stone-400", () => {
+    expect(readingStats).not.toContain('"text-[9px] text-stone-400 mr-1"');
+    expect(readingStats).not.toContain('"text-[9px] text-stone-400 ml-1"');
+  });
+
+  it("AnnotationToolbar (optional) hint uses text-stone-500 not text-stone-400", () => {
+    expect(annotationTb).not.toContain('"text-stone-400">(optional)');
+    expect(annotationTb).toContain('"text-stone-500">(optional)');
+  });
+
+  it("VocabWordTooltip Base form label uses text-stone-500 not text-stone-400 (2.65:1 fail)", () => {
+    expect(vocabTooltip).not.toContain("text-[11px] text-stone-400");
+    expect(vocabTooltip).toContain("text-[11px] text-stone-500");
+  });
+
+  it("VocabWordTooltip Close button uses text-stone-500 (WCAG 1.4.11 non-text 3:1)", () => {
+    expect(vocabTooltip).not.toContain('"text-stone-400 hover:text-stone-600');
+    expect(vocabTooltip).toContain("text-stone-500 hover:text-stone-700");
+  });
+
+  it("DeckCard delete icon uses text-stone-500 not text-stone-400 (WCAG 1.4.11)", () => {
+    expect(deckCard).not.toContain("text-stone-400 hover:text-red-600");
+    expect(deckCard).toContain("text-stone-500 hover:text-red-600");
+  });
+
+  it("ChapterSummary empty state uses text-stone-500 not text-stone-400", () => {
+    expect(chapterSummary).not.toContain("text-center text-stone-400");
+    expect(chapterSummary).toContain("text-center text-stone-500");
+  });
+});

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -162,7 +162,7 @@ export default function AnnotationToolbar({
 
           {/* Note textarea */}
           <div>
-            <label htmlFor="annotation-note" className="block text-xs text-stone-500 mb-1.5">Note <span className="text-stone-400">(optional)</span></label>
+            <label htmlFor="annotation-note" className="block text-xs text-stone-500 mb-1.5">Note <span className="text-stone-500">(optional)</span></label>
             <textarea
               ref={textareaRef}
               id="annotation-note"

--- a/frontend/src/components/ChapterSummary.tsx
+++ b/frontend/src/components/ChapterSummary.tsx
@@ -133,7 +133,7 @@ export default function ChapterSummary({
         )}
 
         {!summary && !loading && !error && (
-          <div className="flex flex-col items-center justify-center h-full text-center text-stone-400 gap-3 py-8">
+          <div className="flex flex-col items-center justify-center h-full text-center text-stone-500 gap-3 py-8">
             <SummaryIcon className="w-10 h-10 text-amber-300" />
             <p className="text-sm">Get a quick overview of this chapter before continuing.</p>
             <button

--- a/frontend/src/components/DeckCard.tsx
+++ b/frontend/src/components/DeckCard.tsx
@@ -55,7 +55,7 @@ export default function DeckCard({ deck, onDelete }: DeckCardProps) {
             onClick={() => onDelete(deck.id)}
             aria-label={`Delete deck ${deck.name}`}
             data-testid={`deck-delete-${deck.id}`}
-            className="min-h-[44px] min-w-[44px] flex items-center justify-center text-stone-400 hover:text-red-600 transition-colors shrink-0"
+            className="min-h-[44px] min-w-[44px] flex items-center justify-center text-stone-500 hover:text-red-600 transition-colors shrink-0"
           >
             <TrashIcon className="w-4 h-4" />
           </button>

--- a/frontend/src/components/ReadingStats.tsx
+++ b/frontend/src/components/ReadingStats.tsx
@@ -164,7 +164,7 @@ export default function ReadingStats({ active, heatmapOnly = false }: Props) {
           {weeks.map((_, wi) => {
             const m = months.find((m) => m.colStart === wi);
             return (
-              <div key={wi} className="text-[9px] text-stone-400 truncate">
+              <div key={wi} className="text-[9px] text-stone-500 truncate">
                 {m?.label ?? ""}
               </div>
             );
@@ -199,11 +199,11 @@ export default function ReadingStats({ active, heatmapOnly = false }: Props) {
 
         {/* Legend */}
         <div className="flex items-center gap-1 mt-2 justify-end">
-          <span className="text-[9px] text-stone-400 mr-1">Less</span>
+          <span className="text-[9px] text-stone-500 mr-1">Less</span>
           {["bg-stone-100", "bg-amber-200", "bg-amber-400", "bg-amber-600", "bg-amber-800"].map((c) => (
             <div key={c} className={`w-3 h-3 rounded-[2px] ${c}`} />
           ))}
-          <span className="text-[9px] text-stone-400 ml-1">More</span>
+          <span className="text-[9px] text-stone-500 ml-1">More</span>
         </div>
       </div>
     </div>

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -78,7 +78,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
       {/* Header */}
       <div className="flex items-center justify-between px-3 pt-2.5 pb-1.5 border-b border-amber-100">
         <span id="vocab-tooltip-title" className="font-semibold text-ink text-sm">{word}</span>
-        <button onClick={onClose} aria-label="Close" className="text-stone-400 hover:text-stone-600 p-0.5 rounded transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"><CloseIcon className="w-3.5 h-3.5" /></button>
+        <button onClick={onClose} aria-label="Close" className="text-stone-500 hover:text-stone-700 p-0.5 rounded transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"><CloseIcon className="w-3.5 h-3.5" /></button>
       </div>
 
       {/* Body */}
@@ -95,7 +95,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
         {!loading && def && def.definitions.length > 0 && (
           <div className="space-y-2">
             {def.lemma && def.lemma !== word && (
-              <p className="text-[11px] text-stone-400">
+              <p className="text-[11px] text-stone-500">
                 Base form: <span className="font-medium text-stone-600">{def.lemma}</span>
               </p>
             )}


### PR DESCRIPTION
## What

Fixes WCAG 1.4.3 (Contrast Minimum AA, 4.5:1) and WCAG 1.4.11 (Non-text Contrast, 3:1) failures in 5 components. All instances of `text-stone-400` (#a8a29e / 2.65:1 on white) replaced with `text-stone-500` (4.86:1 ✓).

## Files changed

- **`ReadingStats.tsx`** — heatmap month labels + legend "Less"/"More" (`text-[9px] text-stone-400` → `text-stone-500`)
- **`AnnotationToolbar.tsx`** — "(optional)" hint in note label
- **`VocabWordTooltip.tsx`** — "Base form:" prefix label; Close icon button (WCAG 1.4.11: icon was 2.65:1 < required 3:1)
- **`DeckCard.tsx`** — delete trash icon button (WCAG 1.4.11: same 2.65:1 failure)
- **`ChapterSummary.tsx`** — empty-state description container

## Test plan

- [x] `ComponentsContrastWave6.test.ts` — 7 static assertions across all 5 files
- [x] All 2438 frontend tests pass

Closes #1362

## Docs follow-up
- [ ] Design Change Log updated in `docs/design-improvement-plan.md`
