### PR TITLE
fix: ensure flashcard_reviews row exists before reviewing a card

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -1272,6 +1272,7 @@ async def review_flashcard(
     """Apply SM-2 algorithm to a flashcard review. Returns updated state or None if not found."""
     from datetime import date, timedelta
 
+    await _ensure_flashcard_rows(user_id)
     async with aiosqlite.connect(DB_PATH) as db:
         db.row_factory = aiosqlite.Row
         async with db.execute(

--- a/backend/tests/test_router_flashcards.py
+++ b/backend/tests/test_router_flashcards.py
@@ -222,3 +222,26 @@ async def test_flashcards_require_auth(anon_client):
     assert (await anon_client.get("/api/vocabulary/flashcards/due")).status_code == 401
     assert (await anon_client.get("/api/vocabulary/flashcards/stats")).status_code == 401
     assert (await anon_client.post("/api/vocabulary/flashcards/1/review", json={"grade": 3})).status_code == 401
+
+
+async def test_review_without_prior_due_fetch_returns_200(client, test_user):
+    """Regression #1461: POST /vocabulary/flashcards/{id}/review must succeed
+    even when GET /flashcards/due was never called first (flashcard_reviews row
+    may not exist yet).  The service must call _ensure_flashcard_rows before
+    checking for the row."""
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    row = await save_word(test_user["id"], "unprompted", BOOK_ID, 0, "Unprompted sentence.")
+    vocab_id = row["id"]
+
+    # Deliberately skip GET /flashcards/due so _ensure_flashcard_rows is NOT
+    # called implicitly before the review.
+    resp = await client.post(
+        f"/api/vocabulary/flashcards/{vocab_id}/review", json={"grade": 3}
+    )
+    assert resp.status_code == 200, (
+        f"Regression #1461: expected 200 for review without prior due-fetch, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    data = resp.json()
+    assert "next_due" in data
+    assert "interval_days" in data


### PR DESCRIPTION
## What changed

`review_flashcard` in `services/db.py` now calls `_ensure_flashcard_rows(user_id)` before looking up the flashcard state. Previously it skipped this call, so if a vocabulary word was saved before the user ever visited the flashcard screen (which triggers `_ensure_flashcard_rows` via `get_flashcards_due`), the `flashcard_reviews` row wouldn't exist and the endpoint would return 404.

`get_flashcards_due` and `get_flashcard_stats` both call `_ensure_flashcard_rows` — `review_flashcard` was the only flashcard-path function that didn't.

## Why

A client that calls `POST /vocabulary/flashcards/{id}/review` directly (without first fetching due cards) would silently receive 404 for valid vocabulary. This also affects any future integration where review is triggered outside the normal "fetch due → review" flow.

## Test plan

- `test_review_without_prior_due_fetch_returns_200`: saves a word, immediately calls review without fetching `/flashcards/due` first, asserts 200 with correct `next_due` and `interval_days` fields
- Existing flashcard tests all still pass
- Full backend suite: 1712 passed
- Full frontend suite: 1750 passed

Closes #1461
