### PR TITLE
fix: render and route multiple annotations per segment (closes #1707)

### DIFF
--- a/frontend/src/__tests__/SentenceReaderMultiAnnotation.test.tsx
+++ b/frontend/src/__tests__/SentenceReaderMultiAnnotation.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Regression tests for #1707:
+ *
+ *   1. Two sub-sentence annotations in the same segment must BOTH render
+ *      visibly. Pre-fix only the first match returned by Array.find rendered.
+ *   2. A click on a non-annotated word in the same segment must NOT route to
+ *      the existing annotation's onAnnotationClick (it should fall through to
+ *      the segment-click path so a new selection / new highlight can begin).
+ *   3. A click on a specific annotated span must route to THAT annotation's
+ *      onAnnotationClick, not whichever `find()` happens to return first.
+ */
+import React from "react";
+import { fireEvent, render } from "@testing-library/react";
+import SentenceReader from "@/components/SentenceReader";
+import type { Annotation } from "@/lib/api";
+
+const noop = () => {};
+
+const sentence = "It was a lonely glade beneath the silent oaks at dawn.";
+
+const annA: Annotation = {
+  id: 1,
+  book_id: 1,
+  chapter_index: 0,
+  sentence_text: "lonely glade",
+  note_text: null,
+  color: "yellow",
+};
+
+const annB: Annotation = {
+  id: 2,
+  book_id: 1,
+  chapter_index: 0,
+  sentence_text: "silent oaks",
+  note_text: null,
+  color: "blue",
+};
+
+describe("SentenceReader multi-annotation rendering (closes #1707)", () => {
+  it("renders BOTH sub-sentence annotation spans inside the same segment", () => {
+    const { container } = render(
+      <SentenceReader
+        text={sentence}
+        duration={0}
+        currentTime={0}
+        isPlaying={false}
+        onSegmentClick={noop}
+        annotations={[annA, annB]}
+      />,
+    );
+    const yellow = container.querySelector(".border-b-2.border-yellow-400");
+    const blue = container.querySelector(".border-b-2.border-blue-400");
+    expect(yellow).not.toBeNull();
+    expect(blue).not.toBeNull();
+    expect(yellow?.textContent).toBe("lonely glade");
+    expect(blue?.textContent).toBe("silent oaks");
+  });
+});
+
+describe("SentenceReader click routing with multiple annotations (closes #1707)", () => {
+  it("clicking annotation B's span dispatches onAnnotationClick with annotation B", () => {
+    const onAnn = jest.fn();
+    const { container } = render(
+      <SentenceReader
+        text={sentence}
+        duration={0}
+        currentTime={0}
+        isPlaying={false}
+        onSegmentClick={noop}
+        annotations={[annA, annB]}
+        onAnnotationClick={onAnn}
+      />,
+    );
+    const blueSpan = container.querySelector(".border-b-2.border-blue-400") as HTMLElement;
+    expect(blueSpan).not.toBeNull();
+    fireEvent.click(blueSpan, { clientX: 0, clientY: 0 });
+    expect(onAnn).toHaveBeenCalledTimes(1);
+    expect(onAnn.mock.calls[0][0]).toMatchObject({ id: 2, sentence_text: "silent oaks" });
+  });
+
+  it("clicking annotation A's span dispatches onAnnotationClick with annotation A", () => {
+    const onAnn = jest.fn();
+    const { container } = render(
+      <SentenceReader
+        text={sentence}
+        duration={0}
+        currentTime={0}
+        isPlaying={false}
+        onSegmentClick={noop}
+        annotations={[annA, annB]}
+        onAnnotationClick={onAnn}
+      />,
+    );
+    const yellowSpan = container.querySelector(".border-b-2.border-yellow-400") as HTMLElement;
+    fireEvent.click(yellowSpan, { clientX: 0, clientY: 0 });
+    expect(onAnn).toHaveBeenCalledTimes(1);
+    expect(onAnn.mock.calls[0][0]).toMatchObject({ id: 1, sentence_text: "lonely glade" });
+  });
+
+  it("clicking on the segment OUTSIDE any annotation span does NOT call onAnnotationClick", () => {
+    const onAnn = jest.fn();
+    const { container } = render(
+      <SentenceReader
+        text={sentence}
+        duration={0}
+        currentTime={0}
+        isPlaying={false}
+        onSegmentClick={noop}
+        annotations={[annA, annB]}
+        onAnnotationClick={onAnn}
+      />,
+    );
+    // Click directly on the wrapping segment span (not on any annotation child).
+    const segSpan = container.querySelector("[data-seg]") as HTMLElement;
+    expect(segSpan).not.toBeNull();
+    fireEvent.click(segSpan, { clientX: 0, clientY: 0 });
+    expect(onAnn).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -361,11 +361,11 @@ function buildSegContent(
   text: string,
   targetWord: string | undefined,
   vocabWords: Set<string> | undefined,
-  annotationMatch?: { start: number; end: number; className: string },
+  annotationMatches?: Array<{ start: number; end: number; className: string; annId: number }>,
 ): React.ReactNode {
-  if (!targetWord && !vocabWords?.size && !annotationMatch) return text;
+  if (!targetWord && !vocabWords?.size && (!annotationMatches || annotationMatches.length === 0)) return text;
 
-  type Match = { start: number; end: number; type: "target" | "vocab" | "annotation"; className?: string };
+  type Match = { start: number; end: number; type: "target" | "vocab" | "annotation"; className?: string; annId?: number };
   const matches: Match[] = [];
 
   const addMatches = (needle: string, type: Match["type"]) => {
@@ -384,8 +384,8 @@ function buildSegContent(
 
   if (targetWord) addMatches(targetWord, "target");
   vocabWords?.forEach((w) => addMatches(w, "vocab"));
-  if (annotationMatch) {
-    matches.push({ ...annotationMatch, type: "annotation" });
+  if (annotationMatches) {
+    for (const m of annotationMatches) matches.push({ ...m, type: "annotation" });
   }
 
   if (!matches.length) return text;
@@ -413,7 +413,7 @@ function buildSegContent(
       );
     } else if (m.type === "annotation") {
       nodes.push(
-        <span key={m.start} className={m.className ?? ""}>
+        <span key={m.start} className={m.className ?? ""} data-ann-id={m.annId}>
           {word}
         </span>,
       );
@@ -593,13 +593,22 @@ export default function SentenceReader({
   }, [annotations]);
 
   // Lookup with substring fallback: annotations from text-selection may store a
-  // substring of the segment text rather than the full sentence.
-  const getAnnotation = useMemo(() => {
+  // substring of the segment text rather than the full sentence. Returns ALL
+  // matching annotations (a single segment may contain multiple sub-sentence
+  // annotations — see #1707). The exact full-segment match (if any) is first.
+  const getAnnotations = useMemo(() => {
     const anns = annotations ?? [];
-    return (segText: string): Annotation | undefined => {
+    return (segText: string): Annotation[] => {
+      const out: Annotation[] = [];
       const exact = annotationMap.get(segText);
-      if (exact) return exact;
-      return anns.find((a) => a.sentence_text.length >= 10 && segText.includes(a.sentence_text));
+      if (exact) out.push(exact);
+      for (const a of anns) {
+        if (a === exact) continue;
+        if (a.sentence_text.length >= 10 && a.sentence_text !== segText && segText.includes(a.sentence_text)) {
+          out.push(a);
+        }
+      }
+      return out;
     };
   }, [annotations, annotationMap]);
 
@@ -694,26 +703,31 @@ export default function SentenceReader({
             seg.text === flashTarget ||
             (flashTarget.length >= 10 && seg.text.includes(flashTarget))
           );
-          const annotation = showAnnotations ? getAnnotation(seg.text) : undefined;
-          // Full-segment annotation underlines the whole span; sub-sentence
-          // annotations only underline the matched substring (handled inside
-          // buildSegContent via annotationMatch).
-          const isFullSegmentAnnotation = !!annotation && annotation.sentence_text === seg.text;
-          const annotationColorClass = annotation
-            ? (ANNOTATION_COLOR_CLASS[annotation.color] ?? ANNOTATION_COLOR_CLASS.yellow)
+          // All annotations whose sentence_text matches this segment (#1707).
+          // The first-matching full-segment annotation drives the wrapping span
+          // colour; every sub-sentence annotation becomes its own data-ann-id
+          // span inside buildSegContent so per-annotation clicks route correctly.
+          const segAnns = showAnnotations ? getAnnotations(seg.text) : [];
+          const fullSegmentAnnotation = segAnns.find((a) => a.sentence_text === seg.text);
+          const annotationClass = fullSegmentAnnotation
+            ? (ANNOTATION_COLOR_CLASS[fullSegmentAnnotation.color] ?? ANNOTATION_COLOR_CLASS.yellow)
             : "";
-          const annotationClass = isFullSegmentAnnotation ? annotationColorClass : "";
-          let annotationMatch: { start: number; end: number; className: string } | undefined;
-          if (annotation && !isFullSegmentAnnotation) {
-            const start = seg.text.indexOf(annotation.sentence_text);
+          const annotationMatches: Array<{ start: number; end: number; className: string; annId: number }> = [];
+          for (const a of segAnns) {
+            if (a === fullSegmentAnnotation) continue;
+            const start = seg.text.indexOf(a.sentence_text);
             if (start >= 0) {
-              annotationMatch = {
+              annotationMatches.push({
                 start,
-                end: start + annotation.sentence_text.length,
-                className: annotationColorClass,
-              };
+                end: start + a.sentence_text.length,
+                className: ANNOTATION_COLOR_CLASS[a.color] ?? ANNOTATION_COLOR_CLASS.yellow,
+                annId: a.id,
+              });
             }
           }
+          // For the existing note-dot UI keep keying off "first annotation
+          // with a note" — multi-note rendering is a separate follow-up.
+          const noteAnnotation = segAnns.find((a) => a.note_text);
           const flashClass = isJumpTarget ? "ring-2 ring-amber-400 bg-amber-50" : "";
           return (
             <span
@@ -725,10 +739,23 @@ export default function SentenceReader({
                 if (disabled || !isSegmentLoaded(seg)) return;
                 // Ignore clicks that are the tail of a text-selection drag
                 if (window.getSelection()?.toString().length) return;
-                const ann = showAnnotations ? getAnnotation(seg.text) : undefined;
-                if (ann && onAnnotationClick) {
-                  onAnnotationClick(ann, { x: e.clientX, y: e.clientY });
-                  return;
+                // Multi-annotation click routing (#1707): walk up from the
+                // event target to the nearest [data-ann-id]; a click that does
+                // not land on any annotation span falls through to the
+                // segment-click path so a fresh selection can begin.
+                if (showAnnotations && onAnnotationClick) {
+                  const annHost = (e.target as HTMLElement | null)?.closest?.("[data-ann-id]") as HTMLElement | null;
+                  if (annHost) {
+                    const id = Number(annHost.getAttribute("data-ann-id"));
+                    const ann = (annotations ?? []).find((a) => a.id === id);
+                    if (ann) {
+                      onAnnotationClick(ann, { x: e.clientX, y: e.clientY });
+                      return;
+                    }
+                  } else if (fullSegmentAnnotation) {
+                    onAnnotationClick(fullSegmentAnnotation, { x: e.clientX, y: e.clientY });
+                    return;
+                  }
                 }
                 if (isPlaying || duration > 0) {
                   onSegmentClick(seg.startTime, seg.text);
@@ -740,15 +767,15 @@ export default function SentenceReader({
               onPointerMove={onWordTap ? handlePointerMove : undefined}
               className={`rounded px-0.5 -mx-0.5 transition-colors duration-200 ${segClass(seg)} ${annotationClass} ${flashClass} ${extraClass}`}
             >
-              {buildSegContent(seg.text, isJumpTarget ? scrollTargetWord : undefined, vocabWords, annotationMatch)}
-              {annotation?.note_text && (
+              {buildSegContent(seg.text, isJumpTarget ? scrollTargetWord : undefined, vocabWords, annotationMatches)}
+              {noteAnnotation?.note_text && (
                 <button
                   onClick={(e) => { e.stopPropagation(); setExpandedNoteFlatIdx((prev) => prev === seg.flatIdx ? null : seg.flatIdx); }}
                   className="inline-flex items-center justify-center ml-0.5 align-middle cursor-pointer min-h-[44px] min-w-[44px] -m-[19px] p-[19px]"
                   aria-label={`Toggle note for: ${seg.text.slice(0, 60)}`}
                   aria-expanded={expandedNoteFlatIdx === seg.flatIdx}
                 >
-                  <span className={`inline-block w-1.5 h-1.5 rounded-full ${NOTE_DOT_CLASS[annotation.color] ?? NOTE_DOT_CLASS.yellow}`} />
+                  <span className={`inline-block w-1.5 h-1.5 rounded-full ${NOTE_DOT_CLASS[noteAnnotation.color] ?? NOTE_DOT_CLASS.yellow}`} />
                 </button>
               )}
               {trailingSpace ? " " : ""}
@@ -778,9 +805,14 @@ export default function SentenceReader({
           );
         }
 
-        // Expanded note card for any annotated sentence in this paragraph
+        // Expanded note card for any annotated sentence in this paragraph.
+        // With multi-annotation support (#1707), pick the first annotation
+        // with a note on the expanded segment.
         const expandedAnn = expandedNoteFlatIdx !== null
-          ? (para.segments.map((s) => s.flatIdx === expandedNoteFlatIdx ? getAnnotation(s.text) : null).find((a) => a != null) ?? null)
+          ? (para.segments
+              .filter((s) => s.flatIdx === expandedNoteFlatIdx)
+              .flatMap((s) => getAnnotations(s.text))
+              .find((a) => a.note_text) ?? null)
           : null;
         const noteCard = expandedAnn?.note_text ? (
           <div className={`mt-1.5 text-xs rounded px-2.5 py-1.5 border ${NOTE_CARD_CLASS[expandedAnn.color] ?? NOTE_CARD_CLASS.yellow}`}>


### PR DESCRIPTION
## What

Fixes two related interaction bugs on the reader's per-sentence annotation surface.

1. **Second sub-sentence highlight in the same segment silently failed to render.** The lookup used `Array.find()` and returned only one annotation per segment; only its substring became a highlight span.

2. **A click anywhere on a segment that had any annotation routed to that single matched annotation's `onAnnotationClick`** — so clicking word C in a sentence that already had word A highlighted opened word A's action drawer, not a fresh path for word C.

## Why

Reported in #1707 as "highlight feature is effectively single-shot per sentence, which makes book annotation almost unusable." The single-annotation lookup was a shortcut from earlier work and wasn't extended when sub-sentence highlights landed.

## How

- `getAnnotation` (single) → `getAnnotations` (array). All matching annotations on a segment are returned; the full-segment match (if any) is first.
- Build an `annotationMatches` array of `{ start, end, className, annId }` for every sub-sentence annotation and pass it through `buildSegContent`. Each rendered annotation span gets a `data-ann-id` attribute.
- The segment `onClick` handler now walks up via `closest("[data-ann-id]")` to identify the clicked annotation (or falls through to seek-to-time if the click landed on plain text). Full-segment annotations still trigger via the wrapper-span click as before.
- Note-dot renders for the first annotation with a note on a segment. Multi-note dot rendering is intentionally left for a follow-up — collapsing N dots into a sensible visual is a design call, not a bug fix.

## Test plan

- [x] New `frontend/src/__tests__/SentenceReaderMultiAnnotation.test.tsx` — 4 tests:
  1. Two sub-sentence annotations both render visibly with their respective colour classes.
  2. Click on annotation A's span → `onAnnotationClick(annA, …)`.
  3. Click on annotation B's span → `onAnnotationClick(annB, …)`.
  4. Click on the segment outside any annotation span → `onAnnotationClick` NOT called (falls through).
- [x] Existing `SentenceReaderPartialHighlight.test.tsx` (single sub-sentence + single full-segment) still passes — the new array path is a strict superset of the old single-match path.
- [x] Full frontend suite: 2568/2568 passing (was 2564).
- [x] Full backend suite: 1382/1382 passing.

Closes #1707
