### PR TITLE
fix: bump annotation note placeholder contrast (text-stone-300 → 400) (closes #1416)

### DIFF
--- a/frontend/src/__tests__/AnnotationToolbarPlaceholderContrast.test.ts
+++ b/frontend/src/__tests__/AnnotationToolbarPlaceholderContrast.test.ts
@@ -1,0 +1,14 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/AnnotationToolbar.tsx"),
+  "utf8",
+);
+
+describe("AnnotationToolbar placeholder contrast (closes #1416)", () => {
+  it("note textarea does not use placeholder:text-stone-300", () => {
+    // text-stone-300 on white = 1.50:1 — barely visible.
+    expect(src).not.toMatch(/placeholder:text-stone-300/);
+  });
+});

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -170,7 +170,7 @@ export default function AnnotationToolbar({
               onChange={(e) => setNote(e.target.value)}
               placeholder="Your thoughts on this passage…"
               rows={4}
-              className="w-full text-sm font-serif text-ink bg-white border border-amber-200 rounded-xl px-3 py-2.5 resize-none focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400 placeholder:text-stone-300 leading-relaxed"
+              className="w-full text-sm font-serif text-ink bg-white border border-amber-200 rounded-xl px-3 py-2.5 resize-none focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400 placeholder:text-stone-400 leading-relaxed"
             />
           </div>
 


### PR DESCRIPTION
## What changed

`AnnotationToolbar.tsx:173` — note textarea placeholder color bumped from `text-stone-300` to `text-stone-400` for visual consistency and basic readability.

## Why

`text-stone-300` (#d6d3d1) on white = 1.50:1 — the placeholder text "Your thoughts on this passage…" was nearly invisible. WCAG 1.4.3 technically exempts placeholders from the 4.5:1 minimum, but 1.50:1 is unusable for low-vision users and inconsistent with every other input placeholder in the app, which uses `text-stone-400` (~2.61:1).

## Test plan

- [x] New static assertion `AnnotationToolbarPlaceholderContrast.test.ts`
- [x] All 2503 frontend tests pass
