### PR TITLE
ux: add aria-label to popular-books list-view buttons (closes #1903)

### DIFF
--- a/frontend/src/__tests__/PopularBooksListViewAriaLabel.test.ts
+++ b/frontend/src/__tests__/PopularBooksListViewAriaLabel.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Regression test for #1903: popular-books list-view buttons must have
+ * aria-label so screen readers announce book title/author without the
+ * rank number and download count cluttering the accessible name.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/page.tsx"),
+  "utf8",
+);
+
+describe("Popular books list-view button accessible name (closes #1903)", () => {
+  it("list-view book button has aria-label referencing book.title", () => {
+    expect(src).toMatch(/aria-label=\{`Open \$\{book\.title\}/);
+  });
+
+  it("aria-label includes author attribution", () => {
+    expect(src).toMatch(/aria-label=\{`Open \$\{book\.title\}[^`]*book\.authors/);
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -728,6 +728,7 @@ export default function Home() {
                         <button
                           key={book.id}
                           onClick={() => handleBookClick(book)}
+                          aria-label={`Open ${book.title}${book.authors.length ? ` by ${book.authors.join(", ")}` : ""}`}
                           className="flex items-center gap-3 w-full px-4 py-3 text-left hover:bg-amber-50 transition-colors"
                         >
                           <span className="text-xs text-stone-500 w-7 text-right shrink-0 tabular-nums">


### PR DESCRIPTION
## What changed

Added `aria-label` to the popular-books list-view buttons in `src/app/page.tsx`.

## Why

Screen readers were announcing these buttons as e.g. `"2 Moby Dick Herman Melville 12,345 button"` — the popularity rank and download count appeared in the accessible name without any context, and there was no action verb. This violates WCAG 2.4.6 (Headings and Labels).

The new `aria-label="Open <title> by <authors>"` overrides the computed accessible name with a clear, descriptive one. Visual output is unchanged.

## Test plan

- New static-source assertion test `PopularBooksListViewAriaLabel.test.ts` verifies the `aria-label` template is present in source
- Full Jest suite: 2765 tests pass

Closes #1903

## Docs follow-up

N/A — no user-visible feature change, just accessible name fix.
