### PR TITLE
ux: add retry button to vocabulary and notes error states (closes #1939)

### DIFF
--- a/frontend/src/__tests__/ErrorStateRetryButton.test.ts
+++ b/frontend/src/__tests__/ErrorStateRetryButton.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Static-source assertions: error states on vocabulary, notes, and notes/[bookId]
+ * pages must have a retry CTA button so users can re-fetch without a full page reload.
+ * Closes #1939.
+ */
+import fs from "fs";
+import path from "path";
+
+const vocabSrc = fs.readFileSync(
+  path.resolve(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8",
+);
+const notesSrc = fs.readFileSync(
+  path.resolve(__dirname, "../app/notes/page.tsx"),
+  "utf8",
+);
+const notesBookSrcPath = path.resolve(
+  __dirname,
+  "../app/notes/[bookId]/page.tsx",
+);
+const notesBookSrc = fs.readFileSync(notesBookSrcPath, "utf8");
+
+// ── Vocabulary page ────────────────────────────────────────────────────────
+const vocabErrorBlock =
+  vocabSrc.match(/fetchError \?[\s\S]{0,800}Try again/)?.[0] ?? "";
+
+describe("vocabulary page error state", () => {
+  it("error block contains 'Try again' button", () => {
+    expect(vocabErrorBlock).toMatch(/Try again/);
+  });
+  it("error block includes an icon (AlertCircleIcon)", () => {
+    expect(vocabErrorBlock).toMatch(/AlertCircleIcon/);
+  });
+  it("error block includes font-serif headline", () => {
+    expect(vocabErrorBlock).toMatch(/font-serif/);
+  });
+});
+
+// ── Notes index page ───────────────────────────────────────────────────────
+const notesErrorBlock =
+  notesSrc.match(/fetchError \?[\s\S]{0,800}Try again/)?.[0] ?? "";
+
+describe("notes index page error state", () => {
+  it("error block contains 'Try again' button", () => {
+    expect(notesErrorBlock).toMatch(/Try again/);
+  });
+  it("error block includes an icon (AlertCircleIcon)", () => {
+    expect(notesErrorBlock).toMatch(/AlertCircleIcon/);
+  });
+  it("error block includes font-serif headline", () => {
+    expect(notesErrorBlock).toMatch(/font-serif/);
+  });
+});
+
+// ── Notes book page ────────────────────────────────────────────────────────
+const notesBookErrorBlock =
+  notesBookSrc.match(/fetchError \?[\s\S]{0,800}Try again/)?.[0] ?? "";
+
+describe("notes book page error state", () => {
+  it("error block contains 'Try again' button", () => {
+    expect(notesBookErrorBlock).toMatch(/Try again/);
+  });
+  it("error block includes an icon (AlertCircleIcon)", () => {
+    expect(notesBookErrorBlock).toMatch(/AlertCircleIcon/);
+  });
+  it("error block includes font-serif headline", () => {
+    expect(notesBookErrorBlock).toMatch(/font-serif/);
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import {
@@ -19,7 +19,7 @@ import {
 } from "@/lib/api";
 
 import { chapterLabel, truncate } from "@/lib/notesMarkdown";
-import { ArrowLeftIcon, TrashIcon, EditIcon, ChevronRightIcon, ChevronDownIcon, ArrowRightIcon, RetryIcon, EmptyNotesIcon, ArrowUpRightIcon } from "@/components/Icons";
+import { ArrowLeftIcon, TrashIcon, EditIcon, ChevronRightIcon, ChevronDownIcon, ArrowRightIcon, RetryIcon, EmptyNotesIcon, ArrowUpRightIcon, AlertCircleIcon } from "@/components/Icons";
 import UndoToast from "@/components/UndoToast";
 
 type ViewMode = "section" | "chapter";
@@ -283,10 +283,9 @@ export default function BookNotesPage() {
 
   const didScrollRef = useRef(false);
 
-  useEffect(() => {
-    if (status === "unauthenticated") { router.replace("/login"); return; }
-    if (status !== "authenticated") return;
+  const loadData = useCallback(() => {
     setFetchError(false);
+    setLoading(true);
     Promise.all([
       getBookChapters(bookId),
       getAnnotations(bookId),
@@ -300,6 +299,13 @@ export default function BookNotesPage() {
       setVocab(voc);
     }).catch(() => setFetchError(true))
       .finally(() => setLoading(false));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bookId]);
+
+  useEffect(() => {
+    if (status === "unauthenticated") { router.replace("/login"); return; }
+    if (status !== "authenticated") return;
+    loadData();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [status, bookId]);
 
@@ -708,8 +714,17 @@ export default function BookNotesPage() {
           </div>
         ) : fetchError ? (
           <div role="alert" className="text-center text-stone-500 mt-20 flex flex-col items-center gap-2">
+            <AlertCircleIcon className="w-12 h-12 text-red-300 mx-auto mb-1" aria-hidden="true" />
             <p className="font-serif text-lg text-red-700 mt-1">Failed to load notes.</p>
-            <p className="text-sm">Please refresh the page to try again.</p>
+            <p className="text-sm">Check your connection and try again.</p>
+            <button
+              type="button"
+              onClick={loadData}
+              className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px]"
+            >
+              <RetryIcon className="w-4 h-4" aria-hidden="true" />
+              Try again
+            </button>
           </div>
         ) : annCount + insCount + vocCount === 0 ? (
           <div className="text-center py-24 text-stone-500">

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -1,9 +1,9 @@
 "use client";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { getAllAnnotations, getAllInsights, getVocabulary, AnnotationWithBook, BookInsightWithBook, VocabularyWord } from "@/lib/api";
-import { NoteIcon, InsightIcon, VocabIcon, EmptyNotesIcon, ArrowLeftIcon, ArrowRightIcon, WordIcon } from "@/components/Icons";
+import { NoteIcon, InsightIcon, VocabIcon, EmptyNotesIcon, ArrowLeftIcon, ArrowRightIcon, WordIcon, AlertCircleIcon, RetryIcon } from "@/components/Icons";
 
 interface BookSummary {
   bookId: number;
@@ -39,10 +39,9 @@ export default function NotesOverviewPage() {
     document.title = "Notes — Book Reader AI";
   }, []);
 
-  useEffect(() => {
-    if (status === "unauthenticated") { router.replace("/login"); return; }
-    if (status !== "authenticated") return;
+  const loadNotes = useCallback(() => {
     setFetchError(false);
+    setLoading(true);
     Promise.all([getAllAnnotations(), getAllInsights(), getVocabulary()])
       .then(([anns, ins, voc]) => {
         setAnnotations(anns);
@@ -51,6 +50,12 @@ export default function NotesOverviewPage() {
       })
       .catch(() => setFetchError(true))
       .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (status === "unauthenticated") { router.replace("/login"); return; }
+    if (status !== "authenticated") return;
+    loadNotes();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [status]);
 
@@ -155,8 +160,17 @@ export default function NotesOverviewPage() {
           </div>
         ) : fetchError ? (
           <div role="alert" className="text-center text-stone-500 mt-20 flex flex-col items-center gap-2">
+            <AlertCircleIcon className="w-12 h-12 text-red-300 mx-auto mb-1" aria-hidden="true" />
             <p className="font-serif text-lg text-red-700 mt-1">Failed to load notes.</p>
-            <p className="text-sm">Please refresh the page to try again.</p>
+            <p className="text-sm">Check your connection and try again.</p>
+            <button
+              type="button"
+              onClick={loadNotes}
+              className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px]"
+            >
+              <RetryIcon className="w-4 h-4" aria-hidden="true" />
+              Try again
+            </button>
           </div>
         ) : filtered.length === 0 ? (
           <div className="text-center py-20 text-stone-500">

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -13,7 +13,7 @@ import {
   VocabularyWord,
   WordDefinition,
 } from "@/lib/api";
-import { EmptyVocabIcon, ArrowLeftIcon, ArrowRightIcon, FlashcardIcon, ArrowUpRightIcon } from "@/components/Icons";
+import { EmptyVocabIcon, ArrowLeftIcon, ArrowRightIcon, FlashcardIcon, ArrowUpRightIcon, AlertCircleIcon, RetryIcon } from "@/components/Icons";
 import TagEditor from "@/components/TagEditor";
 
 type SortMode = "alpha" | "language" | "book" | "recent";
@@ -232,12 +232,18 @@ function VocabularyPageContent() {
     document.title = "Vocabulary — Book Reader AI";
   }, []);
 
-  useEffect(() => {
+  const loadVocab = useCallback(() => {
     setFetchError(false);
+    setLoading(true);
     getVocabulary()
       .then(setWords)
       .catch(() => setFetchError(true))
       .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    loadVocab();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [session?.backendToken]);
 
   useEffect(() => {
@@ -571,8 +577,17 @@ function VocabularyPageContent() {
           </div>
         ) : fetchError ? (
           <div role="alert" className="text-center text-stone-500 mt-20 flex flex-col items-center gap-2">
+            <AlertCircleIcon className="w-12 h-12 text-red-300 mx-auto mb-1" aria-hidden="true" />
             <p className="font-serif text-lg text-red-700 mt-1">Failed to load vocabulary.</p>
-            <p className="text-sm">Please refresh the page to try again.</p>
+            <p className="text-sm">Check your connection and try again.</p>
+            <button
+              type="button"
+              onClick={loadVocab}
+              className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px]"
+            >
+              <RetryIcon className="w-4 h-4" aria-hidden="true" />
+              Try again
+            </button>
           </div>
         ) : words.length === 0 ? (
           <div className="text-center text-stone-500 mt-20 flex flex-col items-center gap-2">


### PR DESCRIPTION
## What changed

Vocabulary, notes index, and notes book pages all showed a bare "Please refresh the page" message when the API fetch failed — no retry action available.

This PR:
- Extracts the fetch call into a named `loadVocab` / `loadNotes` / `loadData` callback in each page
- Replaces the plain error text with a proper error state: `AlertCircleIcon` + font-serif headline + **Try again** button that calls the callback without a full page reload
- Updates the sub-copy from "Please refresh" → "Check your connection and try again."

## Why

Users on flaky connections had no recovery path except a manual browser refresh. A retry button is the minimum expected UX for an error state.

## Test plan

- [x] 9 new static-source assertions in `ErrorStateRetryButton.test.ts` — verify icon, font-serif headline, and "Try again" text in each page's error block
- [x] Full frontend suite: 2576 tests pass
- [x] Backend suite: passing

Closes #1939

[ ] Docs updated (if applicable)
