### PR TITLE
fix: add missing 404/400 tests for GET /books/{id}/chapters/draft (closes #1367)

### DIFF
--- a/backend/tests/test_router_uploads.py
+++ b/backend/tests/test_router_uploads.py
@@ -369,6 +369,38 @@ async def test_get_draft_chapters_before_confirm(client, test_user):
     assert len(data["chapters"]) >= 1
 
 
+async def test_get_draft_chapters_book_not_found_returns_404(client, test_user):
+    """Regression #1367: GET /books/{id}/chapters/draft on a non-existent book must return 404."""
+    resp = await client.get("/api/books/99999/chapters/draft")
+    assert resp.status_code == 404
+
+
+async def test_get_draft_chapters_non_upload_book_returns_400(client, test_user):
+    """Regression #1367: GET /books/{id}/chapters/draft on a Gutenberg book must return 400."""
+    from services.db import save_book
+    await save_book(
+        6060,
+        {"title": "Gutenberg Draft", "authors": [], "languages": [], "subjects": [],
+         "download_count": 0, "cover": ""},
+        "some text",
+    )
+    resp = await client.get("/api/books/6060/chapters/draft")
+    assert resp.status_code == 400
+
+
+async def test_get_draft_chapters_already_confirmed_returns_400(client, test_user):
+    """Regression #1367: GET /books/{id}/chapters/draft after confirming must return 400."""
+    upload_resp = await client.post("/api/books/upload", files=_txt_upload())
+    book_id = upload_resp.json()["book_id"]
+    detected = upload_resp.json()["detected_chapters"]
+    await client.post(
+        f"/api/books/{book_id}/chapters/confirm",
+        json={"chapters": [{"title": ch["title"], "original_index": ch["index"]} for ch in detected]},
+    )
+    resp = await client.get(f"/api/books/{book_id}/chapters/draft")
+    assert resp.status_code == 400
+
+
 async def test_chapters_endpoint_returns_400_for_draft_book(client, test_user):
     """Before confirming, /books/{id}/chapters should return 400."""
     upload_resp = await client.post("/api/books/upload", files=_txt_upload())


### PR DESCRIPTION
## What changed
Added three regression tests for `GET /books/{id}/chapters/draft` endpoint guards (routers/uploads.py lines 179, 181, 187):

1. Non-existent book_id → 404
2. Gutenberg (non-upload) book → 400 (`"source" != "upload"` guard)
3. Already-confirmed upload book → 400 (`"status" == "confirmed"` guard)

## Why
These three code paths had zero test coverage. Any future breakage to these guards would be undetected. The 400 guards prevent users from accidentally re-opening confirmed chapters.

## Test plan
- `test_get_draft_chapters_book_not_found_returns_404`
- `test_get_draft_chapters_non_upload_book_returns_400`
- `test_get_draft_chapters_already_confirmed_returns_400`

All three new tests + full suite pass locally.

Closes #1367
