### PR TITLE
test: cover ge=1 lower-bound on limit/page/deck_id query params (closes #1516)

### DIFF
--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -1299,6 +1299,21 @@ async def test_popular_per_page_too_large_returns_422(client):
     assert resp.status_code == 422, f"Expected 422 for per_page=201 in /books/popular, got {resp.status_code}: {resp.text}"
 
 
+# ── Issue #1516: ge=1 lower-bound on page query param ─────────────────────────
+
+
+async def test_search_page_zero_returns_422(client):
+    """Regression #1516: GET /books/search?page=0 must return 422 (ge=1 violated)."""
+    resp = await client.get("/api/books/search?q=test&page=0")
+    assert resp.status_code == 422, f"Expected 422 for page=0 in /books/search, got {resp.status_code}: {resp.text}"
+
+
+async def test_popular_books_page_zero_returns_422(client):
+    """Regression #1516: GET /books/popular?page=0 must return 422 (ge=1 violated)."""
+    resp = await client.get("/api/books/popular?page=0")
+    assert resp.status_code == 422, f"Expected 422 for page=0 in /books/popular, got {resp.status_code}: {resp.text}"
+
+
 # ── Issue #772: min_length=1 on target_language in RequestTranslationBody ────
 
 

--- a/backend/tests/test_router_search.py
+++ b/backend/tests/test_router_search.py
@@ -321,6 +321,12 @@ async def test_limit_capped(client, test_user):
     assert len(res.json()["results"]) == 50
 
 
+async def test_limit_zero_returns_422(client, test_user):
+    """Regression #1516: GET /search?limit=0 must return 422 (ge=1 violated)."""
+    res = await client.get("/api/search?q=word&limit=0")
+    assert res.status_code == 422, f"Expected 422 for limit=0 in /search, got {res.status_code}: {res.text}"
+
+
 async def test_query_with_fts5_special_chars_does_not_crash(client, test_user):
     async with aiosqlite.connect(db_module.DB_PATH) as db:
         await _seed_annotation(db, test_user["id"], 1, 0,

--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -911,3 +911,22 @@ async def test_definition_whitespace_only_word_returns_422(client, test_user):
     assert resp.status_code == 422, (
         f"Expected 422 for whitespace-only word in /definition, got {resp.status_code}: {resp.text}"
     )
+
+
+# ── Issue #1516: ge=1 lower-bound on deck_id query param ─────────────────────
+
+
+async def test_flashcards_due_deck_id_zero_returns_422(client, test_user):
+    """Regression #1516: GET /vocabulary/flashcards/due?deck_id=0 must return 422 (ge=1 violated)."""
+    resp = await client.get("/api/vocabulary/flashcards/due?deck_id=0")
+    assert resp.status_code == 422, (
+        f"Expected 422 for deck_id=0 in GET /vocabulary/flashcards/due, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_flashcards_stats_deck_id_zero_returns_422(client, test_user):
+    """Regression #1516: GET /vocabulary/flashcards/stats?deck_id=0 must return 422 (ge=1 violated)."""
+    resp = await client.get("/api/vocabulary/flashcards/stats?deck_id=0")
+    assert resp.status_code == 422, (
+        f"Expected 422 for deck_id=0 in GET /vocabulary/flashcards/stats, got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## What

Adds 5 regression tests covering `ge=1` lower-bound enforcement on query params that previously had no test for the zero case:

- `GET /api/books/search?page=0` → 422 (closes #1516)
- `GET /api/books/popular?page=0` → 422
- `GET /api/search?limit=0` → 422
- `GET /api/vocabulary/flashcards/due?deck_id=0` → 422
- `GET /api/vocabulary/flashcards/stats?deck_id=0` → 422

## Why

FastAPI declares `ge=1` on these params but there were no regression tests confirming the constraint fires. Zero-value inputs are a common off-by-one mistake from clients; without a test, a refactor could silently remove the constraint.

## Test plan

- All 5 new tests pass locally
- Full backend suite: 1762 passed
- Full frontend suite: 1750 passed

Closes #1516
