### PR TITLE
ux: restore focus to trigger on AddWordPicker close (WCAG 2.4.3)

### DIFF
--- a/frontend/src/__tests__/DecksAddWordPickerFocus.test.ts
+++ b/frontend/src/__tests__/DecksAddWordPickerFocus.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Regression test for #1880: AddWordPicker dialog must restore focus to the
+ * trigger element on unmount (WCAG 2.4.3 Focus Order).
+ *
+ * The fix captures document.activeElement before moving focus to the close
+ * button, then restores it in the useEffect cleanup.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(process.cwd(), "src/app/decks/[deckId]/page.tsx"),
+  "utf8",
+);
+
+describe("AddWordPicker dialog focus restoration (#1880)", () => {
+  it("captures previous focus before taking focus (WCAG 2.4.3)", () => {
+    // The useEffect that focuses closeRef must save document.activeElement first
+    const idx = src.indexOf("closeRef.current?.focus()");
+    expect(idx).toBeGreaterThan(-1);
+    // Look 200 chars before the focus call for the prev capture
+    const before = src.slice(Math.max(0, idx - 200), idx);
+    expect(before).toContain("document.activeElement");
+  });
+
+  it("restores focus via useEffect cleanup", () => {
+    // The cleanup function must call prev?.focus?.()
+    const idx = src.indexOf("closeRef.current?.focus()");
+    expect(idx).toBeGreaterThan(-1);
+    // Look after the focus call for the cleanup
+    const after = src.slice(idx, idx + 150);
+    expect(after).toContain("prev?.focus");
+  });
+});

--- a/frontend/src/app/decks/[deckId]/page.tsx
+++ b/frontend/src/app/decks/[deckId]/page.tsx
@@ -301,7 +301,9 @@ function AddWordPicker({ candidates, onClose, onAdd }: AddWordPickerProps) {
   const closeRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
+    const prev = document.activeElement as HTMLElement | null;
     closeRef.current?.focus();
+    return () => { prev?.focus?.(); };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## What changed
Fixes `AddWordPicker` dialog in `decks/[deckId]/page.tsx` to restore focus to the trigger element on unmount, satisfying WCAG 2.4.3 (Focus Order).

The `useEffect` that moved focus to the close button on open now also captures `document.activeElement` before focusing and restores it in the cleanup function.

## Why
When a modal dialog closes, keyboard and AT users must return to the element that opened it. Without restoration, focus drops to `document.body` — breaking the keyboard navigation flow for deck management.

## Test plan
- Added `frontend/src/__tests__/DecksAddWordPickerFocus.test.ts` — static assertions verifying:
  - `prev` capture pattern (`document.activeElement`) is present
  - Cleanup return calls `prev?.focus?.()`
- All 2694 frontend tests pass

Closes #1880
