### PR TITLE
ux: fix SentenceReader unloaded-disabled segment contrast (text-stone-400/70 → text-stone-500)

### DIFF
--- a/frontend/src/__tests__/SentenceReaderDisabledContrast.test.ts
+++ b/frontend/src/__tests__/SentenceReaderDisabledContrast.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Contrast regression for issue #1758:
+ * SentenceReader unloaded-disabled segment must not use text-stone-400/70.
+ * text-stone-400 at 70% opacity on white gives ~2.7:1 — fails WCAG AA 4.5:1.
+ * The loaded-disabled state correctly uses text-stone-500 (~4.7:1); unloaded must match.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/SentenceReader.tsx"),
+  "utf8",
+);
+
+describe("SentenceReader disabled-segment contrast (closes #1758)", () => {
+  it("does not use text-stone-400/70 for unloaded disabled segments", () => {
+    expect(src).not.toMatch(/text-stone-400\/70/);
+  });
+});

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -667,7 +667,7 @@ export default function SentenceReader({
           if (disabled) {
             return loaded
               ? "text-stone-500"
-              : "text-stone-400/70";
+              : "text-stone-500";
           }
           return loaded
             ? "hover:bg-amber-50"


### PR DESCRIPTION
## What changed

`SentenceReader.tsx`: changed the unloaded disabled-segment colour from `text-stone-400/70` to `text-stone-500`.

## Why

`text-stone-400` at 70% opacity on white gives ~2.7:1 contrast — well below the WCAG AA minimum of 4.5:1. The text is visible book content users may try to read during TTS loading. `text-stone-500` (~4.7:1) is consistent with the already-correct loaded-disabled state and passes WCAG AA.

Before:
```tsx
if (disabled) {
  return loaded ? "text-stone-500" : "text-stone-400/70";  // unloaded fails
}
```
After:
```tsx
if (disabled) {
  return loaded ? "text-stone-500" : "text-stone-500";  // consistent
}
```

## Test plan

- New `SentenceReaderDisabledContrast.test.ts`: asserts `SentenceReader.tsx` does not contain `text-stone-400/70`.
- All 387 frontend test suites pass (2566 tests).

Closes #1758
