### PR TITLE
test: cover _split_paragraphs_into_budget_chunks empty-input guard (closes #1636)

### DIFF
--- a/backend/tests/test_service_branches.py
+++ b/backend/tests/test_service_branches.py
@@ -247,6 +247,14 @@ async def test_translate_chapters_batch_chapter_block_all_empty_paragraphs():
     assert 0 not in result
 
 
+# ── Issue #1636: _split_paragraphs_into_budget_chunks empty-input guard ──────
+
+def test_split_paragraphs_into_budget_chunks_empty_input():
+    """Regression #1636: line 217 — empty paragraphs list returns [] immediately."""
+    from services.gemini import _split_paragraphs_into_budget_chunks
+    assert _split_paragraphs_into_budget_chunks([], 1000) == []
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # gemini.py — _translate_chapter_in_chunks() branches
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What changed

Added `test_split_paragraphs_into_budget_chunks_empty_input` to `tests/test_service_branches.py`.

This covers `services/gemini.py` line 217: the `if not paragraphs: return []` guard in `_split_paragraphs_into_budget_chunks`. All existing callers pass non-empty lists so the guard had zero coverage.

## Why

Identified via `pytest --cov=services/gemini.py --cov-report=term-missing`. Closes #1636.

## Test plan

- [ ] New test passes
- [ ] Full backend suite: 1858 passed
- [ ] Full frontend suite: 1750 passed
