### PR TITLE
fix: use cursor.rowcount instead of db.total_changes in audio delete endpoints (closes #1438)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -354,8 +354,8 @@ async def get_audio_cache(_admin: dict = Depends(_require_admin)):
 @router.delete("/audio/{book_id}")
 async def delete_book_audio(book_id: int = Path(..., ge=1), _admin: dict = Depends(_require_admin)):
     async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute("DELETE FROM audio_cache WHERE book_id=?", (book_id,))
-        deleted = db.total_changes
+        cur = await db.execute("DELETE FROM audio_cache WHERE book_id=?", (book_id,))
+        deleted = cur.rowcount
         await db.commit()
     return {"ok": True, "deleted": deleted}
 
@@ -363,11 +363,11 @@ async def delete_book_audio(book_id: int = Path(..., ge=1), _admin: dict = Depen
 @router.delete("/audio/{book_id}/{chapter_index}")
 async def delete_chapter_audio(book_id: int = Path(..., ge=1), chapter_index: int = Path(..., ge=0), _admin: dict = Depends(_require_admin)):
     async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute(
+        cur = await db.execute(
             "DELETE FROM audio_cache WHERE book_id=? AND chapter_index=?",
             (book_id, chapter_index),
         )
-        deleted = db.total_changes
+        deleted = cur.rowcount
         await db.commit()
     return {"ok": True, "deleted": deleted}
 

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -3382,3 +3382,46 @@ async def test_retry_failed_whitespace_target_language_returns_422(admin_client)
         f"Regression #1436: whitespace-only target_language in retry-failed must return 422, "
         f"got {res.status_code}: {res.text}"
     )
+
+
+# ── Issue #1438: audio delete endpoints must report accurate rowcount ─────────
+
+
+async def test_delete_chapter_audio_no_rows_returns_zero_deleted(admin_client, admin_db):
+    """Regression #1438: DELETE /admin/audio/{book_id}/{chapter_index} must return
+    deleted=0 when no audio rows exist — not a stale cumulative total_changes count."""
+    res = await admin_client.delete("/api/admin/audio/999/0")
+    assert res.status_code == 200
+    assert res.json()["deleted"] == 0, (
+        f"Regression #1438: expected deleted=0 for non-existent audio, got {res.json()}"
+    )
+
+
+async def test_delete_book_audio_count_matches_rows_seeded(admin_client, admin_db):
+    """Regression #1438: DELETE /admin/audio/{book_id} must return deleted count equal to
+    cursor.rowcount (actual rows removed), not db.total_changes (cumulative)."""
+    await _seed_book(881)
+    await _insert_audio(admin_db, book_id=881, chapter_index=0)
+    await _insert_audio(admin_db, book_id=881, chapter_index=1)
+    await _insert_audio(admin_db, book_id=881, chapter_index=2)
+
+    res = await admin_client.delete("/api/admin/audio/881")
+    assert res.status_code == 200
+    assert res.json()["deleted"] == 3, (
+        f"Regression #1438: expected deleted=3, got {res.json()}"
+    )
+
+
+async def test_delete_chapter_audio_count_matches_rows_seeded(admin_client, admin_db):
+    """Regression #1438: DELETE /admin/audio/{book_id}/{chapter_index} must return
+    deleted count equal to the chunk rows removed for that chapter only."""
+    await _seed_book(882)
+    await _insert_audio(admin_db, book_id=882, chapter_index=0, chunk_index=0)
+    await _insert_audio(admin_db, book_id=882, chapter_index=0, chunk_index=1)
+    await _insert_audio(admin_db, book_id=882, chapter_index=1, chunk_index=0)
+
+    res = await admin_client.delete("/api/admin/audio/882/0")
+    assert res.status_code == 200
+    assert res.json()["deleted"] == 2, (
+        f"Regression #1438: expected deleted=2 for chapter 0, got {res.json()}"
+    )


### PR DESCRIPTION
## What changed

Replaced `db.total_changes` with `cur.rowcount` in `delete_book_audio` and `delete_chapter_audio` in `backend/routers/admin.py`.

## Why

`db.total_changes` is a cumulative counter on the SQLite connection — it tracks all row modifications since the connection was opened, not just the current statement. In the current code a fresh connection is used per request, so the bug was "accidentally correct," but it is fragile: any addition of a prior statement to the same connection block would produce wrong counts. `cursor.rowcount` is the authoritative count for the specific statement that was just executed.

## Test plan

- Added `test_delete_chapter_audio_no_rows_returns_zero_deleted` — verifies `deleted=0` when no audio exists for the given book/chapter.
- Added `test_delete_book_audio_count_matches_rows_seeded` — seeds 3 rows, deletes, expects `deleted=3`.
- Added `test_delete_chapter_audio_count_matches_rows_seeded` — seeds 3 rows across 2 chapters, deletes one chapter, expects `deleted=2`.
- All 11 audio admin tests pass; full suite: 1698 passed.

Closes #1438
