### PR TITLE
fix: bump notes section-toggle chevrons to text-amber-700 (closes #1662)

### DIFF
--- a/frontend/src/__tests__/NotesSectionChevronContrast.test.ts
+++ b/frontend/src/__tests__/NotesSectionChevronContrast.test.ts
@@ -1,0 +1,31 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// notes/[bookId] section-toggle chevrons used text-amber-400 (≈2.18:1
+// on white) — failed WCAG 1.4.11 (3:1 for state indicators on UI
+// components). Closes #1662.
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("notes-by-book section chevron contrast (closes #1662)", () => {
+  it("ChevronRightIcon does not use text-amber-400", () => {
+    const re = /<ChevronRightIcon\s+className="([^"]*)"/g;
+    const matches = Array.from(src.matchAll(re));
+    expect(matches.length).toBeGreaterThan(0);
+    for (const m of matches) {
+      expect(m[1]).not.toMatch(/text-amber-400/);
+    }
+  });
+
+  it("ChevronDownIcon does not use text-amber-400", () => {
+    const re = /<ChevronDownIcon\s+className="([^"]*)"/g;
+    const matches = Array.from(src.matchAll(re));
+    expect(matches.length).toBeGreaterThan(0);
+    for (const m of matches) {
+      expect(m[1]).not.toMatch(/text-amber-400/);
+    }
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -50,7 +50,7 @@ function CollapseHeading({
           : "mt-5 mb-2"
       }`}
     >
-      {isCollapsed ? <ChevronRightIcon className="w-3 h-3 text-amber-400 shrink-0" /> : <ChevronDownIcon className="w-3 h-3 text-amber-400 shrink-0" />}
+      {isCollapsed ? <ChevronRightIcon className="w-3 h-3 text-amber-700 shrink-0" /> : <ChevronDownIcon className="w-3 h-3 text-amber-700 shrink-0" />}
       <Tag className={level === 2
         ? "text-lg font-serif font-semibold text-ink group-hover:text-amber-800 transition-colors"
         : "text-sm font-semibold text-amber-800 uppercase tracking-wide group-hover:text-amber-900 transition-colors"


### PR DESCRIPTION
## What

Bumps the collapsible-section-toggle chevrons in the by-book notes view (`frontend/src/app/notes/[bookId]/page.tsx:53`) from `text-amber-400` to `text-amber-700` for both `ChevronRightIcon` (collapsed) and `ChevronDownIcon` (expanded).

## Why

The chevron is the only visual cue distinguishing collapsed vs expanded states on these section toggles. Per WCAG 1.4.11, state-indicating UI components must have ≥3:1 contrast against the background.

`text-amber-400` (`#fbbf24`) on white measures ≈2.18:1 — fails. `text-amber-700` (`#b45309`) is ≈5.02:1 and clears the bar. Same convention as the recent reader-chrome contrast cleanup (#1640, #1645, #1647, #1649, #1652, #1654, #1657, #1660).

## Test plan

- [x] New regression test `frontend/src/__tests__/NotesSectionChevronContrast.test.ts` matches every `<ChevronRightIcon className="…">` and `<ChevronDownIcon className="…">` in `app/notes/[bookId]/page.tsx` and asserts none use `text-amber-400`. Verified failing pre-fix on both, passing post-fix.
- [x] Full frontend suite: 2540/2540 passing.
- [x] Full backend suite: 1382/1382 passing.

Closes #1662
