### PR TITLE
fix: WCAG 1.4.3 contrast — text-amber-{500,600} at custom sizes (wave 13) (closes #1413)

### DIFF
--- a/frontend/src/__tests__/ContrastWave13.test.ts
+++ b/frontend/src/__tests__/ContrastWave13.test.ts
@@ -1,0 +1,36 @@
+import * as fs from "fs";
+import * as path from "path";
+
+function read(rel: string) {
+  return fs.readFileSync(path.join(__dirname, "..", rel), "utf8");
+}
+
+/**
+ * Counts uses of `text-amber-{500,600}` paired with custom small sizes
+ * (`text-[10px]` or `text-[11px]`) inside the same className. Hover-only
+ * `hover:text-amber-{500,600}` is exempt.
+ */
+function countCustomSmallAmber(content: string): number {
+  const allClassNames = content.match(/className="[^"]*"/g) ?? [];
+  let count = 0;
+  for (const cn of allClassNames) {
+    const hasCustomSmall = /\btext-\[(10|11)px\]/.test(cn);
+    const hasFailingAmber = /(?<!hover:)\btext-amber-(500|600)\b/.test(cn);
+    if (hasCustomSmall && hasFailingAmber) count++;
+  }
+  return count;
+}
+
+describe("WCAG 1.4.3 contrast — text-amber-500/600 at custom sizes (wave 13) (closes #1413)", () => {
+  it("reader page has no text-amber-{500,600} at text-[10px]/[11px]", () => {
+    expect(countCustomSmallAmber(read("app/reader/[bookId]/page.tsx"))).toBe(0);
+  });
+
+  it("home page hero card labels have no text-amber-{500,600} at text-[11px]", () => {
+    expect(countCustomSmallAmber(read("app/page.tsx"))).toBe(0);
+  });
+
+  it("VocabWordTooltip has no text-amber-{500,600} at text-[11px]", () => {
+    expect(countCustomSmallAmber(read("components/VocabWordTooltip.tsx"))).toBe(0);
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -465,7 +465,7 @@ export default function Home() {
                   </div>
                   <div className="grid md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-amber-100">
                     <div className="px-5 py-4">
-                      <p className="text-[11px] font-semibold uppercase tracking-widest text-amber-500 mb-2">Original · Deutsch</p>
+                      <p className="text-[11px] font-semibold uppercase tracking-widest text-amber-700 mb-2">Original · Deutsch</p>
                       <p className="font-serif text-sm leading-relaxed text-ink/80">
                         Habe nun, ach! Philosophie,<br />
                         Juristerei und Medizin,<br />
@@ -476,7 +476,7 @@ export default function Home() {
                       </p>
                     </div>
                     <div className="px-5 py-4">
-                      <p className="text-[11px] font-semibold uppercase tracking-widest text-amber-500 mb-2">Translation · English</p>
+                      <p className="text-[11px] font-semibold uppercase tracking-widest text-amber-700 mb-2">Translation · English</p>
                       <p className="font-serif text-sm leading-relaxed text-ink">
                         I have, alas! Philosophy,<br />
                         Medicine, Jurisprudence too,<br />

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -914,7 +914,7 @@ export default function ReaderPage() {
                   <h1 className="font-serif font-bold text-ink truncate text-sm">{meta.title}</h1>
                   {chapterSource === "upload" && (
                     <span
-                      className="shrink-0 text-[10px] font-medium text-amber-600 bg-amber-100 border border-amber-200 rounded px-1 py-0.5 leading-none"
+                      className="shrink-0 text-[10px] font-medium text-amber-700 bg-amber-100 border border-amber-200 rounded px-1 py-0.5 leading-none"
                       title="Uploaded book — chapters from your own file"
                     >
                       Uploaded
@@ -1885,7 +1885,7 @@ export default function ReaderPage() {
                               >
                                 <span className="text-sm font-semibold text-ink">{lemma}</span>
                                 {isForm && (
-                                  <span className="text-[10px] text-amber-600 shrink-0 italic">{w.word}</span>
+                                  <span className="text-[10px] text-amber-700 shrink-0 italic">{w.word}</span>
                                 )}
                               </button>
                               {/* Context occurrences */}

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -118,7 +118,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
             href={def.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-[11px] text-amber-600 hover:text-amber-800"
+            className="text-[11px] text-amber-700 hover:text-amber-800"
           >
             Wiktionary <ArrowUpRightIcon className="w-3 h-3 inline" aria-hidden="true" />
           </a>


### PR DESCRIPTION
## What changed

Waves 9–12 only matched `text-xs` and `text-sm`. This wave catches the `text-[10px]` and `text-[11px]` instances missed by the regex, which are the smallest UI text in the app and most affected by contrast failures.

`text-amber-600` (#d97706) on white = 3.19:1 ❌ → `text-amber-700` (#b45309) = 5.02:1 ✅
`text-amber-500` (#f59e0b) on white = 2.49:1 ❌ → `text-amber-700` = 5.02:1 ✅

## Files changed

- `app/reader/[bookId]/page.tsx` — "Uploaded" badge, vocab form span
- `app/page.tsx` — "Original · Deutsch" / "Translation · English" hero card labels
- `components/VocabWordTooltip.tsx` — Wiktionary link

## Test plan

- [x] New `ContrastWave13.test.ts` — 3 assertions confirming no `text-amber-{500,600}` paired with `text-[10px]/[11px]` in any of the 3 files (excludes `hover:` states)
- [x] All 2500 frontend tests pass
