### PR TITLE
fix: WCAG 1.4.3 contrast — text-amber-500 at small sizes (wave 11) (closes #1396)

### DIFF
--- a/frontend/src/__tests__/ContrastWave11.test.ts
+++ b/frontend/src/__tests__/ContrastWave11.test.ts
@@ -1,0 +1,34 @@
+import * as fs from "fs";
+import * as path from "path";
+
+function countAmber500AtSmallSize(content: string): number {
+  // Skip hover:text-amber-500 — only static color counts.
+  // Match className strings that contain text-amber-500 alongside text-xs/text-sm.
+  const allClassNames = content.match(/className="[^"]*"/g) ?? [];
+  let count = 0;
+  for (const cn of allClassNames) {
+    const hasSmall = /\btext-(xs|sm)\b/.test(cn);
+    const hasAmber500Static = /(?<!hover:)\btext-amber-500\b/.test(cn);
+    if (hasSmall && hasAmber500Static) count++;
+  }
+  return count;
+}
+
+function read(rel: string) {
+  return fs.readFileSync(path.join(__dirname, "..", rel), "utf8");
+}
+
+describe("WCAG 1.4.3 contrast — text-amber-500 at small sizes (wave 11) (closes #1396)", () => {
+  it("reader page has no text-amber-500 at xs/sm", () => {
+    expect(countAmber500AtSmallSize(read("app/reader/[bookId]/page.tsx"))).toBe(0);
+  });
+  it("WordActionDrawer.tsx has no text-amber-500 at xs/sm", () => {
+    expect(countAmber500AtSmallSize(read("components/WordActionDrawer.tsx"))).toBe(0);
+  });
+  it("BookCard.tsx has no text-amber-500 at xs/sm", () => {
+    expect(countAmber500AtSmallSize(read("components/BookCard.tsx"))).toBe(0);
+  });
+  it("WordLookup.tsx has no text-amber-500 at xs/sm", () => {
+    expect(countAmber500AtSmallSize(read("components/WordLookup.tsx"))).toBe(0);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -941,7 +941,7 @@ export default function ReaderPage() {
                       href={`https://www.gutenberg.org/ebooks/${meta.id}`}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="shrink-0 text-xs text-amber-500 hover:text-amber-700"
+                      className="shrink-0 text-xs text-amber-700 hover:text-amber-800"
                       title="View on Project Gutenberg"
                     ><ArrowUpRightIcon className="w-3 h-3" aria-hidden="true" /></a>
                   )}
@@ -956,7 +956,7 @@ export default function ReaderPage() {
           {/* Chapter navigation — desktop only (mobile uses bottom bar) */}
           <div className="hidden md:flex items-center gap-1 shrink-0">
             {loading ? (
-              <span role="status" className="text-xs text-amber-500 animate-pulse">Loading…</span>
+              <span role="status" className="text-xs text-amber-700 animate-pulse">Loading…</span>
             ) : (
               <>
                 <button
@@ -1417,7 +1417,7 @@ export default function ReaderPage() {
                     disabled={chapterIndex === 0}
                     className="inline-flex items-center gap-1 text-sm text-amber-700 hover:text-amber-900 disabled:opacity-30 min-h-[44px]"
                   ><ArrowLeftIcon className="w-4 h-4" aria-hidden="true" /> Previous chapter</button>
-                  <span className="text-xs text-amber-500 self-center">
+                  <span className="text-xs text-amber-700 self-center">
                     {chapterIndex + 1} / {chapters.length} · {Math.round(((chapterIndex + 1) / chapters.length) * 100)}%
                   </span>
                   <button

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -59,7 +59,7 @@ export default function BookCard({ book, onClick, badge, onRemove }: Props) {
           {book.authors.join(", ")}
         </p>
         {badge && (
-          <span className="mt-1.5 text-xs text-amber-500">{badge}</span>
+          <span className="mt-1.5 text-xs text-amber-700">{badge}</span>
         )}
       </button>
     </div>

--- a/frontend/src/components/WordActionDrawer.tsx
+++ b/frontend/src/components/WordActionDrawer.tsx
@@ -139,7 +139,7 @@ export default function WordActionDrawer({
           <div className="flex items-baseline gap-2">
             <span className="font-serif font-bold text-ink text-xl">{action.word}</span>
             {result?.phonetic && (
-              <span className="text-sm text-amber-500">{result.phonetic}</span>
+              <span className="text-sm text-amber-700">{result.phonetic}</span>
             )}
           </div>
 
@@ -152,7 +152,7 @@ export default function WordActionDrawer({
           )}
 
           {error && (
-            <p role="alert" className="text-sm text-amber-500 italic">{error}</p>
+            <p role="alert" className="text-sm text-amber-700 italic">{error}</p>
           )}
 
           {result && result.meanings.length > 0 && (
@@ -173,7 +173,7 @@ export default function WordActionDrawer({
           {/* Translation context */}
           {action.translationText && (
             <div className="border-l-2 border-amber-300 pl-3 py-1">
-              <p className="text-xs text-amber-500 mb-0.5">Translation</p>
+              <p className="text-xs text-amber-700 mb-0.5">Translation</p>
               <p className="text-sm text-amber-800 italic">{action.translationText}</p>
             </div>
           )}

--- a/frontend/src/components/WordLookup.tsx
+++ b/frontend/src/components/WordLookup.tsx
@@ -100,7 +100,7 @@ export default function WordLookup({ word, position, language, onClose }: Props)
           <div className="flex items-baseline gap-2 mb-2">
             <span className="font-serif font-bold text-ink text-base">{result.word}</span>
             {result.phonetic && (
-              <span className="text-xs text-amber-500">{result.phonetic}</span>
+              <span className="text-xs text-amber-700">{result.phonetic}</span>
             )}
           </div>
           {result.meanings.map((m, i) => (


### PR DESCRIPTION
## What changed

`text-amber-500` (#f59e0b) on white = 2.49:1 — fails WCAG 1.4.3 (needs 4.5:1). Replaces 8 instances of `text-amber-500` at `text-xs`/`text-sm` sizes with `text-amber-700` (5.02:1 on white ✅). `hover:text-amber-500` left intact (hover states are exempt from contrast minimums).

## Files changed

- `app/reader/[bookId]/page.tsx` — Gutenberg link, "Loading…" status, chapter progress label
- `components/WordActionDrawer.tsx` — phonetic, error alert, "Translation" label
- `components/BookCard.tsx` — book badge text
- `components/WordLookup.tsx` — phonetic display

## Test plan

- [x] New static assertion `ContrastWave11.test.ts` — verifies no static `text-amber-500` at `text-xs`/`text-sm` (allows `hover:text-amber-500`)
- [x] All 2489 frontend tests pass
- [x] All 1382 backend tests pass
