### PR TITLE
test: cover DELETE /vocabulary/{id}/tags with whitespace-only tag (closes #1529)

### DIFF
--- a/backend/tests/test_router_vocabulary_tags.py
+++ b/backend/tests/test_router_vocabulary_tags.py
@@ -181,3 +181,19 @@ async def test_delete_tag_oversized_path_returns_422(client, test_user):
     assert resp.status_code == 422, (
         f"Expected 422 for tag > 50 chars in DELETE /vocabulary/tags/{{tag}}, got {resp.status_code}: {resp.text}"
     )
+
+
+@pytest.mark.asyncio
+async def test_delete_tag_whitespace_only_returns_400(client, test_user):
+    """Regression #1529: DELETE /vocabulary/{id}/tags/%20 must return 400, not 500.
+
+    A single space satisfies min_length=1 on the path param but normalize_tag()
+    strips it to '' and raises ValueError. The handler's except-ValueError block
+    (routers/vocabulary.py lines 204-205) must catch it and return 400.
+    """
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    vid = await _save("taggedword3", test_user["id"])
+    resp = await client.delete(f"/api/vocabulary/{vid}/tags/%20")
+    assert resp.status_code == 400, (
+        f"Regression #1529: expected 400 for whitespace-only tag in DELETE, got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## What changed

Added a regression test for `DELETE /vocabulary/{id}/tags/{tag}` with a whitespace-only tag path parameter (closes #1529).

## Why

A single space (`%20` URL-encoded) satisfies `min_length=1` on the path param but `normalize_tag(' ')` strips it to `''` and raises `ValueError('tag cannot be empty')`. The `except ValueError` block at `routers/vocabulary.py` lines 204-205 was the only handler converting this to a 400 response — but that path had zero test coverage. Without the test we can't verify the endpoint returns 400 rather than an unhandled 500.

## Test plan

`test_delete_tag_whitespace_only_returns_400` — sends `DELETE /vocabulary/{id}/tags/%20`, asserts 400.

All 15 vocab-tag tests pass. Full suite: 1790 passed.

- [ ] Docs updated (if applicable)
