### PR TITLE
ux: restore focus to trigger on AnnotationToolbar close (WCAG 2.4.3)

### DIFF
--- a/frontend/src/__tests__/AnnotationToolbarDialogRole.test.tsx
+++ b/frontend/src/__tests__/AnnotationToolbarDialogRole.test.tsx
@@ -1,6 +1,7 @@
 /**
  * Regression test for #1222: AnnotationToolbar panel must have role="dialog",
  * aria-modal="true", and aria-labelledby so screen readers announce it correctly.
+ * #1878: dialog must restore focus to the trigger element on unmount (WCAG 2.4.3).
  */
 import React from "react";
 import { render, screen } from "@testing-library/react";
@@ -50,4 +51,23 @@ test("dialog title says 'Edit note' when editing an existing annotation", () => 
   const labelId = dialog.getAttribute("aria-labelledby");
   const titleEl = document.getElementById(labelId!);
   expect(titleEl!.textContent).toMatch(/edit note/i);
+});
+
+test("restores focus to trigger element on unmount (WCAG 2.4.3 / #1878)", () => {
+  // Simulate a trigger button that had focus before the dialog opened
+  const trigger = document.createElement("button");
+  trigger.textContent = "trigger";
+  document.body.appendChild(trigger);
+  trigger.focus();
+  expect(document.activeElement).toBe(trigger);
+
+  const { unmount } = render(<AnnotationToolbar {...BASE_PROPS} />);
+  // Focus moves to textarea on mount — trigger is no longer focused
+  expect(document.activeElement).not.toBe(trigger);
+
+  unmount();
+  // After unmount, focus must return to the trigger
+  expect(document.activeElement).toBe(trigger);
+
+  document.body.removeChild(trigger);
 });

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -42,7 +42,9 @@ export default function AnnotationToolbar({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
+    const prev = document.activeElement as HTMLElement | null;
     textareaRef.current?.focus();
+    return () => { prev?.focus?.(); };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## What changed
Fixes `AnnotationToolbar` to restore focus to the trigger element on unmount, satisfying WCAG 2.4.3 (Focus Order).

The `useEffect` that moved focus into the textarea on open now also captures `document.activeElement` before focusing and restores it in the cleanup function.

## Why
When a modal dialog closes, keyboard and AT users must return to the element that opened it. Without restoration, focus drops to `document.body` — the user loses their place in the reading flow.

## Test plan
- Extended `frontend/src/__tests__/AnnotationToolbarDialogRole.test.tsx` with an RTL test that:
  1. Focuses a synthetic trigger button
  2. Mounts `AnnotationToolbar` (focus moves to textarea)
  3. Unmounts
  4. Asserts `document.activeElement === trigger`
- All 2692 frontend tests pass

Closes #1878
