### PR TITLE
test: cover model_chain list > 20 items bound in PUT /admin/queue/settings (closes #1520)

### DIFF
--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -2577,6 +2577,18 @@ async def test_queue_settings_oversized_model_chain_item_returns_422(admin_clien
 
 
 @pytest.mark.asyncio
+async def test_queue_settings_too_many_model_chain_items_returns_422(admin_client, admin_db):
+    """Regression #1520: model_chain list > 20 items must return 422 (max_length=20 violated)."""
+    res = await admin_client.put(
+        "/api/admin/queue/settings",
+        json={"model_chain": ["gemini-1.5-flash"] * 21},
+    )
+    assert res.status_code == 422, (
+        f"Regression #1520: expected 422 for model_chain with 21 items, got {res.status_code}: {res.text}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_queue_settings_too_many_languages_returns_422(admin_client, admin_db):
     """Regression #531: auto_translate_languages list > 50 items must return 422."""
     res = await admin_client.put(


### PR DESCRIPTION
## What changed

Added `test_queue_settings_too_many_model_chain_items_returns_422` to `backend/tests/test_router_admin.py`.

`QueueSettingsRequest.model_chain` declares `Field(default=None, max_length=20)` on the list, which means Pydantic should reject payloads with 21+ entries with a 422. This constraint was exercised by no test — the existing suite covered empty lists, whitespace entries, and oversized individual items but not list length.

## Why

Regression coverage gap: the symmetric constraint on `auto_translate_languages` (max_length=50) already had a `too_many_languages` test; `model_chain` was missing the equivalent. Closes #1520.

## Test plan

- New test: `test_queue_settings_too_many_model_chain_items_returns_422` — sends 21 `"gemini-1.5-flash"` entries, asserts 422
- Full test suite: 1763 passed (frontend + backend)

## Docs follow-up

None — test-only change.
