### PR TITLE
ux: add role=group aria-label to vocabulary sort control (closes #1803)

### DIFF
--- a/frontend/src/__tests__/VocabSortGroupLabel.test.ts
+++ b/frontend/src/__tests__/VocabSortGroupLabel.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Regression test for issue #1803:
+ * Vocabulary sort mode segmented control was missing role="group" and aria-label.
+ * Fixed by adding role="group" aria-label="Sort by" to the wrapper div.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8",
+);
+
+describe("Vocabulary sort control group label (closes #1803)", () => {
+  it('sort mode control has role="group"', () => {
+    expect(src).toMatch(/role="group"[^>]*data-testid="sort-mode-control"|data-testid="sort-mode-control"[^>]*role="group"/);
+  });
+
+  it('sort mode control has aria-label="Sort by"', () => {
+    expect(src).toMatch(/aria-label="Sort by"/);
+  });
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -490,7 +490,7 @@ function VocabularyPageContent() {
               placeholder="Search words…"
               className="w-full rounded-xl border border-amber-200 bg-white px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
             />
-            <div className="flex rounded-lg border border-amber-200 overflow-hidden" data-testid="sort-mode-control">
+            <div role="group" aria-label="Sort by" className="flex rounded-lg border border-amber-200 overflow-hidden" data-testid="sort-mode-control">
               {SORT_MODES.map(({ value, label }) => (
                 <button
                   key={value}


### PR DESCRIPTION
## What changed

Added `role="group" aria-label="Sort by"` to the vocabulary sort mode segmented control in `app/vocabulary/page.tsx`.

## Why

The sort control (Alpha / Language / Book / Recent) grouped three `aria-pressed` toggle buttons without a semantic group wrapper. Screen readers would announce "Alpha, button, pressed" with no context that this is a sort control. The tag filter bar immediately adjacent already had `role="group" aria-label="Filter by tag"` — this brings the sort control into parity.

## Test plan

- New test `VocabSortGroupLabel.test.ts` asserts `role="group"` and `aria-label="Sort by"` are present on the sort control div
- All 2585 frontend tests pass

Closes #1803

[ ] Docs updated (if applicable)
