### PR TITLE
ux: fix AddWordPicker dialog hidden from screen readers by aria-hidden wrapper (closes #1854)

### DIFF
--- a/frontend/src/__tests__/AddWordPickerAriaHidden.test.ts
+++ b/frontend/src/__tests__/AddWordPickerAriaHidden.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression for #1854 — AddWordPicker dialog must not be wrapped in
+ * aria-hidden="true"; doing so hides the dialog from all screen readers
+ * (WCAG 4.1.2).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/decks/[deckId]/page.tsx"),
+  "utf-8"
+);
+
+describe("AddWordPicker dialog accessibility (closes #1854)", () => {
+  it("dialog is not wrapped inside an aria-hidden element", () => {
+    // Find the dialog element
+    const dialogIdx = src.indexOf('role="dialog"');
+    expect(dialogIdx).toBeGreaterThan(-1);
+
+    // Look at the surrounding 500 chars before the dialog for aria-hidden="true"
+    const beforeDialog = src.slice(Math.max(0, dialogIdx - 500), dialogIdx);
+
+    // The last opening of a container div before the dialog must not be aria-hidden
+    // Find the last aria-hidden="true" occurrence before the dialog
+    const lastAriaHiddenIdx = beforeDialog.lastIndexOf('aria-hidden="true"');
+
+    if (lastAriaHiddenIdx === -1) {
+      // No aria-hidden before the dialog — pass
+      return;
+    }
+
+    // There must be a closing </div> between the aria-hidden and the dialog
+    // meaning the aria-hidden element is NOT an ancestor of the dialog
+    const textBetween = beforeDialog.slice(lastAriaHiddenIdx);
+    // If the last unclosed div before the dialog has aria-hidden, it wraps the dialog
+    // Check that the backdrop div's aria-hidden="true" is not present on the parent container
+    expect(textBetween).not.toMatch(/aria-hidden="true"[^>]*>\s*$/);
+  });
+
+  it("backdrop overlay div does not have aria-hidden attribute", () => {
+    // The fixed overlay that holds the dialog should not have aria-hidden="true"
+    // Pattern: fixed inset-0 wrapper with aria-hidden
+    expect(src).not.toMatch(/fixed inset-0[^>]*aria-hidden="true"/);
+    expect(src).not.toMatch(/aria-hidden="true"[^>]*fixed inset-0/);
+  });
+
+  it("dialog has role=dialog and aria-modal=true", () => {
+    expect(src).toContain('role="dialog"');
+    expect(src).toContain('aria-modal="true"');
+    expect(src).toContain('aria-labelledby="add-word-picker-title"');
+  });
+});

--- a/frontend/src/app/decks/[deckId]/page.tsx
+++ b/frontend/src/app/decks/[deckId]/page.tsx
@@ -320,7 +320,6 @@ function AddWordPicker({ candidates, onClose, onAdd }: AddWordPickerProps) {
     <div
       className="fixed inset-0 z-50 flex items-end md:items-center justify-center bg-stone-900/40"
       onClick={onClose}
-      aria-hidden="true"
     >
       <div
         role="dialog"


### PR DESCRIPTION
## What changed

Removed `aria-hidden="true"` from the backdrop overlay div in `AddWordPicker` (deck detail page). The attribute was applied to the outermost container which also wraps the `role="dialog"` element — making the entire modal invisible to screen readers.

## Why

`aria-hidden="true"` on an ancestor hides all descendant content from the accessibility tree. Screen reader users could not find or interact with the Add Word picker at all. The correct scope indicator for modal dialogs is `aria-modal="true"` on the dialog element itself, which was already present.

**WCAG 4.1.2 Name, Role, Value (Level A)**

## Test plan

- [x] New static-source regression test: `AddWordPickerAriaHidden.test.ts` — verifies the backdrop overlay does not carry `aria-hidden="true"` and the dialog has `role="dialog"`, `aria-modal="true"`, and `aria-labelledby`
- [x] Full frontend suite: 2652 tests pass
