### PR TITLE
ux: fix InsightChat chapter-divider, save-button, and keyboard-hint contrast

### DIFF
--- a/frontend/src/__tests__/InsightChatSecondaryContrast.test.ts
+++ b/frontend/src/__tests__/InsightChatSecondaryContrast.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Contrast regression for issue #1754:
+ * InsightChat chapter-divider, save-button, and keyboard-hint must not use
+ * text-gray-400 on white/light backgrounds (~2.8:1, fails WCAG AA 4.5:1).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/InsightChat.tsx"),
+  "utf8",
+);
+
+describe("InsightChat secondary contrast fixes (closes #1754)", () => {
+  it("chapter-divider span does not use text-gray-400", () => {
+    // text-[11px] text-gray-400 on the chapter header divider label
+    expect(src).not.toMatch(/text-\[11px\] text-gray-400 font-medium px-1 shrink-0/);
+  });
+
+  it("save-to-notes button active state does not use text-gray-400", () => {
+    // The active (unsaved) branch of the save button
+    expect(src).not.toMatch(/"text-gray-400 hover:text-amber-700"/);
+  });
+
+  it("keyboard hint text does not use text-gray-400", () => {
+    // "Enter to send · Shift+Enter for newline" helper text
+    expect(src).not.toMatch(/text-\[11px\] text-gray-400 mt-1/);
+  });
+});

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -459,7 +459,7 @@ export default function InsightChat({
             return (
               <div key={i} className="flex items-center gap-2 py-1">
                 <div className="flex-1 h-px bg-gray-100" />
-                <span className="text-[11px] text-gray-400 font-medium px-1 shrink-0">
+                <span className="text-[11px] text-gray-600 font-medium px-1 shrink-0">
                   {msg.content}
                 </span>
                 <div className="flex-1 h-px bg-gray-100" />
@@ -538,8 +538,8 @@ export default function InsightChat({
                       title={isSaved ? "Already saved" : "Save to notes"}
                       className={`mt-1.5 flex items-center gap-1 min-h-[44px] text-[11px] transition-colors ${
                         isSaved
-                          ? "text-gray-300 cursor-default"
-                          : "text-gray-400 hover:text-amber-700"
+                          ? "text-gray-500 cursor-default"
+                          : "text-gray-600 hover:text-amber-700"
                       }`}
                     >
                       <BookmarkIcon className="w-3 h-3" fill={isSaved ? "currentColor" : "none"} />
@@ -611,7 +611,7 @@ export default function InsightChat({
             <ArrowUpIcon className="w-4 h-4" />
           </button>
         </div>
-        <p className="text-[11px] text-gray-400 mt-1">Enter to send · Shift+Enter for newline</p>
+        <p className="text-[11px] text-gray-600 mt-1">Enter to send · Shift+Enter for newline</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## What changed

`InsightChat.tsx`: fixed three `text-gray-400` usages that fail WCAG AA contrast on white/light backgrounds:

| Location | Before | After |
|---|---|---|
| Chapter-divider label (line 462) | `text-gray-400` | `text-gray-600` |
| "Save to notes" active state (line 542) | `text-gray-400` | `text-gray-600` |
| "Save to notes" saved/disabled state (line 541) | `text-gray-300` | `text-gray-500` |
| Keyboard hint "Enter to send…" (line 614) | `text-gray-400` | `text-gray-600` |

## Why

`text-gray-400` (`#9ca3af`) on white gives ~2.8:1 contrast — below the WCAG AA minimum of 4.5:1 for `text-xs`/`text-[11px]` small text. All three locations show readable text content that users need to see. `text-gray-600` on white gives ~7:1.

## Test plan

- New `InsightChatSecondaryContrast.test.ts`: three assertions verifying none of the failing patterns remain.
- All 387 frontend test suites pass (2568 tests).

Closes #1754
