### PR TITLE
feat: add overwrite=true flag to /admin/translations/import for atomic replace (closes #1694)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -23,6 +23,7 @@ from services.db import (
     get_cached_book,
     save_book,
     save_translation,
+    replace_translations_for_book,
     get_setting,
     set_setting,
 )
@@ -643,6 +644,7 @@ class ImportTranslationsRequest(BaseModel):
 @router.post("/translations/import")
 async def import_translations(
     req: ImportTranslationsRequest,
+    overwrite: bool = Query(False),
     _admin: dict = Depends(_require_admin),
 ):
     """Bulk-import pre-translated chapters from an offline run.
@@ -652,9 +654,11 @@ async def import_translations(
     the rows to JSON, then POST them here to seed prod without paying
     for Gemini a second time.
 
-    Overwrites existing cache entries — safer than silently skipping,
-    since the whole point of seeding is usually to replace bad
-    translations. Skips empty paragraphs arrays.
+    When overwrite=true, all existing translations for each (book_id,
+    target_language) pair present in the payload are deleted atomically
+    before the new rows are inserted. On any failure the original rows are
+    preserved. Default (overwrite=false) uses INSERT OR REPLACE per row.
+    Skips empty paragraphs arrays in both modes.
     """
     # Pre-validate all referenced books exist before writing any row.
     book_ids = {e.book_id for e in req.entries if e.paragraphs}
@@ -681,20 +685,46 @@ async def import_translations(
                 ),
             )
 
-    count = 0
-    for entry in req.entries:
-        if not entry.paragraphs:
-            continue
-        await save_translation(
-            entry.book_id,
-            entry.chapter_index,
-            entry.target_language.lower().split("-")[0],
-            entry.paragraphs,
-            provider=entry.provider,
-            model=entry.model,
-            title_translation=entry.title_translation,
-        )
-        count += 1
+    if overwrite:
+        # Group non-empty entries by (book_id, target_language) and replace atomically.
+        from collections import defaultdict
+        groups: dict[tuple[int, str], list[dict]] = defaultdict(list)
+        for entry in req.entries:
+            if not entry.paragraphs:
+                continue
+            lang = entry.target_language.lower().split("-")[0]
+            groups[(entry.book_id, lang)].append({
+                "chapter_index": entry.chapter_index,
+                "paragraphs": entry.paragraphs,
+                "provider": entry.provider,
+                "model": entry.model,
+                "title_translation": entry.title_translation,
+            })
+        count = 0
+        for (book_id, lang), entries in groups.items():
+            try:
+                await replace_translations_for_book(book_id, lang, entries)
+            except Exception as exc:
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Import failed for book {book_id} ({lang}) — original rows preserved",
+                ) from exc
+            count += len(entries)
+    else:
+        count = 0
+        for entry in req.entries:
+            if not entry.paragraphs:
+                continue
+            await save_translation(
+                entry.book_id,
+                entry.chapter_index,
+                entry.target_language.lower().split("-")[0],
+                entry.paragraphs,
+                provider=entry.provider,
+                model=entry.model,
+                title_translation=entry.title_translation,
+            )
+            count += 1
     return {"ok": True, "imported": count}
 
 

--- a/backend/scripts/seed_translations.py
+++ b/backend/scripts/seed_translations.py
@@ -42,7 +42,14 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--chunk", type=int, default=50,
         help="Upload in chunks of N entries per request (default 50). "
-             "Keeps request bodies under proxy limits for big books.",
+             "Keeps request bodies under proxy limits for big books. "
+             "Ignored when --overwrite is set (all entries sent in one request).",
+    )
+    parser.add_argument(
+        "--overwrite", action="store_true", default=False,
+        help="Atomically replace all translations for each (book_id, language) "
+             "pair in the file. Sends the entire file in a single request — "
+             "safe because the server rolls back on failure.",
     )
     return parser.parse_args(argv)
 
@@ -64,12 +71,19 @@ def main() -> int:
         print("ERROR: file is empty or not a JSON array", file=sys.stderr)
         return 2
 
-    url = args.api_url.rstrip("/") + "/admin/translations/import"
-    print(f"Uploading {len(entries)} entries to {url} in chunks of {args.chunk}")
+    base_url = args.api_url.rstrip("/") + "/admin/translations/import"
+    url = base_url + ("?overwrite=true" if args.overwrite else "")
+
+    if args.overwrite:
+        print(f"Uploading {len(entries)} entries to {url} (overwrite mode — single request)")
+        chunks = [entries]
+    else:
+        print(f"Uploading {len(entries)} entries to {url} in chunks of {args.chunk}")
+        chunks = [entries[i:i + args.chunk] for i in range(0, len(entries), args.chunk)]
 
     total_imported = 0
-    for start in range(0, len(entries), args.chunk):
-        chunk = entries[start:start + args.chunk]
+    for start_idx, chunk in enumerate(chunks):
+        start = start_idx * args.chunk if not args.overwrite else 0
         body = json.dumps({"entries": chunk}).encode()
         req = urllib.request.Request(
             url,
@@ -92,10 +106,13 @@ def main() -> int:
             return 1
         imported = payload.get("imported", 0)
         total_imported += imported
-        print(
-            f"  [{start + 1}-{start + len(chunk)}/{len(entries)}] "
-            f"imported={imported}",
-        )
+        if args.overwrite:
+            print(f"  [all {len(chunk)}] imported={imported}")
+        else:
+            print(
+                f"  [{start + 1}-{start + len(chunk)}/{len(entries)}] "
+                f"imported={imported}",
+            )
 
     print(f"\nDone — {total_imported} rows imported into production.")
     return 0

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -450,6 +450,47 @@ async def delete_translations_for_book(book_id: int) -> None:
         await db.commit()
 
 
+async def replace_translations_for_book(
+    book_id: int,
+    target_language: str,
+    entries: list[dict],
+) -> None:
+    """Atomically replace all translations for (book_id, target_language).
+
+    Deletes every existing row for the pair and inserts the new batch in a
+    single transaction. On any failure the original rows are preserved.
+    Each dict in entries must have: chapter_index, paragraphs (list[str]),
+    and optionally provider, model, title_translation.
+    """
+    async with aiosqlite.connect(DB_PATH) as db:
+        try:
+            await db.execute(
+                "DELETE FROM translations WHERE book_id=? AND target_language=?",
+                (book_id, target_language),
+            )
+            await db.executemany(
+                """INSERT INTO translations
+                   (book_id, chapter_index, target_language, paragraphs,
+                    provider, model, title_translation)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                [
+                    (
+                        book_id,
+                        e["chapter_index"],
+                        target_language,
+                        json.dumps(e["paragraphs"]),
+                        e.get("provider"),
+                        e.get("model"),
+                        e.get("title_translation"),
+                    )
+                    for e in entries
+                ],
+            )
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+
 
 async def get_cached_book(book_id: int) -> dict | None:
     """Return cached book dict (includes 'text') or None."""

--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -1928,6 +1928,88 @@ async def test_queue_delete_book_normalizes_language(admin_client, admin_db):
     assert count == 0
 
 
+# ── overwrite=true flag ───────────────────────────────────────────────────────
+
+async def test_import_translations_overwrite_replaces_stale_rows(admin_client, admin_db):
+    """overwrite=true deletes ALL rows for a (book_id, lang) pair first, so
+    stale chapters not present in the new payload are removed."""
+    await save_book(200, {**BOOK_META, "id": 200}, BOOK_TEXT)
+    # Seed three stale chapters
+    for ch in range(3):
+        await save_translation(200, ch, "zh", [f"stale-{ch}"])
+
+    resp = await admin_client.post(
+        "/api/admin/translations/import?overwrite=true",
+        json={"entries": [
+            {"book_id": 200, "chapter_index": 0, "target_language": "zh",
+             "paragraphs": ["fresh-0"]},
+            {"book_id": 200, "chapter_index": 1, "target_language": "zh",
+             "paragraphs": ["fresh-1"]},
+            # chapter 2 intentionally omitted — should be deleted
+        ]},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["imported"] == 2
+
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        async with db.execute(
+            "SELECT chapter_index, paragraphs FROM translations "
+            "WHERE book_id=200 AND target_language='zh' ORDER BY chapter_index",
+        ) as cur:
+            rows = await cur.fetchall()
+    assert len(rows) == 2
+    assert rows[0][0] == 0
+    assert json.loads(rows[0][1]) == ["fresh-0"]
+    assert rows[1][0] == 1
+    assert json.loads(rows[1][1]) == ["fresh-1"]
+
+
+async def test_import_translations_overwrite_rollback_on_duplicate(admin_client, admin_db):
+    """overwrite=true with a duplicate chapter_index in the payload triggers a
+    PRIMARY KEY violation; the transaction rolls back and original rows survive."""
+    await save_book(201, {**BOOK_META, "id": 201}, BOOK_TEXT)
+    await save_translation(201, 0, "zh", ["original"])
+
+    resp = await admin_client.post(
+        "/api/admin/translations/import?overwrite=true",
+        json={"entries": [
+            {"book_id": 201, "chapter_index": 0, "target_language": "zh",
+             "paragraphs": ["first"]},
+            {"book_id": 201, "chapter_index": 0, "target_language": "zh",
+             "paragraphs": ["duplicate — causes PK violation"]},
+        ]},
+    )
+    # Request must fail (500 or 422)
+    assert resp.status_code >= 400
+
+    # Original row must still be present (rollback)
+    from services.db import get_cached_translation
+    cached = await get_cached_translation(201, 0, "zh")
+    assert cached == ["original"]
+
+
+async def test_import_translations_overwrite_false_default_unchanged(admin_client, admin_db):
+    """overwrite=false (default) preserves existing insert-or-replace behaviour —
+    chapters not mentioned in the payload are untouched."""
+    await save_book(202, {**BOOK_META, "id": 202}, BOOK_TEXT)
+    await save_translation(202, 0, "zh", ["keep-me"])
+    await save_translation(202, 1, "zh", ["untouched"])
+
+    resp = await admin_client.post(
+        "/api/admin/translations/import",  # no ?overwrite flag
+        json={"entries": [
+            {"book_id": 202, "chapter_index": 0, "target_language": "zh",
+             "paragraphs": ["replaced"]},
+        ]},
+    )
+    assert resp.status_code == 200
+
+    from services.db import get_cached_translation
+    assert await get_cached_translation(202, 0, "zh") == ["replaced"]
+    # chapter 1 untouched — overwrite=false should not delete it
+    assert await get_cached_translation(202, 1, "zh") == ["untouched"]
+
+
 async def test_queue_retry_failed_normalizes_language(admin_client, admin_db):
     """POST /admin/queue/retry-failed with target_language='ZH-CN' must
     revive rows stored under 'zh'."""


### PR DESCRIPTION
## What changed

Adds `?overwrite=true` query param to `POST /admin/translations/import`.

- **`services/db.py`**: new `replace_translations_for_book(book_id, lang, entries)` — atomically DELETEs all rows for `(book_id, target_language)` then INSERTs the new batch in a single transaction; rolls back on any failure so original rows are preserved.
- **`routers/admin.py`**: `overwrite: bool = Query(False)` parameter; when set, groups non-empty entries by `(book_id, lang)` and calls `replace_translations_for_book` for each pair instead of per-row `save_translation`.
- **`scripts/seed_translations.py`**: `--overwrite` flag; disables chunking (sends all entries in one request) so atomicity is preserved across the entire file.

## Why

The two-step manual fix (DELETE then import) left a window where a book had zero translations. If the import partially failed, the book was left empty. This makes the operation single-step and rollback-safe. Closes #1694, unblocks #1695 (Moby Dick zh translation fix).

## Test plan

- `test_import_translations_overwrite_replaces_stale_rows` — stale chapters not in payload are deleted
- `test_import_translations_overwrite_rollback_on_duplicate` — duplicate chapter triggers PK violation → rollback, original row survives
- `test_import_translations_overwrite_false_default_unchanged` — default behavior regression check
- Full backend suite: 1906 passed
