### PR TITLE
test: cover POST /insights chapter-index out-of-range 400 guard (closes #1598)

### DIFF
--- a/backend/tests/test_router_insights.py
+++ b/backend/tests/test_router_insights.py
@@ -455,3 +455,28 @@ async def test_save_insight_returns_dict_when_row_is_none(tmp_db, monkeypatch):
     # Must not raise TypeError even when fetchone returns None.
     result = await save_insight(1, 1, None, "Q?", "A.")
     assert isinstance(result, dict), f"save_insight must return a dict, got {type(result)}"
+
+
+# ── Issue #1598: POST /insights chapter-index out-of-range ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_insight_out_of_range_chapter_returns_400(client, test_user, tmp_db):
+    """Regression #1598: POST /insights with chapter_index beyond the book's
+    chapter count must return 400. Guard: routers/insights.py lines 31-34."""
+    from services.book_chapters import clear_cache as _clear
+    text = "Chapter I\n\n" + "word " * 100 + "\n\nChapter II\n\n" + "word " * 100
+    ins_book_id = 8060
+    await save_book(ins_book_id, {**_META, "id": ins_book_id}, text)
+    _clear()
+    resp = await client.post("/api/insights", json={
+        "book_id": ins_book_id,
+        "chapter_index": 999,
+        "question": "Why?",
+        "answer": "Because.",
+    })
+    assert resp.status_code == 400, (
+        f"Regression #1598: expected 400 for out-of-range chapter_index in insights, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    assert "out of range" in resp.json()["detail"].lower()


### PR DESCRIPTION
## What changed
Added a regression test covering the chapter-index out-of-range guard in `POST /insights`. When `chapter_index >= len(chapters)`, the endpoint raises `HTTPException(400, "Chapter index out of range...")` (routers/insights.py lines 31-34), but this path was completely untested.

## Why
Bug-hunt scan found this 400 guard was untested — a future refactor could silently remove it. Same pattern already tested in `update_reading_progress` (#450) and `POST /annotations` (#1596), but insights had no parallel coverage.

## Test plan
- `test_create_insight_out_of_range_chapter_returns_400`: seeds a 2-chapter book, POSTs insight with `chapter_index=999`, asserts 400 with "out of range" in detail.
- Full backend suite (1822 tests) passes.
- Frontend: 147 suites, 1750 tests pass.

Closes #1598

## Docs follow-up
N/A — no user-visible behaviour change.
