### PR TITLE
ux: add placeholder:text-stone-600 to 7 inputs in QueueTab + admin pages (closes #1826)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -289,11 +289,19 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | Date | Change | File(s) | PR |
 |------|--------|---------|----|
 | 2026-04-28 | `placeholder:text-stone-400` (2.4:1) → `placeholder:text-stone-600` (7.2:1) on 4 inputs | decks/[deckId]/page.tsx, AnnotationToolbar.tsx, SearchBar.tsx, InsightChat.tsx | #1819 |
+| 2026-04-28 | Browser-default placeholder (~3.95:1) → `placeholder:text-stone-600` (7.2:1) on 14 inputs across 6 files | notes/page.tsx, vocabulary/page.tsx, page.tsx, decks/new/page.tsx, profile/page.tsx, TagEditor.tsx | #1824 |
 
 ### UX dead-end fixes
 | Date | Change | File(s) | PR |
 |------|--------|---------|----|
-| 2026-04-28 | DeckCard: added `onClick` prop + content-area button so `/decks` list navigates to `/decks/{id}` | DeckCard.tsx, decks/page.tsx | pending #1820 |
+| 2026-04-28 | DeckCard: added `onClick` prop + content-area button so `/decks` list navigates to `/decks/{id}` | DeckCard.tsx, decks/page.tsx | #1821 |
+
+## Wave 13 — Placeholder Contrast Sweep Round 3 (2026-04-28)
+
+### WCAG 1.4.3 Placeholder contrast
+| Date | Change | File(s) | PR |
+|------|--------|---------|----|
+| 2026-04-28 | Browser-default placeholder → `placeholder:text-stone-600` on 7 remaining inputs in QueueTab and admin pages | QueueTab.tsx, admin/uploads/page.tsx, admin/books/page.tsx | #1828 |
 
 ---
 

--- a/frontend/src/__tests__/PlaceholderTextContrast.test.ts
+++ b/frontend/src/__tests__/PlaceholderTextContrast.test.ts
@@ -11,6 +11,9 @@ const homePageSrc = readFileSync(join(__dirname, "../app/page.tsx"), "utf-8");
 const decksNewSrc = readFileSync(join(__dirname, "../app/decks/new/page.tsx"), "utf-8");
 const profileSrc = readFileSync(join(__dirname, "../app/profile/page.tsx"), "utf-8");
 const tagEditorSrc = readFileSync(join(__dirname, "../components/TagEditor.tsx"), "utf-8");
+const queueTabSrc = readFileSync(join(__dirname, "../components/QueueTab.tsx"), "utf-8");
+const adminUploadsSrc = readFileSync(join(__dirname, "../app/admin/uploads/page.tsx"), "utf-8");
+const adminBooksSrc = readFileSync(join(__dirname, "../app/admin/books/page.tsx"), "utf-8");
 
 function countOccurrences(src: string, pattern: RegExp): number {
   return (src.match(pattern) ?? []).length;
@@ -57,5 +60,19 @@ describe("Placeholder text contrast — WCAG 1.4.3", () => {
 
   it("TagEditor.tsx tag input must use placeholder:text-stone-600", () => {
     expect(countOccurrences(tagEditorSrc, /placeholder:text-stone-600/g)).toBeGreaterThanOrEqual(1);
+  });
+
+  // --- QueueTab and admin pages (wave 13) ---
+
+  it("QueueTab.tsx must use placeholder:text-stone-600 on all 3 settings inputs", () => {
+    expect(countOccurrences(queueTabSrc, /placeholder:text-stone-600/g)).toBeGreaterThanOrEqual(3);
+  });
+
+  it("admin/uploads/page.tsx filter input must use placeholder:text-stone-600", () => {
+    expect(countOccurrences(adminUploadsSrc, /placeholder:text-stone-600/g)).toBeGreaterThanOrEqual(1);
+  });
+
+  it("admin/books/page.tsx must use placeholder:text-stone-600 on all 3 inputs", () => {
+    expect(countOccurrences(adminBooksSrc, /placeholder:text-stone-600/g)).toBeGreaterThanOrEqual(3);
   });
 });

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -232,7 +232,7 @@ export default function BooksPage() {
           value={importId}
           onChange={(e) => setImportId(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && handleImport()}
-          className="flex-1 rounded-lg border border-amber-300 px-3 py-2 text-sm"
+          className="flex-1 rounded-lg border border-amber-300 px-3 py-2 text-sm placeholder:text-stone-600"
         />
         <button
           onClick={handleImport}
@@ -254,7 +254,7 @@ export default function BooksPage() {
           placeholder="Search books by title, author, or ID…"
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="flex-1 rounded-lg border border-amber-300 px-3 py-2 text-sm"
+          className="flex-1 rounded-lg border border-amber-300 px-3 py-2 text-sm placeholder:text-stone-600"
           aria-label="Filter books"
         />
         {searchQuery && (
@@ -524,7 +524,7 @@ export default function BooksPage() {
                                             onKeyDown={(e) => {
                                               if (e.key === "Enter") handleMove(t, moveInput[rowKey] ?? "");
                                             }}
-                                            className="w-14 rounded border border-amber-300 px-1 py-0.5 text-xs"
+                                            className="w-14 rounded border border-amber-300 px-1 py-0.5 text-xs placeholder:text-stone-600"
                                             title="Reassign this translation to another chapter number (1-based)"
                                           />
                                           <button

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -90,7 +90,7 @@ export default function UploadsPage() {
           value={filterInput}
           onChange={(e) => setFilterInput(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && handleFilter()}
-          className="w-48 rounded-lg border border-amber-300 px-3 py-2 text-sm"
+          className="w-48 rounded-lg border border-amber-300 px-3 py-2 text-sm placeholder:text-stone-600"
           aria-label="User ID filter"
           min={1}
         />

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -787,7 +787,7 @@ export default function QueueTab({ adminFetch }: Props) {
                 aria-label="Auto-translate languages"
                 value={langs}
                 onChange={(e) => setLangs(e.target.value)}
-                className="flex-1 rounded border border-amber-300 px-2 py-1 text-sm"
+                className="flex-1 rounded border border-amber-300 px-2 py-1 text-sm placeholder:text-stone-600"
                 placeholder="zh, de, ja"
               />
               <button
@@ -817,7 +817,7 @@ export default function QueueTab({ adminFetch }: Props) {
                 aria-label="Gemini API key"
                 value={apiKey}
                 onChange={(e) => setApiKey(e.target.value)}
-                className="flex-1 rounded border border-amber-300 px-2 py-1 text-sm"
+                className="flex-1 rounded border border-amber-300 px-2 py-1 text-sm placeholder:text-stone-600"
                 placeholder={settings?.has_api_key ? "•••• (leave empty to keep)" : "Paste key"}
               />
               <button
@@ -1070,7 +1070,7 @@ export default function QueueTab({ adminFetch }: Props) {
                   value={customModel}
                   onChange={(e) => setCustomModel(e.target.value)}
                   placeholder="Custom model (e.g. gemini-exp-1206)"
-                  className="flex-1 rounded border border-amber-300 px-2 py-1 text-xs font-mono"
+                  className="flex-1 rounded border border-amber-300 px-2 py-1 text-xs font-mono placeholder:text-stone-600"
                 />
                 <button
                   onClick={() => {


### PR DESCRIPTION
## What changed
Added `placeholder:text-stone-600` to 7 inputs in `QueueTab.tsx` and admin pages that were missed by PR #1824.

**Affected inputs:**
| File | Placeholder |
|---|---|
| `QueueTab.tsx` | `zh, de, ja` (auto-translate languages) |
| `QueueTab.tsx` | `•••• (leave empty to keep)` / `Paste key` (API key) |
| `QueueTab.tsx` | `Custom model (e.g. gemini-exp-1206)` |
| `admin/uploads/page.tsx` | `Filter by user ID…` |
| `admin/books/page.tsx` | `Gutenberg Book ID (e.g. 2229)` |
| `admin/books/page.tsx` | `Search books by title, author, or ID…` |
| `admin/books/page.tsx` | `→Ch` (chapter reassignment) |

## Why
Browser-default placeholder color (~#a8a29e, ~3.95:1 on white) fails WCAG 1.4.3 Success Criterion (requires 4.5:1 for normal text). `text-stone-600` (#57534e) gives ~7.2:1.

## Test plan
- `PlaceholderTextContrast.test.ts` expanded with 3 new assertions covering `QueueTab`, `admin/uploads`, and `admin/books`
- All 2613 frontend tests pass
- Backend tests pass

Closes #1826
