### PR TITLE
fix: bump reader Keyboard-shortcuts toggle off-state to amber-700 (closes #1656)

### DIFF
--- a/frontend/src/__tests__/ReaderKeyboardShortcutsToggleContrast.test.ts
+++ b/frontend/src/__tests__/ReaderKeyboardShortcutsToggleContrast.test.ts
@@ -1,0 +1,42 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// Reader Keyboard-shortcuts toggle (off state) used text-amber-500
+// (≈2.74:1 on white) for its icon — failed WCAG 1.4.11 (3:1 needed for
+// non-text UI components). Closes #1656.
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("reader Keyboard-shortcuts toggle contrast (closes #1656)", () => {
+  it("the <button> element with aria-label=\"Keyboard shortcuts\" does not use text-amber-500 anywhere in its tag", () => {
+    const aria = 'aria-label="Keyboard shortcuts"';
+    const ariaIdx = src.indexOf(aria);
+    expect(ariaIdx).toBeGreaterThan(-1);
+    // Find the opening <button before aria-label and the closing > after it,
+    // capturing the entire opening tag (which contains the multiline className).
+    const buttonStart = src.lastIndexOf("<button", ariaIdx);
+    expect(buttonStart).toBeGreaterThan(-1);
+    // The className uses a template literal with backticks, so the closing
+    // > may be many lines after aria-label. Scan forward for the first
+    // `>` that is *not* inside a backtick.
+    let depth = 0;
+    let inBacktick = false;
+    let tagEnd = -1;
+    for (let i = buttonStart; i < src.length; i++) {
+      const ch = src[i];
+      if (ch === "`") inBacktick = !inBacktick;
+      else if (!inBacktick) {
+        if (ch === "{") depth++;
+        else if (ch === "}") depth--;
+        else if (ch === ">" && depth === 0) { tagEnd = i; break; }
+      }
+    }
+    expect(tagEnd).toBeGreaterThan(buttonStart);
+    const tag = src.slice(buttonStart, tagEnd + 1);
+    expect(tag).toContain(aria);
+    expect(tag).not.toMatch(/text-amber-500/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1194,7 +1194,7 @@ export default function ReaderPage() {
               className={`flex shrink-0 items-center justify-center w-7 h-7 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 rounded-lg border text-xs font-medium transition-colors ${
                 showShortcuts
                   ? "bg-amber-100 border-amber-400 text-amber-800"
-                  : "border-amber-300 text-amber-500 hover:bg-amber-50 hover:text-amber-700"
+                  : "border-amber-300 text-amber-700 hover:bg-amber-50 hover:text-amber-900"
               }`}
             >
               <KeyboardIcon className="w-3.5 h-3.5" />


### PR DESCRIPTION
## What

Bumps the off-state colour of the icon-only Keyboard-shortcuts toggle in the reader top bar (`frontend/src/app/reader/[bookId]/page.tsx:1197`) from `text-amber-500 hover:text-amber-700` to `text-amber-700 hover:text-amber-900`.

## Why

The button is icon-only — `KeyboardIcon` is its sole visible affordance — so contrast must clear WCAG 1.4.11 (≥3:1 for non-text UI components). `text-amber-500` (`#f59e0b`) on white measures ≈2.74:1 — fails. `text-amber-700` (`#b45309`) is ≈5.02:1 and matches the convention used across the recent reader-chrome contrast cleanup (#1640, #1645, #1647, #1649, #1652, #1654).

The visually-related "Marks on/off" toggle one block above (line 1121) also uses `text-amber-500` but pairs it with `opacity-60` as part of its dimmed off-state design. That one is left for a separate follow-up because removing `opacity-60` is a design decision, not a colour swap.

## Test plan

- [x] New regression test `frontend/src/__tests__/ReaderKeyboardShortcutsToggleContrast.test.ts` parses the `<button aria-label="Keyboard shortcuts">` opening tag (handling the multi-line template-literal className) and asserts it does not contain `text-amber-500`. Verified failing pre-fix, passing post-fix.
- [x] Full frontend suite: 2537/2537 passing.
- [x] Full backend suite: 1382/1382 passing.

Closes #1656
