### PR TITLE
fix: reject whitespace-only tags in SmartRules tags_any/tags_all (closes #1453)

### DIFF
--- a/backend/routers/decks.py
+++ b/backend/routers/decks.py
@@ -43,6 +43,15 @@ class SmartRules(BaseModel):
             raise ValueError("language cannot be blank")
         return v
 
+    @field_validator("tags_any", "tags_all")
+    @classmethod
+    def tags_not_blank(cls, v: list | None) -> list | None:
+        if v is not None:
+            for tag in v:
+                if not tag.strip():
+                    raise ValueError("tag entries cannot be blank or whitespace-only")
+        return v
+
 
 class DeckCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=80)

--- a/backend/tests/test_router_decks.py
+++ b/backend/tests/test_router_decks.py
@@ -448,3 +448,51 @@ async def test_smart_rules_whitespace_language_patch_returns_422(client, test_us
     assert resp.status_code == 422, (
         f"Expected 422 for whitespace-only language in SmartRules PATCH, got {resp.status_code}: {resp.text}"
     )
+
+
+# ── Issue #1453: whitespace-only tags in tags_any/tags_all bypass min_length ─
+
+
+async def test_smart_rules_whitespace_tag_in_tags_any_returns_422(client, test_user):
+    """Regression #1453: tags_any=[" "] passes min_length=1 but must return 422.
+    Vocab tags are always normalized (strip+lowercase), so a whitespace-only
+    tag can never match a stored tag — it should be rejected at validation."""
+    resp = await client.post(
+        "/api/decks",
+        json={"name": "WsTagAny", "mode": "smart", "rules_json": {"tags_any": [" "]}},
+    )
+    assert resp.status_code == 422, (
+        f"Regression #1453: whitespace-only tag in tags_any must return 422, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_smart_rules_whitespace_tag_in_tags_all_returns_422(client, test_user):
+    """Regression #1453: tags_all=["\t"] passes min_length=1 but must return 422."""
+    resp = await client.post(
+        "/api/decks",
+        json={"name": "WsTagAll", "mode": "smart", "rules_json": {"tags_all": ["\t"]}},
+    )
+    assert resp.status_code == 422, (
+        f"Regression #1453: whitespace-only tag in tags_all must return 422, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_smart_rules_whitespace_tag_patch_returns_422(client, test_user):
+    """Regression #1453: PATCH /decks/{id} with whitespace tag must also return 422."""
+    create = await client.post(
+        "/api/decks",
+        json={"name": "WsTagPatch", "mode": "smart", "rules_json": {"tags_any": ["python"]}},
+    )
+    assert create.status_code == 201
+    deck_id = create.json()["id"]
+
+    resp = await client.patch(
+        f"/api/decks/{deck_id}",
+        json={"rules_json": {"tags_any": ["  "]}},
+    )
+    assert resp.status_code == 422, (
+        f"Regression #1453: whitespace-only tag in PATCH tags_any must return 422, "
+        f"got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## What changed

Added `@field_validator("tags_any", "tags_all")` to `SmartRules` in `routers/decks.py` that iterates each list element and raises `ValueError` if any entry is blank after stripping. This returns 422 for whitespace-only tags in both `POST /decks` and `PATCH /decks/{id}`.

## Why

Vocabulary tags are normalized via `normalize_tag` (strip + lowercase) before storage, so a whitespace-only string can never match a stored tag. However, `min_length=1` in the `Field(...)` annotation passes a single space through Pydantic validation. The result was a silently accepted deck rule that always returned zero members with no error feedback to the user.

The fix mirrors the existing `language_not_blank` validator (added in #1424) applied to the tag list fields.

## Test plan

- `test_smart_rules_whitespace_tag_in_tags_any_returns_422` — POST with `tags_any=[" "]` → 422
- `test_smart_rules_whitespace_tag_in_tags_all_returns_422` — POST with `tags_all=["\t"]` → 422
- `test_smart_rules_whitespace_tag_patch_returns_422` — PATCH deck with `tags_any=["  "]` → 422
- Full test suite: 1709 backend + 1750 frontend tests pass

## Docs follow-up

None — this is a validation fix with no user-visible behaviour change beyond the new 422 response.
