### PR TITLE
ux: invert CollapseHeading — heading wraps button per WAI-ARIA accordion pattern (closes #1804)

### DIFF
--- a/frontend/src/__tests__/CollapseHeadingNesting.test.ts
+++ b/frontend/src/__tests__/CollapseHeadingNesting.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Regression test for issue #1804:
+ * CollapseHeading nested <h2>/<h3> inside <button> — inverts WAI-ARIA accordion pattern.
+ * Fixed by wrapping <button> inside the heading element instead.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("CollapseHeading heading nesting (closes #1804)", () => {
+  it("heading tag wraps button, not the other way around", () => {
+    // The old pattern was <button ...aria-expanded...> ... <Tag ...>label</Tag> </button>
+    // The new pattern must be <Tag ...><button ...aria-expanded...>label</button></Tag>
+    // Detect old (wrong) pattern: <Tag appearing INSIDE a <button aria-expanded block
+    expect(src).not.toMatch(/<button[^>]*aria-expanded[^>]*>[\s\S]{0,400}<Tag\s/);
+  });
+
+  it("CollapseHeading renders heading element as outer wrapper", () => {
+    // The Tag variable (h2/h3) should be the outermost returned element
+    // Check that the component returns <Tag ... > before <button
+    expect(src).toMatch(/return\s*\(\s*<Tag/);
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -41,28 +41,28 @@ function CollapseHeading({
 }) {
   const Tag = `h${level}` as "h2" | "h3";
   return (
-    <button
-      onClick={onToggle}
-      aria-expanded={!isCollapsed}
-      className={`w-full flex items-center gap-2 text-left group min-h-[44px] ${
-        level === 2
-          ? "mt-8 mb-3 pb-1.5 border-b border-amber-200"
-          : "mt-5 mb-2"
-      }`}
-    >
-      {isCollapsed ? <ChevronRightIcon className="w-3 h-3 text-amber-700 shrink-0" /> : <ChevronDownIcon className="w-3 h-3 text-amber-700 shrink-0" />}
-      <Tag className={level === 2
-        ? "text-lg font-serif font-semibold text-ink group-hover:text-amber-800 transition-colors"
-        : "text-sm font-semibold text-amber-800 uppercase tracking-wide group-hover:text-amber-900 transition-colors"
-      }>
-        {label}
-      </Tag>
-      {count !== undefined && (
-        <span className="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full bg-amber-50 border border-amber-200 text-[10px] font-medium text-amber-700 font-sans ml-1 shrink-0">
-          {count}
+    <Tag className={level === 2 ? "mt-8 mb-3" : "mt-5 mb-2"}>
+      <button
+        onClick={onToggle}
+        aria-expanded={!isCollapsed}
+        className={`w-full flex items-center gap-2 text-left group min-h-[44px] ${
+          level === 2 ? "pb-1.5 border-b border-amber-200" : ""
+        }`}
+      >
+        {isCollapsed ? <ChevronRightIcon className="w-3 h-3 text-amber-700 shrink-0" /> : <ChevronDownIcon className="w-3 h-3 text-amber-700 shrink-0" />}
+        <span className={level === 2
+          ? "text-lg font-serif font-semibold text-ink group-hover:text-amber-800 transition-colors"
+          : "text-sm font-semibold text-amber-800 uppercase tracking-wide group-hover:text-amber-900 transition-colors"
+        }>
+          {label}
         </span>
-      )}
-    </button>
+        {count !== undefined && (
+          <span className="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full bg-amber-50 border border-amber-200 text-[10px] font-medium text-amber-700 font-sans ml-1 shrink-0">
+            {count}
+          </span>
+        )}
+      </button>
+    </Tag>
   );
 }
 


### PR DESCRIPTION
## What changed
Inverted the `CollapseHeading` component in `notes/[bookId]/page.tsx` from `<button><Tag>label</Tag></button>` to `<Tag><button>label</button></Tag>`.

## Why
The WAI-ARIA Accordion Pattern (APG) requires the heading element to **wrap** the disclosure button, not the other way around. Having `<h2>` or `<h3>` as a descendant of `<button>` is also invalid HTML5 — heading elements are flow content; `<button>` only permits phrasing content. Screen readers may announce heading level inconsistently when the content model is violated.

## Test plan
- New test: `CollapseHeadingNesting.test.ts` — static source assertion that `<button>` wraps `<Tag>` (not vice versa)
- Frontend suite: 2589 tests pass (398 suites)

Closes #1804
