### PR TITLE
test: cover max_length=200 on scope query param in GET /search (closes #1496)

### DIFF
--- a/backend/tests/test_router_search.py
+++ b/backend/tests/test_router_search.py
@@ -301,6 +301,12 @@ async def test_query_max_length_rejected(client, test_user):
     assert res.status_code == 422
 
 
+async def test_scope_max_length_rejected(client, test_user):
+    """GET /search with scope longer than max_length=200 must return 422 (closes #1496)."""
+    res = await client.get(f"/api/search?q=word&scope={'a' * 201}")
+    assert res.status_code == 422, f"Expected 422 for oversized scope, got {res.status_code}: {res.text}"
+
+
 async def test_limit_capped(client, test_user):
     async with aiosqlite.connect(db_module.DB_PATH) as db:
         for i in range(60):


### PR DESCRIPTION
## What changed

Added `test_scope_max_length_rejected` to `backend/tests/test_router_search.py` — verifies that `GET /search?scope=<201 chars>` is rejected with HTTP 422 by FastAPI's `Query(..., max_length=200)` constraint.

## Why

The `scope` query parameter has `max_length=200` alongside the `q` parameter which already has an oversized-input test. The `scope` field was the only search param missing its max-length regression test.

## Test plan

- New test passes
- All 22 search tests pass
- All 1734 backend tests pass
- All 1750 frontend tests pass

Closes #1496
