### PR TITLE
test: cover 4 defensive branches in services/db.py (closes #1650)

### DIFF
--- a/backend/tests/test_db_extended.py
+++ b/backend/tests/test_db_extended.py
@@ -36,6 +36,7 @@ from services.db import (
     save_insight,
     get_insights,
     delete_insight,
+    list_cached_books,
 )
 
 
@@ -721,3 +722,63 @@ async def test_get_vocabulary_word_without_occurrence():
     assert len(words) == 1
     assert words[0]["word"] == "orphanword"
     assert words[0]["occurrences"] == []
+
+
+# ── Issue #1650: db.py defensive branch coverage ─────────────────────────────
+
+async def test_init_db_bare_db_path_skips_makedirs():
+    """Regression #1650: line 99→102 False branch — when DB_PATH is a bare filename
+    (no directory component), os.path.dirname returns '' and os.makedirs is skipped."""
+    import pathlib
+    bare = "cov1650_init_bare.db"
+    original = db_module.DB_PATH
+    db_module.DB_PATH = bare
+    try:
+        await init_db()
+    finally:
+        db_module.DB_PATH = original
+        pathlib.Path(bare).unlink(missing_ok=True)
+
+
+async def test_save_translation_queue_cleanup_exception_swallowed():
+    """Regression #1650: lines 426-430 — non-ImportError from mark_queue_row_done
+    is caught and logged; does not re-raise."""
+    book_id = 99513
+    await save_book(book_id, _BOOK_META_1634, "some text")
+    with patch(
+        "services.translation_queue.mark_queue_row_done",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("queue oops"),
+    ):
+        await save_translation(book_id, 0, "de", ["translated text"])
+
+
+async def test_save_book_auto_enqueue_exception_swallowed():
+    """Regression #1650: lines 520-522 — RuntimeError from enqueue_for_book
+    is caught and logged; does not re-raise."""
+    book_id = 99514
+    with patch(
+        "services.translation_queue.enqueue_for_book",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("enqueue fail"),
+    ):
+        await save_book(book_id, _BOOK_META_1634, "some text")
+
+
+async def test_list_cached_books_null_json_fields_not_parsed():
+    """Regression #1650: line 807→806 — when authors/languages/subjects is NULL
+    in the DB, isinstance(d.get(field), str) is False and json.loads is skipped."""
+    import aiosqlite
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            "INSERT OR REPLACE INTO books"
+            " (id, title, authors, languages, subjects, download_count, cover, source)"
+            " VALUES (99515, 'Null JSON Test', NULL, NULL, NULL, 0, '', NULL)"
+        )
+        await db.commit()
+    result = await list_cached_books()
+    entry = next((b for b in result if b["id"] == 99515), None)
+    assert entry is not None
+    assert entry["authors"] is None
+    assert entry["languages"] is None
+    assert entry["subjects"] is None


### PR DESCRIPTION
## What changed

Added 4 regression tests to `backend/tests/test_db_extended.py` covering previously-untested defensive branches in `services/db.py`:

| Branch | Trigger |
|---|---|
| Line 99→102: `if db_dir:` False in `init_db()` | `DB_PATH` is a bare filename — `os.path.dirname` returns `''` |
| Lines 426-430: `except Exception:` in `save_translation()` | `mark_queue_row_done` raises a non-ImportError |
| Lines 520-522: `except Exception:` in `save_book()` | `enqueue_for_book` raises |
| Line 807→806: `isinstance(field, str)` False in `list_cached_books()` | DB row with NULL `authors`/`languages`/`subjects` |

## Why

These branches were the last uncovered defensive guards in `db.py`, keeping the module at 97% branch coverage. Each represents a real failure path (missing directory, queue service unavailable, NULL stored data) that should not propagate as an unhandled exception.

## Test plan

- `test_init_db_bare_db_path_skips_makedirs`: patches `DB_PATH` to a bare filename, calls `init_db()`, asserts no exception
- `test_save_translation_queue_cleanup_exception_swallowed`: patches `mark_queue_row_done` to raise `RuntimeError`, asserts `save_translation` doesn't re-raise
- `test_save_book_auto_enqueue_exception_swallowed`: patches `enqueue_for_book` to raise `RuntimeError`, asserts `save_book` doesn't re-raise
- `test_list_cached_books_null_json_fields_not_parsed`: inserts a book row with NULL fields, asserts `list_cached_books` returns `None` values (not crash)

Closes #1650
