### PR TITLE
ux: use alt='' on BookCard cover image to prevent double title announcement (closes #1867)

### DIFF
--- a/frontend/src/__tests__/BookCard.test.tsx
+++ b/frontend/src/__tests__/BookCard.test.tsx
@@ -29,8 +29,13 @@ test("renders author name", () => {
 
 test("renders cover image when cover URL is provided", () => {
   render(<BookCard book={BOOK} onClick={jest.fn()} />);
-  const img = screen.getByRole("img", { name: "Pride and Prejudice" });
+  // Cover image uses alt="" (decorative — button label comes from the <p> text)
+  // eslint-disable-next-line testing-library/no-container
+  const { container } = render(<BookCard book={BOOK} onClick={jest.fn()} />);
+  const img = container.querySelector("img");
+  expect(img).not.toBeNull();
   expect(img).toHaveAttribute("src", BOOK.cover);
+  expect(img).toHaveAttribute("alt", "");
 });
 
 test("renders SVG placeholder when no cover URL", () => {

--- a/frontend/src/__tests__/BookCardCoverAlt.test.ts
+++ b/frontend/src/__tests__/BookCardCoverAlt.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Regression test for #1867 — BookCard cover image used alt={book.title},
+ * causing screen readers to announce the book title twice (once from the img alt,
+ * once from the visible <p> below it). Cover images inside buttons are decorative;
+ * they must use alt="" so AT ignores them.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(process.cwd(), "src/components/BookCard.tsx"),
+  "utf-8"
+);
+
+describe("BookCard cover image alt text (WCAG 1.1.1)", () => {
+  it("uses alt='' (empty) on the cover img, not alt={book.title}", () => {
+    // Must not have alt={book.title} or alt={book.title} variants
+    expect(src).not.toMatch(/alt=\{book\.title\}/);
+  });
+
+  it("cover img element has an empty alt attribute", () => {
+    // The img with the book cover src should have alt=""
+    const imgBlock = src.match(/<img[\s\S]{0,200}?object-cover[\s\S]{0,200}?>/);
+    expect(imgBlock).not.toBeNull();
+    expect(imgBlock![0]).toContain('alt=""');
+  });
+});

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -41,7 +41,7 @@ export default function BookCard({ book, onClick, badge, onRemove }: Props) {
         {book.cover ? (
           <img
             src={book.cover}
-            alt={book.title}
+            alt=""
             className="w-full h-40 object-cover rounded-lg mb-2"
           />
         ) : (


### PR DESCRIPTION
## What changed

Changed `alt={book.title}` → `alt=""` on the cover `<img>` in `BookCard.tsx`. Updated the existing cover-image test to query by DOM element rather than `getByRole("img", { name })` (which no longer matches a presentational image).

## Why

The cover image sits inside a `<button>` whose accessible name is already computed from the two visible `<p>` elements below it (title + authors). With `alt={book.title}`, screen readers announced the title **twice** per card — once from the image alt text, once from the paragraph. On a library grid with 12+ cards this creates significant redundancy and AT noise.

Setting `alt=""` marks the image as presentational (WCAG 1.1.1 — decorative images inside interactive elements must use empty alt so AT ignores them rather than duplicating the element's accessible name).

Closes #1867

## Test plan

- `BookCardCoverAlt.test.ts` (new): verifies cover img has `alt=""` and does NOT have `alt={book.title}`
- `BookCard.test.tsx` (updated): cover-image assertion updated to use `container.querySelector("img")` and checks `alt=""` directly
- Full frontend suite: 2663 tests pass
