### PR TITLE
feat: pricing-plans PR F — BYOK toggle gated to Pro+ tier (#1790)

### DIFF
--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Path
 from pydantic import BaseModel, Field
-from services.auth import get_current_user, encrypt_api_key, decrypt_api_key, check_book_access
+from services.auth import get_current_user, encrypt_api_key, decrypt_api_key, check_book_access, require_tier
 from services.db import (
     set_user_gemini_key, get_user_by_id, get_reading_progress,
     get_obsidian_settings, update_obsidian_settings, get_cached_book,
@@ -32,8 +32,15 @@ class GeminiKeyRequest(BaseModel):
 @router.post("/gemini-key")
 async def save_gemini_key(
     req: GeminiKeyRequest,
-    user: dict = Depends(get_current_user),
+    user: dict = Depends(require_tier("pro")),
 ):
+    """BYOK: store a per-user Gemini API key. Pro+ tier required.
+
+    See docs/design/pricing-plans.md §"BYOK — bring your own API key".
+    Free users can't set / unset; existing free users who had keys set
+    pre-pricing-launch keep their keys (no migration), but cannot
+    update them until they upgrade.
+    """
     if not req.api_key.strip():
         raise HTTPException(status_code=400, detail="API key cannot be empty")
     encrypted = encrypt_api_key(req.api_key.strip())
@@ -42,7 +49,8 @@ async def save_gemini_key(
 
 
 @router.delete("/gemini-key")
-async def delete_gemini_key(user: dict = Depends(get_current_user)):
+async def delete_gemini_key(user: dict = Depends(require_tier("pro"))):
+    """BYOK: clear the per-user Gemini API key. Pro+ tier required."""
     await set_user_gemini_key(user["id"], None)
     return {"ok": True}
 

--- a/backend/tests/test_byok_tier_gating.py
+++ b/backend/tests/test_byok_tier_gating.py
@@ -1,0 +1,97 @@
+"""PR F of the pricing-plans series (#1790).
+
+BYOK (bring your own key) endpoint gating: POST + DELETE /user/gemini-key
+require Pro+ tier. Free users get 402 with structured detail. Paid users
+proceed normally.
+
+The design (docs/design/pricing-plans.md §"BYOK — bring your own API key")
+makes BYOK a paid-tier feature: it bypasses the Pro chapter cap (because
+the user pays the LLM bill), so it's fair to gate the toggle itself
+behind paid-tier.
+"""
+
+import pytest
+import aiosqlite
+import services.db as db_module
+
+
+async def _set_tier(user_id: int, tier: str) -> None:
+    async with aiosqlite.connect(db_module.DB_PATH) as conn:
+        await conn.execute("UPDATE users SET tier = ? WHERE id = ?", (tier, user_id))
+        await conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_post_gemini_key_blocks_free(client, test_user):
+    """Free user cannot set a BYOK key — 402 with tier_required."""
+    await _set_tier(test_user["id"], "free")
+    resp = await client.post(
+        "/api/user/gemini-key",
+        json={"api_key": "sk_xxx"},
+    )
+    assert resp.status_code == 402
+    assert resp.json()["detail"]["error"] == "tier_required"
+    assert resp.json()["detail"]["required_tier"] == "pro"
+
+
+@pytest.mark.asyncio
+async def test_post_gemini_key_allows_pro(client, test_user):
+    """Pro user can set a BYOK key — succeeds."""
+    # test_user defaults to pro per conftest
+    resp = await client.post(
+        "/api/user/gemini-key",
+        json={"api_key": "sk_pro_xxx"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_post_gemini_key_allows_premium(client, test_user):
+    """Premium user can set a BYOK key — succeeds."""
+    await _set_tier(test_user["id"], "premium")
+    resp = await client.post(
+        "/api/user/gemini-key",
+        json={"api_key": "sk_premium_xxx"},
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_delete_gemini_key_blocks_free(client, test_user):
+    """Free user cannot clear a BYOK key — 402."""
+    await _set_tier(test_user["id"], "free")
+    resp = await client.delete("/api/user/gemini-key")
+    assert resp.status_code == 402
+
+
+@pytest.mark.asyncio
+async def test_delete_gemini_key_allows_pro(client, test_user):
+    """Pro user can clear a BYOK key — succeeds."""
+    resp = await client.delete("/api/user/gemini-key")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_post_gemini_key_anon_returns_401(anon_client):
+    """Anonymous user → 401 (auth gate fires before tier gate)."""
+    resp = await anon_client.post(
+        "/api/user/gemini-key",
+        json={"api_key": "sk_xxx"},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_existing_free_user_with_key_can_still_read(client, test_user):
+    """Free user who set a key BEFORE pricing launch still has it.
+    The /user/me endpoint surfaces hasGeminiKey=true so the UI can
+    show "you have a key set" without being able to update it."""
+    await _set_tier(test_user["id"], "free")
+    # Simulate pre-existing key (set directly, bypassing the gated endpoint).
+    from services.db import set_user_gemini_key
+    from services.auth import encrypt_api_key
+    await set_user_gemini_key(test_user["id"], encrypt_api_key("legacy_sk"))
+    resp = await client.get("/api/user/me")
+    assert resp.status_code == 200
+    assert resp.json()["hasGeminiKey"] is True


### PR DESCRIPTION
## Summary

**PR F** of the pricing-plans series. Gates the existing `POST /user/gemini-key` + `DELETE /user/gemini-key` endpoints behind `require_tier("pro")` so only paid users can set / unset a per-user BYOK key.

Per design doc §"BYOK — bring your own API key": BYOK is a paid-tier feature that **bypasses the Pro chapter cap** (because the user pays the LLM bill directly). It's fair to gate the toggle itself behind paid-tier — free users can't get past the translation-create gate anyway, so a BYOK key would be useless to them.

## Grandfathering

**Existing free users who set a key before pricing launch keep their key** (no migration). They just can't update it until they upgrade. The `hasGeminiKey` field on `/user/me` still reports `true` for those users so the UI can show "you have a key set" — the lock-out is on writes, not reads.

## Tests

7 new in `test_byok_tier_gating.py`:
- Free user POST → 402 with `tier_required` detail.
- Pro user POST → 200.
- Premium user POST → 200.
- Free user DELETE → 402.
- Pro user DELETE → 200.
- Anonymous → 401 (auth gate fires before tier gate).
- Pre-existing free-user key still surfaces in `/user/me` (grandfathering).

Plus regression check: ran `test_router_user.py` (existing 30 tests) alongside — all pass with the new gates in place.

## Series progress (final backend slice)

- **A** ✓ migrations + require_tier + 4 translation-route gates
- **B** ✓ require_book_quota — 3-books/month free
- **C1** ✓ GET /billing/me
- **C2** ✓ Stripe webhook handler with idempotency + tier transitions
- **C3** ✓ POST /billing/checkout + /billing/portal
- **D** ✓ daily expire-subscriptions cron
- **F** (this PR — BYOK toggle gated)
- **E** — frontend pricing + billing UI (UI/UX scope; not Architect)

## What's left

After this merges, the backend pricing implementation is complete. The remaining piece — the frontend `/pricing` page + `/account/billing` page + `<PaywallModal>` + plan badge — is UI/UX scope and should be picked up by that role.

Plus the `user-only` Stripe-config follow-up (Stripe Dashboard products + prices + webhook URL + cron schedule).

Part of #1790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)