### PR TITLE
ux: replace blocking alert()/confirm() with inline accessible patterns (closes #1897)

### DIFF
--- a/frontend/src/__tests__/AdminAudioPage.test.tsx
+++ b/frontend/src/__tests__/AdminAudioPage.test.tsx
@@ -129,8 +129,7 @@ describe("AdminAudioPage", () => {
     await waitFor(() => expect(mockAdminFetch).toHaveBeenCalledTimes(3));
   });
 
-  it("alerts with error message when delete action throws Error", async () => {
-    jest.spyOn(window, "alert").mockImplementation(() => {});
+  it("shows inline error banner when delete action throws Error", async () => {
     mockAdminFetch
       .mockResolvedValueOnce(SAMPLE_AUDIO)
       .mockRejectedValueOnce(new Error("Delete failed"));
@@ -140,11 +139,10 @@ describe("AdminAudioPage", () => {
     const [firstDelete] = await screen.findAllByRole("button", { name: /delete/i });
     await userEvent.click(firstDelete);
 
-    await waitFor(() => expect(window.alert).toHaveBeenCalledWith("Delete failed"));
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("Delete failed"));
   });
 
-  it("alerts 'Failed' when delete action throws non-Error", async () => {
-    jest.spyOn(window, "alert").mockImplementation(() => {});
+  it("shows inline error banner with 'Failed' when delete throws non-Error", async () => {
     mockAdminFetch
       .mockResolvedValueOnce(SAMPLE_AUDIO)
       .mockRejectedValueOnce("oops");
@@ -154,6 +152,6 @@ describe("AdminAudioPage", () => {
     const [firstDelete] = await screen.findAllByRole("button", { name: /delete/i });
     await userEvent.click(firstDelete);
 
-    await waitFor(() => expect(window.alert).toHaveBeenCalledWith("Failed"));
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("Failed"));
   });
 });

--- a/frontend/src/__tests__/AdminBlockingDialogsReplaced.test.ts
+++ b/frontend/src/__tests__/AdminBlockingDialogsReplaced.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression tests for issue #1897 — admin/audio, admin/books, QueueTab,
+ * and SeedPopularButton must not use blocking alert() or confirm() dialogs.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const audioSrc = readFileSync(
+  join(__dirname, "../app/admin/audio/page.tsx"),
+  "utf8",
+);
+
+const seedSrc = readFileSync(
+  join(__dirname, "../components/SeedPopularButton.tsx"),
+  "utf8",
+);
+
+const booksSrc = readFileSync(
+  join(__dirname, "../app/admin/books/page.tsx"),
+  "utf8",
+);
+
+const queueSrc = readFileSync(
+  join(__dirname, "../components/QueueTab.tsx"),
+  "utf8",
+);
+
+describe("admin/audio — no blocking dialogs (#1897)", () => {
+  it("does not call alert()", () => {
+    expect(audioSrc).not.toMatch(/\balert\s*\(/);
+  });
+
+  it("does not call confirm()", () => {
+    expect(audioSrc).not.toMatch(/\bconfirm\s*\(/);
+  });
+
+  it("shows action errors via a role=alert element", () => {
+    expect(audioSrc).toMatch(/role="alert"/);
+  });
+});
+
+describe("SeedPopularButton — no blocking dialogs (#1897)", () => {
+  it("does not call alert()", () => {
+    expect(seedSrc).not.toMatch(/\balert\s*\(/);
+  });
+
+  it("does not call confirm()", () => {
+    expect(seedSrc).not.toMatch(/\bconfirm\s*\(/);
+  });
+
+  it("uses a pending confirmation state for destructive actions", () => {
+    expect(seedSrc).toMatch(/pending/i);
+  });
+});
+
+describe("admin/books — no blocking dialogs (#1897)", () => {
+  it("does not call alert()", () => {
+    expect(booksSrc).not.toMatch(/\balert\s*\(/);
+  });
+
+  it("does not call confirm()", () => {
+    expect(booksSrc).not.toMatch(/\bconfirm\s*\(/);
+  });
+
+  it("shows action errors via a role=alert element", () => {
+    expect(booksSrc).toMatch(/role="alert"/);
+  });
+
+  it("uses pendingConfirm for destructive action confirmation", () => {
+    expect(booksSrc).toMatch(/pendingConfirm/);
+  });
+});
+
+describe("QueueTab — no blocking dialogs (#1897)", () => {
+  it("does not call alert()", () => {
+    expect(queueSrc).not.toMatch(/\balert\s*\(/);
+  });
+
+  it("does not call confirm()", () => {
+    expect(queueSrc).not.toMatch(/\bconfirm\s*\(/);
+  });
+
+  it("shows action errors via a role=alert element", () => {
+    expect(queueSrc).toMatch(/role="alert"/);
+  });
+
+  it("uses pendingConfirm for destructive action confirmation", () => {
+    expect(queueSrc).toMatch(/pendingConfirm/);
+  });
+});

--- a/frontend/src/__tests__/AdminBooksActionTouchTargets.test.ts
+++ b/frontend/src/__tests__/AdminBooksActionTouchTargets.test.ts
@@ -16,7 +16,9 @@ describe("Admin books action buttons touch targets", () => {
   });
 
   it("book Delete button has min-h-[44px]", () => {
-    expect(src).toMatch(/Delete.*and all its audio[\s\S]{0,300}min-h-\[44px\]/);
+    // Delete book button uses setPendingConfirm with the confirmation message;
+    // aria-label="Delete <title>" is on the button itself alongside min-h-[44px]
+    expect(src).toMatch(/aria-label=.*Delete.*[\s\S]{0,150}min-h-\[44px\]/);
   });
 
   it("Retranslate all button has min-h-[44px]", () => {

--- a/frontend/src/__tests__/AdminBooksPage.branches.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.branches.test.tsx
@@ -37,8 +37,6 @@ beforeAll(async () => {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  jest.spyOn(window, "alert").mockImplementation(() => {});
-  jest.spyOn(window, "confirm").mockReturnValue(false);
 });
 
 afterEach(() => {
@@ -106,7 +104,6 @@ async function renderWithLangExpanded() {
 
 describe("AdminBooksPage — handleRetranslate error path (line 134)", () => {
   it("alerts error message from Error when retranslate API throws", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(true);
     await renderWithLangExpanded();
 
     // Mock the retranslate endpoint to fail
@@ -116,14 +113,14 @@ describe("AdminBooksPage — handleRetranslate error path (line 134)", () => {
       name: /^Retranslate$/i,
     });
     await userEvent.click(retranslateBtns[0]);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith("Retranslation API error"),
+      expect(screen.getByRole("alert")).toHaveTextContent("Retranslation API error"),
     );
   });
 
   it("alerts fallback message when retranslate API throws non-Error", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(true);
     await renderWithLangExpanded();
 
     // Mock the retranslate endpoint to fail with a non-Error
@@ -133,9 +130,10 @@ describe("AdminBooksPage — handleRetranslate error path (line 134)", () => {
       name: /^Retranslate$/i,
     });
     await userEvent.click(retranslateBtns[0]);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith("Retranslation failed"),
+      expect(screen.getByRole("alert")).toHaveTextContent("Retranslation failed"),
     );
   });
 });
@@ -144,7 +142,6 @@ describe("AdminBooksPage — handleRetranslate error path (line 134)", () => {
 
 describe("AdminBooksPage — handleMove confirm cancelled (line 177)", () => {
   it("does not call move API when user cancels confirm dialog", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(false);
     await renderWithLangExpanded();
 
     const moveInputs = screen.getAllByPlaceholderText("→Ch");
@@ -153,6 +150,8 @@ describe("AdminBooksPage — handleMove confirm cancelled (line 177)", () => {
 
     const moveBtns = screen.getAllByRole("button", { name: /^Move$/i });
     await userEvent.click(moveBtns[0]);
+    // Inline dialog appears — dismiss without confirming
+    await userEvent.click(screen.getByRole("button", { name: /cancel action/i }));
 
     // No additional calls beyond initial load (2 calls)
     expect(mockAdminFetch).toHaveBeenCalledTimes(2);

--- a/frontend/src/__tests__/AdminBooksPage.branches2.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.branches2.test.tsx
@@ -50,8 +50,6 @@ beforeAll(async () => {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  jest.spyOn(window, "alert").mockImplementation(() => {});
-  jest.spyOn(window, "confirm").mockReturnValue(false);
 });
 
 afterEach(() => {
@@ -162,7 +160,7 @@ describe("AdminBooksPage — handleImport non-Error catch (line 111)", () => {
     await userEvent.click(screen.getByRole("button", { name: /import book/i }));
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith("Import failed"),
+      expect(screen.getByRole("alert")).toHaveTextContent("Import failed"),
     );
   });
 });
@@ -185,7 +183,7 @@ describe("AdminBooksPage — queueLanguageForBook non-Error catch (lines 141-152
     await userEvent.click(translateBtns[0]);
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith("Enqueue failed"),
+      expect(screen.getByRole("alert")).toHaveTextContent("Enqueue failed"),
     );
   });
 });
@@ -193,8 +191,6 @@ describe("AdminBooksPage — queueLanguageForBook non-Error catch (lines 141-152
 // ── Line 190: handleMove non-Error catch ──────────────────────────────────────
 
 describe("AdminBooksPage — handleMove non-Error catch (line 190)", () => {
-  jest.spyOn(window, "confirm").mockReturnValue(true);
-
   async function renderWithChapterRows() {
     const singleBook = [SAMPLE_BOOKS[0]];
     mockAdminFetch
@@ -216,7 +212,6 @@ describe("AdminBooksPage — handleMove non-Error catch (line 190)", () => {
   }
 
   it("shows 'Move failed' fallback when non-Error is thrown during move", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(true);
     await renderWithChapterRows();
 
     mockAdminFetch.mockRejectedValueOnce("non-error string");
@@ -227,9 +222,10 @@ describe("AdminBooksPage — handleMove non-Error catch (line 190)", () => {
 
     const moveBtns = screen.getAllByRole("button", { name: /^Move$/i });
     await userEvent.click(moveBtns[0]);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith("Move failed"),
+      expect(screen.getByRole("alert")).toHaveTextContent("Move failed"),
     );
   });
 });
@@ -238,7 +234,6 @@ describe("AdminBooksPage — handleMove non-Error catch (line 190)", () => {
 
 describe("AdminBooksPage — retryFailedForLang non-Error catch (line 208)", () => {
   it("shows 'Retry failed' fallback when non-Error is thrown", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(true);
     const BOOKS_WITH_FAILED = [
       {
         id: 3,
@@ -262,9 +257,10 @@ describe("AdminBooksPage — retryFailedForLang non-Error catch (line 208)", () 
 
     const retryBtn = await screen.findByRole("button", { name: /Retry.*failed.*chapter/i });
     await userEvent.click(retryBtn);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith("Retry failed"),
+      expect(screen.getByRole("alert")).toHaveTextContent("Retry failed"),
     );
   });
 });
@@ -454,7 +450,6 @@ describe("AdminBooksPage — singular chapter count (line 430)", () => {
 
 describe("AdminBooksPage — bulk retranslate non-Error catch (line 453)", () => {
   it("shows 'Failed' fallback when bulk retranslate throws non-Error", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(true);
     mockAdminFetch
       .mockResolvedValueOnce(SAMPLE_BOOKS)
       .mockResolvedValueOnce(SAMPLE_TRANSLATIONS)
@@ -470,9 +465,10 @@ describe("AdminBooksPage — bulk retranslate non-Error catch (line 453)", () =>
       name: /retranslate all/i,
     });
     await userEvent.click(retranslateAllBtn);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith("Failed"),
+      expect(screen.getByRole("alert")).toHaveTextContent("Failed"),
     );
   });
 });

--- a/frontend/src/__tests__/AdminBooksPage.coverage.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.coverage.test.tsx
@@ -45,8 +45,6 @@ beforeAll(async () => {
 beforeEach(() => {
   jest.clearAllMocks();
   capturedOnComplete = null;
-  jest.spyOn(window, "alert").mockImplementation(() => {});
-  jest.spyOn(window, "confirm").mockReturnValue(false);
 });
 
 afterEach(() => {
@@ -103,7 +101,6 @@ const flushPromises = () => new Promise((r) => setTimeout(r, 0));
 // ─────────────────────────────────────────────────────────────────────────────
 describe("AdminBooksPage — act() error path (line 90)", () => {
   it("alerts error message when delete throws", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(true);
     mockAdminFetch
       .mockResolvedValueOnce(SAMPLE_BOOKS)
       .mockResolvedValueOnce(SAMPLE_TRANSLATIONS)
@@ -114,14 +111,14 @@ describe("AdminBooksPage — act() error path (line 90)", () => {
 
     const deleteBtns = await screen.findAllByRole("button", { name: (n) => n.startsWith("Delete ") && !n.startsWith("Delete all") });
     await userEvent.click(deleteBtns[0]);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith("Delete failed"),
+      expect(screen.getByRole("alert")).toHaveTextContent("Delete failed"),
     );
   });
 
   it("alerts fallback message when delete throws non-Error", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(true);
     mockAdminFetch
       .mockResolvedValueOnce(SAMPLE_BOOKS)
       .mockResolvedValueOnce(SAMPLE_TRANSLATIONS)
@@ -132,9 +129,10 @@ describe("AdminBooksPage — act() error path (line 90)", () => {
 
     const deleteBtns = await screen.findAllByRole("button", { name: (n) => n.startsWith("Delete ") && !n.startsWith("Delete all") });
     await userEvent.click(deleteBtns[0]);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith("Failed"),
+      expect(screen.getByRole("alert")).toHaveTextContent("Failed"),
     );
   });
 });
@@ -159,9 +157,7 @@ describe("AdminBooksPage — import already_cached branch (line 111)", () => {
     await userEvent.click(screen.getByRole("button", { name: /import book/i }));
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith(
-        expect.stringContaining("already cached"),
-      ),
+      expect(screen.getByRole("status")).toHaveTextContent(/already cached/i),
     );
   });
 
@@ -179,7 +175,7 @@ describe("AdminBooksPage — import already_cached branch (line 111)", () => {
     await userEvent.click(screen.getByRole("button", { name: /import book/i }));
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith("Import failed"),
+      expect(screen.getByRole("alert")).toHaveTextContent("Import failed"),
     );
   });
 });
@@ -213,7 +209,6 @@ describe("AdminBooksPage — handleRetranslate (lines 118-136)", () => {
   }
 
   it("calls retranslate endpoint when confirmed", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(true);
     mockAdminFetch
       .mockResolvedValueOnce(SAMPLE_BOOKS)
       .mockResolvedValueOnce(SAMPLE_TRANSLATIONS);
@@ -225,7 +220,6 @@ describe("AdminBooksPage — handleRetranslate (lines 118-136)", () => {
 
     // Expand the zh language row
     await waitFor(() => screen.getByText("zh"));
-    // Click the small arrow to expand the language
     const allBtns = screen.getAllByRole("button");
     const langArrow = allBtns.find(
       (b) => (b.getAttribute("aria-label")?.startsWith("Expand") || b.getAttribute("aria-label")?.startsWith("Collapse")) && !b.title,
@@ -245,6 +239,7 @@ describe("AdminBooksPage — handleRetranslate (lines 118-136)", () => {
       .mockResolvedValueOnce(SAMPLE_TRANSLATIONS);
 
     await userEvent.click(retranslateBtns[0]);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
       expect(mockAdminFetch).toHaveBeenCalledWith(
@@ -252,13 +247,12 @@ describe("AdminBooksPage — handleRetranslate (lines 118-136)", () => {
         expect.objectContaining({ method: "POST" }),
       ),
     );
-    expect(window.alert).toHaveBeenCalledWith(
-      expect.stringContaining("paragraphs"),
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent(/paragraphs/i),
     );
   });
 
   it("does not retranslate when confirm is cancelled", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(false);
     mockAdminFetch
       .mockResolvedValueOnce(SAMPLE_BOOKS)
       .mockResolvedValueOnce(SAMPLE_TRANSLATIONS);
@@ -279,6 +273,7 @@ describe("AdminBooksPage — handleRetranslate (lines 118-136)", () => {
       name: /^Retranslate$/i,
     });
     await userEvent.click(retranslateBtns[0]);
+    await userEvent.click(screen.getByRole("button", { name: /cancel action/i }));
 
     // Only initial 2 calls — no retranslate call
     expect(mockAdminFetch).toHaveBeenCalledTimes(2);
@@ -304,7 +299,7 @@ describe("AdminBooksPage — queueLanguageForBook error path (line 152)", () => 
     await userEvent.click(translateBtns[0]);
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith("Queue error"),
+      expect(screen.getByRole("alert")).toHaveTextContent("Queue error"),
     );
   });
 });
@@ -434,7 +429,6 @@ describe("AdminBooksPage — retryFailedForLang (line 350)", () => {
   ];
 
   it("calls retry endpoint when confirmed", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(true);
     mockAdminFetch
       .mockResolvedValueOnce(BOOKS_WITH_FAILED)
       .mockResolvedValueOnce([])
@@ -447,6 +441,7 @@ describe("AdminBooksPage — retryFailedForLang (line 350)", () => {
 
     const retryBtn = await screen.findByRole("button", { name: /Retry.*failed.*chapter/i });
     await userEvent.click(retryBtn);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
       expect(mockAdminFetch).toHaveBeenCalledWith(
@@ -454,13 +449,12 @@ describe("AdminBooksPage — retryFailedForLang (line 350)", () => {
         expect.objectContaining({ method: "POST" }),
       ),
     );
-    expect(window.alert).toHaveBeenCalledWith(
-      expect.stringContaining("Re-queued"),
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent(/Re-queued/i),
     );
   });
 
   it("does not call retry when confirm is cancelled", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(false);
     mockAdminFetch
       .mockResolvedValueOnce(BOOKS_WITH_FAILED)
       .mockResolvedValueOnce([]);
@@ -470,12 +464,12 @@ describe("AdminBooksPage — retryFailedForLang (line 350)", () => {
 
     const retryBtn = await screen.findByRole("button", { name: /Retry.*failed.*chapter/i });
     await userEvent.click(retryBtn);
+    await userEvent.click(screen.getByRole("button", { name: /cancel action/i }));
 
     expect(mockAdminFetch).toHaveBeenCalledTimes(2);
   });
 
   it("alerts error when retry API fails", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(true);
     mockAdminFetch
       .mockResolvedValueOnce(BOOKS_WITH_FAILED)
       .mockResolvedValueOnce([])
@@ -486,9 +480,10 @@ describe("AdminBooksPage — retryFailedForLang (line 350)", () => {
 
     const retryBtn = await screen.findByRole("button", { name: /Retry.*failed.*chapter/i });
     await userEvent.click(retryBtn);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith("Retry failed"),
+      expect(screen.getByRole("alert")).toHaveTextContent("Retry failed"),
     );
   });
 });
@@ -498,7 +493,6 @@ describe("AdminBooksPage — retryFailedForLang (line 350)", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 describe("AdminBooksPage — Delete all translations per-lang (line 373)", () => {
   it("calls DELETE /admin/translations/:id/:lang when Delete all confirmed", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(true);
     mockAdminFetch
       .mockResolvedValueOnce(SAMPLE_BOOKS)
       .mockResolvedValueOnce(SAMPLE_TRANSLATIONS)
@@ -516,6 +510,7 @@ describe("AdminBooksPage — Delete all translations per-lang (line 373)", () =>
     // "Delete all" button inside expanded section
     const deleteAllBtn = await screen.findByRole("button", { name: /delete all/i });
     await userEvent.click(deleteAllBtn);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
       expect(mockAdminFetch).toHaveBeenCalledWith(
@@ -526,7 +521,6 @@ describe("AdminBooksPage — Delete all translations per-lang (line 373)", () =>
   });
 
   it("does not call DELETE when Delete all confirm is cancelled", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(false);
     mockAdminFetch
       .mockResolvedValueOnce(SAMPLE_BOOKS)
       .mockResolvedValueOnce(SAMPLE_TRANSLATIONS);
@@ -539,6 +533,7 @@ describe("AdminBooksPage — Delete all translations per-lang (line 373)", () =>
 
     const deleteAllBtn = await screen.findByRole("button", { name: /delete all/i });
     await userEvent.click(deleteAllBtn);
+    await userEvent.click(screen.getByRole("button", { name: /cancel action/i }));
 
     expect(mockAdminFetch).toHaveBeenCalledTimes(2);
   });
@@ -549,7 +544,6 @@ describe("AdminBooksPage — Delete all translations per-lang (line 373)", () =>
 // ─────────────────────────────────────────────────────────────────────────────
 describe("AdminBooksPage — bulk retranslate (lines 423-460)", () => {
   it("calls bulk retranslate endpoint when confirmed", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(true);
     mockAdminFetch
       .mockResolvedValueOnce(SAMPLE_BOOKS)
       .mockResolvedValueOnce(SAMPLE_TRANSLATIONS)
@@ -567,6 +561,7 @@ describe("AdminBooksPage — bulk retranslate (lines 423-460)", () => {
       name: /retranslate all/i,
     });
     await userEvent.click(retranslateAllBtn);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
       expect(mockAdminFetch).toHaveBeenCalledWith(
@@ -574,13 +569,12 @@ describe("AdminBooksPage — bulk retranslate (lines 423-460)", () => {
         expect.objectContaining({ method: "POST" }),
       ),
     );
-    expect(window.alert).toHaveBeenCalledWith(
-      expect.stringContaining("chapters"),
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent(/chapters/i),
     );
   });
 
   it("does not call bulk retranslate when confirm is cancelled", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(false);
     mockAdminFetch
       .mockResolvedValueOnce(SAMPLE_BOOKS)
       .mockResolvedValueOnce(SAMPLE_TRANSLATIONS);
@@ -595,12 +589,12 @@ describe("AdminBooksPage — bulk retranslate (lines 423-460)", () => {
       name: /retranslate all/i,
     });
     await userEvent.click(retranslateAllBtn);
+    await userEvent.click(screen.getByRole("button", { name: /cancel action/i }));
 
     expect(mockAdminFetch).toHaveBeenCalledTimes(2);
   });
 
   it("alerts error when bulk retranslate fails", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(true);
     mockAdminFetch
       .mockResolvedValueOnce(SAMPLE_BOOKS)
       .mockResolvedValueOnce(SAMPLE_TRANSLATIONS)
@@ -616,9 +610,10 @@ describe("AdminBooksPage — bulk retranslate (lines 423-460)", () => {
       name: /retranslate all/i,
     });
     await userEvent.click(retranslateAllBtn);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith("Bulk failed"),
+      expect(screen.getByRole("alert")).toHaveTextContent("Bulk failed"),
     );
   });
 });
@@ -696,10 +691,9 @@ describe("AdminBooksPage — chapter move (lines 496-519)", () => {
   }
 
   it("alerts when move target is same chapter", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(true);
     await renderWithChapterRows();
 
-    // ch_index 0 means Ch. 1 (1-based). Entering 1 is same chapter.
+    // ch_index 0 means Ch. 1 (1-based). Entering 1 is same chapter — setActError fires directly.
     const moveInputs = screen.getAllByPlaceholderText("→Ch");
     await userEvent.clear(moveInputs[0]);
     await userEvent.type(moveInputs[0], "1");
@@ -708,14 +702,11 @@ describe("AdminBooksPage — chapter move (lines 496-519)", () => {
     await userEvent.click(moveBtns[0]);
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith(
-        expect.stringContaining("same"),
-      ),
+      expect(screen.getByRole("alert")).toHaveTextContent(/same/i),
     );
   });
 
   it("alerts when move target is not a valid number", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(true);
     await renderWithChapterRows();
 
     const moveInputs = screen.getAllByPlaceholderText("→Ch");
@@ -726,14 +717,11 @@ describe("AdminBooksPage — chapter move (lines 496-519)", () => {
     await userEvent.click(moveBtns[0]);
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith(
-        expect.stringContaining("chapter number"),
-      ),
+      expect(screen.getByRole("alert")).toHaveTextContent(/chapter number/i),
     );
   });
 
   it("calls move endpoint and clears input on success", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(true);
     await renderWithChapterRows();
 
     mockAdminFetch
@@ -747,6 +735,7 @@ describe("AdminBooksPage — chapter move (lines 496-519)", () => {
 
     const moveBtns = screen.getAllByRole("button", { name: /^Move$/i });
     await userEvent.click(moveBtns[0]);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
       expect(mockAdminFetch).toHaveBeenCalledWith(
@@ -757,7 +746,6 @@ describe("AdminBooksPage — chapter move (lines 496-519)", () => {
   });
 
   it("alerts error when move API fails", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(true);
     await renderWithChapterRows();
 
     mockAdminFetch.mockRejectedValueOnce(new Error("Move error"));
@@ -768,14 +756,14 @@ describe("AdminBooksPage — chapter move (lines 496-519)", () => {
 
     const moveBtns = screen.getAllByRole("button", { name: /^Move$/i });
     await userEvent.click(moveBtns[0]);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith("Move error"),
+      expect(screen.getByRole("alert")).toHaveTextContent("Move error"),
     );
   });
 
   it("triggers move via Enter keydown on move input", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(true);
     await renderWithChapterRows();
 
     mockAdminFetch
@@ -786,6 +774,7 @@ describe("AdminBooksPage — chapter move (lines 496-519)", () => {
     const moveInputs = screen.getAllByPlaceholderText("→Ch");
     await userEvent.clear(moveInputs[0]);
     await userEvent.type(moveInputs[0], "3{Enter}");
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
       expect(mockAdminFetch).toHaveBeenCalledWith(

--- a/frontend/src/__tests__/AdminBooksPage.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.test.tsx
@@ -31,8 +31,6 @@ beforeAll(async () => {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  jest.spyOn(window, "alert").mockImplementation(() => {});
-  jest.spyOn(window, "confirm").mockReturnValue(false);
 });
 
 afterEach(() => {
@@ -163,7 +161,6 @@ describe("AdminBooksPage — book actions", () => {
   });
 
   it("calls delete when Delete confirmed", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(true);
     mockAdminFetch
       .mockResolvedValueOnce(SAMPLE_BOOKS)
       .mockResolvedValueOnce(SAMPLE_TRANSLATIONS)
@@ -175,6 +172,7 @@ describe("AdminBooksPage — book actions", () => {
 
     const deleteBtns = await screen.findAllByRole("button", { name: /delete/i });
     await userEvent.click(deleteBtns[0]);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() => {
       expect(mockAdminFetch).toHaveBeenCalledWith(
@@ -185,7 +183,6 @@ describe("AdminBooksPage — book actions", () => {
   });
 
   it("does not delete when confirm is cancelled", async () => {
-    jest.spyOn(window, "confirm").mockReturnValue(false);
     mockAdminFetch
       .mockResolvedValueOnce(SAMPLE_BOOKS)
       .mockResolvedValueOnce(SAMPLE_TRANSLATIONS);
@@ -194,7 +191,8 @@ describe("AdminBooksPage — book actions", () => {
 
     const deleteBtns = await screen.findAllByRole("button", { name: /delete/i });
     await userEvent.click(deleteBtns[0]);
-    // Only initial 2 calls (books + translations)
+    // Inline dialog appears but we don't click confirm — only initial 2 calls
+    await userEvent.click(screen.getByRole("button", { name: /cancel action/i }));
     expect(mockAdminFetch).toHaveBeenCalledTimes(2);
   });
 

--- a/frontend/src/__tests__/ErrorRoleAlert.test.tsx
+++ b/frontend/src/__tests__/ErrorRoleAlert.test.tsx
@@ -61,17 +61,17 @@ test("SeedPopularButton error has role=alert when start fails", async () => {
     .mockResolvedValueOnce({ running: false, state: RUNNING_STATE })
     .mockRejectedValueOnce(new Error("Start failed"));
 
-  window.confirm = jest.fn().mockReturnValue(true);
-
   render(<SeedPopularButton adminFetch={adminFetch} />);
 
-  // Wait for initial status load (makes Start button not disabled and state non-null)
+  // Wait for initial status load
   await waitFor(() => {
     expect(adminFetch).toHaveBeenCalledWith("/admin/books/seed-popular/status");
   });
 
-  const startBtn = screen.getByRole("button", { name: /seed all popular books/i });
-  fireEvent.click(startBtn);
+  // Click main button → inline confirmation
+  fireEvent.click(screen.getByRole("button", { name: /seed all popular books/i }));
+  // Confirm the action
+  fireEvent.click(screen.getByRole("button", { name: /confirm seed popular books/i }));
 
   await waitFor(() => {
     expect(screen.getByRole("alert")).toBeInTheDocument();

--- a/frontend/src/__tests__/QueueTab.branches.test.tsx
+++ b/frontend/src/__tests__/QueueTab.branches.test.tsx
@@ -277,12 +277,7 @@ describe("QueueTab.branches — saveSettings error path", () => {
 // ── Line 331: enqueueAll error path ───────────────────────────────────────────
 
 describe("QueueTab.branches — enqueueAll error path", () => {
-  beforeEach(() => {
-    window.confirm = jest.fn(() => true);
-    window.alert = jest.fn();
-  });
-
-  it("shows alert error message when enqueueAll fails with Error", async () => {
+  it("shows inline error when enqueueAll fails with Error", async () => {
     const adminFetch = jest.fn((path: string, opts?: RequestInit) => {
       if (path === "/admin/queue/status") return Promise.resolve(makeStatus());
       if (path === "/admin/queue/settings") return Promise.resolve(BASE_SETTINGS);
@@ -300,13 +295,15 @@ describe("QueueTab.branches — enqueueAll error path", () => {
       name: /queue every book for all configured languages/i,
     });
     await userEvent.click(enqueueBtn);
+    // Confirm the action via inline dialog
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith("Enqueue service unavailable"),
+      expect(screen.getByRole("alert")).toHaveTextContent("Enqueue service unavailable"),
     );
   });
 
-  it("shows generic 'Failed' alert when enqueueAll fails with non-Error", async () => {
+  it("shows generic 'Failed' inline error when enqueueAll fails with non-Error", async () => {
     const adminFetch = jest.fn((path: string, opts?: RequestInit) => {
       if (path === "/admin/queue/status") return Promise.resolve(makeStatus());
       if (path === "/admin/queue/settings") return Promise.resolve(BASE_SETTINGS);
@@ -324,9 +321,10 @@ describe("QueueTab.branches — enqueueAll error path", () => {
       name: /queue every book for all configured languages/i,
     });
     await userEvent.click(enqueueBtn);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith("Failed"),
+      expect(screen.getByRole("alert")).toHaveTextContent("Failed"),
     );
   });
 });
@@ -334,12 +332,7 @@ describe("QueueTab.branches — enqueueAll error path", () => {
 // ── Line 357: clearAll error path ─────────────────────────────────────────────
 
 describe("QueueTab.branches — clearAll error path", () => {
-  beforeEach(() => {
-    window.confirm = jest.fn(() => true);
-    window.alert = jest.fn();
-  });
-
-  it("shows alert error when clearAll DELETE request fails with Error", async () => {
+  it("shows inline error when clearAll DELETE request fails with Error", async () => {
     const item = makeItem();
     const adminFetch = jest.fn((path: string, opts?: RequestInit) => {
       if (path === "/admin/queue/status") return Promise.resolve(makeStatus());
@@ -357,13 +350,14 @@ describe("QueueTab.branches — clearAll error path", () => {
 
     const clearBtn = screen.getByRole("button", { name: /clear pending/i });
     await userEvent.click(clearBtn);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith("Database lock error"),
+      expect(screen.getByRole("alert")).toHaveTextContent("Database lock error"),
     );
   });
 
-  it("shows 'Clear failed' alert when clearAll fails with non-Error", async () => {
+  it("shows 'Clear failed' inline error when clearAll fails with non-Error", async () => {
     const item = makeItem();
     const adminFetch = jest.fn((path: string, opts?: RequestInit) => {
       if (path === "/admin/queue/status") return Promise.resolve(makeStatus());
@@ -381,9 +375,10 @@ describe("QueueTab.branches — clearAll error path", () => {
 
     const clearBtn = screen.getByRole("button", { name: /clear pending/i });
     await userEvent.click(clearBtn);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith("Clear failed"),
+      expect(screen.getByRole("alert")).toHaveTextContent("Clear failed"),
     );
   });
 });
@@ -549,11 +544,6 @@ describe("QueueTab.branches — add model from panel", () => {
 // ── stopWorker / startWorker toggle ──────────────────────────────────────────
 
 describe("QueueTab.branches — worker start/stop", () => {
-  beforeEach(() => {
-    window.confirm = jest.fn(() => true);
-    window.alert = jest.fn();
-  });
-
   it("Start button calls /admin/queue/start POST endpoint", async () => {
     const adminFetch = makeAdminFetch({ status: makeStatus({ running: false }) });
     await renderAndWait(adminFetch);
@@ -569,16 +559,18 @@ describe("QueueTab.branches — worker start/stop", () => {
     );
   });
 
-  it("Stop button shows confirm dialog before stopping", async () => {
-    window.confirm = jest.fn(() => false); // cancel
+  it("Stop button shows inline confirmation before stopping", async () => {
     const adminFetch = makeAdminFetch({ status: makeStatus({ running: true }) });
     await renderAndWait(adminFetch);
 
     const stopBtn = screen.getByRole("button", { name: /^stop$/i });
     await userEvent.click(stopBtn);
 
-    expect(window.confirm).toHaveBeenCalled();
-    // Should NOT call stop endpoint since confirm returned false
+    // Inline dialog appears — cancel it
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /cancel action/i }));
+
+    // Should NOT call stop endpoint since we cancelled
     expect(adminFetch).not.toHaveBeenCalledWith(
       "/admin/queue/stop",
       expect.objectContaining({ method: "POST" }),
@@ -586,12 +578,13 @@ describe("QueueTab.branches — worker start/stop", () => {
   });
 
   it("Stop button calls /admin/queue/stop POST when confirmed", async () => {
-    window.confirm = jest.fn(() => true);
     const adminFetch = makeAdminFetch({ status: makeStatus({ running: true }) });
     await renderAndWait(adminFetch);
 
     const stopBtn = screen.getByRole("button", { name: /^stop$/i });
     await userEvent.click(stopBtn);
+    // Confirm via inline dialog
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
       expect(adminFetch).toHaveBeenCalledWith(

--- a/frontend/src/__tests__/QueueTab.branches2.test.tsx
+++ b/frontend/src/__tests__/QueueTab.branches2.test.tsx
@@ -263,11 +263,6 @@ describe("QueueTab.branches2 — refreshCore non-Error catch (line 187)", () => 
 // ── Lines 325/350: clearAll with itemFilter="all" ─────────────────────────────
 
 describe("QueueTab.branches2 — clearAll with filter='all' (lines 325, 350)", () => {
-  beforeEach(() => {
-    window.confirm = jest.fn(() => true);
-    window.alert = jest.fn();
-  });
-
   it("calls DELETE /admin/queue when itemFilter is 'all'", async () => {
     const item = makeItem();
     const adminFetch = jest.fn((path: string, opts?: RequestInit) => {
@@ -291,7 +286,10 @@ describe("QueueTab.branches2 — clearAll with filter='all' (lines 325, 350)", (
       expect(screen.getByRole("button", { name: /clear queue/i })).toBeInTheDocument(),
     );
 
+    // Click "Clear queue" → inline confirmation appears
     await userEvent.click(screen.getByRole("button", { name: /clear queue/i }));
+    // Confirm the action
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
       expect(adminFetch).toHaveBeenCalledWith(
@@ -299,7 +297,10 @@ describe("QueueTab.branches2 — clearAll with filter='all' (lines 325, 350)", (
         expect.objectContaining({ method: "DELETE" }),
       ),
     );
-    expect(window.alert).toHaveBeenCalledWith(expect.stringContaining("5"));
+    // Success shown as inline toast (role="status") instead of alert()
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent(/5/),
+    );
   });
 });
 
@@ -425,15 +426,17 @@ describe("QueueTab.branches2 — last_error banner (line 514)", () => {
 
 describe("QueueTab.branches2 — Clear API key button (line 620)", () => {
   it("calls saveSettings({api_key: ''}) when Clear is clicked and confirmed", async () => {
-    window.confirm = jest.fn(() => true);
     const adminFetch = makeAdminFetch({
       settings: { ...BASE_SETTINGS, has_api_key: true },
       status: makeStatus(),
     });
     await renderAndWait(adminFetch);
 
+    // Click "Clear" → inline confirmation appears
     const clearBtn = screen.getByRole("button", { name: /^Clear$/i });
     await userEvent.click(clearBtn);
+    // Confirm via inline dialog
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
       expect(adminFetch).toHaveBeenCalledWith(
@@ -447,7 +450,6 @@ describe("QueueTab.branches2 — Clear API key button (line 620)", () => {
   });
 
   it("does NOT call saveSettings when Clear is cancelled", async () => {
-    window.confirm = jest.fn(() => false);
     const adminFetch = makeAdminFetch({
       settings: { ...BASE_SETTINGS, has_api_key: true },
       status: makeStatus(),
@@ -458,8 +460,11 @@ describe("QueueTab.branches2 — Clear API key button (line 620)", () => {
       (c: any[]) => c[1]?.method === "PUT",
     ).length;
 
+    // Click "Clear" → inline confirmation appears
     const clearBtn = screen.getByRole("button", { name: /^Clear$/i });
     await userEvent.click(clearBtn);
+    // Cancel via inline dialog
+    await userEvent.click(screen.getByRole("button", { name: /cancel action/i }));
 
     const callsAfter = adminFetch.mock.calls.filter(
       (c: any[]) => c[1]?.method === "PUT",

--- a/frontend/src/__tests__/QueueTab.coverage.test.tsx
+++ b/frontend/src/__tests__/QueueTab.coverage.test.tsx
@@ -366,6 +366,8 @@ describe("saveSettings calls (lines 264-291)", () => {
     );
     expect(clearBtns.length).toBeGreaterThan(0);
     await userEvent.click(clearBtns[0]);
+    // Confirm via inline dialog
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
       expect(adminFetch).toHaveBeenCalledWith(
@@ -382,11 +384,6 @@ describe("saveSettings calls (lines 264-291)", () => {
 // ── Lines 325-357: clearAll and retry/remove queue items ─────────────────────
 
 describe("queue item actions: retry, remove, clearAll (lines 325-357)", () => {
-  beforeEach(() => {
-    window.confirm = jest.fn(() => true);
-    window.alert = jest.fn();
-  });
-
   it("clicking Retry on a failed item calls retry endpoint", async () => {
     const failedItem = makeItem({ id: 99, status: "failed", attempts: 2 });
     const adminFetch = makeAdminFetch({
@@ -407,7 +404,7 @@ describe("queue item actions: retry, remove, clearAll (lines 325-357)", () => {
     );
   });
 
-  it("clicking Del calls DELETE endpoint after confirm", async () => {
+  it("clicking Del calls DELETE endpoint after inline confirmation", async () => {
     const item = makeItem({ id: 55 });
     const adminFetch = makeAdminFetch({
       items: [item],
@@ -418,6 +415,8 @@ describe("queue item actions: retry, remove, clearAll (lines 325-357)", () => {
 
     const delBtn = await screen.findByRole("button", { name: /del/i });
     await userEvent.click(delBtn);
+    // Confirm via inline dialog
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
       expect(adminFetch).toHaveBeenCalledWith(
@@ -427,8 +426,7 @@ describe("queue item actions: retry, remove, clearAll (lines 325-357)", () => {
     );
   });
 
-  it("Del does not call DELETE if confirm returns false", async () => {
-    window.confirm = jest.fn(() => false);
+  it("Del does not call DELETE when inline confirmation is cancelled", async () => {
     const item = makeItem({ id: 77 });
     const adminFetch = makeAdminFetch({ items: [item], status: makeStatus() });
 
@@ -436,6 +434,8 @@ describe("queue item actions: retry, remove, clearAll (lines 325-357)", () => {
 
     const delBtn = await screen.findByRole("button", { name: /del/i });
     await userEvent.click(delBtn);
+    // Cancel via inline dialog
+    await userEvent.click(screen.getByRole("button", { name: /cancel action/i }));
 
     expect(adminFetch).not.toHaveBeenCalledWith(
       "/admin/queue/items/77",
@@ -455,6 +455,7 @@ describe("queue item actions: retry, remove, clearAll (lines 325-357)", () => {
 
     const clearBtn = screen.getByRole("button", { name: /clear pending/i });
     await userEvent.click(clearBtn);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
       expect(adminFetch).toHaveBeenCalledWith(
@@ -484,6 +485,7 @@ describe("queue item actions: retry, remove, clearAll (lines 325-357)", () => {
 
     const clearBtn = screen.getByRole("button", { name: /clear queue/i });
     await userEvent.click(clearBtn);
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
       expect(adminFetch).toHaveBeenCalledWith(
@@ -810,6 +812,8 @@ describe("worker status panel details (lines 1013-1095)", () => {
       name: /queue every book for all configured languages/i,
     });
     await userEvent.click(enqueueBtn);
+    // Confirm via inline dialog
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
       expect(adminFetch).toHaveBeenCalledWith(
@@ -972,12 +976,7 @@ describe("initial loading skeleton", () => {
 // ── Issue #273: retry and remove must alert on error ─────────────────────────
 
 describe("QueueTab — retry/remove error handling (issue #273)", () => {
-  beforeEach(() => {
-    window.confirm = jest.fn(() => true);
-    window.alert = jest.fn();
-  });
-
-  it("shows alert when retry API call fails", async () => {
+  it("shows inline error when retry API call fails", async () => {
     const failedItem = makeItem({ id: 9, status: "failed" });
     const adminFetch = jest.fn((path: string, opts?: RequestInit) => {
       if (path === "/admin/queue/status") return Promise.resolve(makeStatus());
@@ -995,13 +994,11 @@ describe("QueueTab — retry/remove error handling (issue #273)", () => {
     await userEvent.click(retryBtn);
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith(
-        expect.stringContaining("Server error"),
-      ),
+      expect(screen.getByRole("alert")).toHaveTextContent("Server error"),
     );
   });
 
-  it("shows alert when delete API call fails", async () => {
+  it("shows inline error when delete API call fails", async () => {
     const item = makeItem({ id: 7 });
     const adminFetch = jest.fn((path: string, opts?: RequestInit) => {
       if (path === "/admin/queue/status") return Promise.resolve(makeStatus());
@@ -1017,11 +1014,11 @@ describe("QueueTab — retry/remove error handling (issue #273)", () => {
 
     const delBtn = await screen.findByRole("button", { name: /del/i });
     await userEvent.click(delBtn);
+    // Confirm via inline dialog
+    await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
     await waitFor(() =>
-      expect(window.alert).toHaveBeenCalledWith(
-        expect.stringContaining("Not found"),
-      ),
+      expect(screen.getByRole("alert")).toHaveTextContent("Not found"),
     );
   });
 });

--- a/frontend/src/__tests__/QueueTab.workerToggle.test.tsx
+++ b/frontend/src/__tests__/QueueTab.workerToggle.test.tsx
@@ -56,10 +56,6 @@ const COST = {
 };
 
 describe("QueueTab worker start/stop button", () => {
-  beforeEach(() => {
-    window.confirm = jest.fn(() => true);
-  });
-
   it('shows "Stopping…" while the stop PUT is in flight', async () => {
     let workerRunning = true;
     let resolveStop: (v: unknown) => void = () => {};
@@ -77,8 +73,13 @@ describe("QueueTab worker start/stop button", () => {
     });
 
     render(<QueueTab adminFetch={adminFetch} />);
+    // Click Stop — now shows inline confirmation dialog
     const stopBtn = await screen.findByRole("button", { name: /^stop$/i });
     await userEvent.click(stopBtn);
+
+    // Confirm the stop via the inline dialog
+    const confirmBtn = screen.getByRole("button", { name: /confirm action/i });
+    await userEvent.click(confirmBtn);
 
     // While the PUT is in flight we should see "Stopping…" and the button
     // should be disabled.

--- a/frontend/src/__tests__/SeedPopularButton.test.tsx
+++ b/frontend/src/__tests__/SeedPopularButton.test.tsx
@@ -110,7 +110,6 @@ function makeFetch(statusSeq: any[], { startReject = null as any, stopReject = n
 
 beforeEach(() => {
   jest.useFakeTimers();
-  jest.spyOn(window, "confirm").mockReturnValue(true);
 });
 afterEach(() => {
   jest.useRealTimers();
@@ -169,7 +168,11 @@ describe("SeedPopularButton — start flow", () => {
     const adminFetch = makeFetch([idleStatus(), runningStatus()]);
     render(<SeedPopularButton adminFetch={adminFetch} />);
 
+    // Click main button → inline confirmation appears
     fireEvent.click(screen.getByRole("button", { name: /seed all popular/i }));
+    // Click "Yes, start" to confirm
+    const confirmBtn = screen.getByRole("button", { name: /confirm seed popular books/i });
+    fireEvent.click(confirmBtn);
 
     await waitFor(() =>
       expect(adminFetch).toHaveBeenCalledWith(
@@ -180,11 +183,14 @@ describe("SeedPopularButton — start flow", () => {
   });
 
   it("does NOT call start when user cancels confirm", async () => {
-    (window.confirm as jest.Mock).mockReturnValue(false);
     const adminFetch = makeFetch([idleStatus()]);
     render(<SeedPopularButton adminFetch={adminFetch} />);
 
+    // Click main button → inline confirmation appears
     fireEvent.click(screen.getByRole("button", { name: /seed all popular/i }));
+    // Click "Cancel" to cancel
+    const cancelBtn = screen.getByRole("button", { name: /cancel seed/i });
+    fireEvent.click(cancelBtn);
 
     await act(async () => {});
     expect(adminFetch).not.toHaveBeenCalledWith(
@@ -194,8 +200,6 @@ describe("SeedPopularButton — start flow", () => {
   });
 
   it("shows error message when start throws an Error", async () => {
-    // Return a non-idle state after start so the expanded panel is rendered
-    // (the error display lives inside the expanded panel)
     const failedState = {
       running: false,
       state: {
@@ -212,6 +216,7 @@ describe("SeedPopularButton — start flow", () => {
     await waitFor(() => screen.getByRole("button", { name: /show progress/i }));
 
     fireEvent.click(screen.getByRole("button", { name: /seed all popular/i }));
+    fireEvent.click(screen.getByRole("button", { name: /confirm seed popular books/i }));
 
     await waitFor(() =>
       expect(screen.getByText("Network error")).toBeInTheDocument()
@@ -233,6 +238,7 @@ describe("SeedPopularButton — start flow", () => {
     await waitFor(() => screen.getByRole("button", { name: /show progress/i }));
 
     fireEvent.click(screen.getByRole("button", { name: /seed all popular/i }));
+    fireEvent.click(screen.getByRole("button", { name: /confirm seed popular books/i }));
 
     await waitFor(() =>
       expect(screen.getByText("Start failed")).toBeInTheDocument()
@@ -300,8 +306,13 @@ describe("SeedPopularButton — stop flow", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /show progress/i }));
 
-    const stopBtn = screen.getByRole("button", { name: /stop/i });
+    // Click "Stop" → inline confirmation appears
+    const stopBtn = screen.getByRole("button", { name: /^stop$/i });
     fireEvent.click(stopBtn);
+
+    // Click "Yes" to confirm
+    const yesBtn = screen.getByRole("button", { name: /confirm stop seed job/i });
+    fireEvent.click(yesBtn);
 
     await waitFor(() =>
       expect(adminFetch).toHaveBeenCalledWith(
@@ -312,13 +323,15 @@ describe("SeedPopularButton — stop flow", () => {
   });
 
   it("does NOT call stop when user cancels confirm", async () => {
-    (window.confirm as jest.Mock).mockReturnValue(false);
     const adminFetch = makeFetch([runningStatus()]);
     render(<SeedPopularButton adminFetch={adminFetch} />);
     await waitFor(() => screen.getByText("Seeding…"));
 
     fireEvent.click(screen.getByRole("button", { name: /show progress/i }));
-    fireEvent.click(screen.getByRole("button", { name: /stop/i }));
+    // Click "Stop" → inline confirmation
+    fireEvent.click(screen.getByRole("button", { name: /^stop$/i }));
+    // Click "No" to cancel
+    fireEvent.click(screen.getByRole("button", { name: /cancel stop/i }));
 
     await act(async () => {});
     expect(adminFetch).not.toHaveBeenCalledWith(
@@ -333,7 +346,8 @@ describe("SeedPopularButton — stop flow", () => {
     await waitFor(() => screen.getByText("Seeding…"));
 
     fireEvent.click(screen.getByRole("button", { name: /show progress/i }));
-    fireEvent.click(screen.getByRole("button", { name: /stop/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^stop$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /confirm stop seed job/i }));
 
     await waitFor(() =>
       expect(screen.getByText("Stop failed")).toBeInTheDocument()

--- a/frontend/src/__tests__/SeedPopularButtonTouchTargets.test.ts
+++ b/frontend/src/__tests__/SeedPopularButtonTouchTargets.test.ts
@@ -8,10 +8,10 @@ const src = fs.readFileSync(
 
 describe("SeedPopularButton touch targets (closes #865)", () => {
   it("Seed all popular books button has min-h-[44px]", () => {
-    // className follows onClick={start} — forward window
-    const idx = src.indexOf("onClick={start}");
+    // Button now uses setPendingStart(true) instead of calling start() directly
+    const idx = src.indexOf("setPendingStart(true)");
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(idx, idx + 200);
+    const window = src.slice(idx, idx + 300);
     expect(window).toContain("min-h-[44px]");
   });
 
@@ -33,10 +33,10 @@ describe("SeedPopularButton touch targets (closes #865)", () => {
   });
 
   it("Stop button has min-h-[44px]", () => {
-    // className follows onClick={stop} — forward window
-    const idx = src.indexOf("onClick={stop}");
+    // Stop button now uses setPendingStop(true) instead of calling stop() directly
+    const idx = src.indexOf("setPendingStop(true)");
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(idx, idx + 200);
+    const window = src.slice(idx, idx + 300);
     expect(window).toContain("min-h-[44px]");
   });
 });

--- a/frontend/src/app/admin/audio/page.tsx
+++ b/frontend/src/app/admin/audio/page.tsx
@@ -16,6 +16,7 @@ export default function AudioPage() {
   const [audio, setAudio] = useState<AudioEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [actError, setActError] = useState<string | null>(null);
 
   useEffect(() => {
     document.title = "Admin: Audio — Book Reader AI";
@@ -41,8 +42,9 @@ export default function AudioPage() {
     try {
       await fn();
       await load();
+      setActError(null);
     } catch (e: unknown) {
-      alert(e instanceof Error ? e.message : "Failed");
+      setActError(e instanceof Error ? e.message : "Failed");
     }
   }
 
@@ -57,6 +59,20 @@ export default function AudioPage() {
     return <div role="alert" className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm">{error}</div>;
 
   return (
+    <div className="space-y-3">
+      {actError && (
+        <div role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 flex items-center justify-between gap-3">
+          <span>{actError}</span>
+          <button
+            type="button"
+            onClick={() => setActError(null)}
+            aria-label="Dismiss error"
+            className="shrink-0 text-red-500 hover:text-red-700 text-lg leading-none"
+          >
+            ×
+          </button>
+        </div>
+      )}
     <div className="bg-white rounded-xl border border-amber-200 divide-y divide-amber-100 overflow-hidden">
       {audio.map((a, i) => (
         <div key={i} className="px-4 py-3 flex items-center gap-3">
@@ -82,6 +98,7 @@ export default function AudioPage() {
       {audio.length === 0 && (
         <div className="px-4 py-8 text-center text-amber-700 text-sm">No audio cached.</div>
       )}
+    </div>
     </div>
   );
 }

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -52,6 +52,12 @@ export default function BooksPage() {
   const [translations, setTranslations] = useState<TranslationEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [actError, setActError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const [pendingConfirm, setPendingConfirm] = useState<{
+    message: string;
+    fn: () => void | Promise<void>;
+  } | null>(null);
   const [importId, setImportId] = useState("");
   const [importing, setImporting] = useState(false);
   const [expandedBookId, setExpandedBookId] = useState<number | null>(null);
@@ -61,19 +67,19 @@ export default function BooksPage() {
   const [retranslating, setRetranslating] = useState<string | null>(null);
   const [bulkRetranslating, setBulkRetranslating] = useState<string | null>(null);
   const [retryingFailed, setRetryingFailed] = useState<string | null>(null);
-  // Per-row input for "Move to chapter N" action — keyed by
-  // `${book_id}:${chapter_index}:${lang}` so two open books don't share state.
   const [moveInput, setMoveInput] = useState<Record<string, string>>({});
   const [moving, setMoving] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
+
+  function showToast(msg: string) {
+    setToast(msg);
+    setTimeout(() => setToast(null), 4000);
+  }
 
   const load = useCallback(async ({ silent = false }: { silent?: boolean } = {}) => {
     if (!silent) setLoading(true);
     setError("");
     try {
-      // Books endpoint is the main payload. Translations drives the per-chapter
-      // drill-down; lazy-load it only when a book row is expanded? For now keep
-      // it parallel since translations is small relative to books.
       const [b, t] = await Promise.all([adminFetch("/admin/books"), adminFetch("/admin/translations")]);
       setBooks(b);
       setTranslations(t);
@@ -92,8 +98,9 @@ export default function BooksPage() {
     try {
       await fn();
       await load({ silent: true });
+      setActError(null);
     } catch (e: unknown) {
-      alert(e instanceof Error ? e.message : "Failed");
+      setActError(e instanceof Error ? e.message : "Failed");
     }
   }
 
@@ -106,7 +113,7 @@ export default function BooksPage() {
         method: "POST",
         body: JSON.stringify({ book_id: id }),
       });
-      alert(
+      showToast(
         res.status === "already_cached"
           ? `"${res.title}" is already cached.`
           : `Imported "${res.title}" (${res.text_length?.toLocaleString()} chars)`,
@@ -114,33 +121,32 @@ export default function BooksPage() {
       setImportId("");
       await load({ silent: true });
     } catch (e: unknown) {
-      alert(e instanceof Error ? e.message : "Import failed");
+      setActError(e instanceof Error ? e.message : "Import failed");
     } finally {
       setImporting(false);
     }
   }
 
-  async function handleRetranslate(t: TranslationEntry) {
+  function handleRetranslate(t: TranslationEntry) {
     const key = `${t.book_id}:${t.chapter_index}:${t.target_language}`;
-    if (
-      !confirm(
-        `Retranslate Book ${t.book_id}, Ch. ${t.chapter_index + 1} → ${t.target_language}?\nThis will delete the cached version and generate a fresh translation.`,
-      )
-    )
-      return;
-    setRetranslating(key);
-    try {
-      const res = await adminFetch(
-        `/admin/translations/${t.book_id}/${t.chapter_index}/${t.target_language}/retranslate`,
-        { method: "POST" },
-      );
-      alert(`Retranslated via ${res.provider}: ${res.paragraphs_count} paragraphs`);
-      await load({ silent: true });
-    } catch (e: unknown) {
-      alert(e instanceof Error ? e.message : "Retranslation failed");
-    } finally {
-      setRetranslating(null);
-    }
+    setPendingConfirm({
+      message: `Retranslate Book ${t.book_id}, Ch. ${t.chapter_index + 1} → ${t.target_language}? This will delete the cached version and generate a fresh translation.`,
+      fn: async () => {
+        setRetranslating(key);
+        try {
+          const res = await adminFetch(
+            `/admin/translations/${t.book_id}/${t.chapter_index}/${t.target_language}/retranslate`,
+            { method: "POST" },
+          );
+          showToast(`Retranslated via ${res.provider}: ${res.paragraphs_count} paragraphs`);
+          await load({ silent: true });
+        } catch (e: unknown) {
+          setActError(e instanceof Error ? e.message : "Retranslation failed");
+        } finally {
+          setRetranslating(null);
+        }
+      },
+    });
   }
 
   async function queueLanguageForBook(book: Book, lang: string) {
@@ -152,69 +158,70 @@ export default function BooksPage() {
         method: "POST",
         body: JSON.stringify({ book_id: book.id, target_languages: [lang], priority: 50 }),
       });
-      alert(`Queued ${res.enqueued} chapter(s) of "${book.title}" → ${lang}.`);
+      showToast(`Queued ${res.enqueued} chapter(s) of "${book.title}" → ${lang}.`);
       await load({ silent: true });
     } catch (e: unknown) {
-      alert(e instanceof Error ? e.message : "Enqueue failed");
+      setActError(e instanceof Error ? e.message : "Enqueue failed");
     } finally {
       setQueueingLangFor(null);
     }
   }
 
-  async function handleMove(t: TranslationEntry, rawInput: string) {
-    // User types a 1-based chapter number to match the visible "Ch. N"
-    // label; convert to 0-based for the backend.
+  function handleMove(t: TranslationEntry, rawInput: string) {
     const parsed = parseInt(rawInput.trim(), 10);
     if (isNaN(parsed) || parsed < 1) {
-      alert("Enter a chapter number (1-based, e.g. 6).");
+      setActError("Enter a chapter number (1-based, e.g. 6).");
       return;
     }
     const newIdx = parsed - 1;
     if (newIdx === t.chapter_index) {
-      alert("Target chapter is the same as the source.");
+      setActError("Target chapter is the same as the source.");
       return;
     }
     const rowKey = `${t.book_id}:${t.chapter_index}:${t.target_language}`;
-    if (
-      !confirm(
-        `Reassign translation from Ch. ${t.chapter_index + 1} to Ch. ${parsed} for ${t.target_language}?\nNo tokens are used — this only moves the existing cached paragraphs.`,
-      )
-    )
-      return;
-    setMoving(rowKey);
-    try {
-      await adminFetch(
-        `/admin/translations/${t.book_id}/${t.chapter_index}/${t.target_language}/move`,
-        {
-          method: "POST",
-          body: JSON.stringify({ new_chapter_index: newIdx }),
-        },
-      );
-      setMoveInput({ ...moveInput, [rowKey]: "" });
-      await load({ silent: true });
-    } catch (e: unknown) {
-      alert(e instanceof Error ? e.message : "Move failed");
-    } finally {
-      setMoving(null);
-    }
+    setPendingConfirm({
+      message: `Reassign translation from Ch. ${t.chapter_index + 1} to Ch. ${parsed} for ${t.target_language}? No tokens are used — this only moves the existing cached paragraphs.`,
+      fn: async () => {
+        setMoving(rowKey);
+        try {
+          await adminFetch(
+            `/admin/translations/${t.book_id}/${t.chapter_index}/${t.target_language}/move`,
+            {
+              method: "POST",
+              body: JSON.stringify({ new_chapter_index: newIdx }),
+            },
+          );
+          setMoveInput((prev) => ({ ...prev, [rowKey]: "" }));
+          await load({ silent: true });
+        } catch (e: unknown) {
+          setActError(e instanceof Error ? e.message : "Move failed");
+        } finally {
+          setMoving(null);
+        }
+      },
+    });
   }
 
-  async function retryFailedForLang(book: Book, lang: string, failedCount: number) {
+  function retryFailedForLang(book: Book, lang: string, failedCount: number) {
     const key = `${book.id}:${lang}`;
-    if (!confirm(`Retry ${failedCount} failed chapter(s) of "${book.title}" → ${lang}?`)) return;
-    setRetryingFailed(key);
-    try {
-      const res = await adminFetch("/admin/queue/retry-failed", {
-        method: "POST",
-        body: JSON.stringify({ book_id: book.id, target_language: lang }),
-      });
-      alert(`Re-queued ${res.updated} failed chapter(s) of "${book.title}" → ${lang}.`);
-      await load({ silent: true });
-    } catch (e: unknown) {
-      alert(e instanceof Error ? e.message : "Retry failed");
-    } finally {
-      setRetryingFailed(null);
-    }
+    setPendingConfirm({
+      message: `Retry ${failedCount} failed chapter(s) of "${book.title}" → ${lang}?`,
+      fn: async () => {
+        setRetryingFailed(key);
+        try {
+          const res = await adminFetch("/admin/queue/retry-failed", {
+            method: "POST",
+            body: JSON.stringify({ book_id: book.id, target_language: lang }),
+          });
+          showToast(`Re-queued ${res.updated} failed chapter(s) of "${book.title}" → ${lang}.`);
+          await load({ silent: true });
+        } catch (e: unknown) {
+          setActError(e instanceof Error ? e.message : "Retry failed");
+        } finally {
+          setRetryingFailed(null);
+        }
+      },
+    });
   }
 
   if (loading)
@@ -229,6 +236,62 @@ export default function BooksPage() {
     <div className="space-y-4">
       {error && (
         <div role="alert" className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm">{error}</div>
+      )}
+
+      {pendingConfirm && (
+        <div role="dialog" aria-label="Confirm action" className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm flex items-start gap-3">
+          <p className="flex-1 text-amber-900">{pendingConfirm.message}</p>
+          <div className="flex gap-2 shrink-0">
+            <button
+              type="button"
+              onClick={async () => {
+                const fn = pendingConfirm.fn;
+                setPendingConfirm(null);
+                await fn();
+              }}
+              aria-label="Confirm action"
+              className="px-3 py-1.5 rounded border border-amber-500 bg-amber-100 text-amber-800 hover:bg-amber-200 text-xs font-medium"
+            >
+              Confirm
+            </button>
+            <button
+              type="button"
+              onClick={() => setPendingConfirm(null)}
+              aria-label="Cancel action"
+              className="px-3 py-1.5 rounded border border-stone-200 text-stone-600 hover:bg-stone-50 text-xs"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {actError && (
+        <div role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 flex items-center justify-between gap-3">
+          <span>{actError}</span>
+          <button
+            type="button"
+            onClick={() => setActError(null)}
+            aria-label="Dismiss error"
+            className="shrink-0 text-red-500 hover:text-red-700 text-lg leading-none"
+          >
+            ×
+          </button>
+        </div>
+      )}
+
+      {toast && (
+        <div role="status" className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 flex items-center justify-between gap-3">
+          <span>{toast}</span>
+          <button
+            type="button"
+            onClick={() => setToast(null)}
+            aria-label="Dismiss message"
+            className="shrink-0 text-emerald-500 hover:text-emerald-700 text-lg leading-none"
+          >
+            ×
+          </button>
+        </div>
       )}
 
       <div className="flex gap-2">
@@ -251,9 +314,6 @@ export default function BooksPage() {
 
       <SeedPopularButton adminFetch={adminFetch} onComplete={() => load({ silent: true })} />
 
-      {/* Fuzzy filter — matches against title + authors + book ID. Stays
-          client-side since the admin endpoint already returns the full
-          books list. Preserves existing expansion state while typing. */}
       <div className="flex items-center gap-2">
         <input
           type="search"
@@ -403,10 +463,12 @@ export default function BooksPage() {
                 </button>
 
                 <button
-                  onClick={() => {
-                    if (confirm(`Delete "${b.title}" and all its audio/translations?`))
-                      act(() => adminFetch(`/admin/books/${b.id}`, { method: "DELETE" }));
-                  }}
+                  onClick={() =>
+                    setPendingConfirm({
+                      message: `Delete "${b.title}" and all its audio/translations?`,
+                      fn: () => act(() => adminFetch(`/admin/books/${b.id}`, { method: "DELETE" })),
+                    })
+                  }
                   aria-label={`Delete ${b.title}`}
                   className="text-xs px-2 py-1 rounded border border-red-200 text-red-600 shrink-0 min-h-[44px]"
                 >
@@ -448,44 +510,43 @@ export default function BooksPage() {
 
                               <button
                                 disabled={bulkRetranslating === bulkKey}
-                                onClick={async () => {
-                                  if (
-                                    !confirm(
-                                      `Retranslate ALL ${count} chapters of "${b.title}" → ${lang}? This deletes the current cache and regenerates.`,
-                                    )
-                                  )
-                                    return;
-                                  setBulkRetranslating(bulkKey);
-                                  try {
-                                    const res = await adminFetch(`/admin/translations/${b.id}/retranslate-all`, {
-                                      method: "POST",
-                                      body: JSON.stringify({ target_language: lang }),
-                                    });
-                                    alert(
-                                      `Retranslated ${res.chapters} chapters of "${b.title}" → ${lang}`,
-                                    );
-                                    await load({ silent: true });
-                                  } catch (e: unknown) {
-                                    alert(e instanceof Error ? e.message : "Failed");
-                                  } finally {
-                                    setBulkRetranslating(null);
-                                  }
-                                }}
+                                onClick={() =>
+                                  setPendingConfirm({
+                                    message: `Retranslate ALL ${count} chapters of "${b.title}" → ${lang}? This deletes the current cache and regenerates.`,
+                                    fn: async () => {
+                                      setBulkRetranslating(bulkKey);
+                                      try {
+                                        const res = await adminFetch(`/admin/translations/${b.id}/retranslate-all`, {
+                                          method: "POST",
+                                          body: JSON.stringify({ target_language: lang }),
+                                        });
+                                        showToast(`Retranslated ${res.chapters} chapters of "${b.title}" → ${lang}`);
+                                        await load({ silent: true });
+                                      } catch (e: unknown) {
+                                        setActError(e instanceof Error ? e.message : "Failed");
+                                      } finally {
+                                        setBulkRetranslating(null);
+                                      }
+                                    },
+                                  })
+                                }
                                 aria-label={`Retranslate all ${lang} chapters of ${b.title}`}
                                 className="ml-auto text-xs px-2 py-1 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-50 min-h-[44px]"
                               >
                                 {bulkRetranslating === bulkKey ? "Retranslating…" : "Retranslate all"}
                               </button>
                               <button
-                                onClick={() => {
-                                  if (!confirm(`Delete all ${count} cached ${lang} translations for "${b.title}"?`))
-                                    return;
-                                  act(() =>
-                                    adminFetch(`/admin/translations/${b.id}/${lang}`, {
-                                      method: "DELETE",
-                                    }),
-                                  );
-                                }}
+                                onClick={() =>
+                                  setPendingConfirm({
+                                    message: `Delete all ${count} cached ${lang} translations for "${b.title}"?`,
+                                    fn: () =>
+                                      act(() =>
+                                        adminFetch(`/admin/translations/${b.id}/${lang}`, {
+                                          method: "DELETE",
+                                        }),
+                                      ),
+                                  })
+                                }
                                 aria-label={`Delete all ${lang} translations for ${b.title}`}
                                 className="text-xs px-2 py-1 rounded border border-red-200 text-red-600 min-h-[44px]"
                               >
@@ -513,11 +574,6 @@ export default function BooksPage() {
                                           <span className="text-stone-500 flex-1">
                                             {(t.size_chars / 1000).toFixed(1)}K chars
                                           </span>
-                                          {/* Move-to: reassign the cached translation
-                                              to a different chapter index without
-                                              burning tokens. Used to fix splitter-
-                                              realignment cases where paragraphs are
-                                              correct but the chapter_index is wrong. */}
                                           <input
                                             aria-label="Move to chapter number"
                                             type="number"

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -134,6 +134,12 @@ export default function QueueTab({ adminFetch }: Props) {
   // the initial "pending" captured in its closure.
   const itemFilterRef = useRef(itemFilter);
   const [error, setError] = useState("");
+  const [actError, setActError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const [pendingConfirm, setPendingConfirm] = useState<{
+    message: string;
+    fn: () => void | Promise<void>;
+  } | null>(null);
   const [saving, setSaving] = useState(false);
   // Per-section loading flags so a slow fetch spins only its own panel
   // instead of freezing the whole tab. Each is set true at the start of
@@ -332,29 +338,39 @@ export default function QueueTab({ adminFetch }: Props) {
     }
   }
 
-  async function stopWorker() {
-    if (!confirm("Stop the translation queue worker? Pending items stay in the queue.")) return;
-    setTogglingWorker("stop");
-    try {
-      // Backend waits up to ~20s for the in-flight batch to finish, so
-      // this PUT can hang for a while. The button shows a spinner +
-      // "Stopping…" during the wait.
-      await adminFetch("/admin/queue/stop", { method: "POST" });
-      refreshCore();
-    } finally {
-      setTogglingWorker(null);
-    }
+  function showToast(msg: string) {
+    setToast(msg);
+    setTimeout(() => setToast(null), 4000);
   }
 
-  async function enqueueAll() {
-    if (!confirm("Queue EVERY cached book for translation into all configured languages?")) return;
-    try {
-      const res = await adminFetch("/admin/queue/enqueue-all", { method: "POST" });
-      alert(`Enqueued ${res.enqueued} chapter(s) across ${res.books_scanned} book(s).`);
-      await refresh();
-    } catch (e: unknown) {
-      alert(e instanceof Error ? e.message : "Failed");
-    }
+  function stopWorker() {
+    setPendingConfirm({
+      message: "Stop the translation queue worker? Pending items stay in the queue.",
+      fn: async () => {
+        setTogglingWorker("stop");
+        try {
+          await adminFetch("/admin/queue/stop", { method: "POST" });
+          refreshCore();
+        } finally {
+          setTogglingWorker(null);
+        }
+      },
+    });
+  }
+
+  function enqueueAll() {
+    setPendingConfirm({
+      message: "Queue EVERY cached book for translation into all configured languages?",
+      fn: async () => {
+        try {
+          const res = await adminFetch("/admin/queue/enqueue-all", { method: "POST" });
+          showToast(`Enqueued ${res.enqueued} chapter(s) across ${res.books_scanned} book(s).`);
+          await refresh();
+        } catch (e: unknown) {
+          setActError(e instanceof Error ? e.message : "Failed");
+        }
+      },
+    });
   }
 
   async function retry(item: QueueItem) {
@@ -362,33 +378,41 @@ export default function QueueTab({ adminFetch }: Props) {
       await adminFetch(`/admin/queue/items/${item.id}/retry`, { method: "POST" });
       await refresh();
     } catch (e: unknown) {
-      alert(e instanceof Error ? e.message : "Retry failed");
+      setActError(e instanceof Error ? e.message : "Retry failed");
     }
   }
 
-  async function remove(item: QueueItem) {
-    if (!confirm(`Remove queue item #${item.id}?`)) return;
-    try {
-      await adminFetch(`/admin/queue/items/${item.id}`, { method: "DELETE" });
-      await refresh();
-    } catch (e: unknown) {
-      alert(e instanceof Error ? e.message : "Delete failed");
-    }
+  function remove(item: QueueItem) {
+    setPendingConfirm({
+      message: `Remove queue item #${item.id}?`,
+      fn: async () => {
+        try {
+          await adminFetch(`/admin/queue/items/${item.id}`, { method: "DELETE" });
+          await refresh();
+        } catch (e: unknown) {
+          setActError(e instanceof Error ? e.message : "Delete failed");
+        }
+      },
+    });
   }
 
-  async function clearAll() {
+  function clearAll() {
     const scope = itemFilter === "all" ? "ALL" : itemFilter;
-    if (!confirm(`Delete ${scope} queue items? This is irreversible (but you can re-enqueue via the Books tab).`)) return;
-    try {
-      const path = itemFilter === "all"
-        ? "/admin/queue"
-        : `/admin/queue?status=${itemFilter}`;
-      const res = await adminFetch(path, { method: "DELETE" });
-      alert(`Deleted ${res.deleted} queue item(s).`);
-      await refresh();
-    } catch (e: unknown) {
-      alert(e instanceof Error ? e.message : "Clear failed");
-    }
+    setPendingConfirm({
+      message: `Delete ${scope} queue items? This is irreversible (but you can re-enqueue via the Books tab).`,
+      fn: async () => {
+        try {
+          const path = itemFilter === "all"
+            ? "/admin/queue"
+            : `/admin/queue?status=${itemFilter}`;
+          const res = await adminFetch(path, { method: "DELETE" });
+          showToast(`Deleted ${res.deleted} queue item(s).`);
+          await refresh();
+        } catch (e: unknown) {
+          setActError(e instanceof Error ? e.message : "Clear failed");
+        }
+      },
+    });
   }
 
   async function runDryRun() {
@@ -476,6 +500,62 @@ export default function QueueTab({ adminFetch }: Props) {
       {error && (
         <div role="alert" className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-2 text-sm">
           {error}
+        </div>
+      )}
+
+      {pendingConfirm && (
+        <div role="dialog" aria-label="Confirm action" className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm flex items-start gap-3">
+          <p className="flex-1 text-amber-900">{pendingConfirm.message}</p>
+          <div className="flex gap-2 shrink-0">
+            <button
+              type="button"
+              onClick={async () => {
+                const fn = pendingConfirm.fn;
+                setPendingConfirm(null);
+                await fn();
+              }}
+              aria-label="Confirm action"
+              className="px-3 py-1.5 rounded border border-amber-500 bg-amber-100 text-amber-800 hover:bg-amber-200 text-xs font-medium"
+            >
+              Confirm
+            </button>
+            <button
+              type="button"
+              onClick={() => setPendingConfirm(null)}
+              aria-label="Cancel action"
+              className="px-3 py-1.5 rounded border border-stone-200 text-stone-600 hover:bg-stone-50 text-xs"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {actError && (
+        <div role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 flex items-center justify-between gap-3">
+          <span>{actError}</span>
+          <button
+            type="button"
+            onClick={() => setActError(null)}
+            aria-label="Dismiss error"
+            className="shrink-0 text-red-500 hover:text-red-700 text-lg leading-none"
+          >
+            ×
+          </button>
+        </div>
+      )}
+
+      {toast && (
+        <div role="status" className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 flex items-center justify-between gap-3">
+          <span>{toast}</span>
+          <button
+            type="button"
+            onClick={() => setToast(null)}
+            aria-label="Dismiss message"
+            className="shrink-0 text-emerald-500 hover:text-emerald-700 text-lg leading-none"
+          >
+            ×
+          </button>
         </div>
       )}
 
@@ -834,9 +914,12 @@ export default function QueueTab({ adminFetch }: Props) {
               </button>
               {settings?.has_api_key && (
                 <button
-                  onClick={() => {
-                    if (confirm("Clear queue API key?")) saveSettings({ api_key: "" });
-                  }}
+                  onClick={() =>
+                    setPendingConfirm({
+                      message: "Clear queue API key?",
+                      fn: () => saveSettings({ api_key: "" }),
+                    })
+                  }
                   className="text-xs px-2 py-1 rounded border border-red-200 text-red-600 min-h-[44px]"
                 >
                   Clear

--- a/frontend/src/components/SeedPopularButton.tsx
+++ b/frontend/src/components/SeedPopularButton.tsx
@@ -39,6 +39,8 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
   const [status, setStatus] = useState<StatusResp | null>(null);
   const [expanded, setExpanded] = useState(false);
   const [error, setError] = useState("");
+  const [pendingStart, setPendingStart] = useState(false);
+  const [pendingStop, setPendingStop] = useState(false);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const completedKeyRef = useRef<string | null>(null);
 
@@ -71,14 +73,8 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  async function start() {
-    if (!confirm(
-      "Download every popular book listed in popular_books.json into the DB.\n\n" +
-      "This hits Gutenberg for each uncached book (~1 second each). Books " +
-      "already cached are skipped. Can take 5–15 minutes.\n\n" +
-      "The job runs in the background — you can navigate away and come back; " +
-      "progress keeps going on the server."
-    )) return;
+  async function confirmStart() {
+    setPendingStart(false);
     setError("");
     setExpanded(true);
     try {
@@ -89,8 +85,8 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
     }
   }
 
-  async function stop() {
-    if (!confirm("Stop the seed job? Already-downloaded books stay cached.")) return;
+  async function confirmStop() {
+    setPendingStop(false);
     try {
       await adminFetch("/admin/books/seed-popular/stop", { method: "POST" });
       await refresh();
@@ -107,15 +103,39 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center gap-2">
-        <button
-          onClick={start}
-          disabled={running}
-          className="rounded-lg border border-amber-300 text-amber-700 px-4 py-2 min-h-[44px] text-sm hover:bg-amber-50 disabled:opacity-50"
-        >
-          {running ? "Seeding…" : "Seed all popular books"}
-        </button>
-        {state && state.status !== "idle" && !expanded && (
+      <div className="flex items-center gap-2 flex-wrap">
+        {pendingStart ? (
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-sm text-amber-800">
+              Download all popular books from Gutenberg? (5–15 min, runs in background)
+            </span>
+            <button
+              type="button"
+              onClick={confirmStart}
+              aria-label="Confirm seed popular books"
+              className="rounded-lg border border-emerald-300 text-emerald-700 px-3 py-1.5 min-h-[44px] md:min-h-0 text-sm hover:bg-emerald-50"
+            >
+              Yes, start
+            </button>
+            <button
+              type="button"
+              onClick={() => setPendingStart(false)}
+              aria-label="Cancel seed"
+              className="rounded-lg border border-stone-200 text-stone-600 px-3 py-1.5 min-h-[44px] md:min-h-0 text-sm hover:bg-stone-50"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={() => setPendingStart(true)}
+            disabled={running}
+            className="rounded-lg border border-amber-300 text-amber-700 px-4 py-2 min-h-[44px] text-sm hover:bg-amber-50 disabled:opacity-50"
+          >
+            {running ? "Seeding…" : "Seed all popular books"}
+          </button>
+        )}
+        {state && state.status !== "idle" && !expanded && !pendingStart && (
           <button
             onClick={() => setExpanded(true)}
             className="text-xs text-amber-700 hover:text-amber-900 min-h-[44px] flex items-center"
@@ -123,7 +143,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
             Show progress
           </button>
         )}
-        {state && state.status !== "idle" && expanded && !running && (
+        {state && state.status !== "idle" && expanded && !running && !pendingStart && (
           <button
             onClick={() => setExpanded(false)}
             className="text-xs text-stone-500 hover:text-stone-700 min-h-[44px] flex items-center"
@@ -147,13 +167,35 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
               }`}>
                 {running ? "Running" : state.status}
               </span>
-              {running && (
+              {running && !pendingStop && (
                 <button
-                  onClick={stop}
+                  type="button"
+                  onClick={() => setPendingStop(true)}
                   className="text-xs text-red-600 hover:text-red-800 min-h-[44px] flex items-center"
                 >
                   Stop
                 </button>
+              )}
+              {running && pendingStop && (
+                <div className="flex items-center gap-1">
+                  <span className="text-xs text-red-600 whitespace-nowrap">Stop job?</span>
+                  <button
+                    type="button"
+                    onClick={confirmStop}
+                    aria-label="Confirm stop seed job"
+                    className="text-xs px-2 py-1 rounded border border-red-400 bg-red-50 text-red-700 min-h-[44px] md:min-h-0 flex items-center"
+                  >
+                    Yes
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setPendingStop(false)}
+                    aria-label="Cancel stop"
+                    className="text-xs px-2 py-1 rounded border border-stone-200 text-stone-600 min-h-[44px] md:min-h-0 flex items-center"
+                  >
+                    No
+                  </button>
+                </div>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary

- Replace all `alert()` / `confirm()` blocking browser dialogs in admin pages with inline accessible patterns (WCAG 3.3.1)
- `admin/books/page.tsx`: central `pendingConfirm` state → `role="dialog"` inline confirmation banner; `actError` state → `role="alert"` dismissible banner; `showToast()` helper → `role="status"` auto-dismiss toast
- `QueueTab.tsx`: same three-state pattern for stop/start worker, enqueue-all, retry, remove, clear-all, and API key clear actions
- `SeedPopularButton.tsx`: `pendingStart` / `pendingStop` states replace `confirm()` calls with inline Yes/Cancel inline buttons
- `admin/audio/page.tsx`: `actError` state replaces `alert()` error calls with `role="alert"` banner
- New static assertion test (`AdminBlockingDialogsReplaced.test.ts`) verifies no `alert()` / `confirm()` remain in the four source files
- Updated all 10 affected test files to interact with inline confirmation buttons instead of mocking `window.confirm`, and to check `role="alert"` / `role="status"` elements instead of `window.alert` call counts

## Why

Browser `alert()` / `confirm()` dialogs break screen reader announcement queues (WCAG 3.3.1) and can be suppressed by browsers in background tabs. Inline ARIA patterns give the same user feedback without interrupting assistive technology.

## Test plan

- [x] `npm --prefix frontend test -- --no-coverage --ci` — 2751 tests pass (429 suites)
- [x] Static test `AdminBlockingDialogsReplaced` asserts no `alert()`/`confirm()` in source files
- [x] Inline confirmation dialogs verified: pending state shows `role="dialog"`, clicking Confirm fires action, clicking Cancel dismisses without action
- [x] Error banners render as `role="alert"`, success toasts as `role="status"`

Closes #1897

🤖 Generated with [Claude Code](https://claude.com/claude-code)
