### PR TITLE
fix: match translation line-height to source in parallel mode (closes #1386)

### DIFF
--- a/frontend/src/__tests__/SentenceReaderParallelLineHeight.test.ts
+++ b/frontend/src/__tests__/SentenceReaderParallelLineHeight.test.ts
@@ -1,0 +1,19 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/SentenceReader.tsx"),
+  "utf8",
+);
+
+describe("parallel translation line-height (closes #1385)", () => {
+  it("translation paragraph in parallel mode does not use leading-relaxed", () => {
+    // data-translation="true" marks the translation column in parallel mode.
+    // The paragraph inside must not have leading-relaxed so it matches the
+    // source text line-height and stanzas align vertically.
+    const match = src.match(
+      /data-translation="true"[\s\S]{0,500}?<p className="[^"]*leading-relaxed[^"]*"/,
+    );
+    expect(match).toBeNull();
+  });
+});

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -780,7 +780,7 @@ export default function SentenceReader({
                 </div>
                 <div className="border-t md:border-t-0 md:border-l border-amber-200 pt-2 md:pt-0 md:pl-6" data-translation="true">
                   {translationText ? (
-                    <p className="font-serif text-base text-amber-800 leading-relaxed italic whitespace-pre-wrap">
+                    <p className="font-serif text-base text-amber-800 italic whitespace-pre-wrap">
                       {translationText}
                     </p>
                   ) : translationLoading ? (


### PR DESCRIPTION
## What changed

Removes `leading-relaxed` (line-height 1.625) from the translation `<p>` in parallel reading mode (`SentenceReader.tsx`). The source text uses Tailwind's default line-height (1.5). Over multiple lines, the 8% difference compounds so each translation stanza is measurably taller than the corresponding source stanza.

## Why

User reported Chinese translation appearing larger/taller than German source text when reading Faust in parallel mode. Visual comparison showed each stanza in the translation column is one line taller than expected, making it hard to follow which lines correspond.

The `leading-relaxed` at line 754 (annotation note expansion) is intentionally kept — only the parallel translation paragraph is changed.

## Test plan

- [x] New static assertion `SentenceReaderParallelLineHeight.test.ts` — verifies `data-translation="true"` column does not contain a `leading-relaxed` paragraph
- [x] Existing `SentenceReader.branches.test.tsx` assertions for annotation note `leading-relaxed` still pass (different site, unaffected)
- [x] 2482 frontend tests pass
- [x] 1382 backend tests pass
