### PR TITLE
ux: add sr-only h2 section headings to admin sub-pages (closes #1961)

### DIFF
--- a/frontend/src/__tests__/AdminSectionHeadings.test.tsx
+++ b/frontend/src/__tests__/AdminSectionHeadings.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Regression test for #1961: admin sub-pages must each have an h2
+ * section heading so screen reader users can navigate by headings.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const mockAdminFetch = jest.fn();
+jest.mock("@/lib/adminFetch", () => ({
+  adminFetch: (...args: unknown[]) => mockAdminFetch(...args),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getMe: () => Promise.resolve({ id: 99 }),
+}));
+
+jest.mock("@/components/SeedPopularButton", () => {
+  const Seed = () => <button>Seed</button>;
+  Seed.displayName = "SeedPopularButton";
+  return { __esModule: true, default: Seed };
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+const BOOK_STATS = { total_books: 0, total_translations: 0, failed_translations: 0 };
+
+import AudioPage from "@/app/admin/audio/page";
+import UsersPage from "@/app/admin/users/page";
+import BooksPage from "@/app/admin/books/page";
+import UploadsPage from "@/app/admin/uploads/page";
+
+test("audio page: has h2 heading for the section", async () => {
+  mockAdminFetch.mockResolvedValueOnce([]);
+  render(<AudioPage />);
+  await waitFor(() => expect(mockAdminFetch).toHaveBeenCalledTimes(1));
+  await flushPromises();
+  expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
+});
+
+test("users page: has h2 heading for the section", async () => {
+  mockAdminFetch.mockResolvedValueOnce([]);
+  render(<UsersPage />);
+  await waitFor(() => expect(mockAdminFetch).toHaveBeenCalledTimes(1));
+  await flushPromises();
+  expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
+});
+
+test("books page: has h2 heading for the section", async () => {
+  mockAdminFetch
+    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce(BOOK_STATS);
+  render(<BooksPage />);
+  await waitFor(() => expect(mockAdminFetch).toHaveBeenCalledTimes(2));
+  await flushPromises();
+  expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
+});
+
+test("uploads page: has h2 heading for the section", async () => {
+  mockAdminFetch.mockResolvedValueOnce([]);
+  render(<UploadsPage />);
+  await waitFor(() => expect(mockAdminFetch).toHaveBeenCalledTimes(1));
+  await flushPromises();
+  expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
+});

--- a/frontend/src/app/admin/audio/page.tsx
+++ b/frontend/src/app/admin/audio/page.tsx
@@ -75,6 +75,7 @@ export default function AudioPage() {
 
   return (
     <div className="space-y-3">
+      <h2 className="sr-only">Audio Cache</h2>
       {actError && (
         <div role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 flex items-center justify-between gap-3">
           <span>{actError}</span>

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -234,6 +234,7 @@ export default function BooksPage() {
 
   return (
     <div className="space-y-4">
+      <h2 className="sr-only">Books</h2>
       {error && (
         <div role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 flex items-center gap-3">
           <AlertCircleIcon className="w-4 h-4 shrink-0" aria-hidden="true" />

--- a/frontend/src/app/admin/queue/page.tsx
+++ b/frontend/src/app/admin/queue/page.tsx
@@ -8,5 +8,10 @@ export default function QueuePage() {
     document.title = "Admin: Queue — Book Reader AI";
   }, []);
 
-  return <QueueTab adminFetch={adminFetch} />;
+  return (
+    <div>
+      <h2 className="sr-only">Translation Queue</h2>
+      <QueueTab adminFetch={adminFetch} />
+    </div>
+  );
 }

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -84,6 +84,7 @@ export default function UploadsPage() {
 
   return (
     <div className="space-y-4">
+      <h2 className="sr-only">Uploads</h2>
       {error && (
         <div role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 flex items-center gap-3">
           <AlertCircleIcon className="w-4 h-4 shrink-0" aria-hidden="true" />

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -77,6 +77,7 @@ export default function UsersPage() {
 
   return (
     <div className="space-y-3">
+      <h2 className="sr-only">Users</h2>
       {actError && (
         <div role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 flex items-center justify-between gap-3">
           <span>{actError}</span>


### PR DESCRIPTION
## What changed

Added a visually-hidden `<h2 className="sr-only">` section heading to every admin sub-page:

- `admin/audio/page.tsx` → "Audio Cache"
- `admin/users/page.tsx` → "Users"
- `admin/books/page.tsx` → "Books"
- `admin/uploads/page.tsx` → "Uploads"
- `admin/queue/page.tsx` → "Translation Queue"

## Why

The admin layout provides an `<h1>Admin Panel</h1>` but each sub-page had no heading below it. Screen reader users navigating with the headings shortcut (H key in NVDA/JAWS) jumped directly from the h1 to page content with no indication of which section they were in. The `aria-current="page"` on the nav tab isn't part of heading navigation.

Closes #1961 (WCAG 2.4.6 Headings and Labels, WCAG 1.3.1 Info and Relationships).

## Test plan

- [x] 4 new regression tests in `AdminSectionHeadings.test.tsx` — one per affected page — verify `role="heading" level=2` is present after data loads
- [x] Full frontend suite: 2865 tests pass
- [x] No visual change (sr-only headings are invisible on screen)
