### PR TITLE
ux: guard BUTTON/A in reader keyboard shortcut handler (WCAG 2.1.1)

### DIFF
--- a/frontend/src/__tests__/ReaderSpaceShortcutGuard.test.ts
+++ b/frontend/src/__tests__/ReaderSpaceShortcutGuard.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf-8"
+);
+
+describe("Reader keyboard shortcut guard (WCAG 2.1.1)", () => {
+  it("keyboard shortcut guard must skip BUTTON tag to preserve Space-to-activate", () => {
+    // The guard must include BUTTON so Space key on a focused button
+    // activates the button rather than triggering TTS play/pause.
+    expect(src).toMatch(/tag === "BUTTON"/);
+  });
+
+  it("keyboard shortcut guard must skip A tag to preserve Space/Enter on links", () => {
+    expect(src).toMatch(/tag === "A"/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -692,9 +692,10 @@ export default function ReaderPage() {
   // Keyboard shortcuts
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      // Skip if user is typing in an input/select/textarea
+      // Skip if focus is on an interactive element — let the element handle its own keys.
+      // Without BUTTON/A here, Space would suppress native button activation (WCAG 2.1.1).
       const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || tag === "BUTTON" || tag === "A") return;
 
       if (e.key === "ArrowLeft" && chapterIndex > 0) {
         e.preventDefault();


### PR DESCRIPTION
## What changed

Expanded the keyboard shortcut guard in `reader/[bookId]/page.tsx` to include `BUTTON` and `A` tags.

**Before:** only `INPUT`, `TEXTAREA`, `SELECT` were excluded from the global `keydown` handler.

**After:** `BUTTON` and `A` are also excluded — so Space on a focused button activates the button natively instead of being swallowed by the TTS play/pause shortcut.

## Why

WCAG 2.1.1 (Keyboard) requires that all functionality operable by pointer is also operable by keyboard. The Space key on a button must activate it. The prior guard called `e.preventDefault()` on Space for any focused element that wasn't an input field, which silently broke Space-to-activate for every `<button>` in the reader (annotation toggles, panel close buttons, etc.).

## Test plan

- `ReaderSpaceShortcutGuard.test.ts` — 2 static-source assertions:
  - guard includes `tag === "BUTTON"`
  - guard includes `tag === "A"`
- Full frontend suite: 2627/2627 ✓

Closes #1837
