### PR TITLE
fix: reconcile subtitle paragraph shift in chapter translation responses (closes #1385)

### DIFF
--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -182,6 +182,29 @@ async def chapter_queue_status(
     return await queue_status_for_chapter(book_id, chapter_index, target_language)
 
 
+def _reconcile_subtitle(
+    paragraphs: list[str], source_text: str, title_translation: str | None
+) -> tuple[list[str], str | None]:
+    """Shift an extra leading translated paragraph into title_translation.
+
+    When a book was translated from plain text before its EPUB became available,
+    the plain-text splitter may have left the chapter subtitle as the first body
+    paragraph. Later the EPUB splitter strips it, leaving the translation one
+    paragraph longer than the source. Shifts the surplus leading paragraph into
+    title_translation so alignment is restored without re-translating.
+    """
+    if title_translation is not None:
+        return paragraphs, title_translation
+    source_paragraphs = [p.strip() for p in source_text.split("\n\n") if p.strip()]
+    if len(paragraphs) != len(source_paragraphs) + 1:
+        return paragraphs, title_translation
+    first = paragraphs[0]
+    # Accept as a subtitle only if it's a single short line (no embedded newlines).
+    if "\n" in first or len(first) > 120:
+        return paragraphs, title_translation
+    return paragraphs[1:], first
+
+
 @router.get("/{book_id}/chapters/{chapter_index}/translation")
 async def get_chapter_translation(
     book_id: int = Path(..., ge=1),
@@ -208,12 +231,15 @@ async def get_chapter_translation(
     cached = await get_cached_translation_with_meta(book_id, chapter_index, target_language)
     if not cached:
         raise HTTPException(status_code=404, detail="Translation not cached")
+    paragraphs, title_translation = _reconcile_subtitle(
+        cached["paragraphs"], _chapters[chapter_index].text, cached.get("title_translation")
+    )
     return {
         "status": "ready",
-        "paragraphs": cached["paragraphs"],
+        "paragraphs": paragraphs,
         "provider": cached.get("provider"),
         "model": cached.get("model"),
-        "title_translation": cached.get("title_translation"),
+        "title_translation": title_translation,
     }
 
 
@@ -269,12 +295,21 @@ async def request_chapter_translation(
         book_id, chapter_index, target_language,
     )
     if cached:
+        paragraphs = cached["paragraphs"]
+        title_translation = cached.get("title_translation")
+        if book_meta:
+            from services.book_chapters import split_with_html_preference as _split
+            _ch = await _split(book_id, book_meta.get("text") or "")
+            if chapter_index < len(_ch):
+                paragraphs, title_translation = _reconcile_subtitle(
+                    paragraphs, _ch[chapter_index].text, title_translation
+                )
         return {
             "status": "ready",
-            "paragraphs": cached["paragraphs"],
+            "paragraphs": paragraphs,
             "provider": cached.get("provider"),
             "model": cached.get("model"),
-            "title_translation": cached.get("title_translation"),
+            "title_translation": title_translation,
         }
 
     # 0b. Book must exist before we can enqueue a new translation.

--- a/backend/tests/test_router_books.py
+++ b/backend/tests/test_router_books.py
@@ -1858,3 +1858,96 @@ async def test_enqueue_all_succeeds_for_confirmed_upload(
     assert data.get("enqueued", 0) >= 1, (
         f"Expected at least 1 chapter enqueued for confirmed upload, got: {data}"
     )
+
+
+# ── Issue #1385: subtitle paragraph shift in translation alignment ─────────────
+
+_SUBTITLE_BOOK_TEXT = (
+    "CHAPTER I\n\n"
+    + "First body paragraph. " * 30 + "\n\n"
+    + "Second body paragraph. " * 30 + "\n\n"
+    + "CHAPTER II\n\n"
+    + "Chapter two body text. " * 100
+)
+_STALE_TRANSLATION = [
+    "Untertitel.",           # extra leading subtitle from old plain-text translation
+    "Erster Absatz.",        # paragraph 0 in current source
+    "Zweiter Absatz.",       # paragraph 1 in current source
+]
+_SUBTITLE_BOOK_META = {**MOCK_META, "id": 9880}
+
+
+async def test_get_translation_reconciles_subtitle_shift(client):
+    """Regression #1385: GET /books/{id}/chapters/0/translation must shift an extra
+    leading translated paragraph into title_translation when len(trans)==len(src)+1
+    and the leading paragraph is a short single-line subtitle."""
+    from services.db import save_translation
+    from services.book_chapters import clear_cache as _clear_ch
+    await save_book(9880, _SUBTITLE_BOOK_META, _SUBTITLE_BOOK_TEXT)
+    _clear_ch(9880)
+    await save_translation(9880, 0, "de", _STALE_TRANSLATION, title_translation=None)
+
+    resp = await client.get("/api/books/9880/chapters/0/translation?target_language=de")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["status"] == "ready"
+    assert data["paragraphs"] == ["Erster Absatz.", "Zweiter Absatz."], (
+        f"Regression #1385: expected subtitle shifted out of paragraphs, got {data['paragraphs']}"
+    )
+    assert data["title_translation"] == "Untertitel.", (
+        f"Regression #1385: expected subtitle in title_translation, got {data['title_translation']!r}"
+    )
+
+
+async def test_get_translation_no_reconcile_when_title_already_set(client):
+    """Regression #1385: reconciliation must not overwrite an existing title_translation."""
+    from services.db import save_translation
+    from services.book_chapters import clear_cache as _clear_ch
+    await save_book(9880, _SUBTITLE_BOOK_META, _SUBTITLE_BOOK_TEXT)
+    _clear_ch(9880)
+    await save_translation(9880, 0, "de", _STALE_TRANSLATION, title_translation="Erstes Kapitel")
+
+    resp = await client.get("/api/books/9880/chapters/0/translation?target_language=de")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    # Should NOT shift — title_translation already has a value
+    assert data["paragraphs"] == _STALE_TRANSLATION
+    assert data["title_translation"] == "Erstes Kapitel"
+
+
+async def test_get_translation_no_reconcile_when_lengths_match(client):
+    """Regression #1385: reconciliation must not fire when paragraph counts already match."""
+    from services.db import save_translation
+    from services.book_chapters import clear_cache as _clear_ch
+    await save_book(9880, _SUBTITLE_BOOK_META, _SUBTITLE_BOOK_TEXT)
+    _clear_ch(9880)
+    matched_translation = ["Erster Absatz.", "Zweiter Absatz."]
+    await save_translation(9880, 0, "de", matched_translation, title_translation=None)
+
+    resp = await client.get("/api/books/9880/chapters/0/translation?target_language=de")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["paragraphs"] == matched_translation
+    assert data["title_translation"] is None
+
+
+async def test_post_translation_cache_hit_reconciles_subtitle_shift(anon_client):
+    """Regression #1385: POST /books/{id}/chapters/0/translation cache-hit path
+    must also reconcile the subtitle shift."""
+    from services.db import save_translation
+    from services.book_chapters import clear_cache as _clear_ch
+    await save_book(9880, _SUBTITLE_BOOK_META, _SUBTITLE_BOOK_TEXT)
+    _clear_ch(9880)
+    await save_translation(9880, 0, "de", _STALE_TRANSLATION, title_translation=None)
+
+    resp = await anon_client.post(
+        "/api/books/9880/chapters/0/translation",
+        json={"target_language": "de"},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["status"] == "ready"
+    assert data["paragraphs"] == ["Erster Absatz.", "Zweiter Absatz."], (
+        f"Regression #1385: POST cache-hit must reconcile subtitle, got {data['paragraphs']}"
+    )
+    assert data["title_translation"] == "Untertitel."


### PR DESCRIPTION
## What changed

Added `_reconcile_subtitle()` helper in `routers/books.py` and applied it at both the GET and POST (cache-hit) translation response paths.

When `len(translated_paragraphs) == len(source_paragraphs) + 1` **and** the first translated paragraph is a short single-line string (≤ 120 chars, no newlines), the extra leading paragraph is shifted into `title_translation` instead of being returned in the `paragraphs` array.

## Why

Books like Moby Dick were translated before their EPUB became available. The plain-text splitter left the chapter subtitle (e.g. "Cetology.") as the first body paragraph. Gemini translated it as `paragraphs[0]`. Later, when the EPUB was indexed, `split_with_html_preference` switched to the EPUB splitter which strips the subtitle from the body — leaving the source at N paragraphs but the translation at N+1. Every subsequent paragraph was off by one from Chapter 32 onwards.

The fix serves correctly aligned translations without requiring a DB migration or re-translation. `title_translation` is already the designated field for translated subtitle/chapter-title text.

## Test plan

- `test_get_translation_reconciles_subtitle_shift` — GET endpoint shifts the extra leading paragraph to `title_translation`
- `test_get_translation_no_reconcile_when_title_already_set` — existing `title_translation` is not overwritten
- `test_get_translation_no_reconcile_when_lengths_match` — no shift when counts already match
- `test_post_translation_cache_hit_reconciles_subtitle_shift` — POST cache-hit path also reconciles
- Full suite: 1928 passed, 0 failures

Closes #1385
