### PR TITLE
fix: add 44px mobile touch target to AnnotationsSidebar anchor links (closes #1547)

### DIFF
--- a/frontend/src/__tests__/AnnotationsSidebarTouchTargets.test.ts
+++ b/frontend/src/__tests__/AnnotationsSidebarTouchTargets.test.ts
@@ -35,3 +35,20 @@ describe("AnnotationsSidebar touch targets (closes #806)", () => {
     expect(window).toContain("min-w-[44px]");
   });
 });
+
+describe("AnnotationsSidebar interactive anchors meet 44px mobile touch target (closes #1547)", () => {
+  it("every <a href=...> opening tag carries min-h-[44px]", () => {
+    // Match <a ...> opening tag, allowing => (arrow fn) inside JSX attrs.
+    const anchorRe = /<a\b((?:=>|[^>])*?)>/g;
+    let m: RegExpExecArray | null;
+    const offenders: string[] = [];
+    while ((m = anchorRe.exec(src)) !== null) {
+      const attrs = m[1];
+      if (!attrs.includes("href")) continue;
+      if (!attrs.includes("min-h-[44px]")) {
+        offenders.push(m[0]);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -144,7 +144,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
                               <a
                                 href={`/notes/${bookId}#annotation-${ann.id}`}
                                 onClick={(e) => { e.stopPropagation(); setOpen(false); }}
-                                className="opacity-60 hover:opacity-100"
+                                className="opacity-60 hover:opacity-100 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 flex items-center justify-center"
                                 title="View in notes page"
                                 aria-label="View in notes page"
                               >
@@ -180,14 +180,14 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
             <a
               href={bookId ? `/notes/${bookId}` : "/notes"}
               onClick={() => setOpen(false)}
-              className="inline-flex items-center gap-1 text-xs text-amber-700 hover:text-amber-900 font-medium transition-colors"
+              className="inline-flex items-center gap-1 text-xs text-amber-700 hover:text-amber-900 font-medium transition-colors min-h-[44px] md:min-h-0"
             >
               {bookId ? "Book notes" : "All notes"} <ArrowRightIcon className="w-3 h-3 shrink-0" />
             </a>
             <a
               href="/notes"
               onClick={() => setOpen(false)}
-              className="text-xs text-stone-500 hover:text-stone-600 transition-colors"
+              className="inline-flex items-center text-xs text-stone-500 hover:text-stone-600 transition-colors min-h-[44px] md:min-h-0"
             >
               All books
             </a>


### PR DESCRIPTION
## What

Add the standard `min-h-[44px] md:min-h-0` mobile touch target to three `<a href=...>` elements in `AnnotationsSidebar.tsx`:

1. The icon-only "View in notes page" link inside each annotation row (rendered ~14px tall before).
2. The footer link "Book notes" / "All notes".
3. The footer link "All books".

The adjacent edit button on each row already used the correct pattern; these anchors were the outliers.

## Why

CLAUDE.md graphic-design rules require interactive elements to be ≥44×44px on mobile. The icon-only arrow link was effectively impossible to tap reliably; the footer links were tight (`text-xs` rendered as ~16px tall).

## Test plan

- [x] Extends existing `AnnotationsSidebarTouchTargets.test.ts` with a regex sweep that fails on any `<a href=...>` opening tag missing `min-h-[44px]`. (Verified failing pre-fix — caught all three offenders — passing post-fix.)
- [x] Full frontend suite passes (2511/2511).
- [ ] Backend suite running locally; change is frontend-only so no backend regressions expected. CI will gate the merge.

Closes #1547
