### PR TITLE
ux: add focus management to reader mobile chat sheet (WCAG 2.4.3, closes #1877)

### DIFF
--- a/frontend/src/__tests__/ReaderAriaExpandedDialog.test.ts
+++ b/frontend/src/__tests__/ReaderAriaExpandedDialog.test.ts
@@ -1,6 +1,8 @@
 /**
  * Regression tests for #1245: reader page disclosure buttons must have
  * aria-expanded, and the mobile chat sheet must have role="dialog".
+ * #1877: chat sheet must also have full WAI-ARIA focus management (ref,
+ * tabIndex=-1, focus-on-open effect, Escape handler).
  */
 import * as fs from "fs";
 import * as path from "path";
@@ -55,5 +57,32 @@ describe("Mobile chat sheet role=dialog (closes #1245)", () => {
     expect(idx).toBeGreaterThan(-1);
     const window = src.slice(idx, idx + 200);
     expect(window).toContain('aria-label="Chat"');
+  });
+
+  it("chat sheet div has ref and tabIndex=-1 for programmatic focus (WCAG 2.4.3 / #1877)", () => {
+    const idx = src.indexOf("Chat sheet (bottom half)");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 200);
+    expect(window).toContain("chatSheetRef");
+    expect(window).toContain("tabIndex={-1}");
+  });
+});
+
+describe("Mobile chat sheet focus management (WCAG 2.4.3 / #1877)", () => {
+  it("declares chatSheetRef via useRef", () => {
+    expect(src).toContain("chatSheetRef = useRef");
+  });
+
+  it("moves focus to chatSheetRef on open", () => {
+    expect(src).toContain("chatSheetRef.current?.focus()");
+  });
+
+  it("has Escape key handler to close chat sheet", () => {
+    // The effect must handle Escape and call both setSidebarOpen and setChatSheetText
+    const idx = src.indexOf('e.key === "Escape"');
+    expect(idx).toBeGreaterThan(-1);
+    const region = src.slice(Math.max(0, idx - 100), idx + 200);
+    expect(region).toContain("setSidebarOpen");
+    expect(region).toContain("setChatSheetText");
   });
 });

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -175,6 +175,29 @@ export default function ReaderPage() {
     setToolbarVisible((v) => !v);
   }
 
+  // Chat sheet (mobile bottom dialog) ref — needed for focus management
+  const chatSheetRef = useRef<HTMLDivElement>(null);
+
+  // Move focus into the chat sheet when it opens; restore on close (WCAG 2.4.3)
+  useEffect(() => {
+    const open = sidebarOpen || !!chatSheetText;
+    if (!open) return;
+    const prev = document.activeElement as HTMLElement | null;
+    chatSheetRef.current?.focus();
+    return () => { prev?.focus?.(); };
+  }, [sidebarOpen, chatSheetText]);
+
+  // Dismiss chat sheet on Escape (WAI-ARIA dialog pattern)
+  useEffect(() => {
+    const open = sidebarOpen || !!chatSheetText;
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") { setSidebarOpen(false); setChatSheetText(null); }
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [sidebarOpen, chatSheetText]);
+
   // Swipe gesture for chapter navigation
   const swipeStartRef = useRef<{ x: number; y: number; t: number } | null>(null);
 
@@ -2142,7 +2165,7 @@ export default function ReaderPage() {
             onClick={() => { setSidebarOpen(false); setChatSheetText(null); }}
           />
           {/* Chat sheet (bottom half) */}
-          <div role="dialog" aria-modal="true" aria-label="Chat" className="h-[55vh] bg-parchment border-t border-amber-200 rounded-t-2xl shadow-2xl flex flex-col animate-slide-up safe-bottom">
+          <div ref={chatSheetRef} tabIndex={-1} role="dialog" aria-modal="true" aria-label="Chat" className="h-[55vh] bg-parchment border-t border-amber-200 rounded-t-2xl shadow-2xl flex flex-col animate-slide-up safe-bottom focus:outline-none">
             {/* Drag handle + close */}
             <div className="flex items-center justify-between px-4 py-2 border-b border-amber-200 shrink-0">
               <div className="w-10 h-1 bg-amber-200 rounded-full" />


### PR DESCRIPTION
## What changed

Fixed missing focus management on the reader page's mobile chat sheet (`role="dialog"`).

Changes in `src/app/reader/[bookId]/page.tsx`:
- Added `chatSheetRef = useRef<HTMLDivElement>(null)` for the dialog element
- Added `ref={chatSheetRef} tabIndex={-1} focus:outline-none` to the dialog div
- Added `useEffect` that moves focus into the sheet when it opens and restores focus to the previous element on close
- Added `useEffect` that registers an `Escape` keydown listener while the sheet is open (dismisses both `sidebarOpen` and `chatSheetText`)

## Why

The mobile chat sheet had `role="dialog" aria-modal="true"` but no focus management — all four WAI-ARIA dialog pattern requirements were absent:

1. No `ref` on the dialog element
2. No focus shift into the dialog on open (screen readers don't know context changed)
3. No `Escape` key handler
4. No focus restoration on close

VoiceOver/TalkBack users opening the chat sheet kept reading content behind the modal backdrop, and had no keyboard path to dismiss it. Same fix pattern as `AnnotationsSidebar.tsx` which is fully compliant.

## Test plan

- Extended `ReaderAriaExpandedDialog.test.ts` with 4 new assertions:
  - `chatSheetRef` in the dialog's `ref` attribute
  - `tabIndex={-1}` on the dialog div
  - `chatSheetRef.current?.focus()` call exists
  - `Escape` handler calls both `setSidebarOpen` and `setChatSheetText`
- All 2693 frontend tests pass

Closes #1877
