### PR TITLE
ux: fix annotation/vocab toolbar badge contrast (amber-600 → amber-800)

### DIFF
--- a/frontend/src/__tests__/BadgeContrastReader.test.ts
+++ b/frontend/src/__tests__/BadgeContrastReader.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Regression for issue #1773:
+ * Annotation and vocabulary count badges in the reader toolbar used
+ * bg-amber-600 text-white — contrast ~3.2:1, fails WCAG AA 4.5:1.
+ * Must not use bg-amber-600 with text-white in badge context.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("reader toolbar badge contrast (closes #1773)", () => {
+  it("does not use bg-amber-600 text-white on 9px badge spans", () => {
+    // Match the specific pattern: rounded-full bg-amber-600 text-white text-[9px]
+    expect(src).not.toMatch(/rounded-full bg-amber-600 text-white text-\[9px\]/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1115,7 +1115,7 @@ export default function ReaderPage() {
             <NoteIcon className="w-3.5 h-3.5 shrink-0" />
             <span className="hidden lg:inline">Notes</span>
             {annotations.length > 0 && (
-              <span className="absolute -top-1.5 -right-1.5 min-w-[16px] h-4 flex items-center justify-center rounded-full bg-amber-600 text-white text-[9px] font-bold px-1">
+              <span className="absolute -top-1.5 -right-1.5 min-w-[16px] h-4 flex items-center justify-center rounded-full bg-amber-800 text-white text-[9px] font-bold px-1">
                 {annotations.length}
               </span>
             )}
@@ -1162,7 +1162,7 @@ export default function ReaderPage() {
             <BookOpenIcon className="w-3.5 h-3.5 shrink-0" />
             <span className="hidden lg:inline">Vocab</span>
             {vocabWords.length > 0 && (
-              <span className="absolute -top-1.5 -right-1.5 min-w-[16px] h-4 flex items-center justify-center rounded-full bg-amber-600 text-white text-[9px] font-bold px-1">
+              <span className="absolute -top-1.5 -right-1.5 min-w-[16px] h-4 flex items-center justify-center rounded-full bg-amber-800 text-white text-[9px] font-bold px-1">
                 {vocabWords.length}
               </span>
             )}


### PR DESCRIPTION
## What changed

The annotation-count and vocab-count toolbar badges used `bg-amber-600 text-white` with `text-[9px]` — tiny text at amber-600 (#d97706) yields ~3.75:1 contrast against white, below the WCAG AA 4.5:1 minimum.

Changed both badge spans in `reader/[bookId]/page.tsx` (lines 1118 and 1165) from `bg-amber-600` to `bg-amber-800` (~8:1 contrast).

## Why

WCAG 2.1 SC 1.4.3 (Contrast, AA). amber-800 (#92400e) on white gives ~8:1, well above the 4.5:1 threshold. The visual difference is subtle — darker amber, still on-brand.

## Test plan

- New Jest static-source test `BadgeContrastReader.test.ts` asserts the `rounded-full bg-amber-600 text-white text-[9px]` pattern no longer appears in `reader/[bookId]/page.tsx`
- Full frontend suite: 2573 tests pass
- Full backend suite: 1929 tests pass

Closes #1773
