### PR TITLE
test: cover long-front-matter True branch in book_parser.py (closes #1632)

### DIFF
--- a/backend/tests/test_book_parser.py
+++ b/backend/tests/test_book_parser.py
@@ -299,6 +299,18 @@ def test_parse_txt_short_front_matter_not_prepended():
     assert "Front Matter" not in titles
 
 
+def test_parse_txt_long_front_matter_prepended():
+    """Regression #1632: line 92 True — front matter with >50 words before the first
+    chapter boundary is prepended as a 'Front Matter' chapter."""
+    front = " ".join([f"word{i}" for i in range(60)])  # 60 words > 50
+    txt = f"{front}\n\nCHAPTER 1\n\nBody text here.\n\nCHAPTER 2\n\nMore body text here.\n"
+    result = parse_txt(txt)
+    titles = [ch["title"] for ch in result["chapters"]]
+    assert "Front Matter" in titles
+    fm = next(ch for ch in result["chapters"] if ch["title"] == "Front Matter")
+    assert "word0" in fm["text"]
+
+
 def test_parse_epub_raises_on_missing_dependency():
     """Regression #1630: line 130 — ImportError on ebooklib is re-raised
     as RuntimeError('ebooklib is not installed')."""


### PR DESCRIPTION
## What changed

Added `test_parse_txt_long_front_matter_prepended` to `tests/test_book_parser.py`.

This exercises the True branch of `services/book_parser.py` line 91:
```python
if len(front.split()) > 50:
    chapters.append({"title": "Front Matter", "text": front})
```

When a book's preamble before the first chapter heading exceeds 50 words, it must be captured as a "Front Matter" chapter. The previous test suite only exercised the False path (≤50-word front matter). Line 92 had 0% coverage.

## Why

Identified via `pytest --cov=services/book_parser.py --cov-report=term-missing`. Closes #1632.

## Test plan

- [ ] New test passes: `pytest tests/test_book_parser.py -k long_front_matter`
- [ ] Full backend suite: 1854 passed
- [ ] Full frontend suite: 1750 passed
