### PR TITLE
fix: return 404 when DELETE /ai/summary finds no summary row (closes #1428)

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -301,11 +301,13 @@ async def delete_summary(book_id: int = Query(..., ge=1), chapter_index: int = Q
     from services.db import DB_PATH
     import aiosqlite
     async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute(
+        cur = await db.execute(
             "DELETE FROM chapter_summaries WHERE book_id=? AND chapter_index=?",
             (book_id, chapter_index),
         )
         await db.commit()
+    if cur.rowcount == 0:
+        raise HTTPException(status_code=404, detail="No cached summary found for this chapter")
     return {"ok": True}
 
 

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -966,6 +966,21 @@ async def test_delete_summary_out_of_bounds_chapter_returns_400(client, test_use
     )
 
 
+async def test_delete_summary_nonexistent_summary_returns_404(client, test_user, tmp_db):
+    """Regression #1428: DELETE /ai/summary must return 404 when the book and chapter exist
+    but no summary row exists — not silently return 200 with no rowcount check."""
+    from services.book_chapters import clear_cache as _clear
+
+    text = "CHAPTER I\n\n" + "word " * 200
+    await save_book(9883, {"id": 9883, "title": "NoSummary", "authors": [], "languages": ["en"], "subjects": [], "download_count": 0, "cover": ""}, text)
+    _clear()
+
+    resp = await client.delete("/api/ai/summary", params={"book_id": 9883, "chapter_index": 0})
+    assert resp.status_code == 404, (
+        f"Regression #1428: DELETE /ai/summary with no summary row must return 404, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+
 
 # ── Issue #500: AI endpoint input bounds ──────────────────────────────────────
 


### PR DESCRIPTION
## What changed
`DELETE /api/ai/summary` now returns 404 when no summary row exists for the given book/chapter, instead of always returning `{"ok": true}`.

## Why
The endpoint validated that the book exists and the chapter index is in range, but never checked `cur.rowcount` after the DELETE. Any call against a chapter with no cached summary got a 200 response, masking incorrect admin tooling and making idempotent retries indistinguishable from successful deletes.

## Test plan
- `test_delete_summary_nonexistent_summary_returns_404`: seeds a book with one chapter (no summary), calls DELETE, asserts 404. Confirmed it fails before the fix and passes after.
- Existing tests `test_delete_summary_nonexistent_book_returns_404` and `test_delete_summary_out_of_bounds_chapter_returns_400` still pass.
- Full suite: 1687 passed.

Closes #1428
