### PR TITLE
fix: fix invalid Gemini model name (500 on Insight) + Insight panel page-scroll bug

### DIFF
--- a/backend/services/gemini.py
+++ b/backend/services/gemini.py
@@ -7,7 +7,7 @@ import re
 from google import genai
 from google.genai import types
 
-MODEL = "gemini-3.1-flash-lite-preview"
+MODEL = "gemini-2.0-flash-lite"
 # Model used by the bulk translator. Defaults to the same model that powers
 # the rest of the app (known to work with the user's key). Admins can override
 # this through the bulk-translate start request if they want to try a

--- a/backend/tests/test_gemini.py
+++ b/backend/tests/test_gemini.py
@@ -15,6 +15,21 @@ def mock_generate(return_value: str):
 
 # ── _lang helper ──────────────────────────────────────────────────────────────
 
+def test_model_name_is_stable_and_valid():
+    """Regression #1388: MODEL must not be a non-existent preview name."""
+    assert "preview" not in gemini.MODEL.lower(), (
+        f"MODEL '{gemini.MODEL}' looks like a preview alias — use a stable model name"
+    )
+    assert gemini.MODEL.startswith("gemini-"), (
+        f"MODEL '{gemini.MODEL}' is not a valid Gemini model identifier"
+    )
+    # Guard against any future typo like 'gemini-3.1' which doesn't exist
+    parts = gemini.MODEL.split("-")
+    assert len(parts) >= 3, (
+        f"MODEL '{gemini.MODEL}' is too short to be a valid Gemini model name"
+    )
+
+
 def test_lang_returns_empty_for_english():
     assert gemini._lang("en") == ""
 

--- a/frontend/src/__tests__/InsightChat.coverage2.test.tsx
+++ b/frontend/src/__tests__/InsightChat.coverage2.test.tsx
@@ -310,3 +310,23 @@ describe("InsightChat — MsgContextBlock onToggle (L389-L390)", () => {
     expect(finalBtns[finalBtns.length - 1]).toHaveAttribute("aria-expanded", "false");
   });
 });
+
+
+// ── Regression #1389: opening Insight panel must not scroll the page ──────────
+
+describe("InsightChat — auto-scroll does not call scrollIntoView (#1389)", () => {
+  it("does not call scrollIntoView when insight loads on panel open", async () => {
+    const scrollIntoViewMock = jest.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+    mockGetInsight.mockResolvedValue({ insight: "Great insight." });
+
+    const { rerender } = render(<InsightChat {...BASE} isVisible={false} />);
+    await act(async () => { rerender(<InsightChat {...BASE} isVisible={true} />); });
+    await act(async () => { await flushPromises(); });
+
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+
+    delete (window.HTMLElement.prototype as any).scrollIntoView;
+  });
+});

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -306,9 +306,11 @@ export default function InsightChat({
   }, [selectedText]);
 
   // ── 6. Auto-scroll ───────────────────────────────────────────────────
+  // Scroll only the messages container — not the page — so opening the
+  // Insight panel doesn't jump the reader back to the top.
   useEffect(() => {
-    if (autoScrollRef.current) {
-      bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    if (autoScrollRef.current && messagesBoxRef.current) {
+      messagesBoxRef.current.scrollTop = messagesBoxRef.current.scrollHeight;
     }
   }, [messages, chatLoading]);
 


### PR DESCRIPTION
## What changed

Two user-reported production bugs in the Insight chat feature:

**1. Invalid Gemini model name (#1388 — P0)**
`backend/services/gemini.py` had `MODEL = "gemini-3.1-flash-lite-preview"` which is not a valid Gemini API model. Every call to `POST /api/ai/insight` and `POST /api/ai/qa` threw an exception, caught and re-raised as HTTP 500. Updated to `gemini-2.0-flash-lite` (stable, equivalent flash-lite tier model).

**2. Opening Insight panel scrolls page to top (#1389 — P1)**
`InsightChat.tsx` auto-scroll effect called `bottomRef.current?.scrollIntoView({ behavior: "smooth" })` without `block: "nearest"`. `scrollIntoView` scrolls ALL ancestor containers including the document, so every time the Insight panel opened and loaded its first message, the reader page jumped to the top. Fixed by scrolling only the messages container directly (`messagesBoxRef.current.scrollTop = messagesBoxRef.current.scrollHeight`).

## Test plan

- Backend: added `test_model_name_is_stable_and_valid` to `test_gemini.py` — asserts MODEL is not a preview alias and follows a valid Gemini identifier pattern.
- Frontend: added regression test in `InsightChat.coverage2.test.tsx` — mocks `scrollIntoView` and asserts it is NOT called when the panel opens and loads.
- Full backend suite: 1665 passed ✓
- Full frontend suite: 2483 passed ✓

Closes #1388, #1389
