### PR TITLE
ux: add aria-label to Obsidian export button in reader header (closes #1912)

### DIFF
--- a/frontend/src/__tests__/ReaderPageObsidianAriaLabel.test.ts
+++ b/frontend/src/__tests__/ReaderPageObsidianAriaLabel.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Regression test for #1912:
+ * The Obsidian vocabulary-export button must have aria-label="Export vocabulary to Obsidian"
+ * so screen readers announce a complete action instead of just "Obsidian".
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Reader page Obsidian export button accessibility (closes #1912)", () => {
+  it("Obsidian export button has aria-label describing the export action", () => {
+    expect(src).toMatch(/aria-label="Export vocabulary to Obsidian"/);
+  });
+
+  it("Obsidian export button does not rely solely on title= for its accessible name", () => {
+    // Verify aria-label appears near the onClick={handleObsidianExport} button attribute
+    const exportBtnSection =
+      src.match(/onClick=\{handleObsidianExport\}[\s\S]{0,400}Obsidian/)?.[0] ?? "";
+    expect(exportBtnSection).toMatch(/aria-label=/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1208,6 +1208,7 @@ export default function ReaderPage() {
             <button
               onClick={handleObsidianExport}
               title="Export vocabulary to Obsidian"
+              aria-label="Export vocabulary to Obsidian"
               className="hidden lg:flex shrink-0 items-center gap-1.5 px-3 py-1.5 min-h-[44px] lg:min-h-0 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-xs font-medium transition-colors"
             >
               <ExportIcon className="w-3.5 h-3.5 shrink-0" />


### PR DESCRIPTION
## What changed

Added `aria-label="Export vocabulary to Obsidian"` to the vocabulary export button in the reader header (`frontend/src/app/reader/[bookId]/page.tsx`).

## Why

The button had `title="Export vocabulary to Obsidian"` and visible text `"Obsidian"`. Since `ExportIcon` is `aria-hidden="true"` (baked into Icons.tsx), the button's computed accessible name was just **"Obsidian"** — unhelpful for screen reader users. `title=` is not reliably announced by NVDA/JAWS when visible text is present.

Adding `aria-label` makes "Export vocabulary to Obsidian" the accessible name, satisfying WCAG 2.1 §4.1.2 Name, Role, Value (Level A).

## Test plan

- New static source assertion test: `ReaderPageObsidianAriaLabel.test.ts`
  - Asserts `aria-label="Export vocabulary to Obsidian"` is present
  - Asserts it appears near `onClick={handleObsidianExport}`
- Full frontend suite: 2777 tests pass

Closes #1912
