### PR TITLE
test: cover POST /annotations chapter-index out-of-range 400 guard (closes #1596)

### DIFF
--- a/backend/tests/test_router_annotations.py
+++ b/backend/tests/test_router_annotations.py
@@ -663,3 +663,27 @@ async def test_patch_annotation_no_fields_returns_current_annotation(client, tes
     assert updated["id"] == ann_id
     assert updated["note_text"] == "original note"
     assert updated["color"] == "yellow"
+
+
+# ── Issue #1596: POST /annotations chapter-index out-of-range ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_annotation_out_of_range_chapter_returns_400(client, test_user, tmp_db):
+    """Regression #1596: POST /annotations with chapter_index beyond the book's
+    chapter count must return 400. Guard: routers/annotations.py lines 37-40."""
+    from services.book_chapters import clear_cache as _clear
+    text = "Chapter I\n\n" + "word " * 100 + "\n\nChapter II\n\n" + "word " * 100
+    ann_book_id = 8050
+    await save_book(ann_book_id, {**_BOOK_META, "id": ann_book_id}, text)
+    _clear()
+    resp = await client.post("/api/annotations", json={
+        "book_id": ann_book_id,
+        "chapter_index": 999,
+        "sentence_text": "A sentence.",
+    })
+    assert resp.status_code == 400, (
+        f"Regression #1596: expected 400 for out-of-range chapter_index, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    assert "out of range" in resp.json()["detail"].lower()


### PR DESCRIPTION
## What changed
Added a regression test covering the chapter-index out-of-range guard in `POST /annotations`. When `chapter_index >= len(chapters)`, the endpoint raises `HTTPException(400, "Chapter index out of range...")` (routers/annotations.py lines 37-40), but this path was completely untested.

## Why
Bug-hunt scan found this 400 guard was untested — a refactor could silently remove it without any failing test. The same pattern is tested in `test_router_user.py` for `update_reading_progress`, but the annotations endpoint had no parallel coverage.

## Test plan
- `test_create_annotation_out_of_range_chapter_returns_400`: seeds a 2-chapter book, POSTs annotation with `chapter_index=999`, asserts 400 with "out of range" in detail.
- Full backend suite (1820 tests) passes.
- Frontend: 147 suites, 1750 tests pass.

Closes #1596

## Docs follow-up
N/A — no user-visible behaviour change.
