### PR TITLE
ci: add Frontend Build workflow as standalone build-correctness check (closes #1661)

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -1,0 +1,59 @@
+name: Frontend Build
+
+# Standalone `next build` check — decouples build correctness from the
+# Vercel preview-deploy quota (issue #1661). When Vercel rate-limits its
+# free-tier 100/day cap, the existing Vercel check fails or never runs,
+# and a healthy PR can look broken. This workflow runs the same
+# `npm run build` invocation Vercel runs, in GitHub-paid CI minutes, so
+# build correctness has a deterministic signal that doesn't depend on a
+# third-party quota.
+#
+# Note: the existing `test-frontend` job in ci.yml also runs `npm run
+# build` at the end. That step stays as belt-and-suspenders for now;
+# this workflow is the dedicated, required check called out by branch
+# protection. A follow-up PR can consolidate if desired.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-build.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-build.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Frontend Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+
+      # Same invocation and dummy env-var set as the build step in
+      # ci.yml's test-frontend job — keeps the two checks behaviourally
+      # identical while we run them in parallel.
+      - name: Verify Next.js production build
+        run: npm run build
+        env:
+          # next-auth v5 validates config at module load. Provide
+          # throwaway values so the build can boot the auth() factory
+          # without crashing.
+          AUTH_SECRET: ci-build-dummy-secret-do-not-use-in-prod
+          AUTH_GOOGLE_ID: ci-build-dummy-id
+          AUTH_GOOGLE_SECRET: ci-build-dummy-secret
+          NEXT_PUBLIC_API_URL: http://stub.test/api


### PR DESCRIPTION
## Summary

Closes #1661. Adds `.github/workflows/frontend-build.yml` — a dedicated workflow that runs the same `npm run build` Vercel runs, in GitHub-paid CI minutes. Decouples build-correctness signal from the Vercel free-tier 100-deployments/day quota that hit on 2026-04-27.

## Design note (inline per Path A)

**Why a separate workflow file instead of just relying on the existing `Verify Next.js production build` step inside `test-frontend`?**

- **Distinct branch-protection check.** Branch protection's required-checks list works at the *check name* level. The existing build step is bundled inside `Frontend tests (Jest)`, so if Jest fails, the build's pass/fail is masked by the parent job's overall status. Separate workflow → separate top-level check (`Frontend Build`) that can be added to required-checks independently.
- **Path scoping.** Triggers only on `frontend/**` + the workflow file itself. Backend-only PRs don't run `next build` (matches existing path-scoping pattern). Same warm-cache speed (~30-90s) as the existing job.
- **Belt-and-suspenders.** The existing `Verify Next.js production build` step in `test-frontend` (`ci.yml`) stays. Both build the same way for now; a follow-up PR can consolidate if desired. Keeping both costs little (cache shared between the two jobs).
- **Identical env vars.** Reuses the `AUTH_SECRET` / `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` / `NEXT_PUBLIC_API_URL` dummy values from the existing build step so behaviour matches exactly.

## What's not in this PR

- **Branch-protection settings update** — this requires GitHub repo-admin permission. Filing as a `user-only` follow-up issue.
- **CLAUDE.md required-checks list mention** — `.github/workflows/*` and `CLAUDE.md` are both PM scope per CLAUDE.md line 150. Filing as a `documentation` follow-up for PM (the workflow YAML itself is here in this PR per the user's direct "Do this issue" instruction).

## Test plan

- [x] YAML syntax validated locally with `python -c "import yaml; yaml.safe_load(...)"`.
- [ ] First post-merge run of the new workflow against a frontend-touching PR shows green build and a check named `Frontend Build`.
- [ ] User adds `Frontend Build` to branch-protection required-checks via GitHub Settings (per the user-only follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)