### PR TITLE
ux: add aria-live region for Save preferences confirmation (WCAG 4.1.3, closes #1869)

### DIFF
--- a/frontend/src/__tests__/ProfilePrefsSavedAnnouncement.test.ts
+++ b/frontend/src/__tests__/ProfilePrefsSavedAnnouncement.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Regression test for #1869 — profile page "Save preferences" button changed
+ * its label to "Saved!" but had no aria-live region. Screen readers don't
+ * reliably announce dynamic button label changes, so a separate role="status"
+ * live region is needed next to the button.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(process.cwd(), "src/app/profile/page.tsx"),
+  "utf-8"
+);
+
+describe("Profile page preferences save feedback (WCAG 4.1.3)", () => {
+  it("has an aria-live region near the Save preferences button", () => {
+    // Find the save button area (uses prefsSaved in its className)
+    const idx = src.lastIndexOf("prefsSaved");
+    expect(idx).toBeGreaterThan(-1);
+    // Within a reasonable window around the last prefsSaved reference (near button), there
+    // must be an aria-live or role="status" live region for the save confirmation
+    const window = src.slice(Math.max(0, idx - 600), idx + 400);
+    const hasLiveRegion =
+      window.includes('aria-live') ||
+      window.includes('role="status"');
+    expect(hasLiveRegion).toBe(true);
+  });
+
+  it("live region content references prefsSaved", () => {
+    // The status div must conditionally render based on prefsSaved
+    const statusPattern = /role="status"[\s\S]{0,200}prefsSaved|prefsSaved[\s\S]{0,200}role="status"/;
+    expect(src).toMatch(statusPattern);
+  });
+});

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -567,6 +567,9 @@ export default function ProfilePage() {
           </div>
 
           {/* Single save button at the bottom of the preferences section */}
+          <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+            {prefsSaved ? "Preferences saved." : ""}
+          </div>
           <button
             onClick={savePreferences}
             className={`w-full rounded-lg py-2.5 min-h-[44px] text-sm font-medium transition-colors ${


### PR DESCRIPTION
## What changed
Added a `role="status" aria-live="polite" aria-atomic="true"` live region (visually hidden via `sr-only`) directly above the Save preferences button on the profile page. When `prefsSaved` flips to `true`, the region announces "Preferences saved." to screen readers.

## Why
WCAG 4.1.3 (Status Messages) requires that dynamically injected success/status messages be communicated to AT without requiring focus. The prior implementation only changed the button label to "Saved!" — screen readers don't reliably announce button label mutations, so users relying on AT received no confirmation that their preferences were saved.

## Test plan
- New regression test `ProfilePrefsSavedAnnouncement.test.ts` (static source analysis):
  - Asserts a `role="status"` or `aria-live` region exists within 600 chars of the last `prefsSaved` JSX reference
  - Asserts the live region content is conditional on `prefsSaved`
- Full frontend suite: 420 suites, 2665 tests passing
- Full backend suite: 2016 tests passing

Closes #1869
