### PR TITLE
fix: strip whitespace-only Apple login name before DB write (closes #1430)

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -90,6 +90,6 @@ async def apple_login(req: AppleAuthRequest):
     user = await get_or_create_user_apple(
         apple_id=apple_id,
         email=payload.get("email", ""),
-        name=req.name,
+        name=req.name.strip(),
     )
     return _user_response(user)

--- a/backend/tests/test_router_auth.py
+++ b/backend/tests/test_router_auth.py
@@ -151,3 +151,26 @@ async def test_apple_login_empty_id_token_returns_422(client):
     """Regression #918: POST /auth/apple with id_token='' must return 422."""
     resp = await client.post("/api/auth/apple", json={"id_token": "", "name": "Alice"})
     assert resp.status_code == 422, f"Expected 422 for empty id_token, got {resp.status_code}: {resp.text}"
+
+
+# ── Issue #1430: whitespace-only Apple name must not overwrite stored name ─────
+
+
+async def test_apple_login_whitespace_name_does_not_overwrite_stored_name(client, tmp_db):
+    """Regression #1430: POST /auth/apple with name='   ' (whitespace) must not
+    overwrite an existing display name in the DB.  NULLIF(?, '') only guards
+    against empty string; whitespace-only passes through and clobbers the name."""
+    apple_payload = {"sub": "apple-ws-1430", "email": "ws1430@example.com"}
+
+    with patch("routers.auth.verify_apple_id_token", new_callable=AsyncMock, return_value=apple_payload):
+        first = await client.post("/api/auth/apple", json={"id_token": "tok", "name": "Alice"})
+    assert first.status_code == 200
+    assert first.json()["user"]["name"] == "Alice"
+
+    with patch("routers.auth.verify_apple_id_token", new_callable=AsyncMock, return_value=apple_payload):
+        second = await client.post("/api/auth/apple", json={"id_token": "tok", "name": "   "})
+    assert second.status_code == 200
+    assert second.json()["user"]["name"] == "Alice", (
+        f"Regression #1430: whitespace-only name should not overwrite 'Alice', "
+        f"got: {second.json()['user']['name']!r}"
+    )


### PR DESCRIPTION
## What changed
`POST /api/auth/apple` now strips whitespace from `req.name` before passing it to `get_or_create_user_apple`.

## Why
`req.name = "   "` (whitespace-only) is truthy in Python, so it bypassed the `if email or name:` guard in `get_or_create_user_apple`. The SQL guard `COALESCE(NULLIF(?, ''), name)` only protects against empty string `''` — `NULLIF(' ', '')` returns `' '` (not NULL), so `COALESCE(' ', name)` returns `' '` and silently overwrites a valid stored display name with whitespace.

For new Apple users the whitespace would also be stored directly as their display name.

## Test plan
- `test_apple_login_whitespace_name_does_not_overwrite_stored_name`: creates a user with `name="Alice"`, then logs in again with `name="   "`, asserts the stored name is still `"Alice"`. Fails before the fix (stored name becomes `"   "`), passes after.
- All existing 16 auth tests still pass.
- Full suite: 1689 passed.

Closes #1430
