### PR TITLE
ux: add missing font-serif headline to AnnotationsSidebar empty state (closes #1932)

### DIFF
--- a/frontend/src/__tests__/AnnotationsSidebarHeadline.test.ts
+++ b/frontend/src/__tests__/AnnotationsSidebarHeadline.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Regression test for #1932:
+ * AnnotationsSidebar empty state must include a font-serif headline.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../components/AnnotationsSidebar.tsx"),
+  "utf8",
+);
+
+// Capture the empty-state branch: from `annotations.length === 0` to the
+// closing of that branch (the else case opens with a fragment `<>`).
+const emptyBlock =
+  src.match(/annotations\.length === 0[\s\S]{0,600}mt-1 text-xs/)?.[0] ?? "";
+
+describe("AnnotationsSidebar empty state (closes #1932)", () => {
+  it("empty-state block is found in source", () => {
+    expect(emptyBlock.length).toBeGreaterThan(0);
+  });
+
+  it("empty state has a font-serif headline", () => {
+    expect(emptyBlock).toMatch(/font-serif/);
+  });
+
+  it("empty state has EmptyNotesIcon", () => {
+    expect(emptyBlock).toMatch(/EmptyNotesIcon/);
+  });
+});

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -110,7 +110,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
             ) : annotations.length === 0 ? (
               <div className="text-center text-stone-500 mt-10 text-sm">
                 <EmptyNotesIcon className="w-10 h-10 text-stone-300 mx-auto mb-2" />
-                <p>No annotations yet.</p>
+                <p className="font-serif text-lg text-stone-500 mt-1">No annotations yet</p>
                 <p className="mt-1 text-xs">Click a sentence and choose Note to add one.</p>
               </div>
             ) : (


### PR DESCRIPTION
## What changed

`AnnotationsSidebar.tsx`: the empty annotations state was missing a `font-serif` headline, violating the design system empty-state rule (icon + serif headline + sub-text + CTA).

Added:
```tsx
<p className="font-serif text-lg text-stone-500 mt-1">No annotations yet</p>
```

between the `EmptyNotesIcon` and the sub-text hint.

## Why

CLAUDE.md design rule: every empty state must have a `font-serif` headline. The previous state had an icon and instructional text but no headline, making it visually inconsistent with all other empty states in the app (vocabulary, notes, search, chapter summary).

## Test plan

- New static-source assertion test `AnnotationsSidebarHeadline.test.ts` verifies the empty-state block contains `font-serif` and `EmptyNotesIcon`
- Full frontend suite: 2806 tests passed
- Full backend suite: 1942 tests passed

Closes #1932

## Docs follow-up

- [ ] Docs updated (if applicable)
