### PR TITLE
feat: pricing-plans PR A — migrations 038+039 + require_tier + 4 translation-route gates (#1790)

### DIFF
--- a/backend/migrations/038_users_tier_columns.sql
+++ b/backend/migrations/038_users_tier_columns.sql
@@ -1,0 +1,15 @@
+-- Issue #1790 / design doc: docs/design/pricing-plans.md
+-- PR A of the pricing-plans series. Adds the per-user tier columns
+-- driving every translation-creation gate. No data movement: existing
+-- rows backfill to 'free' via the column DEFAULT, which is exactly the
+-- right entitlement for any user who hasn't gone through Stripe checkout.
+--
+-- The Stripe-related columns are added in this same migration even
+-- though Stripe code lands in PR C — the columns are inert until then,
+-- and one schema migration is cheaper than two for the rollout window.
+
+ALTER TABLE users ADD COLUMN tier TEXT NOT NULL DEFAULT 'free'
+    CHECK (tier IN ('free', 'pro', 'premium'));
+ALTER TABLE users ADD COLUMN stripe_customer_id TEXT;
+ALTER TABLE users ADD COLUMN stripe_subscription_id TEXT;
+ALTER TABLE users ADD COLUMN tier_period_end TIMESTAMP;

--- a/backend/migrations/039_billing_events.sql
+++ b/backend/migrations/039_billing_events.sql
@@ -1,0 +1,25 @@
+-- Issue #1790 / design doc: docs/design/pricing-plans.md
+-- PR A of the pricing-plans series. Audit log for every Stripe webhook
+-- we receive. The UNIQUE constraint on stripe_event_id makes the
+-- webhook handler trivially idempotent: Stripe redelivers events on
+-- transient failures, and an INSERT collision tells us "already
+-- processed, skip". Forensics value is the second use case — payload_json
+-- preserves the full Stripe event for incident review.
+--
+-- ON DELETE SET NULL on user_id rather than CASCADE: the audit log
+-- should outlive the user account (legally / forensically useful), but
+-- without violating FK constraints when a user is deleted.
+--
+-- This table is empty until PR C adds the /billing/webhook handler.
+
+CREATE TABLE IF NOT EXISTS billing_events (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id         INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    stripe_event_id TEXT    NOT NULL UNIQUE,
+    event_type      TEXT    NOT NULL,
+    payload_json    TEXT    NOT NULL,
+    received_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS billing_events_user
+    ON billing_events(user_id, received_at);

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 from pydantic import BaseModel, Field, field_validator
-from services.auth import get_current_user, decrypt_api_key, check_book_access
+from services.auth import get_current_user, decrypt_api_key, check_book_access, require_tier
 from services.db import (
     get_cached_translation,
     save_translation,
@@ -397,7 +397,7 @@ async def save_translate_cache(req: SaveTranslationRequest, _user: dict = Depend
 
 
 @router.post("/translate")
-async def translate(req: TranslateRequest, user: dict = Depends(get_current_user)):
+async def translate(req: TranslateRequest, user: dict = Depends(require_tier("pro"))):
     """Translate text with auto-fallback: Gemini if key available, else Google Translate (free)."""
     src = req.source_language.strip().lower().split("-")[0]
     tgt = req.target_language.strip().lower().split("-")[0]

--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -15,7 +15,7 @@ from services.db import (
     list_cached_books,
 )
 from services.splitter import build_chapters
-from services.auth import get_current_user, get_optional_user, decrypt_api_key, check_book_access
+from services.auth import get_current_user, get_optional_user, decrypt_api_key, check_book_access, require_tier, TIER_RANK
 
 logger = logging.getLogger(__name__)
 
@@ -342,11 +342,23 @@ async def request_chapter_translation(
             detail=f"Chapter index out of range (book has {len(_chapters)} chapter(s)).",
         )
 
-    # 1. New translation requires login.
+    # 1. New translation requires login + paid tier (Pro / Premium).
+    # Read path (cache hit above) stays open to anonymous users — only
+    # CREATING a new translation costs LLM tokens and is gated.
+    # See docs/design/pricing-plans.md §"Translation-creation gating".
     if user is None:
         raise HTTPException(
             status_code=401,
             detail="Login required to translate this chapter.",
+        )
+    if TIER_RANK.get(user.get("tier") or "free", 0) < TIER_RANK["pro"]:
+        raise HTTPException(
+            status_code=402,
+            detail={
+                "error": "tier_required",
+                "current_tier": user.get("tier") or "free",
+                "required_tier": "pro",
+            },
         )
 
     # 3. Already queued / running?
@@ -396,7 +408,7 @@ async def request_chapter_translation(
 async def enqueue_all_chapters(
     req: RequestTranslationBody,
     book_id: int = Path(..., ge=1),
-    user: dict = Depends(get_current_user),
+    user: dict = Depends(require_tier("pro")),
 ):
     """Queue every not-yet-translated chapter of a book for one language.
 
@@ -456,7 +468,7 @@ async def retry_chapter_translation(
     req: RequestTranslationBody,
     book_id: int = Path(..., ge=1),
     chapter_index: int = Path(..., ge=0),
-    user: dict = Depends(get_current_user),
+    user: dict = Depends(require_tier("pro")),
 ):
     """Re-queue a single chapter whose queue row is in 'failed' state.
 

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -234,3 +234,38 @@ def check_book_access(book: dict | None, user: dict | None) -> None:
         return
     if user is None or (user["id"] != owner_id and user.get("role") != "admin"):
         raise HTTPException(status_code=403, detail="Not your book")
+
+
+# ── Tier-based authorization ────────────────────────────────────────────────
+# See docs/design/pricing-plans.md §"Authorization layer". Free is the
+# default for every user; Pro / Premium are reached via Stripe checkout
+# (PR C) which writes the tier column on webhook receipt.
+
+TIER_RANK = {"free": 0, "pro": 1, "premium": 2}
+
+
+def require_tier(min_tier: str):
+    """Dependency factory: caller passes the minimum tier the route needs.
+
+    Returns 402 Payment Required (not 403) for under-tier users — the
+    HTTP semantic for "your auth is fine, you just need to pay". The
+    structured `detail` lets the frontend pick the right paywall
+    variant without parsing the message string.
+    """
+    if min_tier not in TIER_RANK:
+        raise ValueError(f"Unknown tier: {min_tier!r}")
+
+    async def _dep(user: dict = Depends(get_current_user)) -> dict:
+        current = user.get("tier") or "free"
+        if TIER_RANK.get(current, 0) < TIER_RANK[min_tier]:
+            raise HTTPException(
+                status_code=402,
+                detail={
+                    "error": "tier_required",
+                    "current_tier": current,
+                    "required_tier": min_tier,
+                },
+            )
+        return user
+
+    return _dep

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -58,7 +58,15 @@ async def tmp_db(monkeypatch, tmp_path):
 
 @pytest.fixture
 async def test_user(tmp_db):
-    return await get_or_create_user(**TEST_USER)
+    user = await get_or_create_user(**TEST_USER)
+    # Default test_user to 'pro' so tier-gated routes (translation creation,
+    # /ai/translate, etc.) don't 402 in tests that don't specifically care
+    # about tier gating. Tests that DO test gating (test_pricing_tier_gating)
+    # downgrade to 'free' or upgrade to 'premium' explicitly.
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        await conn.execute("UPDATE users SET tier = 'pro' WHERE id = ?", (user["id"],))
+        await conn.commit()
+    return await get_user_by_id(user["id"])
 
 
 @pytest.fixture

--- a/backend/tests/test_pricing_tier_gating.py
+++ b/backend/tests/test_pricing_tier_gating.py
@@ -1,0 +1,252 @@
+"""PR A of the pricing-plans series (#1790 / docs/design/pricing-plans.md).
+
+Covers:
+  - Migration 038: users.tier defaults to 'free'; CHECK constraint enforces enum.
+  - Migration 039: billing_events table created with UNIQUE on stripe_event_id.
+  - require_tier dependency: 402 below tier, allows at-or-above tier.
+  - Four translation-creation routes return 402 for free users.
+
+Stripe code lives in PR C; the columns and table added here are inert
+until then (no test asserts Stripe behaviour).
+"""
+
+import pytest
+import aiosqlite
+import services.db as db_module
+from services.auth import require_tier, TIER_RANK
+
+
+# ── Migration 038 ────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_migration_038_user_default_tier_free(tmp_db):
+    """A user created without an explicit tier gets 'free'.
+
+    Uses a fresh user (not the conftest test_user fixture, which bumps
+    to 'pro' to keep existing translation-route tests passing). Asserts
+    the column DEFAULT is what the migration says.
+    """
+    from services.db import get_or_create_user
+    fresh = await get_or_create_user(
+        google_id="fresh-default-tier-test",
+        email="fresh@example.com",
+        name="Fresh",
+        picture="",
+    )
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        row = await (await db.execute(
+            "SELECT tier, stripe_customer_id, stripe_subscription_id, tier_period_end FROM users WHERE id = ?",
+            (fresh["id"],),
+        )).fetchone()
+    assert row["tier"] == "free"
+    assert row["stripe_customer_id"] is None
+    assert row["stripe_subscription_id"] is None
+    assert row["tier_period_end"] is None
+
+
+@pytest.mark.asyncio
+async def test_migration_038_check_constraint_rejects_unknown_tier(test_user):
+    """The CHECK constraint blocks tier values outside ('free','pro','premium')."""
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        with pytest.raises(aiosqlite.IntegrityError):
+            await db.execute(
+                "UPDATE users SET tier = 'enterprise' WHERE id = ?",
+                (test_user["id"],),
+            )
+            await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_migration_038_accepts_pro_and_premium(test_user):
+    """The CHECK constraint accepts 'pro' and 'premium'."""
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        for tier in ("pro", "premium"):
+            await db.execute("UPDATE users SET tier = ? WHERE id = ?", (tier, test_user["id"]))
+            await db.commit()
+            db.row_factory = aiosqlite.Row
+            row = await (await db.execute("SELECT tier FROM users WHERE id = ?", (test_user["id"],))).fetchone()
+            assert row["tier"] == tier
+
+
+# ── Migration 039 ────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_migration_039_billing_events_table_exists(test_user):
+    """billing_events table is created and accepts an insert."""
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            "INSERT INTO billing_events (user_id, stripe_event_id, event_type, payload_json) VALUES (?, ?, ?, ?)",
+            (test_user["id"], "evt_test_1", "checkout.session.completed", "{}"),
+        )
+        await db.commit()
+        db.row_factory = aiosqlite.Row
+        row = await (await db.execute("SELECT * FROM billing_events WHERE stripe_event_id = ?", ("evt_test_1",))).fetchone()
+    assert row["user_id"] == test_user["id"]
+    assert row["event_type"] == "checkout.session.completed"
+    assert row["received_at"] is not None  # default CURRENT_TIMESTAMP
+
+
+@pytest.mark.asyncio
+async def test_migration_039_stripe_event_id_unique(test_user):
+    """Replay of the same stripe_event_id is rejected (idempotency primitive)."""
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute(
+            "INSERT INTO billing_events (user_id, stripe_event_id, event_type, payload_json) VALUES (?, ?, ?, ?)",
+            (test_user["id"], "evt_dupe", "subscription.updated", "{}"),
+        )
+        await db.commit()
+        with pytest.raises(aiosqlite.IntegrityError):
+            await db.execute(
+                "INSERT INTO billing_events (user_id, stripe_event_id, event_type, payload_json) VALUES (?, ?, ?, ?)",
+                (test_user["id"], "evt_dupe", "subscription.updated", "{}"),
+            )
+            await db.commit()
+
+
+# ── require_tier dependency ──────────────────────────────────────────────
+
+def test_tier_rank_total_order():
+    assert TIER_RANK["free"] < TIER_RANK["pro"] < TIER_RANK["premium"]
+
+
+def test_require_tier_unknown_min_tier_raises():
+    with pytest.raises(ValueError):
+        require_tier("enterprise")
+
+
+@pytest.mark.asyncio
+async def test_require_tier_blocks_under_tier():
+    """Free user calling a Pro-required route gets 402 with structured detail."""
+    from fastapi import HTTPException
+    dep = require_tier("pro")
+    with pytest.raises(HTTPException) as exc_info:
+        await dep(user={"id": 1, "tier": "free"})
+    assert exc_info.value.status_code == 402
+    assert exc_info.value.detail["error"] == "tier_required"
+    assert exc_info.value.detail["current_tier"] == "free"
+    assert exc_info.value.detail["required_tier"] == "pro"
+
+
+@pytest.mark.asyncio
+async def test_require_tier_allows_at_tier():
+    """Pro user calling a Pro-required route passes."""
+    dep = require_tier("pro")
+    user = {"id": 1, "tier": "pro"}
+    assert await dep(user=user) is user
+
+
+@pytest.mark.asyncio
+async def test_require_tier_allows_above_tier():
+    """Premium user calling a Pro-required route passes."""
+    dep = require_tier("pro")
+    user = {"id": 1, "tier": "premium"}
+    assert await dep(user=user) is user
+
+
+@pytest.mark.asyncio
+async def test_require_tier_premium_blocks_pro():
+    """Pro user calling a Premium-required route gets 402."""
+    from fastapi import HTTPException
+    dep = require_tier("premium")
+    with pytest.raises(HTTPException) as exc_info:
+        await dep(user={"id": 1, "tier": "pro"})
+    assert exc_info.value.status_code == 402
+    assert exc_info.value.detail["required_tier"] == "premium"
+
+
+@pytest.mark.asyncio
+async def test_require_tier_missing_tier_treats_as_free():
+    """A user dict without a tier key (legacy / pre-migration) is treated as free."""
+    from fastapi import HTTPException
+    dep = require_tier("pro")
+    with pytest.raises(HTTPException) as exc_info:
+        await dep(user={"id": 1})  # no 'tier' key
+    assert exc_info.value.status_code == 402
+    assert exc_info.value.detail["current_tier"] == "free"
+
+
+# ── Translation-route gating (4 routes) ──────────────────────────────────
+
+# The conftest `test_user` fixture defaults to 'pro' so existing
+# translation-route tests (which don't care about tier gating) keep
+# passing. These four tests downgrade to 'free' explicitly, then
+# assert the route returns 402.
+
+async def _downgrade_to_free(user_id: int) -> None:
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute("UPDATE users SET tier = 'free' WHERE id = ?", (user_id,))
+        await db.commit()
+
+
+async def _seed_minimal_book(book_id: int) -> None:
+    """Minimal book row for the route to pass its existence/access guards
+    so the tier check is reached (cache-miss path)."""
+    from services.db import save_book
+    await save_book(
+        book_id,
+        {"id": book_id, "title": "Test", "languages": ["en"], "subjects": [],
+         "authors": [], "download_count": 0, "cover": ""},
+        "Chapter I\n\nSome text.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_request_chapter_translation_blocks_free(client, test_user):
+    """Cache-miss POST as a free user → 402 (the gate fires after cache lookup
+    + book/access/draft/same-language/bounds guards)."""
+    await _downgrade_to_free(test_user["id"])
+    await _seed_minimal_book(7777)
+    resp = await client.post(
+        "/api/books/7777/chapters/0/translation",
+        json={"target_language": "zh"},
+    )
+    assert resp.status_code == 402
+    assert resp.json()["detail"]["error"] == "tier_required"
+
+
+@pytest.mark.asyncio
+async def test_retry_chapter_translation_blocks_free(client, test_user):
+    await _downgrade_to_free(test_user["id"])
+    resp = await client.post(
+        "/api/books/2229/chapters/0/translation/retry",
+        json={"target_language": "zh"},
+    )
+    assert resp.status_code == 402
+    assert resp.json()["detail"]["error"] == "tier_required"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_all_chapters_blocks_free(client, test_user):
+    await _downgrade_to_free(test_user["id"])
+    resp = await client.post(
+        "/api/books/2229/translations/enqueue-all",
+        json={"target_language": "zh"},
+    )
+    assert resp.status_code == 402
+    assert resp.json()["detail"]["error"] == "tier_required"
+
+
+@pytest.mark.asyncio
+async def test_ai_translate_blocks_free(client, test_user):
+    await _downgrade_to_free(test_user["id"])
+    resp = await client.post(
+        "/api/ai/translate",
+        json={"text": "hello", "source_language": "en", "target_language": "zh"},
+    )
+    assert resp.status_code == 402
+    assert resp.json()["detail"]["error"] == "tier_required"
+
+
+@pytest.mark.asyncio
+async def test_request_chapter_translation_allows_pro(client, test_user):
+    """Promote to Pro and confirm 402 is gone (the route then fails for other reasons,
+    which is fine — we only assert the tier gate cleared."""
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await db.execute("UPDATE users SET tier = 'pro' WHERE id = ?", (test_user["id"],))
+        await db.commit()
+    resp = await client.post(
+        "/api/books/2229/chapters/0/translation",
+        json={"target_language": "zh"},
+    )
+    assert resp.status_code != 402  # tier gate cleared; downstream may 404 / 403 / 400


### PR DESCRIPTION
## Summary

**PR A** of the pricing-plans series (impl tracker #1790, design doc `docs/design/pricing-plans.md` merged in PR #1779). Foundation only — no Stripe code (PR C territory), no `require_book_quota` (PR B), no BYOK changes (PR F).

## What's in

### Migrations
- **038** — `users.tier` (CHECK `'free'/'pro'/'premium'`, default `'free'`) + Stripe-related columns (`stripe_customer_id`, `stripe_subscription_id`, `tier_period_end`). Stripe columns are inert until PR C wires them.
- **039** — `billing_events` audit table with `UNIQUE(stripe_event_id)` for webhook idempotency. Empty until PR C.

### Authorization
- **`require_tier(min_tier)`** dependency factory in `services/auth.py`. Returns `402 Payment Required` (correct semantic for "auth fine, just pay") with structured detail `{error, current_tier, required_tier}` so the frontend can pick the paywall variant without parsing message strings.

### Route gating
- `POST /books/{id}/chapters/{n}/translation/retry` — `Depends(require_tier("pro"))`
- `POST /books/{id}/translations/enqueue-all` — `Depends(require_tier("pro"))`
- `POST /ai/translate` — `Depends(require_tier("pro"))`
- `POST /books/{id}/chapters/{n}/translation` — **inline** check after the cache-hit short-circuit, not via `Depends`. Preserves the existing behavior tested by `test_chapter_translation_cache_served_without_login` (anonymous users can read existing translations via POST when there's a cache hit). Cache miss + free user → 402.

This last point is a small refinement of the design doc: §"Translation-creation gating" has `request_chapter_translation` as a `Depends`-gated route, but the existing route has a cache-hit short-circuit that serves anonymous users. Per the user's original requirement (*"Everyone can access the existing translation. But to add new translation, you need to upgrade"*), the cache-hit path must stay free. The inline check after the cache short-circuit fixes this.

## Tests

17 new in `test_pricing_tier_gating.py`:
- 3 migration-038 tests (default `free`, CHECK rejects unknown, accepts pro/premium).
- 2 migration-039 tests (table created, `stripe_event_id` UNIQUE).
- 7 `require_tier` unit tests (rank ordering, ValueError on bad min_tier, blocks-under, allows-at, allows-above, premium-blocks-pro, missing-tier-treats-as-free).
- 5 route-gating integration tests (4 routes × free-user 402, plus pro-user proceeds for `request_chapter_translation`).

`conftest.py` change: `test_user` fixture now bumps to `tier='pro'` after creation. Without this, every existing test that POSTs to a translation route would break with 402. Tests that specifically test free-tier behavior (mine + the 4 in this PR) downgrade to `'free'` explicitly.

## Out of scope (follow-up PRs from the impl tracker)

- **PR B** — `require_book_quota` on `GET /books/{id}/chapters` (3-books/month free).
- **PR C** — Stripe checkout + portal + webhook + tests against Stripe test mode.
- **PR D** — `scripts/expire_subscriptions.py` daily cron.
- **PR E** — Frontend `/pricing` + `/account/billing` + `<PaywallModal>` + plan badge.
- **PR F** — `PUT /user/byok` + Pro-cap-bypass-via-BYOK logic.
- **`user-only` follow-up** — Stripe products + prices + webhook config (PR C time).

## Three settle-before-impl decisions (from #1790)

Defaulting to design recommendations + env vars; can be overridden without code change:

1. **Pro chapter cap** — coding `PRO_TRANSLATION_MONTHLY_CAP` env var, default 50. Lands in PR C alongside `require_translation_quota`.
2. **Pricing values** — Stripe Dashboard + env vars; PR C territory.
3. **Reset cadence** — calendar month per design recommendation. PR B implements.

Closes #1790.

## Test plan

- [x] 17 new pricing tests pass.
- [x] Targeted re-run on previously-failing existing tests (`test_chapter_translation_cache_served_without_login`, `test_chapter_translation_normalizes_language_for_cache_hit`, `test_post_translation_cache_hit_reconciles_subtitle_shift`) — all pass with the inline-gate refactor.
- [ ] Full backend pytest in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
