### PR TITLE
test: regression test for confirmed-upload FALSE branch in admin queue_enqueue_book (closes #1709)

### DIFF
--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -1422,6 +1422,36 @@ async def test_enqueue_draft_book_returns_400(admin_client, admin_db):
     assert "draft" in res.json()["detail"].lower() or "confirm" in res.json()["detail"].lower()
 
 
+@pytest.mark.asyncio
+async def test_enqueue_confirmed_upload_book_proceeds(admin_client, admin_db):
+    """Regression #1709: confirmed upload book (no draft chapters) must pass the
+    draft guard in POST /admin/queue/enqueue-book and return 200.
+    Covers FALSE branch admin.py 1244->1249."""
+    import aiosqlite
+    async with aiosqlite.connect(admin_db) as db:
+        cur = await db.execute(
+            """INSERT INTO books (title, authors, languages, subjects, download_count,
+                                  cover, text, images, source, owner_user_id)
+               VALUES ('Confirmed Upload', '[]', '["en"]', '[]', 0, '', '', '[]', 'upload', 1)"""
+        )
+        book_id = cur.lastrowid
+        await db.execute(
+            "INSERT INTO user_book_chapters (book_id, chapter_index, title, text, is_draft) "
+            "VALUES (?, 0, 'Chapter 1', ?, 0)",
+            (book_id, "word " * 200),
+        )
+        await db.commit()
+
+    res = await admin_client.post("/api/admin/queue/enqueue-book", json={
+        "book_id": book_id,
+        "target_languages": ["de"],
+    })
+    assert res.status_code == 200
+    data = res.json()
+    assert data.get("ok") is True
+    assert data.get("enqueued", -1) >= 0
+
+
 # ── Retry-failed bulk endpoint ───────────────────────────────────────────────
 
 async def _seed_failed(book_id: int, chapter_index: int, target_language: str):


### PR DESCRIPTION
## What changed
Added `test_enqueue_confirmed_upload_book_proceeds` to `test_router_admin.py`.

## Why
`POST /admin/queue/enqueue-book` has a draft-upload guard (admin.py line 1244):
```python
if book.get("source") == "upload":
    if await count_draft_user_book_chapters(req.book_id) > 0:
        raise HTTPException(status_code=400, ...)  # TRUE: tested
# FALSE branch 1244->1249: confirmed upload proceeds — was never tested
added = await enqueue_for_book(...)
```
The TRUE branch (draft book → 400) was covered by `test_enqueue_draft_book_returns_400`. The FALSE branch — a confirmed upload book (no draft chapters) proceeding past the guard to enqueue successfully — had no test. Same coverage gap as #1706 (fixed for `routers/books.py`).

## Test plan
- New test creates an upload book with a confirmed chapter (`is_draft=0`), calls the endpoint, and asserts `200 ok=True`
- All 1910 backend tests pass (1909 base + 1 new test; 3 from #1708 not yet on main at test time)

Closes #1709
