### PR TITLE
fix: bump ContextChip more/less toggle to amber-700 (WCAG 1.4.3, closes #1564)

### DIFF
--- a/frontend/src/__tests__/ContextChipToggleContrast.test.ts
+++ b/frontend/src/__tests__/ContextChipToggleContrast.test.ts
@@ -1,0 +1,19 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// text-amber-500 on amber-50 measures ≈2.6:1 — fails WCAG 1.4.3 AA at
+// text-xs. Closes #1564.
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/InsightChat.tsx"),
+  "utf8",
+);
+
+describe("ContextChip more/less toggle contrast (closes #1564)", () => {
+  it("Toggle context button does not use text-amber-500", () => {
+    const idx = src.indexOf('aria-label="Toggle context"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 300), idx + 50);
+    expect(window).not.toMatch(/text-amber-500/);
+  });
+});

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -76,7 +76,7 @@ function ContextChip({
           {needsToggle && (
             <button
               onClick={() => setExpanded((v) => !v)}
-              className="ml-1.5 text-amber-500 hover:text-amber-700 font-medium not-italic min-h-[44px] inline-flex items-center"
+              className="ml-1.5 text-amber-700 hover:text-amber-900 font-medium not-italic min-h-[44px] inline-flex items-center"
               aria-label="Toggle context"
               aria-expanded={expanded}
             >


### PR DESCRIPTION
## What

`frontend/src/components/InsightChat.tsx:79` — bump the "more"/"less" expand toggle inside `ContextChip` from `text-amber-500 hover:text-amber-700` → `text-amber-700 hover:text-amber-900`.

## Why

The chip uses `text-xs` (12px). `text-amber-500` on the amber-50 chip background ≈ **2.6:1** — fails WCAG 1.4.3 AA (needs 4.5:1 for normal text under 18pt non-bold). `text-amber-700` ≈ 5.0:1 brings it above threshold and matches the small-text convention from earlier waves.

## Test plan

- [x] New regression test asserts the "Toggle context" button source contains no `text-amber-500` (verified failing pre-fix, passing post-fix).
- [x] Full frontend suite passes (2519/2519).

Closes #1564
