### PR TITLE
test: regression for GET /admin/books queue status counts (closes #1729)

### DIFF
--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -445,6 +445,19 @@ async def test_get_books_includes_translation_counts(admin_client, admin_db):
     assert book["translations"] == {"en": 2, "zh": 1}
 
 
+async def test_get_books_includes_queue_counts(admin_client, admin_db):
+    """Regression #1729: GET /admin/books must include queue status counts per language."""
+    from services.translation_queue import enqueue
+    await save_book(100, BOOK_META, BOOK_TEXT)
+    await enqueue(100, 0, "de")
+    await enqueue(100, 1, "de")
+
+    res = await admin_client.get("/api/admin/books")
+    assert res.status_code == 200
+    book = next(b for b in res.json() if b["id"] == 100)
+    assert book["queue"] == {"de": {"pending": 2}}
+
+
 async def test_delete_book(admin_client, admin_db):
     await save_book(100, BOOK_META, BOOK_TEXT)
     res = await admin_client.delete("/api/admin/books/100")


### PR DESCRIPTION
## What

Adds a regression test for `GET /api/admin/books` covering the queue-aggregation loop body at line 162 of `admin.py`.

## Why

Coverage showed `queue_by_book.setdefault(book_id, {}).setdefault(lang, {})[status] = n` (line 162) was never executed in tests — existing tests (`test_get_books`, `test_get_books_includes_translation_counts`) both call the endpoint with an empty `translation_queue` table, so the loop body is never reached.

## Test plan

- `test_get_books_includes_queue_counts`: enqueues 2 "pending" chapters for language "de", calls `GET /api/admin/books`, asserts `queue == {"de": {"pending": 2}}`
- Full backend suite: 1922 passed
- Full frontend suite: 1750 passed

Closes #1729
