### PR TITLE
test: cover _epub_toc_containers empty-container and _strip_leading_headings parentless-heading branches (closes #1691)

### DIFF
--- a/backend/tests/test_splitter.py
+++ b/backend/tests/test_splitter.py
@@ -2413,3 +2413,34 @@ def test_epub_nav_anchors_resolve_returns_none_entry_skipped():
 
     result = _epub_nav_anchors(_Book())
     assert result == {}
+
+
+# ── Line 797: _epub_toc_containers empty container skipped ───────────────────
+
+def test_epub_toc_containers_empty_table_is_skipped():
+    """Regression #1691: line 797 — when a container (table/ol/ul) has no
+    tr/li children, the loop continues without adding it to the result."""
+    from services.splitter import _epub_toc_containers
+    from lxml import html as lxmlhtml
+
+    body = lxmlhtml.fromstring(
+        "<body>"
+        "<table></table>"
+        "<p>Some content.</p>"
+        "</body>"
+    )
+    result = _epub_toc_containers(body)
+    assert result == []
+
+
+# ── Line 854→852: _strip_leading_headings parentless heading gracefully skipped
+
+def test_strip_leading_headings_handles_parentless_heading():
+    """Regression #1691: line 854 False branch — when a heading element has no
+    parent (it IS the root of the tree), getparent() returns None and the
+    remove() call is skipped without error."""
+    from services.splitter import _strip_leading_headings
+    from lxml import html as lxmlhtml
+
+    root = lxmlhtml.fromstring("<h1>Title<p>Paragraph text.</p></h1>")
+    _strip_leading_headings(root)


### PR DESCRIPTION
## What changed

Two new tests in `backend/tests/test_splitter.py` covering previously-uncovered branches in `services/splitter.py`:

- **Line 797** (`_epub_toc_containers` empty-container skip): when a `<table>`/`<ol>`/`<ul>` element contains no `<tr>`/`<li>` children, `entries` is empty and the function skips it via `continue`. Covered by passing a body with an empty `<table>`.
- **Line 854→852** (`_strip_leading_headings` parentless-heading): when `heading.getparent()` returns `None` (heading is the tree root), the `remove()` call is safely skipped. Covered by passing a detached `<h1>` element as `body`.

## Why

Both are defensive guards for unusual (but valid) HTML structures: empty TOC containers arise in some EPUB builds, and detached headings can occur when the function is called on a fragment rather than a full body.

## Test plan

- `test_epub_toc_containers_empty_table_is_skipped` — body with `<table></table>` → function returns `[]`.
- `test_strip_leading_headings_handles_parentless_heading` — `lxmlhtml.fromstring("<h1>...</h1>")` gives a root element with `getparent() == None` → function completes without error.

All 1883 backend tests pass. All 1750 frontend tests pass.

Closes #1691

- [ ] Docs updated (if applicable)
