### PR TITLE
test: cover update_annotation no-op path when both fields omitted (closes #1488)

### DIFF
--- a/backend/tests/test_router_annotations.py
+++ b/backend/tests/test_router_annotations.py
@@ -640,3 +640,26 @@ async def test_create_annotation_whitespace_only_sentence_text_returns_400(clien
         f"Expected 400 for whitespace-only sentence_text, got {resp.status_code}: {resp.text}"
     )
     assert "sentence_text" in resp.json()["detail"].lower()
+
+
+# ── Issue #1488: update_annotation no-op path (both fields omitted) ───────────
+
+
+@pytest.mark.asyncio
+async def test_patch_annotation_no_fields_returns_current_annotation(client, test_user, tmp_db):
+    """PATCH /annotations/{id} with empty body returns the annotation unchanged.
+
+    Covers services/db.py update_annotation when clauses=[] (both note_text and
+    color are None). The SELECT still runs and the current row is returned.
+    """
+    from services.db import save_book
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    ann = await create_annotation(test_user["id"], BOOK_ID, 0, "A test sentence.", "original note", "yellow")
+    ann_id = ann["id"]
+
+    patch_resp = await client.patch(f"/api/annotations/{ann_id}", json={})
+    assert patch_resp.status_code == 200
+    updated = patch_resp.json()
+    assert updated["id"] == ann_id
+    assert updated["note_text"] == "original note"
+    assert updated["color"] == "yellow"


### PR DESCRIPTION
## What changed

Added a regression test covering the no-op path in `services/db.py update_annotation` when both `note_text` and `color` are `None` (empty PATCH body). In this case the `if clauses:` guard skips the `UPDATE` statement but still executes the `SELECT` and returns the current row unchanged.

## Why

This path had zero test coverage. A `PATCH /annotations/{id}` with `{}` would silently return the current row with no indication of whether the no-op branch was exercised. The test confirms the SELECT-without-UPDATE path works correctly.

## Test plan

- `test_patch_annotation_no_fields_returns_current_annotation` — creates an annotation, PATCHes with `{}`, asserts 200 and that `note_text`/`color` are unchanged
- All 1733 backend tests pass
- All 1750 frontend tests pass

Closes #1488
