### PR TITLE
feat: pricing-plans PR C3 — POST /billing/checkout + /billing/portal (#1790)

### DIFF
--- a/backend/routers/billing.py
+++ b/backend/routers/billing.py
@@ -1,15 +1,18 @@
 """Billing & subscription endpoints.
 
-PR C1 + C2 of the pricing-plans series (#1790 / docs/design/pricing-plans.md).
+PR C1 + C2 + C3 of the pricing-plans series (#1790 / docs/design/pricing-plans.md).
 - `GET /billing/me` (PR C1): read-only tier + this-month usage.
 - `POST /billing/webhook` (PR C2): receives Stripe webhook events,
   verifies signature, idempotent insert into `billing_events`, dispatches
   to per-event handler in `services.stripe_billing`.
-
-Checkout-session creation + customer-portal session lands in PR C3.
+- `POST /billing/checkout` (PR C3): create a Stripe Checkout Session and
+  return the redirect URL.
+- `POST /billing/portal` (PR C3): create a Customer Portal session for
+  managing the existing subscription.
 """
 
 from fastapi import APIRouter, Depends, Path, Request
+from pydantic import BaseModel, Field
 import aiosqlite
 
 from services import db as _db
@@ -106,3 +109,48 @@ async def stripe_webhook(request: Request) -> dict:
     signature = request.headers.get("stripe-signature", "")
     event = stripe_billing.construct_event(payload, signature)
     return await stripe_billing.record_and_handle(event)
+
+
+class CheckoutRequest(BaseModel):
+    tier: str = Field(..., pattern="^(pro|premium)$")
+    success_url: str = Field(..., min_length=1)
+    cancel_url: str = Field(..., min_length=1)
+
+
+@router.post("/checkout")
+async def create_checkout(req: CheckoutRequest, user: dict = Depends(get_current_user)) -> dict:
+    """Initiate a Stripe Checkout for the requested tier. Returns
+    `{url: ...}` for the frontend to redirect to. The user finishes
+    payment on Stripe; the webhook handler fires the tier promotion."""
+    url = await stripe_billing.create_checkout_session(
+        user_id=user["id"],
+        user_email=user.get("email"),
+        tier=req.tier,
+        success_url=req.success_url,
+        cancel_url=req.cancel_url,
+        existing_customer_id=user.get("stripe_customer_id"),
+    )
+    return {"url": url}
+
+
+class PortalRequest(BaseModel):
+    return_url: str = Field(..., min_length=1)
+
+
+@router.post("/portal")
+async def create_portal(req: PortalRequest, user: dict = Depends(get_current_user)) -> dict:
+    """Create a Customer Portal session for managing the existing
+    subscription. 400 if the user has never checked out (no Stripe
+    customer record yet)."""
+    customer_id = user.get("stripe_customer_id")
+    if not customer_id:
+        from fastapi import HTTPException
+        raise HTTPException(
+            status_code=400,
+            detail="No Stripe customer; subscribe first via /billing/checkout.",
+        )
+    url = await stripe_billing.create_portal_session(
+        customer_id=customer_id,
+        return_url=req.return_url,
+    )
+    return {"url": url}

--- a/backend/services/stripe_billing.py
+++ b/backend/services/stripe_billing.py
@@ -1,12 +1,11 @@
-"""Stripe webhook handling + tier-state transitions.
+"""Stripe billing — webhook receive-side + checkout/portal session creation.
 
-PR C2 of the pricing-plans series (#1790 / docs/design/pricing-plans.md).
-Receives Stripe webhook events, verifies the signature, and applies
-tier transitions to the `users` row. Idempotent via the UNIQUE
-constraint on `billing_events.stripe_event_id` (migration 039 from PR A).
-
-Checkout-session creation + customer-portal session creation will land
-in PR C3. This module is webhook-only.
+PR C2 + C3 of the pricing-plans series (#1790 / docs/design/pricing-plans.md).
+- C2: webhook signature verification, idempotent insert into billing_events,
+  tier-state transitions on subscription lifecycle events.
+- C3: create_checkout_session() + create_portal_session() — invoked from
+  POST /billing/checkout and POST /billing/portal. Stripe SDK calls run
+  on a worker thread so the FastAPI event loop stays responsive.
 """
 
 from __future__ import annotations
@@ -41,9 +40,86 @@ def _webhook_secret() -> str:
 def _api_key() -> str:
     """Set on the stripe SDK module before any API call. The webhook
     handler itself doesn't need an API key (signature verification is
-    secret-based), but the broader billing module needs it for portal /
-    checkout calls in PR C3."""
-    return os.environ.get("STRIPE_API_KEY", "")
+    secret-based), but checkout / portal calls do."""
+    key = os.environ.get("STRIPE_API_KEY", "")
+    if not key:
+        raise HTTPException(
+            status_code=500,
+            detail="STRIPE_API_KEY not configured",
+        )
+    return key
+
+
+def _price_id(tier: str) -> str:
+    """Map tier → Stripe price ID via env var. 422 on unsupported tier
+    (free / unknown), 500 if a Pro/Premium env var isn't configured."""
+    if tier == "pro":
+        price = os.environ.get("STRIPE_PRICE_PRO", "")
+    elif tier == "premium":
+        price = os.environ.get("STRIPE_PRICE_PREMIUM", "")
+    else:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unsupported tier: {tier!r}. Use 'pro' or 'premium'.",
+        )
+    if not price:
+        raise HTTPException(
+            status_code=500,
+            detail=f"STRIPE_PRICE_{tier.upper()} not configured",
+        )
+    return price
+
+
+async def create_checkout_session(*, user_id: int, user_email: str | None,
+                                   tier: str, success_url: str, cancel_url: str,
+                                   existing_customer_id: str | None) -> str:
+    """Create a Stripe Checkout Session and return the redirect URL.
+
+    On first checkout, `existing_customer_id` is None and Stripe creates
+    a new Customer keyed to `user_email`. The local user_id is passed
+    via `client_reference_id` so the webhook handler can resolve to the
+    right user before stripe_customer_id is set on the users row.
+    """
+    stripe.api_key = _api_key()
+    price = _price_id(tier)
+    kwargs: dict[str, Any] = {
+        "mode": "subscription",
+        "line_items": [{"price": price, "quantity": 1}],
+        "success_url": success_url,
+        "cancel_url": cancel_url,
+        "client_reference_id": str(user_id),
+    }
+    if existing_customer_id:
+        kwargs["customer"] = existing_customer_id
+    elif user_email:
+        kwargs["customer_email"] = user_email
+
+    session = await _to_thread(stripe.checkout.Session.create, **kwargs)
+    url = getattr(session, "url", None)
+    if not url:
+        raise HTTPException(status_code=502, detail="Stripe returned no checkout URL")
+    return url
+
+
+async def create_portal_session(*, customer_id: str, return_url: str) -> str:
+    """Create a Customer Portal session for managing the subscription
+    (cancel, update payment, view invoices)."""
+    stripe.api_key = _api_key()
+    session = await _to_thread(
+        stripe.billing_portal.Session.create,
+        customer=customer_id,
+        return_url=return_url,
+    )
+    url = getattr(session, "url", None)
+    if not url:
+        raise HTTPException(status_code=502, detail="Stripe returned no portal URL")
+    return url
+
+
+async def _to_thread(fn, /, *args, **kwargs):
+    """Run a sync Stripe SDK call off the event loop."""
+    import asyncio
+    return await asyncio.to_thread(fn, *args, **kwargs)
 
 
 def construct_event(payload: bytes, signature: str) -> dict[str, Any]:

--- a/backend/tests/test_billing_checkout_portal.py
+++ b/backend/tests/test_billing_checkout_portal.py
@@ -1,0 +1,164 @@
+"""PR C3 of the pricing-plans series (#1790).
+
+Stripe Checkout + Customer Portal session creation. Patches the Stripe
+SDK's session-create methods so tests don't make real Stripe API calls.
+"""
+
+import pytest
+import aiosqlite
+from unittest.mock import patch, MagicMock
+import services.db as db_module
+
+
+@pytest.fixture(autouse=True)
+def _stripe_env(monkeypatch):
+    monkeypatch.setenv("STRIPE_API_KEY", "sk_test_dummy")
+    monkeypatch.setenv("STRIPE_PRICE_PRO", "price_pro_test")
+    monkeypatch.setenv("STRIPE_PRICE_PREMIUM", "price_premium_test")
+
+
+def _mock_session(url: str = "https://checkout.stripe.com/c/pay/cs_test_xxx"):
+    return MagicMock(url=url)
+
+
+# ── POST /billing/checkout ────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_checkout_pro_returns_redirect_url(client, test_user):
+    with patch("stripe.checkout.Session.create", return_value=_mock_session("https://checkout.stripe.com/pay/pro")) as m:
+        resp = await client.post(
+            "/api/billing/checkout",
+            json={"tier": "pro", "success_url": "https://app/ok", "cancel_url": "https://app/cancel"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["url"] == "https://checkout.stripe.com/pay/pro"
+    # Stripe SDK was called with the right args.
+    call_kwargs = m.call_args.kwargs
+    assert call_kwargs["mode"] == "subscription"
+    assert call_kwargs["line_items"] == [{"price": "price_pro_test", "quantity": 1}]
+    assert call_kwargs["client_reference_id"] == str(test_user["id"])
+    assert call_kwargs["success_url"] == "https://app/ok"
+
+
+@pytest.mark.asyncio
+async def test_checkout_premium_uses_premium_price(client, test_user):
+    with patch("stripe.checkout.Session.create", return_value=_mock_session()) as m:
+        await client.post(
+            "/api/billing/checkout",
+            json={"tier": "premium", "success_url": "https://x", "cancel_url": "https://x"},
+        )
+    assert m.call_args.kwargs["line_items"] == [{"price": "price_premium_test", "quantity": 1}]
+
+
+@pytest.mark.asyncio
+async def test_checkout_invalid_tier_returns_422(client):
+    """Pydantic regex validation catches 'free' / 'enterprise' / etc."""
+    resp = await client.post(
+        "/api/billing/checkout",
+        json={"tier": "free", "success_url": "https://x", "cancel_url": "https://x"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_checkout_uses_existing_customer(client, test_user):
+    """Returning customer (already has stripe_customer_id) reuses it
+    instead of creating a new Stripe Customer."""
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        await conn.execute(
+            "UPDATE users SET stripe_customer_id = ? WHERE id = ?",
+            ("cus_existing_xyz", test_user["id"]),
+        )
+        await conn.commit()
+    with patch("stripe.checkout.Session.create", return_value=_mock_session()) as m:
+        await client.post(
+            "/api/billing/checkout",
+            json={"tier": "pro", "success_url": "https://x", "cancel_url": "https://x"},
+        )
+    assert m.call_args.kwargs["customer"] == "cus_existing_xyz"
+    # No customer_email when reusing
+    assert "customer_email" not in m.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_checkout_first_time_uses_email(client, test_user):
+    """First-time customer (no stripe_customer_id) uses customer_email
+    so Stripe creates a new Customer."""
+    with patch("stripe.checkout.Session.create", return_value=_mock_session()) as m:
+        await client.post(
+            "/api/billing/checkout",
+            json={"tier": "pro", "success_url": "https://x", "cancel_url": "https://x"},
+        )
+    assert m.call_args.kwargs.get("customer_email") == test_user["email"]
+    assert "customer" not in m.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_checkout_missing_price_env_returns_500(client, monkeypatch):
+    monkeypatch.delenv("STRIPE_PRICE_PRO", raising=False)
+    resp = await client.post(
+        "/api/billing/checkout",
+        json={"tier": "pro", "success_url": "https://x", "cancel_url": "https://x"},
+    )
+    assert resp.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_checkout_missing_api_key_returns_500(client, monkeypatch):
+    monkeypatch.delenv("STRIPE_API_KEY", raising=False)
+    resp = await client.post(
+        "/api/billing/checkout",
+        json={"tier": "pro", "success_url": "https://x", "cancel_url": "https://x"},
+    )
+    assert resp.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_checkout_requires_auth(anon_client):
+    resp = await anon_client.post(
+        "/api/billing/checkout",
+        json={"tier": "pro", "success_url": "https://x", "cancel_url": "https://x"},
+    )
+    assert resp.status_code == 401
+
+
+# ── POST /billing/portal ──────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_portal_returns_redirect_url(client, test_user):
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        await conn.execute(
+            "UPDATE users SET stripe_customer_id = ? WHERE id = ?",
+            ("cus_portal_test", test_user["id"]),
+        )
+        await conn.commit()
+    with patch("stripe.billing_portal.Session.create",
+               return_value=_mock_session("https://billing.stripe.com/portal/test")) as m:
+        resp = await client.post(
+            "/api/billing/portal",
+            json={"return_url": "https://app/account"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["url"] == "https://billing.stripe.com/portal/test"
+    assert m.call_args.kwargs["customer"] == "cus_portal_test"
+    assert m.call_args.kwargs["return_url"] == "https://app/account"
+
+
+@pytest.mark.asyncio
+async def test_portal_no_customer_returns_400(client, test_user):
+    """User without stripe_customer_id (never checked out) → 400."""
+    resp = await client.post(
+        "/api/billing/portal",
+        json={"return_url": "https://app/account"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_portal_requires_auth(anon_client):
+    resp = await anon_client.post(
+        "/api/billing/portal",
+        json={"return_url": "https://x"},
+    )
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary

**PR C3** of the pricing-plans series. Outbound Stripe integration: session creation for Checkout (initiate subscription) and Customer Portal (manage existing subscription). Together with PR C2's webhook, this completes the Stripe trifecta.

## What's in

- **`services/stripe_billing.py`** extended:
  - `_api_key()` now raises 500 if `STRIPE_API_KEY` is missing (was silent `""` return; fails fast at the call site).
  - `_price_id(tier)` maps tier → `STRIPE_PRICE_{PRO,PREMIUM}` env var. 422 on unsupported tier (`free` / unknown), 500 if env unset.
  - `create_checkout_session()`: `client_reference_id = str(user_id)` so the webhook resolves the user before customer linkage; reuses `existing_customer_id` on re-subscribe; `customer_email` for first checkout.
  - `create_portal_session()`: pass-through to `stripe.billing_portal.Session.create`.
  - All Stripe SDK calls run via `asyncio.to_thread` so the event loop stays responsive.

- **`routers/billing.py`**:
  - `POST /billing/checkout` — `{tier, success_url, cancel_url}` body. Pydantic regex validates tier as `^(pro|premium)$`.
  - `POST /billing/portal` — `{return_url}` body. 400 if user has no `stripe_customer_id` yet (never checked out).

## Tests

11 new in `test_billing_checkout_portal.py`:
- **Checkout (8)**: Pro happy path, Premium uses Premium price, invalid tier → 422, existing-customer reuse, first-time uses `customer_email`, missing `STRIPE_PRICE_PRO` → 500, missing `STRIPE_API_KEY` → 500, anon → 401.
- **Portal (3)**: happy path returns redirect URL, no-customer → 400, anon → 401.

All patches `stripe.checkout.Session.create` / `stripe.billing_portal.Session.create` — no real Stripe calls.

## Series progress

- **A** ✓ (migrations + require_tier + 4 translation-route gates)
- **B** ✓ (require_book_quota — 3-books/month free)
- **C1** ✓ (GET /billing/me)
- **C2** ✓ (Stripe webhook handler with idempotency + tier transitions)
- **C3** (this PR — checkout + portal)
- **D** — expire-subscriptions daily cron
- **E** — frontend pricing + billing UI
- **F** — BYOK toggle

## User-only follow-up (deploy time)

Stripe Dashboard config — products, prices, webhook endpoint — is the user-only piece. Will file the dedicated `user-only` issue once series is closer to done (need to know the exact env vars + webhook URL).

Part of #1790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)