### PR TITLE
ux: set descriptive document.title in reader, notes, and flashcards pages (WCAG 2.4.2)

### DIFF
--- a/frontend/src/__tests__/ReaderNotesDocumentTitle.test.ts
+++ b/frontend/src/__tests__/ReaderNotesDocumentTitle.test.ts
@@ -1,6 +1,6 @@
 /**
- * Regression tests for issue #1888 — reader and notes pages must update
- * document.title when book metadata loads (WCAG 2.4.2 Page Titled).
+ * Regression tests for issue #1888 — reader, notes, and flashcards pages must
+ * update document.title with a descriptive label (WCAG 2.4.2 Page Titled).
  */
 import { readFileSync } from "fs";
 import { join } from "path";
@@ -42,5 +42,22 @@ describe("Notes page — document.title (WCAG 2.4.2, #1888)", () => {
     const region = notesSrc.slice(idx, idx + 200);
     expect(region).toMatch(/meta[.\?!]title/);
     expect(region.toLowerCase()).toMatch(/note/);
+  });
+});
+
+describe("Flashcards page — document.title (WCAG 2.4.2, #1888)", () => {
+  const flashSrc = readFileSync(
+    join(__dirname, "../app/vocabulary/flashcards/page.tsx"),
+    "utf8",
+  );
+
+  it("sets a descriptive document.title", () => {
+    expect(flashSrc).toMatch(/document\.title\s*=/);
+  });
+
+  it("includes Flashcards in document.title", () => {
+    const idx = flashSrc.indexOf("document.title");
+    const region = flashSrc.slice(idx, idx + 100);
+    expect(region.toLowerCase()).toMatch(/flashcard/);
   });
 });

--- a/frontend/src/__tests__/ReaderNotesDocumentTitle.test.ts
+++ b/frontend/src/__tests__/ReaderNotesDocumentTitle.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression tests for issue #1888 — reader and notes pages must update
+ * document.title when book metadata loads (WCAG 2.4.2 Page Titled).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const readerSrc = readFileSync(
+  join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+const notesSrc = readFileSync(
+  join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Reader page — document.title (WCAG 2.4.2, #1888)", () => {
+  it("sets document.title when book meta loads", () => {
+    expect(readerSrc).toMatch(/document\.title\s*=/);
+  });
+
+  it("includes the book title in document.title", () => {
+    const idx = readerSrc.indexOf("document.title");
+    const region = readerSrc.slice(idx, idx + 200);
+    expect(region).toMatch(/meta[.\?!]title/);
+  });
+
+  it("resets document.title on unmount", () => {
+    const idx = readerSrc.indexOf("document.title");
+    const region = readerSrc.slice(idx, idx + 400);
+    expect(region).toMatch(/return\s*\(\s*\)\s*=>/);
+  });
+});
+
+describe("Notes page — document.title (WCAG 2.4.2, #1888)", () => {
+  it("sets document.title when book meta loads", () => {
+    expect(notesSrc).toMatch(/document\.title\s*=/);
+  });
+
+  it("includes the book title and Notes label", () => {
+    const idx = notesSrc.indexOf("document.title");
+    const region = notesSrc.slice(idx, idx + 200);
+    expect(region).toMatch(/meta[.\?!]title/);
+    expect(region.toLowerCase()).toMatch(/note/);
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -313,6 +313,13 @@ export default function BookNotesPage() {
     if (el) setTimeout(() => el.scrollIntoView({ behavior: "smooth", block: "center" }), 300);
   }, [loading]);
 
+  // Update page title when book metadata loads (WCAG 2.4.2)
+  useEffect(() => {
+    if (!meta?.title) return;
+    document.title = `${meta.title} — Notes — Book Reader AI`;
+    return () => { document.title = "My Library — Book Reader AI"; };
+  }, [meta]);
+
   const bookVocab = vocab.filter((v) => v.occurrences.some((o) => o.book_id === bookId));
 
   function toggleCollapse(key: string) {

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -386,6 +386,13 @@ export default function ReaderPage() {
       .finally(() => setLoading(false));
   }, [bookId]);
 
+  // Update page title when book metadata loads (WCAG 2.4.2)
+  useEffect(() => {
+    if (!meta?.title) return;
+    document.title = `${meta.title} — Book Reader AI`;
+    return () => { document.title = "My Library — Book Reader AI"; };
+  }, [meta]);
+
   // Load annotations for this book (requires auth)
   useEffect(() => {
     if (!bookId || !session?.backendToken) return;

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -96,6 +96,12 @@ export default function FlashcardsPage() {
     };
   }, [status]);
 
+  // Update page title (WCAG 2.4.2)
+  useEffect(() => {
+    document.title = "Flashcards — Book Reader AI";
+    return () => { document.title = "Vocabulary — Book Reader AI"; };
+  }, []);
+
   const currentCard = cards[currentIndex] ?? null;
 
   const handleGrade = useCallback(async (grade: number) => {


### PR DESCRIPTION
## What changed
Added `document.title` updates in three pages that previously left the title at the layout default ("My Library — Book Reader AI") throughout the user's session:

- **Reader** (`/reader/[bookId]`): sets `"${book.title} — Book Reader AI"` when meta loads; resets on unmount
- **Notes** (`/notes/[bookId]`): sets `"${book.title} — Notes — Book Reader AI"` when meta loads; resets on unmount
- **Flashcards** (`/vocabulary/flashcards`): sets `"Flashcards — Book Reader AI"` on mount; resets to `"Vocabulary — Book Reader AI"` on unmount

## Why
WCAG 2.4.2 (Page Titled) requires each page to have a title that describes its topic or purpose. Screen reader users navigate by page title to understand where they are — without a specific title, all three pages were indistinguishable from the library home. Users reading a book had no way to tell from the tab title which book was open.

## Test plan
- Added `frontend/src/__tests__/ReaderNotesDocumentTitle.test.ts` with 7 static assertions across all three pages:
  - Reader: sets `document.title`, includes `meta.title`, has unmount cleanup
  - Notes: sets `document.title`, includes `meta.title` and "Notes" label
  - Flashcards: sets `document.title`, includes "Flashcards" label
- All 2708 frontend tests pass

Closes #1888
