### PR TITLE
fix: strip and reject whitespace-only status in GET /admin/queue/items (closes #1442)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1170,6 +1170,10 @@ async def queue_items(
     limit: int = Query(default=200, ge=1, le=1000),
     _admin: dict = Depends(_require_admin),
 ):
+    if status is not None:
+        status = status.strip()
+        if not status:
+            raise HTTPException(status_code=422, detail="status cannot be blank")
     return await list_queue(status=status, book_id=book_id, limit=limit)
 
 

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -3438,3 +3438,16 @@ async def test_queue_clear_whitespace_status_returns_422(admin_client):
         f"Regression #1440: whitespace-only status in DELETE /admin/queue must return 422, "
         f"got {res.status_code}: {res.text}"
     )
+
+
+# ── Issue #1442: whitespace-only status in GET /admin/queue/items ─────────────
+
+
+async def test_queue_items_whitespace_status_returns_422(admin_client):
+    """Regression #1442: GET /admin/queue/items?status=%20 must return 422.
+    min_length=1 passes for a single space; the handler must strip and reject."""
+    res = await admin_client.get("/api/admin/queue/items?status=%20%20")
+    assert res.status_code == 422, (
+        f"Regression #1442: whitespace-only status in GET /admin/queue/items must return 422, "
+        f"got {res.status_code}: {res.text}"
+    )


### PR DESCRIPTION
## What changed

Added `.strip()` + blank-check in the `queue_items` handler (`GET /admin/queue/items`) before passing the `status` param to `list_queue`.

## Why

`min_length=1` passes for `" "`. Without stripping, `list_queue(status=" ")` evaluates `if status:` as truthy and runs `WHERE q.status=' '`, matching zero rows — returning `[]` instead of 422. An admin filtering by status who sends whitespace (e.g., browser auto-fill) sees 0 results with no indication the filter is invalid.

Consistent with the same fix applied to `DELETE /admin/queue` in #1441.

## Test plan

- Added `test_queue_items_whitespace_status_returns_422` — confirms `GET /admin/queue/items?status=%20%20` returns 422.
- All 8 existing queue_items tests still pass.
- Full suite: 1700 passed.

Closes #1442
