### PR TITLE
ux: DeckCard navigation — deck list no longer a dead end (closes #1820)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -283,6 +283,18 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 |------|--------|---------|----|
 | 2026-04-28 | Focus-mode HUD truncated chapter title: added `title` tooltip for hover-reveal | reader/[bookId]/page.tsx | #1770 |
 
+## Wave 12 — Navigation + Contrast (2026-04-28)
+
+### WCAG 1.4.3 Placeholder contrast
+| Date | Change | File(s) | PR |
+|------|--------|---------|----|
+| 2026-04-28 | `placeholder:text-stone-400` (2.4:1) → `placeholder:text-stone-600` (7.2:1) on 4 inputs | decks/[deckId]/page.tsx, AnnotationToolbar.tsx, SearchBar.tsx, InsightChat.tsx | #1819 |
+
+### UX dead-end fixes
+| Date | Change | File(s) | PR |
+|------|--------|---------|----|
+| 2026-04-28 | DeckCard: added `onClick` prop + content-area button so `/decks` list navigates to `/decks/{id}` | DeckCard.tsx, decks/page.tsx | pending #1820 |
+
 ---
 
 

--- a/frontend/src/__tests__/DeckCard.test.tsx
+++ b/frontend/src/__tests__/DeckCard.test.tsx
@@ -72,3 +72,32 @@ test("delete button has an accessible label", () => {
     expect.stringMatching(/delete/i),
   );
 });
+
+test("calls onClick when the card content area is clicked", async () => {
+  const onClick = jest.fn();
+  render(<DeckCard deck={MANUAL_DECK} onClick={onClick} />);
+  const user = userEvent.setup();
+  await user.click(screen.getByTestId(`deck-card-link-${MANUAL_DECK.id}`));
+  expect(onClick).toHaveBeenCalledTimes(1);
+});
+
+test("card content button has accessible label including deck name", () => {
+  render(<DeckCard deck={MANUAL_DECK} onClick={jest.fn()} />);
+  const btn = screen.getByTestId(`deck-card-link-${MANUAL_DECK.id}`);
+  expect(btn).toHaveAttribute("aria-label", expect.stringMatching(/German verbs/i));
+});
+
+test("does not render content button when onClick is not supplied", () => {
+  render(<DeckCard deck={MANUAL_DECK} />);
+  expect(screen.queryByTestId(`deck-card-link-${MANUAL_DECK.id}`)).not.toBeInTheDocument();
+});
+
+test("clicking content button does not trigger onDelete", async () => {
+  const onClick = jest.fn();
+  const onDelete = jest.fn();
+  render(<DeckCard deck={MANUAL_DECK} onClick={onClick} onDelete={onDelete} />);
+  const user = userEvent.setup();
+  await user.click(screen.getByTestId(`deck-card-link-${MANUAL_DECK.id}`));
+  expect(onDelete).not.toHaveBeenCalled();
+  expect(onClick).toHaveBeenCalledTimes(1);
+});

--- a/frontend/src/app/decks/page.tsx
+++ b/frontend/src/app/decks/page.tsx
@@ -121,7 +121,12 @@ export default function DecksPage() {
         ) : (
           <div className="space-y-4">
             {decks.map((d) => (
-              <DeckCard key={d.id} deck={d} onDelete={handleDelete} />
+              <DeckCard
+                key={d.id}
+                deck={d}
+                onClick={() => router.push(`/decks/${d.id}`)}
+                onDelete={handleDelete}
+              />
             ))}
           </div>
         )}

--- a/frontend/src/components/DeckCard.tsx
+++ b/frontend/src/components/DeckCard.tsx
@@ -4,51 +4,69 @@ import { DeckIcon, TrashIcon } from "@/components/Icons";
 
 interface DeckCardProps {
   deck: DeckSummary;
+  onClick?: () => void;
   onDelete?: (id: number) => void | Promise<void>;
 }
 
-export default function DeckCard({ deck, onDelete }: DeckCardProps) {
+export default function DeckCard({ deck, onClick, onDelete }: DeckCardProps) {
   const modeLabel = deck.mode === "smart" ? "Smart" : "Manual";
+
+  const cardContent = (
+    <>
+      <div className="flex items-center gap-2 flex-wrap">
+        <DeckIcon className="w-4 h-4 text-amber-600 shrink-0" />
+        <h2 className="font-serif font-semibold text-ink text-base truncate">
+          {deck.name}
+        </h2>
+        <span
+          data-testid={`deck-mode-${deck.id}`}
+          className="text-xs text-amber-700 bg-amber-50 rounded-full px-2 py-0.5 border border-amber-200"
+        >
+          {modeLabel}
+        </span>
+      </div>
+      {deck.description && (
+        <p className="text-sm text-stone-500 mt-1.5 line-clamp-2">{deck.description}</p>
+      )}
+      <div className="mt-3 flex items-center gap-3 text-xs text-stone-500">
+        <span>
+          <span
+            data-testid={`deck-member-count-${deck.id}`}
+            className="font-medium text-ink"
+          >
+            {deck.member_count}
+          </span>{" "}
+          {deck.member_count === 1 ? "word" : "words"}
+        </span>
+        {deck.due_today > 0 && (
+          <span className="rounded-full bg-amber-700 text-white px-2 py-0.5">
+            <span data-testid={`deck-due-today-${deck.id}`}>{deck.due_today}</span>{" "}
+            due today
+          </span>
+        )}
+      </div>
+    </>
+  );
+
   return (
     <article
       data-testid={`deck-card-${deck.id}`}
       className="rounded-xl border border-amber-100 bg-white p-4 transition-all duration-200 hover:-translate-y-0.5"
     >
       <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2 flex-wrap">
-            <DeckIcon className="w-4 h-4 text-amber-600 shrink-0" />
-            <h2 className="font-serif font-semibold text-ink text-base truncate">
-              {deck.name}
-            </h2>
-            <span
-              data-testid={`deck-mode-${deck.id}`}
-              className="text-xs text-amber-700 bg-amber-50 rounded-full px-2 py-0.5 border border-amber-200"
-            >
-              {modeLabel}
-            </span>
-          </div>
-          {deck.description && (
-            <p className="text-sm text-stone-500 mt-1.5 line-clamp-2">{deck.description}</p>
-          )}
-          <div className="mt-3 flex items-center gap-3 text-xs text-stone-500">
-            <span>
-              <span
-                data-testid={`deck-member-count-${deck.id}`}
-                className="font-medium text-ink"
-              >
-                {deck.member_count}
-              </span>{" "}
-              {deck.member_count === 1 ? "word" : "words"}
-            </span>
-            {deck.due_today > 0 && (
-              <span className="rounded-full bg-amber-700 text-white px-2 py-0.5">
-                <span data-testid={`deck-due-today-${deck.id}`}>{deck.due_today}</span>{" "}
-                due today
-              </span>
-            )}
-          </div>
-        </div>
+        {onClick ? (
+          <button
+            type="button"
+            onClick={onClick}
+            aria-label={`Open deck ${deck.name}`}
+            data-testid={`deck-card-link-${deck.id}`}
+            className="min-w-0 flex-1 text-left hover:opacity-80 transition-opacity"
+          >
+            {cardContent}
+          </button>
+        ) : (
+          <div className="min-w-0 flex-1">{cardContent}</div>
+        )}
         {onDelete && (
           <button
             type="button"


### PR DESCRIPTION
## What changed

- Added an `onClick?: () => void` prop to `DeckCard`
- When `onClick` is provided, the card content area renders as a `<button>` (`data-testid="deck-card-link-{id}"`, `aria-label="Open deck {name}"`) that calls `onClick` on click
- The delete button remains a separate element so clicking delete does not trigger navigation
- In `decks/page.tsx`, each `DeckCard` now receives `onClick={() => router.push('/decks/' + d.id)}`

## Why

The `/decks` page listed all decks with no way to navigate into a deck's detail page. Clicking a card did nothing — a complete dead-end for users who want to view, study, or manage the words in a deck. Closes #1820.

## Test plan

- [x] Added 4 new unit tests to `DeckCard.test.tsx`:
  - Clicking the content button calls `onClick`
  - Content button carries an accessible label including the deck name
  - Content button is absent when `onClick` is not supplied
  - Clicking content button does not trigger `onDelete`
- [x] All 2604 frontend tests pass
- [x] All 1942 backend tests pass
- Manual: navigate to `/decks`, click any deck card body → lands on `/decks/{id}` detail page; delete button still works independently

## Docs follow-up

Design change log updated in `docs/design-improvement-plan.md` (Wave 12).
