### PR TITLE
test: cover POST /admin/queue/dry-run no-key and corrupt-key paths (closes #1586)

### DIFF
--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -3561,3 +3561,32 @@ async def test_retry_failed_oversized_target_language_returns_422(admin_client):
     assert res.status_code == 422, (
         f"Expected 422 for oversized target_language in queue/retry-failed, got {res.status_code}: {res.text}"
     )
+
+
+# ── Issue #1586: dry-run no-key and corrupt-key paths ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_queue_dry_run_no_api_key_returns_400(admin_client):
+    """Regression #1586: POST /admin/queue/dry-run with no queue_api_key must return 400."""
+    with patch("routers.admin.get_setting", new_callable=AsyncMock, return_value=""):
+        res = await admin_client.post("/api/admin/queue/dry-run", json={"target_language": "zh"})
+    assert res.status_code == 400, (
+        f"Regression #1586: expected 400 when queue_api_key is not configured, "
+        f"got {res.status_code}: {res.text}"
+    )
+    assert "api key" in res.json()["detail"].lower() or "key" in res.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_queue_dry_run_corrupt_api_key_returns_400(admin_client):
+    """Regression #1586: POST /admin/queue/dry-run with a corrupt queue_api_key must return 400."""
+    from fastapi import HTTPException as FastAPIHTTPException
+    with patch("routers.admin.get_setting", new_callable=AsyncMock, return_value="not-a-valid-fernet-token"), \
+         patch("routers.admin.decrypt_api_key", side_effect=FastAPIHTTPException(status_code=500, detail="Could not decrypt API key")):
+        res = await admin_client.post("/api/admin/queue/dry-run", json={"target_language": "zh"})
+    assert res.status_code == 400, (
+        f"Regression #1586: expected 400 for corrupt queue_api_key in dry-run, "
+        f"got {res.status_code}: {res.text}"
+    )
+    assert "decrypt" in res.json()["detail"].lower() or "key" in res.json()["detail"].lower()


### PR DESCRIPTION
## Summary

- Adds two regression tests for `POST /admin/queue/dry-run` that cover untested 400 paths
- Path 1: no `queue_api_key` configured → 400 "No Gemini API key configured in queue settings"
- Path 2: corrupt (non-Fernet) `queue_api_key` → `decrypt_api_key` raises `HTTPException(500)` → caught by `except Exception` → re-raised as 400 "Failed to decrypt queue API key"

## Why

`test_queue_dry_run_error_does_not_leak_exception_detail` mocks `decrypt_api_key` to succeed, bypassing both early-exit guards at `routers/admin.py` lines 1044–1050.

## Test plan

- `test_queue_dry_run_no_api_key_returns_400`: patches `get_setting` → `""` → expects 400
- `test_queue_dry_run_corrupt_api_key_returns_400`: patches `get_setting` → non-empty + `decrypt_api_key` → `HTTPException(500)` → expects 400

Closes #1586

## Docs follow-up

None — no user-visible behaviour change.
