### PR TITLE
ux: add aria-live filter count announcement to vocabulary page (closes #1850)

### DIFF
--- a/frontend/src/__tests__/VocabFilterLiveRegion.test.ts
+++ b/frontend/src/__tests__/VocabFilterLiveRegion.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Regression for #1850 — vocabulary filter must announce result count via
+ * an sr-only aria-live region so screen readers know when filtering changes
+ * the word list (WCAG 4.1.3).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/vocabulary/page.tsx"),
+  "utf-8"
+);
+
+describe("Vocabulary filter live region (closes #1850)", () => {
+  it("has an sr-only aria-live region for filter result announcements", () => {
+    // Must have a visually-hidden live region (not just the export status div)
+    // that announces filter results
+    expect(src).toContain("sr-only");
+    // That sr-only element must be inside or accompanied by aria-live
+    const srIdx = src.indexOf("sr-only");
+    const window = src.slice(Math.max(0, srIdx - 300), srIdx + 300);
+    expect(window).toContain("aria-live");
+  });
+
+  it("filter announcement references filtered word count", () => {
+    // The sr-only live region must include the filtered count
+    const srIdx = src.indexOf("sr-only");
+    expect(srIdx).toBeGreaterThan(-1);
+    // Find the aria-live region containing sr-only
+    const window = src.slice(Math.max(0, srIdx - 400), srIdx + 400);
+    // Should reference filtered length or a word count variable
+    expect(window).toMatch(/filtered\.length|filterCount|wordCount/);
+  });
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -479,6 +479,13 @@ function VocabularyPageContent() {
         )}
       </div>
 
+      {/* Visually-hidden live region: announces filter result counts to screen readers */}
+      {(search || selectedTag) && (
+        <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+          {`${filtered.length} word${filtered.length === 1 ? "" : "s"} found.`}
+        </div>
+      )}
+
       <div className="max-w-2xl mx-auto px-4 md:px-6 py-6 md:py-8">
         {words.length > 5 && (
           <div className="mb-6 space-y-3">


### PR DESCRIPTION
## What changed

Added a visually-hidden `role="status" aria-live="polite" aria-atomic="true"` element to `vocabulary/page.tsx` that announces the filter result count to screen readers whenever the user types a search term or selects a tag.

- Active filter (search or tag selected) → announces `"N word(s) found."`
- No filter active → element is not rendered (avoids false announcements on page load)

The existing `aria-live` region (export status, line 470) is preserved unchanged.

## Why

When a screen reader user types in the vocabulary search box or selects a tag, the word list silently shrinks or shows an empty state. Without a live region, AT users have no way to know how many results remain after filtering. WCAG 4.1.3 (Status Messages, Level AA) requires dynamically injected filter/result state to be reachable by screen readers.

The `sr-only` class hides the announcement visually to avoid showing a duplicate word count alongside the list.

## Test plan

- `VocabFilterLiveRegion.test.ts` (new) — asserts `sr-only` element with `aria-live="polite"` exists and references `filtered.length`
- All 2647 existing Jest tests pass, including `VocabularyPage.tagfilter` and `VocabularyPage.branches` tests that check the visible empty-state messages

Closes #1850
