### PR TITLE
fix: clear chapter cache and stale translations after background EPUB fetch (closes #1556)

### DIFF
--- a/backend/services/book_chapters.py
+++ b/backend/services/book_chapters.py
@@ -83,8 +83,10 @@ async def split_with_html_preference(book_id: int, text: str) -> list[Chapter]:
 async def _background_fetch_epub(book_id: int) -> None:
     """Fetch and store EPUB for a pre-existing Gutenberg book (fire-and-forget).
 
-    Does not update the in-memory chapter cache — stored EPUB becomes
-    available on the next cold start.
+    After storing the EPUB, clears the in-memory chapter cache and purges all
+    cached translations for the book. Translations generated under the old
+    plain-text split are misaligned with the new EPUB-based chapter indices
+    (issue #1556).
     """
     try:
         from services.gutenberg import get_book_epub
@@ -96,6 +98,17 @@ async def _background_fetch_epub(book_id: int) -> None:
             logger.info(
                 "Background EPUB cached for book %d (%d KB)", book_id, len(epub_bytes) // 1024
             )
+            # Invalidate the in-memory cache so the next request uses the EPUB-based split.
+            clear_cache(book_id)
+            # Purge translations generated with the old plain-text chapter indices.
+            try:
+                from services.db import delete_translations_for_book
+                await delete_translations_for_book(book_id)
+                logger.info("Cleared stale translations for book %d after EPUB update", book_id)
+            except Exception:
+                logger.warning(
+                    "Failed to clear stale translations for book %d", book_id, exc_info=True
+                )
     except Exception:
         logger.debug("Background EPUB fetch failed for book %d", book_id, exc_info=True)
 

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -443,6 +443,13 @@ async def count_translations_for_book(book_id: int, target_language: str) -> int
     return row[0] if row else 0
 
 
+async def delete_translations_for_book(book_id: int) -> None:
+    """Delete all cached translations for a book across all languages and chapters."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("DELETE FROM translations WHERE book_id=?", (book_id,))
+        await db.commit()
+
+
 
 async def get_cached_book(book_id: int) -> dict | None:
     """Return cached book dict (includes 'text') or None."""

--- a/backend/tests/test_book_chapters.py
+++ b/backend/tests/test_book_chapters.py
@@ -265,3 +265,71 @@ async def test_background_fetch_epub_exception_is_swallowed():
                side_effect=RuntimeError("network unreachable")):
         from services.book_chapters import _background_fetch_epub
         await _background_fetch_epub(789)  # Must not raise
+
+
+# ── _background_fetch_epub cache invalidation (issue #1556) ──────────────────
+
+async def test_background_fetch_epub_clears_chapter_cache_on_success():
+    """Regression #1556: successful EPUB fetch must clear the in-memory chapter
+    cache for that book so the next reader request gets EPUB-based chapters
+    rather than waiting for a cold start.
+    """
+    import services.book_chapters as bc_mod
+    from services.book_chapters import _background_fetch_epub
+    bc_mod._chapter_cache[9001] = _make_chapters("Old text-based chapter")
+
+    with (
+        patch("services.gutenberg.get_book_epub", new_callable=AsyncMock,
+              return_value=(b"epub_bytes", "https://example.com/9001.epub")),
+        patch("services.db.save_book_epub", new_callable=AsyncMock),
+        patch("services.db.delete_translations_for_book", new_callable=AsyncMock),
+    ):
+        await _background_fetch_epub(9001)
+
+    assert 9001 not in bc_mod._chapter_cache, (
+        "Regression #1556: _background_fetch_epub must clear _chapter_cache[book_id] "
+        "after storing the EPUB so EPUB-based chapters are used immediately, not after cold start."
+    )
+
+
+async def test_background_fetch_epub_deletes_stale_translations_on_success():
+    """Regression #1556: successful EPUB fetch must delete cached translations for
+    the book because they were generated with plain-text-based chapter indices
+    that are now misaligned with the EPUB-based chapter structure.
+    """
+    from services.book_chapters import _background_fetch_epub
+
+    with (
+        patch("services.gutenberg.get_book_epub", new_callable=AsyncMock,
+              return_value=(b"epub_bytes", "https://example.com/9002.epub")),
+        patch("services.db.save_book_epub", new_callable=AsyncMock),
+        patch("services.db.delete_translations_for_book", new_callable=AsyncMock) as mock_del,
+    ):
+        await _background_fetch_epub(9002)
+
+    mock_del.assert_called_once_with(9002), (
+        "Regression #1556: _background_fetch_epub must call delete_translations_for_book "
+        "after storing the EPUB to purge stale plain-text-indexed translations."
+    )
+
+
+async def test_background_fetch_epub_no_cache_clear_when_epub_not_returned():
+    """Regression #1556: when get_book_epub returns None, the chapter cache and
+    translations must NOT be touched — nothing changed.
+    """
+    import services.book_chapters as bc_mod
+    from services.book_chapters import _background_fetch_epub
+    original = _make_chapters("Existing chapter")
+    bc_mod._chapter_cache[9003] = original
+
+    with (
+        patch("services.gutenberg.get_book_epub", new_callable=AsyncMock, return_value=None),
+        patch("services.db.save_book_epub", new_callable=AsyncMock),
+        patch("services.db.delete_translations_for_book", new_callable=AsyncMock) as mock_del,
+    ):
+        await _background_fetch_epub(9003)
+
+    assert bc_mod._chapter_cache.get(9003) is original, (
+        "Chapter cache must not change when EPUB fetch returns None."
+    )
+    mock_del.assert_not_called()


### PR DESCRIPTION
## What

When a Gutenberg book has no EPUB stored yet, `split_with_html_preference` falls back to plain-text regex splitting and fires a background EPUB fetch. Any translation cached during this window uses plain-text-based chapter indices. After the EPUB lands and the server restarts, the chapter structure changes (EPUB-based indices) while the translation cache retains the old plain-text indices — paragraphs in the reader become misaligned with the stored translations.

**Root cause:** `_background_fetch_epub` stored the EPUB but neither cleared the in-memory chapter cache nor invalidated the now-stale translation cache.

## Changes

- `services/book_chapters.py` — `_background_fetch_epub` now calls `clear_cache(book_id)` immediately after storing the EPUB (no waiting for cold start) and calls `delete_translations_for_book(book_id)` to purge translations generated under the old plain-text indices.
- `services/db.py` — adds `delete_translations_for_book(book_id)` helper that deletes all translation rows for a book across all languages and chapters.
- `tests/test_book_chapters.py` — three regression tests covering: cache cleared on success, translations deleted on success, neither touched when EPUB fetch returns `None`.

## Test plan

- 3 new regression tests pass
- Full backend suite: 1800 passed
- Full frontend suite: 2515 passed

Closes #1556

## Workaround for affected users

Delete the cached translation for the affected chapter and re-translate (the admin panel's "Delete translation cache" button, or `DELETE /api/ai/translate/cache`).
