### PR TITLE
test: cover update_deck no-op path when PATCH body is empty (closes #1498)

### DIFF
--- a/backend/tests/test_router_decks.py
+++ b/backend/tests/test_router_decks.py
@@ -172,6 +172,23 @@ async def test_patch_deck_name(client, test_user):
     assert resp.json()["name"] == "New"
 
 
+async def test_patch_deck_no_fields_returns_current_deck(client, test_user):
+    """PATCH /decks/{id} with empty body returns the deck unchanged (closes #1498).
+
+    Covers services/decks.py update_deck when fields=[] (no-op path):
+    the SELECT-without-UPDATE short-circuit returns the current row.
+    """
+    created = (await client.post("/api/decks", json={"name": "NoopDeck", "mode": "manual"})).json()
+    deck_id = created["id"]
+
+    resp = await client.patch(f"/api/decks/{deck_id}", json={})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == deck_id
+    assert data["name"] == "NoopDeck"
+    assert data["mode"] == "manual"
+
+
 async def test_patch_deck_404_for_nonexistent_deck(client, test_user):
     """Regression #1365: PATCH /decks/{id} on a non-existent deck must return 404."""
     resp = await client.patch("/api/decks/9999", json={"name": "Ghost"})


### PR DESCRIPTION
## What changed

Added `test_patch_deck_no_fields_returns_current_deck` to `backend/tests/test_router_decks.py` — verifies that `PATCH /decks/{id}` with an empty body returns the current deck unchanged with HTTP 200.

## Why

`services/decks.py update_deck` has a no-op short-circuit at line 159: when no fields are provided (`name=None`, `description=None`, `rules_provided=False`), it skips the UPDATE and calls `get_deck` directly. This path had no test coverage, analogous to the `update_annotation` no-op path covered in PR #1489.

## Test plan

- New test passes
- All 44 deck tests pass
- All 1738+ backend tests pass
- All 1750 frontend tests pass

Closes #1498
