### PR TITLE
ux: add page title to not-found page (WCAG 2.4.2, closes #1864)

### DIFF
--- a/frontend/src/__tests__/NotFoundPageTitle.test.ts
+++ b/frontend/src/__tests__/NotFoundPageTitle.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(process.cwd(), "src/app/not-found.tsx"),
+  "utf-8"
+);
+
+describe("not-found page metadata (WCAG 2.4.2)", () => {
+  it("exports a metadata object with a title", () => {
+    expect(src).toMatch(/export\s+(const\s+metadata|{\s*metadata\s*})/);
+    expect(src).toMatch(/title/);
+  });
+
+  it("title is descriptive (mentions not found)", () => {
+    const match = src.match(/title[^:]*:\s*["']([^"']+)["']/);
+    expect(match).not.toBeNull();
+    const title = match![1].toLowerCase();
+    expect(title).toMatch(/not.found|404|missing/);
+  });
+});

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,5 +1,8 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { BookOpenIcon, ArrowRightIcon } from "@/components/Icons";
+
+export const metadata: Metadata = { title: "Page Not Found" };
 
 export default function NotFound() {
   return (


### PR DESCRIPTION
## What changed

Added `export const metadata: Metadata = { title: "Page Not Found" }` to `frontend/src/app/not-found.tsx`.

## Why

Without this export, Next.js falls back to the layout's default title ("My Library — Book Reader AI") when a user navigates to a 404 URL. Screen readers announce the page title on navigation — a title that says "My Library" while the heading says "Page not found" violates WCAG 2.4.2 (Page Titled, Level A).

With this fix the browser tab and screen reader announce: **"Page Not Found — Book Reader AI"** (composed via the layout `template: "%s — Book Reader AI"`).

Closes #1864

## Test plan

- `NotFoundPageTitle.test.ts` (new): verifies the source exports a metadata object with a descriptive title containing "not found"
- Full frontend suite: 2661 tests pass
