### PR TITLE
feat: pricing-plans PR C2 — Stripe webhook handler with idempotency + tier transitions (#1790)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,3 +18,4 @@ cryptography>=42.0.0
 respx
 pytest-cov
 ebooklib>=0.18
+stripe>=10.0.0

--- a/backend/routers/billing.py
+++ b/backend/routers/billing.py
@@ -1,19 +1,19 @@
 """Billing & subscription endpoints.
 
-PR C1 of the pricing-plans series (#1790 / docs/design/pricing-plans.md).
-Ships a read-only `GET /billing/me` returning the current user's tier
-+ period end + book / translation usage. Stripe checkout / portal /
-webhook routes are out-of-scope for C1 — see PR C2.
+PR C1 + C2 of the pricing-plans series (#1790 / docs/design/pricing-plans.md).
+- `GET /billing/me` (PR C1): read-only tier + this-month usage.
+- `POST /billing/webhook` (PR C2): receives Stripe webhook events,
+  verifies signature, idempotent insert into `billing_events`, dispatches
+  to per-event handler in `services.stripe_billing`.
 
-The usage counters are computed live from existing tables
-(`reading_history` for distinct books this month, `translations` for
-authored translations this month). No new schema.
+Checkout-session creation + customer-portal session lands in PR C3.
 """
 
-from fastapi import APIRouter, Depends, Path
+from fastapi import APIRouter, Depends, Path, Request
 import aiosqlite
 
 from services import db as _db
+from services import stripe_billing
 from services.auth import (
     get_current_user, FREE_TIER_MONTHLY_BOOK_QUOTA,
 )
@@ -85,3 +85,24 @@ async def _count_translations_this_month(user_id: int) -> int:
     so v1 returns 0. Hooks for per-user attribution land in PR C2 along
     with the Stripe webhook + tier transitions."""
     return 0
+
+
+@router.post("/webhook")
+async def stripe_webhook(request: Request) -> dict:
+    """Stripe webhook receiver.
+
+    Stripe POSTs events here on subscription create/update/delete +
+    invoice failures. Signature is verified via STRIPE_WEBHOOK_SECRET
+    env var. The handler is idempotent — replays of the same event_id
+    are caught by UNIQUE on `billing_events.stripe_event_id` and return
+    200 (so Stripe stops retrying).
+
+    No auth gate — Stripe IPs aren't fixed, so the signature header is
+    the only authentication mechanism. Any unauthenticated POST to this
+    endpoint is rejected with 400 by the signature check inside
+    `stripe_billing.construct_event`.
+    """
+    payload = await request.body()
+    signature = request.headers.get("stripe-signature", "")
+    event = stripe_billing.construct_event(payload, signature)
+    return await stripe_billing.record_and_handle(event)

--- a/backend/services/stripe_billing.py
+++ b/backend/services/stripe_billing.py
@@ -1,0 +1,286 @@
+"""Stripe webhook handling + tier-state transitions.
+
+PR C2 of the pricing-plans series (#1790 / docs/design/pricing-plans.md).
+Receives Stripe webhook events, verifies the signature, and applies
+tier transitions to the `users` row. Idempotent via the UNIQUE
+constraint on `billing_events.stripe_event_id` (migration 039 from PR A).
+
+Checkout-session creation + customer-portal session creation will land
+in PR C3. This module is webhook-only.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+import aiosqlite
+import stripe
+from fastapi import HTTPException
+
+from services import db as _db
+
+
+logger = logging.getLogger(__name__)
+
+
+# Lazy-read so tests can monkeypatch env. Stripe SDK keys / webhook secret
+# are required only at the moment the handler runs against a real event.
+def _webhook_secret() -> str:
+    secret = os.environ.get("STRIPE_WEBHOOK_SECRET", "")
+    if not secret:
+        raise HTTPException(
+            status_code=500,
+            detail="STRIPE_WEBHOOK_SECRET not configured",
+        )
+    return secret
+
+
+def _api_key() -> str:
+    """Set on the stripe SDK module before any API call. The webhook
+    handler itself doesn't need an API key (signature verification is
+    secret-based), but the broader billing module needs it for portal /
+    checkout calls in PR C3."""
+    return os.environ.get("STRIPE_API_KEY", "")
+
+
+def construct_event(payload: bytes, signature: str) -> dict[str, Any]:
+    """Verify the webhook signature and return the parsed event.
+
+    Raises 400 on invalid signature / payload. Wraps Stripe SDK
+    exceptions in FastAPI HTTPException for the route handler.
+    """
+    try:
+        event = stripe.Webhook.construct_event(
+            payload, signature, _webhook_secret(),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid payload: {exc}")
+    except stripe.error.SignatureVerificationError as exc:  # type: ignore[attr-defined]
+        raise HTTPException(status_code=400, detail=f"Invalid signature: {exc}")
+    # `event` is a stripe.Event — coerce to dict for storage / handler use.
+    return dict(event)
+
+
+async def record_and_handle(event: dict[str, Any]) -> dict[str, str]:
+    """Insert event into billing_events (idempotent via UNIQUE on
+    stripe_event_id), then dispatch to the per-event-type handler.
+
+    Returns `{"status": "processed"}` on first delivery, or
+    `{"status": "duplicate"}` on replay (the UNIQUE constraint catches
+    it; we return 200 so Stripe stops retrying).
+    """
+    event_id: str = event["id"]
+    event_type: str = event["type"]
+    user_id: int | None = _resolve_user_id(event)
+    payload_json = json.dumps(event)
+
+    async with aiosqlite.connect(_db.DB_PATH) as conn:
+        try:
+            await conn.execute(
+                "INSERT INTO billing_events (user_id, stripe_event_id, event_type, payload_json) "
+                "VALUES (?, ?, ?, ?)",
+                (user_id, event_id, event_type, payload_json),
+            )
+            await conn.commit()
+        except aiosqlite.IntegrityError:
+            # Replay — already processed. Return 200 so Stripe stops retrying.
+            logger.info("Stripe webhook replay ignored: %s", event_id)
+            return {"status": "duplicate"}
+
+    handler = _HANDLERS.get(event_type)
+    if handler is None:
+        logger.info("Stripe webhook event type not handled: %s", event_type)
+        return {"status": "ignored"}
+
+    await handler(event)
+    return {"status": "processed"}
+
+
+def _resolve_user_id(event: dict[str, Any]) -> int | None:
+    """Extract the local user_id from an event. Tries:
+    (1) `client_reference_id` on the object (set on first checkout, reliable
+        for checkout.session.completed before customer is linked).
+    (2) `customer` ID → users.stripe_customer_id mapping (reliable for all
+        post-checkout events on a linked user).
+    """
+    obj = event.get("data", {}).get("object", {})
+    ref = obj.get("client_reference_id")
+    if ref:
+        try:
+            return int(ref)
+        except (ValueError, TypeError):
+            pass
+    customer_id = obj.get("customer") or obj.get("customer_id")
+    if not customer_id:
+        return None
+    return _customer_id_to_user_id_sync(customer_id)
+
+
+def _customer_id_to_user_id_sync(customer_id: str) -> int | None:
+    """Synchronous lookup helper — wrapped in async caller via aiosqlite.
+    Used only at event-record time so user_id is set on the billing_events
+    row even before the dispatcher runs."""
+    import sqlite3
+    try:
+        with sqlite3.connect(_db.DB_PATH) as conn:
+            row = conn.execute(
+                "SELECT id FROM users WHERE stripe_customer_id = ? LIMIT 1",
+                (customer_id,),
+            ).fetchone()
+        return row[0] if row else None
+    except Exception:
+        return None
+
+
+# ── Event handlers ──────────────────────────────────────────────────────
+
+async def _on_checkout_session_completed(event: dict[str, Any]) -> None:
+    """A user just completed first checkout. Set tier + stripe IDs +
+    period end on the users row."""
+    obj = event["data"]["object"]
+    customer_id = obj.get("customer")
+    subscription_id = obj.get("subscription")
+    # The price ID determines the tier — we map via env vars so the
+    # user can set them once in their hosting config.
+    tier = _tier_for_price(_extract_price_id(obj))
+    # Period end comes from the subscription object — checkout session
+    # itself doesn't carry it. We populate at next subscription.updated
+    # event (which Stripe sends concurrently). Leave NULL here.
+    user_id = _customer_id_to_user_id_sync(customer_id) if customer_id else None
+    # If the user had no stripe_customer_id yet, we need client_reference_id
+    # to identify them. Stripe sends this if checkout was created with it.
+    if user_id is None:
+        ref = obj.get("client_reference_id")
+        if ref:
+            try:
+                user_id = int(ref)
+            except ValueError:
+                user_id = None
+    if user_id is None:
+        logger.warning("checkout.session.completed could not resolve user; event=%s", event["id"])
+        return
+
+    async with aiosqlite.connect(_db.DB_PATH) as conn:
+        await conn.execute(
+            "UPDATE users SET tier = ?, stripe_customer_id = ?, stripe_subscription_id = ? WHERE id = ?",
+            (tier, customer_id, subscription_id, user_id),
+        )
+        await conn.commit()
+    logger.info("Checkout completed for user %s: tier=%s sub=%s", user_id, tier, subscription_id)
+
+
+async def _on_subscription_updated(event: dict[str, Any]) -> None:
+    """Tier or period change. Update both."""
+    obj = event["data"]["object"]
+    customer_id = obj.get("customer")
+    subscription_id = obj.get("id")
+    period_end_unix = obj.get("current_period_end")
+    period_end = (
+        # SQLite-friendly ISO format from Unix timestamp.
+        _unix_to_sqlite_datetime(period_end_unix) if period_end_unix else None
+    )
+    tier = _tier_for_price(_extract_price_id(obj))
+
+    user_id = _customer_id_to_user_id_sync(customer_id) if customer_id else None
+    if user_id is None:
+        logger.warning("subscription.updated could not resolve user; event=%s", event["id"])
+        return
+
+    async with aiosqlite.connect(_db.DB_PATH) as conn:
+        await conn.execute(
+            "UPDATE users SET tier = ?, stripe_subscription_id = ?, tier_period_end = ? WHERE id = ?",
+            (tier, subscription_id, period_end, user_id),
+        )
+        await conn.commit()
+    logger.info("Subscription updated for user %s: tier=%s period_end=%s",
+                user_id, tier, period_end)
+
+
+async def _on_subscription_deleted(event: dict[str, Any]) -> None:
+    """Subscription cancelled. **Don't downgrade immediately** — user paid
+    through tier_period_end. Just clear stripe_subscription_id and let
+    the daily expire_subscriptions cron (PR D) downgrade after the period.
+    """
+    obj = event["data"]["object"]
+    customer_id = obj.get("customer")
+
+    user_id = _customer_id_to_user_id_sync(customer_id) if customer_id else None
+    if user_id is None:
+        logger.warning("subscription.deleted could not resolve user; event=%s", event["id"])
+        return
+
+    async with aiosqlite.connect(_db.DB_PATH) as conn:
+        await conn.execute(
+            "UPDATE users SET stripe_subscription_id = NULL WHERE id = ?",
+            (user_id,),
+        )
+        await conn.commit()
+    logger.info("Subscription deleted for user %s — downgrade scheduled at period end", user_id)
+
+
+async def _on_invoice_payment_failed(event: dict[str, Any]) -> None:
+    """Payment failed — log only in v1. Stripe's dunning settings handle
+    the retry cadence + customer email. UI banner ("payment failed") is
+    a follow-up."""
+    obj = event["data"]["object"]
+    customer_id = obj.get("customer")
+    user_id = _customer_id_to_user_id_sync(customer_id) if customer_id else None
+    logger.warning(
+        "invoice.payment_failed for user %s (customer=%s, event=%s)",
+        user_id, customer_id, event["id"],
+    )
+
+
+_HANDLERS = {
+    "checkout.session.completed": _on_checkout_session_completed,
+    "customer.subscription.updated": _on_subscription_updated,
+    "customer.subscription.created": _on_subscription_updated,  # same handler shape
+    "customer.subscription.deleted": _on_subscription_deleted,
+    "invoice.payment_failed": _on_invoice_payment_failed,
+}
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+def _tier_for_price(price_id: str | None) -> str:
+    """Map Stripe price ID → tier string. Env-driven so the user
+    configures price IDs once in their hosting config without a code
+    change."""
+    if not price_id:
+        return "free"
+    if price_id == os.environ.get("STRIPE_PRICE_PRO", ""):
+        return "pro"
+    if price_id == os.environ.get("STRIPE_PRICE_PREMIUM", ""):
+        return "premium"
+    logger.warning("Unknown Stripe price_id: %s — defaulting to 'free'", price_id)
+    return "free"
+
+
+def _extract_price_id(obj: dict[str, Any]) -> str | None:
+    """Walk the various shapes a price ID can appear in across event
+    types: checkout session has `line_items` (expanded) or `items.data`,
+    subscription objects have `items.data[].price.id`."""
+    items = obj.get("items", {})
+    if isinstance(items, dict):
+        data = items.get("data") or []
+        if data and isinstance(data[0], dict):
+            price = data[0].get("price") or {}
+            if isinstance(price, dict):
+                return price.get("id")
+    line_items = obj.get("line_items", {})
+    if isinstance(line_items, dict):
+        data = line_items.get("data") or []
+        if data and isinstance(data[0], dict):
+            price = data[0].get("price") or {}
+            if isinstance(price, dict):
+                return price.get("id")
+    return None
+
+
+def _unix_to_sqlite_datetime(unix_ts: int | float) -> str:
+    """SQLite stores TIMESTAMP as 'YYYY-MM-DD HH:MM:SS' UTC."""
+    from datetime import datetime, timezone
+    return datetime.fromtimestamp(unix_ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")

--- a/backend/tests/test_billing_webhook.py
+++ b/backend/tests/test_billing_webhook.py
@@ -1,0 +1,261 @@
+"""PR C2 of the pricing-plans series (#1790).
+
+Stripe webhook handler tests. Mocks `stripe.Webhook.construct_event`
+so we don't need a real Stripe signing secret — the unit under test is
+the post-verification logic (idempotent insert + tier-state transitions),
+not Stripe's signature crypto.
+"""
+
+import json
+import pytest
+import aiosqlite
+from unittest.mock import patch
+import services.db as db_module
+from services import stripe_billing
+
+
+# Test setup: by default each test enables a STRIPE_WEBHOOK_SECRET so
+# construct_event can run the env-required path. Tests that need a
+# specific event payload patch construct_event directly to bypass real
+# signature verification.
+@pytest.fixture(autouse=True)
+def _stripe_env(monkeypatch):
+    monkeypatch.setenv("STRIPE_WEBHOOK_SECRET", "whsec_test")
+    monkeypatch.setenv("STRIPE_API_KEY", "sk_test_dummy")
+    monkeypatch.setenv("STRIPE_PRICE_PRO", "price_pro_test")
+    monkeypatch.setenv("STRIPE_PRICE_PREMIUM", "price_premium_test")
+
+
+async def _set_customer(user_id: int, customer_id: str) -> None:
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        await conn.execute(
+            "UPDATE users SET stripe_customer_id = ? WHERE id = ?",
+            (customer_id, user_id),
+        )
+        await conn.commit()
+
+
+async def _get_user(user_id: int) -> dict:
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        conn.row_factory = aiosqlite.Row
+        row = await (await conn.execute(
+            "SELECT tier, stripe_customer_id, stripe_subscription_id, tier_period_end FROM users WHERE id = ?",
+            (user_id,),
+        )).fetchone()
+    return dict(row) if row else {}
+
+
+# ── Helpers to build mock events ──────────────────────────────────────
+
+def _checkout_completed(event_id: str, customer_id: str, subscription_id: str, price_id: str, *, client_ref: str | None = None) -> dict:
+    return {
+        "id": event_id,
+        "type": "checkout.session.completed",
+        "data": {
+            "object": {
+                "customer": customer_id,
+                "subscription": subscription_id,
+                "client_reference_id": client_ref,
+                "line_items": {
+                    "data": [{"price": {"id": price_id}}],
+                },
+            }
+        },
+    }
+
+
+def _subscription_updated(event_id: str, customer_id: str, subscription_id: str, price_id: str, period_end_unix: int) -> dict:
+    return {
+        "id": event_id,
+        "type": "customer.subscription.updated",
+        "data": {
+            "object": {
+                "id": subscription_id,
+                "customer": customer_id,
+                "current_period_end": period_end_unix,
+                "items": {"data": [{"price": {"id": price_id}}]},
+            }
+        },
+    }
+
+
+def _subscription_deleted(event_id: str, customer_id: str, subscription_id: str) -> dict:
+    return {
+        "id": event_id,
+        "type": "customer.subscription.deleted",
+        "data": {"object": {"id": subscription_id, "customer": customer_id}},
+    }
+
+
+# ── construct_event signature verification ────────────────────────────
+
+def test_construct_event_missing_secret_raises_500(monkeypatch):
+    monkeypatch.delenv("STRIPE_WEBHOOK_SECRET", raising=False)
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc:
+        stripe_billing.construct_event(b"{}", "sig")
+    assert exc.value.status_code == 500
+
+
+def test_construct_event_bad_signature_raises_400():
+    """Real signature verification fails on a bogus signature header."""
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc:
+        stripe_billing.construct_event(b"{}", "bogus_sig")
+    assert exc.value.status_code == 400
+
+
+# ── record_and_handle: idempotency ────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_replay_returns_duplicate(test_user):
+    """Same event_id submitted twice → second call returns 'duplicate'."""
+    event = _checkout_completed("evt_replay_1", "cus_test_1", "sub_test_1", "price_pro_test", client_ref=str(test_user["id"]))
+    first = await stripe_billing.record_and_handle(event)
+    assert first["status"] == "processed"
+    second = await stripe_billing.record_and_handle(event)
+    assert second["status"] == "duplicate"
+
+
+@pytest.mark.asyncio
+async def test_unhandled_event_type_returns_ignored(test_user):
+    """Event type we don't subscribe to → status 'ignored', no error."""
+    event = {
+        "id": "evt_unhandled_1",
+        "type": "customer.tax_id.created",  # not in our handlers
+        "data": {"object": {"customer": "cus_xxx"}},
+    }
+    result = await stripe_billing.record_and_handle(event)
+    assert result["status"] == "ignored"
+
+
+# ── checkout.session.completed handler ────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_checkout_completed_promotes_to_pro_via_client_reference(test_user):
+    """First-time customer: client_reference_id → user_id, tier = pro per price match."""
+    event = _checkout_completed(
+        "evt_checkout_1", "cus_new_1", "sub_new_1", "price_pro_test",
+        client_ref=str(test_user["id"]),
+    )
+    await stripe_billing.record_and_handle(event)
+    user = await _get_user(test_user["id"])
+    assert user["tier"] == "pro"
+    assert user["stripe_customer_id"] == "cus_new_1"
+    assert user["stripe_subscription_id"] == "sub_new_1"
+
+
+@pytest.mark.asyncio
+async def test_checkout_completed_promotes_to_premium(test_user):
+    event = _checkout_completed(
+        "evt_checkout_premium", "cus_p", "sub_p", "price_premium_test",
+        client_ref=str(test_user["id"]),
+    )
+    await stripe_billing.record_and_handle(event)
+    user = await _get_user(test_user["id"])
+    assert user["tier"] == "premium"
+
+
+@pytest.mark.asyncio
+async def test_checkout_completed_unknown_price_defaults_to_free(test_user):
+    """Unknown price ID → handler defaults to 'free' (defensive)."""
+    event = _checkout_completed(
+        "evt_unknown_price", "cus_u", "sub_u", "price_unknown",
+        client_ref=str(test_user["id"]),
+    )
+    await stripe_billing.record_and_handle(event)
+    user = await _get_user(test_user["id"])
+    assert user["tier"] == "free"
+
+
+@pytest.mark.asyncio
+async def test_checkout_no_customer_or_ref_logs_and_returns(test_user):
+    """No customer + no client_reference_id → can't resolve user; logged but no error."""
+    event = _checkout_completed("evt_orphan", customer_id=None, subscription_id="sub_x", price_id="price_pro_test")
+    result = await stripe_billing.record_and_handle(event)
+    # Insert succeeded; handler logged warning; no DB changes.
+    assert result["status"] == "processed"
+
+
+# ── customer.subscription.updated handler ─────────────────────────────
+
+@pytest.mark.asyncio
+async def test_subscription_updated_sets_period_end(test_user):
+    await _set_customer(test_user["id"], "cus_existing_1")
+    period_end = 1735689600  # 2025-01-01 00:00:00 UTC
+    event = _subscription_updated("evt_sub_upd_1", "cus_existing_1", "sub_x", "price_pro_test", period_end)
+    await stripe_billing.record_and_handle(event)
+    user = await _get_user(test_user["id"])
+    assert user["tier"] == "pro"
+    assert user["stripe_subscription_id"] == "sub_x"
+    assert user["tier_period_end"] == "2025-01-01 00:00:00"
+
+
+@pytest.mark.asyncio
+async def test_subscription_updated_changes_tier(test_user):
+    """Pro → Premium upgrade reflected in tier column."""
+    await _set_customer(test_user["id"], "cus_upgrade_1")
+    # Pre-existing pro state.
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        await conn.execute("UPDATE users SET tier = 'pro' WHERE id = ?", (test_user["id"],))
+        await conn.commit()
+    event = _subscription_updated("evt_upgrade", "cus_upgrade_1", "sub_y", "price_premium_test", 1735689600)
+    await stripe_billing.record_and_handle(event)
+    user = await _get_user(test_user["id"])
+    assert user["tier"] == "premium"
+
+
+# ── customer.subscription.deleted handler ─────────────────────────────
+
+@pytest.mark.asyncio
+async def test_subscription_deleted_does_not_immediately_downgrade(test_user):
+    """User paid through period_end; we just clear stripe_subscription_id."""
+    await _set_customer(test_user["id"], "cus_canc_1")
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        await conn.execute(
+            "UPDATE users SET tier = 'pro', stripe_subscription_id = ?, tier_period_end = ? WHERE id = ?",
+            ("sub_canc", "2026-12-31 23:59:59", test_user["id"]),
+        )
+        await conn.commit()
+    event = _subscription_deleted("evt_del_1", "cus_canc_1", "sub_canc")
+    await stripe_billing.record_and_handle(event)
+    user = await _get_user(test_user["id"])
+    # Tier stays at pro until the daily cron (PR D) sees period_end < now.
+    assert user["tier"] == "pro"
+    assert user["stripe_subscription_id"] is None
+    assert user["tier_period_end"] == "2026-12-31 23:59:59"
+
+
+# ── invoice.payment_failed handler ────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_invoice_payment_failed_logs_only(test_user):
+    """v1 logs only; no DB-state change. Stripe dunning handles retries."""
+    await _set_customer(test_user["id"], "cus_pf_1")
+    event = {
+        "id": "evt_pf_1",
+        "type": "invoice.payment_failed",
+        "data": {"object": {"customer": "cus_pf_1"}},
+    }
+    before = await _get_user(test_user["id"])
+    result = await stripe_billing.record_and_handle(event)
+    after = await _get_user(test_user["id"])
+    assert result["status"] == "processed"
+    # Tier / subscription unchanged.
+    assert before == after
+
+
+# ── billing_events row is inserted ────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_billing_events_row_recorded(test_user):
+    event = _checkout_completed("evt_record_1", "cus_rec", "sub_rec", "price_pro_test", client_ref=str(test_user["id"]))
+    await stripe_billing.record_and_handle(event)
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        conn.row_factory = aiosqlite.Row
+        row = await (await conn.execute(
+            "SELECT user_id, event_type FROM billing_events WHERE stripe_event_id = ?",
+            ("evt_record_1",),
+        )).fetchone()
+    assert row["user_id"] == test_user["id"]
+    assert row["event_type"] == "checkout.session.completed"


### PR DESCRIPTION
## Summary

**PR C2** of the pricing-plans series — receive-side Stripe integration. Listens for subscription lifecycle events and applies tier transitions on the `users` row. Checkout-session creation + customer-portal session land in **PR C3**.

## What's in

- **`stripe` SDK** added to `requirements.txt` (`>=10.0.0`; tested with 15.1.0).
- **`services/stripe_billing.py`** with:
  - `construct_event()` — signature verification via `stripe.Webhook` + `STRIPE_WEBHOOK_SECRET` env var.
  - `record_and_handle()` — idempotent insert into `billing_events` (UNIQUE on `stripe_event_id` catches replays → returns 200 `duplicate` so Stripe stops retrying).
  - **4 event handlers**: `checkout.session.completed`, `customer.subscription.updated`/`.created`, `customer.subscription.deleted`, `invoice.payment_failed`.
  - **Tier resolution** from price_id via `STRIPE_PRICE_PRO`/`STRIPE_PRICE_PREMIUM` env vars; unknown price → `free` (defensive).
  - **User resolution**: `client_reference_id` (first checkout) OR customer-ID mapping to `users.stripe_customer_id` (subsequent events on a linked user).
  - **`subscription.deleted` does NOT immediately downgrade** — clears `stripe_subscription_id` only; user stays on paid tier through `tier_period_end`. The daily `expire_subscriptions` cron (PR D) enforces the actual downgrade.
- **POST /billing/webhook** in the billing router. No auth gate (the Stripe signature header IS the authentication).

## What's NOT in this PR

- `POST /billing/checkout` — PR C3.
- `POST /billing/portal` — PR C3.
- Daily expire-subscriptions cron — PR D.
- Frontend pricing page / billing UI — PR E.
- BYOK toggle endpoint — PR F.

## Tests

13 new in `test_billing_webhook.py`:
- Signature verification: missing secret → 500, bad signature → 400.
- Idempotency: replay of same `stripe_event_id` returns `{status: duplicate}`.
- Unhandled event type: returns `{status: ignored}`.
- `checkout.session.completed`: promotes via client_reference_id, premium upgrade, unknown price → free, no customer/no ref → logged but no DB change.
- `subscription.updated`: sets `tier_period_end` from `current_period_end` Unix timestamp; tier upgrade Pro→Premium reflected.
- `subscription.deleted`: clears `stripe_subscription_id` only; tier + period_end unchanged.
- `invoice.payment_failed`: logs, no DB-state change.
- `billing_events` row insert verified.

## Configuration (user-only follow-up)

PR C3 (or before deploy of this PR's webhook) the user must:

1. Create products + prices in **Stripe Dashboard** for Pro and Premium.
2. Set env vars in production: `STRIPE_API_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_PRO`, `STRIPE_PRICE_PREMIUM`.
3. Configure webhook endpoint in Stripe Dashboard pointing at `<prod>/api/billing/webhook` with events `checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted`, `customer.subscription.created`, `invoice.payment_failed`.

This is `user-only` follow-up — will file once PR C3 lands.

Part of #1790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)