### PR TITLE
chore: bump splitter-version design Status from Draft to Merged

### DIFF
--- a/docs/design/splitter-version-cache-invalidation.md
+++ b/docs/design/splitter-version-cache-invalidation.md
@@ -1,6 +1,6 @@
 # Splitter-Version Cache Invalidation + `resplit_book.py` CLI
 
-**Status:** Draft
+**Status:** Merged (PR #1741, 2026-04-27) — implementation pending
 **Author:** Architect
 **Date:** 2026-04-27
 **Priority:** P2


### PR DESCRIPTION
## Summary

Per CLAUDE.md design-doc frontmatter contract, the Status should reflect the doc's state on main. PR #1741 merged the splitter-version design in cycle 1 today; the frontmatter still said `Draft`. Bumping to `Merged (PR #1741, 2026-04-27) — implementation pending` because the impl PR hasn't shipped yet (it would bump to `Shipped` once impl lands).

This is the Architect's per-PR docs check (CLAUDE.md §Documentation policy — Architect): "if the shipped PR was the last of a design-doc series, the design doc's Status is bumped to Shipped". Since impl is still pending, the intermediate `Merged` state is the right value.

## Test plan

- [x] One-line frontmatter edit
- [x] No code changes; markdown only

🤖 Generated with [Claude Code](https://claude.com/claude-code)