### PR TITLE
fix: bump reader chapter-select chevron to text-amber-700 (closes #1644)

### DIFF
--- a/frontend/src/__tests__/ReaderChapterChevronContrast.test.ts
+++ b/frontend/src/__tests__/ReaderChapterChevronContrast.test.ts
@@ -1,0 +1,22 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// reader/[bookId]/page.tsx overlays a ChevronDownIcon on the chapter
+// <select> using text-amber-500 (≈2.74:1 on white) — fails WCAG 1.4.11
+// (3:1 needed for non-text UI component indicators). Closes #1644.
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("reader chapter-select chevron contrast (closes #1644)", () => {
+  it("ChevronDownIcon never pairs with text-amber-500 in a className", () => {
+    const re = /<ChevronDownIcon\s+className="([^"]*)"/g;
+    const matches = Array.from(src.matchAll(re));
+    expect(matches.length).toBeGreaterThan(0);
+    for (const m of matches) {
+      expect(m[1]).not.toMatch(/text-amber-500/);
+    }
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -980,7 +980,7 @@ export default function ReaderPage() {
                       </option>
                     ))}
                   </select>
-                  <ChevronDownIcon className="pointer-events-none absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 text-amber-500" />
+                  <ChevronDownIcon className="pointer-events-none absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 text-amber-700" />
                 </div>
                 <button
                   onClick={() => goToChapter(Math.min(chapters.length - 1, chapterIndex + 1))}
@@ -2259,7 +2259,7 @@ export default function ReaderPage() {
                   </option>
                 ))}
               </select>
-              <ChevronDownIcon className="pointer-events-none absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 text-amber-500" />
+              <ChevronDownIcon className="pointer-events-none absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 text-amber-700" />
             </div>
 
             <button


### PR DESCRIPTION
## What

Bumps the `ChevronDownIcon` overlaid on the chapter `<select>` in `frontend/src/app/reader/[bookId]/page.tsx` (lines 983 + 2262) from `text-amber-500` to `text-amber-700`. Both occurrences updated.

## Why

The chevron is the user-visible dropdown affordance for the chapter picker — the native `<select>` chevron is hidden by `appearance-none`-style chrome, so this overlaid icon is the **functional UI control indicator**. `text-amber-500` (`#f59e0b`) on white measures ≈2.74:1 — fails WCAG 1.4.11, which requires 3:1 for non-text UI components. `text-amber-700` (`#b45309`) is ≈5.02:1 and clears the bar.

Affects both the reader top-bar chapter `<select>` and its duplicate inside the annotations sidebar.

## Test plan

- [x] New regression test `frontend/src/__tests__/ReaderChapterChevronContrast.test.ts` matches every `<ChevronDownIcon className="…">` in `app/reader/[bookId]/page.tsx` and asserts none use `text-amber-500`. Verified failing pre-fix on both occurrences, passing post-fix.
- [x] Full frontend suite: 2533/2533 passing.
- [x] Full backend suite: 1382/1382 passing.

Closes #1644
