### PR TITLE
ux: add contextual aria-label to admin books Translate button

### DIFF
--- a/frontend/src/__tests__/AdminBooksPage.branches2.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.branches2.test.tsx
@@ -178,7 +178,7 @@ describe("AdminBooksPage — queueLanguageForBook non-Error catch (lines 141-152
     await flushPromises();
 
     const translateBtns = await screen.findAllByRole("button", {
-      name: /\+ translate/i,
+      name: /^Translate .* into/i,
     });
     await userEvent.click(translateBtns[0]);
 

--- a/frontend/src/__tests__/AdminBooksPage.coverage.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.coverage.test.tsx
@@ -294,7 +294,7 @@ describe("AdminBooksPage — queueLanguageForBook error path (line 152)", () => 
     await flushPromises();
 
     const translateBtns = await screen.findAllByRole("button", {
-      name: /\+ translate/i,
+      name: /^Translate .* into/i,
     });
     await userEvent.click(translateBtns[0]);
 
@@ -831,7 +831,7 @@ describe("AdminBooksPage — language selector (lines 371-373)", () => {
     await userEvent.selectOptions(langSelects[0], "de");
 
     // Then queue it
-    const translateBtns = screen.getAllByRole("button", { name: /\+ translate/i });
+    const translateBtns = screen.getAllByRole("button", { name: /^Translate .* into/i });
     await userEvent.click(translateBtns[0]);
 
     await waitFor(() =>

--- a/frontend/src/__tests__/AdminBooksPage.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.test.tsx
@@ -206,7 +206,7 @@ describe("AdminBooksPage — book actions", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const translateBtns = await screen.findAllByRole("button", { name: /\+ translate/i });
+    const translateBtns = await screen.findAllByRole("button", { name: /^Translate .* into/i });
     await userEvent.click(translateBtns[0]);
 
     await waitFor(() => {

--- a/frontend/src/__tests__/AdminBooksTranslateBtnAria.test.ts
+++ b/frontend/src/__tests__/AdminBooksTranslateBtnAria.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Regression test for #1909: Admin books "+Translate" button must have aria-label
+ * referencing the book title so screen readers can distinguish per-book buttons.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/admin/books/page.tsx"),
+  "utf8",
+);
+
+describe("Admin books Translate button aria-label (closes #1909)", () => {
+  it("Translate button has aria-label with book title context", () => {
+    expect(src).toMatch(/aria-label=\{`Translate \$\{b\.title\} into/);
+  });
+
+  it("Translate button does not rely solely on title= for its name", () => {
+    // The button section around queueingLangFor should have an aria-label, not only title=
+    const translateBtnSection = src.match(/queueingLangFor[\s\S]{0,200}Translate/)?.[0] ?? "";
+    expect(translateBtnSection).toMatch(/aria-label=/);
+  });
+});

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -456,8 +456,8 @@ export default function BooksPage() {
                 <button
                   onClick={() => queueLanguageForBook(b, newLangInput[b.id] ?? "zh")}
                   disabled={queueingLangFor?.startsWith(`${b.id}:`)}
+                  aria-label={`Translate ${b.title} into ${QUEUE_LANG_OPTIONS.find((o) => o.code === (newLangInput[b.id] ?? "zh"))?.label ?? (newLangInput[b.id] ?? "zh")}`}
                   className="text-xs px-2 py-1 rounded border border-emerald-300 text-emerald-700 hover:bg-emerald-50 shrink-0 disabled:opacity-50 min-h-[44px]"
-                  title="Queue this book for translation into the selected language"
                 >
                   {queueingLangFor?.startsWith(`${b.id}:`) ? "Queueing…" : "+ Translate"}
                 </button>


### PR DESCRIPTION
## What changed

- Added `aria-label` to the "+ Translate" button in the admin/books page, replacing the non-announcing `title=` attribute.
- The label includes the book title and selected target language: `Translate ${b.title} into ${language}`.
- Updated 3 test files (`AdminBooksPage.test.tsx`, `AdminBooksPage.coverage.test.tsx`, `AdminBooksPage.branches2.test.tsx`) to query the button by its new contextual name pattern.

## Why

The `title=` attribute is not announced by most screen readers (NVDA, JAWS). With multiple books on screen, every "+ Translate" button had the same accessible name — screen reader users couldn't tell which book they were queuing. WCAG 2.4.6 / 4.1.2.

## Test plan

- [x] New static-source test `AdminBooksTranslateBtnAria.test.ts` asserts the `aria-label` pattern
- [x] Full Jest suite: 2775 tests passing

Closes #1909

🤖 Generated with [Claude Code](https://claude.com/claude-code)
