### PR TITLE
fix: drop text-amber-600 override on QueueTab retry_reason (closes #1651)

### DIFF
--- a/frontend/src/__tests__/QueueTabRetryReasonContrast.test.ts
+++ b/frontend/src/__tests__/QueueTabRetryReasonContrast.test.ts
@@ -1,0 +1,17 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// QueueTab retry_reason line used text-amber-600 at text-xs on amber-50
+// (≈3.4:1) — failed WCAG 1.4.3 AA. Closes #1651.
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/QueueTab.tsx"),
+  "utf8",
+);
+
+describe("QueueTab retry_reason contrast (closes #1651)", () => {
+  it("does not pair text-amber-600 with truncate in a className", () => {
+    expect(src).not.toMatch(/text-amber-600[^"]*truncate/);
+    expect(src).not.toMatch(/truncate[^"]*text-amber-600/);
+  });
+});

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -573,7 +573,7 @@ export default function QueueTab({ adminFetch }: Props) {
                 : ""}
             </div>
             {s.retry_reason && (
-              <div className="text-amber-600 truncate">{s.retry_reason}</div>
+              <div className="truncate">{s.retry_reason}</div>
             )}
           </div>
         ) : null}


### PR DESCRIPTION
## What

Drops the `text-amber-600` override on the retry-reason explanation line in `frontend/src/components/QueueTab.tsx:576`, letting it inherit `text-amber-700` from the parent.

## Why

The parent chip is `text-xs text-amber-700 bg-amber-50`. The retry-reason child overrode that with `text-amber-600`, which on `amber-50` measures ≈3.4:1 — fails WCAG 1.4.3 AA (4.5:1 needed for normal text under 18pt). Inheriting `text-amber-700` gives ≈4.7:1 and clears the bar. The first line keeps its `font-medium` weight, so the visual hierarchy between the status line and the reason line is preserved without colour contrast.

Same convention applied across the recent contrast-cleanup waves (#1640, #1645, #1647, #1649, #1642).

## Test plan

- [x] New regression test `frontend/src/__tests__/QueueTabRetryReasonContrast.test.ts` asserts `QueueTab.tsx` no longer pairs `text-amber-600` with `truncate` in either order. Verified failing pre-fix, passing post-fix.
- [x] Full frontend suite: 2535/2535 passing.
- [x] Full backend suite: 1382/1382 passing.

Closes #1651
