### PR TITLE
test: cover POST /ai/summary corrupt queue_api_key → 503 path (closes #1578)

### DIFF
--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -810,6 +810,33 @@ async def test_summary_gemini_error_returns_500_without_detail_leak(client, test
     assert ":" not in detail
 
 
+# ── Issue #1578: corrupt queue_api_key must return 503, not 500 ──────────────
+
+
+async def test_summary_corrupt_queue_api_key_returns_503(client, test_user, tmp_db):
+    """Regression #1578: when the stored queue_api_key is present but cannot be
+    decrypted (e.g. written with a different secret key), POST /ai/summary must
+    return 503 with a safe detail message, not crash with a 500 that leaks the
+    decryption traceback."""
+    await save_book(9872, _BOOK_META, "word " * 300)
+    await set_setting("queue_api_key", "not-a-valid-fernet-token")
+    resp = await client.post("/api/ai/summary", json={
+        "book_id": 9872,
+        "chapter_index": 0,
+        "chapter_text": "Chapter text here.",
+        "book_title": "Test Book",
+        "author": "Author",
+        "chapter_title": "Ch 1",
+    })
+    assert resp.status_code == 503, (
+        f"Regression #1578: expected 503 for corrupt queue_api_key, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    assert "configuration" in resp.json()["detail"].lower(), (
+        f"Expected 'configuration' in error detail, got: {resp.json()}"
+    )
+
+
 # ── Access control for private uploaded books ────────────────────────────────
 
 


### PR DESCRIPTION
## What changed

Added a regression test for the uncovered error path in `POST /api/ai/summary` (lines 269–272 of `routers/ai.py`):

```python
try:
    api_key = _decrypt(raw)
except Exception:
    raise HTTPException(status_code=503, detail="Summary service configuration error.")
```

When the stored `queue_api_key` setting is present but corrupt (e.g. written with a different secret key or manually edited), `decrypt_api_key` raises — the intent is a 503 with a safe message. Without this test, a regression could change this to a raw 500 with a leaking traceback.

## Why

The path had zero test coverage. The existing Gemini failure test (`test_summary_gemini_error_returns_500_without_detail_leak`) stores a *valid* encrypted key — it never exercises the decrypt-failure branch.

## Test plan

- `test_summary_corrupt_queue_api_key_returns_503` — stores `"not-a-valid-fernet-token"` directly in `queue_api_key`, calls `POST /ai/summary`, asserts 503 with `"configuration"` in detail
- Backend suite: 1808 passed ✓
- Frontend suite: 2531 passed ✓

Closes #1578
