### PR TITLE
fix: remove unreachable chapter_index < 0 guard in vocabulary save (closes #1484)

### DIFF
--- a/backend/routers/vocabulary.py
+++ b/backend/routers/vocabulary.py
@@ -59,7 +59,7 @@ async def save(req: WordSave, user: dict = Depends(get_current_user)):
     check_book_access(book, user)
     from services.book_chapters import split_with_html_preference as _split
     _chapters = await _split(req.book_id, book.get("text") or "")
-    if req.chapter_index < 0 or req.chapter_index >= len(_chapters):
+    if req.chapter_index >= len(_chapters):
         raise HTTPException(
             status_code=400,
             detail=f"Chapter index out of range (book has {len(_chapters)} chapter(s)).",


### PR DESCRIPTION
## What changed

Removed the unreachable `req.chapter_index < 0` sub-check in `routers/vocabulary.py` `save` handler (line 62). The condition simplified from:

```python
if req.chapter_index < 0 or req.chapter_index >= len(_chapters):
```
to:
```python
if req.chapter_index >= len(_chapters):
```

## Why

`WordSave.chapter_index` is declared `Field(..., ge=0)`, so FastAPI/Pydantic rejects negative values with a 422 **before** the handler runs. `test_save_word_negative_chapter_index_returns_422` confirms this — the handler never sees a negative value.

This is the same dead-code pattern removed from `routers/user.py` in PR #1477.

## Test plan

- `pytest tests/test_router_vocabulary.py` — 50 passed (including the negative-index 422 test)
- Full backend suite: 1732 passed
- Frontend suite: 1750 passed

Closes #1484
