### PR TITLE
ux: add aria-live region to search results for screen reader announcement (closes #1848)

### DIFF
--- a/frontend/src/__tests__/SearchResultsLiveRegion.test.ts
+++ b/frontend/src/__tests__/SearchResultsLiveRegion.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Regression for #1848 — search results page must announce completion via
+ * an aria-live region so screen readers know results have loaded (WCAG 4.1.3).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/search/page.tsx"),
+  "utf-8"
+);
+
+describe("Search results live region (closes #1848)", () => {
+  it("SearchResultsInner has an aria-live status region for result announcements", () => {
+    expect(src).toContain('aria-live="polite"');
+  });
+
+  it("status region is aria-atomic so the full count is read at once", () => {
+    expect(src).toContain('aria-atomic="true"');
+  });
+
+  it("status region uses role=status", () => {
+    // Find the aria-live region and confirm it also carries role="status"
+    const idx = src.indexOf('aria-live="polite"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 200);
+    expect(window).toContain('role="status"');
+  });
+});

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -131,57 +131,66 @@ function SearchResultsInner() {
       });
   }, [q]);
 
-  if (!q.trim()) {
-    return (
-      <div className="text-center text-stone-500 py-16">
-        <SearchIcon className="w-10 h-10 mx-auto mb-2 text-stone-400" aria-hidden="true" />
-        <p className="font-serif text-lg text-ink">Search your notes, vocabulary, and uploads</p>
-        <p className="text-sm mt-2">Start typing in the search bar.</p>
-      </div>
-    );
-  }
+  const annotations = data?.results.filter((r): r is Extract<InAppSearchResult, { type: "annotation" }> => r.type === "annotation") ?? [];
+  const vocabulary = data?.results.filter((r): r is Extract<InAppSearchResult, { type: "vocabulary" }> => r.type === "vocabulary") ?? [];
+  const chapters = data?.results.filter((r): r is Extract<InAppSearchResult, { type: "chapter" }> => r.type === "chapter") ?? [];
 
-  if (loading) {
-    return (
-      <div role="status" aria-label="Searching" className="space-y-3 animate-pulse py-2">
-        {[1, 2, 3].map((i) => (
-          <div key={i} className="h-20 bg-amber-100 rounded-md" />
-        ))}
-      </div>
-    );
+  let liveMessage = "";
+  if (!loading && q.trim()) {
+    if (error) liveMessage = "Search failed.";
+    else if (data && data.total > 0) liveMessage = `Found ${data.total} result${data.total === 1 ? "" : "s"} for ${q}.`;
+    else if (data) liveMessage = `Search complete. No results found for ${q}.`;
   }
-  if (error) {
-    return (
-      <div role="alert" className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
-        Error: {error}
-      </div>
-    );
-  }
-  if (!data || data.total === 0) {
-    return (
-      <div className="text-center text-stone-500 py-12">
-        <p className="font-serif text-lg text-ink">No matches for &ldquo;{q}&rdquo;.</p>
-        <p className="text-sm mt-2">Try a shorter or different word.</p>
-        <Link
-          href="/"
-          className="mt-5 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px]"
-        >
-          Browse books <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
-        </Link>
-      </div>
-    );
-  }
-
-  const annotations = data.results.filter((r): r is Extract<InAppSearchResult, { type: "annotation" }> => r.type === "annotation");
-  const vocabulary = data.results.filter((r): r is Extract<InAppSearchResult, { type: "vocabulary" }> => r.type === "vocabulary");
-  const chapters = data.results.filter((r): r is Extract<InAppSearchResult, { type: "chapter" }> => r.type === "chapter");
 
   return (
-    <div className="space-y-10">
-      <ResultsSection title="Annotations" items={annotations} />
-      <ResultsSection title="Vocabulary" items={vocabulary} />
-      <ResultsSection title="Chapters" items={chapters} />
-    </div>
+    <>
+      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+        {liveMessage}
+      </div>
+
+      {!q.trim() && (
+        <div className="text-center text-stone-500 py-16">
+          <SearchIcon className="w-10 h-10 mx-auto mb-2 text-stone-400" aria-hidden="true" />
+          <p className="font-serif text-lg text-ink">Search your notes, vocabulary, and uploads</p>
+          <p className="text-sm mt-2">Start typing in the search bar.</p>
+        </div>
+      )}
+
+      {loading && (
+        <div role="status" aria-label="Searching" className="space-y-3 animate-pulse py-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-20 bg-amber-100 rounded-md" />
+          ))}
+        </div>
+      )}
+
+      {!loading && error && (
+        <div role="alert" className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
+          Error: {error}
+        </div>
+      )}
+
+      {!loading && !error && data && data.total === 0 && (
+        <div className="text-center text-stone-500 py-12">
+          <p className="font-serif text-lg text-ink">No matches for &ldquo;{q}&rdquo;.</p>
+          <p className="text-sm mt-2">Try a shorter or different word.</p>
+          <Link
+            href="/"
+            className="mt-5 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px]"
+          >
+            Browse books <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
+          </Link>
+        </div>
+      )}
+
+      {!loading && !error && data && data.total > 0 && (
+        <div className="space-y-10">
+          <ResultsSection title="Annotations" items={annotations} />
+          <ResultsSection title="Vocabulary" items={vocabulary} />
+          <ResultsSection title="Chapters" items={chapters} />
+        </div>
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
## What changed

`SearchResultsInner` (`frontend/src/app/search/page.tsx`) now includes a persistent `role="status" aria-live="polite" aria-atomic="true"` element that announces the search outcome to screen readers:

- **Results found**: "Found N results for {query}."
- **No results**: "Search complete. No results found for {query}."
- **Error**: "Search failed."

Previously, only the loading state was announced (`role="status" aria-label="Searching"`). Result arrival was silent — screen reader users had no way to know the search completed.

## Why

WCAG 4.1.3 (Status Messages, Level AA) requires dynamically injected completion messages to be reachable by assistive technologies without requiring focus. The vocabulary filter page already uses this pattern correctly (`aria-live="polite"` on line 470) — the search page now matches it.

## Test plan

- `SearchResultsLiveRegion.test.ts` (new) — verifies `aria-live="polite"`, `aria-atomic="true"`, and `role="status"` are present in the search page source
- All 2645 existing Jest tests pass
- Existing `SearchPageUx.test.ts` assertions (role=alert on error, Browse books CTA, focus-visible rings) still pass

Closes #1848
