### PR TITLE
test: cover oversized .txt upload returns 413 (closes #1530)

### DIFF
--- a/backend/tests/test_router_uploads.py
+++ b/backend/tests/test_router_uploads.py
@@ -1106,3 +1106,20 @@ async def test_upload_whitespace_title_author_falls_back_to_defaults(client, tes
     assert authors_list[0] == "Unknown", (
         f"Expected fallback 'Unknown' for whitespace author, got {authors_list[0]!r}"
     )
+
+
+# ── Issue #1530: oversized file upload returns 413 ────────────────────────────
+
+async def test_upload_txt_file_too_large_returns_413(client, test_user, monkeypatch):
+    """Regression #1530: POST /upload with a .txt file exceeding the size limit must return 413.
+
+    Monkeypatches MAX_TXT_BYTES to 10 bytes so the test doesn't need a 3 MB payload.
+    """
+    import routers.uploads as _uploads_mod
+    monkeypatch.setattr(_uploads_mod, "MAX_TXT_BYTES", 10)
+    oversized = b"x" * 11
+    resp = await client.post("/api/books/upload", files=_txt_upload(content=oversized))
+    assert resp.status_code == 413, (
+        f"Regression #1530: expected 413 for oversized .txt upload, got {resp.status_code}: {resp.text}"
+    )
+    assert "too large" in resp.json()["detail"].lower()


### PR DESCRIPTION
## What

Adds a regression test covering the 413 response path for oversized `.txt` uploads in `POST /books/upload`.

## Why

`routers/uploads.py` has a `MAX_TXT_BYTES` guard (line ~55) that raises HTTP 413 when the uploaded file exceeds the limit. This branch was previously unreachable by the test suite — no test sent a file larger than the constant. The gap was found during a coverage scan (issue #1530).

The test uses `monkeypatch.setattr` to override `MAX_TXT_BYTES` to 10 bytes so the test payload stays tiny while still exercising the real guard.

## Test plan

- `test_upload_txt_file_too_large_returns_413`: sends an 11-byte `.txt` file with `MAX_TXT_BYTES` patched to 10; asserts `status_code == 413` and `"too large"` in `detail`
- Full backend suite: 1790 passed
- Full frontend suite: 1750 passed

Closes #1530
