### PR TITLE
fix: bump InsightChat MsgContextChip toggle to amber-700 (closes #1641)

### DIFF
--- a/frontend/src/__tests__/InsightChatMsgContextToggleContrast.test.ts
+++ b/frontend/src/__tests__/InsightChatMsgContextToggleContrast.test.ts
@@ -1,0 +1,25 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// MsgContextChip more/less toggle (InsightChat.tsx) still used
+// text-amber-500 (≈2.6:1 on amber-50/80) — fails WCAG 1.4.3 AA. The outer
+// ContextChip was fixed in PR #1565; this inner sibling was missed.
+// Closes #1641.
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/InsightChat.tsx"),
+  "utf8",
+);
+
+describe("InsightChat MsgContextChip toggle contrast (closes #1641)", () => {
+  it("Toggle context button does not use text-amber-500", () => {
+    // Find every Toggle context button in the file and assert none use
+    // text-amber-500 in its className.
+    const re = /className="([^"]*)"\s+aria-label="Toggle context"/g;
+    const matches = Array.from(src.matchAll(re));
+    expect(matches.length).toBeGreaterThan(0);
+    for (const m of matches) {
+      expect(m[1]).not.toMatch(/text-amber-500/);
+    }
+  });
+});

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -637,7 +637,7 @@ function MsgContextBlock({
         {needsToggle && (
           <button
             onClick={onToggle}
-            className="ml-1.5 text-amber-500 hover:text-amber-700 font-medium not-italic min-h-[44px] inline-flex items-center"
+            className="ml-1.5 text-amber-700 hover:text-amber-900 font-medium not-italic min-h-[44px] inline-flex items-center"
             aria-label="Toggle context"
             aria-expanded={expanded}
           >


### PR DESCRIPTION
## What

Bumps the `MsgContextChip` `more`/`less` toggle in `frontend/src/components/InsightChat.tsx:640` from `text-amber-500 hover:text-amber-700` to `text-amber-700 hover:text-amber-900`.

## Why

PR #1565 (closes #1564) fixed the **outer** `ContextChip` — the staging chip above the chat input — to clear WCAG AA. The **inner** `MsgContextChip`, rendered inside individual chat message bubbles to display the saved context preview, is a structurally identical sibling that was missed in that pass and still uses `text-amber-500` on the amber-50/80 background (≈2.6:1, fails 1.4.3 AA).

This brings the inner chip in line with the outer one and with the broader contrast-cleanup waves landed across the frontend.

## Test plan

- [x] New regression test `frontend/src/__tests__/InsightChatMsgContextToggleContrast.test.ts` matches **every** `aria-label="Toggle context"` button in the file and asserts none use `text-amber-500` in their `className`. Verified failing pre-fix on the inner chip, passing post-fix.
- [x] Full frontend suite: 2532/2532 passing.
- [x] Full backend suite: 1382/1382 passing.

Closes #1641
