### PR TITLE
fix: bump reader translation-status pulse to text-amber-700 (closes #1669)

### DIFF
--- a/frontend/src/__tests__/ReaderTranslationStatusContrast.test.ts
+++ b/frontend/src/__tests__/ReaderTranslationStatusContrast.test.ts
@@ -1,0 +1,25 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// Reader translation-status pulse used text-xs text-amber-600 on white
+// (≈3.62:1) — failed WCAG 1.4.3 AA. Closes #1669.
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("reader translation status contrast (closes #1669)", () => {
+  it("the 'Checking for translation…' span does not use text-amber-600", () => {
+    const marker = "Checking for translation…";
+    const markerIdx = src.indexOf(marker);
+    expect(markerIdx).toBeGreaterThan(-1);
+    // Walk back to the nearest <span and forward to the closing >.
+    const spanStart = src.lastIndexOf("<span", markerIdx);
+    expect(spanStart).toBeGreaterThan(-1);
+    const tagEnd = src.indexOf(">", spanStart);
+    expect(tagEnd).toBeGreaterThan(spanStart);
+    const tag = src.slice(spanStart, tagEnd + 1);
+    expect(tag).not.toMatch(/text-amber-600/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1998,7 +1998,7 @@ export default function ReaderPage() {
                     {translationEnabled && (
                       <div role="status" className="text-xs">
                         {translationLoading && !translationUsedProvider && (
-                          <span className="animate-pulse text-amber-600">Checking for translation…</span>
+                          <span className="animate-pulse text-amber-700">Checking for translation…</span>
                         )}
                         {translationLoading && translationUsedProvider.startsWith("queue") && (
                           <span className="animate-pulse text-sky-600">


### PR DESCRIPTION
## What

Bumps the "Checking for translation…" status pulse on the reader's parallel-translation panel (`frontend/src/app/reader/[bookId]/page.tsx:2001`) from `text-amber-600` to `text-amber-700`.

## Why

The status text is rendered at the inherited `text-xs` size on the white reader background. `text-amber-600` (`#d97706`) on white measures ≈3.62:1 — fails WCAG 1.4.3 AA (4.5:1 needed for normal text under 18pt). `text-amber-700` (`#b45309`) is ≈5.02:1 and clears the bar.

Same pattern as the recent QueueTab retry_reason (#1652) and TTSControls progress percentage (#1654) fixes — `text-xs text-amber-6XX` on white is the recurring violation.

## Test plan

- [x] New regression test `frontend/src/__tests__/ReaderTranslationStatusContrast.test.ts` anchors to the literal "Checking for translation…" string and asserts the enclosing `<span>` opening tag does not use `text-amber-600`. Verified failing pre-fix, passing post-fix.
- [x] Full frontend suite: 2544/2544 passing.
- [x] Full backend suite: 1382/1382 passing.

Closes #1669
