### PR TITLE
ux: announce admin books search result count to screen readers (closes #1858)

### DIFF
--- a/frontend/src/__tests__/AdminBooksSearchLiveRegion.test.ts
+++ b/frontend/src/__tests__/AdminBooksSearchLiveRegion.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Regression for #1858 — admin books search result count must be announced
+ * to screen readers via aria-live or role="status" (WCAG 4.1.3).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/admin/books/page.tsx"),
+  "utf-8"
+);
+
+describe("Admin books search live region (closes #1858)", () => {
+  it("result count span has role=status or aria-live", () => {
+    // The visible count (e.g. "5 / 10") when searching must be in a live region
+    const countIdx = src.indexOf("books.length");
+    expect(countIdx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, countIdx - 500), countIdx + 200);
+    expect(window).toMatch(/aria-live|role="status"/);
+  });
+
+  it("search input has aria-label", () => {
+    expect(src).toContain('aria-label="Filter books"');
+  });
+});

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -258,7 +258,7 @@ export default function BooksPage() {
           aria-label="Filter books"
         />
         {searchQuery && (
-          <span className="text-xs text-stone-500">
+          <span role="status" aria-live="polite" aria-atomic="true" className="text-xs text-stone-500">
             {books.filter((b) =>
               fuzzyMatchAny(searchQuery, [b.title, ...(b.authors || []), b.id]),
             ).length}{" "}


### PR DESCRIPTION
## What changed

Added `role="status" aria-live="polite" aria-atomic="true"` to the search result count span in the admin books page.

**Before:** `<span className="text-xs text-stone-500">5 / 12</span>` — silent to screen readers.

**After:** `<span role="status" aria-live="polite" aria-atomic="true" ...>5 / 12</span>` — announces the filtered count as the admin types.

## Why

WCAG 4.1.3 (Status Messages, Level AA): dynamically injected status updates that don't receive focus must use `aria-live` or `role="status"`. Screen reader users typing in the admin books search filter received no feedback about how many results matched.

## Test plan

- [x] New regression test: `AdminBooksSearchLiveRegion.test.ts` — verifies the count span has `aria-live` or `role="status"` in its context, and the input has `aria-label="Filter books"`
- [x] Full frontend suite: 2654 tests pass
