### PR TITLE
test: cover translation-status for empty-text book (closes #1528)

### DIFF
--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -421,6 +421,22 @@ async def test_translation_status_cached_book_no_translations(client):
     assert "bulk_active" not in data
 
 
+async def test_translation_status_empty_text_book_returns_zero_chapters(client):
+    """Regression #1528: book saved with empty text (not yet fetched) returns total_chapters=0.
+
+    Covers routers/books.py line 120 else-branch: when cached.get('text') is '' and
+    source is not 'upload', the if-condition is False and total_chapters stays 0.
+    """
+    book_id = 9997
+    meta = {**MOCK_META, "id": book_id}
+    await save_book(book_id, meta, "")  # empty text — not yet fetched
+    resp = await client.get(f"/api/books/{book_id}/translation-status?target_language=de")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_chapters"] == 0
+    assert data["translated_chapters"] == 0
+
+
 async def test_translation_status_with_translations(client):
     """Cached book with one chapter translated returns correct counts."""
     from services.db import save_translation


### PR DESCRIPTION
## What changed

Added a regression test for `GET /books/{id}/translation-status` where the book is saved with empty text (closes #1528).

## Why

`routers/books.py` line 120: `if cached.get("text") or cached.get("source") == "upload":` — when a Gutenberg book exists in the DB but has no text yet (not fetched from Project Gutenberg), both conditions are False and `total_chapters` stays 0. This else-path was never tested, meaning a future regression there would go undetected.

This is a real production state: popular-list seeding can register books without their text. Calling `translation-status` on such a book should return 200 with `total_chapters=0`.

## Test plan

`test_translation_status_empty_text_book_returns_zero_chapters` — saves a book with `text=""`, calls `GET /books/{book_id}/translation-status?target_language=de`, asserts status 200 and `total_chapters=0`.

Full suite: 1790 passed.

- [ ] Docs updated (if applicable)
