### PR TITLE
test: add coverage for whitespace-only model_chain entry in queue settings (closes #1449)

### DIFF
--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -2309,6 +2309,20 @@ async def test_queue_settings_rejects_model_chain_with_empty_entry(admin_client,
     )
 
 
+async def test_queue_settings_rejects_model_chain_with_whitespace_entry(admin_client, admin_db):
+    """Regression #1449: model_chain with whitespace-only entry must return 400.
+    Pydantic min_length=1 passes a single space, so the handler's strip() check fires.
+    Distinct from the empty-string case which returns 422 from Pydantic."""
+    res = await admin_client.put(
+        "/api/admin/queue/settings",
+        json={"model_chain": ["  ", "gemini-1.5-flash"]},
+    )
+    assert res.status_code == 400, (
+        f"Regression #1449: whitespace-only model_chain entry must return 400, "
+        f"got {res.status_code}: {res.text}"
+    )
+
+
 async def test_queue_settings_rejects_auto_translate_languages_with_whitespace_entry(admin_client, admin_db):
     """Regression #474: whitespace-only language codes in auto_translate_languages
     must be stripped, resulting in valid stored codes only."""


### PR DESCRIPTION
## What changed

Added one regression test for `PUT /admin/queue/settings` with a whitespace-only entry in `model_chain`.

## Why

The handler at `admin.py:1139` correctly catches whitespace entries:
```python
if any(not m.strip() for m in req.model_chain):
    raise HTTPException(status_code=400, detail="model_chain entries cannot be empty strings")
```

But the existing test `test_queue_settings_rejects_model_chain_with_empty_entry` uses `""` (empty string), which is caught by Pydantic's `min_length=1` guard *before* reaching the handler — so line 1139 was never exercised. A whitespace entry (`"  "`) passes `min_length=1` and does reach the handler, leaving the code path untested.

## Test plan

- `test_queue_settings_rejects_model_chain_with_whitespace_entry` — `{"model_chain": ["  ", "gemini-1.5-flash"]}` → 400
- Full suite: 1703 backend + 1750 frontend passing

Closes #1449
