### PR TITLE
test: regression for GET /admin/books active/active_language fields (closes #1731)

### DIFF
--- a/backend/tests/test_router_admin.py
+++ b/backend/tests/test_router_admin.py
@@ -458,6 +458,29 @@ async def test_get_books_includes_queue_counts(admin_client, admin_db):
     assert book["queue"] == {"de": {"pending": 2}}
 
 
+async def test_get_books_shows_active_when_worker_translating(admin_client, admin_db):
+    """Regression #1731: GET /admin/books active/active_language fields must reflect
+    the worker's current_book_id when a translation job is in progress."""
+    from services.translation_queue import worker as queue_worker
+    await save_book(100, BOOK_META, BOOK_TEXT)
+
+    state = queue_worker().state()
+    orig_book_id = state.current_book_id
+    orig_lang = state.current_target_language
+    try:
+        state.current_book_id = 100
+        state.current_target_language = "zh"
+
+        res = await admin_client.get("/api/admin/books")
+        assert res.status_code == 200
+        book = next(b for b in res.json() if b["id"] == 100)
+        assert book["active"] is True
+        assert book["active_language"] == "zh"
+    finally:
+        state.current_book_id = orig_book_id
+        state.current_target_language = orig_lang
+
+
 async def test_delete_book(admin_client, admin_db):
     await save_book(100, BOOK_META, BOOK_TEXT)
     res = await admin_client.delete("/api/admin/books/100")


### PR DESCRIPTION
## What

Adds a regression test for `GET /api/admin/books` covering the worker-state `current_book_id` branch at lines 169-172 of `admin.py`, which populates the `active` and `active_language` fields in the response.

## Why

Coverage showed lines 169-172 were never reached in tests — in all existing tests the translation queue worker singleton has `current_book_id=None`, so the `active`/`active_language` UI fields are always `False`/`null`. There was no test verifying the "working now" glow fields are populated when the worker is actively translating.

## Test plan

- `test_get_books_shows_active_when_worker_translating`: directly sets `worker().state().current_book_id = 100` and `current_target_language = "zh"`, calls `GET /api/admin/books`, asserts `active=True` and `active_language="zh"` for book 100. Restores state in a `finally` block.
- Full backend suite: 1923 passed
- Full frontend suite: 1750 passed

Closes #1731
