### PR TITLE
fix: correct has_more detection at max limit=200 for chat message pagination

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -1175,8 +1175,9 @@ async def get_chat_messages(
     When `before_id` is given, only rows with id < before_id are returned
     — enables reverse-scroll pagination of older history.
     """
-    # Defensive bound — router also enforces but keep the helper safe.
-    safe_limit = max(1, min(limit, 200))
+    # Cap at 201 (one above the router's max of 200) so the router can fetch
+    # limit+1 rows for has_more detection without hitting the cap at limit=200.
+    safe_limit = max(1, min(limit, 201))
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         if before_id is not None:

--- a/backend/tests/test_router_chat.py
+++ b/backend/tests/test_router_chat.py
@@ -288,3 +288,37 @@ async def test_router_rejects_tab_newline_only_content(client, test_user):
     assert res.status_code == 422, (
         f"Expected 422 for tab/newline-only content, got {res.status_code}: {res.text}"
     )
+
+
+# ── Issue #1455: has_more incorrect at max limit ─────────────────────────────
+
+
+async def test_router_has_more_correct_at_max_limit(client, test_user):
+    """Regression #1455: GET /chat/{id}/messages?limit=200 with 201 messages must
+    return has_more=True, not False.
+
+    The internal helper get_chat_messages capped the DB query at 200 rows,
+    preventing the router from fetching the extra row needed for has_more detection
+    when limit=200 (the maximum allowed value). Messages beyond position 200 were
+    silently inaccessible.
+    """
+    await _seed_book(TEST_BOOK_ID)
+    for i in range(201):
+        await append_chat_message(test_user["id"], TEST_BOOK_ID, "user", f"m{i}")
+
+    res = await client.get(f"/api/chat/{TEST_BOOK_ID}/messages?limit=200")
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data["messages"]) == 200
+    assert data["has_more"] is True, (
+        "Regression #1455: has_more must be True when 201 messages exist and limit=200"
+    )
+
+    # Second page must contain the remaining 1 message.
+    last_id = data["messages"][-1]["id"]
+    res2 = await client.get(
+        f"/api/chat/{TEST_BOOK_ID}/messages?limit=200&before_id={last_id}"
+    )
+    data2 = res2.json()
+    assert len(data2["messages"]) == 1
+    assert data2["has_more"] is False


### PR DESCRIPTION
## What

`GET /chat/{book_id}/messages` uses `limit+1` rows internally so the router can detect `has_more`. However, `get_chat_messages` in `services/db.py` capped the DB query at 200 (matching the router's max limit), which prevented the extra row from being fetched when `limit=200`.

Result: with ≥201 messages and `limit=200`, `has_more` was always `False` and the messages beyond position 200 were silently inaccessible.

## Fix

Raise the internal cap from 200 → 201 so the router can always request one extra row for pagination detection:

```python
# Before
safe_limit = max(1, min(limit, 200))

# After
safe_limit = max(1, min(limit, 201))
```

The router enforces `le=200` via `Query(50, ge=1, le=200)`, so external callers cannot pass 201 directly.

## Test plan

- New regression test `test_router_has_more_correct_at_max_limit` seeds 201 messages, fetches with `limit=200`, and asserts `has_more=True` + the second page contains the remaining 1 message.
- Full backend suite: 1710 passed.

Closes #1455
