### PR TITLE
ux: fix VocabWordTooltip saved-state contrast (text-stone-400 → text-stone-600)

### DIFF
--- a/frontend/src/__tests__/ContrastWave14.test.ts
+++ b/frontend/src/__tests__/ContrastWave14.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Contrast regression for issue #1749:
+ * VocabWordTooltip "Saved" state must not use text-stone-400 on bg-stone-100
+ * (~2.3:1 contrast ratio, fails WCAG AA 4.5:1 for normal text).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/VocabWordTooltip.tsx"),
+  "utf8",
+);
+
+describe("VocabWordTooltip saved-state contrast (closes #1749)", () => {
+  it("does not use text-stone-400 in the saved button class", () => {
+    // text-stone-400 on bg-stone-100 ≈ 2.3:1 — fails WCAG AA
+    expect(src).not.toMatch(/bg-stone-100[^"]*text-stone-400|text-stone-400[^"]*bg-stone-100/);
+  });
+});

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -128,7 +128,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
           disabled={saved}
           className={`text-xs font-medium px-3 py-1 min-h-[44px] rounded-lg transition-colors flex items-center justify-center ${
             saved
-              ? "bg-stone-100 text-stone-400 cursor-default"
+              ? "bg-stone-100 text-stone-600 cursor-default"
               : "bg-amber-700 text-white hover:bg-amber-800"
           }`}
         >


### PR DESCRIPTION
## What changed

`VocabWordTooltip.tsx`: changed the disabled "Saved" button class from `text-stone-400` to `text-stone-600`.

## Why

`text-stone-400` on `bg-stone-100` produces ~2.3:1 contrast ratio — well below the WCAG AA requirement of 4.5:1 for normal text. The "Saved" label is meaningful feedback visible to users who have just saved a vocabulary word; it must be legible.

`text-stone-600` on `bg-stone-100` gives ~6.6:1, comfortably passing.

## Test plan

- New `ContrastWave14.test.ts`: asserts `VocabWordTooltip.tsx` does not use `text-stone-400` in the saved-button class.
- All 386 frontend test suites pass (2565 tests).

Closes #1749
