### PR TITLE
fix: assign uploaded books IDs ≥ 1,000,000 to avoid Gutenberg ID collision

### DIFF
--- a/backend/routers/uploads.py
+++ b/backend/routers/uploads.py
@@ -53,11 +53,18 @@ async def _save_upload_book(user_id: int, title: str, author: str, filename: str
                         status_code=429,
                         detail=f"Upload limit reached ({max_books} books). Delete a book to upload more.",
                     )
+            # Assign IDs ≥ 1,000,000 for uploaded books so they don't appear
+            # visually adjacent to Gutenberg IDs (which reach ~78,000) in URLs.
+            async with db.execute(
+                "SELECT MAX(id) FROM books WHERE id >= 1000000"
+            ) as _cur:
+                _row = await _cur.fetchone()
+            next_id = (_row[0] if _row and _row[0] is not None else 999999) + 1
             cur = await db.execute(
-                """INSERT INTO books (title, authors, languages, subjects, download_count,
+                """INSERT INTO books (id, title, authors, languages, subjects, download_count,
                                      cover, text, images, source, owner_user_id)
-                   VALUES (?, ?, '[]', '[]', 0, '', '', '[]', 'upload', ?)""",
-                (title, json.dumps([author]), user_id),
+                   VALUES (?, ?, ?, '[]', '[]', 0, '', '', '[]', 'upload', ?)""",
+                (next_id, title, json.dumps([author]), user_id),
             )
             book_id = cur.lastrowid
             await db.execute(

--- a/backend/tests/test_router_uploads.py
+++ b/backend/tests/test_router_uploads.py
@@ -330,6 +330,17 @@ async def test_delete_uploaded_book_by_non_owner_returns_403(tmp_db, test_user):
     assert "not your book" in del_resp.json()["detail"].lower()
 
 
+async def test_upload_book_id_in_upload_namespace(client, test_user):
+    """Regression #431: uploaded books must receive an ID ≥ 1,000,000 so they
+    don't collide visually with Gutenberg IDs (which reach ~78,000)."""
+    resp = await client.post("/api/books/upload", files=_txt_upload())
+    assert resp.status_code == 200, resp.text
+    book_id = resp.json()["book_id"]
+    assert book_id >= 1_000_000, (
+        f"Regression #431: uploaded book got ID {book_id}, expected ≥ 1,000,000"
+    )
+
+
 async def test_get_draft_chapters_requires_ownership(tmp_db, test_user):
     """Another user cannot access draft chapters that belong to test_user."""
     # Upload as test_user


### PR DESCRIPTION
## What changed

`_save_upload_book` in `routers/uploads.py` now picks an explicit book ID ≥ 1,000,000 for every uploaded book instead of letting SQLite auto-assign `max(id) + 1`.

## Why

Project Gutenberg books are seeded with their real Gutenberg IDs (reaching ~78,000+). SQLite's implicit auto-increment was therefore giving uploaded books IDs like `78066`, making reader URLs such as `/reader/78066` visually indistinguishable from a Gutenberg title URL. This confused users who couldn't tell whether they were looking at one of their uploads or a public-domain book.

## Implementation

Inside the existing `BEGIN IMMEDIATE` transaction (which already prevents TOCTOU races on the upload quota check), we query `MAX(id) FROM books WHERE id >= 1,000,000` and use that as the base for the next ID. No migration is needed — existing uploaded books keep their current IDs; only new uploads are affected. The `BEGIN IMMEDIATE` lock ensures two concurrent uploads cannot collide on the same ID.

## Test plan

- New regression test `test_upload_book_id_in_upload_namespace` asserts `book_id >= 1_000_000` after a `.txt` upload.
- All 47 existing `test_router_uploads.py` tests still pass.
- Full backend suite: **1715 passed**.
- Full frontend suite: **2507 passed**.

Closes #431

## Docs follow-up

No user-visible docs change required; URL appearance is an internal implementation detail not documented in `docs/FEATURES.md`.
