### PR TITLE
test: cover empty-deck early-return guards in flashcard due/stats (closes #1480)

### DIFF
--- a/backend/tests/test_router_flashcards_deck_filter.py
+++ b/backend/tests/test_router_flashcards_deck_filter.py
@@ -94,3 +94,30 @@ async def test_smart_deck_by_tag_filters_due(client, test_user):
     resp = await client.get(f"/api/vocabulary/flashcards/due?deck_id={deck['id']}")
     assert resp.status_code == 200
     assert [c["word"] for c in resp.json()] == ["apfel"]
+
+
+async def test_due_with_empty_deck_returns_empty_list(client, test_user):
+    """Empty manual deck (no members) must return [] without hitting the DB query.
+
+    Covers services/db.py get_flashcards_due early-return guard (vocabulary_ids=[]).
+    """
+    deck = (await client.post("/api/decks", json={"name": "EmptyDeck", "mode": "manual"})).json()
+
+    resp = await client.get(f"/api/vocabulary/flashcards/due?deck_id={deck['id']}")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_stats_with_empty_deck_returns_zeros(client, test_user):
+    """Empty manual deck (no members) must return zero stats without hitting the DB query.
+
+    Covers services/db.py get_flashcard_stats early-return guard (vocabulary_ids=[]).
+    """
+    deck = (await client.post("/api/decks", json={"name": "EmptyStatsDeck", "mode": "manual"})).json()
+
+    resp = await client.get(f"/api/vocabulary/flashcards/stats?deck_id={deck['id']}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 0
+    assert body["due_today"] == 0
+    assert body["reviewed_today"] == 0


### PR DESCRIPTION
## What changed

Added two tests to `tests/test_router_flashcards_deck_filter.py` covering the empty-deck early-return guards in `services/db.py`:

- `test_due_with_empty_deck_returns_empty_list` — `GET /vocabulary/flashcards/due?deck_id=<id>` for a deck with no members returns `[]` (covers line 1244-1245)
- `test_stats_with_empty_deck_returns_zeros` — `GET /vocabulary/flashcards/stats?deck_id=<id>` for a deck with no members returns `{total:0, due_today:0, reviewed_today:0}` (covers line 1335-1336)

## Why

The early-return guards prevent a full-table scan when a user has a deck with no vocabulary members (`vocabulary_ids=[]`). Without test coverage, if the guard were accidentally removed the endpoint would silently scan all user cards instead of returning empty — wrong behaviour with no safety net.

The trigger path is: create a manual deck → don't add any words → request flashcards for that deck. `resolve_deck_vocab_ids` returns `[]` (not `None`, which is the not-found path), so the early-return fires.

## Test plan

- `pytest tests/test_router_flashcards_deck_filter.py` — 8 passed (was 6)
- Full suite: 1732 backend passed, 1750 frontend passed

Closes #1480
