### PR TITLE
test: cover oversized context_text validation in POST /insights (closes #1490)

### DIFF
--- a/backend/tests/test_router_insights.py
+++ b/backend/tests/test_router_insights.py
@@ -366,6 +366,16 @@ async def test_post_insight_oversized_answer_returns_422(client, test_user, tmp_
     assert resp.status_code == 422, f"Expected 422 for oversized answer, got {resp.status_code}"
 
 
+async def test_post_insight_oversized_context_text_returns_422(client, test_user, tmp_db):
+    """POST /insights rejects context_text longer than max_length=5000 (closes #1490)."""
+    await save_book(9886, {**_META, "id": 9886}, "text")
+    resp = await client.post(
+        "/api/insights",
+        json={"book_id": 9886, "question": "Q?", "answer": "A.", "context_text": "c" * 5001},
+    )
+    assert resp.status_code == 422, f"Expected 422 for oversized context_text, got {resp.status_code}"
+
+
 async def test_duplicate_insight_returns_existing_row(client, test_user, tmp_db):
     """POST /insights with identical question deduplicates — returns existing row, GET returns 1 entry (issue #497)."""
     await save_book(9887, {**_META, "id": 9887}, "text")


### PR DESCRIPTION
## What changed

Added `test_post_insight_oversized_context_text_returns_422` to `backend/tests/test_router_insights.py` — verifies that `POST /insights` with `context_text` exceeding 5,000 characters is rejected with HTTP 422 by Pydantic's `max_length=5000` constraint.

## Why

`InsightCreate.context_text` carries a `max_length=5000` limit alongside existing limits on `question` (2,000) and `answer` (20,000), both of which had tests. The `context_text` field was untested, leaving a gap that would not catch accidental removal of the constraint.

## Test plan

- New test passes (1 assertion, no book seed needed — rejection is at Pydantic validation before the handler runs)
- All 30 insights tests pass
- All 1733 backend tests pass (background run)
- All 1750 frontend tests pass

Closes #1490
