### PR TITLE
ux: add missing SearchIcon to search no-results empty state (closes #1928)

### DIFF
--- a/frontend/src/__tests__/SearchNoResultsIcon.test.ts
+++ b/frontend/src/__tests__/SearchNoResultsIcon.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Regression test for #1928:
+ * The search page no-results empty state must include a SearchIcon SVG
+ * before the headline — matching the design-system rule (icon + headline + sub-text + CTA).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/search/page.tsx"),
+  "utf8",
+);
+
+/**
+ * Capture the no-results block anchored on total === 0 check,
+ * up through the CTA link.
+ */
+const noResultsBlock =
+  src.match(/total === 0[\s\S]{0,1000}Browse books/)?.[0] ?? "";
+
+describe("Search no-results empty state (closes #1928)", () => {
+  it("no-results block is found in source", () => {
+    expect(noResultsBlock.length).toBeGreaterThan(0);
+  });
+
+  it("no-results empty state includes SearchIcon", () => {
+    expect(noResultsBlock).toMatch(/SearchIcon/);
+  });
+
+  it("no-results empty state has aria-hidden on the icon", () => {
+    expect(noResultsBlock).toMatch(/aria-hidden="true"/);
+  });
+});

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -173,6 +173,7 @@ function SearchResultsInner() {
 
       {!loading && !error && data && data.total === 0 && (
         <div className="text-center text-stone-500 py-12">
+          <SearchIcon className="w-10 h-10 mx-auto mb-2 text-stone-400" aria-hidden="true" />
           <p className="font-serif text-lg text-ink">No matches for &ldquo;{q}&rdquo;.</p>
           <p className="text-sm mt-2">Try a shorter or different word.</p>
           <Link


### PR DESCRIPTION
## What changed

Added the missing `SearchIcon` SVG to the search page's no-results empty state.

**Before:** no icon — just the `font-serif` headline and CTA button.

**After:** `<SearchIcon className="w-10 h-10 mx-auto mb-2 text-stone-400" aria-hidden="true" />` precedes the headline, consistent with the initial (no-query) empty state immediately above it and the design-system rule (icon + headline + sub-text + CTA).

## Why

Issue #1928: the no-results state violated the design-system empty-state rule (CLAUDE.md Graphic design rules → Empty states: "every empty state needs a subtle illustration or icon"). The icon was already imported and used for the adjacent no-query state — this is a one-line addition.

## Test plan

- New static-source test (`SearchNoResultsIcon.test.ts`): 3 assertions — block found, `SearchIcon` present, `aria-hidden="true"` present — all pass.
- Full frontend suite: 2800 tests pass.

Closes #1928
