### PR TITLE
fix: save_book UPDATE-or-INSERT to prevent ON DELETE CASCADE wipe (closes #1703)

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -512,7 +512,7 @@ async def get_cached_book(book_id: int) -> dict | None:
 
 
 async def save_book(book_id: int, meta: dict, text: str, images: list | None = None) -> None:
-    """Insert or replace a book record (meta + full text + images).
+    """Insert or update a book record (meta + full text + images).
 
     After saving, the translation queue is auto-seeded with this book's
     chapters for every configured target language. The worker (if running)
@@ -521,8 +521,7 @@ async def save_book(book_id: int, meta: dict, text: str, images: list | None = N
     async with aiosqlite.connect(DB_PATH) as db:
         # Guard against clobbering a user's uploaded private book that happens
         # to share the same auto-assigned SQLite ID as a Gutenberg catalog ID.
-        # INSERT OR REPLACE would delete the uploaded row (losing source='upload'
-        # and owner_user_id) and re-insert without those fields. (#467)
+        # (#467)
         async with db.execute(
             "SELECT source FROM books WHERE id=?", (book_id,)
         ) as _cur:
@@ -530,24 +529,35 @@ async def save_book(book_id: int, meta: dict, text: str, images: list | None = N
         if _existing and _existing[0] == "upload":
             return
 
-        await db.execute(
-            """
-            INSERT OR REPLACE INTO books
-                (id, title, authors, languages, subjects, download_count, cover, text, images)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                book_id,
-                meta.get("title", ""),
-                json.dumps(meta.get("authors", [])),
-                json.dumps(meta.get("languages", [])),
-                json.dumps(meta.get("subjects", [])),
-                meta.get("download_count", 0),
-                meta.get("cover", ""),
-                text,
-                json.dumps(images or []),
-            ),
+        params = (
+            meta.get("title", ""),
+            json.dumps(meta.get("authors", [])),
+            json.dumps(meta.get("languages", [])),
+            json.dumps(meta.get("subjects", [])),
+            meta.get("download_count", 0),
+            meta.get("cover", ""),
+            text,
+            json.dumps(images or []),
         )
+
+        if _existing:
+            # UPDATE — never DELETE+INSERT on an existing row; INSERT OR REPLACE
+            # would fire ON DELETE CASCADE and wipe translations, audio_cache,
+            # annotations, etc. (#1703)
+            await db.execute(
+                """UPDATE books
+                   SET title=?, authors=?, languages=?, subjects=?,
+                       download_count=?, cover=?, text=?, images=?
+                   WHERE id=?""",
+                (*params, book_id),
+            )
+        else:
+            await db.execute(
+                """INSERT INTO books
+                   (title, authors, languages, subjects, download_count, cover, text, images, id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (*params, book_id),
+            )
         await db.commit()
 
     # Auto-enqueue for translation. Lazy-imported to avoid a circular import

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -398,3 +398,64 @@ async def test_get_or_create_user_github_stale_return():
     assert result["role"] == "admin", (
         f"Stale return #541: expected role='admin' (post-injection DB state), got {result['role']!r}"
     )
+
+
+# ── Regression #1703: save_book must not cascade-delete translations ──────────
+
+BOOK_1703_META = {
+    "title": "Test Book",
+    "authors": ["Author"],
+    "languages": ["en"],
+    "subjects": [],
+    "download_count": 0,
+    "cover": "",
+}
+
+
+async def test_save_book_twice_preserves_translations():
+    """Regression #1703: calling save_book() on an already-cached Gutenberg book
+    must NOT delete its translations (INSERT OR REPLACE fires ON DELETE CASCADE)."""
+    await save_book(9999, BOOK_1703_META, "chapter text")
+    await save_translation(9999, 0, "zh", ["first translation"])
+
+    # Re-import the book (simulates user clicking 'import' in reader)
+    await save_book(9999, {**BOOK_1703_META, "title": "Updated Title"}, "updated text")
+
+    cached = await get_cached_translation(9999, 0, "zh")
+    assert cached == ["first translation"], (
+        "save_book() wiped translations via ON DELETE CASCADE (#1703)"
+    )
+
+
+async def test_save_book_twice_preserves_audio_cache():
+    """Regression #1703: re-importing a book must not cascade-delete audio_cache rows."""
+    import aiosqlite
+    await save_book(9998, BOOK_1703_META, "text")
+
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            "INSERT INTO audio_cache "
+            "(book_id, chapter_index, chunk_index, provider, voice, content_type, audio) "
+            "VALUES (?,0,0,'tts','en','audio/mp3',X'deadbeef')",
+            (9998,),
+        )
+        await db.commit()
+
+    await save_book(9998, BOOK_1703_META, "new text")
+
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        async with db.execute(
+            "SELECT COUNT(*) FROM audio_cache WHERE book_id=9998"
+        ) as cur:
+            (count,) = await cur.fetchone()
+    assert count == 1, "save_book() wiped audio_cache via ON DELETE CASCADE (#1703)"
+
+
+async def test_save_book_updates_metadata_on_reimport():
+    """save_book() on an existing book should still update title and text."""
+    await save_book(9997, BOOK_1703_META, "old text")
+    await save_book(9997, {**BOOK_1703_META, "title": "New Title"}, "new text")
+
+    book = await get_cached_book(9997)
+    assert book["title"] == "New Title"
+    assert book["text"] == "new text"


### PR DESCRIPTION
## What changed

`services/db.py` — `save_book()` now uses `UPDATE` for existing rows instead of `INSERT OR REPLACE`.

## Why

`INSERT OR REPLACE` silently deletes the existing row before re-inserting, which fires `ON DELETE CASCADE` on every dependent FK. With `PRAGMA foreign_keys = ON` (shipped in #700/#748), every call to `save_book()` on an already-cached book was wiping:
- `translations` (all chapters, all languages)
- `audio_cache`
- `annotations`
- any other table with `book_id ... ON DELETE CASCADE`

The trigger path is the reader "import" button → `POST /books/{id}/import-stream` → `save_book()`. Confirmed in prod: Tale of Two Cities #98 lost all 46 zh translations this way. Closes #1703.

## Fix

- `_existing` guard already existed for `source='upload'` books (#467).
- Extended: if ANY row exists, `UPDATE` the metadata/text columns instead of `REPLACE`. Only `INSERT` for genuinely new books.
- `UPDATE` does not trigger `ON DELETE CASCADE`.

## Test plan

Three regression tests added to `tests/test_db.py`:
- `test_save_book_twice_preserves_translations` — translation row survives re-import
- `test_save_book_twice_preserves_audio_cache` — audio_cache row survives re-import
- `test_save_book_updates_metadata_on_reimport` — title/text are still refreshed on re-import

Full backend suite: 1909 passed.
