### PR TITLE
fix: reject whitespace-only target_language in queue/plan and queue/dry-run (closes #1434)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -990,6 +990,14 @@ class QueuePlanRequest(BaseModel):
     target_language: str = Field(..., min_length=1, max_length=20)
     book_ids: list[Annotated[int, Field(ge=1)]] | None = Field(default=None, max_length=1000)
 
+    @field_validator("target_language")
+    @classmethod
+    def target_language_not_blank(cls, v: str) -> str:
+        s = v.strip().lower().split("-")[0]
+        if not s:
+            raise ValueError("target_language cannot be blank")
+        return s
+
 
 @router.post("/queue/plan")
 async def queue_plan(req: QueuePlanRequest, _admin: dict = Depends(_require_admin)):

--- a/backend/services/translation_queue.py
+++ b/backend/services/translation_queue.py
@@ -197,7 +197,7 @@ async def enqueue(
     inserted or an existing row was revived; 0 if the INSERT OR IGNORE
     path no-op'd because a non-stale row already exists).
     """
-    target_language = target_language.lower().split("-")[0]
+    target_language = target_language.strip().lower().split("-")[0]
     async with aiosqlite.connect(db_module.DB_PATH) as db:
         if reset_failed:
             cursor = await db.execute(
@@ -1251,7 +1251,7 @@ async def plan_work_for_queue(
     from services.db import list_cached_books
     from services.book_chapters import split_with_html_preference
 
-    target_language = target_language.lower().split("-")[0]
+    target_language = target_language.strip().lower().split("-")[0]
     all_books = await list_cached_books()
     plans = []
 

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -3338,3 +3338,31 @@ async def test_enqueue_book_whitespace_target_language_returns_422(admin_client)
         f"Regression #1432: whitespace-only target_language in enqueue-book must return 422, "
         f"got {res.status_code}: {res.text}"
     )
+
+
+# ── Issue #1434: whitespace-only target_language in queue/plan and queue/dry-run ─
+
+
+async def test_queue_plan_whitespace_target_language_returns_422(admin_client):
+    """Regression #1434: POST /admin/queue/plan with target_language='  ' must return 422.
+    min_length=1 passes for single space; the endpoint should still reject it."""
+    res = await admin_client.post(
+        "/api/admin/queue/plan",
+        json={"target_language": "  "},
+    )
+    assert res.status_code == 422, (
+        f"Regression #1434: whitespace-only target_language in queue/plan must return 422, "
+        f"got {res.status_code}: {res.text}"
+    )
+
+
+async def test_queue_dry_run_whitespace_target_language_returns_422(admin_client):
+    """Regression #1434: POST /admin/queue/dry-run with target_language='  ' must return 422."""
+    res = await admin_client.post(
+        "/api/admin/queue/dry-run",
+        json={"target_language": "  "},
+    )
+    assert res.status_code == 422, (
+        f"Regression #1434: whitespace-only target_language in queue/dry-run must return 422, "
+        f"got {res.status_code}: {res.text}"
+    )


### PR DESCRIPTION
## What changed
- `QueuePlanRequest` now has a `@field_validator("target_language")` that strips whitespace, normalises with `.lower().split("-")[0]`, and raises 422 for blank values — matching the existing `BulkRetranslateRequest` pattern.
- `services/translation_queue.py`: added `.strip()` before `.lower()` in the `enqueue` function (line 200) and `plan_work_for_queue` (line 1254) as defensive belt-and-suspenders.

## Why
`" "` (whitespace) passes `min_length=1` Pydantic validation. Without `.strip()`, the router's `req.target_language.lower().split("-")[0]` leaves `" "` intact (truthy), so `plan_work_for_queue` receives a whitespace string and silently returns empty results instead of a 422. For `enqueue`, the whitespace would have been stored as `target_language` in the queue.

## Test plan
- `test_queue_plan_whitespace_target_language_returns_422`: POSTs `{"target_language": "  "}` to `/queue/plan`, asserts 422. Confirmed fails before fix (gets 200 with empty plan), passes after.
- `test_queue_dry_run_whitespace_target_language_returns_422`: Same for `/queue/dry-run`. Fails before (gets 400 from missing API key, proving Pydantic never rejected it), passes after.
- Full suite: 1693 passed.

Closes #1434
