### PR TITLE
feat: pricing-plans PR C1 — GET /billing/me read endpoint (#1790)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -17,6 +17,7 @@ from routers.uploads import router as uploads_router
 from routers.search import router as search_router
 from routers.decks import router as decks_router
 from routers.chat import router as chat_router
+from routers.billing import router as billing_router
 from services.db import init_db
 
 
@@ -100,6 +101,7 @@ app.include_router(uploads_router, prefix="/api")
 app.include_router(search_router, prefix="/api")
 app.include_router(decks_router, prefix="/api")
 app.include_router(chat_router, prefix="/api")
+app.include_router(billing_router, prefix="/api")
 
 
 @app.get("/api/health")

--- a/backend/routers/billing.py
+++ b/backend/routers/billing.py
@@ -1,0 +1,87 @@
+"""Billing & subscription endpoints.
+
+PR C1 of the pricing-plans series (#1790 / docs/design/pricing-plans.md).
+Ships a read-only `GET /billing/me` returning the current user's tier
++ period end + book / translation usage. Stripe checkout / portal /
+webhook routes are out-of-scope for C1 — see PR C2.
+
+The usage counters are computed live from existing tables
+(`reading_history` for distinct books this month, `translations` for
+authored translations this month). No new schema.
+"""
+
+from fastapi import APIRouter, Depends, Path
+import aiosqlite
+
+from services import db as _db
+from services.auth import (
+    get_current_user, FREE_TIER_MONTHLY_BOOK_QUOTA,
+)
+
+
+router = APIRouter(prefix="/billing", tags=["billing"])
+
+
+# Pro chapter cap: env-overridable so the user can tune without a code
+# change. Default 50 per the design doc's recommendation. Lives here
+# rather than at module-import time so tests can mutate via monkeypatch.
+import os
+def _pro_translation_monthly_cap() -> int:
+    try:
+        return int(os.environ.get("PRO_TRANSLATION_MONTHLY_CAP", "50"))
+    except ValueError:
+        return 50
+
+
+@router.get("/me")
+async def billing_me(user: dict = Depends(get_current_user)) -> dict:
+    """Current tier + entitlements + this-month usage for the
+    authenticated user. Frontend `/account/billing` reads this on
+    page load."""
+    tier = user.get("tier") or "free"
+    period_end = user.get("tier_period_end")
+
+    # Books opened this calendar month (free-tier quota signal).
+    books_used = await _count_books_this_month(user["id"])
+    # Translations authored this calendar month (Pro cap signal).
+    translations_used = await _count_translations_this_month(user["id"])
+
+    pro_cap = _pro_translation_monthly_cap()
+
+    return {
+        "tier": tier,
+        "tier_period_end": period_end,
+        "stripe_customer_id": user.get("stripe_customer_id"),
+        "books": {
+            "used": books_used,
+            "quota": (
+                FREE_TIER_MONTHLY_BOOK_QUOTA if tier == "free" else None
+            ),
+        },
+        "translations": {
+            "used": translations_used,
+            "quota": (
+                pro_cap if tier == "pro" else None
+            ),
+        },
+    }
+
+
+async def _count_books_this_month(user_id: int) -> int:
+    """Distinct book_ids the user has opened in the current calendar month.
+    Uses the same calendar-month bound as require_book_quota."""
+    async with aiosqlite.connect(_db.DB_PATH) as conn:
+        row = await (await conn.execute(
+            """SELECT COUNT(DISTINCT book_id) FROM reading_history
+                WHERE user_id = ? AND read_at >= datetime('now', 'start of month')""",
+            (user_id,),
+        )).fetchone()
+    return int(row[0] if row else 0)
+
+
+async def _count_translations_this_month(user_id: int) -> int:
+    """Translations authored by this user in the current calendar month.
+    `translations` doesn't carry a user_id today (it's a shared cache),
+    so v1 returns 0. Hooks for per-user attribution land in PR C2 along
+    with the Stripe webhook + tier transitions."""
+    return 0

--- a/backend/tests/test_billing_me.py
+++ b/backend/tests/test_billing_me.py
@@ -1,0 +1,103 @@
+"""PR C1 of the pricing-plans series (#1790).
+
+Covers GET /billing/me — the read-only endpoint that surfaces the
+current user's tier + this-month usage. Stripe checkout / portal /
+webhook routes land in PR C2.
+"""
+
+import pytest
+import aiosqlite
+import services.db as db_module
+
+
+async def _set_tier(user_id: int, tier: str, period_end: str | None = None) -> None:
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        await conn.execute(
+            "UPDATE users SET tier = ?, tier_period_end = ? WHERE id = ?",
+            (tier, period_end, user_id),
+        )
+        await conn.commit()
+
+
+async def _seed_reading(user_id: int, book_id: int, when: str = "now") -> None:
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        await conn.execute(
+            f"INSERT INTO reading_history (user_id, book_id, chapter_index, read_at) "
+            f"VALUES (?, ?, 0, datetime('{when}'))",
+            (user_id, book_id),
+        )
+        await conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_billing_me_default_pro_user(client, test_user):
+    """Default test_user is pro per conftest. Endpoint returns the basics."""
+    resp = await client.get("/api/billing/me")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["tier"] == "pro"
+    assert body["stripe_customer_id"] is None
+    # Pro: no books quota; has translations cap.
+    assert body["books"]["quota"] is None
+    assert body["translations"]["quota"] == 50  # default PRO_TRANSLATION_MONTHLY_CAP
+
+
+@pytest.mark.asyncio
+async def test_billing_me_free_user_includes_books_quota(client, test_user):
+    await _set_tier(test_user["id"], "free")
+    resp = await client.get("/api/billing/me")
+    body = resp.json()
+    assert body["tier"] == "free"
+    assert body["books"]["quota"] == 3  # FREE_TIER_MONTHLY_BOOK_QUOTA
+    assert body["translations"]["quota"] is None
+
+
+@pytest.mark.asyncio
+async def test_billing_me_premium_no_caps(client, test_user):
+    await _set_tier(test_user["id"], "premium")
+    resp = await client.get("/api/billing/me")
+    body = resp.json()
+    assert body["tier"] == "premium"
+    assert body["books"]["quota"] is None
+    assert body["translations"]["quota"] is None
+
+
+@pytest.mark.asyncio
+async def test_billing_me_books_used_counts_distinct_this_month(client, test_user):
+    """Three distinct books this month + one prior-month → books.used = 3."""
+    await _set_tier(test_user["id"], "free")
+    for b in (1, 2, 3):
+        await _seed_reading(test_user["id"], b)
+    # Same book twice doesn't count twice.
+    await _seed_reading(test_user["id"], 2)
+    # Prior-month entries don't count.
+    await _seed_reading(test_user["id"], 99, when="now', '-2 months")
+    resp = await client.get("/api/billing/me")
+    body = resp.json()
+    assert body["books"]["used"] == 3
+
+
+@pytest.mark.asyncio
+async def test_billing_me_period_end_returned(client, test_user):
+    """tier_period_end round-trips for paid users (will be set by webhook in PR C2)."""
+    await _set_tier(test_user["id"], "pro", period_end="2026-12-31 23:59:59")
+    resp = await client.get("/api/billing/me")
+    body = resp.json()
+    assert body["tier_period_end"] == "2026-12-31 23:59:59"
+
+
+@pytest.mark.asyncio
+async def test_billing_me_pro_cap_env_overridable(client, test_user, monkeypatch):
+    """PRO_TRANSLATION_MONTHLY_CAP env var changes the reported translations.quota
+    for Pro tier, without a code change."""
+    monkeypatch.setenv("PRO_TRANSLATION_MONTHLY_CAP", "200")
+    resp = await client.get("/api/billing/me")
+    body = resp.json()
+    assert body["translations"]["quota"] == 200
+
+
+@pytest.mark.asyncio
+async def test_billing_me_requires_auth(anon_client):
+    """No Bearer token → 401."""
+    resp = await anon_client.get("/api/billing/me")
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary

**PR C1** of the pricing-plans series — a small read-only endpoint surfacing the current user's tier + this-month usage. Frontend `/account/billing` calls this on page load. Stripe checkout / portal / webhook are out-of-scope for C1 — they land in PR C2.

## What's in

- New `backend/routers/billing.py` with `GET /billing/me`.
- Wired into `backend/main.py`.
- Response shape:
  ```json
  {
    "tier": "pro",
    "tier_period_end": "2026-12-31 23:59:59",
    "stripe_customer_id": null,
    "books":        {"used": 3, "quota": null},
    "translations": {"used": 0, "quota": 50}
  }
  ```
- Free: `books.quota = 3` (matches `FREE_TIER_MONTHLY_BOOK_QUOTA` from PR B), `translations.quota = null`.
- Pro: `books.quota = null`, `translations.quota = ` (env, default 50).
- Premium: both quotas `null`.

## What's NOT in this PR

- `POST /billing/checkout` / `portal` / `webhook` — PR C2.
- `translations.used` is hard-coded to 0 in v1; the `translations` table doesn't carry `user_id` today, so per-user attribution lands in PR C2 alongside webhook + cap enforcement (`require_translation_quota`).

## Tests

7 new in `test_billing_me.py`: each tier's response shape (free / pro / premium), books.used distinct-this-month + prior-month-doesn't-count, period_end round-trip, env override of PRO cap, auth-required (anon → 401).

Part of #1790.

## Test plan

- [x] 7 new tests pass locally.
- [ ] Backend pytest in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)