### PR TITLE
fix: accept uppercase/mixed-case file extensions in upload (closes #1781)

### DIFF
--- a/backend/routers/uploads.py
+++ b/backend/routers/uploads.py
@@ -106,10 +106,11 @@ async def upload_book(
     filename = file.filename or ""
     if len(filename) > 255:
         raise HTTPException(status_code=422, detail="Filename too long (max 255 characters).")
-    if filename.endswith(".txt"):
+    filename_lower = filename.lower()
+    if filename_lower.endswith(".txt"):
         fmt = "txt"
         max_size = MAX_TXT_BYTES
-    elif filename.endswith(".epub"):
+    elif filename_lower.endswith(".epub"):
         fmt = "epub"
         max_size = MAX_EPUB_BYTES
     else:

--- a/backend/tests/test_router_uploads.py
+++ b/backend/tests/test_router_uploads.py
@@ -1149,3 +1149,29 @@ async def test_confirm_chapters_unmatched_original_index_saves_empty_text(client
     ch = chapters_resp.json()["chapters"][0]
     assert ch["title"] == "Phantom Chapter"
     assert ch["text"] == ""  # text="" because orig_idx not in orig_by_idx (line 270)
+
+
+# ── Issue #1781: extension check must be case-insensitive ─────────────────────
+
+
+@pytest.mark.parametrize("filename", ["BOOK.TXT", "Book.Txt", "novel.TXT"])
+async def test_upload_accepts_uppercase_txt_extension(client, test_user, filename):
+    """Regression #1781: file upload must accept uppercase/mixed-case .txt extensions."""
+    resp = await client.post("/api/books/upload", files=_txt_upload(filename=filename))
+    assert resp.status_code == 200, (
+        f"Regression #1781: filename {filename!r} must be accepted as .txt, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    assert resp.json()["format"] == "txt"
+
+
+@pytest.mark.parametrize("filename", ["BOOK.EPUB", "Book.Epub", "novel.EPub"])
+async def test_upload_accepts_uppercase_epub_extension(client, test_user, filename):
+    """Regression #1781: file upload must accept uppercase/mixed-case .epub extensions."""
+    epub_bytes = _make_test_epub([("Chapter 1", "Body text. " * 5)])
+    resp = await client.post("/api/books/upload", files=_epub_upload(epub_bytes, filename=filename))
+    assert resp.status_code == 200, (
+        f"Regression #1781: filename {filename!r} must be accepted as .epub, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+    assert resp.json()["format"] == "epub"


### PR DESCRIPTION
## What changed

`backend/routers/uploads.py`: lowercase the filename before extension matching. The `str.endswith` check was case-sensitive, so `BOOK.TXT`, `Book.Epub`, `novel.EPUB` all failed with the misleading "Only .txt and .epub files are supported" error.

The original `filename` is still stored as-is in the DB (preserves user's casing for display); only the format-detection branch is normalized.

## Why

macOS and Windows filesystems are typically case-insensitive, so users dragging in files with uppercase extensions don't realize the case matters. The upload silently fails at the API boundary with a confusing 400. Real bug found during a routine bug-hunt scan.

## Test plan

Two parameterized regression tests, six total cases:
- `test_upload_accepts_uppercase_txt_extension` — `BOOK.TXT`, `Book.Txt`, `novel.TXT` all return 200 with `format=txt`
- `test_upload_accepts_uppercase_epub_extension` — `BOOK.EPUB`, `Book.Epub`, `novel.EPub` all return 200 with `format=epub`
- Full backend suite: 1939 passed, 0 failures

Closes #1781
