### PR TITLE
test: cover POST /admin/queue/dry-run corrupt-key 400 guard (closes #1607)

### DIFF
--- a/backend/tests/test_router_admin_extended.py
+++ b/backend/tests/test_router_admin_extended.py
@@ -694,6 +694,28 @@ async def test_queue_dry_run_no_api_key_returns_400(admin_client, admin_db):
     assert "API key" in res.json()["detail"]
 
 
+@pytest.mark.asyncio
+async def test_queue_dry_run_corrupt_key_returns_400(admin_client, admin_db):
+    """Regression #1607: POST /admin/queue/dry-run must return 400 when the stored
+    queue API key cannot be decrypted (e.g. after key rotation or DB corruption).
+    Guard: routers/admin.py lines 1047-1050."""
+    from services.db import set_setting
+    from services.translation_queue import SETTING_API_KEY
+    from unittest.mock import patch
+
+    await set_setting(SETTING_API_KEY, "corrupt-non-decryptable-value")
+    with patch("routers.admin.decrypt_api_key", side_effect=Exception("bad key")):
+        res = await admin_client.post(
+            "/api/admin/queue/dry-run",
+            json={"target_language": "zh"},
+        )
+    assert res.status_code == 400, (
+        f"Regression #1607: expected 400 for corrupt queue API key in dry-run, "
+        f"got {res.status_code}: {res.text}"
+    )
+    assert "decrypt" in res.json()["detail"].lower()
+
+
 async def test_queue_dry_run_no_books_returns_empty(admin_client, admin_db):
     from services.db import set_setting
     from services.auth import encrypt_api_key


### PR DESCRIPTION
## What changed

Added a regression test for the decrypt-failure guard in `POST /admin/queue/dry-run` (`routers/admin.py` lines 1047-1050).

The existing `test_queue_dry_run_no_api_key_returns_400` covers the case where no key is stored (None). This test covers the second path: a key is stored but `decrypt_api_key` raises (e.g. after key rotation or DB corruption), returning 400 "Failed to decrypt queue API key".

## Why

Bug-hunt scan found the missing coverage. Without this test, a future change that removes or breaks the decrypt-failure path would go undetected — the endpoint would likely fall through to a 500 or leak a raw exception.

## Test plan

- `test_queue_dry_run_corrupt_key_returns_400`: stores a raw corrupt value in SETTING_API_KEY, patches `decrypt_api_key` to raise, asserts 400 + "decrypt" in detail.
- Full backend suite: 1824 passed locally.

Closes #1607
