### PR TITLE
fix: fix WCAG 1.4.3/1.4.11 contrast failures in wave 7 (closes #1364)

### DIFF
--- a/frontend/src/__tests__/ContrastWave7.test.ts
+++ b/frontend/src/__tests__/ContrastWave7.test.ts
@@ -1,0 +1,36 @@
+import fs from "fs";
+import path from "path";
+
+const readApp = (p: string) =>
+  fs.readFileSync(path.resolve(__dirname, `../app/${p}`), "utf8");
+
+const decksNew      = readApp("decks/new/page.tsx");
+const adminUploads  = readApp("admin/uploads/page.tsx");
+const adminBooks    = readApp("admin/books/page.tsx");
+const searchPage    = readApp("search/page.tsx");
+
+describe("Contrast wave 7 (closes #1364)", () => {
+  it("decks/new label hints use text-stone-500 not text-stone-400", () => {
+    expect(decksNew).not.toContain('"text-stone-400 font-normal"');
+    expect(decksNew).toContain('"text-stone-500 font-normal"');
+  });
+
+  it("admin/uploads date cell uses text-stone-500 not text-stone-400", () => {
+    expect(adminUploads).not.toContain("text-stone-400 whitespace-nowrap");
+    expect(adminUploads).toContain("text-stone-500 whitespace-nowrap");
+  });
+
+  it("admin/books expand toggle uses text-stone-500 not text-stone-400 (WCAG 1.4.11)", () => {
+    expect(adminBooks).not.toContain("text-stone-400 hover:text-amber-700");
+    expect(adminBooks).toContain("text-stone-500 hover:text-amber-700");
+  });
+
+  it("admin/books translation size label uses text-stone-500 not text-stone-400", () => {
+    expect(adminBooks).not.toContain('"text-stone-400 flex-1"');
+    expect(adminBooks).toContain('"text-stone-500 flex-1"');
+  });
+
+  it("search page empty-state SearchIcon has aria-hidden (decorative, exempt from 1.4.11)", () => {
+    expect(searchPage).toContain('text-stone-400" aria-hidden="true"');
+  });
+});

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -284,7 +284,7 @@ export default function BooksPage() {
                     setExpandedBookId(isExpanded ? null : b.id);
                     setExpandedLang(null);
                   }}
-                  className="text-stone-400 hover:text-amber-700 flex items-center min-h-[44px] min-w-[44px] justify-center"
+                  className="text-stone-500 hover:text-amber-700 flex items-center min-h-[44px] min-w-[44px] justify-center"
                   title={isExpanded ? `Collapse ${b.title}` : `Expand ${b.title}`}
                   aria-label={isExpanded ? `Collapse ${b.title}` : `Expand ${b.title}`}
                   aria-expanded={isExpanded}
@@ -504,7 +504,7 @@ export default function BooksPage() {
                                           className="px-3 py-1.5 flex items-center gap-2 text-xs"
                                         >
                                           <span className="text-stone-500 w-16">Ch. {t.chapter_index + 1}</span>
-                                          <span className="text-stone-400 flex-1">
+                                          <span className="text-stone-500 flex-1">
                                             {(t.size_chars / 1000).toFixed(1)}K chars
                                           </span>
                                           {/* Move-to: reassign the cached translation

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -162,7 +162,7 @@ export default function UploadsPage() {
                     <td className="px-4 py-2.5 text-stone-500 max-w-[160px] truncate" title={u.uploader_email}>
                       {u.uploader_email}
                     </td>
-                    <td className="px-4 py-2.5 text-stone-400 whitespace-nowrap">{fmt_date(u.uploaded_at)}</td>
+                    <td className="px-4 py-2.5 text-stone-500 whitespace-nowrap">{fmt_date(u.uploaded_at)}</td>
                     <td className="px-4 py-2.5">
                       <button
                         onClick={() => router.push(`/reader/${u.book_id}`)}

--- a/frontend/src/app/decks/new/page.tsx
+++ b/frontend/src/app/decks/new/page.tsx
@@ -106,7 +106,7 @@ export default function DecksNewPage() {
               htmlFor="deck-description"
               className="block text-sm font-medium text-ink mb-1"
             >
-              Description <span className="text-stone-400 font-normal">(optional)</span>
+              Description <span className="text-stone-500 font-normal">(optional)</span>
             </label>
             <textarea
               id="deck-description"
@@ -166,7 +166,7 @@ export default function DecksNewPage() {
               className="rounded-xl border border-amber-200 bg-amber-50/40 p-4 space-y-4"
             >
               <legend className="px-2 text-sm font-medium text-ink">
-                Rules <span className="text-stone-400 font-normal">(leave blank to match everything)</span>
+                Rules <span className="text-stone-500 font-normal">(leave blank to match everything)</span>
               </legend>
 
               <div>
@@ -174,7 +174,7 @@ export default function DecksNewPage() {
                   htmlFor="deck-rule-language"
                   className="block text-sm font-medium text-ink mb-1"
                 >
-                  Language <span className="text-stone-400 font-normal">(e.g. de, en, zh)</span>
+                  Language <span className="text-stone-500 font-normal">(e.g. de, en, zh)</span>
                 </label>
                 <input
                   id="deck-rule-language"
@@ -192,7 +192,7 @@ export default function DecksNewPage() {
                   htmlFor="deck-rule-tags-any"
                   className="block text-sm font-medium text-ink mb-1"
                 >
-                  Tags any of <span className="text-stone-400 font-normal">(comma-separated)</span>
+                  Tags any of <span className="text-stone-500 font-normal">(comma-separated)</span>
                 </label>
                 <input
                   id="deck-rule-tags-any"
@@ -209,7 +209,7 @@ export default function DecksNewPage() {
                   htmlFor="deck-rule-tags-all"
                   className="block text-sm font-medium text-ink mb-1"
                 >
-                  Tags all of <span className="text-stone-400 font-normal">(comma-separated)</span>
+                  Tags all of <span className="text-stone-500 font-normal">(comma-separated)</span>
                 </label>
                 <input
                   id="deck-rule-tags-all"

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -134,7 +134,7 @@ function SearchResultsInner() {
   if (!q.trim()) {
     return (
       <div className="text-center text-stone-500 py-16">
-        <SearchIcon className="w-10 h-10 mx-auto mb-2 text-stone-400" />
+        <SearchIcon className="w-10 h-10 mx-auto mb-2 text-stone-400" aria-hidden="true" />
         <p className="font-serif text-lg text-ink">Search your notes, vocabulary, and uploads</p>
         <p className="text-sm mt-2">Start typing in the search bar.</p>
       </div>


### PR DESCRIPTION
## What

WCAG 1.4.3 / 1.4.11 contrast fixes — wave 7. Closes #1364.

Five remaining `text-stone-400` failures (2.65:1 on white, below the 4.5:1 AA minimum) and one decorative icon missing `aria-hidden`:

| File | Change |
|---|---|
| `app/decks/new/page.tsx` | 5 label hint spans `(optional)`, `(leave blank…)`, `(e.g. de, en, zh)`, `(comma-separated)` ×2 → `text-stone-500` (4.86:1 ✓) |
| `app/admin/uploads/page.tsx` | Date cell `text-stone-400 whitespace-nowrap` → `text-stone-500` |
| `app/admin/books/page.tsx` | Expand-toggle icon `text-stone-400 hover:text-amber-700` → `text-stone-500` (WCAG 1.4.11 ✓); translation size label `"text-stone-400 flex-1"` → `text-stone-500` |
| `app/search/page.tsx` | Decorative empty-state `SearchIcon` — add `aria-hidden="true"` (exempt from 1.4.11) |

## Tests

New `ContrastWave7.test.ts` — 5 static assertions (file-content checks). All pass; 2436 total suite green.

## Docs follow-up

Design change log in `docs/design-improvement-plan.md` covered by ongoing contrast-audit PR series.
