### PR TITLE
ux: add missing SearchIcon to home page Gutenberg search empty state (closes #1937)

### DIFF
--- a/frontend/src/__tests__/HomeSearchEmptyIcon.test.ts
+++ b/frontend/src/__tests__/HomeSearchEmptyIcon.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Regression test for #1937:
+ * Home page Gutenberg search empty state must include a SearchIcon
+ * per the design system empty-state rule (icon + font-serif + sub-text).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(join(__dirname, "../app/page.tsx"), "utf8");
+
+// Capture the Gutenberg search no-results block through the sub-text hint.
+const noResultsBlock =
+  src.match(/searchedQuery && searchResults\.length === 0[\s\S]{0,600}language filter/)?.[0] ?? "";
+
+describe("Home page Gutenberg search empty state (closes #1937)", () => {
+  it("no-results block is found in source", () => {
+    expect(noResultsBlock.length).toBeGreaterThan(0);
+  });
+
+  it("no-results empty state includes SearchIcon", () => {
+    expect(noResultsBlock).toMatch(/SearchIcon/);
+  });
+
+  it("SearchIcon has aria-hidden for decorative use", () => {
+    expect(noResultsBlock).toMatch(/aria-hidden/);
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,7 +6,7 @@ import BookCard from "@/components/BookCard";
 import UndoToast from "@/components/UndoToast";
 import BookDetailModal from "@/components/BookDetailModal";
 import ReadingStats from "@/components/ReadingStats";
-import { FireIcon, ArrowLeftIcon, ArrowRightIcon, BookOpenIcon, NoteIcon, InsightIcon, VocabIcon, BookCoverPlaceholderIcon, GlobeIcon, SummaryIcon, SpeakerIcon, GridViewIcon, ListViewIcon, SettingsIcon } from "@/components/Icons";
+import { FireIcon, ArrowLeftIcon, ArrowRightIcon, BookOpenIcon, NoteIcon, InsightIcon, VocabIcon, BookCoverPlaceholderIcon, GlobeIcon, SummaryIcon, SpeakerIcon, GridViewIcon, ListViewIcon, SettingsIcon, SearchIcon } from "@/components/Icons";
 import { SearchBar } from "@/components/SearchBar";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
@@ -635,6 +635,7 @@ export default function Home() {
 
               {!searching && searchedQuery && searchResults.length === 0 && !searchError && (
                 <div className="text-center py-10 text-amber-700">
+                  <SearchIcon className="w-10 h-10 mx-auto mb-2 text-amber-400" aria-hidden="true" />
                   <p className="text-lg font-serif mb-1">No books found for &ldquo;{searchedQuery}&rdquo;</p>
                   <p className="text-sm text-amber-700">Try a different title, author, or language filter.</p>
                 </div>


### PR DESCRIPTION
## What changed

`frontend/src/app/page.tsx`: added `SearchIcon` to the Gutenberg search no-results empty state in the Discover tab.

**Before:**
```tsx
<div className="text-center py-10 text-amber-700">
  <p className="text-lg font-serif mb-1">No books found for …</p>
  <p className="text-sm text-amber-700">Try a different title…</p>
</div>
```

**After:**
```tsx
<div className="text-center py-10 text-amber-700">
  <SearchIcon className="w-10 h-10 mx-auto mb-2 text-amber-400" aria-hidden="true" />
  <p className="text-lg font-serif mb-1">No books found for …</p>
  <p className="text-sm text-amber-700">Try a different title…</p>
</div>
```

`SearchIcon` was not previously imported in `page.tsx` — also added to the import line.

## Why

CLAUDE.md design rule: every empty state must have an icon + `font-serif` headline + sub-text. This empty state had headline + sub-text but no icon, inconsistent with all other search empty states (in-app search was fixed in #1929).

## Test plan

- New `HomeSearchEmptyIcon.test.ts`: static-source assertions for `SearchIcon` presence and `aria-hidden`
- Full frontend suite: 2813 tests passed
- Backend suite running in CI

Closes #1937

## Docs follow-up

- [ ] Docs updated (if applicable)
