### PR TITLE
fix: reject whitespace-only language in SmartRules (closes #1424)

### DIFF
--- a/backend/routers/decks.py
+++ b/backend/routers/decks.py
@@ -36,6 +36,13 @@ class SmartRules(BaseModel):
 
     model_config = {"extra": "forbid"}
 
+    @field_validator("language")
+    @classmethod
+    def language_not_blank(cls, v: str | None) -> str | None:
+        if v is not None and not v.strip():
+            raise ValueError("language cannot be blank")
+        return v
+
 
 class DeckCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=80)

--- a/backend/tests/test_router_decks.py
+++ b/backend/tests/test_router_decks.py
@@ -415,3 +415,36 @@ async def test_create_deck_raises_runtime_error_not_assertion_error_on_get_failu
     with patch.object(decks_service, "get_deck", new=AsyncMock(return_value=None)):
         with pytest.raises(RuntimeError, match="deck INSERT succeeded"):
             await decks_service.create_deck(test_user["id"], "TestDeck", "", "manual", None)
+
+
+# ── Issue #1424: whitespace-only language in SmartRules bypasses min_length ───
+
+
+async def test_smart_rules_whitespace_language_returns_422(client, test_user):
+    """Regression #1424: SmartRules.language="  " passes min_length=1 but must
+    still be rejected with 422 — whitespace-only is semantically empty."""
+    resp = await client.post(
+        "/api/decks",
+        json={"name": "WsLang", "mode": "smart", "rules_json": {"language": "  "}},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for whitespace-only language in SmartRules, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_smart_rules_whitespace_language_patch_returns_422(client, test_user):
+    """Regression #1424: PATCH /decks/{id} with whitespace language must also return 422."""
+    create = await client.post(
+        "/api/decks",
+        json={"name": "WsLangPatch", "mode": "smart", "rules_json": {"language": "en"}},
+    )
+    assert create.status_code == 201
+    deck_id = create.json()["id"]
+
+    resp = await client.patch(
+        f"/api/decks/{deck_id}",
+        json={"rules_json": {"language": "\t\n"}},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for whitespace-only language in SmartRules PATCH, got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## What

Adds a `@field_validator` to `SmartRules.language` in `routers/decks.py` that rejects whitespace-only language codes with 422.

## Why

Issue #1424: `SmartRules.language` is declared `min_length=1`, so `" "` (one space) passes Pydantic validation. The value reaches `services/decks.py:262` (`params.append(rules["language"])`) verbatim, producing `WHERE v.language = ' '` — a query that silently matches nothing instead of returning a validation error.

This is the same whitespace-bypass pattern fixed in admin translation endpoints (#1408, #1422) and the search query (#1401).

## Fix

Added `@field_validator("language")` to `SmartRules` that strips and raises `ValueError` if blank. Applies to both `POST /decks` (create) and `PATCH /decks/{id}` (update).

## Test plan

- `test_smart_rules_whitespace_language_returns_422` — POST with `language="  "` → 422
- `test_smart_rules_whitespace_language_patch_returns_422` — PATCH with `language="\t\n"` → 422
- Full backend suite: 1682 passed

Closes #1424
