### PR TITLE
test: cover 4 uncovered branches in services/wiktionary.py (closes #1628)

### DIFF
--- a/backend/tests/test_wiktionary.py
+++ b/backend/tests/test_wiktionary.py
@@ -378,3 +378,57 @@ async def test_ai_lookup_url_is_empty_string():
     assert result["url"] == "", (
         "AI fallback must not return a Wiktionary URL — the user would land on a missing page"
     )
+
+
+# ── Issue #1628: uncovered branches ─────────────────────────────────────────
+
+
+def test_extract_lemma_fallback_plain_text_same_as_current_word():
+    """Regression #1628: fallback plain-text regex (line 38) matches but candidate ==
+    current_word → branch 41→44 (return None) must be taken.
+
+    The existing same-word test uses '<b>whale</b>' — HTML tags prevent the fallback
+    regex from matching because it requires plain alpha chars directly after 'of '.
+    This test uses plain text so the fallback regex fires and line 41 is reached."""
+    assert _extract_lemma("plural of whale", "whale") is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_caps_at_three_across_multiple_entries():
+    """Regression #1628: when definitions span 2+ entries the inner break (line 108)
+    and outer break (line 110) must both fire once the total reaches 3.
+
+    test_lookup_caps_definitions_at_three only uses 1 entry with 5 definitions;
+    the inner loop slices [:2] so it adds at most 2 per entry — neither break fires."""
+    json_data = {
+        "en": [
+            {
+                "partOfSpeech": "noun",
+                "definitions": [{"definition": "Def 1"}, {"definition": "Def 2"}],
+            },
+            {
+                "partOfSpeech": "verb",
+                "definitions": [{"definition": "Def 3"}, {"definition": "Def 4"}],
+            },
+        ]
+    }
+    with patch("services.wiktionary.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=_make_mock_response(200, json_data))
+
+        result = await lookup("word", "en")
+
+    assert len(result["definitions"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_ai_lookup_strips_code_fences():
+    """Regression #1628: Gemini sometimes wraps JSON in ``` fences.
+    Lines 142-143 strip them; without this the json.loads call raises."""
+    fenced = '```json\n{"lemma":"laufen","definitions":[{"pos":"verb","text":"to run"}]}\n```'
+    with patch("services.gemini._generate", new=AsyncMock(return_value=fenced)):
+        result = await ai_lookup("lief", "de", api_key="test-key")
+    assert result["lemma"] == "laufen"
+    assert len(result["definitions"]) == 1


### PR DESCRIPTION
## What changed

Added 3 tests to `tests/test_wiktionary.py` covering 4 previously unreachable branches in `services/wiktionary.py` (92% → 100%):

1. **`test_extract_lemma_fallback_plain_text_same_as_current_word`** — covers branch `41→44`. The existing same-word test uses `"plural of <b>whale</b>"` (HTML), which prevents the fallback plain-text regex (line 38) from matching at all, so line 41 was never reached. Plain-text `"plural of whale"` reaches line 41 with `candidate == current_word` → False branch → `return None`.

2. **`test_lookup_caps_at_three_across_multiple_entries`** — covers `break` at lines 108 (inner) and 110 (outer). The existing cap test uses 1 entry with 5 definitions; the inner loop slices `[:2]`, so only 2 definitions are added and neither break fires. Two entries with 2 defs each: entry 1 adds 2, entry 2 adds 1 → total 3 → both breaks fire.

3. **`test_ai_lookup_strips_code_fences`** — covers lines 142-143. All prior `ai_lookup` tests return clean JSON; this one returns ` ```json\n{...}\n``` ` so the two `re.sub` stripping calls execute.

## Test plan

- `pytest tests/test_wiktionary.py --cov=services.wiktionary` → **100%** (was 92%)
- Full suite: 1848 passed

Closes #1628
