### PR TITLE
ux: add missing font-serif headline to ChapterSummary idle empty state (closes #1930)

### DIFF
--- a/frontend/src/__tests__/ChapterSummaryHeadline.test.ts
+++ b/frontend/src/__tests__/ChapterSummaryHeadline.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Regression test for #1930:
+ * ChapterSummary idle empty state must have a font-serif headline — not just
+ * icon + sub-text + CTA.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../components/ChapterSummary.tsx"),
+  "utf8",
+);
+
+/**
+ * Capture the idle empty state block: from "!summary && !loading && !error"
+ * through the Generate Summary button.
+ */
+const idleBlock =
+  src.match(/!summary && !loading && !error[\s\S]{0,800}Generate Summary/)?.[0] ?? "";
+
+describe("ChapterSummary idle empty state (closes #1930)", () => {
+  it("idle empty state block is found in source", () => {
+    expect(idleBlock.length).toBeGreaterThan(0);
+  });
+
+  it("idle empty state has a font-serif headline", () => {
+    expect(idleBlock).toMatch(/font-serif/);
+  });
+
+  it("idle empty state has SummaryIcon", () => {
+    expect(idleBlock).toMatch(/SummaryIcon/);
+  });
+});

--- a/frontend/src/components/ChapterSummary.tsx
+++ b/frontend/src/components/ChapterSummary.tsx
@@ -136,6 +136,7 @@ export default function ChapterSummary({
         {!summary && !loading && !error && (
           <div className="flex flex-col items-center justify-center h-full text-center text-stone-500 gap-3 py-8">
             <SummaryIcon className="w-10 h-10 text-amber-300" />
+            <p className="font-serif text-lg text-stone-500 mt-1">Chapter Summary</p>
             <p className="text-sm">Get a quick overview of this chapter before continuing.</p>
             <button
               onClick={load}


### PR DESCRIPTION
## What changed

Added a missing `font-serif` headline to the `ChapterSummary` component's idle empty state (shown before the user requests a summary).

**Before:**
```tsx
<SummaryIcon className="w-10 h-10 text-amber-300" />
<p className="text-sm">Get a quick overview of this chapter before continuing.</p>
```

**After:**
```tsx
<SummaryIcon className="w-10 h-10 text-amber-300" />
<p className="font-serif text-lg text-stone-500 mt-1">Chapter Summary</p>
<p className="text-sm">Get a quick overview of this chapter before continuing.</p>
```

## Why

Issue #1930: the idle state had icon ✓, sub-text ✓, CTA ✓ but was missing the `font-serif` headline required by the design-system empty-state rule (CLAUDE.md → Graphic design rules → Empty states).

## Test plan

- New static-source test (`ChapterSummaryHeadline.test.ts`): 3 assertions — idle block found, `font-serif` present, `SummaryIcon` present — all pass.
- Full frontend suite: 2803 tests pass.

Closes #1930
