### PR TITLE
fix: reject whitespace-only languages in enqueue-book target_languages (closes #1432)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1171,6 +1171,18 @@ class EnqueueBookRequest(BaseModel):
     priority: int = 50   # lower than default so admin enqueues jump the line
     reset_failed: bool = False
 
+    @field_validator("target_languages")
+    @classmethod
+    def target_languages_not_blank(
+        cls, v: list[str] | None
+    ) -> list[str] | None:
+        if v is None:
+            return v
+        for lang in v:
+            if not lang.strip():
+                raise ValueError("target_languages entries cannot be blank")
+        return v
+
 
 @router.post("/queue/enqueue-book")
 async def queue_enqueue_book(

--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -260,7 +260,7 @@ async def enqueue_for_book(
 
     inserted = 0
     for lang in target_languages:
-        lang = lang.lower().split("-")[0]
+        lang = lang.strip().lower().split("-")[0]
         if not lang or lang == source:
             continue
         for idx, ch in enumerate(chapters):

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -3322,3 +3322,19 @@ async def test_queue_delete_book_whitespace_language_returns_422(admin_client, a
     assert res.status_code == 422, (
         f"Expected 422 for whitespace target_language in queue_delete_book, got {res.status_code}: {res.text}"
     )
+
+
+# ── Issue #1432: whitespace-only language in enqueue-book target_languages ─────
+
+
+async def test_enqueue_book_whitespace_target_language_returns_422(admin_client):
+    """Regression #1432: POST /admin/queue/enqueue-book with whitespace-only entry in
+    target_languages must return 422 — ' ' passes min_length=1 but is semantically empty."""
+    res = await admin_client.post(
+        "/api/admin/queue/enqueue-book",
+        json={"book_id": 1, "target_languages": ["  "]},
+    )
+    assert res.status_code == 422, (
+        f"Regression #1432: whitespace-only target_language in enqueue-book must return 422, "
+        f"got {res.status_code}: {res.text}"
+    )


### PR DESCRIPTION
## What changed
- `EnqueueBookRequest` now has a `@field_validator("target_languages")` that rejects whitespace-only entries with 422.
- `services/translation_queue.py` line 263: added `.strip()` before `.lower().split("-")[0]` as a defensive belt-and-suspenders fix.

## Why
`" "` (single space) passes `min_length=1` Pydantic validation. Without `.strip()`, `" ".lower().split("-")[0]` returns `" "` (truthy), so the existing `if not lang` guard never fires and the whitespace string is inserted into the `translation_queue` table as `target_language`. The worker then creates a permanently-failing queue item trying to translate to a blank language.

## Test plan
- `test_enqueue_book_whitespace_target_language_returns_422`: POSTs `target_languages=["  "]`, asserts 422. Confirmed fails before the fix (gets 404 from book lookup, proving Pydantic didn't reject it), passes after.
- Full suite: 1691 passed.

Closes #1432
