### PR TITLE
test: cover _background_fetch_epub success and exception paths (closes #1470)

### DIFF
--- a/backend/tests/test_book_chapters.py
+++ b/backend/tests/test_book_chapters.py
@@ -228,3 +228,40 @@ async def test_concurrent_calls_return_identical_chapter_list():
         f"Concurrent calls returned different chapter lists: "
         f"{[c.title for c in results[0]]} vs {[c.title for c in results[1]]}"
     )
+
+
+# ── _background_fetch_epub ────────────────────────────────────────────────────
+
+async def test_background_fetch_epub_success_saves_to_db():
+    """Regression #1470: success path — epub returned → save_book_epub called."""
+    fake_epub = b"epub content here"
+    fake_url = "https://gutenberg.org/files/123/123.epub"
+    with (
+        patch("services.gutenberg.get_book_epub", new_callable=AsyncMock,
+              return_value=(fake_epub, fake_url)),
+        patch("services.db.save_book_epub", new_callable=AsyncMock) as mock_save,
+    ):
+        from services.book_chapters import _background_fetch_epub
+        await _background_fetch_epub(123)
+
+    mock_save.assert_called_once_with(123, fake_epub, fake_url)
+
+
+async def test_background_fetch_epub_no_result_does_not_save():
+    """Regression #1470: if get_book_epub returns None, save_book_epub is not called."""
+    with (
+        patch("services.gutenberg.get_book_epub", new_callable=AsyncMock, return_value=None),
+        patch("services.db.save_book_epub", new_callable=AsyncMock) as mock_save,
+    ):
+        from services.book_chapters import _background_fetch_epub
+        await _background_fetch_epub(456)
+
+    mock_save.assert_not_called()
+
+
+async def test_background_fetch_epub_exception_is_swallowed():
+    """Regression #1470: exceptions inside the task must not propagate (fire-and-forget)."""
+    with patch("services.gutenberg.get_book_epub", new_callable=AsyncMock,
+               side_effect=RuntimeError("network unreachable")):
+        from services.book_chapters import _background_fetch_epub
+        await _background_fetch_epub(789)  # Must not raise


### PR DESCRIPTION
## What changed

Added three tests in `backend/tests/test_book_chapters.py` that call `_background_fetch_epub` directly (not through `asyncio.create_task`), covering previously-dead branches:

- `test_background_fetch_epub_success_saves_to_db` — `get_book_epub` returns `(bytes, url)` → `save_book_epub` is called with the correct args
- `test_background_fetch_epub_no_result_does_not_save` — `get_book_epub` returns `None` → `save_book_epub` is NOT called
- `test_background_fetch_epub_exception_is_swallowed` — `get_book_epub` raises `RuntimeError` → exception is swallowed, task does not propagate

## Why

Coverage report showed `services/book_chapters.py` lines 93–100 at 0% — the entire body of `_background_fetch_epub` was never executed because every caller in the test suite monkeypatched the function away. A regression in the store logic (wrong args to `save_book_epub`, accidental exception propagation) would go undetected.

## Test plan

- `pytest tests/test_book_chapters.py` — 16 passed (13 existing + 3 new)
- Full suite: 1722 passed, 0 failed

Closes #1470
