### PR TITLE
ux: make sidebar resize handle keyboard-accessible (closes #1915)

### DIFF
--- a/frontend/src/__tests__/ReaderPageResizeHandle.test.ts
+++ b/frontend/src/__tests__/ReaderPageResizeHandle.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Regression test for #1915:
+ * The sidebar resize handle must be keyboard-accessible with proper ARIA attributes.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Reader page sidebar resize handle accessibility (closes #1915)", () => {
+  it("resize handle has role separator", () => {
+    expect(src).toMatch(/role="separator"/);
+  });
+
+  it("resize handle has aria-label", () => {
+    expect(src).toMatch(/aria-label="Resize reader sidebar"/);
+  });
+
+  it("resize handle has tabIndex for keyboard focus", () => {
+    // tabIndex={0} makes it reachable via keyboard Tab
+    const resizeSection = src.match(/onResizeStart[\s\S]{0,1200}Drag to resize/)?.[0] ?? "";
+    expect(resizeSection).toMatch(/tabIndex=\{0\}/);
+  });
+
+  it("resize handle has onKeyDown for arrow-key resizing", () => {
+    const resizeSection = src.match(/onResizeStart[\s\S]{0,1200}Drag to resize/)?.[0] ?? "";
+    expect(resizeSection).toMatch(/onKeyDown=/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1700,7 +1700,18 @@ export default function ReaderPage() {
         {sidebarOpen && (
           <div
             onMouseDown={onResizeStart}
-            className="hidden md:block w-1.5 shrink-0 cursor-col-resize bg-amber-100 hover:bg-amber-400 active:bg-amber-500 transition-colors relative group"
+            onKeyDown={(e) => {
+              if (e.key === "ArrowLeft") setSidebarWidth((w) => Math.max(240, w - 25));
+              else if (e.key === "ArrowRight") setSidebarWidth((w) => Math.min(700, w + 25));
+            }}
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize reader sidebar"
+            aria-valuenow={sidebarWidth}
+            aria-valuemin={240}
+            aria-valuemax={700}
+            tabIndex={0}
+            className="hidden md:block w-1.5 shrink-0 cursor-col-resize bg-amber-100 hover:bg-amber-400 active:bg-amber-500 focus:bg-amber-400 focus:outline-none transition-colors relative group"
             title="Drag to resize"
           >
             {/* Three-dot grip indicator */}


### PR DESCRIPTION
## What changed

Made the reader sidebar resize handle keyboard-accessible (WCAG 2.1 §2.1.1 Keyboard + §4.1.2 Name, Role, Value).

- Added `role="separator"` with `aria-orientation="vertical"` and `aria-label="Resize reader sidebar"`
- Added `aria-valuenow`, `aria-valuemin={240}`, `aria-valuemax={700}` so screen readers can announce the current width
- Added `tabIndex={0}` so keyboard users can Tab to the handle
- Added `onKeyDown` handler: ArrowLeft shrinks sidebar by 25px (min 240px), ArrowRight grows it by 25px (max 700px)
- Added `focus:bg-amber-400 focus:outline-none` styling for visible focus ring

Before this fix the resize handle was a mouse-only drag target with no ARIA role, no focusability, and no keyboard interaction — completely inaccessible to keyboard and AT users.

## Why

Closes #1915. WCAG 2.1 §2.1.1 requires all functionality available via mouse to also be available via keyboard.

## Test plan

- `ReaderPageResizeHandle.test.ts` — 4 static-source assertions verifying `role="separator"`, `aria-label`, `tabIndex={0}`, and `onKeyDown` are all present in the resize handle markup
- Full Jest suite: 2781 tests passed
- Full pytest suite: 2016 tests passed

[ ] Docs updated (n/a — interaction design change logged in change-log below)
