### PR TITLE
test: fix duplicate test name that silently skipped attempts-preservation check (closes #1611)

### DIFF
--- a/backend/tests/test_translation_queue_unit.py
+++ b/backend/tests/test_translation_queue_unit.py
@@ -231,8 +231,8 @@ async def test_enqueue_preserves_lower_priority():
     assert row[0] == 10  # MIN(100, 10) = 10
 
 
-async def test_enqueue_reset_failed_does_not_touch_running_row():
-    """enqueue(reset_failed=True) must not reset a row that is currently running.
+async def test_enqueue_reset_failed_running_row_status_preserved():
+    """Regression #1611: enqueue(reset_failed=True) must not reset a row that is currently running.
 
     Without the WHERE guard, the UPSERT unconditionally sets status='pending',
     turning a live in-flight row into a pending row. The worker's _mark_done


### PR DESCRIPTION
## What changed

Renamed the second definition of `test_enqueue_reset_failed_does_not_touch_running_row` in `backend/tests/test_translation_queue_unit.py` to `test_enqueue_reset_failed_running_row_status_preserved`.

## Why

Python silently overwrites the first function definition when two functions share the same name. The first definition (lines 189–216) was dead code: pytest collected only the second. The first definition uniquely asserts that `attempts` is not zeroed when a running row is skipped — the exact invariant described in Regression #321. That invariant was never tested.

## Test plan

- `pytest tests/test_translation_queue_unit.py` now collects 34 tests (was 33) and passes 100%.
- `test_enqueue_reset_failed_does_not_touch_running_row` (first definition, book_id=20) now runs and asserts both `status == 'running'` and `attempts == 1`.
- `test_enqueue_reset_failed_running_row_status_preserved` (renamed second, book_id=7) continues to run.
- Full suite: 1828 passed.

Closes #1611
