### PR TITLE
test: cover SearchBar branches (closes #1677)

### DIFF
--- a/frontend/src/__tests__/SearchBar.coverage.test.tsx
+++ b/frontend/src/__tests__/SearchBar.coverage.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Branch-coverage tests for SearchBar (closes #1677). The pre-existing
+ * SearchBar.test.tsx covers the basic open/submit flow; this file picks
+ * up the three uncovered branches: global "/" shortcut (with input/
+ * contentEditable guards), the explicit Esc close-button click, and the
+ * <form onSubmit> wiring.
+ */
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+import { SearchBar } from "@/components/SearchBar";
+
+beforeEach(() => {
+  mockPush.mockReset();
+  document.body.innerHTML = "";
+});
+
+// Dispatch a bubbling keydown from a specific element so event.target is
+// set naturally (Event.target is a read-only getter — we cannot Object.assign
+// it). The component listens on `window`; the bubble path reaches it.
+function dispatchKeyOn(el: EventTarget, key: string) {
+  el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+}
+
+describe("SearchBar — global '/' keyboard shortcut (#1677)", () => {
+  test("'/' opens the bar when focus is on the document body", async () => {
+    render(<SearchBar />);
+    expect(screen.queryByRole("search")).not.toBeInTheDocument();
+    await act(async () => {
+      dispatchKeyOn(document.body, "/");
+    });
+    expect(screen.getByRole("search")).toBeInTheDocument();
+  });
+
+  test("'/' is ignored when focus is inside an <input>", async () => {
+    const otherInput = document.createElement("input");
+    document.body.appendChild(otherInput);
+    render(<SearchBar />);
+    await act(async () => {
+      dispatchKeyOn(otherInput, "/");
+    });
+    expect(screen.queryByRole("search")).not.toBeInTheDocument();
+  });
+
+  test("'/' is ignored when focus is in a contentEditable element", async () => {
+    // JSDOM does not auto-derive `isContentEditable` from the attribute the
+    // same way real browsers do, so we stub the property to true on a span
+    // (so its tagName is neither INPUT nor TEXTAREA, exercising only the
+    // contentEditable branch of the guard).
+    const ce = document.createElement("span");
+    Object.defineProperty(ce, "isContentEditable", { value: true });
+    document.body.appendChild(ce);
+    render(<SearchBar />);
+    await act(async () => {
+      dispatchKeyOn(ce, "/");
+    });
+    expect(screen.queryByRole("search")).not.toBeInTheDocument();
+  });
+
+  test("non-'/' keys never open the bar", async () => {
+    render(<SearchBar />);
+    await act(async () => {
+      dispatchKeyOn(document.body, "k");
+    });
+    expect(screen.queryByRole("search")).not.toBeInTheDocument();
+  });
+});
+
+describe("SearchBar — Esc close button (#1677)", () => {
+  test("clicking the Esc close button collapses the bar and clears the query", async () => {
+    const user = userEvent.setup();
+    render(<SearchBar />);
+    await user.click(screen.getByRole("button", { name: /open search/i }));
+    const input = screen.getByLabelText(/search your content/i) as HTMLInputElement;
+    await user.type(input, "leftover");
+    expect(input.value).toBe("leftover");
+    await user.click(screen.getByRole("button", { name: /close search/i }));
+    // Bar collapses; reopening shows an empty input — the query was cleared.
+    expect(screen.queryByLabelText(/search your content/i)).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /open search/i }));
+    expect(
+      (screen.getByLabelText(/search your content/i) as HTMLInputElement).value,
+    ).toBe("");
+  });
+});
+
+describe("SearchBar — form onSubmit (#1677)", () => {
+  test("submitting the form (not just Enter on input) navigates", async () => {
+    const user = userEvent.setup();
+    render(<SearchBar />);
+    await user.click(screen.getByRole("button", { name: /open search/i }));
+    const input = screen.getByLabelText(/search your content/i);
+    await user.type(input, "Tolstoy");
+    const form = screen.getByRole("search");
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+    expect(mockPush).toHaveBeenCalledWith("/search?q=Tolstoy");
+  });
+
+  test("submitting an empty form is a no-op (whitespace-trim guard)", async () => {
+    const user = userEvent.setup();
+    render(<SearchBar />);
+    await user.click(screen.getByRole("button", { name: /open search/i }));
+    const form = screen.getByRole("search");
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Adds 7 tests for `frontend/src/components/SearchBar.tsx`'s previously-uncovered branch paths, lifting branch coverage from **52.94% → 94.11%**.

| Metric | Before | After |
|--------|--------|-------|
| Statements | 73.46% | 97.95% |
| Branches | 52.94% | **94.11%** |
| Functions | 83.33% | 100% |
| Lines | 74.41% | 100% |

## Why

The pre-existing `SearchBar.test.tsx` covered the basic open/Enter-submit/Escape/maxLength flow but missed three branch paths:

1. **Global "/" keydown shortcut** (lines 25-31) — the body-level shortcut that opens the bar, plus its guards against firing while focus is in `<input>` / `<textarea>` / `[contenteditable]`.
2. **`<form onSubmit>` wiring** (lines 75-76) — the form-level submit path. Existing tests only triggered submit indirectly via the input's Enter key (which calls `submit()` directly through `onKeyDown`).
3. **Esc close-button onClick** (lines 96-97) — the explicit button click path. The Escape *key* path was tested; the button click was not.

## What's covered

- `'/' opens the bar when focus is on document.body`
- `'/' is ignored when focus is in an <input>`
- `'/' is ignored when focus is in a contentEditable element` (uses `Object.defineProperty` to set `isContentEditable` since JSDOM doesn't auto-derive it from the attribute)
- `non-'/' keys never open the bar`
- `Esc close button collapses the bar and clears the query`
- `submitting the form (not just Enter on input) navigates`
- `submitting an empty form is a no-op (whitespace-trim guard)`

## What's intentionally not covered

The single remaining uncovered line is the `if (!el) return;` null guard for `e.target` (line 26) — JSDOM always sets `target` on dispatched events, so the null path is unreachable from a test. It's defence-in-depth against future target-less event injection.

## Test plan

- [x] New test file `SearchBar.coverage.test.tsx` — 7 tests, all green.
- [x] Full frontend suite: 2562/2562 passing (was 2555).
- [x] Full backend suite: 1382/1382 passing.

Closes #1677
