### PR TITLE
fix: bump homepage Continue-reading arrow to text-amber-700 (closes #1646)

### DIFF
--- a/frontend/src/__tests__/HomepageContinueArrowContrast.test.ts
+++ b/frontend/src/__tests__/HomepageContinueArrowContrast.test.ts
@@ -1,0 +1,21 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// page.tsx Continue-reading card used text-amber-400 on the trailing
+// ArrowRightIcon (≈2.18:1 on white) — failed WCAG 1.4.11. Closes #1646.
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/page.tsx"),
+  "utf8",
+);
+
+describe("homepage continue-reading arrow contrast (closes #1646)", () => {
+  it("ArrowRightIcon never pairs with text-amber-400 in a className", () => {
+    const re = /<ArrowRightIcon\s+className="([^"]*)"/g;
+    const matches = Array.from(src.matchAll(re));
+    expect(matches.length).toBeGreaterThan(0);
+    for (const m of matches) {
+      expect(m[1]).not.toMatch(/text-amber-400/);
+    }
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -310,7 +310,7 @@ export default function Home() {
                       Chapter {recentBooks[0].lastChapter + 1} · {timeAgo(recentBooks[0].lastRead)}
                     </p>
                   </div>
-                  <ArrowRightIcon className="w-4 h-4 text-amber-400 shrink-0" />
+                  <ArrowRightIcon className="w-4 h-4 text-amber-700 shrink-0" />
                 </button>
               </section>
             )}


### PR DESCRIPTION
## What

Bumps the trailing `ArrowRightIcon` on the homepage **Continue reading** card (`frontend/src/app/page.tsx:313`) from `text-amber-400` to `text-amber-700`.

## Why

`text-amber-400` (`#fbbf24`) on white measures ≈2.18:1 — fails WCAG 1.4.11 (3:1 needed for non-text UI components). The arrow is the explicit "tap to continue" affordance on the homepage's most prominent CTA, so it's a UI control indicator, not pure decoration. `text-amber-700` (`#b45309`) is ≈5.02:1 and matches the convention used for the sibling icons on the same page (FireIcon / BookOpenIcon / VocabIcon / NoteIcon are all `text-amber-600` or `text-amber-700`).

## Test plan

- [x] New regression test `frontend/src/__tests__/HomepageContinueArrowContrast.test.ts` matches every `<ArrowRightIcon className="…">` in `app/page.tsx` and asserts none use `text-amber-400`. Verified failing pre-fix, passing post-fix.
- [x] Full frontend suite: 2533/2533 passing.
- [x] Full backend suite: 1382/1382 passing.

Closes #1646
