### PR TITLE
fix: replace Unicode arrow chars used as UI icons with SVG icons (closes #1539)

### DIFF
--- a/frontend/src/__tests__/UnicodeArrowIconsBanned.test.ts
+++ b/frontend/src/__tests__/UnicodeArrowIconsBanned.test.ts
@@ -1,0 +1,29 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// Per CLAUDE.md graphic design rules, UI icons must come from Icons.tsx (SVG),
+// not Unicode arrow characters which render inconsistently across OS/browser.
+// Closes #1539.
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(__dirname, "..", rel), "utf8");
+}
+
+describe("Unicode arrows must not be used as UI icons (closes #1539)", () => {
+  it("QueueTab does not use ↑ or ↓ as button content for chain reorder", () => {
+    const src = read("components/QueueTab.tsx");
+    // Match Unicode arrow as direct JSX text content (between > and <).
+    expect(src).not.toMatch(/>\s*↑\s*</);
+    expect(src).not.toMatch(/>\s*↓\s*</);
+  });
+
+  it("SeedPopularButton does not use ↓ as a downloading indicator", () => {
+    const src = read("components/SeedPopularButton.tsx");
+    expect(src).not.toMatch(/↓\s*\{state\.current_book_title/);
+  });
+
+  it("InsightChat does not use ↑ as a load-earlier glyph", () => {
+    const src = read("components/InsightChat.tsx");
+    expect(src).not.toMatch(/↑\s*Load earlier/);
+  });
+});

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -360,6 +360,14 @@ export function ChevronDownIcon({ className = "w-4 h-4" }: IconProps) {
   );
 }
 
+export function ChevronUpIcon({ className = "w-4 h-4" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <polyline points="18 15 12 9 6 15"/>
+    </svg>
+  );
+}
+
 export function KeyboardIcon({ className = "w-4 h-4" }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -433,9 +433,10 @@ export default function InsightChat({
         {hasEarlier && (
           <button
             onClick={loadEarlier}
-            className="w-full text-xs text-gray-400 hover:text-gray-600 py-1.5 min-h-[44px] rounded-lg border border-gray-100 hover:bg-gray-50 transition-colors"
+            className="w-full text-xs text-gray-400 hover:text-gray-600 py-1.5 min-h-[44px] rounded-lg border border-gray-100 hover:bg-gray-50 transition-colors inline-flex items-center justify-center gap-1.5"
           >
-            ↑ Load earlier ({loadedFrom} more)
+            <ArrowUpIcon className="w-3 h-3" />
+            <span>Load earlier ({loadedFrom} more)</span>
           </button>
         )}
 

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { CheckIcon, AlertCircleIcon, CloseIcon } from "@/components/Icons";
+import { CheckIcon, AlertCircleIcon, CloseIcon, ChevronUpIcon, ChevronDownIcon } from "@/components/Icons";
 import {
   CHAIN_PRESETS,
   DEFAULT_CHAIN,
@@ -1003,7 +1003,7 @@ export default function QueueTab({ adminFetch }: Props) {
                         title={`Move ${labelForModel(m)} up`}
                         aria-label={`Move ${labelForModel(m)} up`}
                       >
-                        ↑
+                        <ChevronUpIcon className="w-4 h-4" />
                       </button>
                       <button
                         onClick={() => {
@@ -1017,7 +1017,7 @@ export default function QueueTab({ adminFetch }: Props) {
                         title={`Move ${labelForModel(m)} down`}
                         aria-label={`Move ${labelForModel(m)} down`}
                       >
-                        ↓
+                        <ChevronDownIcon className="w-4 h-4" />
                       </button>
                     </div>
                     <button

--- a/frontend/src/components/SeedPopularButton.tsx
+++ b/frontend/src/components/SeedPopularButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { CheckIcon, AlertCircleIcon } from "@/components/Icons";
+import { CheckIcon, AlertCircleIcon, ChevronDownIcon } from "@/components/Icons";
 
 type AdminFetch = (path: string, options?: RequestInit) => Promise<any>;
 
@@ -196,8 +196,9 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
           )}
 
           {running && state.current_book_title && (
-            <p className="text-xs text-amber-700 truncate">
-              ↓ {state.current_book_title}
+            <p className="text-xs text-amber-700 truncate flex items-center gap-1">
+              <ChevronDownIcon className="w-3.5 h-3.5 shrink-0" />
+              <span className="truncate">{state.current_book_title}</span>
             </p>
           )}
 


### PR DESCRIPTION
## What

Replace Unicode arrow characters (`↑` `↓`) used as UI icons with SVG icons from `Icons.tsx`:

- **`QueueTab.tsx`** — chain reorder Move-up/Move-down buttons → `<ChevronUpIcon />` / `<ChevronDownIcon />`
- **`SeedPopularButton.tsx`** — currently-downloading marker → `<ChevronDownIcon />`
- **`InsightChat.tsx`** — load-earlier button glyph → `<ArrowUpIcon />`
- Adds `ChevronUpIcon` to `Icons.tsx` (mirror of existing `ChevronDownIcon`).

## Why

CLAUDE.md graphic design rules forbid Unicode/emoji glyphs as UI icons — they render inconsistently across OS/browser (thin glyph on macOS/Windows, emoji-styled on iOS), and `text-xs` (12px) makes them visually weak. All UI icons must come from `@/components/Icons.tsx`.

## Test plan

- [x] New unit test `UnicodeArrowIconsBanned.test.ts` asserts the four sites do not contain Unicode arrows (verified failing pre-fix, passing post-fix).
- [x] Full frontend suite passes (2510/2510).
- [x] Full backend suite passes (1792/1792).

Closes #1539
