### PR TITLE
ux: add focus-visible rings to flashcard, reader annotation, and sidebar cards (closes #1785)

### DIFF
--- a/frontend/src/__tests__/FocusVisibleCards.test.ts
+++ b/frontend/src/__tests__/FocusVisibleCards.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Focus-visible regression for issue #1785:
+ * Flashcard flip card, reader annotation card, and AnnotationsSidebar card
+ * all use role="button" + tabIndex={0} but lacked focus-visible ring styles,
+ * violating WCAG 2.4.7 (Focus Visible, Level AA).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const flashcardSrc = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/flashcards/page.tsx"),
+  "utf8",
+);
+const readerSrc = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+const sidebarSrc = fs.readFileSync(
+  path.join(__dirname, "../components/AnnotationsSidebar.tsx"),
+  "utf8",
+);
+
+describe("focus-visible rings on interactive cards (closes #1785)", () => {
+  it("flashcard flip card has focus-visible ring", () => {
+    expect(flashcardSrc).toMatch(/focus-visible:ring/);
+  });
+
+  it("reader inline annotation card has focus-visible ring", () => {
+    // The reader has multiple role=button divs; check the annotation renderCard pattern
+    expect(readerSrc).toMatch(/colorBadge\[ann\.color\].*focus-visible:ring|focus-visible:ring.*colorBadge\[ann\.color\]/s);
+  });
+
+  it("AnnotationsSidebar annotation card has focus-visible ring", () => {
+    expect(sidebarSrc).toMatch(/COLOR_BADGE\[ann\.color\].*focus-visible:ring|focus-visible:ring.*COLOR_BADGE\[ann\.color\]/s);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1723,7 +1723,7 @@ export default function ReaderPage() {
                     role="button"
                     tabIndex={0}
                     aria-label={`Jump to annotation: ${ann.sentence_text.slice(0, 60)}`}
-                    className={`rounded-lg border px-3 py-2.5 cursor-pointer hover:opacity-80 transition-opacity ${colorBadge[ann.color] ?? colorBadge.yellow}`}
+                    className={`rounded-lg border px-3 py-2.5 cursor-pointer hover:opacity-80 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 ${colorBadge[ann.color] ?? colorBadge.yellow}`}
                     onClick={() => {
                       if (ann.chapter_index !== chapterIndex) {
                         goToChapter(ann.chapter_index);

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -222,7 +222,7 @@ export default function FlashcardsPage() {
               aria-label={flipped ? `${currentCard.word} — definition side, press to flip back` : `Word: ${currentCard.word}. Press to reveal definition.`}
               onClick={() => setFlipped(f => !f)}
               onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setFlipped(f => !f); }}
-              className="cursor-pointer rounded-2xl border border-amber-200 bg-white p-8 min-h-[200px] flex flex-col items-center justify-center gap-3 hover:-translate-y-0.5 transition-all duration-200 select-none"
+              className="cursor-pointer rounded-2xl border border-amber-200 bg-white p-8 min-h-[200px] flex flex-col items-center justify-center gap-3 hover:-translate-y-0.5 transition-all duration-200 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
               style={{ boxShadow: "var(--shadow-card)" }}
             >
               <span className="text-xs text-stone-500 uppercase tracking-wide">

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -131,7 +131,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
                         role="button"
                         tabIndex={0}
                         aria-label={`Jump to annotation: ${ann.sentence_text.slice(0, 60)}`}
-                        className={`rounded-lg border px-3 py-2.5 cursor-pointer hover:opacity-80 transition-opacity ${COLOR_BADGE[ann.color] ?? COLOR_BADGE.yellow}`}
+                        className={`rounded-lg border px-3 py-2.5 cursor-pointer hover:opacity-80 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 ${COLOR_BADGE[ann.color] ?? COLOR_BADGE.yellow}`}
                         onClick={() => { onJump(ann); setOpen(false); }}
                         onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onJump(ann); setOpen(false); } }}
                       >


### PR DESCRIPTION
## What changed

Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1` to three interactive card elements that use `role="button"` + `tabIndex={0}` but lacked any keyboard focus indicator:

1. **Flashcard flip card** (`vocabulary/flashcards/page.tsx`) — the main card div users press to reveal the answer
2. **Reader inline annotation card** (`reader/[bookId]/page.tsx`) — `renderCard` divs in the Notes tab
3. **AnnotationsSidebar annotation card** (`AnnotationsSidebar.tsx`) — annotation entries in the sidebar drawer

## Why

Closes #1785. WCAG 2.4.7 (Focus Visible, Level AA) requires that all keyboard-focusable elements show a visible focus indicator. These three elements had `tabIndex={0}` and keyboard handlers (`onKeyDown`) but no `focus-visible:ring`, making keyboard navigation invisible and inaccessible.

## Test plan

`FocusVisibleCards.test.ts` — static-source assertions verifying each of the three affected elements now carries `focus-visible:ring` in its className:
- Flashcard flip card: `expect(flashcardSrc).toMatch(/focus-visible:ring/)`
- Reader renderCard: `expect(readerSrc).toMatch(/colorBadge\[ann\.color\].*focus-visible:ring/s)`
- Sidebar card: `expect(sidebarSrc).toMatch(/COLOR_BADGE\[ann\.color\].*focus-visible:ring/s)`

All 2579 frontend tests pass; 1929+ backend tests pass.

## Docs follow-up

- [ ] Docs updated (if applicable)
