### PR TITLE
ux: add aria-label + role=status to admin books translating badge (closes #1971)

### DIFF
--- a/frontend/src/__tests__/AdminBooksTranslatingBadge.test.tsx
+++ b/frontend/src/__tests__/AdminBooksTranslatingBadge.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Regression test for #1971: admin books "translating" badge must have
+ * aria-label="Translating to <lang>" so screen readers don't announce
+ * "translating right arrow de".
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+const mockAdminFetch = jest.fn();
+
+jest.mock("@/lib/adminFetch", () => ({
+  adminFetch: (...args: unknown[]) => mockAdminFetch(...args),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("@/components/SeedPopularButton", () => {
+  const Seed = ({ onComplete }: { onComplete: () => void }) => (
+    <button onClick={onComplete}>Seed popular</button>
+  );
+  Seed.displayName = "SeedPopularButton";
+  return { __esModule: true, default: Seed };
+});
+
+let BooksPage: React.ComponentType;
+beforeAll(async () => {
+  const mod = await import("@/app/admin/books/page");
+  BooksPage = mod.default;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+const ACTIVE_BOOK = {
+  id: 1,
+  title: "Faust",
+  authors: ["Goethe"],
+  languages: ["de"],
+  download_count: 50,
+  text_length: 20000,
+  word_count: 3000,
+  translations: {},
+  queue: {},
+  active: true,
+  active_language: "en",
+};
+
+test("active translating badge has aria-label announcing 'Translating to <lang>'", async () => {
+  mockAdminFetch.mockResolvedValue(ACTIVE_BOOK);
+  // First call = GET /admin/books (returns array), subsequent calls can be for settings etc
+  mockAdminFetch.mockImplementation((url: string) => {
+    if (url === "/admin/books") return Promise.resolve([ACTIVE_BOOK]);
+    return Promise.resolve({});
+  });
+
+  render(<BooksPage />);
+  await flushPromises();
+
+  await screen.findByText("Faust");
+
+  // The translating badge must announce "Translating to en" not "translating right arrow en"
+  const badge = screen.getByRole("status", { name: /translating to en/i });
+  expect(badge).toBeInTheDocument();
+});

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -374,7 +374,11 @@ export default function BooksPage() {
                   <div className="flex items-center gap-2">
                     <span className="font-medium text-ink text-sm truncate" title={b.title}>{b.title}</span>
                     {b.active && (
-                      <span className="text-xs px-1.5 py-0.5 rounded-full bg-emerald-100 text-emerald-700 animate-pulse">
+                      <span
+                        className="text-xs px-1.5 py-0.5 rounded-full bg-emerald-100 text-emerald-700 animate-pulse"
+                        role="status"
+                        aria-label={`Translating to ${b.active_language}`}
+                      >
                         translating → {b.active_language}
                       </span>
                     )}


### PR DESCRIPTION
## What changed

`app/admin/books/page.tsx`: The active-translation badge (`translating → de`) now has `role="status"` and `aria-label="Translating to <lang>"`.

**Before:** Screen readers announced *"translating right arrow de"* — the `→` glyph had no text alternative (WCAG 1.3.1 violation).  
**After:** Screen readers announce *"Translating to de"*, and the `role="status"` ensures AT users are notified when translation becomes active.

## Why

Unicode directional arrows (`→`) have no implicit accessible name. The badge is informational — admin users monitoring translation state deserve accurate AT output. Closes #1971.

## Test plan

- [x] `AdminBooksTranslatingBadge.test.tsx` — queries `getByRole("status", { name: /translating to en/i })` on an active book; fails before fix, passes after
- [x] Full Jest suite: 2890 tests pass
