### PR TITLE
fix: reject whitespace-only api_key and model in PUT /admin/queue/settings (closes #1444)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1129,10 +1129,13 @@ async def queue_set_settings(
     if req.enabled is not None:
         await set_setting(SETTING_ENABLED, "1" if req.enabled else "0")
     if req.api_key is not None:
-        if req.api_key == "":
-            await set_setting(SETTING_API_KEY, "")
+        stripped_key = req.api_key.strip()
+        if not stripped_key and req.api_key:
+            raise HTTPException(status_code=422, detail="api_key cannot be blank")
+        if stripped_key:
+            await set_setting(SETTING_API_KEY, encrypt_api_key(stripped_key))
         else:
-            await set_setting(SETTING_API_KEY, encrypt_api_key(req.api_key))
+            await set_setting(SETTING_API_KEY, "")
     if req.auto_translate_languages is not None:
         await set_setting(
             SETTING_AUTO_LANGS,
@@ -1147,7 +1150,10 @@ async def queue_set_settings(
     if req.rpd is not None:
         await set_setting(SETTING_RPD, str(req.rpd))
     if req.model is not None:
-        await set_setting(SETTING_MODEL, req.model)
+        stripped_model = req.model.strip()
+        if not stripped_model:
+            raise HTTPException(status_code=422, detail="model cannot be blank")
+        await set_setting(SETTING_MODEL, stripped_model)
     if req.model_chain is not None:
         if not req.model_chain:
             raise HTTPException(status_code=400, detail="model_chain cannot be empty")

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -3451,3 +3451,34 @@ async def test_queue_items_whitespace_status_returns_422(admin_client):
         f"Regression #1442: whitespace-only status in GET /admin/queue/items must return 422, "
         f"got {res.status_code}: {res.text}"
     )
+
+
+# ── Issue #1444: whitespace-only api_key / model in PUT /admin/queue/settings ─
+
+
+async def test_queue_settings_whitespace_api_key_returns_422(admin_client):
+    """Regression #1444: PUT /admin/queue/settings with api_key='  ' must return 422.
+    A whitespace api_key passes the == '' check and gets encrypted + stored as an
+    invalid Anthropic API key, causing silent translation failures."""
+    res = await admin_client.put(
+        "/api/admin/queue/settings",
+        json={"api_key": "   "},
+    )
+    assert res.status_code == 422, (
+        f"Regression #1444: whitespace-only api_key in queue/settings must return 422, "
+        f"got {res.status_code}: {res.text}"
+    )
+
+
+async def test_queue_settings_whitespace_model_returns_422(admin_client):
+    """Regression #1444: PUT /admin/queue/settings with model='  ' must return 422.
+    A whitespace model name passes min_length=1 and gets stored as-is, causing
+    the worker to call the API with an invalid model identifier."""
+    res = await admin_client.put(
+        "/api/admin/queue/settings",
+        json={"model": "   "},
+    )
+    assert res.status_code == 422, (
+        f"Regression #1444: whitespace-only model in queue/settings must return 422, "
+        f"got {res.status_code}: {res.text}"
+    )


### PR DESCRIPTION
## What changed

`PUT /admin/queue/settings` did not strip or validate whitespace-only values for `api_key` and `model`:

- **`api_key`**: The guard was `if req.api_key == ""` (exact empty string). A value like `"   "` passed the check, got encrypted via `encrypt_api_key("   ")`, and was stored as the translation worker's Anthropic API key. Subsequent translation jobs would then fail with opaque API errors instead of "API key not configured."
- **`model`**: Had `min_length=1` on the Pydantic field but no `.strip()`, so a whitespace-only model name was stored as-is, causing the worker to submit API calls with an invalid model identifier.

`user.py`'s `save_gemini_key` already handled this correctly (strips before encrypting). This fix brings `admin.py`'s queue settings into the same pattern.

## Fix

- Strip `api_key` before checking; raise 422 if the stripped value is blank and the original was non-empty. Empty string `""` still clears the stored key (existing clear-key behaviour preserved).
- Strip `model` before storing; raise 422 if blank after strip.

## Test plan

- `test_queue_settings_whitespace_api_key_returns_422` — confirms `{"api_key": "   "}` returns 422
- `test_queue_settings_whitespace_model_returns_422` — confirms `{"model": "   "}` returns 422
- Full suite: 1702 backend + 1750 frontend tests passing

Closes #1444
