### PR TITLE
test: cover per_page ge=1/le=200 bounds on GET /books/popular (closes #1514)

### DIFF
--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -1284,6 +1284,21 @@ async def test_popular_books_page_too_large_returns_422(client):
     assert resp.status_code == 422, f"Expected 422 for page > 10000, got {resp.status_code}: {resp.text}"
 
 
+# ── Issue #1514: per_page bounds on /books/popular (ge=1, le=200) ─────────────
+
+
+async def test_popular_per_page_zero_returns_422(client):
+    """Regression #1514: GET /books/popular?per_page=0 must return 422 (ge=1 violated)."""
+    resp = await client.get("/api/books/popular?per_page=0")
+    assert resp.status_code == 422, f"Expected 422 for per_page=0 in /books/popular, got {resp.status_code}: {resp.text}"
+
+
+async def test_popular_per_page_too_large_returns_422(client):
+    """Regression #1514: GET /books/popular?per_page=201 must return 422 (le=200 violated)."""
+    resp = await client.get("/api/books/popular?per_page=201")
+    assert resp.status_code == 422, f"Expected 422 for per_page=201 in /books/popular, got {resp.status_code}: {resp.text}"
+
+
 # ── Issue #772: min_length=1 on target_language in RequestTranslationBody ────
 
 


### PR DESCRIPTION
## What changed
Added 2 regression tests for `GET /books/popular` `per_page` query param bounds: `per_page=0` (violates `ge=1`) and `per_page=201` (violates `le=200`) must both return 422.

## Why
Bug #1514: `per_page: int = Query(50, ge=1, le=200)` on `/books/popular` had tests for the `page` upper-bound (issue #739) but no tests for `per_page` bounds — the symmetric coverage gap. Note: `/books/search` does not have a `per_page` param, so no test needed there.

## Test plan
- `test_popular_per_page_zero_returns_422` — `per_page=0` → 422
- `test_popular_per_page_too_large_returns_422` — `per_page=201` → 422

- [ ] Docs updated (if applicable)
