### PR TITLE
ux: show context sentence on flashcard answer side (closes #1798)

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -1289,7 +1289,10 @@ async def get_flashcards_due(
         sql = """
             SELECT fr.vocabulary_id, fr.interval_days, fr.ease_factor,
                    fr.repetitions, fr.due_date, fr.last_reviewed_at,
-                   v.word, v.created_at AS saved_at
+                   v.word, v.created_at AS saved_at,
+                   (SELECT wo.sentence_text FROM word_occurrences wo
+                    WHERE wo.vocabulary_id = fr.vocabulary_id
+                    ORDER BY wo.id ASC LIMIT 1) AS context
             FROM flashcard_reviews fr
             JOIN vocabulary v ON v.id = fr.vocabulary_id
             WHERE fr.user_id = ? AND fr.due_date <= date('now')

--- a/backend/tests/test_router_flashcards.py
+++ b/backend/tests/test_router_flashcards.py
@@ -60,6 +60,20 @@ async def test_due_flashcards_include_vocab_fields(client, test_user):
     assert "due_date" in card
 
 
+async def test_due_flashcards_include_context_sentence(client, test_user):
+    """Due card response includes the context sentence where the word was saved (closes #1798)."""
+    await save_book(BOOK_ID, _BOOK_META, "text")
+    await save_word(test_user["id"], "ephemera", BOOK_ID, 0, "Life is ephemera.")
+
+    resp = await client.get("/api/vocabulary/flashcards/due")
+    assert resp.status_code == 200
+    cards = resp.json()
+    card = next((c for c in cards if c["word"] == "ephemera"), None)
+    assert card is not None
+    assert "context" in card
+    assert card["context"] == "Life is ephemera."
+
+
 async def test_due_flashcards_own_only(client, test_user):
     """Due cards are scoped to the requesting user only."""
     from services.db import get_or_create_user

--- a/frontend/src/__tests__/FlashcardContext.test.ts
+++ b/frontend/src/__tests__/FlashcardContext.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Regression test for issue #1798:
+ * Flashcard answer side was blank — context sentence not shown on flip.
+ * Fixed by rendering currentCard.context in the flipped card body.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const pageSrc = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/flashcards/page.tsx"),
+  "utf8",
+);
+
+const apiSrc = fs.readFileSync(
+  path.join(__dirname, "../lib/api.ts"),
+  "utf8",
+);
+
+describe("Flashcard context sentence (closes #1798)", () => {
+  it("Flashcard interface in api.ts includes context field", () => {
+    expect(apiSrc).toMatch(/interface Flashcard[\s\S]{0,200}context\??\s*:\s*string/);
+  });
+
+  it("flashcards page renders currentCard.context when flipped", () => {
+    expect(pageSrc).toMatch(/currentCard\.context/);
+  });
+
+  it("flipped card content region has aria-live for screen reader announcement", () => {
+    expect(pageSrc).toMatch(/aria-live/);
+  });
+});

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -226,16 +226,23 @@ export default function FlashcardsPage() {
               style={{ boxShadow: "var(--shadow-card)" }}
             >
               <span className="text-xs text-stone-500 uppercase tracking-wide">
-                {flipped ? "Definition" : "Word"}
+                {flipped ? "Context" : "Word"}
               </span>
               {!flipped ? (
                 <span className="font-serif text-3xl text-ink font-bold text-center">
                   {currentCard.word}
                 </span>
               ) : (
-                <div className="text-center space-y-2">
-                  <p className="text-sm text-stone-500 italic">
-                    Tap a grade button below to continue
+                <div className="text-center space-y-2" aria-live="polite">
+                  {currentCard.context ? (
+                    <p className="font-serif text-base text-ink leading-relaxed">
+                      {currentCard.context}
+                    </p>
+                  ) : (
+                    <p className="text-sm text-stone-500 italic">No context saved</p>
+                  )}
+                  <p className="text-xs text-stone-500 mt-2">
+                    How well did you remember <span className="font-medium text-ink">{currentCard.word}</span>?
                   </p>
                 </div>
               )}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -890,6 +890,7 @@ export interface Flashcard {
   repetitions: number;
   last_reviewed_at: string | null;
   saved_at: string | null;
+  context: string | null;
 }
 
 export interface FlashcardReviewResult {


### PR DESCRIPTION
## What changed

- **Backend** (`backend/services/db.py`): `get_flashcards_due` SQL query now includes a correlated subquery that fetches the first `sentence_text` from `word_occurrences` as `context`. No schema change — the data already exists.
- **Frontend API** (`frontend/src/lib/api.ts`): `Flashcard` interface gains `context: string | null`.
- **Frontend UI** (`frontend/src/app/vocabulary/flashcards/page.tsx`): Flipped card body now renders the context sentence. Falls back to "No context saved" when null. Added `aria-live="polite"` on the content region so screen readers announce the flip.

## Why

The flashcard answer side was completely blank — it only showed "Tap a grade button below to continue" with no definition or context. Users had no way to verify their recall before grading (Again/Hard/Good/Easy). The context sentence (already stored in `word_occurrences`) gives enough cue to check memory without needing a separate definition API.

## Test plan

- New backend test: `test_due_flashcards_include_context_sentence` — saves word with sentence, asserts `context` field is present and correct in due-cards response
- New frontend tests (`FlashcardContext.test.ts`): asserts `Flashcard` interface has `context`, page renders `currentCard.context`, and `aria-live` is present
- All 2583 frontend tests and 18 flashcard backend tests pass

Closes #1798

## Docs follow-up
- [ ] Design change log entry added to `docs/design-improvement-plan.md` (Wave 10)
