### PR TITLE
ux: fix <main role="status"> overriding ARIA landmark in upload loading states

### DIFF
--- a/frontend/src/__tests__/UploadMainLandmark.test.ts
+++ b/frontend/src/__tests__/UploadMainLandmark.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const uploadPageSrc = readFileSync(join(__dirname, "../app/upload/page.tsx"), "utf-8");
+const chaptersPageSrc = readFileSync(join(__dirname, "../app/upload/[bookId]/chapters/page.tsx"), "utf-8");
+
+describe("Upload pages — main landmark integrity (WCAG 1.3.6)", () => {
+  it("upload/page.tsx must not use <main role=\"status\"> — overrides landmark with live region", () => {
+    expect(uploadPageSrc).not.toMatch(/<main\s[^>]*role="status"/);
+  });
+
+  it("upload/page.tsx loading state must use div[role=\"status\"] inside main#main-content", () => {
+    expect(uploadPageSrc).toMatch(/role="status"\s*aria-label="Loading upload page"/);
+    expect(uploadPageSrc).toMatch(/id="main-content"/);
+  });
+
+  it("upload/[bookId]/chapters/page.tsx must not use <main role=\"status\">", () => {
+    expect(chaptersPageSrc).not.toMatch(/<main\s[^>]*role="status"/);
+  });
+
+  it("upload/[bookId]/chapters/page.tsx loading state must use div[role=\"status\"] inside main#main-content", () => {
+    expect(chaptersPageSrc).toMatch(/role="status"\s*aria-label="Loading chapters"/);
+    expect(chaptersPageSrc).toMatch(/id="main-content"/);
+  });
+});

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -69,8 +69,10 @@ export default function ChapterEditorPage() {
 
   if (loading) {
     return (
-      <main role="status" aria-label="Loading chapters" className="min-h-screen bg-parchment flex items-center justify-center">
-        <div className="w-6 h-6 border-2 border-amber-400 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
+      <main id="main-content" className="min-h-screen bg-parchment flex items-center justify-center">
+        <div role="status" aria-label="Loading chapters">
+          <span className="w-6 h-6 border-2 border-amber-400 border-t-amber-700 rounded-full animate-spin block" aria-hidden="true" />
+        </div>
       </main>
     );
   }

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -84,8 +84,10 @@ export default function UploadPage() {
 
   if (status === "loading") {
     return (
-      <main role="status" aria-label="Loading upload page" className="min-h-screen bg-parchment flex items-center justify-center">
-        <div className="w-6 h-6 border-2 border-amber-400 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
+      <main id="main-content" className="min-h-screen bg-parchment flex items-center justify-center">
+        <div role="status" aria-label="Loading upload page">
+          <span className="w-6 h-6 border-2 border-amber-400 border-t-amber-700 rounded-full animate-spin block" aria-hidden="true" />
+        </div>
       </main>
     );
   }


### PR DESCRIPTION
## What changed

Fixes an incorrect ARIA role on two upload-page loading states. Both pages used `<main role="status">` which overrides the implicit `main` landmark with a live-region role — breaking screen-reader keyboard navigation (the `m` shortcut stops jumping to main content).

**Before:**
```tsx
<main role="status" aria-label="Loading upload page" ...>
  <div ... aria-hidden="true" />
</main>
```

**After:**
```tsx
<main id="main-content" ...>
  <div role="status" aria-label="Loading upload page">
    <span ... aria-hidden="true" />
  </div>
</main>
```

Files fixed:
- `frontend/src/app/upload/page.tsx` — auth-loading state
- `frontend/src/app/upload/[bookId]/chapters/page.tsx` — chapters-loading state

## Why

WAI-ARIA spec §5.3.2 prohibits applying role="status" to the `<main>` element. Doing so replaces the implicit `main` landmark with a live-region role, causing WCAG 1.3.6 (Identify Purpose) failures and breaking AT navigation.

## Test plan

- [x] New test file `UploadMainLandmark.test.ts` — 4 assertions: no `<main role="status">`, correct `div[role="status"]` inside `main#main-content` on both pages
- [x] Full frontend suite: 2617 tests, 405 suites — all pass
- [x] Rebased onto latest main (clean)

Closes #1829
