### PR TITLE
test: cover _google_translate verse empty-line branch (closes #1626)

### DIFF
--- a/backend/tests/test_translate_extended.py
+++ b/backend/tests/test_translate_extended.py
@@ -192,6 +192,25 @@ async def test_translate_text_gemini_without_key_raises():
         )
 
 
+async def test_google_translate_verse_empty_line_preserved():
+    """Regression #1626: a whitespace-only line within a verse paragraph maps to \"\"
+    (lines 121-122 in _google_translate). The empty line must NOT be sent to
+    GoogleTranslator — only non-empty lines should be translated."""
+    # 5 short lines + 1 whitespace-only line = detected as verse (6 lines, 5 non-empty < 55 chars)
+    verse = "Short line one\nShort line two\n   \nShort line four\nShort line five\nShort line six"
+    with patch("deep_translator.GoogleTranslator") as MockGT:
+        instance = MockGT.return_value
+        instance.translate.side_effect = ["Zeile eins", "Zeile zwei", "Zeile vier", "Zeile fünf", "Zeile sechs"]
+
+        result = await _google_translate(verse, "en", "de")
+
+    assert len(result) == 1
+    output_lines = result[0].split("\n")
+    assert len(output_lines) == 6
+    assert output_lines[2] == ""  # whitespace-only line becomes empty string
+    assert instance.translate.call_count == 5  # only the 5 non-empty lines translated
+
+
 async def test_translate_text_defaults_to_google():
     with patch("deep_translator.GoogleTranslator") as MockGT:
         instance = MockGT.return_value


### PR DESCRIPTION
## What changed

Added one async test to `tests/test_translate_extended.py`:

**`test_google_translate_verse_empty_line_preserved`** — exercises the untested branch in `_google_translate` (lines 121-122) where a whitespace-only line within a verse paragraph produces `""` in the output without calling `GoogleTranslator`. Verifies:
- The empty slot appears at the correct position in the output
- `GoogleTranslator.translate` is only called for the 5 non-empty lines (not the blank one)

## Why

`services/translate.py` was at 96% — lines 121-122 (`if not stripped: translated_lines.append(""); continue`) were unreachable in the existing test suite because `test_google_translate_verse_line_by_line` used a verse with no blank inner lines.

## Test plan

- `pytest tests/test_translate_extended.py` — 23 passed (was 22)
- Full suite: 1846 passed

Closes #1626
