### PR TITLE
fix: bump admin nav unselected tab to text-amber-700 (closes #1637)

### DIFF
--- a/frontend/src/__tests__/AdminNavTabContrast.test.ts
+++ b/frontend/src/__tests__/AdminNavTabContrast.test.ts
@@ -1,0 +1,16 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// admin/layout.tsx unselected tab used text-amber-600 (≈3.62:1 on white)
+// at text-sm — fails WCAG 1.4.3 AA. Closes #1637.
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/admin/layout.tsx"),
+  "utf8",
+);
+
+describe("admin nav unselected tab contrast (closes #1637)", () => {
+  it("does not pair border-transparent with text-amber-600", () => {
+    expect(src).not.toMatch(/border-transparent\s+text-amber-600/);
+  });
+});

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -99,7 +99,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
               className={`px-3 md:px-4 py-2.5 md:py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap min-h-[44px] md:min-h-0 flex items-center ${
                 current === key
                   ? "border-amber-700 text-amber-900"
-                  : "border-transparent text-amber-600 hover:text-amber-800"
+                  : "border-transparent text-amber-700 hover:text-amber-900"
               }`}
             >
               {label}


### PR DESCRIPTION
## What

Bumps the admin section-nav unselected-tab colour from `text-amber-600 hover:text-amber-800` to `text-amber-700 hover:text-amber-900` in `frontend/src/app/admin/layout.tsx`. Mirrors the homepage Library-tab fix shipped in #1580.

## Why

`text-amber-600` (`#d97706`) on white at `text-sm` measures ≈3.62:1 — fails WCAG 1.4.3 AA, which requires 4.5:1 for normal text. `text-amber-700` (`#b45309`) on white is ≈5.02:1 and clears the bar; `text-amber-900` on hover keeps the visible state-change.

Spotted during a contrast audit after the homepage tab fix landed — the admin nav uses the same Tailwind pattern and exhibits the same violation.

## Test plan

- [x] New regex regression test `frontend/src/__tests__/AdminNavTabContrast.test.ts` asserts `admin/layout.tsx` no longer pairs `border-transparent` with `text-amber-600`. Verified failing pre-fix, passing post-fix.
- [x] Full frontend suite: 2532/2532 passing.
- [x] Full backend suite: 1382/1382 passing.

Closes #1637
