### PR TITLE
fix: return 400 for enqueue-all on unconfirmed uploaded books

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -377,6 +377,13 @@ async def enqueue_all_chapters(
     if not book_meta:
         raise HTTPException(status_code=404, detail="Book not found")
     check_book_access(book_meta, user)
+    if book_meta.get("source") == "upload":
+        from services.db import count_draft_user_book_chapters
+        if await count_draft_user_book_chapters(book_id) > 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Book chapters not yet confirmed. Confirm the chapter structure before translating.",
+            )
     source = (book_meta.get("languages") or [None])[0]
     if source and source.lower().split("-")[0] == target_language:
         raise HTTPException(

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -4,6 +4,7 @@ Tests for routers/books.py
 External calls (Gutenberg) are mocked so tests are fast and offline.
 """
 
+import io
 import pytest
 from unittest.mock import AsyncMock, patch
 import services.db as db_module
@@ -1499,4 +1500,37 @@ async def test_popular_books_whitespace_language_returns_all(client, popular_cac
     assert resp_ws.json()["total"] == resp_all.json()["total"], (
         f"Whitespace language should behave like no filter: total={resp_ws.json()['total']} "
         f"expected {resp_all.json()['total']}"
+    )
+
+
+# ── Regression #1463: enqueue-all must reject unconfirmed uploaded books ──────
+
+
+async def test_enqueue_all_returns_400_for_draft_upload(client, test_user):
+    """Regression #1463: POST /books/{id}/translations/enqueue-all on an uploaded
+    book with unconfirmed (draft) chapters must return 400, not silently return
+    {ok: true, enqueued: 0}.  Consistent with POST /chapters/{idx}/translation
+    which already returns 400 for the same scenario."""
+    sample_txt = (
+        b"My Draft Book\n\nChapter 1\n\nSome content here.\n\n"
+        b"Chapter 2\n\nMore content follows.\n"
+    )
+    upload_resp = await client.post(
+        "/api/books/upload",
+        files={"file": ("draft.txt", io.BytesIO(sample_txt), "text/plain")},
+    )
+    assert upload_resp.status_code == 200, upload_resp.text
+    book_id = upload_resp.json()["book_id"]
+
+    # Deliberately skip confirmation so chapters remain in draft state.
+    resp = await client.post(
+        f"/api/books/{book_id}/translations/enqueue-all",
+        json={"target_language": "de"},
+    )
+    assert resp.status_code == 400, (
+        f"Regression #1463: expected 400 for enqueue-all on draft upload, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    assert "not yet confirmed" in resp.json().get("detail", "").lower(), (
+        f"Expected 'not yet confirmed' in error detail, got: {resp.json()}"
     )


### PR DESCRIPTION
## What changed

`POST /books/{book_id}/translations/enqueue-all` now returns **400** when the
target book is an uploaded file whose chapters have not yet been confirmed
(draft state). Previously it returned `{"ok": true, "enqueued": 0}` — a
misleading 200 that gave no indication why nothing was queued.

## Why

`POST /books/{book_id}/chapters/{idx}/translation` (the per-chapter endpoint)
already guards this case with an explicit 400 and the message
_"Book chapters not yet confirmed. Confirm the chapter structure before
translating."_  The enqueue-all endpoint was inconsistent.

Root cause: `enqueue_for_book` delegates to `split_with_html_preference`,
which returns `[]` for unconfirmed uploads (draft rows excluded). Without
a pre-check, the caller silently got 0 enqueued with HTTP 200.

## Test plan

- New regression test `test_enqueue_all_returns_400_for_draft_upload` in
  `test_router_books.py`: uploads a .txt file, skips confirmation, calls
  enqueue-all, asserts 400 with "not yet confirmed" in the error detail.
- Full backend suite: 1714 passed.
- Full frontend suite: 1750 passed.

Closes #1463
