### PR TITLE
ux: add AlertCircleIcon to import and chapter-editor error banners (closes #1955)

### DIFF
--- a/frontend/src/__tests__/ChapterEditor.erroricon.test.tsx
+++ b/frontend/src/__tests__/ChapterEditor.erroricon.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Regression test for #1955: chapter-editor inline confirm-error banner
+ * must include AlertCircleIcon (SVG) when confirmChapters fails.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("next/navigation", () => ({
+  useParams: () => ({ bookId: "42" }),
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const mockGetDraftChapters = jest.fn();
+const mockConfirmChapters = jest.fn();
+
+jest.mock("@/lib/api", () => ({
+  getDraftChapters: (...args: unknown[]) => mockGetDraftChapters(...args),
+  confirmChapters: (...args: unknown[]) => mockConfirmChapters(...args),
+  ApiError: class ApiError extends Error {
+    constructor(message: string) { super(message); this.name = "ApiError"; }
+  },
+}));
+
+import ChapterEditorPage from "@/app/upload/[bookId]/chapters/page";
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+const CHAPTERS = {
+  chapters: [{ index: 0, title: "Chapter 1", word_count: 500, preview: "In the beginning..." }],
+};
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+test("inline confirm-error alert contains SVG icon (AlertCircleIcon)", async () => {
+  mockGetDraftChapters.mockResolvedValue(CHAPTERS);
+  mockConfirmChapters.mockRejectedValue(new Error("server error"));
+
+  render(<ChapterEditorPage />);
+  await flushPromises();
+
+  await screen.findByText("Chapter 1");
+
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: /confirm.*start reading/i }));
+  await flushPromises();
+
+  await waitFor(() => {
+    const alert = screen.getByRole("alert");
+    const svg = alert.querySelector("svg");
+    expect(svg).not.toBeNull();
+  });
+});

--- a/frontend/src/__tests__/ImportPage.erroricon.test.tsx
+++ b/frontend/src/__tests__/ImportPage.erroricon.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Regression test for #1955: import page inline error banner must include
+ * AlertCircleIcon (SVG) when the import stream throws an error.
+ */
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+
+jest.mock("next/navigation", () => ({
+  useParams: jest.fn().mockReturnValue({ bookId: "1342" }),
+  useRouter: jest.fn().mockReturnValue({ push: jest.fn() }),
+  useSearchParams: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue(null) }),
+}));
+
+const mockImportBookStream = jest.fn();
+
+jest.mock("@/lib/api", () => {
+  const actual = jest.requireActual("@/lib/api");
+  return {
+    ...actual,
+    importBookStream: (...args: unknown[]) => mockImportBookStream(...args),
+  };
+});
+
+import ImportPage from "@/app/import/[bookId]/page";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+async function* failStream() {
+  throw new Error("network error");
+  yield {}; // unreachable
+}
+
+test("import error alert contains SVG icon (AlertCircleIcon)", async () => {
+  mockImportBookStream.mockReturnValue(failStream());
+
+  render(<ImportPage />);
+  fireEvent.click(screen.getByRole("button", { name: /start import/i }));
+
+  await waitFor(() => {
+    const alert = screen.queryByRole("alert");
+    expect(alert).not.toBeNull();
+    const svg = alert!.querySelector("svg");
+    expect(svg).not.toBeNull();
+  });
+});

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -296,8 +296,9 @@ export default function BookImportPage() {
           )}
 
           {error && (
-            <div role="alert" className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-3 py-2 text-sm mb-4">
-              {error}
+            <div role="alert" className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-3 py-2 text-sm mb-4 flex items-center gap-2">
+              <AlertCircleIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
+              <span>{error}</span>
             </div>
           )}
 

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -150,8 +150,9 @@ export default function ChapterEditorPage() {
 
       {error && (
         <div className="max-w-5xl mx-auto w-full px-4 md:px-6 pt-4">
-          <div role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-            {error}
+          <div role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 flex items-center gap-2">
+            <AlertCircleIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
+            <span>{error}</span>
           </div>
         </div>
       )}


### PR DESCRIPTION
## What changed

Two pages (`/import/[bookId]` and `/upload/[bookId]/chapters`) had bare `role="alert"` banners with no icon when an inline action failed. Both pages already imported `AlertCircleIcon` but weren't using it in the error banner.

- **`/import/[bookId]`**: error shown when import stream throws (network error or API error)
- **`/upload/[bookId]/chapters`**: error shown when `confirmChapters` fails after chapters have loaded

Added `AlertCircleIcon` + flex row to each, matching the pattern from #1953.

## Why

Completes the error-banner icon audit. All `role="alert"` banners in the app now have an icon.

## Test plan

- [x] `ChapterEditor.erroricon.test.tsx`: confirm-error alert has SVG after `confirmChapters` rejects
- [x] `ImportPage.erroricon.test.tsx`: import-error alert has SVG after stream throws
- [x] Full frontend suite: 2853/2853 passing

Closes #1955
