### PR TITLE
fix: strip and reject whitespace-only status in DELETE /admin/queue (closes #1440)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1254,6 +1254,10 @@ async def queue_clear(
     ?status=failed  → wipe just the failed rows (safe to retry clean).
     No filter       → clear the entire queue (admin confirms in the UI).
     """
+    if status is not None:
+        status = status.strip()
+        if not status:
+            raise HTTPException(status_code=422, detail="status cannot be blank")
     deleted = await clear_queue(status)
     return {"ok": True, "deleted": deleted}
 

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -3425,3 +3425,16 @@ async def test_delete_chapter_audio_count_matches_rows_seeded(admin_client, admi
     assert res.json()["deleted"] == 2, (
         f"Regression #1438: expected deleted=2 for chapter 0, got {res.json()}"
     )
+
+
+# ── Issue #1440: whitespace-only status in DELETE /admin/queue ────────────────
+
+
+async def test_queue_clear_whitespace_status_returns_422(admin_client):
+    """Regression #1440: DELETE /admin/queue?status=%20 must return 422.
+    min_length=1 passes for a single space; the handler must strip and reject."""
+    res = await admin_client.delete("/api/admin/queue?status=%20%20")
+    assert res.status_code == 422, (
+        f"Regression #1440: whitespace-only status in DELETE /admin/queue must return 422, "
+        f"got {res.status_code}: {res.text}"
+    )


### PR DESCRIPTION
## What changed

Added `.strip()` + blank-check in `queue_clear` handler (`DELETE /admin/queue`) before passing the `status` param to `clear_queue`.

## Why

`min_length=1` passes for `" "` (single space). Without stripping, `clear_queue("  ")` evaluates `if status:` as truthy and runs `WHERE status='  '`, matching zero rows — returning `{"ok":true,"deleted":0}` silently. An admin trying to clear all items without a status filter (who accidentally submitted whitespace) would get a misleading zero-cleared response with no error.

## Test plan

- Added `test_queue_clear_whitespace_status_returns_422` — confirms `DELETE /admin/queue?status=%20%20` returns 422.
- Existing `test_queue_clear_empty_status_returns_422` (#807) still passes.
- Full suite: 1699 passed.

Closes #1440
