### PR TITLE
ux: add aria-label to BookCard main button (closes #1963)

### DIFF
--- a/frontend/src/__tests__/BookCard.test.tsx
+++ b/frontend/src/__tests__/BookCard.test.tsx
@@ -99,3 +99,26 @@ test("remove button meets 44px minimum touch target size", () => {
   expect(removeBtn.className).toContain("min-w-[44px]");
   expect(removeBtn.className).toContain("min-h-[44px]");
 });
+
+// ── aria-label on main card button (#1963) ─────────────────────────────────────
+
+test("main card button has aria-label announcing the open action and book title", () => {
+  render(<BookCard book={BOOK} onClick={jest.fn()} />);
+  // When onRemove is absent there is only one button — the card itself.
+  const card = screen.getByRole("button", { name: `Open ${BOOK.title} by ${BOOK.authors[0]}` });
+  expect(card).toBeInTheDocument();
+});
+
+test("main card button aria-label omits 'by ...' when no authors", () => {
+  render(<BookCard book={{ ...BOOK, authors: [] }} onClick={jest.fn()} />);
+  const card = screen.getByRole("button", { name: `Open ${BOOK.title}` });
+  expect(card).toBeInTheDocument();
+});
+
+test("main card button aria-label joins multiple authors", () => {
+  render(
+    <BookCard book={{ ...BOOK, authors: ["Author A", "Author B"] }} onClick={jest.fn()} />,
+  );
+  const card = screen.getByRole("button", { name: "Open Pride and Prejudice by Author A, Author B" });
+  expect(card).toBeInTheDocument();
+});

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -31,6 +31,7 @@ export default function BookCard({ book, onClick, badge, onRemove }: Props) {
       <button
         data-testid="book-card"
         onClick={onClick}
+        aria-label={`Open ${book.title}${book.authors.length ? ` by ${book.authors.join(", ")}` : ""}`}
         className="text-left rounded-xl border border-amber-200 bg-white p-3 flex flex-col w-full transition-all duration-200 hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
         style={{ boxShadow: "var(--shadow-card)" }}
         onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card-hover)"; }}


### PR DESCRIPTION
## What changed

Added `aria-label` to the main clickable button in `BookCard` (`frontend/src/components/BookCard.tsx`).

**Before:** Screen readers computed an accessible name from the button's text content, announcing something like *"Jane Eyre Charlotte Brontë Ch. 1 · 2h ago"* with no indication of the action.

**After:** The button explicitly announces *"Open Jane Eyre by Charlotte Brontë"*, matching the same pattern already used by list-view book rows in the Popular Classics section on the home page.

## Why

WCAG 2.4.6 — controls should have descriptive accessible names that communicate both the action and the target. The generic text-content name was ambiguous to screen reader users navigating by button shortcut.

## Test plan

- Added 3 regression tests to `BookCard.test.tsx`:
  - `aria-label` with title + authors
  - `aria-label` with title only (no authors)
  - `aria-label` with multiple authors joined by comma
- All 15 `BookCard` tests pass; full 2868-test suite passes.

Closes #1963
