### PR TITLE
fix: use DB chapter text for summaries, not client-supplied text (closes #1738)

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -273,7 +273,7 @@ async def summary(req: SummaryRequest, _user: dict = Depends(get_current_user)):
 
         try:
             content = await gemini.generate_chapter_summary(
-                api_key, req.chapter_text, req.book_title, req.author, req.chapter_title
+                api_key, _chapters[req.chapter_index].text, req.book_title, req.author, req.chapter_title
             )
         except Exception as exc:
             logger.exception("POST /ai/summary book=%s ch=%s: %s", req.book_id, req.chapter_index, exc)

--- a/backend/tests/test_router_ai.py
+++ b/backend/tests/test_router_ai.py
@@ -1796,3 +1796,50 @@ async def test_summary_no_queue_api_key_returns_503(client, test_user, tmp_db):
         f"got {resp.status_code}: {resp.text}"
     )
     assert "not available" in resp.json()["detail"].lower() or "configured" in resp.json()["detail"].lower()
+
+
+# ── Issue #1738: summary cache poison via client-supplied chapter_text ─────────
+
+
+async def test_summary_uses_db_chapter_text_not_client_supplied(client, test_user, tmp_db):
+    """Regression #1738: POST /ai/summary must use the chapter text from the DB,
+    not req.chapter_text. Any authenticated user can supply arbitrary chapter_text
+    to poison the shared summary cache; the endpoint must ignore it and use the
+    server-side chapter text instead."""
+    from services.auth import encrypt_api_key as _enc
+    from services.book_chapters import clear_cache as _clear
+
+    real_chapter_text = "word " * 200
+    book_text = "CHAPTER I\n\n" + real_chapter_text
+    await save_book(9974, {**_BOOK_META, "id": 9974}, book_text)
+    _clear()
+    await set_setting("queue_api_key", _enc("test-gemini-key"))
+
+    captured_text: list[str] = []
+
+    async def _capture_generate(api_key, chapter_text, *args, **kwargs):
+        captured_text.append(chapter_text)
+        return "A legitimate summary."
+
+    attacker_text = "INJECTED ATTACKER CONTENT: cache poisoned!"
+
+    with patch("routers.ai.gemini") as mock_gemini:
+        mock_gemini.generate_chapter_summary = _capture_generate
+        mock_gemini.MODEL = "gemini-pro"
+        resp = await client.post("/api/ai/summary", json={
+            "book_id": 9974,
+            "chapter_index": 0,
+            "chapter_text": attacker_text,
+            "book_title": "Faust",
+            "author": "Goethe",
+        })
+
+    assert resp.status_code == 200
+    assert len(captured_text) == 1, "generate_chapter_summary should be called exactly once"
+    assert attacker_text not in captured_text[0], (
+        f"Regression #1738: req.chapter_text was forwarded to Gemini instead of "
+        f"the DB chapter text. Captured: {repr(captured_text[0][:120])}"
+    )
+    assert "word" in captured_text[0], (
+        f"Expected DB chapter text to be passed to Gemini, got: {repr(captured_text[0][:120])}"
+    )


### PR DESCRIPTION
## What changed

`POST /ai/summary` was forwarding the client-supplied `req.chapter_text` directly to Gemini and caching the result under the book/chapter key. Any authenticated user could submit arbitrary text to permanently poison the shared summary cache for other users.

Fix: the endpoint now ignores `req.chapter_text` and instead uses `_chapters[req.chapter_index].text`, which is the chapter text fetched from the database.

## Why

Cache entries are keyed by `(book_id, chapter_index)` and shared across all users. Letting the client control the text that gets cached is a privilege-escalation / content-poisoning vector.

## Test plan

- Regression test `test_summary_uses_db_chapter_text_not_client_supplied` (new): sends `chapter_text = "INJECTED ATTACKER CONTENT"` in the request, captures what text is passed to `gemini.generate_chapter_summary`, and asserts the attacker string is never forwarded.
- Full backend suite: 1925 passed, 0 failures.

Closes #1738
