### PR TITLE
test: cover ValueError→400 in decks and persist-failure 500 in chat (closes #1566)

### DIFF
--- a/backend/tests/test_router_chat.py
+++ b/backend/tests/test_router_chat.py
@@ -372,3 +372,25 @@ async def test_get_messages_before_id_zero_returns_422(client, test_user):
     assert res.status_code == 422, (
         f"Expected 422 for before_id=0 in GET /chat/messages, got {res.status_code}: {res.text}"
     )
+
+
+# ── Issue #1566: persist-failure 500 path ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_post_message_persist_failure_returns_500(client, test_user):
+    """Regression #1566: POST /chat/{id}/messages must return 500 when
+    append_chat_message returns None (routers/chat.py line 89).
+    """
+    from unittest.mock import AsyncMock, patch
+    await _seed_book(TEST_BOOK_ID)
+    with patch("routers.chat.append_chat_message", new_callable=AsyncMock, return_value=None):
+        res = await client.post(
+            f"/api/chat/{TEST_BOOK_ID}/messages",
+            json={"role": "user", "content": "hello"},
+        )
+    assert res.status_code == 500, (
+        f"Regression #1566: expected 500 when append_chat_message returns None, "
+        f"got {res.status_code}: {res.text}"
+    )
+    assert "persist" in res.json()["detail"].lower()

--- a/backend/tests/test_router_decks.py
+++ b/backend/tests/test_router_decks.py
@@ -750,3 +750,51 @@ async def test_smart_rules_tags_any_whitespace_only_returns_422(client, test_use
         f"Regression #1543: expected 422 for whitespace-only tag in tags_any, "
         f"got {resp.status_code}: {resp.text}"
     )
+
+
+# ── Issue #1566: ValueError → 400 in create_deck and update_deck ─────────────
+
+
+async def test_create_deck_service_value_error_returns_400(client, test_user):
+    """Regression #1566: POST /decks must return 400 when the service layer raises
+    ValueError (routers/decks.py line 109).
+    """
+    from unittest.mock import AsyncMock, patch
+    with patch("routers.decks.decks_service.create_deck",
+               new_callable=AsyncMock,
+               side_effect=ValueError("invalid deck configuration")):
+        resp = await client.post(
+            "/api/decks",
+            json={"name": "TestDeck", "mode": "manual"},
+        )
+    assert resp.status_code == 400, (
+        f"Regression #1566: expected 400 when create_deck raises ValueError, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    assert "invalid deck configuration" in resp.json()["detail"]
+
+
+async def test_patch_deck_service_value_error_returns_400(client, test_user):
+    """Regression #1566: PATCH /decks/{id} must return 400 when update_deck raises
+    ValueError for invalid rules_json (routers/decks.py lines 143-144).
+    """
+    from unittest.mock import AsyncMock, patch
+    create_resp = await client.post(
+        "/api/decks",
+        json={"name": "PatchTarget1566", "mode": "manual"},
+    )
+    assert create_resp.status_code == 201
+    deck_id = create_resp.json()["id"]
+
+    with patch("routers.decks.decks_service.update_deck",
+               new_callable=AsyncMock,
+               side_effect=ValueError("rules validation failed")):
+        resp = await client.patch(
+            f"/api/decks/{deck_id}",
+            json={"rules_json": {"tags_any": ["valid-tag"]}},
+        )
+    assert resp.status_code == 400, (
+        f"Regression #1566: expected 400 when update_deck raises ValueError, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    assert "rules validation failed" in resp.json()["detail"]


### PR DESCRIPTION
## What

Adds three regression tests covering previously-unreachable error-handling branches found during a coverage sweep:

1. **`routers/decks.py:109`** — `POST /decks` returns 400 when `create_deck` service raises `ValueError`  
2. **`routers/decks.py:143-144`** — `PATCH /decks/{id}` returns 400 when `update_deck` service raises `ValueError`  
3. **`routers/chat.py:89`** — `POST /chat/{id}/messages` returns 500 when `append_chat_message` returns `None`

All three tests use `unittest.mock.patch` to inject the failure condition directly.

## Why

These branches existed as dead code from the test suite's perspective. If someone changed the status code or removed the handler, nothing would catch it.

## Test plan

- 3 new tests pass in isolation
- Full backend suite: 1801 passed
- Full frontend suite: 2520 passed

Closes #1566
