### PR TITLE
docs(journal): fill 2026-04-26 entry (sections 3, 5, 6)

### DIFF
--- a/docs/journal/daily/2026-04-26.md
+++ b/docs/journal/daily/2026-04-26.md
@@ -1,0 +1,39 @@
+<!-- THIS PAGE IS AUTO-GENERATED. Edit the source script or report, not this file. Re-run `python -m scripts.generate_docs` after changes. -->
+
+
+# 2026-04-26
+
+## 1. What shipped
+
+_Auto-populated by the nightly workflow from merged PRs grouped by role._
+
+## 2. Reports generated
+
+_Auto-populated from changes in the `reports/` folder._
+
+## 3. Pipeline / workflow lessons
+
+- **Routing-drift pattern: a11y-as-bug.** Twelve separate UI/UX-class issues today (aria-label, role=dialog, role=alert, aria-pressed, aria-expanded, etc.) were filed with `bug`-only labels, routing them to Dev rather than UI/UX. Backfilled `ux` each time. Effective convention has split into "ux-labeled = UI/UX" + "bug-labeled-but-actually-ux = Dev"; work got done either way, but the `--label bug` filter is now misleading. Worth an explicit CLAUDE.md note: "a11y / aria-* / role=… issues should carry `ux` even when phrased as bugs."
+- **Bundle pattern paid off three times in one day.** PR #1263 (closed #1254+#1256+#1260, the homepage+QueueTab error-display dup-overlap), PR #1274 (admin users + audio delete, #1270+#1273), and PR #1291 (3 toggle issues #1281+#1282+#1283). Each saved 2 CI cycles vs filing-separately, and avoided the rebase conflicts these neighboring file changes would have produced. UI/UX adopted the pattern mid-day; throughput visibly improved on the toggle cluster after they did.
+- **PM coordination comments are advisory, not blocking.** Cycle 84 dup-overlap on the #1250/#1251 progress-bar issues: my "let #1250 land first, scope-reduce #1251" comment didn't take — Dev shipped the umbrella PR #1257 anyway, superseding #1250. Lucky outcome: the auto-close-issues workflow (#1185) caught the supersede and closed #1250 cleanly. But the PM comment alone wouldn't have prevented duplicate work; the structural fix is at the issue-filing layer, not the PR layer.
+- **UI/UX session self-applies P2 now (cycle 193 onward).** First time a session has applied priority labels at PR creation without my backfill — saves a label-backfill round each cycle. Worth highlighting as a sub-pattern others can copy.
+- **Slow CI compounding under cluster work.** PR #1271 sat ~3 hours BLOCKED, repeatedly rebased by adjacent merges, each rebase restarting Frontend E2E + Backend pytest. Auto-merge stayed armed, no failures — defensible. But the throughput-cap on a single PR under a hot merge train is real; capacity planning for cluster days should expect this.
+
+## 4. Next things
+
+_Auto-populated from open architecture / feat / bug issues ranked by priority._
+
+## 5. Incidents / near-misses
+
+- **No incidents.** No production breakage, no rule-bypasses, no Path B gate violations, no reverts. The only "near-miss" was the cycle-84 dup-overlap on #1250/#1251 — and even that resolved cleanly via the auto-close-issues workflow rather than human intervention.
+- **Long CI wait on #1271** (~3 hours, 16:37 → 19:40) is worth flagging as a ceiling-test for the rebase-on-every-merge pattern under heavy cluster work. Not an incident — auto-merge stayed armed, no test failures, no PR was lost — but it's the slowest single PR of the post-overhaul era.
+
+## 6. Decisions and abandoned paths
+
+- **Page-by-page over global token swap for the `text-stone-400` contrast cluster.** UI/UX shipped 8 separate waves (#1344 flashcards → #1370 wave 8) rather than a single CSS-token revision in `globals.css`. Defensible: each PR was small, rebases were clean, no conflicts. Trade-off: the same root token (`text-stone-400 = 2.65:1`) is touched repeatedly across files instead of fixed once. If the cluster recurs (audits surface new pages), revisit the global-token approach; for now, page-by-page won.
+- **Helper function over class-based dedup for auto-admin logic.** Dev's #1350 refactor extracted `_new_user_role_approved` as a module-level helper rather than introducing a `UserCreationContext` class or similar abstraction. Matches the codebase's existing function-first style; no speculative abstraction.
+- **Multi-close PR bundles are the new default for theme-clustered issues.** After three successful bundles today (#1263, #1274, #1291), and the supersede-via-bundle resolution of the cycle-84 #1250/#1251 dup, the working assumption going forward is: when 3+ issues touch the same file/component pattern, file one PR closing all of them rather than one PR per issue.
+
+## 7. User-facing changelog
+
+_Auto-drafted from PR titles; PM edits for tone._


### PR DESCRIPTION
## What changed

Added `aria-label` to two data tables in the admin panel that lacked programmatic accessible names:

- `admin/uploads/page.tsx` — uploads list table → `aria-label="Uploaded books"`
- `QueueTab.tsx` — translation plan estimate table → `aria-label="Books to translate"`

## Why

WCAG 1.3.1 (Info and Relationships, Level A) requires data tables to have a programmatic label so screen readers can announce "Uploaded books table, 7 columns" instead of just "table, 7 columns". Without a label, users relying on assistive technology have no way to identify what a table contains before navigating into it.

## Test plan

- New static assertion test `TableAriaLabel.test.ts` verifies both `<table>` elements carry `aria-label`.
- No visual change — purely an accessibility attribute addition.

Closes #1376
