### PR TITLE
ux: replace aria-expanded with aria-pressed on reader sidebar panel buttons (closes #1862)

### DIFF
--- a/frontend/src/__tests__/ReaderSidebarTabAria.test.ts
+++ b/frontend/src/__tests__/ReaderSidebarTabAria.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Regression test for #1862 — reader sidebar panel buttons used aria-expanded
+ * (correct for accordion/disclosure) instead of aria-pressed (correct for
+ * toggle buttons that open a specific panel). Screens readers were announcing
+ * a false "expanded/collapsed" state when the user switched between panels
+ * while the sidebar stayed open.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(process.cwd(), "src/app/reader/[bookId]/page.tsx"),
+  "utf-8"
+);
+
+const SIDEBAR_TABS = ["chat", "translate", "summary", "notes", "vocab"] as const;
+
+describe("Reader sidebar panel toggle buttons", () => {
+  it("uses aria-pressed (not aria-expanded) on sidebar panel buttons", () => {
+    // Each of the 5 panel buttons should expose aria-pressed
+    for (const tab of SIDEBAR_TABS) {
+      // Look for aria-pressed being set near setSidebarTab("<tab>")
+      const ariaPressed = new RegExp(`setSidebarTab\\("${tab}"\\)[\\s\\S]{0,400}aria-pressed`);
+      expect(src).toMatch(ariaPressed);
+    }
+  });
+
+  it("does not use aria-expanded on sidebar panel toggle buttons", () => {
+    // aria-expanded must NOT appear paired with setSidebarTab calls
+    // (those should now use aria-pressed)
+    const badPattern = /setSidebarTab\("[^"]+"\)[\s\S]{0,400}aria-expanded/;
+    expect(src).not.toMatch(badPattern);
+  });
+});

--- a/frontend/src/__tests__/ReaderSidebarToggleAria.test.ts
+++ b/frontend/src/__tests__/ReaderSidebarToggleAria.test.ts
@@ -15,27 +15,29 @@ function checkButton(anchorText: string, label: string) {
   const hasStaticLabel = window.includes(`aria-label="${label}"`);
   const hasDynamicLabel = window.includes(`aria-label={`) && window.includes(label);
   expect(hasStaticLabel || hasDynamicLabel).toBe(true);
-  expect(window).toContain("aria-expanded");
+  // aria-pressed is correct for toggle buttons that open a panel;
+  // aria-expanded was replaced in #1862 (it's for accordion/disclosure patterns)
+  expect(window).toContain("aria-pressed");
 }
 
-describe("reader desktop header sidebar toggle buttons aria-label and aria-expanded (closes #951)", () => {
-  it("Insight chat toggle has aria-label and aria-expanded", () => {
+describe("reader desktop header sidebar toggle buttons aria-label and aria-pressed (closes #951, #1862)", () => {
+  it("Insight chat toggle has aria-label and aria-pressed", () => {
     checkButton('setSidebarTab("chat")', "Insight sidebar");
   });
 
-  it("Translate toggle has aria-label and aria-expanded", () => {
+  it("Translate toggle has aria-label and aria-pressed", () => {
     checkButton('setSidebarTab("translate")', "Translate");
   });
 
-  it("Chapter summary toggle has aria-label and aria-expanded", () => {
+  it("Chapter summary toggle has aria-label and aria-pressed", () => {
     checkButton('setSidebarTab("summary")', "Chapter summary");
   });
 
-  it("Notes toggle has aria-label and aria-expanded", () => {
+  it("Notes toggle has aria-label and aria-pressed", () => {
     checkButton('setSidebarTab("notes")', "Annotations & notes");
   });
 
-  it("Vocabulary toggle has aria-label and aria-expanded", () => {
+  it("Vocabulary toggle has aria-label and aria-pressed", () => {
     checkButton('setSidebarTab("vocab")', "Vocabulary");
   });
 });

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1056,7 +1056,7 @@ export default function ReaderPage() {
             onClick={() => { setSidebarTab("chat"); setSidebarOpen((v) => sidebarTab === "chat" ? !v : true); }}
             title="Toggle insight chat"
             aria-label="Insight sidebar"
-            aria-expanded={sidebarOpen && sidebarTab === "chat"}
+            aria-pressed={sidebarOpen && sidebarTab === "chat"}
             className={`hidden md:flex shrink-0 items-center gap-1.5 px-2 lg:px-3 py-1.5 min-h-[44px] md:min-h-0 rounded-lg border text-xs font-medium transition-colors ${
               sidebarOpen && (sidebarTab === "chat")
                 ? "bg-amber-700 text-white border-amber-700"
@@ -1072,7 +1072,7 @@ export default function ReaderPage() {
             onClick={() => { setSidebarTab("translate"); setSidebarOpen((v) => sidebarTab === "translate" ? !v : true); }}
             title="Translation"
             aria-label="Translate"
-            aria-expanded={sidebarOpen && sidebarTab === "translate"}
+            aria-pressed={sidebarOpen && sidebarTab === "translate"}
             className={`hidden md:flex shrink-0 items-center gap-1.5 px-2 lg:px-3 py-1.5 min-h-[44px] md:min-h-0 rounded-lg border text-xs font-medium transition-colors ${
               sidebarOpen && sidebarTab === "translate"
                 ? "bg-amber-700 text-white border-amber-700"
@@ -1090,7 +1090,7 @@ export default function ReaderPage() {
             onClick={() => { setSidebarTab("summary"); setSidebarOpen((v) => sidebarTab === "summary" ? !v : true); }}
             title="Chapter summary"
             aria-label="Chapter summary"
-            aria-expanded={sidebarOpen && sidebarTab === "summary"}
+            aria-pressed={sidebarOpen && sidebarTab === "summary"}
             className={`hidden md:flex shrink-0 items-center gap-1.5 px-2 lg:px-3 py-1.5 min-h-[44px] md:min-h-0 rounded-lg border text-xs font-medium transition-colors ${
               sidebarOpen && sidebarTab === "summary"
                 ? "bg-amber-700 text-white border-amber-700"
@@ -1109,7 +1109,7 @@ export default function ReaderPage() {
             }}
             title="Annotations & notes"
             aria-label={annotations.length > 0 ? `Annotations & notes (${annotations.length})` : "Annotations & notes"}
-            aria-expanded={sidebarOpen && sidebarTab === "notes"}
+            aria-pressed={sidebarOpen && sidebarTab === "notes"}
             className={`relative hidden md:flex shrink-0 items-center gap-1.5 px-2 lg:px-3 py-1.5 min-h-[44px] md:min-h-0 rounded-lg border text-xs font-medium transition-colors ${
               sidebarOpen && sidebarTab === "notes"
                 ? "bg-amber-700 text-white border-amber-700"
@@ -1156,7 +1156,7 @@ export default function ReaderPage() {
             }}
             title="Vocabulary"
             aria-label={vocabWords.length > 0 ? `Vocabulary (${vocabWords.length} words)` : "Vocabulary"}
-            aria-expanded={sidebarOpen && sidebarTab === "vocab"}
+            aria-pressed={sidebarOpen && sidebarTab === "vocab"}
             className={`relative hidden md:flex shrink-0 items-center gap-1.5 px-2 lg:px-3 py-1.5 min-h-[44px] md:min-h-0 rounded-lg border text-xs font-medium transition-colors ${
               sidebarOpen && sidebarTab === "vocab"
                 ? "bg-amber-700 text-white border-amber-700"


### PR DESCRIPTION
## What changed

Replaced `aria-expanded` with `aria-pressed` on the five reader sidebar panel toggle buttons (Insight, Translate, Summary, Notes, Vocabulary).

## Why

`aria-expanded` is the correct attribute for accordion and disclosure widgets — it announces "expanded" or "collapsed" to screen readers when a single collapsible region opens or closes. These buttons control a *panel switcher*: clicking an already-active button toggles the sidebar, while clicking a different button switches the visible panel without collapsing the sidebar. This caused screen readers to announce a misleading "Translate, collapsed / Insight, expanded" transition when the user only switched panels — the sidebar never closed.

`aria-pressed` correctly conveys the toggle state: the button reports "pressed" when its panel is currently visible, and "not pressed" otherwise. There is no false collapse/expand announcement when switching panels.

Closes #1862 — WCAG 4.1.2 (Name, Role, Value)

## Test plan

- `ReaderSidebarTabAria.test.ts` (new): verifies all 5 panel buttons use `aria-pressed`, not `aria-expanded`
- `ReaderSidebarToggleAria.test.ts` (updated): updated existing test to assert `aria-pressed` (previously asserted `aria-expanded`)
- Full frontend suite: 2658 tests pass
