### PR TITLE
fix: return 409 when removing member from smart deck

### DIFF
--- a/backend/routers/decks.py
+++ b/backend/routers/decks.py
@@ -178,7 +178,10 @@ async def remove_member(
     vocabulary_id: int = Path(..., ge=1),
     user: dict = Depends(get_current_user),
 ):
-    removed = await decks_service.remove_manual_member(user["id"], deck_id, vocabulary_id)
+    try:
+        removed = await decks_service.remove_manual_member(user["id"], deck_id, vocabulary_id)
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     if not removed:
         raise HTTPException(status_code=404, detail="Deck member not found")
     return None

--- a/backend/services/decks.py
+++ b/backend/services/decks.py
@@ -212,11 +212,14 @@ async def remove_manual_member(user_id: int, deck_id: int, vocabulary_id: int) -
     async with aiosqlite.connect(_db_module.DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         async with db.execute(
-            "SELECT 1 FROM decks WHERE id = ? AND user_id = ?",
+            "SELECT mode FROM decks WHERE id = ? AND user_id = ?",
             (deck_id, user_id),
         ) as cur:
-            if await cur.fetchone() is None:
-                return False
+            deck = await cur.fetchone()
+        if deck is None:
+            return False
+        if deck["mode"] != "manual":
+            raise ValueError("Cannot remove members from a smart deck")
         cur = await db.execute(
             "DELETE FROM deck_members WHERE deck_id = ? AND vocabulary_id = ?",
             (deck_id, vocabulary_id),

--- a/backend/tests/test_router_decks.py
+++ b/backend/tests/test_router_decks.py
@@ -262,6 +262,22 @@ async def test_remove_member_404_for_nonexistent_deck(client, test_user):
     assert resp.status_code == 404
 
 
+async def test_remove_member_409_for_smart_deck(client, test_user):
+    """Regression #1459: DELETE /decks/{id}/members/{vid} on a smart deck must return 409,
+    not 404 (consistent with POST /decks/{id}/members which already returns 409)."""
+    await _book()
+    vid = await _save("smart_word", test_user["id"])
+    deck = (await client.post(
+        "/api/decks",
+        json={"name": "SmartD", "mode": "smart", "rules_json": {}},
+    )).json()
+
+    resp = await client.delete(f"/api/decks/{deck['id']}/members/{vid}")
+    assert resp.status_code == 409, (
+        f"Regression #1459: expected 409 for smart deck member removal, got {resp.status_code}: {resp.text}"
+    )
+
+
 # ── Smart deck rule resolution ──────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What changed

`services/decks.remove_manual_member` was missing the deck-mode guard that `add_manual_member` already had. For a smart deck, the `DELETE FROM deck_members` finds no rows (smart decks have no manual members), so `rowcount = 0` → returns `False` → router raised 404 "Deck member not found" instead of the expected 409.

Fix: changed the query from `SELECT 1` to `SELECT mode`, added `if deck["mode"] != "manual": raise ValueError(...)` mirroring `add_manual_member`, and added a `try/except ValueError` in the router to convert it to 409.

## Why

`POST /decks/{id}/members` (add) already returns 409 for smart decks. The delete endpoint returning 404 for the same condition was an inconsistency — callers that correctly got 409 on add had no way to distinguish "not a member" from "wrong deck type" on remove.

## Test plan

- `test_remove_member_409_for_smart_deck`: creates a smart deck, attempts `DELETE /decks/{id}/members/{vid}`, asserts 409
- Existing `test_remove_member`, `test_remove_member_404_for_nonexistent_deck` still pass
- Full backend suite: 1712 passed
- Full frontend suite: 1750 passed

Closes #1459
