### PR TITLE
fix: extract admin uploads empty-state SVG into Icons.tsx (closes #1682)

### DIFF
--- a/frontend/src/__tests__/AdminUploadsEmptyIcon.test.ts
+++ b/frontend/src/__tests__/AdminUploadsEmptyIcon.test.ts
@@ -1,0 +1,26 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// admin/uploads/page.tsx had an inline <svg> for the empty-state
+// illustration, breaking the codebase convention that all SVG icons
+// live in components/Icons.tsx (see EmptyNotesIcon, EmptyVocabIcon,
+// BookCoverPlaceholderIcon). Closes #1682.
+
+const uploadsSrc = fs.readFileSync(
+  path.join(__dirname, "../app/admin/uploads/page.tsx"),
+  "utf8",
+);
+const iconsSrc = fs.readFileSync(
+  path.join(__dirname, "../components/Icons.tsx"),
+  "utf8",
+);
+
+describe("admin uploads empty-state icon refactor (closes #1682)", () => {
+  it("admin/uploads/page.tsx no longer contains a raw <svg opening tag", () => {
+    expect(uploadsSrc).not.toMatch(/<svg\b/);
+  });
+
+  it("Icons.tsx exports EmptyUploadIcon", () => {
+    expect(iconsSrc).toMatch(/export function EmptyUploadIcon\b/);
+  });
+});

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -2,7 +2,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { adminFetch } from "@/lib/adminFetch";
-import { CloseIcon } from "@/components/Icons";
+import { CloseIcon, EmptyUploadIcon } from "@/components/Icons";
 
 interface UploadEntry {
   book_id: number;
@@ -114,20 +114,7 @@ export default function UploadsPage() {
 
       {uploads.length === 0 ? (
         <div className="bg-white rounded-xl border border-amber-200 px-4 py-12 text-center">
-          <svg
-            className="mx-auto mb-3 w-10 h-10 text-amber-200"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={1.5}
-              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
-            />
-          </svg>
+          <EmptyUploadIcon className="mx-auto mb-3 w-10 h-10 text-amber-200" />
           <p className="font-serif text-ink mb-1">No uploads yet</p>
           <p className="text-sm text-stone-500">
             {activeFilter ? `No uploads found for user ${activeFilter}.` : "No books have been uploaded by users."}

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -315,6 +315,14 @@ export function EmptyVocabIcon({ className = "w-14 h-14" }: IconProps) {
   );
 }
 
+export function EmptyUploadIcon({ className = "w-10 h-10" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/>
+    </svg>
+  );
+}
+
 export function AlertCircleIcon({ className = "w-4 h-4" }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">


### PR DESCRIPTION
## What

Extracts the inline `<svg>` empty-state illustration on `/admin/uploads` into a new `EmptyUploadIcon` component in `frontend/src/components/Icons.tsx`, and replaces the inline SVG in `app/admin/uploads/page.tsx` with the component import.

## Why

The "No uploads yet" empty state was the **only** inline `<svg>` left in the entire `frontend/src/app/` tree. Codebase convention (see `EmptyNotesIcon`, `EmptyVocabIcon`, `BookCoverPlaceholderIcon` in `Icons.tsx`) and the CLAUDE.md graphic design rules call for all SVG icons to live in `components/Icons.tsx`. Inline SVGs make refactors and design-token changes harder to track.

No visual change — same path, same `viewBox`, same default sizing, same colour token (`text-amber-200`).

## Test plan

- [x] New regression test `frontend/src/__tests__/AdminUploadsEmptyIcon.test.ts`:
  1. Asserts `app/admin/uploads/page.tsx` no longer contains a raw `<svg` opening tag.
  2. Asserts `components/Icons.tsx` exports `EmptyUploadIcon`.
- [x] Full frontend suite: 2564/2564 passing (was 2562).
- [x] Full backend suite: 1382/1382 passing.

Closes #1682
