### PR TITLE
ux: add AlertCircleIcon to inline action-error banners (closes #1953)

### DIFF
--- a/frontend/src/__tests__/SearchPage.errorstate.test.tsx
+++ b/frontend/src/__tests__/SearchPage.errorstate.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * Regression test for #1953: in-app search page error banner must include
+ * AlertCircleIcon (SVG), not just bare red text.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+
+const mockSearchParams = { get: (k: string) => (k === "q" ? "hamlet" : null) };
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const mockSearchFn = jest.fn();
+jest.mock("@/lib/api", () => ({
+  searchInAppContent: (...args: unknown[]) => mockSearchFn(...args),
+}));
+
+import SearchPage from "@/app/search/page";
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  mockSearchFn.mockReset();
+});
+
+test("search error alert contains an SVG icon (AlertCircleIcon)", async () => {
+  mockSearchFn.mockRejectedValue(new Error("network error"));
+  render(<SearchPage />);
+  await flushPromises();
+
+  const alert = await screen.findByRole("alert");
+  expect(alert).toBeInTheDocument();
+  const svg = alert.querySelector("svg");
+  expect(svg).not.toBeNull();
+});
+
+test("search error alert is gone after re-render with successful response", async () => {
+  mockSearchFn
+    .mockRejectedValueOnce(new Error("fail"))
+    .mockResolvedValueOnce({ query: "hamlet", total: 0, results: [] });
+
+  const { rerender } = render(<SearchPage />);
+  await flushPromises();
+
+  expect(await screen.findByRole("alert")).toBeInTheDocument();
+
+  // Change search params to trigger re-fetch
+  mockSearchParams.get = (k: string) => (k === "q" ? "othello" : null);
+  rerender(<SearchPage />);
+  await flushPromises();
+
+  await waitFor(() => {
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/UploadPage.erroricon.test.tsx
+++ b/frontend/src/__tests__/UploadPage.erroricon.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Regression test for #1953: upload page error banner must include
+ * AlertCircleIcon (SVG), not just bare red text.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  useParams: () => ({}),
+}));
+
+const mockUseSession = jest.fn();
+jest.mock("next-auth/react", () => ({
+  useSession: (...args: unknown[]) => mockUseSession(...args),
+}));
+
+const mockUploadBook = jest.fn();
+const mockGetUploadQuota = jest.fn();
+jest.mock("@/lib/api", () => ({
+  uploadBook: (...args: unknown[]) => mockUploadBook(...args),
+  getUploadQuota: (...args: unknown[]) => mockGetUploadQuota(...args),
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+      this.name = "ApiError";
+    }
+  },
+}));
+
+import UploadPage from "@/app/upload/page";
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  mockUseSession.mockReturnValue({ status: "authenticated", data: { backendToken: "tok" } });
+  mockGetUploadQuota.mockResolvedValue({ used: 0, max: 10 });
+});
+
+test("upload error alert contains an SVG icon (AlertCircleIcon)", async () => {
+  const { ApiError } = jest.requireMock("@/lib/api");
+  mockUploadBook.mockRejectedValue(new ApiError(413, "File too large"));
+
+  render(<UploadPage />);
+  await flushPromises();
+
+  const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+  const bigFile = new File(["x".repeat(100)], "big.txt", { type: "text/plain" });
+  await userEvent.upload(input, bigFile);
+
+  await waitFor(() => {
+    const alert = screen.queryByRole("alert");
+    expect(alert).not.toBeNull();
+    const svg = alert!.querySelector("svg");
+    expect(svg).not.toBeNull();
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -602,8 +602,9 @@ export default function Home() {
               </div>
 
               {searchError && (
-                <div role="alert" className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 mb-4 text-sm">
-                  {searchError}
+                <div role="alert" className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 mb-4 text-sm flex items-center gap-2">
+                  <AlertCircleIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
+                  <span>{searchError}</span>
                 </div>
               )}
 

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
 
-import { SearchIcon, ArrowLeftIcon, ArrowRightIcon } from "@/components/Icons";
+import { AlertCircleIcon, SearchIcon, ArrowLeftIcon, ArrowRightIcon } from "@/components/Icons";
 import { InAppSearchResponse, InAppSearchResult, searchInAppContent } from "@/lib/api";
 
 function SnippetHtml({ snippet }: { snippet: string }) {
@@ -166,8 +166,9 @@ function SearchResultsInner() {
       )}
 
       {!loading && error && (
-        <div role="alert" className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
-          Error: {error}
+        <div role="alert" className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg px-4 py-3 flex items-center gap-2">
+          <AlertCircleIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
+          <span>Error: {error}</span>
         </div>
       )}
 

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { uploadBook, getUploadQuota, UploadQuota, ApiError } from "@/lib/api";
-import { UploadIcon, ArrowLeftIcon } from "@/components/Icons";
+import { AlertCircleIcon, UploadIcon, ArrowLeftIcon } from "@/components/Icons";
 
 export default function UploadPage() {
   const router = useRouter();
@@ -186,8 +186,9 @@ export default function UploadPage() {
 
         {/* Error */}
         {error && (
-          <div role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-            {error}
+          <div role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 flex items-center gap-2">
+            <AlertCircleIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
+            <span>{error}</span>
           </div>
         )}
 


### PR DESCRIPTION
## What changed

Three pages displayed bare red text `role="alert"` banners with no icon when an inline user action failed:

- **`/upload`** — file upload failure
- **`/search`** (in-app content search) — search API failure
- **`/`** (home page) — Gutenberg book search failure

Added `AlertCircleIcon` to each banner as a flex row, matching the visual pattern established across admin action-error banners.

## Why

Unlike the initial-load error series fixed in #1939–#1952, these are action-triggered errors where the user's natural retry is to repeat the action. A dedicated Retry button is not needed, but the icon was missing for visual consistency.

## Test plan

- [x] New `SearchPage.errorstate.test.tsx`: search error alert contains SVG icon; alert clears after successful re-fetch
- [x] New `UploadPage.erroricon.test.tsx`: upload error alert contains SVG icon
- [x] Full frontend suite: 2854/2854 passing (includes newly merged `AdminPages.errorstate.test.tsx` from #1952)

Closes #1953
