### PR TITLE
fix: add rel="noopener noreferrer" to InsightChat target=_blank links (closes #1541)

### DIFF
--- a/frontend/src/__tests__/InsightChatTargetBlankRel.test.ts
+++ b/frontend/src/__tests__/InsightChatTargetBlankRel.test.ts
@@ -1,0 +1,27 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// Per codebase convention and tabnabbing prevention, every anchor with
+// target="_blank" must also carry rel="noopener noreferrer". Closes #1541.
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/InsightChat.tsx"),
+  "utf8",
+);
+
+describe("InsightChat target=_blank links carry rel=noopener (closes #1541)", () => {
+  it("does not have a target=\"_blank\" anchor without rel=\"noopener", () => {
+    // Find every <a ...target="_blank"...> ... and assert "noopener" appears
+    // somewhere inside the same opening tag.
+    const anchorRe = /<a\b([^>]*?)>/g;
+    let m: RegExpExecArray | null;
+    const offenders: string[] = [];
+    while ((m = anchorRe.exec(src)) !== null) {
+      const attrs = m[1];
+      if (attrs.includes('target="_blank"') && !attrs.includes("noopener")) {
+        offenders.push(m[0]);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -416,7 +416,7 @@ export default function InsightChat({
       {!hasGeminiKey && (
         <div className="px-3 py-2 bg-amber-50 border-b border-amber-100 text-xs text-amber-800">
           Insights require a{" "}
-          <a href="/profile" target="_blank" className="underline font-medium">Gemini API key</a>{" "}
+          <a href="/profile" target="_blank" rel="noopener noreferrer" className="underline font-medium">Gemini API key</a>{" "}
           — free from Google AI Studio.
         </div>
       )}
@@ -581,7 +581,7 @@ export default function InsightChat({
         {!hasGeminiKey && (
           <div className="bg-amber-50 border border-amber-100 rounded-lg px-3 py-2 mb-2 text-xs text-amber-800">
             Chat requires a{" "}
-            <a href="/profile" target="_blank" className="underline font-medium">Gemini API key</a>.
+            <a href="/profile" target="_blank" rel="noopener noreferrer" className="underline font-medium">Gemini API key</a>.
           </div>
         )}
 


### PR DESCRIPTION
## What

Add `rel="noopener noreferrer"` to the two `target="_blank"` anchors in `InsightChat.tsx` (lines 419, 584 — the "Gemini API key" links pointing to `/profile`). Every other `target="_blank"` in the frontend already pairs the two attributes; these were the only outliers.

## Why

- **Tabnabbing prevention** — `rel="noopener"` is the standard defensive pair for `target="_blank"`. The links currently point same-origin so the realistic risk is small, but the attribute keeps the rule robust if those links ever go cross-origin.
- **Consistency** — codebase-wide pattern (BookDetailModal, VocabWordTooltip, reader page, vocabulary page).
- **Lint hygiene** — matches `react/jsx-no-target-blank`.

## Test plan

- [x] New regression test `InsightChatTargetBlankRel.test.ts` parses every `<a ...>` opening tag in the source and asserts no `target="_blank"` appears without `noopener` (verified failing pre-fix, passing post-fix).
- [x] Full frontend suite passes (2509/2509).
- [x] Full backend suite passes (1793/1793).

Closes #1541
