### PR TITLE
ux: add sr-only text to component skeleton live regions (WCAG 4.1.3, closes #1873)

### DIFF
--- a/frontend/src/__tests__/QueueTab.coverage.test.tsx
+++ b/frontend/src/__tests__/QueueTab.coverage.test.tsx
@@ -961,8 +961,8 @@ describe("initial loading skeleton", () => {
 
     render(<QueueTab adminFetch={adminFetch} />);
 
-    // Should show loading skeleton text
-    expect(screen.getByText(/loading queue/i)).toBeInTheDocument();
+    // Should show loading skeleton text (sr-only + visible copy both match)
+    expect(screen.getAllByText(/loading queue/i).length).toBeGreaterThanOrEqual(1);
 
     // Resolve status so test can clean up
     resolveStatus(makeStatus());

--- a/frontend/src/__tests__/SkeletonSrOnlyText.test.ts
+++ b/frontend/src/__tests__/SkeletonSrOnlyText.test.ts
@@ -29,6 +29,7 @@ function findStatusWithoutSrOnly(src: string): string[] {
 }
 
 const FILES = [
+  // app/ pages (covered by #1871 / PR #1872)
   "src/app/loading.tsx",
   "src/app/page.tsx",
   "src/app/admin/layout.tsx",
@@ -46,9 +47,17 @@ const FILES = [
   "src/app/search/page.tsx",
   "src/app/upload/page.tsx",
   "src/app/upload/[bookId]/chapters/page.tsx",
+  // components/ (follow-up #1873)
+  "src/components/ReadingStats.tsx",
+  "src/components/AnnotationsSidebar.tsx",
+  "src/components/ChapterSummary.tsx",
+  "src/components/InsightChat.tsx",
+  "src/components/QueueTab.tsx",
+  "src/components/SentenceReader.tsx",
+  "src/components/TranslationView.tsx",
 ];
 
-describe("Skeleton live regions have sr-only text (WCAG 4.1.3 / #1871)", () => {
+describe("Skeleton live regions have sr-only text (WCAG 4.1.3 / #1871 #1873)", () => {
   for (const file of FILES) {
     it(`${file} — all role="status" aria-label skeletons include sr-only text`, () => {
       const src = readSrc(file);

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -104,6 +104,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
           <div className="flex-1 overflow-y-auto p-4 space-y-6 pb-0">
             {loading && annotations.length === 0 ? (
               <div role="status" aria-label="Loading annotations" className="flex justify-center mt-10">
+                <span className="sr-only">Loading annotations...</span>
                 <span className="w-5 h-5 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
               </div>
             ) : annotations.length === 0 ? (
@@ -116,6 +117,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
               <>
                 {loading && (
                   <div role="status" aria-label="Refreshing annotations" className="flex justify-center py-1">
+                    <span className="sr-only">Refreshing annotations...</span>
                     <span className="w-4 h-4 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
                   </div>
                 )}

--- a/frontend/src/components/ChapterSummary.tsx
+++ b/frontend/src/components/ChapterSummary.tsx
@@ -99,6 +99,7 @@ export default function ChapterSummary({
       <div className="flex-1 overflow-y-auto p-4">
         {loading && (
           <div role="status" aria-label="Loading summary">
+            <span className="sr-only">Loading summary...</span>
             <div className="space-y-3 animate-pulse">
               <div className="h-4 bg-amber-100 rounded w-3/4" />
               <div className="h-4 bg-amber-100 rounded w-full" />

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -443,6 +443,7 @@ export default function InsightChat({
         {/* Initial loading skeleton */}
         {chatLoading && messages.length === 0 && (
           <div role="status" aria-label="Loading messages">
+            <span className="sr-only">Loading messages...</span>
             <div className="space-y-2 animate-pulse pt-1 px-1">
               {[1, 0.85, 1, 0.7, 1, 0.8].map((w, i) => (
                 <div key={i} className="h-3 bg-stone-100 rounded" style={{ width: `${w * 100}%` }} />
@@ -555,6 +556,7 @@ export default function InsightChat({
         {/* Typing indicator */}
         {chatLoading && messages.length > 0 && (
           <div className="flex gap-2" role="status" aria-label="AI is typing" aria-live="polite">
+            <span className="sr-only">AI is typing...</span>
             <div className="w-5 h-5 rounded-full bg-amber-100 border border-amber-200 flex items-center justify-center shrink-0 mt-0.5" aria-hidden="true">
               <div className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
             </div>

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -437,6 +437,7 @@ export default function QueueTab({ adminFetch }: Props) {
   if (!initialLoaded && !error) {
     return (
       <div role="status" aria-label="Loading queue" className="space-y-3 animate-pulse">
+        <span className="sr-only">Loading queue...</span>
         <div className="bg-white rounded-xl border border-amber-200 p-4">
           <div className="flex items-center gap-3">
             <div className="w-2.5 h-2.5 rounded-full bg-stone-300" />

--- a/frontend/src/components/ReadingStats.tsx
+++ b/frontend/src/components/ReadingStats.tsx
@@ -97,6 +97,7 @@ export default function ReadingStats({ active, heatmapOnly = false }: Props) {
   if (!active || (loading && !stats)) {
     return (
       <div role="status" aria-label="Loading reading stats" className="space-y-4 animate-pulse">
+        <span className="sr-only">Loading reading stats...</span>
         {!heatmapOnly && (
           <div className="grid grid-cols-2 gap-3">
             {[...Array(4)].map((_, i) => (

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -876,6 +876,7 @@ export default function SentenceReader({
                     </p>
                   ) : translationLoading ? (
                     <div role="status" aria-label="Loading translation">
+                      <span className="sr-only">Loading translation...</span>
                       <div className="space-y-2 animate-pulse">
                         {Array.from({ length: 3 }).map((_, j) => (
                           <div key={j} className={`h-3 bg-amber-100 rounded ${j === 2 ? "w-2/3" : "w-full"}`} />
@@ -896,6 +897,7 @@ export default function SentenceReader({
             {noteCard}
             {translationLoading && textParaIdx === 0 && !translationText && (
               <div role="status" aria-label="Loading translation">
+                <span className="sr-only">Loading translation...</span>
                 <div className="mt-1 space-y-1 animate-pulse">
                   <div className="h-3 bg-amber-100 rounded w-full" />
                   <div className="h-3 bg-amber-100 rounded w-5/6" />

--- a/frontend/src/components/TranslationView.tsx
+++ b/frontend/src/components/TranslationView.tsx
@@ -49,6 +49,7 @@ export default function TranslationView({ paragraphs, translations, displayMode,
                 </p>
               ) : loading ? (
                 <div role="status" aria-label="Loading translation" className="space-y-2 animate-pulse">
+                  <span className="sr-only">Loading translation...</span>
                   {Array.from({ length: 3 }).map((_, j) => (
                     <div key={j} className={`h-3 bg-amber-100 rounded ${j === 2 ? "w-2/3" : "w-full"}`} />
                   ))}
@@ -71,6 +72,7 @@ export default function TranslationView({ paragraphs, translations, displayMode,
           </p>
           {loading && i === 0 && !translations.length && (
             <div role="status" aria-label="Loading translation" className="mt-1 space-y-1 animate-pulse">
+              <span className="sr-only">Loading translation...</span>
               <div className="h-3 bg-amber-100 rounded w-full" />
               <div className="h-3 bg-amber-100 rounded w-5/6" />
             </div>


### PR DESCRIPTION
## What changed

Follow-up to #1872 — extends sr-only accessible text to 7 component files that were missed in the first pass:

- `ReadingStats.tsx` — loading stats skeleton
- `AnnotationsSidebar.tsx` — loading annotations + refreshing annotations spinners
- `ChapterSummary.tsx` — loading summary skeleton
- `InsightChat.tsx` — loading messages skeleton + AI is typing indicator
- `QueueTab.tsx` — loading queue skeleton
- `SentenceReader.tsx` — two loading translation skeletons
- `TranslationView.tsx` — two loading translation skeletons

Each `role="status" aria-label="..."` container now has `<span className="sr-only">...</span>` as its first child so screen readers announce the loading state on mount (WCAG 4.1.3).

## Why

ARIA live regions (`role="status"`) announce **text content changes**, not `aria-label`. Containers containing only animated skeleton `<div>`s are completely silent to assistive technology.

## Test plan

- Extended `SkeletonSrOnlyText.test.ts` to cover all 7 component files (24 total)
- Updated `QueueTab.coverage.test.tsx` to use `getAllByText` since the QueueTab skeleton already had visible "Loading queue…" text — the sr-only span now causes two matches
- All 2689 frontend tests pass
- All 2016 backend tests pass

Closes #1873
