### PR TITLE
ux: add aria-invalid and aria-describedby to form inputs with validation errors (WCAG 3.3.1)

### DIFF
--- a/frontend/src/__tests__/FormAriaInvalidDescribedBy.test.ts
+++ b/frontend/src/__tests__/FormAriaInvalidDescribedBy.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression tests for issue #1891 — form inputs with validation errors must
+ * use aria-invalid and aria-describedby to link error messages (WCAG 3.3.1).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const decksSrc = readFileSync(
+  join(__dirname, "../app/decks/new/page.tsx"),
+  "utf8",
+);
+const tagEditorSrc = readFileSync(
+  join(__dirname, "../components/TagEditor.tsx"),
+  "utf8",
+);
+const profileSrc = readFileSync(
+  join(__dirname, "../app/profile/page.tsx"),
+  "utf8",
+);
+
+describe("Decks/new form — aria-invalid + aria-describedby (WCAG 3.3.1, #1891)", () => {
+  it("deck name input has aria-invalid attribute", () => {
+    expect(decksSrc).toMatch(/aria-invalid=/);
+  });
+
+  it("deck name input has aria-describedby linking to error", () => {
+    expect(decksSrc).toMatch(/aria-describedby=/);
+  });
+
+  it("error element has an id that matches the describedby reference", () => {
+    // aria-describedby may be a JSX expression like {error ? "deck-form-error" : undefined}
+    // Check that the same id string appears both in aria-describedby and id=
+    expect(decksSrc).toMatch(/"deck-form-error"/);
+    expect(decksSrc).toMatch(/id="deck-form-error"/);
+  });
+});
+
+describe("TagEditor — aria-invalid + aria-describedby (WCAG 3.3.1, #1891)", () => {
+  it("tag input has aria-invalid attribute", () => {
+    expect(tagEditorSrc).toMatch(/aria-invalid=/);
+  });
+
+  it("tag error element has an id containing error identifier", () => {
+    // id may be a template literal like `tag-editor-error-${vocabularyId}`
+    expect(tagEditorSrc).toMatch(/id=.*error/);
+  });
+});
+
+describe("Profile page — aria-describedby on API key input (WCAG 3.3.1, #1891)", () => {
+  it("API key input has aria-describedby", () => {
+    expect(profileSrc).toMatch(/aria-describedby=/);
+  });
+});

--- a/frontend/src/app/decks/new/page.tsx
+++ b/frontend/src/app/decks/new/page.tsx
@@ -101,6 +101,8 @@ export default function DecksNewPage() {
               onChange={(e) => setName(e.target.value)}
               maxLength={80}
               data-testid="deck-name-input"
+              aria-invalid={!!error}
+              aria-describedby={error ? "deck-form-error" : undefined}
               className="w-full rounded-xl border border-amber-200 bg-white px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 placeholder:text-stone-600"
               placeholder="e.g. German verbs"
             />
@@ -263,6 +265,7 @@ export default function DecksNewPage() {
 
           {error && (
             <p
+              id="deck-form-error"
               data-testid="deck-form-error"
               role="alert"
               className="text-sm text-red-600"

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -324,6 +324,8 @@ export default function ProfilePage() {
                 placeholder="AIza…"
                 value={keyInput}
                 onChange={(e) => setKeyInput(e.target.value)}
+                aria-invalid={keyMessage ? !keyMessage.ok : undefined}
+                aria-describedby="gemini-key-message"
                 className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-amber-400 placeholder:text-stone-600"
               />
               <button
@@ -336,7 +338,7 @@ export default function ProfilePage() {
             </div>
           )}
 
-          <p role="status" aria-live="polite" aria-atomic="true" className={`mt-3 text-sm ${keyMessage ? (keyMessage.ok ? "text-emerald-700" : "text-red-600") : ""}`}>
+          <p id="gemini-key-message" role="status" aria-live="polite" aria-atomic="true" className={`mt-3 text-sm ${keyMessage ? (keyMessage.ok ? "text-emerald-700" : "text-red-600") : ""}`}>
             {keyMessage?.text ?? ""}
           </p>
         </section>

--- a/frontend/src/components/TagEditor.tsx
+++ b/frontend/src/components/TagEditor.tsx
@@ -144,6 +144,8 @@ export default function TagEditor({
           maxLength={50}
           placeholder="new tag"
           aria-label="New tag"
+          aria-invalid={!!error}
+          aria-describedby={error ? `tag-editor-error-${vocabularyId}` : undefined}
           className="rounded-full border border-amber-300 bg-white px-2 py-0.5 text-xs text-ink focus:outline-none focus:ring-2 focus:ring-amber-400 w-24 placeholder:text-stone-600"
           data-testid={`tag-input-${vocabularyId}`}
         />
@@ -161,7 +163,7 @@ export default function TagEditor({
       )}
 
       {error && (
-        <span className="text-xs text-red-600" role="alert">
+        <span id={`tag-editor-error-${vocabularyId}`} className="text-xs text-red-600" role="alert">
           {error}
         </span>
       )}


### PR DESCRIPTION
## What changed
Added `aria-invalid` and `aria-describedby` to form inputs that show validation errors, across three components:

**`decks/new/page.tsx`** — deck name input:
- `aria-invalid={!!error}` on the name input
- `aria-describedby="deck-form-error"` pointing to the error element
- `id="deck-form-error"` on the error `<p>`

**`components/TagEditor.tsx`** — new tag input:
- `aria-invalid={!!error}` on the tag input  
- `aria-describedby={error ? \`tag-editor-error-${vocabularyId}\` : undefined}`
- `id={\`tag-editor-error-${vocabularyId}\`}` on the error `<span>`

**`profile/page.tsx`** — Gemini API key input:
- `aria-invalid={keyMessage ? !keyMessage.ok : undefined}`
- `aria-describedby="gemini-key-message"` pointing to the existing status `<p>`
- `id="gemini-key-message"` on the status paragraph

## Why
`grep -r "aria-invalid\|aria-describedby" frontend/src/` returned no results — the pattern was completely absent. Without these attributes:
- Screen readers only hear the error when it first appears (via `role="alert"`)
- When a user tabs back to an invalid input, no error is re-announced and the field's invalid state is invisible to AT
- WCAG 3.3.1 (Error Identification) and 1.3.1 (Info and Relationships) require the input-to-error relationship be programmatically determinable

## Test plan
- Added `frontend/src/__tests__/FormAriaInvalidDescribedBy.test.ts` with 6 static assertions verifying `aria-invalid`, `aria-describedby`, and matching error `id` are present in all three components
- All 2714 frontend tests pass

Closes #1891
