### PR TITLE
fix: WCAG 1.4.3 contrast — text-amber-600 in components (wave 10) (closes #1392)

### DIFF
--- a/frontend/src/__tests__/ContrastWave10.test.ts
+++ b/frontend/src/__tests__/ContrastWave10.test.ts
@@ -1,0 +1,41 @@
+import * as fs from "fs";
+import * as path from "path";
+
+function countAmber600AtSmallSize(content: string): number {
+  const matches = content.match(/className="[^"]*text-(?:xs|sm)[^"]*text-amber-600[^"]*"/g) ?? [];
+  const matches2 = content.match(/className="[^"]*text-amber-600[^"]*text-(?:xs|sm)[^"]*"/g) ?? [];
+  return new Set([...matches, ...matches2]).size;
+}
+
+function read(rel: string) {
+  return fs.readFileSync(path.join(__dirname, "..", rel), "utf8");
+}
+
+describe("WCAG 1.4.3 contrast — text-amber-600 at small sizes (wave 10) (closes #1392)", () => {
+  it("ReadingStats.tsx has no text-amber-600 at xs/sm", () => {
+    expect(countAmber600AtSmallSize(read("components/ReadingStats.tsx"))).toBe(0);
+  });
+  it("WordActionDrawer.tsx has no text-amber-600 at xs/sm", () => {
+    expect(countAmber600AtSmallSize(read("components/WordActionDrawer.tsx"))).toBe(0);
+  });
+  it("QueueTab.tsx has no text-amber-600 at xs/sm", () => {
+    expect(countAmber600AtSmallSize(read("components/QueueTab.tsx"))).toBe(0);
+  });
+  it("VocabWordTooltip.tsx has no text-amber-600 at xs/sm", () => {
+    expect(countAmber600AtSmallSize(read("components/VocabWordTooltip.tsx"))).toBe(0);
+  });
+  it("SeedPopularButton.tsx has no text-amber-600 at xs/sm", () => {
+    expect(countAmber600AtSmallSize(read("components/SeedPopularButton.tsx"))).toBe(0);
+  });
+  it("ChapterSummary.tsx has no text-amber-600 at xs/sm", () => {
+    expect(countAmber600AtSmallSize(read("components/ChapterSummary.tsx"))).toBe(0);
+  });
+  it("BookDetailModal.tsx has no text-amber-600 at xs/sm", () => {
+    expect(countAmber600AtSmallSize(read("components/BookDetailModal.tsx"))).toBe(0);
+  });
+  it("upload/[bookId]/chapters/page.tsx has no text-amber-600 at xs/sm", () => {
+    expect(
+      countAmber600AtSmallSize(read("app/upload/[bookId]/chapters/page.tsx")),
+    ).toBe(0);
+  });
+});

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -102,7 +102,7 @@ export default function ChapterEditorPage() {
           <div className="flex items-center gap-3">
             <button
               onClick={() => router.push("/upload")}
-              className="text-sm text-amber-600 hover:text-amber-800 transition-colors min-h-[44px] flex items-center"
+              className="text-sm text-amber-700 hover:text-amber-800 transition-colors min-h-[44px] flex items-center"
             >
               <ArrowLeftIcon className="w-4 h-4 inline" aria-hidden="true" /> Back
             </button>

--- a/frontend/src/components/BookDetailModal.tsx
+++ b/frontend/src/components/BookDetailModal.tsx
@@ -150,7 +150,7 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
             href={`https://www.gutenberg.org/ebooks/${book.id}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-xs text-amber-600 hover:text-amber-800 hover:underline ml-auto"
+            className="text-xs text-amber-700 hover:text-amber-800 hover:underline ml-auto"
           >
             View on Project Gutenberg <ArrowUpRightIcon className="w-3 h-3 inline" aria-hidden="true" />
           </a>

--- a/frontend/src/components/ChapterSummary.tsx
+++ b/frontend/src/components/ChapterSummary.tsx
@@ -89,7 +89,7 @@ export default function ChapterSummary({
           <button
             onClick={load}
             title="Regenerate summary"
-            className="text-xs text-amber-600 hover:text-amber-800 hover:underline transition-colors min-h-[44px] flex items-center px-1"
+            className="text-xs text-amber-700 hover:text-amber-800 hover:underline transition-colors min-h-[44px] flex items-center px-1"
           >
             {summary ? <><RetryIcon className="w-3 h-3 inline" aria-hidden="true" /> Refresh</> : "Generate"}
           </button>

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -747,7 +747,7 @@ export default function QueueTab({ adminFetch }: Props) {
             <div className="space-y-3 max-h-64 overflow-y-auto bg-amber-50/50 rounded-lg p-3">
               {Object.entries(dryRunResult.preview).map(([idx, paragraphs]) => (
                 <div key={idx} className="text-sm font-serif">
-                  <div className="text-xs text-amber-600 mb-1">Chapter {Number(idx) + 1}</div>
+                  <div className="text-xs text-amber-700 mb-1">Chapter {Number(idx) + 1}</div>
                   {paragraphs.map((p, i) => (
                     <p key={i} className="mb-1 text-ink">{p}</p>
                   ))}

--- a/frontend/src/components/ReadingStats.tsx
+++ b/frontend/src/components/ReadingStats.tsx
@@ -126,7 +126,7 @@ export default function ReadingStats({ active, heatmapOnly = false }: Props) {
                 <p className="text-sm font-semibold text-amber-900">
                   {stats.streak}-day reading streak!
                 </p>
-                <p className="text-xs text-amber-600">
+                <p className="text-xs text-amber-700">
                   Longest: {stats.longest_streak} days
                 </p>
               </div>

--- a/frontend/src/components/SeedPopularButton.tsx
+++ b/frontend/src/components/SeedPopularButton.tsx
@@ -211,7 +211,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
 
           {state.log.length > 0 && (
             <details className="mt-2">
-              <summary className="text-xs text-amber-600 cursor-pointer">
+              <summary className="text-xs text-amber-700 cursor-pointer">
                 Recent events ({state.log.length})
               </summary>
               <ul className="mt-1 text-xs space-y-0.5 max-h-40 overflow-y-auto">

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -84,7 +84,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
       {/* Body */}
       <div className="px-3 py-2.5 max-h-40 overflow-y-auto">
         {loading && (
-          <div className="flex items-center gap-2 text-amber-600 text-xs py-1" role="status">
+          <div className="flex items-center gap-2 text-amber-700 text-xs py-1" role="status">
             <span className="w-3 h-3 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin shrink-0" aria-hidden="true" />
             Looking up definition…
           </div>

--- a/frontend/src/components/WordActionDrawer.tsx
+++ b/frontend/src/components/WordActionDrawer.tsx
@@ -145,7 +145,7 @@ export default function WordActionDrawer({
 
           {/* Dictionary definitions */}
           {loading && (
-            <div role="status" aria-label="Looking up word" className="flex items-center gap-2 text-amber-600 text-sm">
+            <div role="status" aria-label="Looking up word" className="flex items-center gap-2 text-amber-700 text-sm">
               <span className="w-3 h-3 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
               Looking up...
             </div>


### PR DESCRIPTION
## What changed

Wave 9 (PR #1387) fixed `text-amber-600` at small sizes in 10 app-level pages. This PR covers the remaining instances in shared components that were missed.

`text-amber-600` (#d97706) on white = 3.19:1 — fails WCAG 1.4.3 (needs 4.5:1).
`text-amber-700` (#b45309) on white = 5.02:1 ✅

## Files changed

- `components/ReadingStats.tsx` — streak stat label
- `components/WordActionDrawer.tsx` — "Looking up word" loading status
- `components/QueueTab.tsx` — chapter heading in dry-run preview
- `components/VocabWordTooltip.tsx` — loading status
- `components/SeedPopularButton.tsx` — details `<summary>`
- `components/ChapterSummary.tsx` — Regenerate button
- `components/BookDetailModal.tsx` — Gutenberg link
- `app/upload/[bookId]/chapters/page.tsx` — Back button

## Test plan

- [x] New static assertion `ContrastWave10.test.ts` — 8 assertions confirming `text-amber-600` at `text-xs`/`text-sm` no longer appears in the 8 files
- [x] All 2491 frontend tests pass
- [x] All 1382 backend tests pass
