### PR TITLE
fix: add id=main-content to error, 404, and upload edge-state pages (closes #1371)

### DIFF
--- a/frontend/src/__tests__/SkipLinkTarget.test.ts
+++ b/frontend/src/__tests__/SkipLinkTarget.test.ts
@@ -1,0 +1,30 @@
+import fs from "fs";
+import path from "path";
+
+const src = (rel: string) =>
+  fs.readFileSync(path.join(process.cwd(), "src", rel), "utf-8");
+
+const errorPage = src("app/error.tsx");
+const notFoundPage = src("app/not-found.tsx");
+const uploadPage = src("app/upload/page.tsx");
+const chaptersPage = src("app/upload/[bookId]/chapters/page.tsx");
+
+describe("Skip navigation link target (WCAG 2.4.1) (closes #1371)", () => {
+  it("error.tsx <main> has id=main-content so skip link target exists", () => {
+    expect(errorPage).toContain('id="main-content"');
+  });
+
+  it("not-found.tsx <main> has id=main-content so skip link target exists", () => {
+    expect(notFoundPage).toContain('id="main-content"');
+  });
+
+  it("upload/page.tsx unauthenticated state <main> has id=main-content", () => {
+    // The file should contain at least two occurrences: unauthenticated state + main content state
+    const matches = uploadPage.match(/id="main-content"/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("upload/[bookId]/chapters/page.tsx error state <main> has id=main-content", () => {
+    expect(chaptersPage).toContain('id="main-content"');
+  });
+});

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 export default function ErrorPage({ error, reset }: Props) {
   return (
-    <main className="min-h-screen bg-parchment flex items-center justify-center px-4">
+    <main id="main-content" className="min-h-screen bg-parchment flex items-center justify-center px-4">
       <div role="alert" className="text-center max-w-sm">
         <AlertCircleIcon className="w-14 h-14 mx-auto mb-4 text-red-400" aria-hidden="true" />
         <h1 className="font-serif text-2xl font-bold text-ink mb-2">Something went wrong</h1>

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -3,7 +3,7 @@ import { BookOpenIcon, ArrowRightIcon } from "@/components/Icons";
 
 export default function NotFound() {
   return (
-    <main className="min-h-screen bg-parchment flex items-center justify-center px-4">
+    <main id="main-content" className="min-h-screen bg-parchment flex items-center justify-center px-4">
       <div className="text-center max-w-sm">
         <BookOpenIcon className="w-14 h-14 mx-auto mb-4 text-amber-300" aria-hidden="true" />
         <h1 className="font-serif text-2xl font-bold text-ink mb-2">Page not found</h1>

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -77,7 +77,7 @@ export default function ChapterEditorPage() {
 
   if (error && chapters.length === 0) {
     return (
-      <main className="min-h-screen bg-parchment flex items-center justify-center px-4">
+      <main id="main-content" className="min-h-screen bg-parchment flex items-center justify-center px-4">
         <div role="alert" className="text-center max-w-sm">
           <p className="font-serif text-lg text-ink mb-2">Could not load chapters</p>
           <p className="text-sm text-red-600 mb-6">{error}</p>

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -64,7 +64,7 @@ export default function UploadPage() {
 
   if (status === "unauthenticated") {
     return (
-      <main className="min-h-screen bg-parchment flex items-center justify-center px-4">
+      <main id="main-content" className="min-h-screen bg-parchment flex items-center justify-center px-4">
         <div className="text-center max-w-sm">
           <UploadIcon className="w-12 h-12 text-amber-400 mx-auto mb-4" />
           <h1 className="font-serif text-xl font-semibold text-ink mb-2">Sign in to upload books</h1>


### PR DESCRIPTION
## What

Closes #1371. Adds `id="main-content"` to four `<main>` elements that were missing the skip-link target.

The root layout provides a skip navigation link (`<a href="#main-content">Skip to main content</a>`) per WCAG 2.4.1. Without the target anchor on these pages, keyboard users couldn't bypass the header navigation on error, 404, and upload edge-state screens.

| File | State fixed |
|---|---|
| `app/error.tsx` | always (error boundary) |
| `app/not-found.tsx` | always (404 page) |
| `app/upload/page.tsx` | unauthenticated state |
| `app/upload/[bookId]/chapters/page.tsx` | chapter-load error state |

## Tests

New `SkipLinkTarget.test.ts` — 4 static assertions. 2466 total suite green.
