### PR TITLE
feat: move cost estimate from single-chapter button to queue-all button

### DIFF
--- a/frontend/src/__tests__/ReaderGeminiCostEstimate.test.tsx
+++ b/frontend/src/__tests__/ReaderGeminiCostEstimate.test.tsx
@@ -1,6 +1,8 @@
 /**
- * Tests for issue #1739: per-chapter Gemini cost estimate in the reader
- * translation sidebar, shown only when hasGeminiKey === true.
+ * Tests for translation cost estimate in the reader sidebar.
+ * Originally issue #1739 (per-chapter estimate under "Translate this chapter").
+ * Updated: cost moved to the "Translate remaining N" queue button area,
+ * showing total queue cost estimate (notStarted × avg chapter cost).
  */
 import React from "react";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
@@ -175,7 +177,13 @@ const SAMPLE_SESSION = {
   user: { id: 1 },
 };
 
-function setupMocks({ hasGeminiKey }: { hasGeminiKey: boolean }) {
+function setupMocks({
+  hasGeminiKey,
+  translationStatus = null,
+}: {
+  hasGeminiKey: boolean;
+  translationStatus?: Record<string, number> | null;
+}) {
   mockUseSession.mockReturnValue({ data: { ...SAMPLE_SESSION }, status: "authenticated" });
 
   mockGetBookChapters.mockResolvedValue({
@@ -194,7 +202,7 @@ function setupMocks({ hasGeminiKey }: { hasGeminiKey: boolean }) {
 
   mockGetAnnotations.mockResolvedValue([]);
   mockGetVocabulary.mockResolvedValue([]);
-  mockGetBookTranslationStatus.mockResolvedValue(null);
+  mockGetBookTranslationStatus.mockResolvedValue(translationStatus);
   mockGetChapterTranslation.mockResolvedValue({ status: "not_found" });
   mockGetChapterQueueStatus.mockResolvedValue({ status: "not_found" });
   mockSaveReadingProgress.mockResolvedValue({});
@@ -209,34 +217,58 @@ async function openTranslateSidebar() {
   fireEvent.click(translateTab);
 }
 
-describe("Reader — Gemini cost estimate in translation sidebar (issue #1739)", () => {
-  it("shows cost estimate near the translate button when hasGeminiKey is true", async () => {
-    setupMocks({ hasGeminiKey: true });
+const STATUS_WITH_UNTRANSLATED = {
+  translated_chapters: 0,
+  total_chapters: 5,
+  queue_pending: 0,
+  queue_running: 0,
+  queue_failed: 0,
+  active: true,
+  active_language: "de",
+};
+
+describe("Reader — cost estimate near queue button (translation sidebar)", () => {
+  it("shows cost estimate near the queue button when hasGeminiKey is true and chapters remain", async () => {
+    setupMocks({ hasGeminiKey: true, translationStatus: STATUS_WITH_UNTRANSLATED });
     render(<ReaderPage />);
 
     await openTranslateSidebar();
 
-    // The translate button should appear
-    const translateBtn = await screen.findByRole("button", { name: /translate this chapter/i });
-    expect(translateBtn).toBeInTheDocument();
+    // The "Translate remaining N" queue button should appear
+    const queueBtn = await screen.findByRole("button", { name: /translate remaining/i });
+    expect(queueBtn).toBeInTheDocument();
 
-    // Cost estimate should be visible near the button
+    // Cost estimate should be visible near the queue button (not under "Translate this chapter")
     await waitFor(() => {
-      const costEl = screen.queryByText(/\$|tokens/i);
+      const costEl = screen.queryByText(/rough estimate/i);
       expect(costEl).toBeInTheDocument();
     });
   });
 
-  it("does not show cost estimate when hasGeminiKey is false", async () => {
-    setupMocks({ hasGeminiKey: false });
+  it("does not show cost estimate under the single-chapter translate button", async () => {
+    setupMocks({ hasGeminiKey: true, translationStatus: null });
     render(<ReaderPage />);
 
     await openTranslateSidebar();
 
-    await screen.findByRole("button", { name: /translate this chapter/i });
+    const translateBtn = await screen.findByRole("button", { name: /translate this chapter/i });
+    expect(translateBtn).toBeInTheDocument();
 
-    // Cost estimate should NOT appear when no Gemini key
-    const costEl = screen.queryByText(/\$\d|\d+K tokens/i);
+    // No cost estimate should appear when there's no book-level queue section
+    const costEl = screen.queryByText(/rough estimate/i);
+    expect(costEl).not.toBeInTheDocument();
+  });
+
+  it("does not show cost estimate when hasGeminiKey is false", async () => {
+    setupMocks({ hasGeminiKey: false, translationStatus: STATUS_WITH_UNTRANSLATED });
+    render(<ReaderPage />);
+
+    await openTranslateSidebar();
+
+    await screen.findByRole("button", { name: /translate remaining/i });
+
+    // Cost estimate should NOT appear without a Gemini key
+    const costEl = screen.queryByText(/rough estimate/i);
     expect(costEl).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -20,17 +20,21 @@ import ChapterSummary from "@/components/ChapterSummary";
 import AuthPromptModal from "@/components/AuthPromptModal";
 import { SunIcon, MoonIcon, SepiaIcon, ChatIcon, GlobeIcon, NoteIcon, EditIcon, BookmarkIcon, BookOpenIcon, ExportIcon, SummaryIcon, PlayIcon, PauseIcon, CloseIcon, KeyboardIcon, FocusIcon, ArrowLeftIcon, ArrowRightIcon, ChevronDownIcon, ChevronRightIcon, EmptyVocabIcon, ArrowUpRightIcon } from "@/components/Icons";
 
-// Gemini Flash pricing constants — used for per-chapter cost estimate in the translation sidebar.
+// Gemini Flash pricing constants — used for total queue cost estimate in the translation sidebar.
 const FLASH_COST_PER_M = 2.5; // USD per 1M output tokens
 const TOKENS_PER_WORD = 1.4;
 const WORDS_DEFAULT = 2000;
 
-function chapterCostLabel(text?: string): string {
+function queueTotalCostLabel(text: string | undefined, chapterCount: number): string {
   const words = text ? text.split(/\s+/).filter(Boolean).length : WORDS_DEFAULT;
-  const tokens = Math.round(words * TOKENS_PER_WORD);
+  const tokens = Math.round(words * TOKENS_PER_WORD) * chapterCount;
   const usd = (tokens / 1_000_000) * FLASH_COST_PER_M;
   const cost = usd < 0.005 ? "< $0.01" : `~$${usd.toFixed(2)}`;
-  const tok = tokens >= 1000 ? `~${(tokens / 1000).toFixed(1)}K` : `~${tokens}`;
+  const tok = tokens >= 1_000_000
+    ? `~${(tokens / 1_000_000).toFixed(1)}M`
+    : tokens >= 1000
+    ? `~${(tokens / 1000).toFixed(1)}K`
+    : `~${tokens}`;
   return `${cost} · ${tok} tokens`;
 }
 
@@ -2004,11 +2008,6 @@ export default function ReaderPage() {
                             >
                               Translate this chapter
                             </button>
-                            {hasGeminiKey === true && (
-                              <p className="mt-1 text-xs text-stone-500 text-center" aria-label="Estimated Gemini translation cost for this chapter">
-                                {chapterCostLabel(current?.text)}
-                              </p>
-                            )}
                           </>
                         ) : (
                           <p className="text-xs text-amber-700">
@@ -2067,13 +2066,20 @@ export default function ReaderPage() {
                             </span>
                           </div>
                           {notStarted > 0 && (
-                            <button
-                              onClick={handleTranslateWholeBook}
-                              disabled={enqueueingBook}
-                              className="mt-2 w-full text-xs px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-50 min-h-[44px]"
-                            >
-                              {enqueueingBook ? "Queueing…" : `Translate remaining ${notStarted}`}
-                            </button>
+                            <>
+                              <button
+                                onClick={handleTranslateWholeBook}
+                                disabled={enqueueingBook}
+                                className="mt-2 w-full text-xs px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-50 min-h-[44px]"
+                              >
+                                {enqueueingBook ? "Queueing…" : `Translate remaining ${notStarted}`}
+                              </button>
+                              {hasGeminiKey === true && !enqueueingBook && (
+                                <p className="mt-1 text-xs text-stone-500 text-center" aria-label="Rough cost estimate for queuing remaining chapters">
+                                  Rough estimate: {queueTotalCostLabel(current?.text, notStarted)}
+                                </p>
+                              )}
+                            </>
                           )}
                         </div>
                       );


### PR DESCRIPTION
## What changed

- Renamed `chapterCostLabel` → `queueTotalCostLabel(text, chapterCount)` — now computes the **total** estimated cost for all remaining chapters, not just one.
- Removed the cost estimate from under the single-chapter "Translate this chapter" button.
- Added the estimate below the "Translate remaining N" queue button (only shown when `hasGeminiKey === true` and `notStarted > 0`).
- Updated `ReaderGeminiCostEstimate.test.tsx`: tests now verify the estimate appears near the queue button with `translationStatus` set, and confirm it no longer appears under "Translate this chapter".

## Why

When a user opens a freshly imported book, the reader shows a "Translate this chapter" button with a cost hint. This was confusing: there is no background enqueue happening during import — the user explicitly queues translation. The per-chapter cost estimate belonged next to the action that actually commits to queuing (the "Translate remaining N" button), where showing the **total** cost for all remaining chapters is actionable and contextually accurate.

## Test plan

- `shows cost estimate near the queue button when hasGeminiKey is true and chapters remain` — estimate appears near "Translate remaining N"
- `does not show cost estimate under the single-chapter translate button` — no estimate when `bookTranslationStatus` is null
- `does not show cost estimate when hasGeminiKey is false` — gated by key presence
- Full frontend suite: 2567 passed, 0 failures
