### PR TITLE
test: cover SmartRules tags_not_blank null and blank-tag branches (closes #1543)

### DIFF
--- a/backend/tests/test_router_decks.py
+++ b/backend/tests/test_router_decks.py
@@ -720,3 +720,33 @@ async def test_create_deck_bad_mode_raises(tmp_db, test_user):
     from services.decks import create_deck
     with pytest.raises(ValueError, match="mode must be"):
         await create_deck(test_user["id"], "Deck", "", "invalid_mode", None)
+
+
+# ── Issue #1543: SmartRules tags_not_blank null and blank-tag paths ────────────
+
+
+async def test_smart_rules_tags_any_null_is_valid(client, test_user):
+    """Regression #1543: POST /decks with tags_any=null must succeed (line 49→53 branch).
+    The tags_not_blank validator must return early when v is None.
+    """
+    resp = await client.post(
+        "/api/decks",
+        json={"name": "NullTagsDeck", "mode": "smart", "rules_json": {"tags_any": None}},
+    )
+    assert resp.status_code == 201, (
+        f"Regression #1543: expected 201 for tags_any=null, got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_smart_rules_tags_any_whitespace_only_returns_422(client, test_user):
+    """Regression #1543: POST /decks with whitespace-only tag in tags_any must return 422.
+    Covers line 52 — the raise ValueError branch inside the tags_not_blank for-loop.
+    """
+    resp = await client.post(
+        "/api/decks",
+        json={"name": "BlankTagDeck", "mode": "smart", "rules_json": {"tags_any": ["   "]}},
+    )
+    assert resp.status_code == 422, (
+        f"Regression #1543: expected 422 for whitespace-only tag in tags_any, "
+        f"got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
## What

Adds two regression tests covering uncovered branches in `SmartRules.tags_not_blank` validator (`routers/decks.py` lines 49–52):

1. `tags_any=null` — explicitly passing null exercises the `if v is not None:` false branch (line 49→53)
2. `tags_any=["   "]` — whitespace-only tag entry exercises the `raise ValueError` at line 52

## Why

The `tags_not_blank` field validator runs for both `tags_any` and `tags_all`. Existing tests either omit the field (validator not called) or pass valid non-empty tags. Neither branch was fully exercised. Gap found during coverage scan (issue #1543).

## Test plan

- `test_smart_rules_tags_any_null_is_valid`: sends `{"tags_any": null}` in rules_json; asserts 201 (null is a valid explicit value)
- `test_smart_rules_tags_any_whitespace_only_returns_422`: sends `{"tags_any": ["   "]}`; asserts 422 (whitespace-only tag is rejected)
- Full backend suite: 1795 passed
- Full frontend suite: 1750 passed

Closes #1543
