### PR TITLE
test: regression for _find_connected_books word deduplication (closes #1721)

### DIFF
--- a/backend/tests/test_router_vocabulary.py
+++ b/backend/tests/test_router_vocabulary.py
@@ -1116,3 +1116,40 @@ async def test_export_obsidian_corrupt_github_token_returns_400(client, test_use
         f"got {resp.status_code}: {resp.text}"
     )
     assert "decrypted" in resp.json()["detail"].lower() or "decrypt" in resp.json()["detail"].lower()
+
+
+# ── Issue #1721: _find_connected_books deduplication ──────────────────────────
+
+
+def test_find_connected_books_deduplicates_shared_word():
+    """Regression #1721: _find_connected_books must count a word only once per
+    foreign book even if that word appears in multiple chapters of the foreign book.
+
+    Covers vocabulary.py line 390 — the FALSE branch of
+    `if word not in book_words[bid]["shared_words"]:` (deduplication guard).
+
+    Without the guard a word appearing in 3 chapters would be counted 3 times,
+    potentially inflating the shared-words count and producing false positives."""
+    from routers.vocabulary import _find_connected_books
+
+    BOOK_A = 1
+    BOOK_B = 2
+
+    all_vocab = [
+        {
+            "word": "whale",
+            "occurrences": [
+                {"book_id": BOOK_A, "chapter_index": 0, "sentence_text": "A whale.", "book_title": "Book A"},
+                # same word appears in TWO chapters of Book B — must be counted once
+                {"book_id": BOOK_B, "chapter_index": 0, "sentence_text": "The whale breached.", "book_title": "Book B"},
+                {"book_id": BOOK_B, "chapter_index": 1, "sentence_text": "Another whale sighting.", "book_title": "Book B"},
+            ],
+        },
+    ]
+
+    connected = _find_connected_books(BOOK_A, all_vocab, min_shared=1)
+
+    assert len(connected) == 1, f"Expected 1 connected book, got {len(connected)}: {connected}"
+    assert connected[0]["shared_words"] == ["whale"], (
+        f"Expected ['whale'] once (deduplicated), got: {connected[0]['shared_words']}"
+    )


### PR DESCRIPTION
## What

Adds a unit regression test for the `_find_connected_books` helper in `routers/vocabulary.py`. The function deduplicates shared words per foreign book (line 390: `if word not in book_words[bid]["shared_words"]:`). The FALSE branch of this check — reached when the same word appears in multiple chapters of the same foreign book — had no test coverage.

## Why

Without this deduplication guard, a vocabulary word that appears in N chapters of a foreign book would be added N times to the `shared_words` list. This would incorrectly inflate the shared-word count and cause false positives in the "connected books" feature (books sharing fewer words than the threshold would appear as connected). The guard already exists and works correctly — this PR adds the regression test to ensure it stays correct.

## Test plan

- `test_find_connected_books_deduplicates_shared_word`: seeds the word "whale" in book A (ch0) and in book B at TWO chapters (ch0 + ch1); asserts `shared_words == ["whale"]` (not `["whale", "whale"]`)
- Full backend suite: 1918 passed

Closes #1721
