### PR TITLE
fix: bump Gemini-reminder Dismiss button to text-amber-700 (closes #1648)

### DIFF
--- a/frontend/src/__tests__/GeminiReminderDismissContrast.test.ts
+++ b/frontend/src/__tests__/GeminiReminderDismissContrast.test.ts
@@ -1,0 +1,22 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// reader/[bookId]/page.tsx Gemini-reminder Dismiss button used
+// text-amber-500 on amber-50 (≈2.5:1) — failed WCAG 1.4.11. Closes #1648.
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Gemini reminder Dismiss button contrast (closes #1648)", () => {
+  it("Dismiss button does not use text-amber-500", () => {
+    // Match the className on a button whose aria-label="Dismiss".
+    const re = /className="([^"]*)"\s+aria-label="Dismiss"/g;
+    const matches = Array.from(src.matchAll(re));
+    expect(matches.length).toBeGreaterThan(0);
+    for (const m of matches) {
+      expect(m[1]).not.toMatch(/text-amber-500/);
+    }
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -827,7 +827,7 @@ export default function ReaderPage() {
           </span>
           <button
             onClick={() => setGeminiReminderVisible(false)}
-            className="shrink-0 text-amber-500 hover:text-amber-700 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 flex items-center justify-center"
+            className="shrink-0 text-amber-700 hover:text-amber-900 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 flex items-center justify-center"
             aria-label="Dismiss"
           >
             <CloseIcon aria-hidden="true" className="w-4 h-4" />


### PR DESCRIPTION
## What

Bumps the Dismiss button on the reader's Gemini-API-key reminder banner (`frontend/src/app/reader/[bookId]/page.tsx:830`) from `text-amber-500 hover:text-amber-700` to `text-amber-700 hover:text-amber-900`.

## Why

The button is icon-only — its `CloseIcon` is the *only* visible affordance, so contrast on it has to clear WCAG 1.4.11 (≥3:1 for non-text UI components). The banner background is `bg-amber-50`. `text-amber-500` (`#f59e0b`) on `amber-50` (`#fffbeb`) measures ≈2.5:1 — fails. `text-amber-700` (`#b45309`) on `amber-50` is ≈4.7:1 and matches the convention used across the recent reader-chrome contrast cleanup (#1640, #1645, #1647, #1642).

## Test plan

- [x] New regression test `frontend/src/__tests__/GeminiReminderDismissContrast.test.ts` matches the className adjacent to `aria-label="Dismiss"` and asserts it does not contain `text-amber-500`. Verified failing pre-fix, passing post-fix.
- [x] Full frontend suite: 2534/2534 passing.
- [x] Full backend suite: 1382/1382 passing.

Closes #1648
