### PR TITLE
fix: bump InsightChat ContextChip Remove icon to amber-600 (WCAG 1.4.11, closes #1562)

### DIFF
--- a/frontend/src/__tests__/InsightChipRemoveIconContrast.test.ts
+++ b/frontend/src/__tests__/InsightChipRemoveIconContrast.test.ts
@@ -1,0 +1,19 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// text-amber-400 (#fbbf24) on white measures ≈2.2:1 — fails WCAG 1.4.11
+// (≥3:1 for graphical UI components). Closes #1562.
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/InsightChat.tsx"),
+  "utf8",
+);
+
+describe("InsightChat ContextChip Remove button icon meets 1.4.11 (closes #1562)", () => {
+  it("Remove context button does not use text-amber-400", () => {
+    const idx = src.indexOf('aria-label="Remove context"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 300), idx + 50);
+    expect(window).not.toMatch(/text-amber-400/);
+  });
+});

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -87,7 +87,7 @@ function ContextChip({
         {onRemove && (
           <button
             onClick={onRemove}
-            className="shrink-0 text-amber-400 hover:text-amber-700 min-h-[44px] min-w-[44px] flex items-center justify-center"
+            className="shrink-0 text-amber-600 hover:text-amber-700 min-h-[44px] min-w-[44px] flex items-center justify-center"
             title="Remove context"
             aria-label="Remove context"
           >


### PR DESCRIPTION
## What

`frontend/src/components/InsightChat.tsx:90` — bump the icon-only "Remove context" button color from `text-amber-400` → `text-amber-600` (hover stays `amber-700`).

## Why

`text-amber-400` (#fbbf24) on white = **≈2.2:1**, fails WCAG 1.4.11 (Non-text Contrast, AA: ≥3:1 for graphical UI components). `text-amber-600` (#d97706) = ≈3.62:1, comfortably above threshold. Hover stays at `text-amber-700` (~5:1) for clear interactive differentiation.

`text-amber-500` would still fail at 2.74:1, so this is the minimum acceptable bump.

## Test plan

- [x] New regression test asserts the "Remove context" button source contains no `text-amber-400` (verified failing pre-fix, passing post-fix).
- [x] Full frontend suite passes (2519/2519).

Closes #1562
