### PR TITLE
fix: add aria-expanded to notes Collapse all button (WCAG 4.1.2) (closes #1390)

### DIFF
--- a/frontend/src/__tests__/NotesCollapseAllAriaExpanded.test.ts
+++ b/frontend/src/__tests__/NotesCollapseAllAriaExpanded.test.ts
@@ -1,0 +1,15 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("notes collapse-all button aria-expanded (WCAG 4.1.2) (closes #1390)", () => {
+  it("Collapse all / Expand all button has aria-expanded", () => {
+    // The button's visible text already changes, but aria-expanded is required
+    // by WCAG 4.1.2 so screen readers can announce state without reading the label.
+    expect(src).toMatch(/toggleCollapseAll[\s\S]{0,200}?aria-expanded=/);
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -645,6 +645,7 @@ export default function BookNotesPage() {
           {(annCount + insCount + vocCount) > 0 && !loading && (
             <button
               onClick={toggleCollapseAll}
+              aria-expanded={!isAllCollapsed}
               className="text-xs text-stone-500 hover:text-stone-600 shrink-0 transition-colors min-h-[44px]"
             >
               {isAllCollapsed ? "Expand all" : "Collapse all"}


### PR DESCRIPTION
## What changed

Adds `aria-expanded={!isAllCollapsed}` to the global Collapse all / Expand all button on `/notes/[bookId]`.

## Why

WCAG 4.1.2 (Name, Role, Value, Level A) requires that the state of UI components be programmatically determinable. The button's visible label changes between "Expand all" and "Collapse all", but `aria-expanded` was missing — screen readers had no programmatic state to announce.

Individual section headers already correctly use `aria-expanded` (line 46 of the same file); this aligns the global toggle.

## Test plan

- [x] New static assertion `NotesCollapseAllAriaExpanded.test.ts` — verifies the `toggleCollapseAll` button has `aria-expanded`
- [x] All 2483 frontend tests pass
- [x] All 1382 backend tests pass
