### PR TITLE
test: add coverage for generate_chapter_summary prompt logic (closes #1619)

### DIFF
--- a/backend/tests/test_gemini.py
+++ b/backend/tests/test_gemini.py
@@ -384,3 +384,66 @@ async def test_translate_chapters_batch_error_includes_raw_preview():
             await gemini.translate_chapters_batch(
                 "key", [(0, "t"), (1, "t")], "en", "zh",
             )
+
+
+# ── generate_chapter_summary (issue #1619) ────────────────────────────────────
+
+
+async def test_generate_chapter_summary_with_chapter_title():
+    """Regression #1619: generate_chapter_summary must include the chapter title
+    in the prompt when chapter_title is provided (line 124: chapter_label)."""
+    captured = {}
+
+    async def fake_generate(api_key, system, prompt, max_tokens):
+        captured["prompt"] = prompt
+        return "Summary text."
+
+    with patch("services.gemini._generate", side_effect=fake_generate):
+        result = await gemini.generate_chapter_summary(
+            "key", "Some chapter text.", "Moby Dick", "Melville", chapter_title="The Chase"
+        )
+
+    assert result == "Summary text."
+    assert "The Chase" in captured["prompt"], (
+        f"chapter_title must appear in prompt, got: {captured['prompt']!r}"
+    )
+    assert "Moby Dick" in captured["prompt"]
+    assert "Melville" in captured["prompt"]
+
+
+async def test_generate_chapter_summary_without_chapter_title():
+    """Regression #1619: when chapter_title is omitted, no label should appear
+    in the prompt (branch 124: empty chapter_label)."""
+    captured = {}
+
+    async def fake_generate(api_key, system, prompt, max_tokens):
+        captured["prompt"] = prompt
+        return "Summary."
+
+    with patch("services.gemini._generate", side_effect=fake_generate):
+        await gemini.generate_chapter_summary("key", "Text.", "Pride and Prejudice", "Austen")
+
+    assert " — " not in captured["prompt"], (
+        f"No chapter label expected when chapter_title='', got: {captured['prompt']!r}"
+    )
+
+
+async def test_generate_chapter_summary_truncates_long_text():
+    """Regression #1619: chapter_text longer than 4000 chars must be truncated
+    to 4000 chars in the prompt (line 123: excerpt = chapter_text[:4000].strip())."""
+    long_text = "x" * 8000
+    captured = {}
+
+    async def fake_generate(api_key, system, prompt, max_tokens):
+        captured["prompt"] = prompt
+        return "Summary."
+
+    with patch("services.gemini._generate", side_effect=fake_generate):
+        await gemini.generate_chapter_summary("key", long_text, "Book", "Author")
+
+    assert "x" * 4001 not in captured["prompt"], (
+        "Prompt must not contain more than 4000 chars of excerpt"
+    )
+    assert "x" * 4000 in captured["prompt"], (
+        "Prompt must contain exactly 4000 chars of excerpt"
+    )


### PR DESCRIPTION
## What changed

Added 3 unit tests for `generate_chapter_summary` in `backend/tests/test_gemini.py`.

## Why

`services/gemini.py:generate_chapter_summary()` (lines 119–130) had **zero test coverage**. The function builds a structured prompt for chapter summarization, including optional chapter title labeling and 4000-char excerpt truncation — both critical for prompt quality. No test existed to catch regressions in either path.

## Test plan

- `test_generate_chapter_summary_with_chapter_title` — mocks `_generate`, calls with `chapter_title="The Chase"`, verifies the title appears in the prompt alongside book title and author
- `test_generate_chapter_summary_without_chapter_title` — omits `chapter_title`, verifies no ` — ` label appears in the prompt (the empty `chapter_label` branch)
- `test_generate_chapter_summary_truncates_long_text` — passes 8000-char text, verifies prompt contains exactly 4000 `x` chars (not 4001+)

`services/gemini.py` coverage: 96% → 99%. Full suite: 1841 passed.

Closes #1619
