### PR TITLE
ux: announce flashcard card position to screen readers after grading (closes #1856)

### DIFF
--- a/frontend/src/__tests__/FlashcardCounterLiveRegion.test.ts
+++ b/frontend/src/__tests__/FlashcardCounterLiveRegion.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression for #1856 — flashcard page must announce the current card
+ * position and word to screen readers after grading via an aria-live region
+ * (WCAG 4.1.3 Status Messages).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/vocabulary/flashcards/page.tsx"),
+  "utf-8"
+);
+
+describe("Flashcard page card counter live region (closes #1856)", () => {
+  it("has an aria-live region that announces card progress to screen readers", () => {
+    expect(src).toContain('aria-live="polite"');
+  });
+
+  it("card counter or announcement references currentIndex", () => {
+    const liveIdx = src.indexOf('aria-live="polite"');
+    expect(liveIdx).toBeGreaterThan(-1);
+    // The live region(s) should include card position info
+    // Look in the region of the counter or the live region itself
+    expect(src).toMatch(/currentIndex|cardAnnouncement|aria-live/);
+  });
+
+  it("card counter paragraph is wrapped in a role=status element", () => {
+    // The counter showing card N of M must be in a live region
+    const counterIdx = src.indexOf("remaining");
+    expect(counterIdx).toBeGreaterThan(-1);
+    // Within 200 chars before "remaining" there should be aria-live or role=status
+    const before = src.slice(Math.max(0, counterIdx - 300), counterIdx);
+    expect(before).toMatch(/aria-live|role="status"/);
+  });
+});

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -279,9 +279,10 @@ export default function FlashcardsPage() {
               </div>
             )}
 
-            {/* Card counter */}
-            <p className="text-center text-xs text-stone-500">
+            {/* Card counter — role=status so screen readers announce position after grading */}
+            <p role="status" aria-live="polite" aria-atomic="true" className="text-center text-xs text-stone-500">
               {currentIndex + 1} of {cards.length} remaining
+              {currentCard ? `: ${currentCard.word}` : ""}
             </p>
           </div>
         ) : null}


### PR DESCRIPTION
## What changed

Wrapped the flashcard card counter (`N of M remaining`) in `role="status" aria-live="polite" aria-atomic="true"` and appended the current word to the announcement text.

**Before:** `<p>2 of 10 remaining</p>` — completely silent to screen readers after grading.

**After:** `<p role="status" aria-live="polite" aria-atomic="true">2 of 10 remaining: Ephemeral</p>` — announces position and next word on every card transition.

## Why

WCAG 4.1.3 (Status Messages, Level AA) requires dynamically injected status updates that don't receive focus to use `aria-live` or `role="status"`. Screen reader users grading flashcards received no feedback about where they were in the deck.

## Test plan

- [x] New static-source regression test: `FlashcardCounterLiveRegion.test.ts` — verifies card counter has `role="status"` and `aria-live="polite"` in close proximity
- [x] Full frontend suite: 2652 tests pass
