### PR TITLE
fix: restore long-press annotation and fix TTS page-scroll (#1735, #1736)

### DIFF
--- a/frontend/src/__tests__/SentenceReader.annotation1735.test.tsx
+++ b/frontend/src/__tests__/SentenceReader.annotation1735.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Regression #1735: long-press annotation broken after PR #782 removed onAnnotate.
+ * Verifies that:
+ *   - onAnnotate is called on a 500ms long-press when onWordTap is NOT provided
+ *   - onAnnotate is NOT called when the press is shorter than 500ms
+ *   - onAnnotate is NOT called when neither onWordTap nor onAnnotate is provided
+ */
+
+import React from "react";
+import { render, act } from "@testing-library/react";
+import SentenceReader from "@/components/SentenceReader";
+
+const noop = () => {};
+
+function dispatchPointerEvent(
+  el: HTMLElement,
+  type: "pointerdown" | "pointermove" | "pointerup" | "pointercancel",
+  coords: { clientX: number; clientY: number } = { clientX: 0, clientY: 0 },
+) {
+  const event = new MouseEvent(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "clientX", { value: coords.clientX });
+  Object.defineProperty(event, "clientY", { value: coords.clientY });
+  el.dispatchEvent(event);
+}
+
+describe("SentenceReader — onAnnotate regression #1735", () => {
+  afterEach(() => jest.useRealTimers());
+
+  it("calls onAnnotate with sentence text after 500ms long-press when onWordTap is not provided", () => {
+    jest.useFakeTimers();
+    const onAnnotate = jest.fn();
+    const { container } = render(
+      <SentenceReader
+        text="Here is a sentence for annotation."
+        duration={0}
+        currentTime={0}
+        isPlaying={false}
+        onSegmentClick={noop}
+        onAnnotate={onAnnotate}
+        chapterIndex={2}
+      />
+    );
+
+    const segs = Array.from(container.querySelectorAll("[data-seg]")) as HTMLElement[];
+    expect(segs.length).toBeGreaterThan(0);
+
+    dispatchPointerEvent(segs[0], "pointerdown", { clientX: 10, clientY: 10 });
+    expect(onAnnotate).not.toHaveBeenCalled();
+
+    act(() => { jest.advanceTimersByTime(500); });
+    expect(onAnnotate).toHaveBeenCalledTimes(1);
+    expect(onAnnotate).toHaveBeenCalledWith(
+      "Here is a sentence for annotation.",
+      2,
+    );
+  });
+
+  it("does not call onAnnotate when press is released before 500ms", () => {
+    jest.useFakeTimers();
+    const onAnnotate = jest.fn();
+    const { container } = render(
+      <SentenceReader
+        text="Short press should not annotate."
+        duration={0}
+        currentTime={0}
+        isPlaying={false}
+        onSegmentClick={noop}
+        onAnnotate={onAnnotate}
+        chapterIndex={0}
+      />
+    );
+
+    const segs = Array.from(container.querySelectorAll("[data-seg]")) as HTMLElement[];
+    dispatchPointerEvent(segs[0], "pointerdown", { clientX: 10, clientY: 10 });
+    act(() => { jest.advanceTimersByTime(200); });
+    dispatchPointerEvent(segs[0], "pointerup", { clientX: 10, clientY: 10 });
+    act(() => { jest.advanceTimersByTime(400); });
+
+    expect(onAnnotate).not.toHaveBeenCalled();
+  });
+
+  it("does not call onAnnotate when neither onAnnotate nor onWordTap is provided (segment has no pointer handler)", () => {
+    jest.useFakeTimers();
+    const { container } = render(
+      <SentenceReader
+        text="No handler sentence."
+        duration={0}
+        currentTime={0}
+        isPlaying={false}
+        onSegmentClick={noop}
+      />
+    );
+
+    const segs = Array.from(container.querySelectorAll("[data-seg]")) as HTMLElement[];
+    dispatchPointerEvent(segs[0], "pointerdown", { clientX: 10, clientY: 10 });
+    act(() => { jest.advanceTimersByTime(600); });
+    // Just verifies no crash
+    expect(segs.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/__tests__/SentenceReader.scroll1736.test.tsx
+++ b/frontend/src/__tests__/SentenceReader.scroll1736.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Regression #1736: TTS auto-scroll calls scrollIntoView on the body instead
+ * of scrolling only #reader-scroll, causing the whole page to scroll upward.
+ *
+ * Fix: when #reader-scroll exists, use container.scrollTo() directly.
+ * scrollIntoView() is only used as a fallback when the container is absent.
+ */
+
+import React from "react";
+import { render, act } from "@testing-library/react";
+import SentenceReader from "@/components/SentenceReader";
+
+const noop = () => {};
+
+describe("SentenceReader — TTS auto-scroll uses #reader-scroll container (#1736)", () => {
+  let scrollTo: jest.Mock;
+  let readerEl: HTMLDivElement;
+
+  beforeEach(() => {
+    scrollTo = jest.fn();
+    readerEl = document.createElement("div");
+    readerEl.id = "reader-scroll";
+    // Mock getBoundingClientRect on the container
+    readerEl.getBoundingClientRect = jest.fn().mockReturnValue({
+      top: 0, bottom: 500, height: 500, left: 0, right: 800, width: 800,
+      x: 0, y: 0, toJSON: () => ({}),
+    } as DOMRect);
+    Object.defineProperty(readerEl, "scrollTop", { writable: true, value: 0 });
+    readerEl.scrollTo = scrollTo;
+    document.body.appendChild(readerEl);
+  });
+
+  afterEach(() => {
+    readerEl.remove();
+    jest.restoreAllMocks();
+  });
+
+  it("calls container.scrollTo (not scrollIntoView) when active segment is out of view", () => {
+    const scrollIntoViewMock = jest.fn();
+
+    // Render with no audio initially
+    const { rerender } = render(
+      <SentenceReader
+        text="First sentence here. Second sentence here."
+        duration={10}
+        currentTime={0}
+        isPlaying={false}
+        onSegmentClick={noop}
+      />
+    );
+
+    // Mock scrollIntoView on all elements
+    document.querySelectorAll("[data-seg]").forEach((el) => {
+      (el as HTMLElement).scrollIntoView = scrollIntoViewMock;
+      // Make the element appear out of view (below the container)
+      (el as HTMLElement).getBoundingClientRect = jest.fn().mockReturnValue({
+        top: 600, bottom: 620, height: 20, left: 0, right: 200, width: 200,
+        x: 0, y: 600, toJSON: () => ({}),
+      } as DOMRect);
+    });
+
+    // Start playing — active segment should scroll into view
+    act(() => {
+      rerender(
+        <SentenceReader
+          text="First sentence here. Second sentence here."
+          duration={10}
+          currentTime={0.1}
+          isPlaying={true}
+          onSegmentClick={noop}
+        />
+      );
+    });
+
+    // container.scrollTo should be called, not scrollIntoView
+    expect(scrollTo).toHaveBeenCalled();
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call container.scrollTo when active segment is already in view", () => {
+    const { rerender } = render(
+      <SentenceReader
+        text="Visible sentence in view."
+        duration={10}
+        currentTime={0}
+        isPlaying={false}
+        onSegmentClick={noop}
+      />
+    );
+
+    // Make element appear within the container bounds (relTop=100, relBottom=120, containerHeight=500)
+    document.querySelectorAll("[data-seg]").forEach((el) => {
+      (el as HTMLElement).getBoundingClientRect = jest.fn().mockReturnValue({
+        top: 100, bottom: 120, height: 20, left: 0, right: 200, width: 200,
+        x: 0, y: 100, toJSON: () => ({}),
+      } as DOMRect);
+    });
+
+    act(() => {
+      rerender(
+        <SentenceReader
+          text="Visible sentence in view."
+          duration={10}
+          currentTime={0.1}
+          isPlaying={true}
+          onSegmentClick={noop}
+        />
+      );
+    });
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1404,6 +1404,9 @@ export default function ReaderPage() {
                   onSegmentClick={(startTime) => {
                     ttsSeekRef.current(startTime);
                   }}
+                  onAnnotate={session?.backendToken ? (text, ci) => {
+                    setAnnotationPanel({ sentenceText: text, chapterIndex: ci });
+                  } : undefined}
                   focusParagraphIdx={paragraphFocus ? focusParagraphIdx : undefined}
                   paragraphFocusEnabled={paragraphFocus}
                   onParagraphVisible={handleParagraphVisible}

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -317,6 +317,11 @@ interface Props {
     chapterIndex: number;
     translationText?: string;
   }) => void;
+  /**
+   * Called on a 500ms long-press when onWordTap is not provided.
+   * Opens the note/highlight editor for the pressed sentence.
+   */
+  onAnnotate?: (sentenceText: string, chapterIndex: number) => void;
   /** When false, annotation underlines and note dots are hidden. Default true. */
   showAnnotations?: boolean;
   /** Word to highlight (amber pulse) inside the flash-target sentence. */
@@ -446,6 +451,7 @@ export default function SentenceReader({
   annotations,
   scrollTargetSentence,
   onWordTap,
+  onAnnotate,
   showAnnotations = true,
   scrollTargetWord,
   vocabWords,
@@ -500,11 +506,27 @@ export default function SentenceReader({
     return best;
   }, [allSegments, currentTime, duration]);
 
-  // Auto-scroll active segment into view
+  // Auto-scroll active segment into view — scroll only #reader-scroll, not the window.
+  // scrollIntoView() on iOS Safari scrolls multiple ancestors including the body,
+  // which causes the whole page to jump upward (#1736). Use container.scrollTo() directly.
   const activeRef = useRef<HTMLElement | null>(null);
   useEffect(() => {
-    if (currentIdx >= 0 && isPlaying) {
-      activeRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    if (currentIdx < 0 || !isPlaying || !activeRef.current) return;
+    const el = activeRef.current;
+    const container = document.getElementById("reader-scroll");
+    if (!container) {
+      el.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      return;
+    }
+    const containerRect = container.getBoundingClientRect();
+    const elRect = el.getBoundingClientRect();
+    const relTop = elRect.top - containerRect.top;
+    const relBottom = elRect.bottom - containerRect.top;
+    if (relTop < 0 || relBottom > containerRect.height) {
+      container.scrollTo({
+        top: container.scrollTop + relTop - containerRect.height / 3,
+        behavior: "smooth",
+      });
     }
   }, [currentIdx, isPlaying]);
 
@@ -652,7 +674,7 @@ export default function SentenceReader({
             : "text-stone-500";
         };
 
-        // Long press (500ms) → open word action drawer.
+        // Long press (500ms) → open word action drawer or annotation panel.
         // Note: we intentionally do NOT preventDefault() on touch pointerdown.
         // Suppressing the native selection loupe also blocks sub-sentence
         // drag-selection on mobile (see #364). Motion-based disambiguation
@@ -661,7 +683,7 @@ export default function SentenceReader({
         // the drawer; if the loupe briefly appears before the timer fires,
         // removeAllRanges() inside the timer clears it.
         const handleSegLongPress = (e: React.PointerEvent, seg: Segment) => {
-          if (!onWordTap) return;
+          if (!onWordTap && !onAnnotate) return;
           const startX = e.clientX;
           const startY = e.clientY;
           longPressStartPos.current = { x: startX, y: startY };
@@ -670,29 +692,33 @@ export default function SentenceReader({
             // Prevent text selection
             window.getSelection()?.removeAllRanges();
 
-            // Extract word at press position
-            let word = "";
-            if ("caretRangeFromPoint" in document) {
-              const range = (document as any).caretRangeFromPoint(startX, startY);
-              if (range) { range.expand("word"); word = range.toString().trim(); }
-            }
-            if (!word) {
-              word = seg.text.split(/\s+/).reduce((a: string, b: string) => (b.length > a.length ? b : a), "");
-            }
-            word = word.replace(/^[^a-zA-Z\u00C0-\u024F\u0400-\u04FF]+/, "")
-                       .replace(/[^a-zA-Z\u00C0-\u024F\u0400-\u04FF]+$/, "");
-            if (!word || word.length < 2) word = seg.text.split(/\s+/)[0] ?? "";
-
             // Haptic feedback
             if (navigator.vibrate) navigator.vibrate(10);
 
-            onWordTap({
-              word,
-              sentenceText: seg.text,
-              startTime: seg.startTime,
-              chapterIndex,
-              translationText: translationText || undefined,
-            });
+            if (onWordTap) {
+              // Extract word at press position
+              let word = "";
+              if ("caretRangeFromPoint" in document) {
+                const range = (document as any).caretRangeFromPoint(startX, startY);
+                if (range) { range.expand("word"); word = range.toString().trim(); }
+              }
+              if (!word) {
+                word = seg.text.split(/\s+/).reduce((a: string, b: string) => (b.length > a.length ? b : a), "");
+              }
+              word = word.replace(/^[^a-zA-Z\u00C0-\u024F\u0400-\u04FF]+/, "")
+                         .replace(/[^a-zA-Z\u00C0-\u024F\u0400-\u04FF]+$/, "");
+              if (!word || word.length < 2) word = seg.text.split(/\s+/)[0] ?? "";
+
+              onWordTap({
+                word,
+                sentenceText: seg.text,
+                startTime: seg.startTime,
+                chapterIndex,
+                translationText: translationText || undefined,
+              });
+            } else if (onAnnotate) {
+              onAnnotate(seg.text, chapterIndex);
+            }
           }, 500);
         };
 
@@ -761,10 +787,10 @@ export default function SentenceReader({
                   onSegmentClick(seg.startTime, seg.text);
                 }
               }}
-              onPointerDown={onWordTap ? (e) => handleSegLongPress(e, seg) : undefined}
-              onPointerUp={onWordTap ? cancelLongPress : undefined}
-              onPointerCancel={onWordTap ? cancelLongPress : undefined}
-              onPointerMove={onWordTap ? handlePointerMove : undefined}
+              onPointerDown={(onWordTap || onAnnotate) ? (e) => handleSegLongPress(e, seg) : undefined}
+              onPointerUp={(onWordTap || onAnnotate) ? cancelLongPress : undefined}
+              onPointerCancel={(onWordTap || onAnnotate) ? cancelLongPress : undefined}
+              onPointerMove={(onWordTap || onAnnotate) ? handlePointerMove : undefined}
               className={`rounded px-0.5 -mx-0.5 transition-colors duration-200 ${segClass(seg)} ${annotationClass} ${flashClass} ${extraClass}`}
             >
               {buildSegContent(seg.text, isJumpTarget ? scrollTargetWord : undefined, vocabWords, annotationMatches)}


### PR DESCRIPTION
## What changed

- **Restored `onAnnotate` prop in `SentenceReader`** (closes #1735): PR #782 removed `onAnnotate` and made pointer-down handlers conditional on `onWordTap` being provided. Since the reader page doesn't use `onWordTap`, all segment pointer handlers were `undefined`, silently breaking the long-press annotation flow on mobile. `onAnnotate` is restored as a fallback: 500ms long-press calls `onAnnotate(sentenceText, chapterIndex)` when `onWordTap` is absent. Pointer event handlers are now bound when either `onWordTap` or `onAnnotate` is provided.

- **Fixed TTS auto-scroll scrolling the whole page** (closes #1736): `scrollIntoView()` on iOS Safari scrolls multiple scrollable ancestors including the window body, causing the whole page to jump upward during TTS playback. Replaced with `container.scrollTo()` directly on `#reader-scroll`. Falls back to `scrollIntoView` only when the container is not found.

- **Wired `onAnnotate` in reader page**: passes `setAnnotationPanel` for logged-in users, opening the centered modal note editor on long-press.

## Test plan

- `SentenceReader.annotation1735.test.tsx`: 500ms long-press calls `onAnnotate`; short press does not; no-handler case is still a no-op.
- `SentenceReader.scroll1736.test.tsx`: when `#reader-scroll` exists, `container.scrollTo` is called (not `scrollIntoView`) when active segment scrolls out of view; does not scroll when already in view.
- Full suite: 2573 frontend + 1382 backend tests pass.

## Docs follow-up

None required — no user-visible documentation change.
