### PR TITLE
test: cover _segment_body_by_anchors <a name> and None-anchor branches (closes #1689)

### DIFF
--- a/backend/tests/test_splitter.py
+++ b/backend/tests/test_splitter.py
@@ -2577,3 +2577,49 @@ def test_build_chapters_from_epub_all_skipped_returns_empty_list():
         result = build_chapters_from_epub(b"fake")
 
     assert result == []
+
+
+# ── Lines 1096, 1102: _segment_body_by_anchors <a name> and None-anchor ──────
+
+def test_segment_body_by_anchors_indexes_a_name_attribute():
+    """Regression #1689: line 1096 — when the body contains an <a name='...'>
+    tag, its name attribute is added to anchor_positions so it can be used
+    as a navPoint target."""
+    from services.splitter import _segment_body_by_anchors
+    from lxml import html as lxmlhtml
+
+    doc = lxmlhtml.fromstring(
+        "<html><body>"
+        "<a name='sect1'>old-style anchor</a>"
+        "<p>Chapter content.</p>"
+        "</body></html>"
+    )
+    body = doc.find(".//body")
+    # "sect1" is resolvable only via the <a name> path (line 1096)
+    result = _segment_body_by_anchors(body, [("sect1", "Section One")], "My Book")
+
+    assert len(result) == 1
+    assert result[0][0] == "Section One"
+
+
+def test_segment_body_by_anchors_none_anchor_id_is_skipped_in_validation():
+    """Regression #1689: line 1102 — a None anchor_id in the anchors list is
+    skipped during the validation loop (it represents 'top of spine item') and
+    the function proceeds normally."""
+    from services.splitter import _segment_body_by_anchors
+    from lxml import html as lxmlhtml
+
+    doc = lxmlhtml.fromstring(
+        "<html><body>"
+        "<p>Lead content.</p>"
+        "<p id='ch2'>Chapter 2 start.</p>"
+        "</body></html>"
+    )
+    body = doc.find(".//body")
+    # None anchor = top-of-file slice; "ch2" must exist in DOM to not bail out
+    anchors = [(None, "Chapter 1"), ("ch2", "Chapter 2")]
+    result = _segment_body_by_anchors(body, anchors, "My Book")
+
+    assert len(result) == 2
+    assert result[0][0] == "Chapter 1"
+    assert result[1][0] == "Chapter 2"


### PR DESCRIPTION
## What changed

Two new tests in `backend/tests/test_splitter.py` covering previously-uncovered branches in `services/splitter.py`:

- **Line 1096** (`_segment_body_by_anchors` `<a name>` anchor indexing): when the body contains `<a name="sect1">` (old-style Gutenberg anchors), the `name` attribute is indexed in `anchor_positions` so navPoints can target it. Covered by passing a body with such an anchor and verifying the result resolves.
- **Line 1102** (`_segment_body_by_anchors` None-anchor skip): when `anchors` contains an entry with `anchor_id = None` (navPoint pointing to top-of-spine-item with no `#` fragment), the validation loop hits `continue` and skips it. Covered by passing `[(None, "Chapter 1"), ("ch2", "Chapter 2")]` and verifying the function returns two slices.

## Why

Both branches handle real-world EPUB structures: `<a name>` is used by older Gutenberg EPUBs (pre-HTML5), and `None` anchors arise when an NCX navPoint href has no `#` fragment. Neither was reachable with the existing test fixtures.

## Test plan

- `test_segment_body_by_anchors_indexes_a_name_attribute` — builds a minimal lxml body with `<a name='sect1'>`, calls `_segment_body_by_anchors` with `[("sect1", "Section One")]`, asserts 1-element result with correct title.
- `test_segment_body_by_anchors_none_anchor_id_is_skipped_in_validation` — calls with `[(None, "Chapter 1"), ("ch2", "Chapter 2")]` and a body containing `<p id='ch2'>`, asserts 2-element result.

All 1883 backend tests pass. All 1750 frontend tests pass.

Closes #1689

- [ ] Docs updated (if applicable)
