### PR TITLE
test: cover DELETE /ai/summary non-admin 403 path (closes #1538)

### DIFF
--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -1691,3 +1691,20 @@ async def test_references_oversized_response_language_returns_422(client, test_u
     assert resp.status_code == 422, (
         f"Expected 422 for oversized response_language in /ai/references, got {resp.status_code}: {resp.text}"
     )
+
+
+# ── Issue #1538: DELETE /ai/summary non-admin 403 ────────────────────────────
+
+
+async def test_delete_summary_non_admin_returns_403(client, test_user):
+    """Regression #1538: DELETE /ai/summary by a non-admin user must return 403.
+    The admin-only guard at routers/ai.py line 290 was uncovered because the default
+    test_user is always auto-promoted to admin in a fresh tmp_db.
+    """
+    from services.db import set_user_role
+    await set_user_role(test_user["id"], "user")
+    resp = await client.delete("/api/ai/summary", params={"book_id": 1, "chapter_index": 0})
+    assert resp.status_code == 403, (
+        f"Regression #1538: expected 403 for non-admin DELETE /ai/summary, "
+        f"got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## What

Adds a regression test covering the 403 "Admin only" response from `DELETE /ai/summary` when called by a non-admin user.

## Why

`routers/ai.py` line 290 raises `HTTPException(403, "Admin only")` when a non-admin user calls `DELETE /ai/summary`. The branch was unreachable in the test suite because `test_user` is always auto-promoted to `admin` (first user in a fresh `tmp_db`). Gap found during coverage scan (issue #1538).

The test uses `set_user_role(test_user["id"], "user")` to demote the default user before calling the endpoint — an existing pattern established in `test_router_ai.py` tests for private-book access.

## Test plan

- `test_delete_summary_non_admin_returns_403`: demotes `test_user` to `role='user'`, then calls `DELETE /api/ai/summary?book_id=1&chapter_index=0`; asserts `status_code == 403`
- Full backend suite: 1793 passed
- Full frontend suite: 1750 passed

Closes #1538
