### PR TITLE
ux: fix InsightChat load-earlier button contrast (text-gray-400 → text-gray-600)

### DIFF
--- a/frontend/src/__tests__/InsightChatLoadEarlierContrast.test.ts
+++ b/frontend/src/__tests__/InsightChatLoadEarlierContrast.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Contrast regression for issue #1751:
+ * InsightChat "Load earlier" button must not use text-gray-400 on white background.
+ * text-gray-400 (#9ca3af) on white gives ~2.8:1 — fails WCAG AA 4.5:1 for text-xs.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/InsightChat.tsx"),
+  "utf8",
+);
+
+describe("InsightChat load-earlier button contrast (closes #1751)", () => {
+  it("does not use text-gray-400 alongside hover:text-gray-600 on the load-earlier button", () => {
+    // The pattern text-gray-400 hover:text-gray-600 is the failing combination
+    expect(src).not.toMatch(/text-gray-400\s+hover:text-gray-600/);
+  });
+});

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -433,7 +433,7 @@ export default function InsightChat({
         {hasEarlier && (
           <button
             onClick={loadEarlier}
-            className="w-full text-xs text-gray-400 hover:text-gray-600 py-1.5 min-h-[44px] rounded-lg border border-gray-100 hover:bg-gray-50 transition-colors inline-flex items-center justify-center gap-1.5"
+            className="w-full text-xs text-gray-600 hover:text-gray-800 py-1.5 min-h-[44px] rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors inline-flex items-center justify-center gap-1.5"
           >
             <ArrowUpIcon className="w-3 h-3" />
             <span>Load earlier ({loadedFrom} more)</span>


### PR DESCRIPTION
## What changed

`InsightChat.tsx`: updated the "Load earlier" button colour classes:
- `text-gray-400` → `text-gray-600` (resting text)
- `hover:text-gray-600` → `hover:text-gray-800` (hover text)
- `border-gray-100` → `border-gray-200` (border, near-invisible on white before)

## Why

`text-gray-400` (`#9ca3af`) on `bg-white` produces ~2.8:1 contrast — below the WCAG AA minimum of 4.5:1 for `text-xs` (small text). `text-gray-600` on white gives ~5.7:1, comfortably passing.

The border fix makes the button boundary visible even at rest (gray-100 on white is essentially invisible).

## Test plan

- New `InsightChatLoadEarlierContrast.test.ts`: asserts that `InsightChat.tsx` no longer contains the `text-gray-400 hover:text-gray-600` pattern.
- All 386 frontend test suites pass (2565 tests).

Closes #1751
