### PR TITLE
fix: WCAG 1.4.3 contrast — text-amber-400 in popular books list (wave 12) (closes #1405)

### DIFF
--- a/frontend/src/__tests__/ContrastWave12.test.ts
+++ b/frontend/src/__tests__/ContrastWave12.test.ts
@@ -1,0 +1,21 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const pageSrc = fs.readFileSync(
+  path.join(__dirname, "../app/page.tsx"),
+  "utf8",
+);
+
+describe("WCAG 1.4.3 contrast — text-amber-400 at small sizes (wave 12) (closes #1405)", () => {
+  it("popular books list rank index does not use text-amber-400", () => {
+    expect(pageSrc).not.toMatch(
+      /<span className="text-xs text-amber-400[^"]*tabular-nums">\s*\{\(popularPage - 1\)/,
+    );
+  });
+
+  it("popular books list download count does not use text-amber-400", () => {
+    expect(pageSrc).not.toMatch(
+      /<span className="text-xs text-amber-400[^"]*tabular-nums">\s*\{book\.download_count/,
+    );
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -719,7 +719,7 @@ export default function Home() {
                           onClick={() => handleBookClick(book)}
                           className="flex items-center gap-3 w-full px-4 py-3 text-left hover:bg-amber-50 transition-colors"
                         >
-                          <span className="text-xs text-amber-400 w-7 text-right shrink-0 tabular-nums">
+                          <span className="text-xs text-stone-500 w-7 text-right shrink-0 tabular-nums">
                             {(popularPage - 1) * PER_PAGE + idx + 1}
                           </span>
                           {book.cover ? (
@@ -735,7 +735,7 @@ export default function Home() {
                             <p className="text-xs text-amber-700 truncate">{book.authors.join(", ")}</p>
                           </div>
                           {book.download_count > 0 ? (
-                            <span className="text-xs text-amber-400 shrink-0 tabular-nums">
+                            <span className="text-xs text-stone-500 shrink-0 tabular-nums">
                               {book.download_count.toLocaleString()}
                             </span>
                           ) : null}


### PR DESCRIPTION
## What changed

`text-amber-400` (#fbbf24) on white = 1.69:1 — fails WCAG 1.4.3 (4.5:1 minimum), making the rank index and download count in the popular-books list nearly invisible to users with low vision.

Replaces `text-amber-400` → `text-stone-500` (#78716c, 4.83:1 on white) for both spans on `app/page.tsx`. Stone-500 preserves the secondary-text visual hierarchy without competing with primary content the way amber-700 would.

## Out of scope

- `notes/[bookId]/page.tsx:227` — `before:text-amber-400` is a `·` bullet decoration; decorative content is exempt.
- `TTSControls.tsx:450` — disabled-state button; WCAG 1.4.3 exempts inactive controls.

## Test plan

- [x] New static assertion `ContrastWave12.test.ts` — verifies rank index and download count no longer use `text-amber-400`
- [x] All 2495 frontend tests pass
- [x] All 1382 backend tests pass
