### PR TITLE
ux: announce home page book discovery search results to screen readers (closes #1860)

### DIFF
--- a/frontend/src/__tests__/HomeSearchLiveRegion.test.ts
+++ b/frontend/src/__tests__/HomeSearchLiveRegion.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Regression for #1860 — home page book discovery search results must
+ * announce the result count to screen readers via an aria-live region
+ * (WCAG 4.1.3 Status Messages).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(join(__dirname, "../app/page.tsx"), "utf-8");
+
+describe("Home page discovery search live region (closes #1860)", () => {
+  it("has an sr-only aria-live region for search result announcements", () => {
+    expect(src).toContain("sr-only");
+    const srIdx = src.indexOf("sr-only");
+    const window = src.slice(Math.max(0, srIdx - 300), srIdx + 300);
+    expect(window).toContain("aria-live");
+  });
+
+  it("live region references search result count", () => {
+    const srIdx = src.indexOf("sr-only");
+    expect(srIdx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, srIdx - 400), srIdx + 400);
+    expect(window).toMatch(/searchResults\.length|resultCount|searchCount/);
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -601,6 +601,15 @@ export default function Home() {
                 </div>
               )}
 
+              {/* Visually-hidden live region: announces search result count to screen readers */}
+              {!searching && searchedQuery && !searchError && (
+                <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+                  {searchResults.length > 0
+                    ? `Found ${searchResults.length} book${searchResults.length === 1 ? "" : "s"} for ${searchedQuery}.`
+                    : `Search complete. No results for ${searchedQuery}.`}
+                </div>
+              )}
+
               {searching && (
                 <div role="status" aria-label="Loading search results">
                   <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 mb-4">


### PR DESCRIPTION
## What changed

Added a visually-hidden `role="status" aria-live="polite" aria-atomic="true"` region to the "Discover Books" search section on the home page. It appears after the search completes (not during loading) and announces:

- **Results found:** `"Found N book(s) for <query>."`  
- **No results:** `"Search complete. No results for <query>."`  
- **Error:** already covered by the existing `role="alert"` div

## Why

WCAG 4.1.3 (Status Messages, Level AA): when search results load dynamically without focus moving, screen readers must be notified via `aria-live`. The Discover Books search had a loading skeleton with `role="status"` but no announcement when the actual results appeared. Compare to `/search/page.tsx` which gained this fix in #1848.

## Test plan

- [x] New regression test: `HomeSearchLiveRegion.test.ts` — verifies `sr-only` element with `aria-live` and `searchResults.length` reference exist in the page source
- [x] Existing `HomePage.test.tsx` still passes (no-results text duplication avoided by using distinct phrasing in the live region)
- [x] Full frontend suite: 2656 tests pass
