### PR TITLE
fix: add missing 404 tests for PATCH/DELETE deck on non-existent deck (closes #1365)

### DIFF
--- a/backend/tests/test_router_decks.py
+++ b/backend/tests/test_router_decks.py
@@ -172,6 +172,18 @@ async def test_patch_deck_name(client, test_user):
     assert resp.json()["name"] == "New"
 
 
+async def test_patch_deck_404_for_nonexistent_deck(client, test_user):
+    """Regression #1365: PATCH /decks/{id} on a non-existent deck must return 404."""
+    resp = await client.patch("/api/decks/9999", json={"name": "Ghost"})
+    assert resp.status_code == 404
+
+
+async def test_delete_deck_404_for_nonexistent_deck(client, test_user):
+    """Regression #1365: DELETE /decks/{id} on a non-existent deck must return 404."""
+    resp = await client.delete("/api/decks/9999")
+    assert resp.status_code == 404
+
+
 async def test_delete_deck_cascades_members(client, test_user):
     await _book()
     vid = await _save("cascades", test_user["id"])


### PR DESCRIPTION
## What changed

Added two regression tests for `PATCH /decks/{id}` and `DELETE /decks/{id}` on non-existent deck IDs.

Both endpoints had 404 guards with zero test coverage:
- `routers/decks.py:117` — `if existing is None: raise HTTPException(404)` in `patch_deck`
- `routers/decks.py:139` — `if not deleted: raise HTTPException(404)` in `delete_deck`

A refactor could silently remove either guard without triggering any test failure.

## Tests added

- `test_patch_deck_404_for_nonexistent_deck` — `PATCH /api/decks/9999` → 404
- `test_delete_deck_404_for_nonexistent_deck` — `DELETE /api/decks/9999` → 404

## Test plan

- [x] Both new tests pass (existing behavior is correct; tests pin it)
- [x] All 33 deck router tests pass
- [x] Full backend suite: 1659+ passed
- [x] Frontend: 1750 passed

Closes #1365
