### PR TITLE
test: cover oversized title_translation in import-translations endpoint (closes #1494)

### DIFF
--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -2438,6 +2438,20 @@ async def test_import_translations_oversized_provider_returns_422(admin_client, 
 
 
 @pytest.mark.asyncio
+async def test_import_translations_oversized_title_translation_returns_422(admin_client, admin_db):
+    """Regression #1494: title_translation > 500 chars in import entry must return 422."""
+    res = await admin_client.post(
+        "/api/admin/translations/import",
+        json={"entries": [{"book_id": 1, "chapter_index": 0,
+                           "target_language": "de", "paragraphs": ["hello"],
+                           "title_translation": "t" * 501}]},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for oversized title_translation in import, got {res.status_code}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_queue_settings_oversized_api_key_returns_422(admin_client, admin_db):
     """Regression #521: PUT /admin/queue/settings with api_key > 500 chars must return 422."""
     res = await admin_client.put(


### PR DESCRIPTION
## What changed

Added `test_import_translations_oversized_title_translation_returns_422` to `backend/tests/test_router_admin.py` — verifies that `POST /admin/translations/import` with `title_translation` exceeding 500 characters is rejected with HTTP 422.

## Why

`ImportTranslationEntry.title_translation` carries `max_length=500` alongside tested fields `target_language`, `provider`, and `paragraphs`, but the `title_translation` limit had no automated coverage. A future refactor removing the constraint would pass the full suite undetected without this test.

## Test plan

- New test passes (Pydantic validation fires before the handler — no DB seed needed)
- All 1733+ backend tests pass
- All 1750 frontend tests pass

Closes #1494
