### PR TITLE
ux: fix screen-reader-unfriendly unicode arrows in vocab drawer and upload button (closes #1969)

### DIFF
--- a/frontend/src/__tests__/UnicodeArrowA11y.test.tsx
+++ b/frontend/src/__tests__/UnicodeArrowA11y.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Regression tests for WCAG 1.3.1 compliance on unicode arrows used as
+ * typographic indicators (closes #1969).
+ *
+ * Covers:
+ *  - Vocabulary definition drawer lemma indicator (← lemma)
+ *    must have aria-label="base form: <lemma>" so screen readers
+ *    don't announce "left arrow amor"
+ *  - Upload chapters confirm button must NOT contain a trailing "→"
+ *    (decorative arrow removed from button text)
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// ── Vocabulary page mocks ────────────────────────────────────────────────────
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { backendToken: "token" } }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getVocabulary: jest.fn(),
+  deleteVocabularyWord: jest.fn(),
+  exportVocabularyToObsidian: jest.fn(),
+  getWordDefinition: jest.fn(),
+  listVocabularyTags: jest.fn().mockResolvedValue([]),
+  getVocabularyWordTags: jest.fn().mockResolvedValue([]),
+  addVocabularyWordTag: jest.fn().mockResolvedValue({ tag: "" }),
+  removeVocabularyWordTag: jest.fn().mockResolvedValue(undefined),
+  ApiError: class ApiError extends Error { status = 500; },
+}));
+
+import * as api from "@/lib/api";
+import VocabularyPage from "@/app/vocabulary/page";
+
+const mockGetVocabulary = api.getVocabulary as jest.MockedFunction<typeof api.getVocabulary>;
+const mockGetWordDefinition = api.getWordDefinition as jest.MockedFunction<typeof api.getWordDefinition>;
+
+const SAMPLE_WORDS = [
+  {
+    id: 1,
+    word: "running",
+    lemma: "running",
+    language: "en",
+    occurrences: [{ book_id: 1, book_title: "Test Book", chapter_index: 0, sentence_text: "He was running fast." }],
+  },
+];
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetVocabulary.mockResolvedValue(SAMPLE_WORDS);
+});
+
+// ── vocabulary drawer lemma indicator ─────────────────────────────────────────
+
+test("lemma indicator span has aria-label 'base form: <lemma>' when lemma differs from word", async () => {
+  // API returns a lemma ("run") different from the clicked word ("running")
+  mockGetWordDefinition.mockResolvedValue({
+    lemma: "run",
+    language: "en",
+    definitions: [{ pos: "verb", text: "to move quickly" }],
+    url: "",
+  });
+
+  render(<VocabularyPage />);
+  await flushPromises();
+  await screen.findByText("running");
+
+  await userEvent.click(screen.getByRole("button", { name: "running" }));
+
+  // Wait for definition to load
+  await waitFor(() => expect(screen.getByText("to move quickly")).toBeInTheDocument());
+
+  // The lemma indicator must have an aria-label that screen readers can use
+  const lemmaIndicator = screen.getByText(/← run/);
+  expect(lemmaIndicator).toHaveAttribute("aria-label", "base form: run");
+});
+
+test("lemma indicator is absent when word equals lemma", async () => {
+  mockGetWordDefinition.mockResolvedValue({
+    lemma: "running",
+    language: "en",
+    definitions: [{ pos: "verb", text: "continuous motion" }],
+    url: "",
+  });
+
+  render(<VocabularyPage />);
+  await flushPromises();
+  await screen.findByText("running");
+
+  await userEvent.click(screen.getByRole("button", { name: "running" }));
+  await waitFor(() => expect(screen.getByText("continuous motion")).toBeInTheDocument());
+
+  // No lemma arrow should be present when they match
+  expect(screen.queryByText(/←/)).not.toBeInTheDocument();
+});

--- a/frontend/src/__tests__/UploadConfirmBtnArrow.test.tsx
+++ b/frontend/src/__tests__/UploadConfirmBtnArrow.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * Regression test for #1969: confirm button on upload/chapters page must not
+ * contain a trailing "→" that screen readers announce as "right arrow".
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("next/navigation", () => ({
+  useParams: () => ({ bookId: "42" }),
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getDraftChapters: jest.fn().mockResolvedValue({
+    chapters: [
+      { index: 0, title: "Chapter 1", word_count: 300, preview: "It begins." },
+    ],
+  }),
+  confirmChapters: jest.fn(),
+  ApiError: class ApiError extends Error {},
+}));
+
+import ChapterEditorPage from "@/app/upload/[bookId]/chapters/page";
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+test("confirm button text does not contain a trailing → arrow", async () => {
+  render(<ChapterEditorPage />);
+  await flushPromises();
+  await screen.findByText("Chapter 1");
+
+  const confirmBtn = screen.getByRole("button", { name: /Confirm & Start Reading/i });
+  expect(confirmBtn).toBeInTheDocument();
+  expect(confirmBtn.textContent).not.toContain("→");
+});

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -143,7 +143,7 @@ export default function ChapterEditorPage() {
             {confirming && (
               <span className="w-3.5 h-3.5 border-2 border-white/40 border-t-white rounded-full animate-spin" aria-hidden="true" />
             )}
-            {confirming ? "Saving…" : "Confirm & Start Reading →"}
+            {confirming ? "Saving…" : "Confirm & Start Reading"}
           </button>
         </div>
       </header>

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -166,7 +166,7 @@ function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
           <div className="flex items-baseline justify-between gap-2">
             <span className="font-serif font-bold text-ink text-xl">{word}</span>
             {def && def.lemma !== word && (
-              <span className="text-sm text-amber-700">← {def.lemma}</span>
+              <span className="text-sm text-amber-700" aria-label={`base form: ${def.lemma}`}>← {def.lemma}</span>
             )}
           </div>
 


### PR DESCRIPTION
## What changed

- **`app/vocabulary/page.tsx`**: Added `aria-label="base form: <lemma>"` to the lemma indicator span (`← amor`). Screen readers previously announced *"left arrow amor"* — now they announce *"base form: amor"*, conveying the linguistic relationship correctly (WCAG 1.3.1).
- **`app/upload/[bookId]/chapters/page.tsx`**: Removed the decorative `→` from the confirm button text. Screen readers announced *"Confirm and Start Reading right arrow"* — the arrow was purely decorative and adds nothing to the label.

## Why

Unicode directional arrows (`←`, `→`) used as typographic indicators have no implicit screen reader text. Without `aria-label`, a blind user hears raw glyph names which are meaningless in context. Closes #1969.

## Test plan

- [x] `UnicodeArrowA11y.test.tsx` — verifies lemma indicator span has `aria-label="base form: run"` when lemma differs from word; verifies indicator absent when lemma equals word
- [x] `UploadConfirmBtnArrow.test.tsx` — verifies confirm button text does not contain `→`
- [x] Full Jest suite: 2892 tests pass
