### PR TITLE
fix: Highlight stores selected substring + renders partial underline (closes #1410)

### DIFF
--- a/frontend/e2e/reader-highlight.spec.ts
+++ b/frontend/e2e/reader-highlight.spec.ts
@@ -1,9 +1,10 @@
 /**
- * E2E: SelectionToolbar Highlight passes full sentence context (#407)
+ * E2E: SelectionToolbar Highlight passes the user's selection (#1410)
  *
- * When a user selects a word and clicks Highlight, the annotation POST
- * must send the **full sentence** (from the nearest [data-seg] element)
- * as sentence_text — not just the selected substring.
+ * Originally (#407 / #400) this test asserted the toolbar must send the
+ * **full sentence** because the renderer couldn't paint partial highlights.
+ * Per #1410 the renderer now handles substring annotations correctly, and
+ * the write path was changed to store what the user actually selected.
  */
 import { test, expect } from "./base";
 import { mockBackend, MOCK_CHAPTERS } from "./fixtures";
@@ -12,7 +13,7 @@ test.beforeEach(async ({ page }) => {
   await mockBackend(page);
 });
 
-test("highlight sends full sentence text, not raw selection substring", async ({ page }) => {
+test("highlight sends the user's selected substring, not the full sentence", async ({ page }) => {
   // Capture the annotation POST body for assertion
   let annotationBody: Record<string, unknown> | null = null;
   await page.route("**/api/annotations", (route) => {
@@ -72,11 +73,10 @@ test("highlight sends full sentence text, not raw selection substring", async ({
   await expect(yellowBtn).toBeVisible({ timeout: 6000 });
   await yellowBtn.click();
 
-  // Verify the POST was made with the full sentence, not just "It"
+  // Verify the POST was made with just the user's selection ("It"), not the full sentence
   expect(annotationBody).not.toBeNull();
   const sentenceText = (annotationBody as Record<string, unknown>)?.sentence_text as string;
-  expect(sentenceText).not.toBe("It");
-  expect(sentenceText).toBe(segText);
-  // Confirm it contains the full sentence text
-  expect(sentenceText.length).toBeGreaterThan(5);
+  expect(sentenceText).toBe("It");
+  // Confirm it is NOT the full sentence
+  expect(sentenceText).not.toBe(segText);
 });

--- a/frontend/src/__tests__/SelectionToolbarHighlightSubsentence.test.tsx
+++ b/frontend/src/__tests__/SelectionToolbarHighlightSubsentence.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Regression for #1410: Highlight button must save the selected text,
+ * not the surrounding sentence context.
+ */
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import SelectionToolbar from "@/components/SelectionToolbar";
+
+function makeReaderEl() {
+  const el = document.createElement("div");
+  el.id = "reader-scroll";
+  document.body.appendChild(el);
+  return el;
+}
+
+/**
+ * Simulate a sub-sentence selection inside a real-world DOM:
+ *   <p>It was a lonely glade beneath the oaks.</p>
+ * Selecting only "lonely glade beneath" — the parent <p> sets `selection.context`
+ * to the full sentence, but `selection.text` is the partial selection.
+ */
+function simulateSubsentenceSelection(reader: HTMLElement) {
+  const p = document.createElement("p");
+  const fullSentence = "It was a lonely glade beneath the oaks.";
+  p.textContent = fullSentence;
+  reader.appendChild(p);
+
+  const phraseStart = fullSentence.indexOf("lonely glade beneath");
+  const phraseEnd = phraseStart + "lonely glade beneath".length;
+  const range = document.createRange();
+  const textNode = p.firstChild as Text;
+  range.setStart(textNode, phraseStart);
+  range.setEnd(textNode, phraseEnd);
+
+  range.getBoundingClientRect = jest.fn().mockReturnValue({
+    left: 100, right: 200, top: 300, bottom: 320,
+    width: 100, height: 20, x: 100, y: 300,
+    toJSON: () => ({}),
+  } as DOMRect);
+
+  jest.spyOn(window, "getSelection").mockReturnValue({
+    toString: () => "lonely glade beneath",
+    getRangeAt: () => range,
+    rangeCount: 1,
+    removeAllRanges: jest.fn(),
+  } as unknown as Selection);
+}
+
+describe("SelectionToolbar Highlight — sub-sentence selection (closes #1410)", () => {
+  let readerEl: HTMLElement;
+
+  beforeEach(() => {
+    readerEl = makeReaderEl();
+    jest.spyOn(window, "getSelection").mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    readerEl.remove();
+    jest.restoreAllMocks();
+  });
+
+  it("Highlight saves only the selected phrase, not the full sentence", () => {
+    const onHighlight = jest.fn();
+    render(<SelectionToolbar onHighlight={onHighlight} />);
+    simulateSubsentenceSelection(readerEl);
+    act(() => { document.dispatchEvent(new Event("selectionchange")); });
+
+    fireEvent.click(screen.getByRole("button", { name: /Highlight/i }));
+
+    // Bug was: passed full sentence "It was a lonely glade beneath the oaks."
+    // Fix: pass only the user's selection.
+    expect(onHighlight).toHaveBeenCalledWith("lonely glade beneath");
+    expect(onHighlight).not.toHaveBeenCalledWith(
+      expect.stringContaining("It was a lonely glade beneath the oaks"),
+    );
+  });
+});

--- a/frontend/src/__tests__/SentenceReader.extended.test.tsx
+++ b/frontend/src/__tests__/SentenceReader.extended.test.tsx
@@ -717,7 +717,13 @@ describe("SentenceReader annotation substring matching", () => {
     const segs = getSegments(container);
     const annotatedSeg = segs.find((s) => s.textContent?.includes("She came back"));
     expect(annotatedSeg).toBeDefined();
-    expect(annotatedSeg?.className).toContain("border-green-400");
+    // Per #1410: substring annotations underline the matched substring only,
+    // not the full segment span. So the wrapper must NOT carry the underline,
+    // but a child element should.
+    expect(annotatedSeg?.className).not.toContain("border-green-400");
+    const inner = annotatedSeg?.querySelector(".border-green-400");
+    expect(inner).not.toBeNull();
+    expect(inner?.textContent).toContain("watches below");
   });
 
   it("exact-match annotation still works after substring fallback added", () => {

--- a/frontend/src/__tests__/SentenceReaderPartialHighlight.test.tsx
+++ b/frontend/src/__tests__/SentenceReaderPartialHighlight.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Regression for #1410: a sub-sentence annotation must render as a substring
+ * underline, not a full-segment underline. Pairs with the SelectionToolbar fix
+ * that now stores the user's actual selection as sentence_text.
+ */
+import React from "react";
+import { render } from "@testing-library/react";
+import SentenceReader from "@/components/SentenceReader";
+import type { Annotation } from "@/lib/api";
+
+const noop = () => {};
+
+describe("SentenceReader partial annotation rendering (closes #1410)", () => {
+  it("substring annotation does NOT underline the whole segment span", () => {
+    const sentence = "It was a lonely glade beneath the oaks.";
+    const annotations: Annotation[] = [
+      {
+        id: 1,
+        book_id: 1,
+        chapter_index: 0,
+        sentence_text: "lonely glade beneath",
+        note_text: null,
+        color: "yellow",
+      },
+    ];
+
+    const { container } = render(
+      <SentenceReader
+        text={sentence}
+        duration={0}
+        currentTime={0}
+        isPlaying={false}
+        onSegmentClick={noop}
+        annotations={annotations}
+      />,
+    );
+
+    const segSpan = container.querySelector("[data-seg]") as HTMLElement;
+    expect(segSpan).not.toBeNull();
+    // Wrapping span MUST NOT carry the annotation underline class
+    expect(segSpan.className).not.toMatch(/border-b-2/);
+    // The substring "lonely glade beneath" must be wrapped with the
+    // annotation color class somewhere inside the segment.
+    const inner = segSpan.querySelector(".border-b-2.border-yellow-400");
+    expect(inner).not.toBeNull();
+    expect(inner?.textContent).toBe("lonely glade beneath");
+  });
+
+  it("full-sentence annotation underlines the whole segment span (unchanged)", () => {
+    const sentence = "Full sentence text.";
+    const annotations: Annotation[] = [
+      {
+        id: 2,
+        book_id: 1,
+        chapter_index: 0,
+        sentence_text: "Full sentence text.",
+        note_text: null,
+        color: "blue",
+      },
+    ];
+
+    const { container } = render(
+      <SentenceReader
+        text={sentence}
+        duration={0}
+        currentTime={0}
+        isPlaying={false}
+        onSegmentClick={noop}
+        annotations={annotations}
+      />,
+    );
+
+    const segSpan = container.querySelector("[data-seg]") as HTMLElement;
+    expect(segSpan.className).toMatch(/border-b-2/);
+    expect(segSpan.className).toMatch(/border-blue-400/);
+  });
+});

--- a/frontend/src/__tests__/reader-ux-bugs-398-401.test.tsx
+++ b/frontend/src/__tests__/reader-ux-bugs-398-401.test.tsx
@@ -5,8 +5,10 @@
  *         in focus mode would make it invisible).
  * #399 — seekTo while paused must not let a browser timeupdate event on the
  *         paused audio element override the seeked currentTime.
- * #400 — SelectionToolbar Highlight must pass the full sentence context, not
- *         just the selected substring.
+ * #400 — (revised by #1410) SelectionToolbar Highlight must pass the
+ *         user's actual selection, not the surrounding sentence. Partial
+ *         highlights now render as substring underlines via buildSegContent
+ *         instead of forcing full-sentence storage.
  * #401 — SentenceReader must assign correct chunkIdx even when the segment
  *         text and chunk text differ only in whitespace.
  */
@@ -24,7 +26,7 @@ function makeReaderEl() {
   return el;
 }
 
-describe("SelectionToolbar Highlight — bug #400", () => {
+describe("SelectionToolbar Highlight — bug #400 (revised by #1410)", () => {
   let readerEl: HTMLElement;
 
   beforeEach(() => {
@@ -36,7 +38,7 @@ describe("SelectionToolbar Highlight — bug #400", () => {
     jest.restoreAllMocks();
   });
 
-  it("calls onHighlight with full sentence context when selection is inside a data-seg span", () => {
+  it("calls onHighlight with the user's actual selection (partial), not the full sentence", () => {
     const onHighlight = jest.fn();
     render(<SelectionToolbar onHighlight={onHighlight} />);
 
@@ -72,8 +74,9 @@ describe("SelectionToolbar Highlight — bug #400", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Highlight/i }));
 
-    // Must receive the full sentence, not just "sentence"
-    expect(onHighlight).toHaveBeenCalledWith("Full sentence text.");
+    // Must receive the user's selected substring — partial highlight is
+    // rendered visually as an underline on the substring (see SentenceReader).
+    expect(onHighlight).toHaveBeenCalledWith("sentence");
   });
 
   it("falls back to selected text when no sentence context is found", () => {

--- a/frontend/src/components/SelectionToolbar.tsx
+++ b/frontend/src/components/SelectionToolbar.tsx
@@ -128,7 +128,7 @@ export default function SelectionToolbar({ onRead, onHighlight, onNote, onChat, 
         </button>
       )}
       {onHighlight && (
-        <button aria-label="Highlight" onClick={() => { if (!onHighlight || !selection) return; onHighlight(selection.context || selection.text); window.getSelection()?.removeAllRanges(); setSelection(null); }} className={btnClass}>
+        <button aria-label="Highlight" onClick={() => { if (!onHighlight || !selection) return; onHighlight(selection.text); window.getSelection()?.removeAllRanges(); setSelection(null); }} className={btnClass}>
           <HighlightIcon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
           Highlight
         </button>

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -361,10 +361,11 @@ function buildSegContent(
   text: string,
   targetWord: string | undefined,
   vocabWords: Set<string> | undefined,
+  annotationMatch?: { start: number; end: number; className: string },
 ): React.ReactNode {
-  if (!targetWord && !vocabWords?.size) return text;
+  if (!targetWord && !vocabWords?.size && !annotationMatch) return text;
 
-  type Match = { start: number; end: number; type: "target" | "vocab" };
+  type Match = { start: number; end: number; type: "target" | "vocab" | "annotation"; className?: string };
   const matches: Match[] = [];
 
   const addMatches = (needle: string, type: Match["type"]) => {
@@ -383,10 +384,16 @@ function buildSegContent(
 
   if (targetWord) addMatches(targetWord, "target");
   vocabWords?.forEach((w) => addMatches(w, "vocab"));
+  if (annotationMatch) {
+    matches.push({ ...annotationMatch, type: "annotation" });
+  }
 
   if (!matches.length) return text;
 
-  matches.sort((a, b) => a.start - b.start);
+  // Sort by start; on tie, prefer annotation > target > vocab so the partial
+  // highlight wins over an inner vocab underline.
+  const typeOrder = { annotation: 0, target: 1, vocab: 2 } as const;
+  matches.sort((a, b) => a.start - b.start || typeOrder[a.type] - typeOrder[b.type]);
   const deduped: Match[] = [];
   let lastEnd = 0;
   for (const m of matches) {
@@ -403,6 +410,12 @@ function buildSegContent(
         <mark key={m.start} className="bg-amber-300 text-inherit rounded px-0.5 not-italic animate-pulse">
           {word}
         </mark>,
+      );
+    } else if (m.type === "annotation") {
+      nodes.push(
+        <span key={m.start} className={m.className ?? ""}>
+          {word}
+        </span>,
       );
     } else {
       nodes.push(
@@ -678,9 +691,25 @@ export default function SentenceReader({
             (flashTarget.length >= 10 && seg.text.includes(flashTarget))
           );
           const annotation = showAnnotations ? getAnnotation(seg.text) : undefined;
-          const annotationClass = annotation
+          // Full-segment annotation underlines the whole span; sub-sentence
+          // annotations only underline the matched substring (handled inside
+          // buildSegContent via annotationMatch).
+          const isFullSegmentAnnotation = !!annotation && annotation.sentence_text === seg.text;
+          const annotationColorClass = annotation
             ? (ANNOTATION_COLOR_CLASS[annotation.color] ?? ANNOTATION_COLOR_CLASS.yellow)
             : "";
+          const annotationClass = isFullSegmentAnnotation ? annotationColorClass : "";
+          let annotationMatch: { start: number; end: number; className: string } | undefined;
+          if (annotation && !isFullSegmentAnnotation) {
+            const start = seg.text.indexOf(annotation.sentence_text);
+            if (start >= 0) {
+              annotationMatch = {
+                start,
+                end: start + annotation.sentence_text.length,
+                className: annotationColorClass,
+              };
+            }
+          }
           const flashClass = isJumpTarget ? "ring-2 ring-amber-400 bg-amber-50" : "";
           return (
             <span
@@ -707,7 +736,7 @@ export default function SentenceReader({
               onPointerMove={onWordTap ? handlePointerMove : undefined}
               className={`rounded px-0.5 -mx-0.5 transition-colors duration-200 ${segClass(seg)} ${annotationClass} ${flashClass} ${extraClass}`}
             >
-              {buildSegContent(seg.text, isJumpTarget ? scrollTargetWord : undefined, vocabWords)}
+              {buildSegContent(seg.text, isJumpTarget ? scrollTargetWord : undefined, vocabWords, annotationMatch)}
               {annotation?.note_text && (
                 <button
                   onClick={(e) => { e.stopPropagation(); setExpandedNoteFlatIdx((prev) => prev === seg.flatIdx ? null : seg.flatIdx); }}


### PR DESCRIPTION
## What changed

Fixes the desktop bug where drag-selecting a sub-sentence phrase and clicking **Highlight** would underline the entire sentence instead of just the selected phrase.

Two coordinated changes:

1. **`SelectionToolbar.tsx`** — The Highlight button passed `selection.context || selection.text` to `onHighlight()` (i.e. the full parent sentence). Now it passes `selection.text`, consistent with Read/Note/Chat/Word.

2. **`SentenceReader.tsx`** — Annotation rendering now distinguishes full-segment vs substring annotations. Full-segment annotations still underline the whole `<span>` (unchanged). Substring annotations apply the color class only to the matched range via a new `annotationMatch` parameter on `buildSegContent`.

## Why

`#400` originally chose to force `selection.context` because the renderer would otherwise underline the whole segment via the existing substring fallback in `getAnnotation` — making partial highlights look identical to full ones. Now the renderer handles partial ranges correctly, so the write path can store what the user actually selected.

The substring lookup in `getAnnotation` (#398) is unchanged and continues to support annotations stored as substrings.

## Out of scope

`#364` (mobile sub-sentence selection) remains open. Mobile is still blocked by the long-press `e.preventDefault()` that suppresses the native selection loupe in `SentenceReader`. That's a separate change and warrants its own design discussion.

## Test plan

- [x] New `SelectionToolbarHighlightSubsentence.test.tsx` — proves the toolbar passes the user's selection (verified failing before the fix)
- [x] New `SentenceReaderPartialHighlight.test.tsx` — verifies substring annotations render only on the substring; full annotations still underline the whole span
- [x] Updated `reader-ux-bugs-398-401.test.tsx` (#400) and `SentenceReader.extended.test.tsx` to expect new behavior, with comments tying back to #1410
- [x] All 2500 frontend tests pass
- [x] All 1382 backend tests pass
