### PR TITLE
fix: bump vocabulary Delete button to text-red-600 (closes #1665)

### DIFF
--- a/frontend/src/__tests__/VocabularyDeleteButtonContrast.test.ts
+++ b/frontend/src/__tests__/VocabularyDeleteButtonContrast.test.ts
@@ -1,0 +1,18 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// vocabulary/page.tsx per-form Delete button used text-xs text-red-400
+// (≈3.34:1 on white) for visible "Delete" text — failed WCAG 1.4.3 AA.
+// Closes #1665.
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8",
+);
+
+describe("vocabulary Delete button contrast (closes #1665)", () => {
+  it("does not pair text-xs with text-red-400 in a className", () => {
+    expect(src).not.toMatch(/text-xs[^"]*text-red-400/);
+    expect(src).not.toMatch(/text-red-400[^"]*text-xs/);
+  });
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -388,7 +388,7 @@ function VocabularyPageContent() {
                 onClick={() => handleDelete(f.word)}
                 disabled={deleting === f.word}
                 aria-label={`Delete ${f.word}`}
-                className="text-xs text-red-400 hover:text-red-600 disabled:opacity-50 transition-colors min-h-[44px] md:min-h-0 flex items-center px-2"
+                className="text-xs text-red-600 hover:text-red-800 disabled:opacity-50 transition-colors min-h-[44px] md:min-h-0 flex items-center px-2"
                 data-testid={`delete-${f.word}`}
               >
                 {deleting === f.word ? "…" : "Delete"}


### PR DESCRIPTION
## What

Bumps the per-form Delete button on the vocabulary page (`frontend/src/app/vocabulary/page.tsx:391`) from `text-red-400 hover:text-red-600` to `text-red-600 hover:text-red-800`.

## Why

The button has visible "Delete" text at `text-xs` (12px). `text-red-400` (`#f87171`) on white measures ≈3.34:1 — fails WCAG 1.4.3 AA (4.5:1 needed for normal text under 18pt). `text-red-600` (`#dc2626`) is ≈4.84:1 and clears the bar; `text-red-800` on hover keeps the visible state-change.

This was the only `text-xs text-red-400` pairing remaining in the codebase — sibling text-bearing red buttons (admin/users Delete, profile Sign out, AnnotationToolbar Delete with text content) already follow the `text-red-6XX` convention.

## Test plan

- [x] New regression test `frontend/src/__tests__/VocabularyDeleteButtonContrast.test.ts` asserts `app/vocabulary/page.tsx` no longer pairs `text-xs` with `text-red-400` in either order. Verified failing pre-fix, passing post-fix.
- [x] Full frontend suite: 2540/2540 passing.
- [x] Full backend suite: 1382/1382 passing.

Closes #1665
