### PR TITLE
ux: context-rich aria-labels for QueueTab queue-item buttons (closes #1899)

### DIFF
--- a/frontend/src/__tests__/QueueTab.branches2.test.tsx
+++ b/frontend/src/__tests__/QueueTab.branches2.test.tsx
@@ -433,7 +433,7 @@ describe("QueueTab.branches2 — Clear API key button (line 620)", () => {
     await renderAndWait(adminFetch);
 
     // Click "Clear" → inline confirmation appears
-    const clearBtn = screen.getByRole("button", { name: /^Clear$/i });
+    const clearBtn = screen.getByRole("button", { name: /clear gemini api key/i });
     await userEvent.click(clearBtn);
     // Confirm via inline dialog
     await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
@@ -461,7 +461,7 @@ describe("QueueTab.branches2 — Clear API key button (line 620)", () => {
     ).length;
 
     // Click "Clear" → inline confirmation appears
-    const clearBtn = screen.getByRole("button", { name: /^Clear$/i });
+    const clearBtn = screen.getByRole("button", { name: /clear gemini api key/i });
     await userEvent.click(clearBtn);
     // Cancel via inline dialog
     await userEvent.click(screen.getByRole("button", { name: /cancel action/i }));

--- a/frontend/src/__tests__/QueueTab.coverage.test.tsx
+++ b/frontend/src/__tests__/QueueTab.coverage.test.tsx
@@ -413,7 +413,7 @@ describe("queue item actions: retry, remove, clearAll (lines 325-357)", () => {
 
     await renderAndWait(adminFetch);
 
-    const delBtn = await screen.findByRole("button", { name: /del/i });
+    const delBtn = await screen.findByRole("button", { name: /remove.*from queue/i });
     await userEvent.click(delBtn);
     // Confirm via inline dialog
     await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
@@ -432,7 +432,7 @@ describe("queue item actions: retry, remove, clearAll (lines 325-357)", () => {
 
     await renderAndWait(adminFetch);
 
-    const delBtn = await screen.findByRole("button", { name: /del/i });
+    const delBtn = await screen.findByRole("button", { name: /remove.*from queue/i });
     await userEvent.click(delBtn);
     // Cancel via inline dialog
     await userEvent.click(screen.getByRole("button", { name: /cancel action/i }));
@@ -1012,7 +1012,7 @@ describe("QueueTab — retry/remove error handling (issue #273)", () => {
 
     await renderAndWait(adminFetch);
 
-    const delBtn = await screen.findByRole("button", { name: /del/i });
+    const delBtn = await screen.findByRole("button", { name: /remove.*from queue/i });
     await userEvent.click(delBtn);
     // Confirm via inline dialog
     await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));

--- a/frontend/src/__tests__/QueueTabItemAriaLabels.test.ts
+++ b/frontend/src/__tests__/QueueTabItemAriaLabels.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Regression test for #1899: queue-item Retry/Del buttons and API-key Clear
+ * button must have context-rich aria-labels (WCAG 2.4.6).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/QueueTab.tsx"),
+  "utf8",
+);
+
+describe("QueueTab queue-item button accessible names (closes #1899)", () => {
+  it("Retry button has aria-label referencing book_title and target_language", () => {
+    // The Retry button's aria-label must include book context
+    expect(src).toContain("it.book_title");
+    // Find the section near the Retry button text
+    const retryIdx = src.lastIndexOf(">\\n                      Retry");
+    // Alternatively just check the aria-label template contains the right variables
+    expect(src).toMatch(/aria-label=\{`Retry \$\{it\.book_title[\s\S]{1,200}target_language\}`\}/);
+  });
+
+  it("Del button has aria-label with 'Remove' and book context", () => {
+    expect(src).toMatch(/aria-label=\{`Remove \$\{it\.book_title[\s\S]{1,200}target_language[\s\S]{1,30}queue`\}/);
+  });
+
+  it("API-key Clear button has descriptive aria-label", () => {
+    expect(src).toContain('aria-label="Clear Gemini API key"');
+  });
+});

--- a/frontend/src/__tests__/QueueTabPlanningSettingsTouchTargets.test.ts
+++ b/frontend/src/__tests__/QueueTabPlanningSettingsTouchTargets.test.ts
@@ -27,7 +27,7 @@ describe("QueueTab planning/settings buttons touch targets", () => {
   });
 
   it("Clear API key button has min-h-[44px]", () => {
-    expect(src).toMatch(/Clear queue API key[\s\S]{0,200}min-h-\[44px\]/);
+    expect(src).toMatch(/Clear queue API key[\s\S]{0,280}min-h-\[44px\]/);
   });
 
   it("model chain add buttons have min-h-[44px]", () => {

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -920,6 +920,7 @@ export default function QueueTab({ adminFetch }: Props) {
                       fn: () => saveSettings({ api_key: "" }),
                     })
                   }
+                  aria-label="Clear Gemini API key"
                   className="text-xs px-2 py-1 rounded border border-red-200 text-red-600 min-h-[44px]"
                 >
                   Clear
@@ -1396,6 +1397,7 @@ export default function QueueTab({ adminFetch }: Props) {
                   {it.status === "failed" && (
                     <button
                       onClick={() => retry(it)}
+                      aria-label={`Retry ${it.book_title || `book ${it.book_id}`} ch${it.chapter_index + 1} → ${it.target_language}`}
                       className="px-1.5 py-0.5 rounded border border-amber-300 text-amber-700 min-h-[44px] flex items-center"
                     >
                       Retry
@@ -1403,6 +1405,7 @@ export default function QueueTab({ adminFetch }: Props) {
                   )}
                   <button
                     onClick={() => remove(it)}
+                    aria-label={`Remove ${it.book_title || `book ${it.book_id}`} ch${it.chapter_index + 1} → ${it.target_language} from queue`}
                     className="px-1.5 py-0.5 rounded border border-red-200 text-red-600 min-h-[44px] flex items-center"
                   >
                     Del


### PR DESCRIPTION
## What changed
- `QueueTab.tsx`: Retry and Del buttons in the queue-item list now carry context-rich `aria-label` attributes containing book title, chapter number, and target language (e.g. `"Retry Test Book ch1 → zh"`). This lets screen readers distinguish each button in a long list (WCAG 2.4.6 — Headings and Labels).
- Clear API key button gets `aria-label="Clear Gemini API key"` so its purpose is unambiguous out of context.

## Why
Without descriptive labels, a screen reader announces "Retry, Retry, Retry…" for every queue item — users have no way to tell which book each button acts on. Closes #1899.

## Test plan
- New `QueueTabItemAriaLabels.test.ts` (3 tests): static source assertions verify all three aria-label patterns are present.
- Updated `QueueTab.coverage.test.tsx` (3 tests): Del-button queries updated from `/del/i` → `/remove.*from queue/i` to match the new accessible name.
- Updated `QueueTab.branches2.test.tsx` (2 tests): Clear-button queries updated from `/^Clear$/i` → `/clear gemini api key/i`.
- Updated `QueueTabPlanningSettingsTouchTargets.test.ts` (1 test): widened regex window for Clear button touch-target check to accommodate the new aria-label text.
- Full suite: 2754/2754 frontend tests pass.

## Docs follow-up
Design change logged: aria-label pattern for list-item buttons per WCAG 2.4.6.
