### PR TITLE
ux: add regression test for EmptyNotesIcon in notes search-filtered empty state (closes #1927)

### DIFF
--- a/frontend/src/__tests__/NotesSearchFilteredEmptyState.test.ts
+++ b/frontend/src/__tests__/NotesSearchFilteredEmptyState.test.ts
@@ -1,7 +1,7 @@
 /**
- * Regression test for #1925:
- * Notes overview page search-filtered empty state must include a font-serif
- * headline and a clear-search CTA button — not just a bare <p>.
+ * Regression tests for #1925 and #1927:
+ * Notes overview page search-filtered empty state must include an SVG icon,
+ * a font-serif headline, and a clear-search CTA button.
  */
 import { readFileSync } from "fs";
 import { join } from "path";
@@ -12,14 +12,21 @@ const src = readFileSync(
 );
 
 /**
+ * Capture the entire filtered.length === 0 block (icon + inner branches)
+ * through the clear-search CTA. This is wide enough to include the
+ * EmptyNotesIcon placed outside the books.length === 0 sub-conditional.
+ */
+const filteredEmptyBlock =
+  src.match(/filtered\.length === 0[\s\S]{0,2000}Clear search/)?.[0] ?? "";
+
+/**
  * Anchor on the search-filter sub-case: when books exist but filtered is empty.
- * We capture from "books.length === 0" negation context up to the closing
- * of that branch (the else case).
+ * Captures just the else branch (font-serif headline + clear CTA).
  */
 const searchEmptyBlock =
   src.match(/books\.length === 0[\s\S]{0,1600}Clear search/)?.[0] ?? "";
 
-describe("Notes search-filtered empty state (closes #1925)", () => {
+describe("Notes search-filtered empty state (closes #1925, #1927)", () => {
   it("search-filter empty block is found in source", () => {
     expect(searchEmptyBlock.length).toBeGreaterThan(0);
   });
@@ -30,5 +37,9 @@ describe("Notes search-filtered empty state (closes #1925)", () => {
 
   it("search-filter empty state has a clear-search button calling setSearch", () => {
     expect(searchEmptyBlock).toMatch(/setSearch\(""\)/);
+  });
+
+  it("filtered empty state outer block includes EmptyNotesIcon (closes #1927)", () => {
+    expect(filteredEmptyBlock).toMatch(/EmptyNotesIcon/);
   });
 });


### PR DESCRIPTION
## What changed

`NotesSearchFilteredEmptyState.test.ts`: extended the existing regression test (#1925) to also assert that `EmptyNotesIcon` is present in the filtered empty state.

The icon was already in place — `EmptyNotesIcon` sits on the outer `filtered.length === 0` div, before the `books.length === 0` sub-conditional, so it renders for both the truly-empty and search-filtered branches. However the existing test's regex started from `books.length === 0` (the inner branch) and therefore never captured the icon.

Added a second regex anchored at `filtered.length === 0` through `Clear search` that covers the full outer block and asserts `EmptyNotesIcon` is present.

## Why

Closes the gap left by #1927: prevents future refactors from silently moving the icon inside only the truly-empty branch (which would break the filtered empty state visually with no test failure).

## Test plan

- New assertion in existing test file: `filtered.length === 0` block contains `EmptyNotesIcon`
- Full frontend suite: 2807 tests passed
- Backend suite running in CI

Closes #1927

## Docs follow-up

- [ ] Docs updated (if applicable)
