### PR TITLE
docs(journal): add P0 Gemini outage to 2026-04-26 §5 incidents

### DIFF
--- a/docs/journal/daily/2026-04-26.md
+++ b/docs/journal/daily/2026-04-26.md
@@ -25,8 +25,13 @@ _Auto-populated from open architecture / feat / bug issues ranked by priority._
 
 ## 5. Incidents / near-misses
 
-- **No incidents.** No production breakage, no rule-bypasses, no Path B gate violations, no reverts. The only "near-miss" was the cycle-84 dup-overlap on #1250/#1251 — and even that resolved cleanly via the auto-close-issues workflow rather than human intervention.
+- **🔴 P0 production outage: invalid Gemini model name (#1388).** All Gemini-backed AI features (Insight chat, summaries, QA) returned 500 because `backend/services/gemini.py` had `MODEL = "gemini-3.1-flash-lite-preview"` — not a valid model name in the Gemini API. User-reported at 22:54. Dev claimed within seconds and said "fixing invalid model name and scroll bug together in one PR" (bundling with #1389, an unrelated frontend Insight scroll bug). **Dev then went silent for ~24 minutes.** PM nudge at 23:01 unanswered; PM escalated to **#1395** (`user-only`+`bug`+`P0`) at 23:06 asking the user to wake the Dev session, push the 1-line fix themselves, or surface the right model name. **PR #1397 finally landed at 23:18** (+40/-3 across `gemini.py` + `InsightChat.tsx` + tests), bundled #1388+#1389 as planned. Dev was slow, not stuck. Total user-facing outage window: ~25 min from filing to PR open; production restored on merge.
+- **Lessons from the P0**:
+  1. Bundling P0 + non-urgent P1 in one PR introduces avoidable latency. The Gemini fix was 1 line; the scroll bug was 30 lines of frontend. Splitting and shipping #1388 alone in 2 minutes would have been cleaner. PM nudge included this guidance — the next outage we should be more directive about it.
+  2. PM's escalation path (filing `user-only` after no Dev response) worked — but the trigger was time-based (~13 min of silence), not a structural signal. Could be tightened: any P0 with no PR in 5 min should auto-escalate.
+  3. The actual root-cause (invalid model name) was likely introduced by a previous AI-assisted edit. A regression test in #1397 asserting the model name is in a known-good allowlist would have caught it pre-merge. Worth proposing as a CI gate in tomorrow's review.
 - **Long CI wait on #1271** (~3 hours, 16:37 → 19:40) is worth flagging as a ceiling-test for the rebase-on-every-merge pattern under heavy cluster work. Not an incident — auto-merge stayed armed, no test failures, no PR was lost — but it's the slowest single PR of the post-overhaul era.
+- **Other near-miss**: cycle-84 dup-overlap on #1250/#1251 — PM coordination comment didn't take, but the auto-close-issues workflow (#1185) caught the supersede cleanly, so no duplicate work shipped.
 
 ## 6. Decisions and abandoned paths
 


### PR DESCRIPTION
## Summary

Updates `docs/journal/daily/2026-04-26.md` §5 (Incidents / near-misses). The earlier journal-fill PR (#1379) said "no incidents" — true at filing time, but a P0 production outage hit afterward and is now the day's defining incident.

## What's added

- **P0 production outage entry**: full timeline of #1388 (invalid Gemini model name → 500 on all AI endpoints), Dev's ~24 min silence, PM nudge → #1395 user-only escalation → PR #1397 fix shipped.
- **Three lessons captured**:
  1. Bundling P0 + non-urgent P1 in one PR adds avoidable latency. Should split for fastest restore.
  2. PM time-based escalation (~13 min) worked but could be tightened — any P0 without a PR in 5 min should auto-escalate.
  3. The root cause (invalid hard-coded model name) suggests adding a regression test asserting the model name is in a known-good allowlist; worth a CI-gate proposal tomorrow.

## Test plan

- [x] No code touched — CI paths-filter (#891) skips heavy jobs
- [x] Single-section edit, format preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
