### PR TITLE
ux: add aria-live filter count announcement to notes page (closes #1852)

### DIFF
--- a/frontend/src/__tests__/NotesFilterLiveRegion.test.ts
+++ b/frontend/src/__tests__/NotesFilterLiveRegion.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Regression for #1852 — notes page book filter must announce result count via
+ * sr-only aria-live region so screen readers know when filtering changes the
+ * book list (WCAG 4.1.3).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/notes/page.tsx"),
+  "utf-8"
+);
+
+describe("Notes page filter live region (closes #1852)", () => {
+  it("has an sr-only aria-live status region for filter result announcements", () => {
+    expect(src).toContain("sr-only");
+    const srIdx = src.indexOf("sr-only");
+    const window = src.slice(Math.max(0, srIdx - 300), srIdx + 300);
+    expect(window).toContain("aria-live");
+  });
+
+  it("filter announcement references filtered book count", () => {
+    const srIdx = src.indexOf("sr-only");
+    expect(srIdx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, srIdx - 400), srIdx + 400);
+    expect(window).toMatch(/filtered\.length|filterCount|bookCount/);
+  });
+});

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -141,6 +141,13 @@ export default function NotesOverviewPage() {
           onChange={(e) => setSearch(e.target.value)}
         />
 
+        {/* Visually-hidden live region: announces filter result counts to screen readers */}
+        {search.trim() && !loading && (
+          <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+            {`${filtered.length} book${filtered.length === 1 ? "" : "s"} found.`}
+          </div>
+        )}
+
         {loading ? (
           <div role="status" aria-label="Loading notes" className="flex justify-center py-20">
             <span className="w-6 h-6 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />


### PR DESCRIPTION
## What changed

Added a visually-hidden `role="status" aria-live="polite" aria-atomic="true"` element to `notes/page.tsx` that announces the book filter result count to screen readers when the search input is active:

- Filter active + results: `"N book(s) found."`
- Filter active + no results: `"0 books found."`
- No filter (empty search): element not rendered

## Why

When a user types in the notes page search box to filter books, the list updates silently. The empty-state message ("No books match your search.") appears without a live region, so screen reader users have no indication of how many books remain after filtering.

This is the same WCAG 4.1.3 (Status Messages, Level AA) pattern fixed in #1849 (search results) and #1851 (vocabulary filter). The `sr-only` class hides the count visually to avoid duplicate display alongside the visible results.

## Test plan

- `NotesFilterLiveRegion.test.ts` (new) — asserts `sr-only` element with `aria-live="polite"` exists and references `filtered.length`
- All 2649 existing Jest tests pass

Closes #1852
