### PR TITLE
fix: add aria-label to admin data tables (WCAG 1.3.1) (closes #1376)

### DIFF
--- a/frontend/src/__tests__/TableAriaLabel.test.ts
+++ b/frontend/src/__tests__/TableAriaLabel.test.ts
@@ -1,0 +1,18 @@
+import fs from "fs";
+import path from "path";
+
+const src = (rel: string) =>
+  fs.readFileSync(path.join(process.cwd(), "src", rel), "utf-8");
+
+const uploadsPage = src("app/admin/uploads/page.tsx");
+const queueTab = src("components/QueueTab.tsx");
+
+describe("Data table accessible names (WCAG 1.3.1) (closes #1376)", () => {
+  it("admin/uploads/page.tsx table has aria-label", () => {
+    expect(uploadsPage).toMatch(/<table[^>]+aria-label=/);
+  });
+
+  it("QueueTab.tsx planning table has aria-label", () => {
+    expect(queueTab).toMatch(/<table[^>]+aria-label=/);
+  });
+});

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -136,7 +136,7 @@ export default function UploadsPage() {
       ) : (
         <div className="bg-white rounded-xl border border-amber-200 overflow-hidden">
           <div className="overflow-x-auto">
-            <table className="w-full text-sm">
+            <table className="w-full text-sm" aria-label="Uploaded books">
               <thead>
                 <tr className="border-b border-amber-200 bg-amber-50/60">
                   <th scope="col" className="px-4 py-2.5 text-left font-medium text-amber-800">Title</th>

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -717,7 +717,7 @@ export default function QueueTab({ adminFetch }: Props) {
             </p>
             {planResult.books.length > 0 && (
               <div className="max-h-40 overflow-y-auto border border-amber-100 rounded text-xs">
-                <table className="w-full">
+                <table className="w-full" aria-label="Books to translate">
                   <thead className="bg-amber-50">
                     <tr>
                       <th scope="col" className="text-left px-2 py-1 text-stone-600">Book</th>


### PR DESCRIPTION
## What changed

Added `aria-label` to two data tables in the admin panel that lacked programmatic accessible names:

- `admin/uploads/page.tsx` — uploads list table → `aria-label="Uploaded books"`
- `QueueTab.tsx` — translation plan estimate table → `aria-label="Books to translate"`

## Why

WCAG 1.3.1 (Info and Relationships, Level A) requires data tables to have a programmatic label so screen readers can announce "Uploaded books table, 7 columns" instead of just "table, 7 columns". Without a label, users relying on assistive technology have no way to identify what a table contains before navigating into it.

## Test plan

- New static assertion test `TableAriaLabel.test.ts` verifies both `<table>` elements carry `aria-label`.
- No visual change — purely an accessibility attribute addition.

Closes #1376
