### PR TITLE
chore: remove stale empty-string entry from MODEL_LIMITS (closes #1783)

### DIFF
--- a/backend/services/model_limits.py
+++ b/backend/services/model_limits.py
@@ -42,12 +42,6 @@ DEFAULT_CHAIN: list[str] = [
 UNLIMITED_RPD = 1_000_000  # treat as effectively unlimited
 
 MODEL_LIMITS: dict[str, _Limits] = {
-    # "" = server-side default (currently gemini-3.1-flash-lite-preview).
-    # Same quota + pricing as gemini-3.1-flash-lite on Tier 1.
-    "": {
-        "rpm": 4000, "rpd": 150000, "max_output_tokens": 7500,
-        "input_usd_per_m": 0.10, "output_usd_per_m": 0.40,
-    },
     # Frontier 3.1 family
     "gemini-3.1-pro-preview": {
         "rpm": 25, "rpd": 250, "max_output_tokens": 60000,

--- a/backend/tests/test_model_limits.py
+++ b/backend/tests/test_model_limits.py
@@ -1,0 +1,35 @@
+"""Tests for services.model_limits."""
+
+from services.model_limits import (
+    MODEL_LIMITS,
+    DEFAULT_CHAIN,
+    CUSTOM_LIMITS,
+    limits_for,
+)
+
+
+def test_model_limits_has_no_empty_string_key():
+    """Regression #1783: the empty-string key was a stale alias for the old
+    server default (gemini-3.1-flash-lite-preview). Removed in cleanup —
+    callers always pass real model names from the chain. Lock in absence."""
+    assert "" not in MODEL_LIMITS, (
+        "MODEL_LIMITS must not contain an empty-string key — that entry was "
+        "a stale alias for an old default model and is no longer needed."
+    )
+
+
+def test_default_chain_models_all_have_limits():
+    """Every model in DEFAULT_CHAIN must have a corresponding MODEL_LIMITS
+    entry — otherwise the queue worker would fall back to CUSTOM_LIMITS for
+    well-known curated-default models."""
+    for model in DEFAULT_CHAIN:
+        assert model in MODEL_LIMITS, (
+            f"DEFAULT_CHAIN model '{model}' has no entry in MODEL_LIMITS — "
+            f"add an entry or remove from DEFAULT_CHAIN."
+        )
+
+
+def test_limits_for_unknown_model_falls_back_to_custom():
+    """Unknown models must use the conservative CUSTOM_LIMITS fallback."""
+    assert limits_for("definitely-not-a-real-model") == CUSTOM_LIMITS
+    assert limits_for("") == CUSTOM_LIMITS  # post-#1783 cleanup


### PR DESCRIPTION
## What changed

Removed the `""` (empty-string) entry from `MODEL_LIMITS` in `backend/services/model_limits.py`. The entry was an alias for an old server default that was bumped in PR #1397 — its comment + values were never updated, leaving them as forensic landmines.

Added `backend/tests/test_model_limits.py` with three small tests:
1. `test_model_limits_has_no_empty_string_key` — locks in the absence of the stale alias.
2. `test_default_chain_models_all_have_limits` — every model in `DEFAULT_CHAIN` must have a real entry.
3. `test_limits_for_unknown_model_falls_back_to_custom` — `""` and unknown models correctly fall through to `CUSTOM_LIMITS`.

## Why

In practice nothing queries `limits_for("")` — every callsite passes a real model name from the configured chain. The `MODEL_LIMITS.get(model, CUSTOM_LIMITS)` fallback already handles unknown lookups conservatively, which is the correct default for any unexpected `""` query.

But the stale comment ("currently gemini-3.1-flash-lite-preview") was the basis for the false-alarm bug report #1772, where an Architect mistakenly believed the server default still pinned to a stale preview model. Removing the entry eliminates the misleading documentation source.

## Test plan

- 3 new model_limits tests pass
- Translation queue suite (118 tests) unaffected
- Full backend suite: 1942 passed, 0 failures (+3 from the new tests)

Closes #1783
