### PR TITLE
chore: remove unreachable chapter_index < 0 guard in user.py (closes #1476)

### DIFF
--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -67,8 +67,6 @@ async def update_reading_progress(
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
     check_book_access(book, user)
-    if req.chapter_index < 0:
-        raise HTTPException(status_code=400, detail="chapter_index must be >= 0")
     from services.book_chapters import split_with_html_preference as _split
     _chapters = await _split(book_id, book.get("text") or "")
     if req.chapter_index >= len(_chapters):


### PR DESCRIPTION
## What changed

Removed two lines of dead code from `routers/user.py` `update_reading_progress`:

```python
# removed:
if req.chapter_index < 0:
    raise HTTPException(status_code=400, detail="chapter_index must be >= 0")
```

## Why

`ProgressUpdate.chapter_index` is declared `Field(..., ge=0)`. FastAPI/Pydantic raises a 422 before the handler runs, so this branch can never execute. The existing test `test_reading_progress_rejects_negative_chapter_index` explicitly asserts 422, confirming the Pydantic layer handles it. Keeping unreachable exception paths violates CLAUDE.md: "No error handling for scenarios that cannot happen."

## Test plan

- `pytest tests/test_router_user.py` — 30 passed (all existing, no behaviour change)
- Full suite: 1729 passed, 0 failed

Closes #1476
