### PR TITLE
test: cover oversized tag in POST and DELETE vocabulary tag endpoints (closes #1502)

### DIFF
--- a/backend/tests/test_router_vocabulary_tags.py
+++ b/backend/tests/test_router_vocabulary_tags.py
@@ -151,3 +151,33 @@ async def test_tags_cascade_on_word_delete(client, test_user):
 
     resp = await client.get("/api/vocabulary/tags")
     assert resp.json() == []
+
+
+# ── Issue #1502: oversized tag max_length enforcement ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_add_tag_oversized_returns_422(client, test_user):
+    """Regression #1502: POST /vocabulary/{id}/tags with tag > 50 chars must return 422.
+    TagAdd.tag declares max_length=50; Pydantic must reject the oversized value."""
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    vid = await _save("taggedword", test_user["id"])
+    resp = await client.post(
+        f"/api/vocabulary/{vid}/tags",
+        json={"tag": "x" * 51},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for tag > 50 chars in POST /vocabulary/tags, got {resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_tag_oversized_path_returns_422(client, test_user):
+    """Regression #1502: DELETE /vocabulary/{id}/tags/{tag} with tag > 50 chars must return 422.
+    The path param declares max_length=50; Pydantic must reject the oversized value."""
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    vid = await _save("taggedword2", test_user["id"])
+    resp = await client.delete(f"/api/vocabulary/{vid}/tags/{'x' * 51}")
+    assert resp.status_code == 422, (
+        f"Expected 422 for tag > 50 chars in DELETE /vocabulary/tags/{{tag}}, got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## What changed

Added 2 regression tests covering `max_length=50` enforcement on vocabulary tag fields that were missing oversized-input coverage:

- `POST /api/vocabulary/{id}/tags` — `TagAdd.tag` body field (max_length=50)
- `DELETE /api/vocabulary/{id}/tags/{tag}` — `tag` path parameter (max_length=50)

## Why

Both `TagAdd.tag` and the path param `tag` declare `max_length=50` via Pydantic, but no test confirmed that oversized values (>50 chars) are rejected with 422. Other vocabulary fields (word, sentence_text, lang) already have oversized tests; tag was the only gap.

## Test plan

- `test_add_tag_oversized_returns_422` — sends 51-char tag to `POST /vocabulary/{id}/tags`, asserts 422
- `test_delete_tag_oversized_path_returns_422` — sends 51-char path segment to `DELETE /vocabulary/{id}/tags/{tag}`, asserts 422
- Full backend suite: 1742 passed ✓
- Full frontend suite: 1750 passed ✓

Closes #1502
