### PR TITLE
fix: strip whitespace-only language param in /books/search and /books/popular (closes #1426)

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -36,6 +36,7 @@ async def search(
     q = q.strip()
     if not q:
         raise HTTPException(status_code=422, detail="q cannot be blank")
+    language = language.strip()
     return await search_books(q, language, page)
 
 
@@ -56,6 +57,7 @@ async def popular_books(
     The manifest is either the new dict format {language: [books]} produced by
     seed_books.py --collections, or the legacy flat list.
     """
+    language = language.strip()
     global _popular_cache
     if _popular_cache is None:
         if not os.path.isfile(_POPULAR_BOOKS_PATH):

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -1459,3 +1459,31 @@ async def test_fetch_and_cache_continues_when_epub_fetch_fails(client):
         meta, text = await _fetch_and_cache(99002)
     assert meta == fake_meta
     assert text == fake_text
+
+
+# ── Issue #1426: whitespace-only language in /search and /popular ─────────────
+
+
+async def test_search_whitespace_language_stripped(client):
+    """Regression #1426: GET /books/search?language=%20 must strip whitespace and
+    call search_books with an empty string, not pass ' ' to the Gutenberg API."""
+    from unittest.mock import AsyncMock, call
+    mock_result = {"count": 0, "books": []}
+    with patch("routers.books.search_books", new_callable=AsyncMock, return_value=mock_result) as mock_sb:
+        resp = await client.get("/api/books/search?q=test&language=%20%20")
+    assert resp.status_code == 200
+    assert mock_sb.call_args == call("test", "", 1), (
+        f"search_books should be called with stripped language='', got: {mock_sb.call_args}"
+    )
+
+
+async def test_popular_books_whitespace_language_returns_all(client, popular_cache):
+    """Regression #1426: GET /books/popular?language=%20 must treat whitespace as
+    no-filter and return all books, not return 0 results for a bogus ' ' key."""
+    resp_all = await client.get("/api/books/popular")
+    resp_ws = await client.get("/api/books/popular?language=%20%20")
+    assert resp_ws.status_code == 200
+    assert resp_ws.json()["total"] == resp_all.json()["total"], (
+        f"Whitespace language should behave like no filter: total={resp_ws.json()['total']} "
+        f"expected {resp_all.json()['total']}"
+    )


### PR DESCRIPTION
## What changed
- `GET /api/books/search?language=%20` now strips whitespace before passing `language` to `search_books`, so a blank-looking param doesn't get forwarded to the Gutenberg API.
- `GET /api/books/popular?language=%20` now strips whitespace before the cache lookup, so a whitespace-only param is treated as "no filter" instead of returning an empty result set.

## Why
`language = " "` is truthy in Python, so it bypassed the `if language:` guard in both handlers and was passed downstream — either as a bogus Gutenberg API filter or as a missing dict key in the popular-books cache. Both produce silently wrong results.

## Test plan
- `test_search_whitespace_language_stripped`: mocks `search_books` and asserts it's called with `""` when `?language=%20%20` is supplied.
- `test_popular_books_whitespace_language_returns_all`: uses the `popular_cache` fixture to assert `?language=%20%20` returns the same total as no language filter.
- Full suite: 1684 passed.

Closes #1426
