### PR TITLE
test: regression for move_translation 404 when book not in cache (closes #1719)

### DIFF
--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -1785,6 +1785,20 @@ async def test_move_translation_404_when_source_missing(admin_client, admin_db):
     assert res.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_move_translation_404_when_book_not_in_cache(admin_client, admin_db):
+    """Regression #1719: move must return 404 when the book itself doesn't
+    exist in the cache — distinct from the 404 when only the source
+    translation is missing.
+    Covers admin.py line ~842 (raise HTTPException 404 'Book not found in cache')."""
+    res = await admin_client.post(
+        "/api/admin/translations/99999/0/de/move",
+        json={"new_chapter_index": 1},
+    )
+    assert res.status_code == 404
+    assert "Book not found" in res.json()["detail"]
+
+
 async def test_move_translation_clears_queue_at_destination(admin_client, admin_db):
     """If a queue row exists at the destination (pending/failed/whatever),
     it would later cause the worker to translate over the moved row.


### PR DESCRIPTION
## What

Adds a regression test for `move_translation` when the `book_id` doesn't exist in the books cache. The endpoint returns 404 with "Book not found in cache" at `admin.py` line ~842 — this path had no test coverage.

## Why

The existing `test_move_translation_404_when_source_missing` only covers the case where the book exists but the source chapter translation is missing. The earlier 404 guard (book not in cache at all) was completely untested, leaving a regression risk if the book-lookup logic changes.

## Test plan

- `test_move_translation_404_when_book_not_in_cache`: calls `POST /api/admin/translations/99999/0/de/move` with no book seeded; asserts 404 with "Book not found" in detail
- Full backend suite: 1917 passed

Closes #1719
