### PR TITLE
test: cover _walk_toc_with_path False branches in splitter.py (closes #1685)

### DIFF
--- a/backend/tests/test_splitter.py
+++ b/backend/tests/test_splitter.py
@@ -2279,3 +2279,43 @@ def test_epub_heading_title_returns_empty_on_parse_exception(monkeypatch):
     import lxml.html
     monkeypatch.setattr(lxml.html, "fromstring", lambda _: (_ for _ in ()).throw(ValueError("bad xml")))
     assert _epub_heading_title(b"<html></html>") == ""
+
+
+# ── Lines 937→939, 943→932: _walk_toc_with_path False branches ───────────────
+
+def test_walk_toc_with_path_tuple_no_href_still_recurses_children():
+    """Regression #1685: line 937→939 — when a tuple entry's section has no
+    href/title, on_entry is not called for that section but children are still
+    walked so their entries can fire on_entry."""
+    from services.splitter import _walk_toc_with_path
+
+    class _Section:
+        href = None
+        title = None
+
+    class _Leaf:
+        href = "child.xhtml"
+        title = "Child Chapter"
+
+    calls = []
+    toc_items = [(_Section(), [_Leaf()])]
+    _walk_toc_with_path(toc_items, lambda href, title, path: calls.append((href, title)))
+
+    assert len(calls) == 1
+    assert calls[0] == ("child.xhtml", "Child Chapter")
+
+
+def test_walk_toc_with_path_non_tuple_no_href_silently_skipped():
+    """Regression #1685: line 943→932 — a non-tuple TOC leaf with no href
+    (or no title) is silently skipped; on_entry is never called."""
+    from services.splitter import _walk_toc_with_path
+
+    class _EmptyLeaf:
+        href = None
+        title = None
+
+    calls = []
+    toc_items = [_EmptyLeaf()]
+    _walk_toc_with_path(toc_items, lambda href, title, path: calls.append((href, title)))
+
+    assert calls == []


### PR DESCRIPTION
## What changed

Two new tests in `backend/tests/test_splitter.py` covering previously-uncovered False branches in `services/splitter.py`:

- **Line 937→939** — `_walk_toc_with_path` tuple entry with no href/title: when a `(section, children)` tuple in the EPUB TOC has a section with no href or title, `on_entry` is skipped but children are still walked.
- **Line 943→932** — `_walk_toc_with_path` non-tuple leaf with no href/title: a non-tuple leaf entry with no href or title is silently skipped without calling `on_entry`.

## Why

Both branches are in the EPUB TOC traversal logic. The False branches were never exercised because existing tests always provide sections with valid href and title. These can arise with malformed or unusual EPUB TOC structures.

## Test plan

- `test_walk_toc_with_path_tuple_no_href_still_recurses_children` — creates a `(section, [child])` where section has no href/title, verifies child's `on_entry` is still called (recursion works).
- `test_walk_toc_with_path_non_tuple_no_href_silently_skipped` — creates a leaf entry with no href/title, verifies `on_entry` is never called.

Both tests call `_walk_toc_with_path` directly with minimal mock objects.

All 1879 backend tests pass. All 1750 frontend tests pass.

Closes #1685

- [ ] Docs updated (if applicable)
