### PR TITLE
test: cover retranslate-all 404 for nonexistent book (closes #1592)

### DIFF
--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -3605,3 +3605,21 @@ async def test_queue_dry_run_corrupt_api_key_returns_400(admin_client):
         f"got {res.status_code}: {res.text}"
     )
     assert "decrypt" in res.json()["detail"].lower() or "key" in res.json()["detail"].lower()
+
+
+# ── Issue #1592: retranslate_all 404 for nonexistent book ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_retranslate_all_returns_404_for_nonexistent_book(admin_client):
+    """Regression #1592: POST /admin/translations/{id}/retranslate-all must return
+    404 when the book doesn't exist in cache. Guard: routers/admin.py line 716."""
+    res = await admin_client.post(
+        "/api/admin/translations/99999/retranslate-all",
+        json={"target_language": "zh"},
+    )
+    assert res.status_code == 404, (
+        f"Regression #1592: expected 404 for nonexistent book in retranslate-all, "
+        f"got {res.status_code}: {res.text}"
+    )
+    assert "not found" in res.json()["detail"].lower()


### PR DESCRIPTION
## What changed
Added a regression test covering the 404 guard in `POST /admin/translations/{id}/retranslate-all`. When the book doesn't exist in cache, the endpoint raises `HTTPException(404, "Book not found in cache")` (routers/admin.py line 716), but no test previously exercised this path.

## Why
Bug-hunt scan found this 404 guard was untested — a refactor could silently remove it without any failing test.

## Test plan
- `test_retranslate_all_returns_404_for_nonexistent_book`: POSTs to retranslate-all with book_id=99999, asserts 404 with "not found" in detail.
- Full backend suite (1819 tests) passes.
- Frontend: 147 suites, 1750 tests pass.

Closes #1592

## Docs follow-up
N/A — no user-visible behaviour change.
