### PR TITLE
fix: bump text-orange-600 to orange-700 at text-xs (WCAG 1.4.3, closes #1572)

### DIFF
--- a/frontend/src/__tests__/TextOrange600Contrast.test.ts
+++ b/frontend/src/__tests__/TextOrange600Contrast.test.ts
@@ -1,0 +1,25 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// text-orange-600 (#ea580c) on white at text-xs measures ≈3.49:1 — fails
+// WCAG 1.4.3 AA (4.5:1 needed). Closes #1572.
+
+const usersSrc = fs.readFileSync(
+  path.join(__dirname, "../app/admin/users/page.tsx"),
+  "utf8",
+);
+
+const queueSrc = fs.readFileSync(
+  path.join(__dirname, "../components/QueueTab.tsx"),
+  "utf8",
+);
+
+describe("text-orange-600 removed at small sizes (closes #1572)", () => {
+  it("admin/users does not use text-orange-600", () => {
+    expect(usersSrc).not.toMatch(/text-orange-600/);
+  });
+
+  it("QueueTab does not use text-orange-600", () => {
+    expect(queueSrc).not.toMatch(/text-orange-600/);
+  });
+});

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -85,7 +85,7 @@ export default function UsersPage() {
                 }
                 aria-label={u.approved ? `Revoke ${u.name}` : `Approve ${u.name}`}
                 className={`text-xs px-3 py-2 md:px-2 md:py-1 rounded border min-h-[44px] md:min-h-0 flex items-center ${
-                  u.approved ? "border-orange-200 text-orange-600" : "border-emerald-200 text-emerald-600"
+                  u.approved ? "border-orange-200 text-orange-700" : "border-emerald-200 text-emerald-600"
                 }`}
               >
                 {u.approved ? "Revoke" : "Approve"}

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -1057,7 +1057,7 @@ export default function QueueTab({ adminFetch }: Props) {
                     >
                       + {opt.label}
                       {!opt.recommended && (
-                        <span className="ml-1 text-xs text-orange-600">
+                        <span className="ml-1 text-xs text-orange-700">
                           (not recommended)
                         </span>
                       )}


### PR DESCRIPTION
## What

Two sites bumped from `text-orange-600` → `text-orange-700`:

- `frontend/src/app/admin/users/page.tsx:88` — "Revoke" button (when user.approved is true).
- `frontend/src/components/QueueTab.tsx:1060` — "(not recommended)" inline label on model picker.

## Why

`text-orange-600` (#ea580c) on white at `text-xs` (12px) measures **≈3.49:1** — fails WCAG 1.4.3 AA (needs 4.5:1 for normal text under 18pt non-bold). `text-orange-700` (#c2410c) ≈5.56:1 brings it above the threshold.

## Test plan

- [x] New regression test asserts neither file contains `text-orange-600` (verified failing pre-fix, passing post-fix).
- [x] Full frontend suite passes (2522/2522).

Closes #1572
