### PR TITLE
test: cover oversized target_language in queue/plan, queue/dry-run, queue/retry-failed (closes #1500)

### DIFF
--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -3510,3 +3510,42 @@ async def test_queue_settings_whitespace_model_returns_422(admin_client):
         f"Regression #1444: whitespace-only model in queue/settings must return 422, "
         f"got {res.status_code}: {res.text}"
     )
+
+
+# ── Issue #1500: QueuePlanRequest and RetryFailedRequest oversized target_language ──
+
+
+@pytest.mark.asyncio
+async def test_queue_plan_oversized_target_language_returns_422(admin_client):
+    """Regression #1500: POST /admin/queue/plan with target_language > 20 chars must return 422."""
+    res = await admin_client.post(
+        "/api/admin/queue/plan",
+        json={"target_language": "x" * 21},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for oversized target_language in queue/plan, got {res.status_code}: {res.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_queue_dry_run_oversized_target_language_returns_422(admin_client):
+    """Regression #1500: POST /admin/queue/dry-run with target_language > 20 chars must return 422."""
+    res = await admin_client.post(
+        "/api/admin/queue/dry-run",
+        json={"target_language": "x" * 21},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for oversized target_language in queue/dry-run, got {res.status_code}: {res.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_retry_failed_oversized_target_language_returns_422(admin_client):
+    """Regression #1500: POST /admin/queue/retry-failed with target_language > 20 chars must return 422."""
+    res = await admin_client.post(
+        "/api/admin/queue/retry-failed",
+        json={"target_language": "x" * 21},
+    )
+    assert res.status_code == 422, (
+        f"Expected 422 for oversized target_language in queue/retry-failed, got {res.status_code}: {res.text}"
+    )


### PR DESCRIPTION
## What changed

Added 3 regression tests covering `max_length=20` enforcement on `target_language` body fields that were missing oversized-input coverage:

- `POST /api/admin/queue/plan` — `QueuePlanRequest.target_language`
- `POST /api/admin/queue/dry-run` — `QueuePlanRequest.target_language`
- `POST /api/admin/queue/retry-failed` — `RetryFailedRequest.target_language`

## Why

These fields declare `max_length=20` via Pydantic `Field` but had no test confirming Pydantic returns 422 for oversized values. Parallel tests exist for the empty/min_length case but not max_length. Found during systematic admin.py max_length coverage sweep.

## Test plan

- `test_queue_plan_oversized_target_language_returns_422` — sends 21-char string to `/queue/plan`, asserts 422
- `test_queue_dry_run_oversized_target_language_returns_422` — same for `/queue/dry-run`
- `test_retry_failed_oversized_target_language_returns_422` — same for `/queue/retry-failed`
- Full backend suite: 1742 passed ✓
- Full frontend suite: 1750 passed ✓

Closes #1500
