### PR TITLE
test: cover SmartRules oversized language and tags_any list in decks (closes #1504)

### DIFF
--- a/backend/tests/test_router_decks.py
+++ b/backend/tests/test_router_decks.py
@@ -568,3 +568,34 @@ async def test_patch_deck_oversized_description_returns_422(client, test_user):
     deck_id = create.json()["id"]
     resp = await client.patch(f"/api/decks/{deck_id}", json={"description": "d" * 501})
     assert resp.status_code == 422, f"Expected 422 for oversized description in PATCH, got {resp.status_code}: {resp.text}"
+
+
+# ── Issue #1504: SmartRules.language and tags_any list max_length ─────────────
+
+
+@pytest.mark.asyncio
+async def test_smart_rules_oversized_language_returns_422(client, test_user):
+    """Regression #1504: SmartRules.language > 20 chars must return 422.
+    language declares max_length=20; the empty/whitespace cases are already covered
+    but the oversized-string case was missing."""
+    resp = await client.post(
+        "/api/decks",
+        json={"name": "LangDeck", "mode": "smart", "rules_json": {"language": "x" * 21}},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized language in SmartRules, got {resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_smart_rules_oversized_tags_any_list_returns_422(client, test_user):
+    """Regression #1504: SmartRules.tags_any list with > 100 items must return 422.
+    tags_any declares max_length=100 on the list; the per-item max_length=50 case is covered
+    but the list-length cap was missing (by contrast tags_all list > 100 already has a test)."""
+    resp = await client.post(
+        "/api/decks",
+        json={"name": "HugeTagsAny", "mode": "smart", "rules_json": {"tags_any": ["t"] * 101}},
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for tags_any list > 100 items in SmartRules, got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## What changed

Added 2 regression tests for `SmartRules` constraint fields in the decks router that were missing oversized-value coverage:

- `SmartRules.language` (max_length=20): had empty/whitespace tests but no test for a >20-char string
- `SmartRules.tags_any` list (max_length=100): had per-item string length test but no test for a list with >100 items (unlike `tags_all` which already had this coverage)

## Why

Both fields declare Pydantic constraints that are enforced before the handler runs. Without regression tests, a future change to the model could silently drop these constraints. The symmetric `tags_all` oversized-list test exists; `tags_any` was the asymmetric gap.

## Test plan

- `test_smart_rules_oversized_language_returns_422` — sends 21-char language to POST /decks, asserts 422
- `test_smart_rules_oversized_tags_any_list_returns_422` — sends 101-item tags_any list to POST /decks, asserts 422
- Full backend suite: 1743 passed ✓
- Full frontend suite: 1750 passed ✓

Closes #1504
