### PR TITLE
ux: upgrade notes search-filtered empty state with serif headline and clear-search CTA (closes #1925)

### DIFF
--- a/frontend/src/__tests__/NotesSearchFilteredEmptyState.test.ts
+++ b/frontend/src/__tests__/NotesSearchFilteredEmptyState.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Regression test for #1925:
+ * Notes overview page search-filtered empty state must include a font-serif
+ * headline and a clear-search CTA button — not just a bare <p>.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/notes/page.tsx"),
+  "utf8",
+);
+
+/**
+ * Anchor on the search-filter sub-case: when books exist but filtered is empty.
+ * We capture from "books.length === 0" negation context up to the closing
+ * of that branch (the else case).
+ */
+const searchEmptyBlock =
+  src.match(/books\.length === 0[\s\S]{0,1600}Clear search/)?.[0] ?? "";
+
+describe("Notes search-filtered empty state (closes #1925)", () => {
+  it("search-filter empty block is found in source", () => {
+    expect(searchEmptyBlock.length).toBeGreaterThan(0);
+  });
+
+  it("search-filter empty state has a font-serif headline", () => {
+    expect(searchEmptyBlock).toMatch(/font-serif/);
+  });
+
+  it("search-filter empty state has a clear-search button calling setSearch", () => {
+    expect(searchEmptyBlock).toMatch(/setSearch\(""\)/);
+  });
+});

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -174,7 +174,17 @@ export default function NotesOverviewPage() {
                 </button>
               </>
             ) : (
-              <p className="text-sm">No books match your search.</p>
+              <>
+                <p className="font-serif text-lg text-stone-500 mt-1">No books match &ldquo;{search}&rdquo;</p>
+                <p className="text-sm">Try a different search term.</p>
+                <button
+                  type="button"
+                  onClick={() => setSearch("")}
+                  className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px]"
+                >
+                  Clear search
+                </button>
+              </>
             )}
           </div>
         ) : (


### PR DESCRIPTION
## What changed

Upgraded the notes overview page's search-filtered empty state from a bare `<p>` tag to a proper empty state with a `font-serif` headline and a clear-search CTA button.

**Before:**
```tsx
<p className="text-sm">No books match your search.</p>
```

**After:** font-serif headline ("No books match «query»"), sub-text, and a "Clear search" button that calls `setSearch("")` to reset the filter.

## Why

Issue #1925: when a search yields no matching books, users had no indication of what to do next and no way to clear the search without scrolling to the top. Violates the design system empty-state rule (icon + serif headline + sub-text + CTA button).

## Test plan

- New static-source test (`NotesSearchFilteredEmptyState.test.ts`): 3 assertions covering font-serif headline, `setSearch("")` reset call, and block capture — all pass.
- Full frontend suite: 2796 tests pass.

Closes #1925
