### PR TITLE
ux: fix TTSControls button aria-labels and decorative icon aria-hidden

### DIFF
--- a/frontend/src/__tests__/TTSControlsCancelAriaLabel.test.ts
+++ b/frontend/src/__tests__/TTSControlsCancelAriaLabel.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Regression test for #1907: TTSControls "Preparing…" (cancel) button must have
+ * aria-label so screen readers announce the cancellation action, not just "Preparing…".
+ * Decorative icons in TTS buttons should be aria-hidden to avoid noise.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/TTSControls.tsx"),
+  "utf8",
+);
+
+describe("TTSControls button accessibility (closes #1907)", () => {
+  it("loading/cancel button has aria-label describing cancellation", () => {
+    expect(src).toMatch(/aria-label="Cancel audio loading"/);
+  });
+
+  it("CloseIcon inside loading button is aria-hidden", () => {
+    expect(src).toMatch(/<CloseIcon[^>]*aria-hidden="true"/);
+  });
+
+  it("PauseIcon inside Pause button is aria-hidden", () => {
+    expect(src).toMatch(/<PauseIcon[^>]*aria-hidden="true"/);
+  });
+
+  it("PlayIcon inside Read button is aria-hidden", () => {
+    expect(src).toMatch(/<PlayIcon[^>]*aria-hidden="true"/);
+  });
+
+  it("RetryIcon inside Retry button is aria-hidden", () => {
+    expect(src).toMatch(/<RetryIcon[^>]*aria-hidden="true"/);
+  });
+});

--- a/frontend/src/components/TTSControls.tsx
+++ b/frontend/src/components/TTSControls.tsx
@@ -411,11 +411,11 @@ export default function TTSControls({
           <button
             onClick={cancelLoad}
             className="rounded-lg bg-amber-300 text-amber-900 px-4 py-2.5 md:py-1.5 text-sm flex items-center gap-2 hover:bg-amber-400 min-h-[44px] md:min-h-0"
-            title="Click to cancel"
+            aria-label="Cancel audio loading"
           >
             <span className="w-3 h-3 border-2 border-amber-700/40 border-t-amber-800 rounded-full animate-spin" aria-hidden="true" />
             Preparing…
-            <CloseIcon className="w-3.5 h-3.5" />
+            <CloseIcon className="w-3.5 h-3.5" aria-hidden="true" />
           </button>
         ) : status === "playing" ? (
           <button
@@ -423,7 +423,7 @@ export default function TTSControls({
             onClick={pause}
             className="rounded-lg bg-amber-200 text-amber-900 px-4 py-2.5 md:py-1.5 text-sm hover:bg-amber-300 min-h-[44px] md:min-h-0 flex items-center gap-1.5"
           >
-            <PauseIcon className="w-3.5 h-3.5" />
+            <PauseIcon className="w-3.5 h-3.5" aria-hidden="true" />
             Pause
           </button>
         ) : status === "paused" ? (
@@ -432,7 +432,7 @@ export default function TTSControls({
             onClick={play}
             className="rounded-lg bg-amber-700 text-white px-4 py-2.5 md:py-1.5 text-sm hover:bg-amber-800 min-h-[44px] md:min-h-0 flex items-center gap-1.5"
           >
-            <PlayIcon className="w-3.5 h-3.5" />
+            <PlayIcon className="w-3.5 h-3.5" aria-hidden="true" />
             Read
           </button>
         ) : status === "error" ? (
@@ -441,7 +441,7 @@ export default function TTSControls({
             className="rounded-lg bg-red-100 text-red-800 border border-red-300 px-3 py-2.5 md:py-1.5 text-sm hover:bg-red-200 min-h-[44px] md:min-h-0 flex items-center gap-1.5"
             title={errorMsg || "Audio failed"}
           >
-            <RetryIcon className="w-3.5 h-3.5" />
+            <RetryIcon className="w-3.5 h-3.5" aria-hidden="true" />
             Retry
           </button>
         ) : (
@@ -449,7 +449,7 @@ export default function TTSControls({
             disabled
             className="rounded-lg bg-amber-100 text-amber-400 px-4 py-2.5 md:py-1.5 text-sm cursor-not-allowed min-h-[44px] md:min-h-0 flex items-center gap-1.5"
           >
-            <PlayIcon className="w-3.5 h-3.5" />
+            <PlayIcon className="w-3.5 h-3.5" aria-hidden="true" />
             Read
           </button>
         )}


### PR DESCRIPTION
## What changed

- Added `aria-label="Cancel audio loading"` to the TTSControls loading/cancel button (was relying on visible text "Preparing…" which lacks action semantics for screen readers).
- Added `aria-hidden="true"` to all decorative icons in TTS buttons (CloseIcon, PauseIcon, PlayIcon ×2, RetryIcon) so screen readers announce only the button's text/label, not icon names.
- Removed `title="Click to cancel"` tooltip (tooltip text is not announced by screen readers; the `aria-label` supersedes it).

## Why

The "Preparing…" button's accessible name gave no indication it was a cancel action. Decorative icons (CloseIcon etc.) were polluting the computed accessible name with noise. Fixes WCAG 4.1.2 (Name, Role, Value).

## Test plan

- [x] New static-source test `TTSControlsCancelAriaLabel.test.ts` asserts all 5 attributes in the TSX source
- [x] Full Jest suite: 2770 tests passing

Closes #1907

🤖 Generated with [Claude Code](https://claude.com/claude-code)
