### PR TITLE
fix: require Gemini key for enqueue_all_chapters, consistent with single-chapter endpoint

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -391,6 +391,18 @@ async def enqueue_all_chapters(
             detail="Cannot translate to the same language as the original.",
         )
 
+    # Require user's own Gemini key — do not drain the admin queue key.
+    raw_key = user.get("gemini_key")
+    try:
+        decrypted_key = decrypt_api_key(raw_key) if raw_key else None
+    except HTTPException:
+        decrypted_key = None
+    if not decrypted_key:
+        raise HTTPException(
+            status_code=403,
+            detail="A Gemini API key is required to translate chapters. Please add one in your profile settings.",
+        )
+
     from services.translation_queue import enqueue_for_book, worker
 
     queued_by = user.get("email") or user.get("name") or f"user#{user.get('id')}"

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -335,12 +335,15 @@ async def test_retry_chapter_translation_revives_failed_row(client):
     assert row["priority"] == 10
 
 
-async def test_enqueue_all_chapters_for_user(client):
+async def test_enqueue_all_chapters_for_user(client, test_user):
     """POST /books/{id}/translations/enqueue-all queues every not-yet-
     translated chapter of the book in the requested language at
     priority=20 (between admin per-book 50 and reader on-demand 10)."""
     import aiosqlite
     import services.db as db_module
+    from services.db import set_user_gemini_key
+    from services.auth import encrypt_api_key
+    await set_user_gemini_key(test_user["id"], encrypt_api_key("my-key"))
     # Long enough text to split into 2 chapters under the plain-text splitter.
     text = (
         "CHAPTER I\n\n" + ("First chapter word. " * 40) + "\n\n"
@@ -713,6 +716,20 @@ async def test_enqueue_all_same_language_returns_400(client):
         json={"target_language": "en"},
     )
     assert resp.status_code == 400
+
+
+async def test_enqueue_all_requires_gemini_key(client):
+    """Regression #1733: POST /books/{id}/translations/enqueue-all must return 403
+    when the authenticated user has no Gemini key, consistent with the single-chapter
+    endpoint which has the same guard."""
+    en_meta = {**MOCK_META, "id": 7003}
+    await save_book(7003, en_meta, "Chapter I\n\nSome text here.")
+    resp = await client.post(
+        "/api/books/7003/translations/enqueue-all",
+        json={"target_language": "de"},
+    )
+    assert resp.status_code == 403, f"Expected 403 for user without Gemini key, got {resp.status_code}: {resp.text}"
+    assert "Gemini" in resp.json()["detail"]
 
 
 async def test_chapter_translation_corrupted_gemini_key_returns_403(client, test_user):
@@ -1823,6 +1840,9 @@ async def test_enqueue_all_succeeds_for_confirmed_upload(
     """Regression #1706: POST /books/{id}/translations/enqueue-all on a fully
     confirmed upload book must proceed past the draft guard (line 382->387).
     At least one chapter should be enqueued."""
+    from services.db import set_user_gemini_key
+    from services.auth import encrypt_api_key
+    await set_user_gemini_key(test_user["id"], encrypt_api_key("my-key"))
     await insert_private_book(book_id=9871, owner_user_id=test_user["id"])
 
     resp = await client.post(


### PR DESCRIPTION
## Summary

- `POST /books/{id}/translations/enqueue-all` lacked the Gemini API key guard that `POST /books/{id}/chapters/{n}/translation` has — any authenticated user could queue all chapters using the admin's queue key
- Added the same "require user's own Gemini key" check to `enqueue_all_chapters` (books.py ~line 393)
- Updated `test_enqueue_all_chapters_for_user` and `test_enqueue_all_succeeds_for_confirmed_upload` to set a Gemini key (these tests tested the happy path, which now requires a key)

## Why

The single-chapter endpoint comment reads: _"Require user's own Gemini key — do not drain the admin queue key."_ The bulk-enqueue endpoint had no such guard, so a user without a key could queue 50+ chapters while a user requesting a single chapter got a 403.

## Test plan

- [x] `test_enqueue_all_requires_gemini_key` — new regression: 403 without Gemini key
- [x] `test_enqueue_all_chapters_for_user` — updated to provide Gemini key; passes
- [x] `test_enqueue_all_succeeds_for_confirmed_upload` — updated to provide Gemini key; passes
- [x] All other `enqueue_all_*` tests pass (non-existent book → 404, same language → 400, draft upload → 400, non-owner → 403)
- [x] 1924 backend tests pass, 1750 frontend tests pass

Closes #1733

🤖 Generated with [Claude Code](https://claude.com/claude-code)
