### PR TITLE
test: cover _epub_heading_title heading-found and exception paths (closes #1681)

### DIFF
--- a/backend/tests/test_splitter.py
+++ b/backend/tests/test_splitter.py
@@ -2260,3 +2260,22 @@ def test_build_chapters_from_epub_strips_heading_when_ncx_title_is_substring():
     assert body.lstrip().startswith("It was a dark"), (
         f"Body should start with the actual prose, got: {body[:120]!r}"
     )
+
+
+# ── Lines 1150-1154: _epub_heading_title heading-found and exception paths ────
+
+def test_epub_heading_title_returns_first_heading_text():
+    """Regression #1681: lines 1150-1152 — when XHTML contains a heading,
+    _epub_heading_title returns its text content."""
+    from services.splitter import _epub_heading_title
+    raw = b"<html><body><h1>My Chapter</h1><p>Some prose.</p></body></html>"
+    assert _epub_heading_title(raw) == "My Chapter"
+
+
+def test_epub_heading_title_returns_empty_on_parse_exception(monkeypatch):
+    """Regression #1681: lines 1153-1154 — when lxml.html.fromstring raises,
+    _epub_heading_title catches the exception and returns empty string."""
+    from services.splitter import _epub_heading_title
+    import lxml.html
+    monkeypatch.setattr(lxml.html, "fromstring", lambda _: (_ for _ in ()).throw(ValueError("bad xml")))
+    assert _epub_heading_title(b"<html></html>") == ""


### PR DESCRIPTION
## What changed

Two new tests in `backend/tests/test_splitter.py` covering previously-uncovered lines in `services/splitter.py`:

- **Lines 1150-1152** — `_epub_heading_title` heading-found path: verifies that when the XHTML contains an `<h1>` element, the function returns its text content.
- **Lines 1153-1154** — `_epub_heading_title` exception handler: verifies that when `lxml.html.fromstring` raises, the exception is swallowed and an empty string is returned.

## Why

`_epub_heading_title` is a fallback for EPUB chapter title extraction. Neither its success path nor its exception handler had any test coverage.

## Test plan

- `test_epub_heading_title_returns_first_heading_text` — passes `b"<html><body><h1>My Chapter</h1>...</h1></body></html>"` and asserts the return is `"My Chapter"`.
- `test_epub_heading_title_returns_empty_on_parse_exception` — monkeypatches `lxml.html.fromstring` to raise `ValueError`, asserts the function returns `""`.

All 1879 backend tests pass. All 1750 frontend tests pass.

Closes #1681

- [ ] Docs updated (if applicable)
