### PR TITLE
fix: bump homepage tab + view-toggle contrast (WCAG 1.4.3 + 1.4.11, closes #1579)

### DIFF
--- a/frontend/src/__tests__/HomepageTabToggleContrast.test.ts
+++ b/frontend/src/__tests__/HomepageTabToggleContrast.test.ts
@@ -1,0 +1,31 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// page.tsx tabs use text-amber-600 (3.62:1 on white) at text-sm — fails
+// WCAG 1.4.3 AA. Grid/List view toggles use text-amber-500 (2.74:1) —
+// fails 1.4.11. Closes #1579.
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/page.tsx"),
+  "utf8",
+);
+
+describe("homepage tab + view-toggle contrast (closes #1579)", () => {
+  it("unselected tab does not use text-amber-600", () => {
+    expect(src).not.toMatch(/border-transparent\s+text-amber-600/);
+  });
+
+  it("Grid view toggle does not use text-amber-500", () => {
+    const idx = src.indexOf('aria-label="Grid view"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 50), idx + 400);
+    expect(window).not.toMatch(/text-amber-500/);
+  });
+
+  it("List view toggle does not use text-amber-500", () => {
+    const idx = src.indexOf('aria-label="List view"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 50), idx + 400);
+    expect(window).not.toMatch(/text-amber-500/);
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -219,7 +219,7 @@ export default function Home() {
               className={`px-5 py-3 min-h-[44px] text-sm font-medium border-b-2 transition-colors ${
                 tab === key
                   ? "border-amber-700 text-amber-900"
-                  : "border-transparent text-amber-600 hover:text-amber-800"
+                  : "border-transparent text-amber-700 hover:text-amber-900"
               }`}
             >
               {label}
@@ -658,7 +658,7 @@ export default function Home() {
                     title="Grid view"
                     aria-label="Grid view"
                     aria-pressed={popularView === "grid"}
-                    className={`p-1.5 min-h-[44px] min-w-[44px] flex items-center justify-center rounded transition-colors ${popularView === "grid" ? "bg-amber-100 text-amber-800" : "text-amber-500 hover:text-amber-700"}`}
+                    className={`p-1.5 min-h-[44px] min-w-[44px] flex items-center justify-center rounded transition-colors ${popularView === "grid" ? "bg-amber-100 text-amber-800" : "text-amber-600 hover:text-amber-700"}`}
                   >
                     <GridViewIcon className="w-4 h-4" />
                   </button>
@@ -667,7 +667,7 @@ export default function Home() {
                     title="List view"
                     aria-label="List view"
                     aria-pressed={popularView === "list"}
-                    className={`p-1.5 min-h-[44px] min-w-[44px] flex items-center justify-center rounded transition-colors ${popularView === "list" ? "bg-amber-100 text-amber-800" : "text-amber-500 hover:text-amber-700"}`}
+                    className={`p-1.5 min-h-[44px] min-w-[44px] flex items-center justify-center rounded transition-colors ${popularView === "list" ? "bg-amber-100 text-amber-800" : "text-amber-600 hover:text-amber-700"}`}
                   >
                     <ListViewIcon className="w-4 h-4" />
                   </button>


### PR DESCRIPTION
## What

Two homepage contrast bumps in `frontend/src/app/page.tsx`:

- Library-tabs unselected state: `text-amber-600 hover:text-amber-800` → `text-amber-700 hover:text-amber-900`.
- Grid/List view toggle icons: `text-amber-500 hover:text-amber-700` → `text-amber-600 hover:text-amber-700`.

## Why

- Tab labels (text-sm, 14px): amber-600 on white ≈3.62:1 — fails WCAG 1.4.3 AA. amber-700 ≈5.02:1.
- View toggle icons: amber-500 on white ≈2.74:1 — fails WCAG 1.4.11 (3:1 for graphical UI). amber-600 ≈3.62:1.

## Test plan

- [x] New regression test asserts unselected tab does not use `text-amber-600` and view toggles do not use `text-amber-500` (verified failing pre-fix, passing post-fix).
- [x] Full frontend suite passes (2531/2531).

Closes #1579
