### PR TITLE
fix: reject whitespace-only target_language in queue_delete_book endpoint (closes #1422)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1236,7 +1236,11 @@ async def queue_delete_book(
     target_language: str | None = Query(default=None, min_length=1, max_length=20),
     _admin: dict = Depends(_require_admin),
 ):
-    norm = target_language.lower().split("-")[0] if target_language else None
+    if target_language is not None:
+        target_language = target_language.strip().lower().split("-")[0]
+        if not target_language:
+            raise HTTPException(status_code=422, detail="target_language cannot be blank")
+    norm = target_language
     deleted = await delete_queue_for_book(book_id, target_language=norm)
     return {"ok": True, "deleted": deleted}
 

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -3270,3 +3270,15 @@ async def test_import_translations_whitespace_target_language_returns_422(admin_
     assert res.status_code == 422, (
         f"Expected 422 for whitespace target_language in import, got {res.status_code}: {res.text}"
     )
+
+
+# ── Issue #1422: whitespace-only target_language in queue_delete_book ─────────
+
+
+async def test_queue_delete_book_whitespace_language_returns_422(admin_client, admin_db):
+    """Regression #1422: DELETE /admin/queue/book/{id}?target_language=%20%20
+    must return 422, not silently pass a whitespace language to the DB."""
+    res = await admin_client.delete("/api/admin/queue/book/1?target_language=%20%20")
+    assert res.status_code == 422, (
+        f"Expected 422 for whitespace target_language in queue_delete_book, got {res.status_code}: {res.text}"
+    )


### PR DESCRIPTION
## What

Fixes `DELETE /api/admin/queue/book/{book_id}?target_language=<value>` silently accepting whitespace-only language values.

## Why

Issue #1422: `target_language` is a `Query(..., min_length=1, max_length=20)` parameter. A URL-encoded whitespace value like `%20%20` (length 2) passes the `min_length=1` guard, then `target_language.lower().split("-")[0]` returns `"  "` — a whitespace string passed to `delete_queue_for_book` as the language filter, silently matching nothing instead of returning 422.

This is the same pattern fixed for four other admin translation endpoints in #1408.

## Fix

Added `.strip()` before `.lower().split("-")[0]` and a 422 guard if the stripped result is blank, in `queue_delete_book` in `backend/routers/admin.py`.

## Test plan

- `test_queue_delete_book_whitespace_language_returns_422` — `?target_language=%20%20` → 422
- Full backend suite: 1680 passed

Closes #1422
