### PR TITLE
ux: fix delete-button icon contrast — red-400 → red-500 (closes #1796)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -245,6 +245,30 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-25 | Desktop touch-target scoping: `md:min-h-0` on reader header buttons (44px becomes mobile-only) | reader/[bookId]/page.tsx, CLAUDE.md | #1081 |
 | 2026-04-25 | Browse-books CTA on vocabulary + notes empty states | vocabulary/page.tsx, notes/page.tsx | #1093 |
 
+## Wave 10 — Accessibility Round 2 (2026-04-28)
+
+### WCAG 2.4.7 Focus Visible — focus rings on card-style buttons
+| Date | Change | File(s) | PR |
+|------|--------|---------|----|
+| 2026-04-28 | `focus-visible:ring-2 focus-visible:ring-amber-400` on flashcard, reader annotation, and sidebar cards | flashcards/page.tsx, reader/[bookId]/page.tsx, AnnotationsSidebar.tsx | #1793 |
+
+### WCAG 1.4.3 Contrast (text) — amber-600 → amber-700
+| Date | Change | File(s) | PR |
+|------|--------|---------|----|
+| 2026-04-28 | "Translate this chapter" button: `bg-amber-600` → `bg-amber-700` (3.75:1 → 5:1 on white) | reader/[bookId]/page.tsx | #1794 |
+
+### WCAG 4.1.2 Name, Role, Value — settings panel semantics
+| Date | Change | File(s) | PR |
+|------|--------|---------|----|
+| 2026-04-28 | Removed `role="dialog"` from TypographyPanel — non-modal popover should not declare dialog role without `aria-modal="true"` | TypographyPanel.tsx | #1795 |
+
+### WCAG 1.4.11 Non-text Contrast — icon color
+| Date | Change | File(s) | PR |
+|------|--------|---------|----|
+| 2026-04-28 | Delete-annotation buttons: `text-red-400` (#f87171, 2.8:1) → `text-red-500` (#ef4444, 3.8:1) on white | notes/[bookId]/page.tsx | #1797 |
+
+---
+
 ## #364 — Mobile sub-sentence selection (design note, 2026-04-27)
 
 **Status:** Shipped. Design note merged in #1671; implementation drops the touch `preventDefault` per Approach B.

--- a/frontend/src/__tests__/DeleteBtnRed400Contrast.test.ts
+++ b/frontend/src/__tests__/DeleteBtnRed400Contrast.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Non-text contrast regression for issue #1796:
+ * Delete-annotation buttons in notes/[bookId]/page.tsx used text-red-400
+ * (#f87171 on white ≈ 2.8:1) — fails WCAG 1.4.11 Non-text Contrast (3:1)
+ * for UI component icons.
+ * Fixed by bumping to text-red-500 (#ef4444 on white ≈ 3.8:1 — passes).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Delete button non-text contrast (closes #1796)", () => {
+  it("delete buttons do not use text-red-400 (fails WCAG 1.4.11 < 3:1)", () => {
+    // Match the specific button patterns where text-red-400 was used
+    expect(src).not.toMatch(
+      /text-red-400[^"]*hover:text-red-600[^"]*transition-colors[^"]*p-1/,
+    );
+    expect(src).not.toMatch(
+      /text-red-400[^"]*hover:text-red-600[^"]*transition-colors[^"]*min-h-\[44px\]/,
+    );
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -150,7 +150,7 @@ function AnnotationCard({
           <button
             onClick={onDelete}
             disabled={isDeleting}
-            className="text-red-400 hover:text-red-600 disabled:opacity-40 transition-colors p-1 min-h-[44px] flex items-center justify-center"
+            className="text-red-500 hover:text-red-600 disabled:opacity-40 transition-colors p-1 min-h-[44px] flex items-center justify-center"
             title="Delete annotation"
             aria-label={`Delete annotation: ${ann.sentence_text.slice(0, 60)}`}
           >
@@ -202,7 +202,7 @@ function InsightCard({
         <button
           onClick={onDelete}
           disabled={isDeleting}
-          className="text-red-400 hover:text-red-600 disabled:opacity-40 transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
+          className="text-red-500 hover:text-red-600 disabled:opacity-40 transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
           title="Delete insight"
           aria-label={`Delete insight: ${ins.question.slice(0, 60)}`}
         >


### PR DESCRIPTION
## What changed

Bumped delete-annotation button icon color from `text-red-400` to `text-red-500` in `notes/[bookId]/page.tsx`.

Two buttons were affected:
- Compact delete button (`.../p-1`) on the annotations list
- Full-height delete button (`.../min-h-[44px]`) on the insights/flashcard list

## Why

`text-red-400` (#f87171 on white) has a contrast ratio of ~2.8:1, which fails **WCAG 1.4.11 Non-text Contrast** (minimum 3:1 for UI component icons). `text-red-500` (#ef4444 on white) is ~3.8:1 — passes.

## Test plan

- New regression test `DeleteBtnRed400Contrast.test.ts` asserts neither delete button pattern uses `text-red-400`
- All 2580 frontend tests pass

Closes #1796

## Docs follow-up
- [ ] Design change log updated in `docs/design-improvement-plan.md`
