### PR TITLE
ux: add document.title to pending, upload, decks/new, and all admin pages (WCAG 2.4.2)

### DIFF
--- a/frontend/src/__tests__/MissingPageTitles.test.ts
+++ b/frontend/src/__tests__/MissingPageTitles.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Regression tests for issue #1893 — pending, upload, decks/new, and all admin
+ * pages must set document.title (WCAG 2.4.2 Page Titled).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const pages: Array<[string, string, RegExp]> = [
+  ["pending/page.tsx", "Pending", /pending/i],
+  ["upload/page.tsx", "Upload", /upload/i],
+  ["upload/[bookId]/chapters/page.tsx", "Upload chapters", /upload|chapter/i],
+  ["decks/new/page.tsx", "New Deck", /deck/i],
+  ["admin/page.tsx", "Admin", /admin/i],
+  ["admin/books/page.tsx", "Admin: Books", /admin|book/i],
+  ["admin/audio/page.tsx", "Admin: Audio", /admin|audio/i],
+  ["admin/users/page.tsx", "Admin: Users", /admin|user/i],
+  ["admin/bulk/page.tsx", "Admin: Bulk", /admin|bulk/i],
+  ["admin/queue/page.tsx", "Admin: Queue", /admin|queue/i],
+  ["admin/uploads/page.tsx", "Admin: Uploads", /admin|upload/i],
+];
+
+describe("Missing page titles — document.title (WCAG 2.4.2, #1893)", () => {
+  for (const [relPath, label, titlePattern] of pages) {
+    const src = readFileSync(join(__dirname, `../app/${relPath}`), "utf8");
+
+    describe(`${label} page`, () => {
+      it("sets document.title", () => {
+        expect(src).toMatch(/document\.title\s*=/);
+      });
+
+      it("includes a descriptive label in document.title", () => {
+        const idx = src.indexOf("document.title");
+        const region = src.slice(idx, idx + 120);
+        expect(region).toMatch(titlePattern);
+      });
+    });
+  }
+});

--- a/frontend/src/app/admin/audio/page.tsx
+++ b/frontend/src/app/admin/audio/page.tsx
@@ -17,6 +17,10 @@ export default function AudioPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
+  useEffect(() => {
+    document.title = "Admin: Audio — Book Reader AI";
+  }, []);
+
   const load = useCallback(async () => {
     setError("");
     try {

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -43,6 +43,11 @@ const QUEUE_LANG_OPTIONS = [
 
 export default function BooksPage() {
   const router = useRouter();
+
+  useEffect(() => {
+    document.title = "Admin: Books — Book Reader AI";
+  }, []);
+
   const [books, setBooks] = useState<Book[]>([]);
   const [translations, setTranslations] = useState<TranslationEntry[]>([]);
   const [loading, setLoading] = useState(true);

--- a/frontend/src/app/admin/bulk/page.tsx
+++ b/frontend/src/app/admin/bulk/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 export default function BulkRedirect() {
   const router = useRouter();
   useEffect(() => {
+    document.title = "Admin: Bulk — Book Reader AI";
     router.replace("/admin/queue");
   }, [router]);
   return null;

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 export default function AdminIndex() {
   const router = useRouter();
   useEffect(() => {
+    document.title = "Admin — Book Reader AI";
     router.replace("/admin/users");
   }, [router]);
   return null;

--- a/frontend/src/app/admin/queue/page.tsx
+++ b/frontend/src/app/admin/queue/page.tsx
@@ -1,7 +1,12 @@
 "use client";
+import { useEffect } from "react";
 import QueueTab from "@/components/QueueTab";
 import { adminFetch } from "@/lib/adminFetch";
 
 export default function QueuePage() {
+  useEffect(() => {
+    document.title = "Admin: Queue — Book Reader AI";
+  }, []);
+
   return <QueueTab adminFetch={adminFetch} />;
 }

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -36,6 +36,10 @@ export default function UploadsPage() {
   const [filterInput, setFilterInput] = useState("");
   const [activeFilter, setActiveFilter] = useState<string>("");
 
+  useEffect(() => {
+    document.title = "Admin: Uploads — Book Reader AI";
+  }, []);
+
   const load = useCallback(
     async (userId?: string) => {
       setLoading(true);

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -19,6 +19,10 @@ export default function UsersPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
+  useEffect(() => {
+    document.title = "Admin: Users — Book Reader AI";
+  }, []);
+
   const load = useCallback(async () => {
     setError("");
     try {

--- a/frontend/src/app/decks/new/page.tsx
+++ b/frontend/src/app/decks/new/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { FormEvent, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ApiError, createDeck, DeckMode } from "@/lib/api";
 import { ArrowLeftIcon, DeckIcon } from "@/components/Icons";
@@ -13,6 +13,11 @@ function splitTags(input: string): string[] {
 
 export default function DecksNewPage() {
   const router = useRouter();
+
+  useEffect(() => {
+    document.title = "New Deck — Book Reader AI";
+  }, []);
+
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [mode, setMode] = useState<DeckMode>("manual");

--- a/frontend/src/app/pending/page.tsx
+++ b/frontend/src/app/pending/page.tsx
@@ -1,8 +1,13 @@
 "use client";
+import { useEffect } from "react";
 import { signOut } from "next-auth/react";
 import { ClockIcon } from "@/components/Icons";
 
 export default function PendingApprovalPage() {
+  useEffect(() => {
+    document.title = "Account Pending — Book Reader AI";
+  }, []);
+
   return (
     <main id="main-content" className="min-h-screen bg-parchment flex items-center justify-center px-4">
       <div className="w-full max-w-sm text-center">

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -22,6 +22,10 @@ export default function ChapterEditorPage() {
   const [confirming, setConfirming] = useState(false);
 
   useEffect(() => {
+    document.title = "Upload: Review Chapters — Book Reader AI";
+  }, []);
+
+  useEffect(() => {
     if (!bookId) return;
     getDraftChapters(Number(bookId))
       .then((data) => {

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -10,6 +10,10 @@ export default function UploadPage() {
   const { status } = useSession();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  useEffect(() => {
+    document.title = "Upload a Book — Book Reader AI";
+  }, []);
+
   const [quota, setQuota] = useState<UploadQuota | null>(null);
   const [dragging, setDragging] = useState(false);
   const [uploading, setUploading] = useState(false);


### PR DESCRIPTION
## What changed

Added `document.title` assignments (via `useEffect`) to 11 pages that previously left the browser tab with a stale title from whichever page the user navigated from.

**Pages fixed:**
- `/pending` → "Account Pending — Book Reader AI"
- `/upload` → "Upload a Book — Book Reader AI"
- `/upload/[bookId]/chapters` → "Upload: Review Chapters — Book Reader AI"
- `/decks/new` → "New Deck — Book Reader AI"
- `/admin` → "Admin — Book Reader AI" *(redirect page)*
- `/admin/books` → "Admin: Books — Book Reader AI"
- `/admin/audio` → "Admin: Audio — Book Reader AI"
- `/admin/users` → "Admin: Users — Book Reader AI"
- `/admin/bulk` → "Admin: Bulk — Book Reader AI" *(redirect page)*
- `/admin/queue` → "Admin: Queue — Book Reader AI"
- `/admin/uploads` → "Admin: Uploads — Book Reader AI"

## Why

WCAG 2.4.2 (Page Titled) requires every page/view to have a descriptive title. Without it, screen reader users hear a stale title from their previous page, which is disorienting. Follow-up to #1888 (which fixed reader, notes, flashcards, vocabulary, decks, profile, and search pages).

## Test plan

- New static analysis test `MissingPageTitles.test.ts` with 22 assertions — 2 per page (title assigned, label keyword present)
- Full frontend suite: 2733/2733 pass
- No backend changes

Closes #1893
