### PR TITLE
fix: bump admin text-stone-300 labels to text-stone-500 (WCAG 1.4.3, closes #1559)

### DIFF
--- a/frontend/src/__tests__/AdminTextStone300Contrast.test.ts
+++ b/frontend/src/__tests__/AdminTextStone300Contrast.test.ts
@@ -1,0 +1,25 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// text-stone-300 (#d6d3d1) on white = 1.5:1 — fails WCAG 1.4.3 AA
+// dramatically. Closes #1559.
+
+const usersSrc = fs.readFileSync(
+  path.join(__dirname, "../app/admin/users/page.tsx"),
+  "utf8",
+);
+
+const booksSrc = fs.readFileSync(
+  path.join(__dirname, "../app/admin/books/page.tsx"),
+  "utf8",
+);
+
+describe("admin pages do not render visible text in text-stone-300 (closes #1559)", () => {
+  it("admin/users does not have <span class=...text-stone-300>", () => {
+    expect(usersSrc).not.toMatch(/<span[^>]*text-stone-300/);
+  });
+
+  it("admin/books does not have <span class=...text-stone-300>", () => {
+    expect(booksSrc).not.toMatch(/<span[^>]*text-stone-300/);
+  });
+});

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -312,7 +312,7 @@ export default function BooksPage() {
 
                 <div className="flex flex-wrap gap-1 items-center">
                   {allLangs.length === 0 ? (
-                    <span className="text-xs text-stone-300">no translations</span>
+                    <span className="text-xs text-stone-500">no translations</span>
                   ) : (
                     allLangs.map((lang) => {
                       const count = b.translations?.[lang] || 0;

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -102,7 +102,7 @@ export default function UsersPage() {
               </button>
             </div>
           )}
-          {u.id === myId && <span className="text-xs text-stone-300">You</span>}
+          {u.id === myId && <span className="text-xs text-stone-500">You</span>}
         </div>
       ))}
     </div>


### PR DESCRIPTION
## What

Bump two admin-page text spans from `text-stone-300` → `text-stone-500`:

- `frontend/src/app/admin/users/page.tsx:105` — "You" label on the current admin's row.
- `frontend/src/app/admin/books/page.tsx:315` — "no translations" empty-state per book row.

## Why

`text-stone-300` (#d6d3d1) on white = **≈1.5:1** — fails WCAG 1.4.3 AA dramatically (needs 4.5:1 for normal text). Both labels carry meaning ("You" identifies your row; "no translations" is a real status), so the dim styling actively obscures information.

`text-stone-500` (#78716c) gives ≈4.61:1 (AA ✓) and matches the meta-label tone already used elsewhere in the same files.

## Test plan

- [x] New regression test asserts neither file has a `<span ... text-stone-300 ...>` (verified failing pre-fix, passing post-fix).
- [x] Full frontend suite passes (2517/2517).

Closes #1559
