### PR TITLE
fix: reject whitespace-only target_language in queue/retry-failed (closes #1436)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1312,6 +1312,16 @@ class RetryFailedRequest(BaseModel):
     book_id: int | None = Field(default=None, ge=1)
     target_language: str | None = Field(default=None, min_length=1, max_length=20)
 
+    @field_validator("target_language")
+    @classmethod
+    def target_language_not_blank(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        s = v.strip().lower().split("-")[0]
+        if not s:
+            raise ValueError("target_language cannot be blank")
+        return s
+
 
 @router.post("/queue/retry-failed")
 async def queue_retry_failed(

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -3366,3 +3366,19 @@ async def test_queue_dry_run_whitespace_target_language_returns_422(admin_client
         f"Regression #1434: whitespace-only target_language in queue/dry-run must return 422, "
         f"got {res.status_code}: {res.text}"
     )
+
+
+# ── Issue #1436: whitespace-only target_language in queue/retry-failed ─────────
+
+
+async def test_retry_failed_whitespace_target_language_returns_422(admin_client):
+    """Regression #1436: POST /admin/queue/retry-failed with target_language='  ' must
+    return 422 — whitespace passes min_length=1 but silently matches zero rows."""
+    res = await admin_client.post(
+        "/api/admin/queue/retry-failed",
+        json={"target_language": "  "},
+    )
+    assert res.status_code == 422, (
+        f"Regression #1436: whitespace-only target_language in retry-failed must return 422, "
+        f"got {res.status_code}: {res.text}"
+    )


### PR DESCRIPTION
## What changed

Added `@field_validator("target_language")` to `RetryFailedRequest` in `backend/routers/admin.py`. The validator strips whitespace, lowercases, and strips language subtags — then rejects blank values with a 422 before the handler runs.

## Why

`min_length=1` passes for a single space `" "`. Without a validator, whitespace-only `target_language` reached line ~1334: `params.append(req.target_language.lower().split("-")[0])`, producing `"  "` (truthy), and the resulting `WHERE target_language = '  '` matched zero rows — silently returning `{"ok":true,"updated":0}` instead of rejecting the input.

## Test plan

- Added `test_retry_failed_whitespace_target_language_returns_422` — confirms `POST /api/admin/queue/retry-failed` with `target_language="  "` returns 422.
- Full test suite: 1695 passed.

Closes #1436
