### PR TITLE
ux: add font-serif headlines to reader sidebar notes and vocab empty states (closes #1935)

### DIFF
--- a/frontend/e2e/annotation-translation.spec.ts
+++ b/frontend/e2e/annotation-translation.spec.ts
@@ -171,7 +171,7 @@ test("Notes sidebar shows empty state when no annotations", async ({ page }) => 
   await page.getByRole("button", { name: /notes/i }).click();
 
   // Empty state text should appear (default "This chapter" filter view)
-  await expect(page.getByText("No annotations in this chapter yet.")).toBeVisible({ timeout: 3000 });
+  await expect(page.getByText("No annotations in this chapter")).toBeVisible({ timeout: 3000 });
 });
 
 test("Notes sidebar shows existing annotations from API", async ({ page }) => {

--- a/frontend/src/__tests__/ReaderPage.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.test.tsx
@@ -493,7 +493,7 @@ describe("ReaderPage — sidebar tabs", () => {
     const notesBtn = await screen.findByTitle("Annotations & notes");
     await userEvent.click(notesBtn);
 
-    expect(await screen.findByText("No annotations in this chapter yet.")).toBeInTheDocument();
+    expect(await screen.findByText("No annotations in this chapter")).toBeInTheDocument();
   });
 
   it("opens vocab sidebar when 📚 Vocab button is clicked", async () => {
@@ -504,7 +504,7 @@ describe("ReaderPage — sidebar tabs", () => {
     const vocabBtn = await screen.findByTitle("Vocabulary");
     await userEvent.click(vocabBtn);
 
-    expect(await screen.findByText("No words saved in this chapter yet.")).toBeInTheDocument();
+    expect(await screen.findByText("No vocabulary in this chapter")).toBeInTheDocument();
   });
 
   it("toggling the same sidebar button twice closes it", async () => {
@@ -1125,7 +1125,7 @@ describe("ReaderPage — notes sidebar content", () => {
 
     // Sidebar should be closed (no more annotation text visible)
     await waitFor(() => {
-      expect(screen.queryByText("No annotations yet.")).not.toBeInTheDocument();
+      expect(screen.queryByText("No annotations yet")).not.toBeInTheDocument();
     });
   });
 });
@@ -1657,7 +1657,7 @@ describe("ReaderPage — notes sidebar chapter filter", () => {
     const notesBtn = await screen.findByTitle("Annotations & notes");
     await userEvent.click(notesBtn);
 
-    expect(await screen.findByText("No annotations in this chapter yet.")).toBeInTheDocument();
+    expect(await screen.findByText("No annotations in this chapter")).toBeInTheDocument();
   });
 
   it("switching to 'All chapters' shows annotations from all chapters grouped by chapter", async () => {

--- a/frontend/src/__tests__/ReaderSidebarEmptyHeadlines.test.ts
+++ b/frontend/src/__tests__/ReaderSidebarEmptyHeadlines.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Regression test for #1935:
+ * Reader sidebar notes tab and vocab tab empty states must include
+ * a font-serif headline per the design system empty-state rule.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+// Notes tab: capture from filteredNotes.length === 0 through the sub-text
+const notesEmptyBlock =
+  src.match(/filteredNotes\.length === 0[\s\S]{0,600}Long-press/)?.[0] ?? "";
+
+// Vocab tab: capture from filteredVocab.length === 0 through the sub-text
+const vocabEmptyBlock =
+  src.match(/filteredVocab\.length === 0[\s\S]{0,600}Select text/)?.[0] ?? "";
+
+describe("Reader sidebar notes-tab empty state (closes #1935)", () => {
+  it("notes empty block is found in source", () => {
+    expect(notesEmptyBlock.length).toBeGreaterThan(0);
+  });
+
+  it("notes empty state has a font-serif headline", () => {
+    expect(notesEmptyBlock).toMatch(/font-serif/);
+  });
+
+  it("notes empty state has NoteIcon", () => {
+    expect(notesEmptyBlock).toMatch(/NoteIcon/);
+  });
+});
+
+describe("Reader sidebar vocab-tab empty state (closes #1935)", () => {
+  it("vocab empty block is found in source", () => {
+    expect(vocabEmptyBlock.length).toBeGreaterThan(0);
+  });
+
+  it("vocab empty state has a font-serif headline", () => {
+    expect(vocabEmptyBlock).toMatch(/font-serif/);
+  });
+
+  it("vocab empty state has EmptyVocabIcon", () => {
+    expect(vocabEmptyBlock).toMatch(/EmptyVocabIcon/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1847,7 +1847,7 @@ export default function ReaderPage() {
                     ) : filteredNotes.length === 0 ? (
                       <div className="text-center text-stone-500 mt-10 text-sm">
                         <NoteIcon className="w-8 h-8 mx-auto mb-2 opacity-40" />
-                        <p>{notesView === "chapter" ? "No annotations in this chapter yet." : "No annotations yet."}</p>
+                        <p className="font-serif text-lg text-stone-500 mt-1">{notesView === "chapter" ? "No annotations in this chapter" : "No annotations yet"}</p>
                         <p className="mt-1 text-xs">Long-press a sentence to add one.</p>
                       </div>
                     ) : notesView === "chapter" ? (
@@ -1936,7 +1936,7 @@ export default function ReaderPage() {
                     {filteredVocab.length === 0 ? (
                       <div className="text-center text-stone-500 mt-10 text-sm">
                         <EmptyVocabIcon className="w-10 h-10 text-stone-300 mx-auto mb-2" />
-                        <p>No words saved{vocabView === "chapter" ? " in this chapter" : ""} yet.</p>
+                        <p className="font-serif text-lg text-stone-500 mt-1">{vocabView === "chapter" ? "No vocabulary in this chapter" : "No vocabulary saved yet"}</p>
                         <p className="mt-1 text-xs">Select text to save words to vocabulary.</p>
                       </div>
                     ) : (


### PR DESCRIPTION
## What changed

`reader/[bookId]/page.tsx`: added `font-serif` headlines to two sidebar panel empty states that had an icon and sub-text but no headline.

**Notes tab** (line ~1848):
```tsx
// Before
<p>{notesView === "chapter" ? "No annotations in this chapter yet." : "No annotations yet."}</p>

// After
<p className="font-serif text-lg text-stone-500 mt-1">
  {notesView === "chapter" ? "No annotations in this chapter" : "No annotations yet"}
</p>
```

**Vocab tab** (line ~1937):
```tsx
// Before
<p>No words saved{vocabView === "chapter" ? " in this chapter" : ""} yet.</p>

// After
<p className="font-serif text-lg text-stone-500 mt-1">
  {vocabView === "chapter" ? "No vocabulary in this chapter" : "No vocabulary saved yet"}
</p>
```

The compact bottom-toolbar notes expand panel (line ~2266) was intentionally left unchanged — it's a `max-h-60` floating panel where a `font-serif text-lg` headline would be disproportionate.

## Why

CLAUDE.md design rule: every empty state must have an icon + `font-serif` headline + sub-text. The reader sidebar is the core UX flow; these panels had icon + sub-text but were missing the headline.

## Test plan

- New `ReaderSidebarEmptyHeadlines.test.ts`: 6 static-source assertions for both empty states (block found, font-serif present, icon present)
- Updated `ReaderPage.test.tsx`: 3 existing tests updated to match new copy strings
- Full frontend suite: 2815 tests passed
- Backend suite running in CI

Closes #1935

## Docs follow-up

- [ ] Docs updated (if applicable)
