### PR TITLE
ux: move per-chapter Gemini cost estimate from import page to reader sidebar

### DIFF
--- a/frontend/src/__tests__/ContrastWave8.test.ts
+++ b/frontend/src/__tests__/ContrastWave8.test.ts
@@ -44,11 +44,6 @@ describe("Contrast wave 8 (closes #1369)", () => {
     expect(chaptersPage).toContain("text-sm text-stone-500 text-center mt-8");
   });
 
-  it("import page cost breakdown uses text-stone-500 not text-stone-400", () => {
-    expect(importPage).not.toContain('"text-stone-400">');
-    expect(importPage).toContain('"text-stone-500">');
-  });
-
   it("import page footer note uses text-stone-500 not text-stone-400", () => {
     expect(importPage).not.toContain("text-xs text-stone-400 mt-4");
     expect(importPage).toContain("text-xs text-stone-500 mt-4");

--- a/frontend/src/__tests__/ImportChaptersRoleAlert.test.ts
+++ b/frontend/src/__tests__/ImportChaptersRoleAlert.test.ts
@@ -15,13 +15,6 @@ const chaptersPage = fs.readFileSync(
 );
 
 describe("Import + chapters error states", () => {
-  it("import translateError block has role=alert", () => {
-    const idx = importPage.indexOf("{translateError &&");
-    expect(idx).toBeGreaterThan(0);
-    const block = importPage.slice(idx, idx + 500);
-    expect(block).toContain('role="alert"');
-  });
-
   it("import error block has role=alert", () => {
     // The 'error' state block (different from translateError)
     const idx = importPage.indexOf("bg-red-50 border border-red-200 text-red-700 rounded-lg");

--- a/frontend/src/__tests__/ImportPage.branches.test.tsx
+++ b/frontend/src/__tests__/ImportPage.branches.test.tsx
@@ -42,16 +42,11 @@ jest.mock("@/lib/api", () => {
   return {
     ...actual,
     importBookStream: jest.fn(),
-    enqueueBookTranslation: jest.fn(),
     ApiError: actual.ApiError,
   };
 });
 
-jest.mock("@/lib/settings", () => ({
-  getSettings: jest.fn().mockReturnValue({ translationLang: "de" }),
-}));
-
-const { importBookStream, enqueueBookTranslation } = require("@/lib/api");
+const { importBookStream } = require("@/lib/api");
 
 async function* makeStream(events: object[]) {
   for (const ev of events) yield ev;
@@ -326,258 +321,14 @@ describe("ImportPage — skipToReading (lines 213-216)", () => {
   });
 });
 
-// ── handleTranslate — success path ───────────────────────────────────────────
+// ── canStartReading shows "Start reading now" ────────────────────────────────
 
-describe("ImportPage — handleTranslate success (lines 218-224)", () => {
-  it("shows translation queued banner after successful enqueue", async () => {
+describe("ImportPage — canStartReading shows Start reading now button", () => {
+  it("shows 'Start reading now' after chapters event before done", async () => {
     importBookStream.mockReturnValue(
       makeStream([
-        { event: "meta", title: "Test Book", source_language: "en" },
-        { event: "chapters", total: 5 },
-        { event: "done" },
-      ])
-    );
-    enqueueBookTranslation.mockResolvedValue(undefined);
-
-    render(<BookImportPage />);
-    await clickAndFlush(/start import/i);
-
-    await waitFor(() =>
-      expect(screen.getByText(/Pre-translate this book/i)).toBeInTheDocument()
-    );
-
-    await clickAndFlush(/Translate in background/i);
-
-    await waitFor(() =>
-      expect(screen.getByText(/Translation queued/i)).toBeInTheDocument()
-    );
-    expect(enqueueBookTranslation).toHaveBeenCalledWith(42, "de");
-  });
-
-  it("shows 'Enqueuing…' while handleTranslate is in flight", async () => {
-    importBookStream.mockReturnValue(
-      makeStream([
-        { event: "meta", source_language: "en" },
         { event: "chapters", total: 3 },
-        { event: "done" },
-      ])
-    );
-
-    let resolveEnqueue!: () => void;
-    enqueueBookTranslation.mockReturnValue(
-      new Promise<void>((res) => { resolveEnqueue = res; })
-    );
-
-    render(<BookImportPage />);
-    await clickAndFlush(/start import/i);
-
-    await waitFor(() =>
-      expect(screen.getByText(/Pre-translate this book/i)).toBeInTheDocument()
-    );
-
-    await clickAndFlush(/Translate in background/i);
-
-    // While pending, shows "Enqueuing…"
-    await waitFor(() =>
-      expect(screen.getByText(/Enqueuing…/i)).toBeInTheDocument()
-    );
-
-    await act(async () => { resolveEnqueue(); });
-  });
-});
-
-// ── handleTranslate — failure path ───────────────────────────────────────────
-
-describe("ImportPage — handleTranslate failure (lines 224-228)", () => {
-  it("shows translateError when enqueue fails with Error", async () => {
-    importBookStream.mockReturnValue(
-      makeStream([
-        { event: "meta", source_language: "en" },
-        { event: "chapters", total: 3 },
-        { event: "done" },
-      ])
-    );
-    enqueueBookTranslation.mockRejectedValue(new Error("Quota exceeded"));
-
-    render(<BookImportPage />);
-    await clickAndFlush(/start import/i);
-
-    await waitFor(() =>
-      expect(screen.getByText(/Pre-translate this book/i)).toBeInTheDocument()
-    );
-
-    await clickAndFlush(/Translate in background/i);
-
-    await waitFor(() =>
-      expect(screen.getByText("Quota exceeded")).toBeInTheDocument()
-    );
-  });
-
-  it("shows fallback error when non-Error is thrown during handleTranslate", async () => {
-    importBookStream.mockReturnValue(
-      makeStream([
-        { event: "meta", source_language: "en" },
-        { event: "chapters", total: 3 },
-        { event: "done" },
-      ])
-    );
-    enqueueBookTranslation.mockRejectedValue("string error");
-
-    render(<BookImportPage />);
-    await clickAndFlush(/start import/i);
-
-    await waitFor(() =>
-      expect(screen.getByText(/Pre-translate this book/i)).toBeInTheDocument()
-    );
-
-    await clickAndFlush(/Translate in background/i);
-
-    await waitFor(() =>
-      expect(screen.getByText("Failed to enqueue translation")).toBeInTheDocument()
-    );
-  });
-});
-
-// ── "Skip for now" button in translate prompt ─────────────────────────────────
-
-describe("ImportPage — skip translation prompt (line 396-400)", () => {
-  it("'Skip for now' hides translate prompt and shows Done message", async () => {
-    jest.useFakeTimers();
-    const { useRouter } = require("next/navigation");
-    const push = jest.fn();
-    useRouter.mockReturnValue({ push });
-
-    importBookStream.mockReturnValue(
-      makeStream([
-        { event: "meta", source_language: "en" },
-        { event: "chapters", total: 3 },
-        { event: "done" },
-      ])
-    );
-
-    render(<BookImportPage />);
-    await act(async () => { fireEvent.click(screen.getByRole("button", { name: /start import/i })); });
-
-    await waitFor(() =>
-      expect(screen.getByText(/Pre-translate this book/i)).toBeInTheDocument()
-    );
-
-    const skipForNowBtn = screen.getByRole("button", { name: /Skip for now/i });
-    await act(async () => { fireEvent.click(skipForNowBtn); });
-
-    // After skip, readyToRedirect=true → shows Done message
-    await waitFor(() =>
-      expect(screen.getByText(/Done — opening your book/i)).toBeInTheDocument()
-    );
-
-    act(() => jest.advanceTimersByTime(1200));
-    expect(push).toHaveBeenCalledWith("/reader/42");
-
-    jest.useRealTimers();
-  });
-});
-
-// ── fmtCost helper (lines 47-50) ─────────────────────────────────────────────
-
-describe("ImportPage — fmtCost helper via translate prompt (lines 47-50)", () => {
-  it("shows '< $0.01' for very cheap books (line 48)", async () => {
-    // 1 word → tokens ≈ 1.4 → usd ≈ 0.0000035 < 0.005 → "< $0.01"
-    importBookStream.mockReturnValue(
-      makeStream([
-        { event: "meta", source_language: "en" },
-        { event: "chapters", total: 1, total_words: 1 },
-        { event: "done" },
-      ])
-    );
-
-    render(<BookImportPage />);
-    await clickAndFlush(/start import/i);
-
-    await waitFor(() =>
-      expect(screen.getByText(/Pre-translate this book/i)).toBeInTheDocument()
-    );
-
-    expect(screen.getByText(/< \$0\.01/)).toBeInTheDocument();
-  });
-
-  it("shows formatted cost for larger books (line 49)", async () => {
-    // 1M words → tokens = 1.4M → usd = 3.5 → "~$3.50"
-    importBookStream.mockReturnValue(
-      makeStream([
-        { event: "meta", source_language: "en" },
-        { event: "chapters", total: 10, total_words: 1_000_000 },
-        { event: "done" },
-      ])
-    );
-
-    render(<BookImportPage />);
-    await clickAndFlush(/start import/i);
-
-    await waitFor(() =>
-      expect(screen.getByText(/Pre-translate this book/i)).toBeInTheDocument()
-    );
-
-    expect(screen.getByText(/~\$3\.50/)).toBeInTheDocument();
-  });
-});
-
-// ── estimateCost with no totalWords (line 41) ─────────────────────────────────
-
-describe("ImportPage — estimateCost without totalWords (line 41)", () => {
-  it("shows cost estimate based on chapter count alone", async () => {
-    // No total_words → estimateCost uses chapters * 2000 avg
-    importBookStream.mockReturnValue(
-      makeStream([
-        { event: "meta", source_language: "en" },
-        { event: "chapters", total: 5 },  // no total_words
-        { event: "done" },
-      ])
-    );
-
-    render(<BookImportPage />);
-    await clickAndFlush(/start import/i);
-
-    await waitFor(() =>
-      expect(screen.getByText(/Pre-translate this book/i)).toBeInTheDocument()
-    );
-
-    // Cost display should be visible (any format)
-    const costEl = screen.getByText(/~\$|< \$/);
-    expect(costEl).toBeInTheDocument();
-  });
-
-  it("shows word count when total_words is available", async () => {
-    // With total_words, the prompt shows "~N words"
-    importBookStream.mockReturnValue(
-      makeStream([
-        { event: "meta", source_language: "en" },
-        { event: "chapters", total: 3, total_words: 12000 },
-        { event: "done" },
-      ])
-    );
-
-    render(<BookImportPage />);
-    await clickAndFlush(/start import/i);
-
-    await waitFor(() =>
-      expect(screen.getByText(/Pre-translate this book/i)).toBeInTheDocument()
-    );
-
-    // Word count appears in the description
-    expect(screen.getByText(/12,000 words/)).toBeInTheDocument();
-  });
-});
-
-// ── canStartReading shows "Start reading now" (lines 441-447) ────────────────
-
-describe("ImportPage — canStartReading + showTranslatePrompt interaction", () => {
-  it("shows 'Start reading now' when canStartReading and !showTranslatePrompt", async () => {
-    // Source language = target language → no translate prompt
-    // chapters → canStartReading = true
-    importBookStream.mockReturnValue(
-      makeStream([
-        { event: "meta", source_language: "de" }, // same as target "de"
-        { event: "chapters", total: 3 },
+        // no done event → not redirecting yet
       ])
     );
 
@@ -589,11 +340,10 @@ describe("ImportPage — canStartReading + showTranslatePrompt interaction", () 
     );
   });
 
-  it("hides 'Start reading now' when showTranslatePrompt is true", async () => {
-    // source != target → showTranslatePrompt=true → button hidden
+  it("hides 'Start reading now' after done event (redirect takes over)", async () => {
+    jest.useFakeTimers();
     importBookStream.mockReturnValue(
       makeStream([
-        { event: "meta", source_language: "en" },
         { event: "chapters", total: 3 },
         { event: "done" },
       ])
@@ -602,14 +352,16 @@ describe("ImportPage — canStartReading + showTranslatePrompt interaction", () 
     render(<BookImportPage />);
     await clickAndFlush(/start import/i);
 
+    // After done, redirect message shows and Start reading now is hidden
     await waitFor(() =>
-      expect(screen.getByText(/Pre-translate this book/i)).toBeInTheDocument()
+      expect(screen.getByText(/Done — opening your book/i)).toBeInTheDocument()
     );
 
-    // "Start reading now" should NOT be visible when translate prompt is shown
     expect(
       screen.queryByRole("button", { name: /Start reading now/i })
     ).not.toBeInTheDocument();
+
+    jest.useRealTimers();
   });
 });
 

--- a/frontend/src/__tests__/ImportPage.test.tsx
+++ b/frontend/src/__tests__/ImportPage.test.tsx
@@ -18,16 +18,11 @@ jest.mock("@/lib/api", () => {
   return {
     ...actual,
     importBookStream: jest.fn(),
-    enqueueBookTranslation: jest.fn().mockResolvedValue({ ok: true, enqueued: 5 }),
     ApiError: actual.ApiError,
   };
 });
 
-jest.mock("@/lib/settings", () => ({
-  getSettings: jest.fn().mockReturnValue({ translationLang: "de" }),
-}));
-
-const { importBookStream, enqueueBookTranslation } = require("@/lib/api");
+const { importBookStream } = require("@/lib/api");
 
 async function* makeStream(events: object[]) {
   for (const ev of events) yield ev;

--- a/frontend/src/__tests__/ImportPageNoTranslatePrompt.test.tsx
+++ b/frontend/src/__tests__/ImportPageNoTranslatePrompt.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Regression test for #1739: the "Pre-translate this book?" panel has been
+ * removed from the import page (moved to the reader translation sidebar).
+ * Verify that the panel never appears, even when source != target language.
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import BookImportPage from "@/app/import/[bookId]/page";
+
+jest.mock("next/navigation", () => ({
+  useParams: jest.fn().mockReturnValue({ bookId: "42" }),
+  useRouter: jest.fn().mockReturnValue({ push: jest.fn() }),
+  useSearchParams: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue(null) }),
+}));
+
+jest.mock("@/lib/api", () => {
+  const actual = jest.requireActual("@/lib/api");
+  return {
+    ...actual,
+    importBookStream: jest.fn(),
+    ApiError: actual.ApiError,
+  };
+});
+
+jest.mock("@/lib/settings", () => ({
+  getSettings: jest.fn().mockReturnValue({ translationLang: "de" }),
+}));
+
+const { importBookStream } = require("@/lib/api");
+
+async function* makeStream(events: object[]) {
+  for (const ev of events) yield ev;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("ImportPage — translate prompt removed (issue #1739)", () => {
+  it("does not show translate prompt when source != target language after done event", async () => {
+    importBookStream.mockReturnValue(
+      makeStream([
+        { event: "meta", title: "Faust", source_language: "en" },
+        { event: "chapters", total: 5 },
+        { event: "done" },
+      ])
+    );
+
+    render(<BookImportPage />);
+    fireEvent.click(screen.getByRole("button", { name: /start import/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Done — opening your book/i)).toBeInTheDocument()
+    );
+
+    expect(screen.queryByText(/Pre-translate this book/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Translate in background/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Skip for now/i)).not.toBeInTheDocument();
+  });
+
+  it("redirects automatically after done without waiting for translation action", async () => {
+    const { useRouter } = require("next/navigation");
+    const push = jest.fn();
+    useRouter.mockReturnValue({ push });
+
+    importBookStream.mockReturnValue(
+      makeStream([
+        { event: "meta", source_language: "en" },
+        { event: "chapters", total: 3 },
+        { event: "done" },
+      ])
+    );
+
+    render(<BookImportPage />);
+    fireEvent.click(screen.getByRole("button", { name: /start import/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Done — opening your book/i)).toBeInTheDocument()
+    );
+
+    act(() => jest.advanceTimersByTime(1200));
+    expect(push).toHaveBeenCalledWith("/reader/42");
+  });
+});

--- a/frontend/src/__tests__/ImportUploadChaptersTouchTargets.test.ts
+++ b/frontend/src/__tests__/ImportUploadChaptersTouchTargets.test.ts
@@ -26,14 +26,6 @@ describe("Import and upload-chapters flow touch targets (closes #838)", () => {
     checkBefore(importPage, "Skip\n");
   });
 
-  it("Translate in background button has min-h-[44px]", () => {
-    checkBefore(importPage, "Translate in background");
-  });
-
-  it("Skip for now button has min-h-[44px]", () => {
-    checkBefore(importPage, "Skip for now");
-  });
-
   it("Start reading now button has min-h-[44px]", () => {
     checkBefore(importPage, "Start reading now");
   });

--- a/frontend/src/__tests__/ReaderGeminiCostEstimate.test.tsx
+++ b/frontend/src/__tests__/ReaderGeminiCostEstimate.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * Tests for issue #1739: per-chapter Gemini cost estimate in the reader
+ * translation sidebar, shown only when hasGeminiKey === true.
+ */
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+
+// ─── next-auth ────────────────────────────────────────────────────────────────
+const mockUseSession = jest.fn();
+jest.mock("next-auth/react", () => ({
+  useSession: (...args: unknown[]) => mockUseSession(...args),
+}));
+
+// ─── next/navigation ─────────────────────────────────────────────────────────
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useParams: () => ({ bookId: "42" }),
+  useRouter: () => ({ push: mockPush, replace: jest.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+// ─── @/lib/api ────────────────────────────────────────────────────────────────
+const mockGetBookChapters = jest.fn();
+const mockGetMe = jest.fn();
+const mockGetAnnotations = jest.fn();
+const mockGetVocabulary = jest.fn();
+const mockGetBookTranslationStatus = jest.fn();
+const mockGetChapterTranslation = jest.fn();
+const mockGetChapterQueueStatus = jest.fn();
+const mockRequestChapterTranslation = jest.fn();
+const mockRetryChapterTranslation = jest.fn();
+const mockEnqueueBookTranslation = jest.fn();
+const mockDeleteTranslationCache = jest.fn();
+const mockSaveReadingProgress = jest.fn();
+const mockSaveVocabularyWord = jest.fn();
+const mockGetWordDefinition = jest.fn();
+const mockExportVocabularyToObsidian = jest.fn();
+const mockSaveInsight = jest.fn();
+const mockSynthesizeSpeech = jest.fn();
+
+jest.mock("@/lib/api", () => ({
+  getBookChapters: (...a: unknown[]) => mockGetBookChapters(...a),
+  getMe: (...a: unknown[]) => mockGetMe(...a),
+  getAnnotations: (...a: unknown[]) => mockGetAnnotations(...a),
+  getVocabulary: (...a: unknown[]) => mockGetVocabulary(...a),
+  getBookTranslationStatus: (...a: unknown[]) => mockGetBookTranslationStatus(...a),
+  getChapterTranslation: (...a: unknown[]) => mockGetChapterTranslation(...a),
+  getChapterQueueStatus: (...a: unknown[]) => mockGetChapterQueueStatus(...a),
+  requestChapterTranslation: (...a: unknown[]) => mockRequestChapterTranslation(...a),
+  retryChapterTranslation: (...a: unknown[]) => mockRetryChapterTranslation(...a),
+  enqueueBookTranslation: (...a: unknown[]) => mockEnqueueBookTranslation(...a),
+  deleteTranslationCache: (...a: unknown[]) => mockDeleteTranslationCache(...a),
+  saveReadingProgress: (...a: unknown[]) => mockSaveReadingProgress(...a),
+  saveVocabularyWord: (...a: unknown[]) => mockSaveVocabularyWord(...a),
+  getWordDefinition: (...a: unknown[]) => mockGetWordDefinition(...a),
+  exportVocabularyToObsidian: (...a: unknown[]) => mockExportVocabularyToObsidian(...a),
+  saveInsight: (...a: unknown[]) => mockSaveInsight(...a),
+  synthesizeSpeech: (...a: unknown[]) => mockSynthesizeSpeech(...a),
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(msg: string, status: number) { super(msg); this.status = status; }
+  },
+}));
+
+// ─── @/lib/recentBooks ───────────────────────────────────────────────────────
+jest.mock("@/lib/recentBooks", () => ({
+  recordRecentBook: jest.fn(),
+  saveLastChapter: jest.fn(),
+  getLastChapter: jest.fn().mockReturnValue(0),
+}));
+
+// ─── @/lib/settings ──────────────────────────────────────────────────────────
+jest.mock("@/lib/settings", () => ({
+  getSettings: jest.fn().mockReturnValue({
+    translationEnabled: true,
+    translationLang: "de",
+    insightLang: "en",
+    ttsRate: 1,
+    ttsPitch: 1,
+    ttsGender: "female",
+    displayMode: "inline",
+    fontSize: "base",
+    lineHeight: "normal",
+    contentWidth: "normal",
+    fontFamily: "serif",
+    paragraphFocus: false,
+  }),
+  saveSettings: jest.fn(),
+}));
+
+// ─── Heavy UI components ──────────────────────────────────────────────────────
+jest.mock("@/components/TTSControls", () => ({
+  __esModule: true,
+  default: () => <div data-testid="tts-controls" />,
+}));
+
+jest.mock("@/components/SentenceReader", () => ({
+  __esModule: true,
+  default: () => <div data-testid="sentence-reader" />,
+}));
+
+jest.mock("@/components/InsightChat", () => {
+  const LANGUAGES = [
+    { code: "en", label: "English" },
+    { code: "de", label: "German" },
+    { code: "fr", label: "French" },
+  ];
+  return {
+    __esModule: true,
+    default: () => <div data-testid="insight-chat" />,
+    LANGUAGES,
+  };
+});
+
+jest.mock("@/components/SelectionToolbar", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/components/AnnotationToolbar", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/components/TranslationView", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/components/VocabularyToast", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/components/VocabWordTooltip", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/components/AnnotationsSidebar", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/components/WordActionDrawer", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/components/ChapterSummary", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/components/TypographyPanel", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/components/UndoToast", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import ReaderPage from "@/app/reader/[bookId]/page";
+
+const CHAPTER_TEXT = "Word ".repeat(2000).trim(); // 2000 words
+const SAMPLE_CHAPTERS = [
+  { title: "Chapter One", text: CHAPTER_TEXT },
+];
+
+const SAMPLE_SESSION = {
+  backendToken: "test-token",
+  backendUser: { id: 1, name: "TestUser", picture: "" },
+  user: { id: 1 },
+};
+
+function setupMocks({ hasGeminiKey }: { hasGeminiKey: boolean }) {
+  mockUseSession.mockReturnValue({ data: { ...SAMPLE_SESSION }, status: "authenticated" });
+
+  mockGetBookChapters.mockResolvedValue({
+    meta: { id: 42, title: "Test Book", authors: [], languages: ["en"], download_count: 0 },
+    chapters: SAMPLE_CHAPTERS,
+  });
+
+  mockGetMe.mockResolvedValue({
+    id: 1,
+    name: "TestUser",
+    email: "t@t.com",
+    picture: "",
+    is_admin: false,
+    hasGeminiKey,
+  });
+
+  mockGetAnnotations.mockResolvedValue([]);
+  mockGetVocabulary.mockResolvedValue([]);
+  mockGetBookTranslationStatus.mockResolvedValue(null);
+  mockGetChapterTranslation.mockResolvedValue({ status: "not_found" });
+  mockGetChapterQueueStatus.mockResolvedValue({ status: "not_found" });
+  mockSaveReadingProgress.mockResolvedValue({});
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+async function openTranslateSidebar() {
+  const translateTab = await screen.findByRole("button", { name: /translate/i });
+  fireEvent.click(translateTab);
+}
+
+describe("Reader — Gemini cost estimate in translation sidebar (issue #1739)", () => {
+  it("shows cost estimate near the translate button when hasGeminiKey is true", async () => {
+    setupMocks({ hasGeminiKey: true });
+    render(<ReaderPage />);
+
+    await openTranslateSidebar();
+
+    // The translate button should appear
+    const translateBtn = await screen.findByRole("button", { name: /translate this chapter/i });
+    expect(translateBtn).toBeInTheDocument();
+
+    // Cost estimate should be visible near the button
+    await waitFor(() => {
+      const costEl = screen.queryByText(/\$|tokens/i);
+      expect(costEl).toBeInTheDocument();
+    });
+  });
+
+  it("does not show cost estimate when hasGeminiKey is false", async () => {
+    setupMocks({ hasGeminiKey: false });
+    render(<ReaderPage />);
+
+    await openTranslateSidebar();
+
+    await screen.findByRole("button", { name: /translate this chapter/i });
+
+    // Cost estimate should NOT appear when no Gemini key
+    const costEl = screen.queryByText(/\$\d|\d+K tokens/i);
+    expect(costEl).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -4,11 +4,9 @@ import { useEffect, useRef, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import {
   importBookStream,
-  enqueueBookTranslation,
   ImportEvent,
   ApiError,
 } from "@/lib/api";
-import { getSettings } from "@/lib/settings";
 import { CheckCircleIcon, AlertCircleIcon, RetryIcon, CircleDotIcon } from "@/components/Icons";
 
 type Stage = "fetching" | "splitting";
@@ -30,30 +28,6 @@ const STAGE_LABELS: Record<Stage, string> = {
   splitting: "Split chapters",
 };
 
-// Gemini Flash paid-tier pricing for cost estimate display only.
-const FLASH_OUTPUT_COST_PER_M = 2.5; // USD per 1M output tokens
-const WORDS_PER_CHAPTER_AVG = 2000;
-const TOKENS_PER_WORD = 1.4;
-
-function estimateCost(
-  chapters: number,
-  totalWords?: number,
-): { tokens: number; usd: number } {
-  const words = totalWords ?? chapters * WORDS_PER_CHAPTER_AVG;
-  const tokens = Math.round(words * TOKENS_PER_WORD);
-  const usd = (tokens / 1_000_000) * FLASH_OUTPUT_COST_PER_M;
-  return { tokens, usd };
-}
-
-function fmtCost(usd: number): string {
-  if (usd < 0.005) return "< $0.01";
-  return `~$${usd.toFixed(2)}`;
-}
-
-function fmtNum(n: number): string {
-  return n.toLocaleString();
-}
-
 export default function BookImportPage() {
   const { bookId } = useParams<{ bookId: string }>();
   const router = useRouter();
@@ -65,24 +39,12 @@ export default function BookImportPage() {
   const [stages, setStages] = useState<Record<Stage, StageState>>(INITIAL);
   const [bookTitle, setBookTitle] = useState("");
   const [chapterCount, setChapterCount] = useState(0);
-  const [totalWords, setTotalWords] = useState<number | undefined>();
-  const [sourceLanguage, setSourceLanguage] = useState("");
   const [error, setError] = useState("");
   const [loginRequired, setLoginRequired] = useState(false);
   const [isDone, setIsDone] = useState(false);
   const [started, setStarted] = useState(false);
-  // "idle" | "pending" | "enqueued" | "skipped"
-  const [translateState, setTranslateState] = useState<
-    "idle" | "pending" | "enqueued" | "skipped"
-  >("idle");
-  const [translateError, setTranslateError] = useState("");
 
-  const targetLangRef = useRef("");
   const abortRef = useRef<AbortController | null>(null);
-
-  useEffect(() => {
-    targetLangRef.current = getSettings().translationLang || "en";
-  }, []);
 
   function updateStage(stage: Stage, patch: Partial<StageState>) {
     setStages((prev) => ({ ...prev, [stage]: { ...prev[stage], ...patch } }));
@@ -122,13 +84,11 @@ export default function BookImportPage() {
 
     if (ev.event === "meta") {
       if (ev.title) setBookTitle(ev.title);
-      if (ev.source_language) setSourceLanguage(ev.source_language);
       return;
     }
 
     if (ev.event === "chapters") {
       setChapterCount(ev.total || 0);
-      setTotalWords(ev.total_words);
       updateStage("splitting", {
         status: "done",
         total: ev.total || 0,
@@ -188,23 +148,11 @@ export default function BookImportPage() {
     return () => abortRef.current?.abort();
   }, []);
 
-  // Redirect once done AND user has acted on the translation prompt (or it doesn't apply).
-  const translationActioned =
-    translateState === "enqueued" || translateState === "skipped";
-  const tl = targetLangRef.current;
-  const showTranslatePrompt =
-    isDone &&
-    chapterCount > 0 &&
-    !!tl &&
-    tl !== sourceLanguage &&
-    !translationActioned;
-  const readyToRedirect = isDone && (translationActioned || !showTranslatePrompt);
-
   useEffect(() => {
-    if (!readyToRedirect) return;
+    if (!isDone) return;
     const t = setTimeout(() => router.push(nextUrl), 1200);
     return () => clearTimeout(t);
-  }, [readyToRedirect, nextUrl, router]);
+  }, [isDone, nextUrl, router]);
 
   function cancel() {
     abortRef.current?.abort();
@@ -216,23 +164,8 @@ export default function BookImportPage() {
     router.push(nextUrl);
   }
 
-  async function handleTranslate() {
-    setTranslateState("pending");
-    setTranslateError("");
-    try {
-      await enqueueBookTranslation(Number(bookId), tl);
-      setTranslateState("enqueued");
-    } catch (e) {
-      setTranslateError(
-        e instanceof Error ? e.message : "Failed to enqueue translation",
-      );
-      setTranslateState("idle");
-    }
-  }
-
   const canStartReading =
     stages.splitting.status === "done" && chapterCount > 0;
-  const cost = estimateCost(chapterCount, totalWords);
 
   return (
     <main id="main-content" className="min-h-screen bg-parchment flex items-center justify-center px-4 py-8">
@@ -347,70 +280,6 @@ export default function BookImportPage() {
             </div>
           )}
 
-          {/* Translation cost confirmation panel — shown after import completes */}
-          {showTranslatePrompt && (
-            <div className="border border-amber-200 rounded-xl p-5 mb-4 bg-amber-50/50">
-              <p className="text-sm font-semibold text-ink mb-1">
-                Pre-translate this book?
-              </p>
-              <p className="text-xs text-stone-500 mb-3">
-                {chapterCount} chapters
-                {totalWords ? ` · ~${fmtNum(totalWords)} words` : ""}
-                {" · target: "}
-                <span className="font-medium text-ink">{tl}</span>
-              </p>
-
-              <div className="space-y-2 mb-4">
-                {/* Primary option — Gemini */}
-                <div className="rounded-lg bg-white border border-amber-200 px-3 py-2.5 text-xs">
-                  <div className="flex items-baseline justify-between gap-2 mb-0.5">
-                    <span className="font-semibold text-ink">Gemini Flash</span>
-                    <span className="font-semibold text-amber-700">{fmtCost(cost.usd)}</span>
-                  </div>
-                  <p className="text-stone-500">
-                    ~{fmtNum(cost.tokens)} output tokens · $2.50/M on paid tier.{" "}
-                    <span className="text-emerald-600 font-medium">Free on free tier.</span>
-                    {" Runs in background."}
-                  </p>
-                </div>
-                {/* Secondary option — Google Translate */}
-                <div className="rounded-lg bg-stone-50 border border-stone-200 px-3 py-2 text-xs text-stone-500">
-                  <span className="font-medium text-stone-600">Google Translate</span>
-                  {" — always free, lower quality. Available chapter-by-chapter in the reader sidebar."}
-                </div>
-              </div>
-
-              {translateError && (
-                <p role="alert" className="text-xs text-red-700 bg-red-50 border border-red-200 rounded-lg px-3 py-2 mb-2">{translateError}</p>
-              )}
-
-              <div className="flex gap-2">
-                <button
-                  onClick={handleTranslate}
-                  disabled={translateState === "pending"}
-                  className="flex-1 rounded-lg bg-amber-700 text-white min-h-[44px] text-xs font-medium hover:bg-amber-800 disabled:opacity-50 flex items-center justify-center"
-                >
-                  {translateState === "pending"
-                    ? "Enqueuing…"
-                    : "Translate in background"}
-                </button>
-                <button
-                  onClick={() => setTranslateState("skipped")}
-                  className="rounded-lg border border-stone-300 text-stone-600 px-3 min-h-[44px] text-xs hover:bg-stone-50 flex items-center"
-                >
-                  Skip for now
-                </button>
-              </div>
-            </div>
-          )}
-
-          {translateState === "enqueued" && (
-            <p className="text-xs text-emerald-700 mb-3">
-              Translation queued — you can read now while it runs in the
-              background.
-            </p>
-          )}
-
           {loginRequired && (
             <div className="bg-amber-50 border border-amber-200 rounded-xl p-6 text-center mb-4">
               <p className="font-serif text-base font-semibold text-ink mb-1">Login required</p>
@@ -432,15 +301,15 @@ export default function BookImportPage() {
             </div>
           )}
 
-          {readyToRedirect && (
+          {isDone && (
             <p className="text-sm text-emerald-700 mb-4">
               Done — opening your book…
             </p>
           )}
 
-          {started && !readyToRedirect && (
+          {started && !isDone && (
             <div className="flex gap-2">
-              {canStartReading && !showTranslatePrompt && (
+              {canStartReading && (
                 <button
                   onClick={skipToReading}
                   className="flex-1 rounded-lg bg-amber-700 text-white min-h-[44px] text-sm font-medium hover:bg-amber-800 flex items-center justify-center"

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -20,6 +20,20 @@ import ChapterSummary from "@/components/ChapterSummary";
 import AuthPromptModal from "@/components/AuthPromptModal";
 import { SunIcon, MoonIcon, SepiaIcon, ChatIcon, GlobeIcon, NoteIcon, EditIcon, BookmarkIcon, BookOpenIcon, ExportIcon, SummaryIcon, PlayIcon, PauseIcon, CloseIcon, KeyboardIcon, FocusIcon, ArrowLeftIcon, ArrowRightIcon, ChevronDownIcon, ChevronRightIcon, EmptyVocabIcon, ArrowUpRightIcon } from "@/components/Icons";
 
+// Gemini Flash pricing constants — used for per-chapter cost estimate in the translation sidebar.
+const FLASH_COST_PER_M = 2.5; // USD per 1M output tokens
+const TOKENS_PER_WORD = 1.4;
+const WORDS_DEFAULT = 2000;
+
+function chapterCostLabel(text?: string): string {
+  const words = text ? text.split(/\s+/).filter(Boolean).length : WORDS_DEFAULT;
+  const tokens = Math.round(words * TOKENS_PER_WORD);
+  const usd = (tokens / 1_000_000) * FLASH_COST_PER_M;
+  const cost = usd < 0.005 ? "< $0.01" : `~$${usd.toFixed(2)}`;
+  const tok = tokens >= 1000 ? `~${(tokens / 1000).toFixed(1)}K` : `~${tokens}`;
+  return `${cost} · ${tok} tokens`;
+}
+
 // In-memory cache: bookId → chapters (survives client-side navigation)
 const chaptersCache = new Map<string, BookChapter[]>();
 const metaCache = new Map<string, BookMeta>();
@@ -1983,12 +1997,19 @@ export default function ReaderPage() {
                     {translationEnabled && !translationLoading && translatedParagraphs.length === 0 && translationUsedProvider === "" && (
                       <div className="mb-4">
                         {session?.backendToken ? (
-                          <button
-                            onClick={handleTranslateThisChapter}
-                            className="w-full px-3 py-2 min-h-[44px] rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-sm font-medium transition-colors"
-                          >
-                            Translate this chapter
-                          </button>
+                          <>
+                            <button
+                              onClick={handleTranslateThisChapter}
+                              className="w-full px-3 py-2 min-h-[44px] rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-sm font-medium transition-colors"
+                            >
+                              Translate this chapter
+                            </button>
+                            {hasGeminiKey === true && (
+                              <p className="mt-1 text-xs text-stone-500 text-center" aria-label="Estimated Gemini translation cost for this chapter">
+                                {chapterCostLabel(current?.text)}
+                              </p>
+                            )}
+                          </>
                         ) : (
                           <p className="text-xs text-amber-700">
                             <a href="/api/auth/signin" className="underline font-medium">Sign in</a> to translate this chapter.


### PR DESCRIPTION
## What changed

- **Import page** (`import/[bookId]/page.tsx`): Removed the post-import "Pre-translate this book?" panel entirely. The import flow is now lean: fetch → split → read. Auto-redirects to the reader as soon as import is done.
- **Reader sidebar** (`reader/[bookId]/page.tsx`): Added a per-chapter Gemini cost estimate (`~$0.01 · ~2.8K tokens`) directly below the "Translate this chapter" button, shown only when the user has a Gemini API key configured (`hasGeminiKey === true`). Users without a key never see paid pricing.

## Why

Cost estimate is most relevant at the moment of triggering a paid translation, not at import time. Moving it eliminates a friction-laden confirmation panel from the import flow and places the cost information where it's actionable (in the reader sidebar, right before the user clicks translate). Closes #1739.

## Test plan

- [x] `ImportPageNoTranslatePrompt.test.tsx` — verifies translate prompt no longer appears after done event (even with source ≠ target language)
- [x] `ReaderGeminiCostEstimate.test.tsx` — verifies cost estimate appears below translate button when `hasGeminiKey=true`, and is absent when `hasGeminiKey=false`
- [x] Updated `ImportPage.branches.test.tsx` — removed tests for removed UI; added new tests for simplified `canStartReading` behavior
- [x] Updated `ContrastWave8.test.ts`, `ImportChaptersRoleAlert.test.ts`, `ImportUploadChaptersTouchTargets.test.ts` — removed assertions for removed UI elements
- [x] All 2564 frontend tests pass; all 1382 backend tests pass

## Docs follow-up

N/A — no user-facing feature page change; the cost estimate is a minor UX improvement.
