### PR TITLE
ux: restore focus to trigger on VocabWordTooltip close (WCAG 2.4.3)

### DIFF
--- a/frontend/src/__tests__/VocabWordTooltipDialog.test.ts
+++ b/frontend/src/__tests__/VocabWordTooltipDialog.test.ts
@@ -1,6 +1,7 @@
 /**
  * Regression test for #1315: VocabWordTooltip must be announced to screen
  * readers as a dialog with an accessible name and receive focus on mount.
+ * #1881: dialog must restore focus to the trigger on unmount (WCAG 2.4.3).
  */
 import * as fs from "fs";
 import * as path from "path";
@@ -30,5 +31,16 @@ describe("VocabWordTooltip dialog accessibility (closes #1315)", () => {
 
   it("moves focus into dialog on mount via useEffect", () => {
     expect(src).toContain(".focus()");
+  });
+
+  it("captures previous focus and restores it on unmount (WCAG 2.4.3 / #1881)", () => {
+    // The focus useEffect must capture document.activeElement before taking focus
+    const idx = src.indexOf("ref.current?.focus()");
+    expect(idx).toBeGreaterThan(-1);
+    const before = src.slice(Math.max(0, idx - 200), idx);
+    expect(before).toContain("document.activeElement");
+    // And the cleanup must restore it
+    const after = src.slice(idx, idx + 100);
+    expect(after).toContain("prev?.focus");
   });
 });

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -45,9 +45,11 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
     return () => document.removeEventListener("keydown", handleKey);
   }, [onClose]);
 
-  // Move focus into the dialog on mount so screen readers announce it
+  // Move focus into the dialog on mount so screen readers announce it; restore on close
   useEffect(() => {
+    const prev = document.activeElement as HTMLElement | null;
     ref.current?.focus();
+    return () => { prev?.focus?.(); };
   }, []);
 
   // Position near the selection, keep within viewport


### PR DESCRIPTION
## What changed
Fixes `VocabWordTooltip` to restore focus to the trigger element on unmount, satisfying WCAG 2.4.3 (Focus Order).

The `useEffect` that moved focus into the dialog on open now also captures `document.activeElement` before focusing and restores it in the cleanup function.

## Why
When a tooltip/popover dialog closes, keyboard and AT users must return to the element that opened it. Without restoration, focus drops to `document.body` — users lose their position in the reading text.

## Test plan
- Extended `frontend/src/__tests__/VocabWordTooltipDialog.test.ts` with an assertion verifying the `prev?.focus?.()` cleanup pattern is present
- All 2695 frontend tests pass

Closes #1881
