### PR TITLE
fix: reject whitespace-only word in GET /vocabulary/definition/{word} (closes #1398)

### DIFF
--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -84,6 +84,9 @@ async def get_definition(
     lang: str = Query(default="en", min_length=1, max_length=20),
     user: dict = Depends(get_current_user),
 ):
+    word = word.strip()
+    if not word:
+        raise HTTPException(status_code=422, detail="word cannot be blank")
     lang = lang.strip().lower().split("-")[0]
     if not lang:
         raise HTTPException(status_code=422, detail="lang cannot be blank")

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -877,3 +877,17 @@ async def test_export_obsidian_whitespace_target_language_returns_422(client, te
     assert resp.status_code == 422, (
         f"Expected 422 for whitespace target_language in /vocabulary/export/obsidian, got {resp.status_code}: {resp.text}"
     )
+
+
+# ── Issue #1398: whitespace-only word in /definition/{word} ──────────────────
+
+
+async def test_definition_whitespace_only_word_returns_422(client, test_user):
+    """Regression #1398: GET /vocabulary/definition/%20%20 must return 422.
+
+    A whitespace-only URL-encoded word passes max_length validation but should
+    be rejected before making external Wiktionary / Gemini API calls."""
+    resp = await client.get("/api/vocabulary/definition/%20%20%20")
+    assert resp.status_code == 422, (
+        f"Expected 422 for whitespace-only word in /definition, got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## What changed

`GET /vocabulary/definition/{word}` accepted URL-encoded whitespace path segments (e.g. `%20%20%20`) — Pydantic's `max_length=200` passed with length 3, and the raw unstripped word was forwarded to:
1. `wiktionary.lookup("   ", lang)` — external Wiktionary HTTP request with a whitespace word
2. If user has a Gemini key and Wiktionary returned no definitions: `wiktionary.ai_lookup("   ", lang, api_key)` — burning the user's Gemini API quota on a meaningless lookup

The `lang` query parameter already had this guard (lines 87-89). Applied the same pattern to `word`: strip + raise 422 if blank.

## Test plan

- Added `test_definition_whitespace_only_word_returns_422` in `test_router_vocabulary.py`
- Reproduces the bug: `GET /api/vocabulary/definition/%20%20%20` must return 422
- Full backend: 1665 passed ✓ (all vocabulary tests pass)
- Full frontend: 2483 passed ✓

Closes #1398
