### PR TITLE
ux: add role=status to import page completion message (closes #1846)

### DIFF
--- a/frontend/src/__tests__/ImportPageStatus.test.ts
+++ b/frontend/src/__tests__/ImportPageStatus.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Regression for #1846 — import page success and stage messages must have
+ * live region roles so screen readers announce completion (WCAG 4.1.3).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/import/[bookId]/page.tsx"),
+  "utf-8"
+);
+
+describe("Import page status messages (closes #1846)", () => {
+  it('isDone success message has role="status"', () => {
+    const idx = src.indexOf("Done — opening your book");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 50);
+    expect(window).toContain('role="status"');
+  });
+});

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -302,7 +302,7 @@ export default function BookImportPage() {
           )}
 
           {isDone && (
-            <p className="text-sm text-emerald-700 mb-4">
+            <p role="status" className="text-sm text-emerald-700 mb-4">
               Done — opening your book…
             </p>
           )}


### PR DESCRIPTION
## What changed

Added `role="status"` to the "Done — opening your book…" paragraph in `import/[bookId]/page.tsx`.

## Why

The success message was dynamically injected when import completed but had no live region. Screen readers (NVDA, VoiceOver, Narrator) only announce dynamically inserted content when it appears in a live region (`role="status"`, `role="alert"`, or `aria-live`). Without it, screen reader users had no confirmation that the import succeeded — the page would navigate silently.

WCAG 4.1.3 (Status Messages, Level AA) requires status messages to be programmatically determinable without receiving focus.

## Test plan

- New `ImportPageStatus.test.ts` — static analysis asserting `role="status"` is present near the "Done" string
- All 2636 frontend tests pass

Closes #1846
