### PR TITLE
ux: add 44×44px touch targets to admin dismiss error/success buttons (closes #1959)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -170,6 +170,12 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-22 | 6.1 | Vocabulary: EmptyVocabIcon SVG empty state | ✅ Done |
 | 2026-04-22 | 6.2 | Notes header: icon+count stat pills | ✅ Done |
 | 2026-04-22 | 6.3 | Profile: section category labels | ✅ Done |
+| 2026-04-28 | 8.1 | Admin error pages: AlertCircleIcon + Retry button (audio, users) | ✅ Done |
+| 2026-04-28 | 8.2 | Admin inline error banners: AlertCircleIcon + Retry (books, uploads) | ✅ Done |
+| 2026-04-28 | 8.3 | Upload, search, home page error banners: AlertCircleIcon added | ✅ Done |
+| 2026-04-28 | 8.4 | Import and chapter-editor error banners: AlertCircleIcon added | ✅ Done |
+| 2026-04-28 | 8.5 | Admin tables: title attributes on truncated book/user/file text | ✅ Done |
+| 2026-04-28 | 8.6 | Admin dismiss error/message buttons: 44×44px mobile touch targets | ✅ Done |
 
 ---
 

--- a/frontend/src/__tests__/AdminDismissTouch.test.tsx
+++ b/frontend/src/__tests__/AdminDismissTouch.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Regression test for #1959: dismiss error/success buttons in admin panels
+ * must meet 44×44px mobile touch target requirements.
+ */
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const mockAdminFetch = jest.fn();
+jest.mock("@/lib/adminFetch", () => ({
+  adminFetch: (...args: unknown[]) => mockAdminFetch(...args),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getMe: () => Promise.resolve({ id: 99 }),
+}));
+
+jest.mock("@/components/SeedPopularButton", () => {
+  const Seed = () => <button>Seed</button>;
+  Seed.displayName = "SeedPopularButton";
+  return { __esModule: true, default: Seed };
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+function hasMinH44(el: Element): boolean {
+  return el.className.includes("min-h-[44px]");
+}
+
+function hasMinW44(el: Element): boolean {
+  return el.className.includes("min-w-[44px]");
+}
+
+// --- admin/users: dismiss error button ---
+import UsersPage from "@/app/admin/users/page";
+
+const USER = {
+  id: 2,
+  email: "user@example.com",
+  name: "Test User",
+  picture: "",
+  role: "user",
+  approved: 1,
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+test("users page: dismiss error button has min-h-[44px] and min-w-[44px]", async () => {
+  // Load succeeds, then approve action fails → actError banner shows dismiss button
+  mockAdminFetch.mockResolvedValueOnce([USER]); // initial load
+  render(<UsersPage />);
+  await flushPromises();
+
+  await screen.findByText("Test User");
+
+  // Approve action fails → actError
+  mockAdminFetch.mockRejectedValueOnce(new Error("server error")); // PUT approve
+  mockAdminFetch.mockResolvedValueOnce([USER]); // reload call
+
+  fireEvent.click(screen.getByRole("button", { name: /revoke test user/i }));
+
+  const dismissBtn = await screen.findByRole("button", { name: /dismiss error/i });
+  expect(hasMinH44(dismissBtn)).toBe(true);
+  expect(hasMinW44(dismissBtn)).toBe(true);
+});
+
+// --- admin/books: dismiss error button ---
+import BooksPage from "@/app/admin/books/page";
+
+const BOOK_STATS = { total_books: 0, total_translations: 0, failed_translations: 0 };
+
+test("books page: dismiss error button has min-h-[44px] and min-w-[44px]", async () => {
+  // Load succeeds with no books, then import action fails → actError
+  mockAdminFetch
+    .mockResolvedValueOnce([])        // /admin/books
+    .mockResolvedValueOnce(BOOK_STATS); // /admin/translations
+  render(<BooksPage />);
+
+  await waitFor(() => {
+    expect(mockAdminFetch).toHaveBeenCalledTimes(2);
+  });
+  await flushPromises();
+
+  // Set import ID and click Import Book
+  const idInput = await screen.findByPlaceholderText(/Gutenberg Book ID/i);
+  fireEvent.change(idInput, { target: { value: "123" } });
+
+  // Import POST fails → actError; then reload on error path
+  mockAdminFetch.mockRejectedValueOnce(new Error("not found")); // POST import
+  // No reload needed since import catch doesn't call load()
+
+  fireEvent.click(screen.getByRole("button", { name: /import book/i }));
+  await flushPromises();
+
+  const dismissBtn = await screen.findByRole("button", { name: /dismiss error/i });
+  expect(hasMinH44(dismissBtn)).toBe(true);
+  expect(hasMinW44(dismissBtn)).toBe(true);
+});

--- a/frontend/src/app/admin/audio/page.tsx
+++ b/frontend/src/app/admin/audio/page.tsx
@@ -82,7 +82,7 @@ export default function AudioPage() {
             type="button"
             onClick={() => setActError(null)}
             aria-label="Dismiss error"
-            className="shrink-0 text-red-500 hover:text-red-700"
+            className="shrink-0 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 flex items-center justify-center text-red-500 hover:text-red-700"
           >
             <CloseIcon className="w-4 h-4" aria-hidden="true" />
           </button>

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -284,7 +284,7 @@ export default function BooksPage() {
             type="button"
             onClick={() => setActError(null)}
             aria-label="Dismiss error"
-            className="shrink-0 text-red-500 hover:text-red-700"
+            className="shrink-0 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 flex items-center justify-center text-red-500 hover:text-red-700"
           >
             <CloseIcon className="w-4 h-4" aria-hidden="true" />
           </button>
@@ -298,7 +298,7 @@ export default function BooksPage() {
             type="button"
             onClick={() => setToast(null)}
             aria-label="Dismiss message"
-            className="shrink-0 text-emerald-500 hover:text-emerald-700"
+            className="shrink-0 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 flex items-center justify-center text-emerald-500 hover:text-emerald-700"
           >
             <CloseIcon className="w-4 h-4" aria-hidden="true" />
           </button>

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -84,7 +84,7 @@ export default function UsersPage() {
             type="button"
             onClick={() => setActError(null)}
             aria-label="Dismiss error"
-            className="shrink-0 text-red-500 hover:text-red-700"
+            className="shrink-0 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 flex items-center justify-center text-red-500 hover:text-red-700"
           >
             <CloseIcon className="w-4 h-4" aria-hidden="true" />
           </button>

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -538,7 +538,7 @@ export default function QueueTab({ adminFetch }: Props) {
             type="button"
             onClick={() => setActError(null)}
             aria-label="Dismiss error"
-            className="shrink-0 text-red-500 hover:text-red-700"
+            className="shrink-0 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 flex items-center justify-center text-red-500 hover:text-red-700"
           >
             <CloseIcon className="w-4 h-4" aria-hidden="true" />
           </button>
@@ -552,7 +552,7 @@ export default function QueueTab({ adminFetch }: Props) {
             type="button"
             onClick={() => setToast(null)}
             aria-label="Dismiss message"
-            className="shrink-0 text-emerald-500 hover:text-emerald-700"
+            className="shrink-0 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 flex items-center justify-center text-emerald-500 hover:text-emerald-700"
           >
             <CloseIcon className="w-4 h-4" aria-hidden="true" />
           </button>


### PR DESCRIPTION
## What changed

Added `min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0` and `flex items-center justify-center` to all six icon-only "Dismiss error" / "Dismiss message" buttons in admin panels:

- `admin/users/page.tsx` — Dismiss error
- `admin/books/page.tsx` — Dismiss error + Dismiss message  
- `admin/audio/page.tsx` — Dismiss error
- `components/QueueTab.tsx` — Dismiss error + Dismiss message

## Why

These are 16×16px icon-only buttons with no minimum touch target, making them unreliable to tap on mobile. The `md:min-h-0 md:min-w-0` modifier preserves compact desktop chrome while giving mobile users a properly-sized 44×44px target per WCAG 2.5.5.

## Test plan

- `AdminDismissTouch.test.tsx` — 2 new regression tests verify dismiss error buttons have `min-h-[44px]` and `min-w-[44px]` classes after triggering actError in admin/users and admin/books
- Full Jest suite: 2861 tests pass
- Full pytest suite: 1942 tests pass

Closes #1959
