### PR TITLE
ux: remove role=dialog from TypographyPanel — non-modal popover (closes #1789)

### DIFF
--- a/frontend/src/__tests__/TypographyPanelDialogRole.test.ts
+++ b/frontend/src/__tests__/TypographyPanelDialogRole.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Accessibility regression for issue #1789:
+ * TypographyPanel used role="dialog" without aria-modal="true", causing
+ * screen readers to roam page content behind the panel (WCAG 4.1.2 Level A).
+ * Fix: remove role="dialog"; the panel is a non-modal settings popover —
+ * no role annotation is needed (aria-label is sufficient).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/TypographyPanel.tsx"),
+  "utf8",
+);
+
+describe("TypographyPanel dialog role (closes #1789)", () => {
+  it("does not use role=dialog without aria-modal", () => {
+    const hasDialogRole = /role="dialog"/.test(src);
+    const hasAriaModal = /aria-modal="true"/.test(src);
+    // Either no role=dialog, or role=dialog accompanied by aria-modal=true
+    if (hasDialogRole) {
+      expect(hasAriaModal).toBe(true);
+    } else {
+      expect(hasDialogRole).toBe(false);
+    }
+  });
+});

--- a/frontend/src/__tests__/TypographyPanelRole.test.ts
+++ b/frontend/src/__tests__/TypographyPanelRole.test.ts
@@ -1,7 +1,9 @@
 /**
- * Regression test for #1340: TypographyPanel must have role="dialog" and
- * aria-label so screen readers announce the floating settings panel, and
- * the reader trigger buttons must have aria-controls pointing to the panel.
+ * Regression test for #1340 (updated by #1789):
+ * TypographyPanel must have aria-label so screen readers announce the floating
+ * settings panel, and trigger buttons must have aria-controls pointing to it.
+ * role="dialog" was removed in #1789 — the panel is a non-modal popover; using
+ * role="dialog" without aria-modal caused AT to roam behind the panel (WCAG 4.1.2).
  */
 import * as fs from "fs";
 import * as path from "path";
@@ -17,12 +19,13 @@ const readerSrc = fs.readFileSync(
 );
 
 describe("TypographyPanel accessible panel semantics (closes #1340)", () => {
-  it('panel root has role="dialog"', () => {
-    expect(panelSrc).toContain('role="dialog"');
-  });
-
-  it("panel root has aria-label", () => {
+  it("panel root has aria-label (no role=dialog — non-modal popover, see #1789)", () => {
     expect(panelSrc).toContain('aria-label="Typography settings"');
+    // Verify role=dialog was removed; if present it must be accompanied by aria-modal
+    const hasDialogRole = /role="dialog"/.test(panelSrc);
+    if (hasDialogRole) {
+      expect(panelSrc).toContain('aria-modal="true"');
+    }
   });
 
   it('panel root has id="typography-panel"', () => {

--- a/frontend/src/components/TypographyPanel.tsx
+++ b/frontend/src/components/TypographyPanel.tsx
@@ -129,7 +129,6 @@ export default function TypographyPanel({
     <div
       ref={panelRef}
       id="typography-panel"
-      role="dialog"
       aria-label="Typography settings"
       style={fixedStyle}
       className={`${anchorPos ? "" : "absolute top-full right-0 mt-1 z-50 "}bg-white border border-amber-200 rounded-xl shadow-lg p-4 w-64 animate-fade-in`}


### PR DESCRIPTION
## What changed

Removed `role="dialog"` from `TypographyPanel.tsx` (line 132). The panel keeps `aria-label="Typography settings"` and `id="typography-panel"`.

Also updated `TypographyPanelRole.test.ts` to reflect the corrected semantics from #1789 — the original #1340 fix needed `aria-label` + `id`, not `role="dialog"`.

## Why

Closes #1789. `role="dialog"` without `aria-modal="true"` causes screen readers (VoiceOver, NVDA) to continue exposing background page content while the panel is visible — a WCAG 4.1.2 Level A violation.

The typography settings panel is a non-modal popover (closes on click-outside or Escape; does not trap focus). Using `role="dialog"` incorrectly implied modal semantics. Removing the role eliminates the AT-roaming issue while keeping the accessible name (`aria-label`) so the panel is still announced correctly.

## Test plan

- `TypographyPanelDialogRole.test.ts` — new test that asserts: if `role="dialog"` is present it must be paired with `aria-modal="true"`; passes because role is now absent
- `TypographyPanelRole.test.ts` — updated to reflect corrected semantics (removed assertion for `role="dialog"`, retained `aria-label` + `id` + `aria-controls` checks)
- All 2576 frontend tests pass

## Docs follow-up

- [ ] Docs updated (if applicable)
