### PR TITLE
fix: bump WordLookup loading/error text to amber-700 (WCAG 1.4.3, closes #1553)

### DIFF
--- a/frontend/src/__tests__/WordLookupContrast.test.ts
+++ b/frontend/src/__tests__/WordLookupContrast.test.ts
@@ -1,0 +1,26 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// text-amber-600 (#d97706) on white = ~3.62:1 — fails WCAG 1.4.3 AA at
+// text-sm. Closes #1553.
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/WordLookup.tsx"),
+  "utf8",
+);
+
+describe("WordLookup loading/error contrast (closes #1553)", () => {
+  it("loading status div does not use text-amber-600", () => {
+    const idx = src.indexOf('role="status"');
+    expect(idx).toBeGreaterThan(-1);
+    const opening = src.slice(Math.max(0, idx - 200), idx);
+    expect(opening).not.toMatch(/text-amber-600/);
+  });
+
+  it("error alert paragraph does not use text-amber-600", () => {
+    const idx = src.indexOf('role="alert"');
+    expect(idx).toBeGreaterThan(-1);
+    const opening = src.slice(Math.max(0, idx - 60), idx + 80);
+    expect(opening).not.toMatch(/text-amber-600/);
+  });
+});

--- a/frontend/src/components/WordLookup.tsx
+++ b/frontend/src/components/WordLookup.tsx
@@ -85,14 +85,14 @@ export default function WordLookup({ word, position, language, onClose }: Props)
   return (
     <div ref={ref} style={style} className="sm:w-72 max-h-64 overflow-y-auto rounded-xl border border-amber-300 bg-white shadow-lg p-3 text-sm">
       {loading && (
-        <div className="flex items-center gap-2 text-amber-600" role="status">
+        <div className="flex items-center gap-2 text-amber-700" role="status">
           <span className="w-3 h-3 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
           Looking up &ldquo;{word}&rdquo;...
         </div>
       )}
 
       {error && (
-        <p role="alert" className="text-amber-600 italic">{error} for &ldquo;{word}&rdquo;</p>
+        <p role="alert" className="text-amber-700 italic">{error} for &ldquo;{word}&rdquo;</p>
       )}
 
       {result && (


### PR DESCRIPTION
## What

Two-line className change in `frontend/src/components/WordLookup.tsx`:
- Line 88: loading status `text-amber-600` → `text-amber-700`
- Line 95: error paragraph `text-amber-600` → `text-amber-700`

## Why

`text-amber-600` (#d97706) on white at `text-sm` (14px) measures **≈3.62:1** — WCAG 1.4.3 AA requires 4.5:1 for normal text under 18pt non-bold. `text-amber-700` lifts it to ≈5.02:1 and matches the rest of the codebase (waves 9-13 already converged on amber-700 for small UI text).

## Test plan

- [x] New regression test `WordLookupContrast.test.ts` asserts both nodes (`role="status"` and `role="alert"`) do not use `text-amber-600` (verified failing pre-fix, passing post-fix).
- [x] Full frontend suite passes (2514/2514).
- [ ] Backend unaffected (frontend-only). CI will gate.

Closes #1553
