### PR TITLE
ux: make API-key and Obsidian save confirmations always-present live regions (WCAG 4.1.3, closes #1875)

### DIFF
--- a/frontend/src/__tests__/ProfileObsidianFeedbackRole.test.ts
+++ b/frontend/src/__tests__/ProfileObsidianFeedbackRole.test.ts
@@ -1,6 +1,9 @@
 /**
- * Regression tests for #1255: profile page feedback messages and reader
- * obsidian toast must have live-region roles so screen readers announce them.
+ * Regression tests for #1255 and #1875:
+ * - Profile page feedback messages must have live-region roles so screen readers announce them.
+ * - #1875: keyMessage and obsidianMsg containers must be always-present in the DOM (not
+ *   conditionally mounted) so AT observes a text-content change, not a new element mount.
+ *   Always-present pattern: role="status" aria-live="polite" with text={msg?.text ?? ""}.
  */
 import * as fs from "fs";
 import * as path from "path";
@@ -14,19 +17,26 @@ const reader = fs.readFileSync(
   "utf8"
 );
 
-describe("Profile page feedback messages have live-region roles (closes #1255)", () => {
-  it("keyMessage paragraph has role=status or role=alert", () => {
-    const idx = profile.indexOf("keyMessage &&");
+describe("Profile page feedback messages have always-present live-region roles (#1255 #1875)", () => {
+  it("keyMessage uses always-present role=status with aria-live (not conditionally mounted)", () => {
+    // After #1875 fix: no conditional mount — the element is always in the DOM
+    expect(profile).not.toContain("keyMessage &&");
+    // The always-present element must have role="status" and aria-live
+    const idx = profile.indexOf('keyMessage?.text');
     expect(idx).toBeGreaterThan(-1);
-    const region = profile.slice(idx, idx + 300);
+    const region = profile.slice(Math.max(0, idx - 200), idx + 100);
     expect(region).toMatch(/role="status"|role="alert"/);
+    expect(region).toContain('aria-live');
   });
 
-  it("obsidianMsg paragraph has role=status or role=alert", () => {
-    const idx = profile.indexOf("obsidianMsg &&");
+  it("obsidianMsg uses always-present role=status with aria-live (not conditionally mounted)", () => {
+    // After #1875 fix: no conditional mount
+    expect(profile).not.toContain("obsidianMsg &&");
+    const idx = profile.indexOf('obsidianMsg?.text');
     expect(idx).toBeGreaterThan(-1);
-    const region = profile.slice(idx, idx + 300);
+    const region = profile.slice(Math.max(0, idx - 200), idx + 100);
     expect(region).toMatch(/role="status"|role="alert"/);
+    expect(region).toContain('aria-live');
   });
 });
 

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -336,11 +336,9 @@ export default function ProfilePage() {
             </div>
           )}
 
-          {keyMessage && (
-            <p role="status" className={`mt-3 text-sm ${keyMessage.ok ? "text-emerald-700" : "text-red-600"}`}>
-              {keyMessage.text}
-            </p>
-          )}
+          <p role="status" aria-live="polite" aria-atomic="true" className={`mt-3 text-sm ${keyMessage ? (keyMessage.ok ? "text-emerald-700" : "text-red-600") : ""}`}>
+            {keyMessage?.text ?? ""}
+          </p>
         </section>
 
         {/* ── Obsidian Export Settings ────────────────────────────────────── */}
@@ -441,11 +439,9 @@ export default function ProfilePage() {
                 {obsidianSaving ? "Saving…" : "Save Obsidian settings"}
               </button>
 
-              {obsidianMsg && (
-                <p role="status" className={`text-sm ${obsidianMsg.ok ? "text-emerald-700" : "text-red-600"}`}>
-                  {obsidianMsg.text}
-                </p>
-              )}
+              <p role="status" aria-live="polite" aria-atomic="true" className={`text-sm ${obsidianMsg ? (obsidianMsg.ok ? "text-emerald-700" : "text-red-600") : ""}`}>
+                {obsidianMsg?.text ?? ""}
+              </p>
             </div>
           )}
         </section>


### PR DESCRIPTION
## What changed

Fixed two dynamically-mounted `role="status"` feedback paragraphs in the profile page that screen readers never announced:

- **Gemini API key save confirmation** (was `{keyMessage && <p role="status">...`)
- **Obsidian settings save confirmation** (was `{obsidianMsg && <p role="status">...`)

Both are now always present in the DOM with empty content when idle, using `msg?.text ?? ""`. Added `aria-live="polite" aria-atomic="true"` explicitly for clarity.

## Why

ARIA live regions announce **text-content changes**, not new element mounts. A conditionally-rendered `role="status"` element is invisible to AT until it exists — by which time it's too late for the announcement. Same root cause as #1869.

## Test plan

- Updated `ProfileObsidianFeedbackRole.test.ts`:
  - Asserts `keyMessage &&` and `obsidianMsg &&` patterns are GONE (prevents regression to conditional mount)
  - Asserts always-present `role="status"` + `aria-live` exists near `keyMessage?.text` and `obsidianMsg?.text`
- All 2689 frontend tests pass

Closes #1875
