### PR TITLE
test: cover normalize_tag non-string guard and length cap (closes #1624)

### DIFF
--- a/backend/tests/test_router_vocabulary_tags.py
+++ b/backend/tests/test_router_vocabulary_tags.py
@@ -183,6 +183,26 @@ async def test_delete_tag_oversized_path_returns_422(client, test_user):
     )
 
 
+# ── normalize_tag unit tests (issue #1624) ───────────────────────────────────
+
+
+def test_normalize_tag_rejects_non_string():
+    """Regression #1624: normalize_tag must raise ValueError when given a non-str (line 20).
+    Direct callers (not going through HTTP/pydantic) could pass an int or None."""
+    from services.vocab_tags import normalize_tag
+    with pytest.raises(ValueError, match="string"):
+        normalize_tag(123)
+
+
+def test_normalize_tag_rejects_oversized_tag():
+    """Regression #1624: normalize_tag must raise ValueError when stripped tag > 50 chars (line 25).
+    The HTTP router caps at max_length=50 before the service is called, so this
+    guard is only reachable by direct callers."""
+    from services.vocab_tags import normalize_tag, MAX_TAG_LEN
+    with pytest.raises(ValueError, match="exceeds"):
+        normalize_tag("x" * (MAX_TAG_LEN + 1))
+
+
 @pytest.mark.asyncio
 async def test_delete_tag_whitespace_only_returns_400(client, test_user):
     """Regression #1529: DELETE /vocabulary/{id}/tags/%20 must return 400, not 500.


### PR DESCRIPTION
## What changed

Added 2 direct unit tests to `tests/test_router_vocabulary_tags.py` for the defensive branches in `services/vocab_tags.normalize_tag`:

1. **`test_normalize_tag_rejects_non_string`** — verifies `normalize_tag(123)` raises `ValueError("tag must be a string")` (line 20). Unreachable via HTTP because FastAPI/pydantic validates path params as `str` before the service is called.

2. **`test_normalize_tag_rejects_oversized_tag`** — verifies `normalize_tag("x" * 51)` raises `ValueError("tag exceeds 50 chars")` (line 25). Unreachable via HTTP because the router enforces `max_length=50` on the path param before reaching the service.

## Why

`services/vocab_tags.py` was at 92% — both uncovered lines are in `normalize_tag`. Direct callers (not going via HTTP) could trigger them, so the guards are load-bearing and worth testing.

## Test plan

- `pytest tests/test_router_vocabulary_tags.py` — 17 passed (was 15)
- Full suite: 1845 passed

Closes #1624
