### PR TITLE
chore: remove stale delete_queue_item import from routers/admin.py (closes #1474)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -50,7 +50,6 @@ from services.translation_queue import (
     plan_work_for_queue,
     clear_queue,
     delete_queue_for_book,
-    delete_queue_item,
     enqueue_for_book,
     get_auto_languages,
     list_queue,


### PR DESCRIPTION
## What changed

Removed the stale `delete_queue_item` import from `routers/admin.py` (line 53). One-line deletion, no functional change.

## Why

`delete_queue_item` was imported from `services.translation_queue` but never called. The admin router's `queue_delete_item` endpoint has its own inline SQL (with an added `status != 'running'` safety guard), so the service function is completely unused. The stale import caused `services/translation_queue.py` lines 620–626 to register as 0% covered even though the module is otherwise well-tested.

## Test plan

- `pytest tests/test_router_admin.py tests/test_router_admin_extended.py` — 258 passed
- Full suite: 1725 passed, 0 failed

Closes #1474
