### PR TITLE
fix: return 404 for non-existent book_id in POST /vocabulary/export/obsidian (closes #1457)

### DIFF
--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -469,6 +469,10 @@ async def export_obsidian(
 
     try:
         if req.book_id is not None:
+            book = await get_cached_book(req.book_id)
+            if not book:
+                raise HTTPException(status_code=404, detail="Book not found")
+            check_book_access(book, user)
             url = await _build_and_push_book(req.book_id)
             return {"urls": [url]}
         else:

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -386,6 +386,26 @@ async def test_export_obsidian_blocked_for_private_book_non_owner(client, test_u
     )
 
 
+async def test_export_obsidian_404_for_missing_book(client, test_user):
+    """Regression #1457: POST /vocabulary/export/obsidian with a non-existent book_id
+    must return 404, not silently export an empty markdown file."""
+    enc_token = encrypt_api_key("ghp_test_token")
+    from services.db import update_obsidian_settings
+    await update_obsidian_settings(
+        test_user["id"], enc_token, "user/notes", "Books",
+    )
+
+    with patch("routers.vocabulary._github_put", new_callable=AsyncMock), \
+         patch("routers.vocabulary.translate_text", new_callable=AsyncMock, return_value=[]):
+        resp = await client.post(
+            "/api/vocabulary/export/obsidian", json={"book_id": 99999}
+        )
+
+    assert resp.status_code == 404, (
+        f"Regression #1457: expected 404 for non-existent book, got {resp.status_code}: {resp.text}"
+    )
+
+
 async def test_export_github_api_error_returns_502(client, test_user):
     await _setup_export(test_user)
 


### PR DESCRIPTION
## What changed

`POST /vocabulary/export/obsidian` now returns 404 when an explicit `book_id` is provided but the book does not exist in the cache.

## Why

Previously, `_build_and_push_book` checked `if book: check_book_access(book, user)` but silently continued when `get_cached_book` returned `None`. It would push an empty/default markdown file to GitHub and return 200. Users had no indication the book was missing.

The fix adds a book existence check and `check_book_access` call in the outer scope before delegating to `_build_and_push_book` for the explicit single-book export path. The export-all path (no `book_id`) is unaffected — it iterates over book IDs from the user's own vocabulary, which are always valid.

## Test plan

- Added `test_export_obsidian_404_for_missing_book` — calls the endpoint with `book_id=99999` (non-existent), asserts 404.
- All 1711 backend tests pass; all 1750 frontend tests pass.

Closes #1457
