### PR TITLE
test: cover oversized response_language on insight/qa/references endpoints (closes #1506)

### DIFF
--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -1553,3 +1553,48 @@ async def test_translate_cache_get_rejects_whitespace_target_language(client, te
         f"Regression #1451: whitespace-only target_language in GET /translate/cache "
         f"must return 422, got {resp.status_code}: {resp.text}"
     )
+
+
+# ── Issue #1506: response_language max_length=20 on insight/qa/references ────
+
+
+@pytest.mark.asyncio
+async def test_insight_oversized_response_language_returns_422(client, test_user):
+    """Regression #1506: POST /ai/insight with response_language > 20 chars must return 422."""
+    resp = await client.post("/api/ai/insight", json={
+        "chapter_text": "Some text.",
+        "book_title": "Book",
+        "author": "Author",
+        "response_language": "x" * 21,
+    })
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized response_language in /ai/insight, got {resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_qa_oversized_response_language_returns_422(client, test_user):
+    """Regression #1506: POST /ai/qa with response_language > 20 chars must return 422."""
+    resp = await client.post("/api/ai/qa", json={
+        "question": "What?",
+        "passage": "Some passage text.",
+        "book_title": "Book",
+        "author": "Author",
+        "response_language": "x" * 21,
+    })
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized response_language in /ai/qa, got {resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_references_oversized_response_language_returns_422(client, test_user):
+    """Regression #1506: POST /ai/references with response_language > 20 chars must return 422."""
+    resp = await client.post("/api/ai/references", json={
+        "book_title": "Book",
+        "author": "Author",
+        "response_language": "x" * 21,
+    })
+    assert resp.status_code == 422, (
+        f"Expected 422 for oversized response_language in /ai/references, got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## What changed

Added 3 regression tests covering `max_length=20` enforcement on `response_language` body fields that were missing oversized-input coverage:

- `POST /api/ai/insight` — `InsightRequest.response_language`
- `POST /api/ai/qa` — `QARequest.response_language`
- `POST /api/ai/references` — `ReferencesRequest.response_language`

## Why

All three models declare `response_language: str = Field(default="en", min_length=1, max_length=20)`. Whitespace-only tests existed (issue #1054) but no test verified that values >20 chars are rejected with 422. Found during systematic max_length coverage sweep of `routers/ai.py`.

## Test plan

- `test_insight_oversized_response_language_returns_422` — 21-char value → 422
- `test_qa_oversized_response_language_returns_422` — 21-char value → 422
- `test_references_oversized_response_language_returns_422` — 21-char value → 422
- Full backend suite: 1746 passed ✓
- Full frontend suite: 1750 passed ✓

Closes #1506
