### PR TITLE
ux: add aria-label to admin books chapter-translation row buttons (closes #1905)

### DIFF
--- a/frontend/src/__tests__/AdminBooksChapterBtnAriaLabels.test.ts
+++ b/frontend/src/__tests__/AdminBooksChapterBtnAriaLabels.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Regression test for #1905: admin books chapter-translation row buttons
+ * must have aria-label so screen readers can distinguish "Move Ch. 1 zh"
+ * from "Move Ch. 2 zh" (WCAG 4.1.2 Name, Role, Value).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/admin/books/page.tsx"),
+  "utf8",
+);
+
+describe("Admin books page chapter-row button aria-labels (closes #1905)", () => {
+  it("Move button has aria-label with chapter index and target language", () => {
+    expect(src).toMatch(/aria-label=\{`Move Ch\. \$\{t\.chapter_index \+ 1\} \$\{t\.target_language\}/);
+  });
+
+  it("Retranslate button has aria-label with chapter index and target language", () => {
+    expect(src).toMatch(/aria-label=\{`Retranslate Ch\. \$\{t\.chapter_index \+ 1\} \$\{t\.target_language\}/);
+  });
+
+  it("Delete chapter translation button has aria-label with chapter index and target language", () => {
+    expect(src).toMatch(/aria-label=\{`Delete Ch\. \$\{t\.chapter_index \+ 1\} \$\{t\.target_language\}/);
+  });
+});

--- a/frontend/src/__tests__/AdminBooksPage.branches.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.branches.test.tsx
@@ -110,7 +110,7 @@ describe("AdminBooksPage — handleRetranslate error path (line 134)", () => {
     mockAdminFetch.mockRejectedValueOnce(new Error("Retranslation API error"));
 
     const retranslateBtns = await screen.findAllByRole("button", {
-      name: /^Retranslate$/i,
+      name: /^Retranslate Ch\./i,
     });
     await userEvent.click(retranslateBtns[0]);
     await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
@@ -127,7 +127,7 @@ describe("AdminBooksPage — handleRetranslate error path (line 134)", () => {
     mockAdminFetch.mockRejectedValueOnce("something went wrong");
 
     const retranslateBtns = await screen.findAllByRole("button", {
-      name: /^Retranslate$/i,
+      name: /^Retranslate Ch\./i,
     });
     await userEvent.click(retranslateBtns[0]);
     await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
@@ -148,7 +148,7 @@ describe("AdminBooksPage — handleMove confirm cancelled (line 177)", () => {
     await userEvent.clear(moveInputs[0]);
     await userEvent.type(moveInputs[0], "3");
 
-    const moveBtns = screen.getAllByRole("button", { name: /^Move$/i });
+    const moveBtns = screen.getAllByRole("button", { name: /^Move Ch\./i });
     await userEvent.click(moveBtns[0]);
     // Inline dialog appears — dismiss without confirming
     await userEvent.click(screen.getByRole("button", { name: /cancel action/i }));

--- a/frontend/src/__tests__/AdminBooksPage.branches2.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.branches2.test.tsx
@@ -220,7 +220,7 @@ describe("AdminBooksPage — handleMove non-Error catch (line 190)", () => {
     await userEvent.clear(moveInputs[0]);
     await userEvent.type(moveInputs[0], "5");
 
-    const moveBtns = screen.getAllByRole("button", { name: /^Move$/i });
+    const moveBtns = screen.getAllByRole("button", { name: /^Move Ch\./i });
     await userEvent.click(moveBtns[0]);
     await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
@@ -558,7 +558,7 @@ describe("AdminBooksPage — moveInput onChange (lines 512-518)", () => {
     await userEvent.type(moveInputs[0], "4");
     expect(moveInputs[0].value).toBe("4");
 
-    const moveBtns = screen.getAllByRole("button", { name: /^Move$/i });
+    const moveBtns = screen.getAllByRole("button", { name: /^Move Ch\./i });
     expect(moveBtns[0]).not.toBeDisabled();
   });
 });

--- a/frontend/src/__tests__/AdminBooksPage.coverage.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.coverage.test.tsx
@@ -226,9 +226,9 @@ describe("AdminBooksPage — handleRetranslate (lines 118-136)", () => {
     );
     if (langArrow) await userEvent.click(langArrow);
 
-    // Now "Retranslate" per-chapter button should appear
+    // Now "Retranslate Ch." per-chapter button should appear
     const retranslateBtns = await screen.findAllByRole("button", {
-      name: /^Retranslate$/i,
+      name: /^Retranslate Ch\./i,
     });
     expect(retranslateBtns.length).toBeGreaterThan(0);
 
@@ -270,7 +270,7 @@ describe("AdminBooksPage — handleRetranslate (lines 118-136)", () => {
     if (langArrow) await userEvent.click(langArrow);
 
     const retranslateBtns = await screen.findAllByRole("button", {
-      name: /^Retranslate$/i,
+      name: /^Retranslate Ch\./i,
     });
     await userEvent.click(retranslateBtns[0]);
     await userEvent.click(screen.getByRole("button", { name: /cancel action/i }));
@@ -652,13 +652,9 @@ describe("AdminBooksPage — chapter-level delete (lines 530-543)", () => {
 
     // After expanding, we have these buttons in order:
     //   Expand/Collapse book, ▶/▼ lang, "Retranslate all", "Delete all" (lang-level),
-    //   then per-chapter: "Move", "Retranslate", "Delete"
-    // The chapter-level Delete buttons have no red border class that matches
-    // "Delete all". Use getAllByRole and pick the last "Delete" (chapter row).
-    const deleteBtns = screen.getAllByRole("button", { name: /^Delete$/i });
-    // The last Delete buttons are the chapter-level ones (after book-level Delete
-    // which only appears once since we have one book)
-    // Chapter Delete is the very last button named "Delete"
+    //   then per-chapter: "Move Ch.", "Retranslate Ch.", "Delete Ch."
+    // Chapter-level Delete buttons have aria-label "Delete Ch. N zh translation".
+    const deleteBtns = screen.getAllByRole("button", { name: /^Delete Ch\./i });
     await userEvent.click(deleteBtns[deleteBtns.length - 1]);
 
     await waitFor(() =>
@@ -698,7 +694,7 @@ describe("AdminBooksPage — chapter move (lines 496-519)", () => {
     await userEvent.clear(moveInputs[0]);
     await userEvent.type(moveInputs[0], "1");
 
-    const moveBtns = screen.getAllByRole("button", { name: /^Move$/i });
+    const moveBtns = screen.getAllByRole("button", { name: /^Move Ch\./i });
     await userEvent.click(moveBtns[0]);
 
     await waitFor(() =>
@@ -713,7 +709,7 @@ describe("AdminBooksPage — chapter move (lines 496-519)", () => {
     await userEvent.clear(moveInputs[0]);
     await userEvent.type(moveInputs[0], "0");
 
-    const moveBtns = screen.getAllByRole("button", { name: /^Move$/i });
+    const moveBtns = screen.getAllByRole("button", { name: /^Move Ch\./i });
     await userEvent.click(moveBtns[0]);
 
     await waitFor(() =>
@@ -733,7 +729,7 @@ describe("AdminBooksPage — chapter move (lines 496-519)", () => {
     await userEvent.clear(moveInputs[0]);
     await userEvent.type(moveInputs[0], "5");
 
-    const moveBtns = screen.getAllByRole("button", { name: /^Move$/i });
+    const moveBtns = screen.getAllByRole("button", { name: /^Move Ch\./i });
     await userEvent.click(moveBtns[0]);
     await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 
@@ -754,7 +750,7 @@ describe("AdminBooksPage — chapter move (lines 496-519)", () => {
     await userEvent.clear(moveInputs[0]);
     await userEvent.type(moveInputs[0], "5");
 
-    const moveBtns = screen.getAllByRole("button", { name: /^Move$/i });
+    const moveBtns = screen.getAllByRole("button", { name: /^Move Ch\./i });
     await userEvent.click(moveBtns[0]);
     await userEvent.click(screen.getByRole("button", { name: /confirm action/i }));
 

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -592,6 +592,7 @@ export default function BooksPage() {
                                           <button
                                             onClick={() => handleMove(t, moveInput[rowKey] ?? "")}
                                             disabled={moving === rowKey || !(moveInput[rowKey] ?? "").trim()}
+                                            aria-label={`Move Ch. ${t.chapter_index + 1} ${t.target_language} translation`}
                                             className="px-2 py-0.5 rounded border border-sky-300 text-sky-700 hover:bg-sky-50 disabled:opacity-50 min-h-[44px]"
                                           >
                                             {moving === rowKey ? "…" : "Move"}
@@ -599,6 +600,7 @@ export default function BooksPage() {
                                           <button
                                             onClick={() => handleRetranslate(t)}
                                             disabled={retranslating === rowKey}
+                                            aria-label={`Retranslate Ch. ${t.chapter_index + 1} ${t.target_language}`}
                                             className="px-2 py-0.5 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-50 min-h-[44px]"
                                           >
                                             {retranslating === rowKey ? "…" : "Retranslate"}
@@ -612,6 +614,7 @@ export default function BooksPage() {
                                                 ),
                                               )
                                             }
+                                            aria-label={`Delete Ch. ${t.chapter_index + 1} ${t.target_language} translation`}
                                             className="px-2 py-0.5 rounded border border-red-200 text-red-600 min-h-[44px]"
                                           >
                                             Delete


### PR DESCRIPTION
## What changed

Added contextual `aria-label` to the three action buttons in the admin books page chapter-translation list rows: **Move**, **Retranslate**, and **Delete**.

## Why

When multiple chapter rows are shown, all three button types had identical accessible names ("Move", "Retranslate", "Delete") with no context about which chapter or language each one acts on. Screen readers couldn't distinguish them — a WCAG 4.1.2 (Name, Role, Value) violation.

New labels: `"Move Ch. N lang translation"`, `"Retranslate Ch. N lang"`, `"Delete Ch. N lang translation"`.

Updated 3 existing test files (`AdminBooksPage.coverage`, `.branches`, `.branches2`) to query buttons by the new descriptive names instead of the old exact-match patterns.

## Test plan

- New static-source assertion test `AdminBooksChapterBtnAriaLabels.test.ts` verifies all three `aria-label` templates
- All 83 AdminBooksPage tests pass with updated name queries
- Full Jest suite: 2766 tests pass

Closes #1905

## Docs follow-up

N/A — admin-only change, no user-visible feature impact.
