### PR TITLE
fix: bump VocabWordTooltip Save button to amber-700 (WCAG 1.4.3, closes #1557)

### DIFF
--- a/frontend/src/__tests__/VocabWordTooltipSaveContrast.test.ts
+++ b/frontend/src/__tests__/VocabWordTooltipSaveContrast.test.ts
@@ -1,0 +1,16 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// White on amber-600 measures ≈3.62:1 — fails WCAG 1.4.3 AA at text-xs.
+// Closes #1557.
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/VocabWordTooltip.tsx"),
+  "utf8",
+);
+
+describe("VocabWordTooltip Save button contrast (closes #1557)", () => {
+  it("Save button does not use bg-amber-600 text-white", () => {
+    expect(src).not.toMatch(/bg-amber-600\s+text-white/);
+  });
+});

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -129,7 +129,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
           className={`text-xs font-medium px-3 py-1 min-h-[44px] rounded-lg transition-colors flex items-center justify-center ${
             saved
               ? "bg-stone-100 text-stone-400 cursor-default"
-              : "bg-amber-600 text-white hover:bg-amber-700"
+              : "bg-amber-700 text-white hover:bg-amber-800"
           }`}
         >
           {saved ? (


### PR DESCRIPTION
## What

Bump the "Save to vocab" button in `VocabWordTooltip.tsx`:

- `bg-amber-600 text-white hover:bg-amber-700` → `bg-amber-700 text-white hover:bg-amber-800`

## Why

White on amber-600 (#d97706) at `text-xs` (12px) is **≈3.62:1** contrast — fails WCAG 1.4.3 AA. amber-700 (#b45309) is ≈5.02:1 (AA ✓), amber-800 (#92400e) for hover is ≈7:1 (AAA).

Matches every other primary CTA in the codebase already using `bg-amber-700` (BookDetailModal, AuthPromptModal, AnnotationToolbar, etc.).

## Test plan

- [x] New regression test asserts source contains no `bg-amber-600 text-white` pairing (verified failing pre-fix, passing post-fix).
- [x] Full frontend suite passes (2514/2514).

Closes #1557
