### PR TITLE
ux: make notes export confirmation an always-present live region (WCAG 4.1.3)

### DIFF
--- a/frontend/src/__tests__/NotesExportLiveRegion.test.ts
+++ b/frontend/src/__tests__/NotesExportLiveRegion.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Regression test for #1886: notes export confirmation must be announced via
+ * an accessible live region (WCAG 4.1.3 — Status Messages).
+ *
+ * The conditional {exportMsg && <p>...} pattern is silent to AT because
+ * dynamic DOM insertion without aria-live is not announced. Fix: always-present
+ * container using the role="status" + aria-live="polite" pattern.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Notes export confirmation live region (closes #1886)", () => {
+  it("export message uses always-present live region (not conditional mount)", () => {
+    // The broken pattern: {exportMsg && <element>}
+    // After the fix, exportMsg should be used as content, not as a render gate
+    // Look for the always-present pattern: exportMsg ?? "" or exportMsg?.
+    expect(src).toMatch(/exportMsg\s*\?\?|\bexportMsg\?\.text/);
+  });
+
+  it("export status container has role=status or role=alert", () => {
+    // Find the always-present live region (near exportMsg ?? "")
+    const idx = src.indexOf("exportMsg ?? ");
+    expect(idx).toBeGreaterThan(-1);
+    const region = src.slice(Math.max(0, idx - 300), idx + 100);
+    expect(region).toMatch(/role="status"|role="alert"/);
+  });
+
+  it("export status container has aria-live", () => {
+    const idx = src.indexOf("exportMsg ?? ");
+    expect(idx).toBeGreaterThan(-1);
+    const region = src.slice(Math.max(0, idx - 300), idx + 100);
+    expect(region).toContain("aria-live");
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -687,13 +687,16 @@ export default function BookNotesPage() {
           </button>
         </div>
 
-        {exportMsg && (
-          <div className="max-w-3xl mx-auto mt-2">
-            <p className="text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded px-3 py-1.5 truncate">
-              {exportMsg}
-            </p>
-          </div>
-        )}
+        <div className="max-w-3xl mx-auto mt-2">
+          <p
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className={`text-xs truncate px-3 py-1.5 rounded transition-all ${exportMsg ? "bg-amber-50 border border-amber-200 text-amber-800" : ""}`}
+          >
+            {exportMsg ?? ""}
+          </p>
+        </div>
       </header>
 
       {/* Content */}


### PR DESCRIPTION
## What changed
Changed the notes page export confirmation message from a conditionally-mounted element to an always-present live region using the `exportMsg ?? ""` pattern.

**Before:**
```tsx
{exportMsg && (
  <div className="…">{exportMsg}</div>
)}
```

**After:**
```tsx
<p
  role="status"
  aria-live="polite"
  aria-atomic="true"
  className={`… ${exportMsg ? "bg-amber-50 border border-amber-200 text-amber-800" : ""}`}
>
  {exportMsg ?? ""}
</p>
```

## Why
When `exportMsg` was conditionally mounted, the `role="status"` element didn't exist before the message appeared. Screen readers register live regions at parse time — a newly inserted `role="status"` node is unreliable for AT announcement. The always-present pattern (empty string when no message) ensures AT has the live region registered before any content is placed in it. WCAG 4.1.3 (Status Messages).

## Test plan
- Added `frontend/src/__tests__/NotesExportLiveRegion.test.ts` with 3 static assertions:
  - Always-present pattern (`exportMsg ?? ""`) is used instead of conditional mount
  - `role="status"` or `role="alert"` is present near the expression
  - `aria-live` is present near the expression
- All 2702 frontend tests pass

Closes #1886
