### PR TITLE
ux: add aria-labels to notes page per-book count badges (closes #1917)

### DIFF
--- a/frontend/src/__tests__/NotesPageCountBadgeAria.test.ts
+++ b/frontend/src/__tests__/NotesPageCountBadgeAria.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression test for #1917:
+ * Notes page per-book count badges must have aria-labels so screen readers
+ * can announce "3 annotations" instead of just "3".
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/notes/page.tsx"),
+  "utf8",
+);
+
+// Extract only the per-book list badge section (book.annCount / book.insCount / book.vocCount)
+// — distinct from the header total summary which was already labelled.
+const listBadgeSection =
+  src.match(/book\.annCount > 0[\s\S]{0,1200}book\.vocCount > 0[\s\S]{0,500}/)?.[0] ?? "";
+
+describe("Notes page per-book count badge accessibility (closes #1917)", () => {
+  it("annotation count badge has aria-label containing 'annotation'", () => {
+    expect(listBadgeSection).toMatch(/aria-label=.*annotation/);
+  });
+
+  it("insight count badge has aria-label containing 'insight'", () => {
+    expect(listBadgeSection).toMatch(/aria-label=.*insight/);
+  });
+
+  it("vocabulary count badge has aria-label containing 'vocabular'", () => {
+    expect(listBadgeSection).toMatch(/aria-label=.*vocabular/);
+  });
+
+  it("count numbers inside per-book badges are aria-hidden", () => {
+    expect(listBadgeSection).toMatch(/aria-hidden="true"/);
+  });
+});

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -192,21 +192,21 @@ export default function NotesOverviewPage() {
                     </p>
                     <div className="flex flex-wrap gap-2 mt-1.5">
                       {book.annCount > 0 && (
-                        <span className="inline-flex items-center gap-1 text-xs text-amber-700 bg-amber-50 border border-amber-100 rounded-full px-2 py-0.5">
+                        <span aria-label={`${book.annCount} annotation${book.annCount !== 1 ? "s" : ""}`} className="inline-flex items-center gap-1 text-xs text-amber-700 bg-amber-50 border border-amber-100 rounded-full px-2 py-0.5">
                           <NoteIcon className="w-3 h-3 shrink-0" />
-                          {book.annCount}
+                          <span aria-hidden="true">{book.annCount}</span>
                         </span>
                       )}
                       {book.insCount > 0 && (
-                        <span className="inline-flex items-center gap-1 text-xs text-sky-700 bg-sky-50 border border-sky-100 rounded-full px-2 py-0.5">
+                        <span aria-label={`${book.insCount} AI insight${book.insCount !== 1 ? "s" : ""}`} className="inline-flex items-center gap-1 text-xs text-sky-700 bg-sky-50 border border-sky-100 rounded-full px-2 py-0.5">
                           <InsightIcon className="w-3 h-3 shrink-0" />
-                          {book.insCount}
+                          <span aria-hidden="true">{book.insCount}</span>
                         </span>
                       )}
                       {book.vocCount > 0 && (
-                        <span className="inline-flex items-center gap-1 text-xs text-emerald-700 bg-emerald-50 border border-emerald-100 rounded-full px-2 py-0.5">
+                        <span aria-label={`${book.vocCount} vocabulary word${book.vocCount !== 1 ? "s" : ""}`} className="inline-flex items-center gap-1 text-xs text-emerald-700 bg-emerald-50 border border-emerald-100 rounded-full px-2 py-0.5">
                           <VocabIcon className="w-3 h-3 shrink-0" />
-                          {book.vocCount}
+                          <span aria-hidden="true">{book.vocCount}</span>
                         </span>
                       )}
                     </div>


### PR DESCRIPTION
## What changed

Added `aria-label` to the per-book count badges (annotations, AI insights, vocabulary words) on the `/notes` book list. The icon SVGs have `aria-hidden="true"`, so screen readers only heard bare numbers like "3 2 1" with no context about what each count represented.

**Before:** screen reader reads "Moby Dick 3 2 1 3 months ago"  
**After:** screen reader reads "Moby Dick 3 annotations 2 AI insights 1 vocabulary word 3 months ago"

The numeric spans are now wrapped in `aria-hidden="true"` `<span>` elements so assistive technology uses the parent `aria-label` exclusively.

Note: the header summary badges (totalAnn / totalIns / totalVoc) already had `aria-label` — this fix targets the per-book list cards only.

## Why

Closes #1917. WCAG 1.3.1 (Info and Relationships) requires that meaning conveyed visually through icons must also be available to assistive technology.

## Test plan

- `NotesPageCountBadgeAria.test.ts` — 4 static-source assertions scoped to the per-book list section, verifying each badge type has an `aria-label` and numeric counts are `aria-hidden`
- Full Jest suite: 2785 tests passed
- Full pytest suite: 2016 tests passed

[ ] Docs updated (n/a)
