### PR TITLE
ux: fix 'Translate this chapter' button contrast — amber-600 → amber-700 (closes #1788)

### DIFF
--- a/frontend/src/__tests__/TranslateBtnContrast.test.ts
+++ b/frontend/src/__tests__/TranslateBtnContrast.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Contrast regression for issue #1788:
+ * "Translate this chapter" button used bg-amber-600 text-white text-sm —
+ * amber-600 (#d97706) on white ≈ 3.75:1, failing WCAG AA 4.5:1.
+ * Fixed by bumping to bg-amber-700 (#b45309 on white ≈ 5:1).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const readerSrc = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Translate button contrast (closes #1788)", () => {
+  it("translate chapter button does not use bg-amber-600 with white text", () => {
+    // className appears before the button text in JSX source order
+    expect(readerSrc).not.toMatch(
+      /bg-amber-600[^"]*text-white[^"]*"[\s\S]{0,200}Translate this chapter/,
+    );
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2004,7 +2004,7 @@ export default function ReaderPage() {
                           <>
                             <button
                               onClick={handleTranslateThisChapter}
-                              className="w-full px-3 py-2 min-h-[44px] rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-sm font-medium transition-colors"
+                              className="w-full px-3 py-2 min-h-[44px] rounded-lg bg-amber-700 hover:bg-amber-800 text-white text-sm font-medium transition-colors"
                             >
                               Translate this chapter
                             </button>


### PR DESCRIPTION
## What changed

Changed `bg-amber-600` → `bg-amber-700` on the "Translate this chapter" button (`reader/[bookId]/page.tsx:2007`). Also bumped `hover:bg-amber-700` → `hover:bg-amber-800` for consistency.

## Why

Closes #1788. The button used `bg-amber-600 text-white text-sm` — amber-600 (#d97706) on white ≈ 3.75:1, which **fails WCAG AA** (minimum 4.5:1 for normal/small text). amber-700 (#b45309) on white ≈ 5:1 — passes.

Companion to #1784 and #1787 which fixed the other `bg-amber-600 text-white` contrast failures in the app.

## Test plan

`TranslateBtnContrast.test.ts` — static-source assertion verifying the button className no longer contains `bg-amber-600 ... text-white` preceding "Translate this chapter". All 2577 frontend tests pass.

## Docs follow-up

- [ ] Docs updated (if applicable)
