### PR TITLE
ux: make chapter editor cards keyboard-accessible (WCAG 2.1.1)

### DIFF
--- a/frontend/src/__tests__/ChapterCardKeyboard.test.ts
+++ b/frontend/src/__tests__/ChapterCardKeyboard.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/upload/[bookId]/chapters/page.tsx"),
+  "utf-8"
+);
+
+describe("Chapter editor cards — keyboard accessibility (WCAG 2.1.1)", () => {
+  it("chapter card div must have tabIndex so keyboard users can focus it", () => {
+    expect(src).toMatch(/tabIndex=\{0\}/);
+  });
+
+  it("chapter card div must have role=\"button\" to expose it as interactive", () => {
+    expect(src).toMatch(/role="button"/);
+  });
+
+  it("chapter card div must have onKeyDown to activate on Enter/Space", () => {
+    expect(src).toMatch(/onKeyDown/);
+  });
+
+  it("chapter card div must have aria-label with chapter info", () => {
+    expect(src).toMatch(/aria-label=\{/);
+  });
+});

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -143,7 +143,11 @@ export default function ChapterEditorPage() {
             return (
               <div
                 key={ch.original_index + "-" + i}
+                role="button"
+                tabIndex={0}
+                aria-label={`Chapter ${i + 1}: ${ch.title}${selected === i ? " (selected)" : ""}`}
                 onClick={() => setSelected(i)}
+                onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && setSelected(i)}
                 className={`rounded-xl border p-3 cursor-pointer transition-all duration-150 ${
                   selected === i
                     ? "border-amber-400 bg-amber-50"


### PR DESCRIPTION
## What changed

Added keyboard accessibility to chapter cards in the chapter editor page (`/upload/[bookId]/chapters`).

**Before:** Each card was a plain `<div onClick>` — no `tabIndex`, no `role`, no `onKeyDown`. Keyboard users could tab to the title input and delete button inside each card, but couldn't select a card to update the preview panel without a mouse click.

**After:** Each card now has:
- `role="button"` — exposes the card as an interactive control to AT
- `tabIndex={0}` — makes the card focusable in the tab order
- `aria-label="Chapter N: <title> (selected)"` — gives screen readers a meaningful name and indicates which card is selected
- `onKeyDown` — activates on Enter or Space, matching button interaction convention

## Why

WCAG 2.1.1 (Keyboard) requires all functionality to be operable without a mouse. The preview panel was only reachable by clicking — keyboard-only and AT users had no path to select a chapter.

## Test plan

- [x] New test `ChapterCardKeyboard.test.ts` — 4 assertions: `tabIndex={0}`, `role="button"`, `onKeyDown`, `aria-label={`
- [x] Full frontend suite: 2621 tests, 406 suites — all pass
- [x] Rebased onto latest main (clean, #1830 skipped as already upstream)

Closes #1833
