### PR TITLE
ux: show error state on popular-books fetch failure in home page (closes #1944)

### DIFF
--- a/frontend/src/__tests__/HomePage.branches.test.tsx
+++ b/frontend/src/__tests__/HomePage.branches.test.tsx
@@ -320,15 +320,17 @@ describe("HomePage — getReadingProgress merges backend data (lines 73-83)", ()
 // ── Line 116: getPopularBooks catch branch ────────────────────────────────────
 
 describe("HomePage — getPopularBooks error (line 116)", () => {
-  it("sets empty popular books when API fails", async () => {
+  it("shows error state (not empty-state) when API fails", async () => {
     mockGetPopularBooks.mockRejectedValue(new Error("Network error"));
 
     await renderHome();
 
-    // Should show "No popular books available yet."
+    // Should show error state with retry button, not the empty-library message
     await waitFor(() =>
-      expect(screen.getByText("No popular books available yet.")).toBeInTheDocument(),
+      expect(screen.getByRole("alert")).toBeInTheDocument(),
     );
+    expect(screen.queryByText("No popular books available yet.")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/__tests__/HomePage.popularerror.test.tsx
+++ b/frontend/src/__tests__/HomePage.popularerror.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Regression test for #1944: home page popular-books section must show a
+ * proper error state (with a retry button) when getPopularBooks() fails —
+ * not the "No popular books available yet." empty-state message.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ status: "unauthenticated", data: null }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const mockGetPopularBooks = jest.fn();
+const mockGetMe = jest.fn().mockResolvedValue({ role: "user" });
+const mockSearchBooks = jest.fn();
+const mockGetReadingProgress = jest.fn().mockResolvedValue([]);
+const mockGetUserStats = jest.fn().mockResolvedValue(null);
+
+jest.mock("@/lib/api", () => ({
+  getPopularBooks: (...args: unknown[]) => mockGetPopularBooks(...args),
+  getMe: (...args: unknown[]) => mockGetMe(...args),
+  searchBooks: (...args: unknown[]) => mockSearchBooks(...args),
+  getReadingProgress: (...args: unknown[]) => mockGetReadingProgress(...args),
+  getUserStats: (...args: unknown[]) => mockGetUserStats(...args),
+}));
+
+jest.mock("@/lib/recentBooks", () => ({
+  getRecentBooks: () => [],
+  removeRecentBook: jest.fn(),
+  recordRecentBook: jest.fn(),
+}));
+
+jest.mock("@/components/BookCard", () => {
+  const BookCard = ({ book }: { book: { id: number; title: string } }) => (
+    <div data-testid={`book-card-${book.id}`}>{book.title}</div>
+  );
+  BookCard.displayName = "BookCard";
+  return BookCard;
+});
+
+jest.mock("@/components/BookDetailModal", () => {
+  const BookDetailModal = () => null;
+  BookDetailModal.displayName = "BookDetailModal";
+  return BookDetailModal;
+});
+
+jest.mock("@/components/UndoToast", () => {
+  const UndoToast = () => null;
+  UndoToast.displayName = "UndoToast";
+  return UndoToast;
+});
+
+jest.mock("@/components/ReadingStats", () => {
+  const ReadingStats = () => null;
+  ReadingStats.displayName = "ReadingStats";
+  return ReadingStats;
+});
+
+jest.mock("@/components/SeedPopularButton", () => {
+  const SeedPopularButton = () => null;
+  SeedPopularButton.displayName = "SeedPopularButton";
+  return SeedPopularButton;
+});
+
+import Home from "@/app/page";
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test("shows error state (not empty-state) when getPopularBooks fails", async () => {
+  mockGetPopularBooks.mockRejectedValue(new Error("network error"));
+  render(<Home />);
+  await flushPromises();
+
+  // Should NOT show the "no books available" empty state
+  expect(screen.queryByText(/No popular books available/i)).not.toBeInTheDocument();
+
+  // Should show an error state with retry
+  expect(await screen.findByRole("alert")).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+});
+
+test("retry button re-fetches and shows books on success", async () => {
+  const BOOKS = {
+    books: [{ id: 1, title: "Moby Dick", authors: ["Melville"], subjects: [], languages: ["en"], download_count: 1000, cover_url: null }],
+    total: 1,
+  };
+  mockGetPopularBooks
+    .mockRejectedValueOnce(new Error("network error"))
+    .mockResolvedValueOnce(BOOKS);
+
+  render(<Home />);
+  await flushPromises();
+
+  const retryBtn = await screen.findByRole("button", { name: /try again/i });
+  const user = userEvent.setup();
+  await user.click(retryBtn);
+
+  await waitFor(() => {
+    expect(screen.getByTestId("book-card-1")).toBeInTheDocument();
+  });
+  expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+});
+
+test("genuine empty response shows no-books message, not error state", async () => {
+  mockGetPopularBooks.mockResolvedValue({ books: [], total: 0 });
+  render(<Home />);
+
+  expect(await screen.findByText(/No popular books available/i)).toBeInTheDocument();
+  expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: /try again/i })).not.toBeInTheDocument();
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,7 +6,7 @@ import BookCard from "@/components/BookCard";
 import UndoToast from "@/components/UndoToast";
 import BookDetailModal from "@/components/BookDetailModal";
 import ReadingStats from "@/components/ReadingStats";
-import { FireIcon, ArrowLeftIcon, ArrowRightIcon, BookOpenIcon, NoteIcon, InsightIcon, VocabIcon, BookCoverPlaceholderIcon, GlobeIcon, SummaryIcon, SpeakerIcon, GridViewIcon, ListViewIcon, SettingsIcon, SearchIcon } from "@/components/Icons";
+import { FireIcon, ArrowLeftIcon, ArrowRightIcon, BookOpenIcon, NoteIcon, InsightIcon, VocabIcon, BookCoverPlaceholderIcon, GlobeIcon, SummaryIcon, SpeakerIcon, GridViewIcon, ListViewIcon, SettingsIcon, SearchIcon, AlertCircleIcon, RetryIcon } from "@/components/Icons";
 import { SearchBar } from "@/components/SearchBar";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
@@ -103,6 +103,7 @@ export default function Home() {
 
   const [popularBooks, setPopularBooks] = useState<BookMeta[]>([]);
   const [popularLoading, setPopularLoading] = useState(false);
+  const [popularError, setPopularError] = useState(false);
   const [popularLang, setPopularLang] = useState("");
   const [popularPage, setPopularPage] = useState(1);
   const [popularTotal, setPopularTotal] = useState(0);
@@ -112,17 +113,22 @@ export default function Home() {
 
   const searchGenRef = useRef(0);
 
-  useEffect(() => {
-    if (tab !== "discover") return;
+  function loadPopularBooks() {
+    setPopularError(false);
     setPopularLoading(true);
-    const fetch = getPopularBooks(popularLang, popularPage);
-    fetch
+    getPopularBooks(popularLang, popularPage)
       .then((data) => {
         setPopularBooks(data.books);
         setPopularTotal(data.total);
       })
-      .catch(() => { setPopularBooks([]); setPopularTotal(0); })
+      .catch(() => { setPopularError(true); })
       .finally(() => setPopularLoading(false));
+  }
+
+  useEffect(() => {
+    if (tab !== "discover") return;
+    loadPopularBooks();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tab, popularLang, popularPage]);
 
   function handlePopularLangChange(lang: string) {
@@ -782,7 +788,23 @@ export default function Home() {
                 </>
               )}
 
-              {!popularLoading && popularBooks.length === 0 && (
+              {!popularLoading && popularError && (
+                <div role="alert" className="text-center py-10 flex flex-col items-center gap-2">
+                  <AlertCircleIcon className="w-10 h-10 text-red-300 mx-auto" aria-hidden="true" />
+                  <p className="font-serif text-base text-red-700">Failed to load books.</p>
+                  <p className="text-sm text-stone-500">Check your connection and try again.</p>
+                  <button
+                    type="button"
+                    onClick={loadPopularBooks}
+                    className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px]"
+                  >
+                    <RetryIcon className="w-4 h-4" aria-hidden="true" />
+                    Try again
+                  </button>
+                </div>
+              )}
+
+              {!popularLoading && !popularError && popularBooks.length === 0 && (
                 <p className="text-center py-10 text-amber-700 text-sm">
                   No popular books available yet.
                 </p>


### PR DESCRIPTION
## What changed

`app/page.tsx` silently coerced `getPopularBooks()` errors into an empty list:
```ts
.catch(() => { setPopularBooks([]); setPopularTotal(0); })
```
This caused network failures on the Discover tab to render "No popular books available yet." — indistinguishable from a genuinely empty catalogue.

## Why

Users on flaky connections had no indication the catalogue failed to load and no way to retry without a full page reload.

## Fix

- Added a `popularError` boolean state.
- On catch, set `popularError = true` (don't clobber the existing list).
- Added a `loadPopularBooks` function to enable retry without re-triggering the effect.
- JSX now renders three distinct states: loading → error (AlertCircleIcon + "Try again" button) → empty (no books returned) → list.
- Updated the stale `HomePage.branches.test.tsx` assertion that validated the old wrong behaviour.
- Added `HomePage.popularerror.test.tsx` with 3 tests: error state shown, retry restores list, genuine-empty shows correct message.

Follows the same pattern as #1939 (vocabulary/notes), #1941 (decks), and prior retry-button fixes.

## Test plan

- [ ] `npx jest "HomePage.popular" --no-coverage` — 3 tests pass
- [ ] Full `npm test -- --no-coverage --ci` — 2834 tests pass (451 suites)

Closes #1944
