### PR TITLE
ux: add title attributes to truncated text in admin tables (closes #1957)

### DIFF
--- a/frontend/src/__tests__/AdminTruncateTitle.test.tsx
+++ b/frontend/src/__tests__/AdminTruncateTitle.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Regression test for #1957: truncated text in admin tables must have
+ * title attributes so users can hover to reveal full content.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const mockAdminFetch = jest.fn();
+jest.mock("@/lib/adminFetch", () => ({
+  adminFetch: (...args: unknown[]) => mockAdminFetch(...args),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getMe: () => Promise.resolve({ id: 99 }),
+}));
+
+jest.mock("@/components/SeedPopularButton", () => {
+  const Seed = () => <button>Seed</button>;
+  Seed.displayName = "SeedPopularButton";
+  return { __esModule: true, default: Seed };
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+// --- admin/uploads ---
+import UploadsPage from "@/app/admin/uploads/page";
+
+const UPLOAD = {
+  book_id: 1,
+  title: "A Very Long Book Title That Will Definitely Get Truncated In The Table",
+  filename: "very-long-filename-that-also-gets-truncated.epub",
+  file_size: 1048576,
+  format: "epub",
+  uploaded_at: "2026-01-01T00:00:00Z",
+  uploader_email: "user@example.com",
+  uploader_name: "Test User",
+};
+
+test("uploads table: truncated title and filename have title attributes", async () => {
+  mockAdminFetch.mockResolvedValue([UPLOAD]);
+  render(<UploadsPage />);
+  await flushPromises();
+
+  await screen.findByText(UPLOAD.title);
+
+  const titleCell = screen.getByText(UPLOAD.title).closest("td");
+  expect(titleCell).not.toBeNull();
+  expect(titleCell!.getAttribute("title")).toBe(UPLOAD.title);
+
+  const filenameCell = screen.getByText(UPLOAD.filename).closest("td");
+  expect(filenameCell).not.toBeNull();
+  expect(filenameCell!.getAttribute("title")).toBe(UPLOAD.filename);
+});
+
+// --- admin/users ---
+import UsersPage from "@/app/admin/users/page";
+
+const USER = {
+  id: 1,
+  email: "a-very-long-email-address-that-truncates@example-domain.com",
+  name: "A Very Long Name That Will Truncate In The List View",
+  picture: "",
+  role: "user",
+  approved: 1,
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+test("users list: truncated name and email have title attributes", async () => {
+  mockAdminFetch.mockResolvedValue([USER]);
+  render(<UsersPage />);
+  await flushPromises();
+
+  await screen.findByText(USER.name);
+
+  const nameEl = screen.getByText(USER.name);
+  expect(nameEl.getAttribute("title")).toBe(USER.name);
+
+  const emailEl = screen.getByText(USER.email);
+  expect(emailEl.getAttribute("title")).toBe(USER.email);
+});
+
+// --- admin/books ---
+import BooksPage from "@/app/admin/books/page";
+
+const BOOK_STATS = { total_books: 1, total_translations: 0, failed_translations: 0 };
+const BOOK = {
+  id: 1,
+  title: "A Very Long Book Title That Gets Truncated In The Admin Books Panel",
+  active: false,
+  active_language: null,
+  translations: {},
+};
+
+test("books list: truncated title has title attribute", async () => {
+  mockAdminFetch
+    .mockResolvedValueOnce([BOOK])          // /admin/books
+    .mockResolvedValueOnce(BOOK_STATS);     // /admin/translations
+  render(<BooksPage />);
+  await flushPromises();
+
+  await screen.findByText(BOOK.title);
+
+  const titleEl = screen.getByText(BOOK.title);
+  expect(titleEl.getAttribute("title")).toBe(BOOK.title);
+});

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -371,7 +371,7 @@ export default function BooksPage() {
 
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
-                    <span className="font-medium text-ink text-sm truncate">{b.title}</span>
+                    <span className="font-medium text-ink text-sm truncate" title={b.title}>{b.title}</span>
                     {b.active && (
                       <span className="text-xs px-1.5 py-0.5 rounded-full bg-emerald-100 text-emerald-700 animate-pulse">
                         translating → {b.active_language}

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -154,8 +154,8 @@ export default function UploadsPage() {
               <tbody className="divide-y divide-amber-100">
                 {uploads.map((u) => (
                   <tr key={`${u.book_id}-${u.filename}`} className="hover:bg-amber-50/40">
-                    <td className="px-4 py-2.5 font-medium text-ink max-w-[200px] truncate">{u.title}</td>
-                    <td className="px-4 py-2.5 text-stone-500 max-w-[160px] truncate">{u.filename}</td>
+                    <td className="px-4 py-2.5 font-medium text-ink max-w-[200px] truncate" title={u.title}>{u.title}</td>
+                    <td className="px-4 py-2.5 text-stone-500 max-w-[160px] truncate" title={u.filename}>{u.filename}</td>
                     <td className="px-4 py-2.5">
                       <span className="text-xs px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-200">
                         {u.format}

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -103,7 +103,7 @@ export default function UsersPage() {
             )}
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2">
-                <span className="font-medium text-ink text-sm truncate">{u.name}</span>
+                <span className="font-medium text-ink text-sm truncate" title={u.name}>{u.name}</span>
                 {u.role === "admin" && (
                   <span className="text-xs bg-amber-100 text-amber-800 px-1.5 py-0.5 rounded">admin</span>
                 )}
@@ -111,7 +111,7 @@ export default function UsersPage() {
                   <span className="text-xs bg-orange-100 text-orange-800 px-1.5 py-0.5 rounded">pending</span>
                 )}
               </div>
-              <p className="text-xs text-stone-500 truncate">{u.email}</p>
+              <p className="text-xs text-stone-500 truncate" title={u.email}>{u.email}</p>
             </div>
             {u.id !== myId && (
               <div className="flex gap-1 items-center">


### PR DESCRIPTION
## What changed

Added `title` attributes to truncated text elements in all three admin panels so hovering over a truncated cell reveals the full content:

- `admin/uploads`: book title (`u.title`) and filename (`u.filename`) table cells
- `admin/users`: user name (`u.name`) span and email (`u.email`) paragraph
- `admin/books`: book title (`b.title`) span

The `uploader_email` column in uploads already had this pattern — this change applies it consistently.

## Why

Admins managing books, users, and uploads had no way to see the full content of long titles, filenames, or email addresses — the truncated text was unrecoverable without navigating away.

## Test plan

- `AdminTruncateTitle.test.tsx` — 3 new regression tests (one per admin page) verify that each truncated element has `title={value}` matching the displayed text
- Full Jest suite: 2859 tests pass
- Full pytest suite: passing

Closes #1957
