### PR TITLE
fix: add test for already-queued chapter translation early return (closes #1366)

### DIFF
--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -700,6 +700,39 @@ async def test_retry_translation_rejects_nonexistent_book(client):
     assert resp.status_code == 404
 
 
+async def test_chapter_translation_returns_queue_status_when_already_queued(client, test_user):
+    """Regression #1366: POST translation when chapter is already queued must return
+    {status, position, attempts} instead of re-enqueueing.
+
+    routers/books.py:316 early-returns when qstatus['queued'] is True.
+    Without this path, a second translate request from the reader UI would
+    behave incorrectly (double-enqueue or missing status feedback).
+    """
+    from services.db import set_user_gemini_key
+    from services.auth import encrypt_api_key
+    await save_book(9999, MOCK_META, "text")
+    await set_user_gemini_key(test_user["id"], encrypt_api_key("my-key"))
+
+    # First request — enqueues the translation
+    first = await client.post(
+        "/api/books/9999/chapters/0/translation",
+        json={"target_language": "de"},
+    )
+    assert first.status_code == 200
+
+    # Second request for the same chapter/language — should return queue status
+    second = await client.post(
+        "/api/books/9999/chapters/0/translation",
+        json={"target_language": "de"},
+    )
+    assert second.status_code == 200
+    data = second.json()
+    assert "status" in data
+    assert data["status"] in ("pending", "running")
+    assert "position" in data
+    assert "attempts" in data
+
+
 async def test_get_chapter_translation_normalizes_language(client):
     """GET .../translation?target_language=ZH must find a cached 'zh' row.
 


### PR DESCRIPTION
## What changed
Added a regression test for the early-return path when a chapter translation is already queued (routers/books.py line 317).

When `POST /books/{id}/chapters/{idx}/translation` is called and the chapter is already queued, the router returns `{status, position, attempts}` instead of re-enqueueing. This path had no test coverage.

## Why
The already-queued early return at line 317 was uncovered — a regression there would silently re-enqueue work that was already scheduled.

## Test plan
- `test_chapter_translation_returns_queue_status_when_already_queued`: seeds a book, sets a Gemini key, POSTs translation twice, and asserts the second response contains `{status, position, attempts}`.

Closes #1366
