### PR TITLE
ux: include count in Notes/Vocab button aria-label; hide badge from SR (WCAG 4.1.2)

### DIFF
--- a/frontend/src/__tests__/ReaderAriaExpandedDialog.test.ts
+++ b/frontend/src/__tests__/ReaderAriaExpandedDialog.test.ts
@@ -19,9 +19,11 @@ describe("Reader page disclosure button aria-expanded (closes #1245)", () => {
   });
 
   it("Notes button has aria-expanded", () => {
-    const idx = src.indexOf('aria-label="Notes"');
+    // Mobile notes button uses a dynamic aria-label (includes count when > 0).
+    // Anchor on the setNotesExpanded call inside the button's onClick.
+    const idx = src.indexOf('setNotesExpanded((v) => !v)');
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(idx, idx + 100);
+    const window = src.slice(idx, idx + 500);
     expect(window).toContain("aria-expanded");
   });
 

--- a/frontend/src/__tests__/ReaderBadgeAriaHidden.test.ts
+++ b/frontend/src/__tests__/ReaderBadgeAriaHidden.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf-8"
+);
+
+describe("Reader toolbar count badges (WCAG 4.1.2)", () => {
+  it("badge spans must have aria-hidden so screen readers ignore the visual count", () => {
+    // Each badge <span> must carry aria-hidden="true". The badge spans are
+    // identified by their distinctive bg-amber-800 rounded-full combo.
+    // After the fix there are 3 such spans (notes desktop, vocab, notes mobile).
+    const lines = src.split("\n");
+    const badgeLines = lines.filter(
+      (l) => l.includes("rounded-full") && l.includes("bg-amber-800")
+    );
+    // Every badge line must include aria-hidden="true"
+    expect(badgeLines.length).toBeGreaterThanOrEqual(3);
+    badgeLines.forEach((line) => {
+      expect(line).toContain('aria-hidden="true"');
+    });
+  });
+
+  it("Notes button aria-label must be dynamic and include annotation count", () => {
+    // The Notes sidebar button's aria-label must reference annotations.length
+    // so screen readers can hear "Annotations & notes (3)" instead of just the label.
+    expect(src).toMatch(/aria-label=\{[^}]*Annotations & notes/);
+  });
+
+  it("Vocab button aria-label must be dynamic and include vocab count", () => {
+    expect(src).toMatch(/aria-label=\{[^}]*Vocabulary/);
+  });
+});

--- a/frontend/src/__tests__/ReaderPage.branches.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches.test.tsx
@@ -1147,7 +1147,7 @@ describe("ReaderPage.branches — mobile notes expand panel", () => {
     render(<ReaderPage />);
     await flushPromises();
 
-    const mobileNotesBtn = await screen.findByRole("button", { name: "Notes" });
+    const mobileNotesBtn = await screen.findByRole("button", { name: /^Notes/ });
     await userEvent.click(mobileNotesBtn);
 
     await waitFor(() => {
@@ -1173,7 +1173,7 @@ describe("ReaderPage.branches — mobile notes expand panel", () => {
     render(<ReaderPage />);
     await flushPromises();
 
-    const mobileNotesBtn = await screen.findByRole("button", { name: "Notes" });
+    const mobileNotesBtn = await screen.findByRole("button", { name: /^Notes/ });
     await userEvent.click(mobileNotesBtn);
 
     await waitFor(() => {

--- a/frontend/src/__tests__/ReaderPage.branches2.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches2.test.tsx
@@ -1322,7 +1322,7 @@ describe("ReaderPage.branches2 — mobile notes panel same-chapter click", () =>
     render(<ReaderPage />);
     await flushPromises();
 
-    const mobileNotesBtn = await screen.findByRole("button", { name: "Notes" });
+    const mobileNotesBtn = await screen.findByRole("button", { name: /^Notes/ });
     await userEvent.click(mobileNotesBtn);
 
     await waitFor(() => {
@@ -1357,7 +1357,7 @@ describe("ReaderPage.branches2 — mobile notes panel same-chapter click", () =>
     render(<ReaderPage />);
     await flushPromises();
 
-    const mobileNotesBtn = await screen.findByRole("button", { name: "Notes" });
+    const mobileNotesBtn = await screen.findByRole("button", { name: /^Notes/ });
     await userEvent.click(mobileNotesBtn);
 
     await waitFor(() => {

--- a/frontend/src/__tests__/ReaderSidebarToggleAria.test.ts
+++ b/frontend/src/__tests__/ReaderSidebarToggleAria.test.ts
@@ -10,7 +10,11 @@ function checkButton(anchorText: string, label: string) {
   const idx = src.indexOf(anchorText);
   expect(idx).toBeGreaterThan(-1);
   const window = src.slice(idx, idx + 600);
-  expect(window).toContain(`aria-label="${label}"`);
+  // Accept either a static aria-label="..." or a dynamic aria-label={...} that
+  // contains the label text (e.g. when the label includes a runtime count).
+  const hasStaticLabel = window.includes(`aria-label="${label}"`);
+  const hasDynamicLabel = window.includes(`aria-label={`) && window.includes(label);
+  expect(hasStaticLabel || hasDynamicLabel).toBe(true);
   expect(window).toContain("aria-expanded");
 }
 

--- a/frontend/src/__tests__/ReaderToolbarTouchTargets.test.ts
+++ b/frontend/src/__tests__/ReaderToolbarTouchTargets.test.ts
@@ -32,7 +32,9 @@ describe("reader desktop toolbar touch targets (closes #871)", () => {
   });
 
   it("Notes toggle has min-h-[44px]", () => {
-    checkForward('"Annotations & notes"');
+    // Radius enlarged: dynamic aria-label expression is longer than the old static form,
+    // so min-h-[44px] now sits further from the title="..." anchor.
+    checkForward('"Annotations & notes"', 400);
   });
 
   it("Show/hide annotation marks button has min-h-[44px]", () => {
@@ -41,7 +43,8 @@ describe("reader desktop toolbar touch targets (closes #871)", () => {
   });
 
   it("Vocabulary toggle has min-h-[44px]", () => {
-    checkForward('title="Vocabulary"');
+    // Radius enlarged: dynamic aria-label is longer than the old static form.
+    checkForward('title="Vocabulary"', 400);
   });
 
   it("Obsidian export button has min-h-[44px]", () => {

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1108,7 +1108,7 @@ export default function ReaderPage() {
               setSidebarTab("notes"); setSidebarOpen((v) => sidebarTab === "notes" ? !v : true);
             }}
             title="Annotations & notes"
-            aria-label="Annotations & notes"
+            aria-label={annotations.length > 0 ? `Annotations & notes (${annotations.length})` : "Annotations & notes"}
             aria-expanded={sidebarOpen && sidebarTab === "notes"}
             className={`relative hidden md:flex shrink-0 items-center gap-1.5 px-2 lg:px-3 py-1.5 min-h-[44px] md:min-h-0 rounded-lg border text-xs font-medium transition-colors ${
               sidebarOpen && sidebarTab === "notes"
@@ -1119,7 +1119,7 @@ export default function ReaderPage() {
             <NoteIcon className="w-3.5 h-3.5 shrink-0" />
             <span className="hidden lg:inline">Notes</span>
             {annotations.length > 0 && (
-              <span className="absolute -top-1.5 -right-1.5 min-w-[16px] h-4 flex items-center justify-center rounded-full bg-amber-800 text-white text-[9px] font-bold px-1">
+              <span aria-hidden="true" className="absolute -top-1.5 -right-1.5 min-w-[16px] h-4 flex items-center justify-center rounded-full bg-amber-800 text-white text-[9px] font-bold px-1">
                 {annotations.length}
               </span>
             )}
@@ -1155,7 +1155,7 @@ export default function ReaderPage() {
               setSidebarTab("vocab"); setSidebarOpen((v) => sidebarTab === "vocab" ? !v : true);
             }}
             title="Vocabulary"
-            aria-label="Vocabulary"
+            aria-label={vocabWords.length > 0 ? `Vocabulary (${vocabWords.length} words)` : "Vocabulary"}
             aria-expanded={sidebarOpen && sidebarTab === "vocab"}
             className={`relative hidden md:flex shrink-0 items-center gap-1.5 px-2 lg:px-3 py-1.5 min-h-[44px] md:min-h-0 rounded-lg border text-xs font-medium transition-colors ${
               sidebarOpen && sidebarTab === "vocab"
@@ -1166,7 +1166,7 @@ export default function ReaderPage() {
             <BookOpenIcon className="w-3.5 h-3.5 shrink-0" />
             <span className="hidden lg:inline">Vocab</span>
             {vocabWords.length > 0 && (
-              <span className="absolute -top-1.5 -right-1.5 min-w-[16px] h-4 flex items-center justify-center rounded-full bg-amber-800 text-white text-[9px] font-bold px-1">
+              <span aria-hidden="true" className="absolute -top-1.5 -right-1.5 min-w-[16px] h-4 flex items-center justify-center rounded-full bg-amber-800 text-white text-[9px] font-bold px-1">
                 {vocabWords.length}
               </span>
             )}
@@ -2308,12 +2308,12 @@ export default function ReaderPage() {
                   ? "bg-amber-700 text-white border-amber-700"
                   : "text-amber-700 bg-amber-50 border-amber-200"
               }`}
-              aria-label="Notes"
+              aria-label={annotations.length > 0 ? `Notes (${annotations.length})` : "Notes"}
               aria-expanded={notesExpanded}
             >
               <NoteIcon className="w-5 h-5" />
               {annotations.length > 0 && (
-                <span className="absolute -top-1 -right-1 min-w-[14px] h-3.5 flex items-center justify-center rounded-full bg-amber-800 text-white text-[8px] font-bold px-0.5">
+                <span aria-hidden="true" className="absolute -top-1 -right-1 min-w-[14px] h-3.5 flex items-center justify-center rounded-full bg-amber-800 text-white text-[8px] font-bold px-0.5">
                   {annotations.length}
                 </span>
               )}


### PR DESCRIPTION
## What changed

Three count badges on reader toolbar buttons now satisfy WCAG 4.1.2 (Name, Role, Value):

1. **Desktop Notes button** — `aria-label` is now dynamic: `"Annotations & notes (3)"` when 3 annotations exist, `"Annotations & notes"` when empty.
2. **Desktop Vocabulary button** — `aria-label` is now `"Vocabulary (5 words)"` when 5 words saved.
3. **Mobile Notes button** — same pattern: `"Notes (2)"` / `"Notes"`.

All three badge `<span>` elements gained `aria-hidden="true"` so the count is not double-read.

## Why

The visual count badge (a tiny red pill `"3"`) inside each button had no screen-reader equivalent. A screen reader would say "Annotations & notes" but never mention the count. Under WCAG 4.1.2, the accessible name must fully convey the control's state. Including the count in the `aria-label` is the standard pattern (same as GitHub's notification count on nav icons).

## Test plan

- `ReaderBadgeAriaHidden.test.ts` — 3 new static-source assertions:
  - All `bg-amber-800 rounded-full` badge spans have `aria-hidden="true"`
  - Notes button `aria-label` is a dynamic expression containing "Annotations & notes"
  - Vocab button `aria-label` is a dynamic expression containing "Vocabulary"
- 5 existing tests updated to handle the longer dynamic `aria-label` expression (window radius, regex queries).
- Full frontend suite: 2630/2630 ✓

Closes #1839
