### PR TITLE
test: cover GET /ai/translate/cache cache-miss 404 path (closes #1533)

### DIFF
--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -168,6 +168,25 @@ async def test_translate_cache_get_returns_404_when_missing(client):
     assert resp.status_code == 404
 
 
+async def test_translate_cache_get_returns_404_not_cached(client):
+    """Regression #1533: GET /translate/cache for a book with chapters but no translation
+    must return 404 with detail 'Not cached' (routers/ai.py line 345).
+
+    The existing test uses book_id=999 (nonexistent) and hits 'Book not found' at
+    line 325 — never reaching the 'Not cached' path at line 345.
+    """
+    _m = {"title": "Cache Miss Book", "authors": [], "languages": ["en"],
+          "subjects": [], "download_count": 0, "cover": ""}
+    await save_book(7771, _m, "Chapter 1\n\nSome text.")
+    resp = await client.get(
+        "/api/ai/translate/cache?book_id=7771&chapter_index=0&target_language=de"
+    )
+    assert resp.status_code == 404, (
+        f"Regression #1533: expected 404 for untranslated chapter, got {resp.status_code}: {resp.text}"
+    )
+    assert resp.json()["detail"] == "Not cached"
+
+
 async def test_translate_cache_get_normalizes_language(client):
     """GET /translate/cache?target_language=ZH must hit a 'zh' row.
 


### PR DESCRIPTION
## What

Adds a regression test covering the 404 "Not cached" response from `GET /ai/translate/cache` when the requested chapter has never been translated.

## Why

`routers/ai.py` line 345 raises `HTTPException(404, "Not cached")` when the chapter exists but has no cached translation. The branch was previously unreachable by the test suite — all existing translate-cache tests either hit a cached translation or a missing book. Gap found during coverage scan (issue #1533).

## Test plan

- `test_translate_cache_get_returns_404_not_cached`: saves a book with text, then calls `GET /ai/translate/cache?book_id=...&chapter_index=0&target_language=de` without ever translating it; asserts `status_code == 404` and `detail == "Not cached"`
- Full backend suite: 1791 passed
- Full frontend suite: 1750 passed

Closes #1533
