### PR TITLE
fix: fix WCAG 1.4.3/1.4.11 contrast failures in wave 8 (closes #1369)

### DIFF
--- a/frontend/src/__tests__/ContrastWave8.test.ts
+++ b/frontend/src/__tests__/ContrastWave8.test.ts
@@ -1,0 +1,99 @@
+import fs from "fs";
+import path from "path";
+
+const src = (rel: string) =>
+  fs.readFileSync(path.join(process.cwd(), "src", rel), "utf-8");
+
+const uploadPage = src("app/upload/page.tsx");
+const chaptersPage = src("app/upload/[bookId]/chapters/page.tsx");
+const importPage = src("app/import/[bookId]/page.tsx");
+const loginPage = src("app/login/page.tsx");
+const sentenceReader = src("components/SentenceReader.tsx");
+const annotationToolbar = src("components/AnnotationToolbar.tsx");
+const annotationsSidebar = src("components/AnnotationsSidebar.tsx");
+const bookDetailModal = src("components/BookDetailModal.tsx");
+const notesBookPage = src("app/notes/[bookId]/page.tsx");
+const deckIdPage = src("app/decks/[deckId]/page.tsx");
+const profilePage = src("app/profile/page.tsx");
+
+describe("Contrast wave 8 (closes #1369)", () => {
+  // ─── Text contrast (WCAG 1.4.3) ────────────────────────────────────────
+
+  it("upload page Tips heading uses text-stone-500 not text-stone-400", () => {
+    expect(uploadPage).not.toContain('text-stone-400">Tips');
+    expect(uploadPage).toContain('text-stone-500">Tips');
+  });
+
+  it("chapters page detected count uses text-stone-500 not text-stone-400", () => {
+    expect(chaptersPage).not.toContain("text-sm font-normal text-stone-400");
+    expect(chaptersPage).toContain("text-sm font-normal text-stone-500");
+  });
+
+  it("chapters page Preview heading uses text-stone-500 not text-stone-400", () => {
+    expect(chaptersPage).not.toContain("text-stone-400 mb-3");
+    expect(chaptersPage).toContain("text-stone-500 mb-3");
+  });
+
+  it("chapters page ellipsis uses text-stone-500 not text-stone-400", () => {
+    expect(chaptersPage).not.toContain('"text-stone-400">…');
+    expect(chaptersPage).toContain('"text-stone-500">…');
+  });
+
+  it("chapters page empty state uses text-stone-500 not text-stone-400", () => {
+    expect(chaptersPage).not.toContain("text-sm text-stone-400 text-center mt-8");
+    expect(chaptersPage).toContain("text-sm text-stone-500 text-center mt-8");
+  });
+
+  it("import page cost breakdown uses text-stone-500 not text-stone-400", () => {
+    expect(importPage).not.toContain('"text-stone-400">');
+    expect(importPage).toContain('"text-stone-500">');
+  });
+
+  it("import page footer note uses text-stone-500 not text-stone-400", () => {
+    expect(importPage).not.toContain("text-xs text-stone-400 mt-4");
+    expect(importPage).toContain("text-xs text-stone-500 mt-4");
+  });
+
+  it("login page footer note uses text-stone-500 not text-stone-400", () => {
+    expect(loginPage).not.toContain("text-xs text-stone-400 mt-6");
+    expect(loginPage).toContain("text-xs text-stone-500 mt-6");
+  });
+
+  it("SentenceReader not-loaded word uses text-stone-500 not text-stone-400", () => {
+    expect(sentenceReader).not.toContain(': "text-stone-400";');
+    expect(sentenceReader).toContain(': "text-stone-500";');
+  });
+
+  // ─── Icon button contrast (WCAG 1.4.11) ────────────────────────────────
+
+  it("AnnotationToolbar close button uses text-stone-500 not text-stone-400 (WCAG 1.4.11)", () => {
+    expect(annotationToolbar).not.toContain("text-stone-400 hover:text-stone-600 hover:bg-amber-50");
+    expect(annotationToolbar).toContain("text-stone-500 hover:text-stone-700 hover:bg-amber-50");
+  });
+
+  it("AnnotationsSidebar close button uses text-stone-500 not text-stone-400 (WCAG 1.4.11)", () => {
+    expect(annotationsSidebar).not.toContain('"text-stone-400 hover:text-stone-600 min-h-[44px]');
+    expect(annotationsSidebar).toContain('"text-stone-500 hover:text-stone-700 min-h-[44px]');
+  });
+
+  it("BookDetailModal close button uses text-stone-500 not text-stone-400 (WCAG 1.4.11)", () => {
+    expect(bookDetailModal).not.toContain("text-stone-400 hover:bg-stone-100 hover:text-stone-600");
+    expect(bookDetailModal).toContain("text-stone-500 hover:bg-stone-100 hover:text-stone-700");
+  });
+
+  it("notes edit button uses text-stone-500 not text-stone-400 (WCAG 1.4.11)", () => {
+    expect(notesBookPage).not.toContain("text-stone-400 hover:text-stone-600 transition-colors p-1");
+    expect(notesBookPage).toContain("text-stone-500 hover:text-stone-700 transition-colors p-1");
+  });
+
+  it("deck member trash button uses text-stone-500 not text-stone-400 (WCAG 1.4.11)", () => {
+    expect(deckIdPage).not.toContain("rounded-lg text-stone-400 hover:text-red-600");
+    expect(deckIdPage).toContain("rounded-lg text-stone-500 hover:text-red-600");
+  });
+
+  // ─── Decorative icon: aria-hidden ──────────────────────────────────────
+
+  it("profile ChevronRight in deck button has aria-hidden (decorative, exempt from 1.4.11)", () => {
+    expect(profilePage).toContain('text-stone-400 shrink-0" aria-hidden="true"');
+  });
+});

--- a/frontend/src/app/decks/[deckId]/page.tsx
+++ b/frontend/src/app/decks/[deckId]/page.tsx
@@ -245,7 +245,7 @@ export default function DeckDetailPage() {
                         type="button"
                         onClick={() => handleRemove(w.id)}
                         aria-label={`Remove ${w.word} from deck`}
-                        className="shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg text-stone-400 hover:text-red-600 hover:bg-red-50 transition-colors"
+                        className="shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg text-stone-500 hover:text-red-600 hover:bg-red-50 transition-colors"
                       >
                         <TrashIcon className="w-4 h-4" />
                       </button>

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -367,7 +367,7 @@ export default function BookImportPage() {
                     <span className="font-semibold text-ink">Gemini Flash</span>
                     <span className="font-semibold text-amber-700">{fmtCost(cost.usd)}</span>
                   </div>
-                  <p className="text-stone-400">
+                  <p className="text-stone-500">
                     ~{fmtNum(cost.tokens)} output tokens · $2.50/M on paid tier.{" "}
                     <span className="text-emerald-600 font-medium">Free on free tier.</span>
                     {" Runs in background."}
@@ -458,7 +458,7 @@ export default function BookImportPage() {
           )}
         </div>
 
-        <p className="text-center text-xs text-stone-400 mt-4">
+        <p className="text-center text-xs text-stone-500 mt-4">
           Translations are cached — other readers of the same book share the
           result.
         </p>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -62,7 +62,7 @@ function LoginForm() {
           </div>
         </div>
 
-        <p className="text-center text-xs text-stone-400 mt-6">
+        <p className="text-center text-xs text-stone-500 mt-6">
           Your reading data stays on your own device.
         </p>
       </div>

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -141,7 +141,7 @@ function AnnotationCard({
           </a>
           <button
             onClick={onEdit}
-            className="text-stone-400 hover:text-stone-600 transition-colors p-1 min-h-[44px] flex items-center justify-center"
+            className="text-stone-500 hover:text-stone-700 transition-colors p-1 min-h-[44px] flex items-center justify-center"
             title="Edit note"
             aria-label={`Edit annotation: ${ann.sentence_text.slice(0, 60)}`}
           >

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -272,7 +272,7 @@ export default function ProfilePage() {
                     <span className="text-xs font-medium text-amber-700 shrink-0">
                       {d.due_today} due
                     </span>
-                    <ChevronRightIcon className="w-4 h-4 text-stone-400 shrink-0" />
+                    <ChevronRightIcon className="w-4 h-4 text-stone-400 shrink-0" aria-hidden="true" />
                   </button>
                 </li>
               ))}

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -108,7 +108,7 @@ export default function ChapterEditorPage() {
             </button>
             <h1 className="font-serif text-lg font-semibold text-ink">
               Review Chapters
-              <span className="ml-2 text-sm font-normal text-stone-400">({chapters.length} detected)</span>
+              <span className="ml-2 text-sm font-normal text-stone-500">({chapters.length} detected)</span>
             </h1>
           </div>
           <button
@@ -187,17 +187,17 @@ export default function ChapterEditorPage() {
         <div className="bg-white rounded-xl border border-amber-100 p-5 overflow-y-auto">
           {selectedChapter ? (
             <>
-              <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-400 mb-3">Preview</h2>
+              <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-500 mb-3">Preview</h2>
               <p className="font-serif font-semibold text-ink mb-3">{selectedChapter.title}</p>
               <p className="text-sm text-stone-600 leading-relaxed whitespace-pre-wrap font-serif">
                 {selectedChapter.preview}
                 {selectedChapter.preview.length >= 300 && (
-                  <span className="text-stone-400">…</span>
+                  <span className="text-stone-500">…</span>
                 )}
               </p>
             </>
           ) : (
-            <p className="text-sm text-stone-400 text-center mt-8">Select a chapter to preview</p>
+            <p className="text-sm text-stone-500 text-center mt-8">Select a chapter to preview</p>
           )}
         </div>
       </div>

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -186,7 +186,7 @@ export default function UploadPage() {
 
         {/* Format hints */}
         <div className="rounded-xl border border-amber-100 bg-white/60 p-4 space-y-2">
-          <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-400">Tips</h2>
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-500">Tips</h2>
           <ul className="text-sm text-amber-800 space-y-1 list-disc list-inside">
             <li>Plain text (.txt) files work best when chapters start with &quot;Chapter I&quot;, &quot;CHAPTER 1&quot;, etc.</li>
             <li>EPUB files are parsed automatically using the book&apos;s built-in structure.</li>

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -121,7 +121,7 @@ export default function AnnotationToolbar({
           <button
             onClick={onClose}
             aria-label="Close"
-            className="rounded-lg p-1.5 min-h-[44px] min-w-[44px] flex items-center justify-center text-stone-400 hover:text-stone-600 hover:bg-amber-50 transition-colors"
+            className="rounded-lg p-1.5 min-h-[44px] min-w-[44px] flex items-center justify-center text-stone-500 hover:text-stone-700 hover:bg-amber-50 transition-colors"
           >
             <CloseIcon className="w-4 h-4" />
           </button>

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -94,7 +94,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
             <h2 id="annotations-heading" className="font-serif font-semibold text-ink text-sm">Annotations</h2>
             <button
               onClick={() => setOpen(false)}
-              className="text-stone-400 hover:text-stone-600 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg transition-colors"
+              className="text-stone-500 hover:text-stone-700 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg transition-colors"
               aria-label="Close"
             >
               <CloseIcon className="w-4 h-4" />

--- a/frontend/src/components/BookDetailModal.tsx
+++ b/frontend/src/components/BookDetailModal.tsx
@@ -94,7 +94,7 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
           <button
             onClick={onClose}
             aria-label="Close"
-            className="shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-full text-stone-400 hover:bg-stone-100 hover:text-stone-600 transition-colors"
+            className="shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-full text-stone-500 hover:bg-stone-100 hover:text-stone-700 transition-colors"
           >
             <CloseIcon className="w-4 h-4" />
           </button>

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -627,7 +627,7 @@ export default function SentenceReader({
           }
           return loaded
             ? "hover:bg-amber-50"
-            : "text-stone-400";
+            : "text-stone-500";
         };
 
         // Long press (500ms) → open word action drawer


### PR DESCRIPTION
## What

WCAG 1.4.3 / 1.4.11 contrast fixes — wave 8. Closes #1369.

### Text contrast failures (WCAG 1.4.3)

`text-stone-400` (2.65:1 on white) → `text-stone-500` (4.86:1 ✓):

| File | Change |
|---|---|
| `app/upload/page.tsx` | Tips section heading |
| `app/upload/[bookId]/chapters/page.tsx` | detected count, Preview heading, ellipsis, empty state |
| `app/import/[bookId]/page.tsx` | cost breakdown text + footer note |
| `app/login/page.tsx` | footer note |
| `components/SentenceReader.tsx` | not-loaded word segments |

### Icon button contrast failures (WCAG 1.4.11)

`text-stone-400` (2.65:1, below 3:1 non-text minimum) → `text-stone-500` (4.86:1 ✓):

| File | Component |
|---|---|
| `components/AnnotationToolbar.tsx` | Close button |
| `components/AnnotationsSidebar.tsx` | Close button |
| `components/BookDetailModal.tsx` | Close button |
| `app/notes/[bookId]/page.tsx` | Edit annotation button |
| `app/decks/[deckId]/page.tsx` | Remove-from-deck trash button |

### Decorative icon

- `app/profile/page.tsx` — ChevronRight in deck navigation button → `aria-hidden="true"` (supplementary to text label; exempt from 1.4.11)

## Tests

New `ContrastWave8.test.ts` — 15 static assertions. All pass; 2451 total suite green.
