### PR TITLE
ux: follow-up page titles for decks, pending, import, chapter routes (closes #1844)

### DIFF
--- a/frontend/src/__tests__/PageTitles.test.ts
+++ b/frontend/src/__tests__/PageTitles.test.ts
@@ -58,3 +58,26 @@ describe("WCAG 2.4.2 — per-page <title> (closes #1841)", () => {
     expect(src).toMatch(/export\s+(async\s+)?function\s+generateMetadata/);
   });
 });
+
+describe("WCAG 2.4.2 — follow-up page titles (closes #1844)", () => {
+  const staticLayouts = [
+    "pending/layout.tsx",
+    "decks/layout.tsx",
+    "decks/new/layout.tsx",
+    "import/[bookId]/layout.tsx",
+    "upload/[bookId]/chapters/layout.tsx",
+  ];
+
+  staticLayouts.forEach((rel) => {
+    it(`${rel} has a distinct metadata title`, () => {
+      const src = readLayout(rel);
+      expect(hasMetadataExport(src)).toBe(true);
+      expect(hasDistinctTitle(src)).toBe(true);
+    });
+  });
+
+  it("decks/[deckId]/layout.tsx exports generateMetadata for dynamic deck title", () => {
+    const src = readLayout("decks/[deckId]/layout.tsx");
+    expect(src).toMatch(/export\s+(async\s+)?function\s+generateMetadata/);
+  });
+});

--- a/frontend/src/app/decks/[deckId]/layout.tsx
+++ b/frontend/src/app/decks/[deckId]/layout.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ deckId: string }>;
+}): Promise<Metadata> {
+  const { deckId } = await params;
+  try {
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+    const res = await fetch(`${apiUrl}/decks/${deckId}`, { cache: "no-store" });
+    if (res.ok) {
+      const deck = await res.json();
+      if (deck?.name) return { title: deck.name };
+    }
+  } catch {
+    // fallback below
+  }
+  return { title: "Deck" };
+}
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/decks/layout.tsx
+++ b/frontend/src/app/decks/layout.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = { title: "Decks" };
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/decks/new/layout.tsx
+++ b/frontend/src/app/decks/new/layout.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = { title: "New Deck" };
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/import/[bookId]/layout.tsx
+++ b/frontend/src/app/import/[bookId]/layout.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = { title: "Import" };
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/pending/layout.tsx
+++ b/frontend/src/app/pending/layout.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = { title: "Account Pending" };
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/upload/[bookId]/chapters/layout.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/layout.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = { title: "Chapter Editor" };
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}


### PR DESCRIPTION
## What changed

Follow-up to #1842 — six user-facing routes that were missed still had no distinct `<title>`, causing all to fall through to the root layout default "My Library — Book Reader AI". Added co-located `layout.tsx` server components for each:

| Route | Title |
|---|---|
| `pending/` | "Account Pending" |
| `decks/` | "Decks" |
| `decks/new/` | "New Deck" |
| `decks/[deckId]/` | Deck name from API (falls back to "Deck") |
| `import/[bookId]/` | "Import" |
| `upload/[bookId]/chapters/` | "Chapter Editor" |

## Why

WCAG 2.4.2 (Level A) requires every page to have a title describing its topic. These routes were missed in the initial pass (#1842).

## Test plan

- Extended `PageTitles.test.ts` from 10 to 16 cases — 6 new assertions covering all routes above
- All 2641 frontend tests pass

Closes #1844
