### PR TITLE
test: cover confirm_chapters unmatched original_index saves empty text (closes #1534)

### DIFF
--- a/backend/tests/test_router_uploads.py
+++ b/backend/tests/test_router_uploads.py
@@ -1123,3 +1123,29 @@ async def test_upload_txt_file_too_large_returns_413(client, test_user, monkeypa
         f"Regression #1530: expected 413 for oversized .txt upload, got {resp.status_code}: {resp.text}"
     )
     assert "too large" in resp.json()["detail"].lower()
+
+
+# ── Issue #1534: unmatched original_index in confirm_chapters ─────────────────
+
+
+async def test_confirm_chapters_unmatched_original_index_saves_empty_text(client, test_user):
+    """Regression #1534: confirm with an original_index that doesn't match any detected
+    chapter saves the chapter with empty text (routers/uploads.py line 270).
+    """
+    upload_resp = await client.post("/api/books/upload", files=_txt_upload())
+    assert upload_resp.status_code == 200
+    book_id = upload_resp.json()["book_id"]
+
+    # Use original_index=999 — a value that won't match any detected chapter (max index is ~1)
+    resp = await client.post(
+        f"/api/books/{book_id}/chapters/confirm",
+        json={"chapters": [{"title": "Phantom Chapter", "original_index": 999}]},
+    )
+    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+    assert resp.json()["chapter_count"] == 1
+
+    chapters_resp = await client.get(f"/api/books/{book_id}/chapters")
+    assert chapters_resp.status_code == 200
+    ch = chapters_resp.json()["chapters"][0]
+    assert ch["title"] == "Phantom Chapter"
+    assert ch["text"] == ""  # text="" because orig_idx not in orig_by_idx (line 270)


### PR DESCRIPTION
## What

Adds a regression test covering the empty-text fallback at `routers/uploads.py` line 270, where a `ConfirmChapterSpec` references an `original_index` that does not match any detected chapter index.

## Why

All existing `confirm_chapters` tests pass only valid `original_index` values that match real detected chapter indices. Line 270 (the `else: text = ""` branch) was never reached by the test suite. Gap found during coverage scan (issue #1534).

## Test plan

- `test_confirm_chapters_unmatched_original_index_saves_empty_text`: uploads a `.txt` file (2 chapters at indices 0, 1), then confirms with `original_index: 999`; asserts the chapter is saved with `title == "Phantom Chapter"` and `text == ""`
- Full backend suite: 1792 passed
- Full frontend suite: 1750 passed

Closes #1534
