### PR TITLE
test: cover GET /chapters/{idx}/translation out-of-range 400 guard (closes #1602)

### DIFF
--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -1671,3 +1671,24 @@ async def test_get_chapters_returns_400_for_draft_upload(client, test_user):
     assert "not yet confirmed" in resp.json().get("detail", "").lower(), (
         f"Expected 'not yet confirmed' in detail, got: {resp.json()}"
     )
+
+
+@pytest.mark.asyncio
+async def test_get_chapter_translation_out_of_range_chapter_returns_400(client, test_user):
+    """Regression #1602: GET /books/{id}/chapters/{idx}/translation with chapter_index
+    beyond the book's chapter count must return 400.
+    Guard: routers/books.py lines 202-206 inside get_chapter_translation."""
+    from services.book_chapters import clear_cache as _clear
+
+    text = "CHAPTER I\n\n" + "word " * 200 + "\n\nCHAPTER II\n\n" + "word " * 200
+    await save_book(9880, {**MOCK_META, "id": 9880}, text)
+    _clear()
+
+    resp = await client.get(
+        "/api/books/9880/chapters/999/translation?target_language=de"
+    )
+    assert resp.status_code == 400, (
+        f"Regression #1602: expected 400 for out-of-bounds chapter_index=999 on 2-chapter book, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    assert "out of range" in resp.json()["detail"].lower()


### PR DESCRIPTION
## What changed

Added a regression test for the chapter-index bounds check in `GET /books/{book_id}/chapters/{chapter_index}/translation` (`get_chapter_translation`, `routers/books.py` lines 202-206).

The parallel guards on the queue-status endpoint (`test_queue_status_out_of_bounds_chapter_returns_400`) and the POST-translate endpoint (`test_request_translation_out_of_bounds_chapter_returns_400`) were already covered; the GET-translation path had no test.

## Why

Bug-hunt scan identified the missing coverage: any caller passing an out-of-bounds `chapter_index` to `GET /chapters/{idx}/translation` would hit the guard correctly, but no test would catch a future regression that removed or broke the check.

## Test plan

- `test_get_chapter_translation_out_of_range_chapter_returns_400`: seeds a 2-chapter book, sends `GET /api/books/{id}/chapters/999/translation?target_language=de`, asserts 400 + "out of range" in detail.
- Full backend suite: 1824 passed locally.

Closes #1602
