### PR TITLE
test: cover function-coverage gaps — BookCard, providers, admin/uploads, admin/users (closes #1987)

### DIFF
--- a/frontend/src/__tests__/AdminUploadsCoverage.test.tsx
+++ b/frontend/src/__tests__/AdminUploadsCoverage.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Coverage tests for app/admin/uploads/page.tsx — functions not covered by existing tests.
+ * Closes #1987 — targets: clearFilter (lines 70-74), Open button router.push (line 172).
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockAdminFetch = jest.fn();
+jest.mock("@/lib/adminFetch", () => ({
+  adminFetch: (...args: unknown[]) => mockAdminFetch(...args),
+}));
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: (...args: unknown[]) => mockPush(...args) }),
+  usePathname: () => "/admin/uploads",
+}));
+
+jest.mock("@/lib/api", () => ({
+  getMe: () => Promise.resolve({ id: 1, role: "admin" }),
+  getAuthToken: () => "test-token",
+  awaitSession: () => Promise.resolve(),
+}));
+
+import UploadsPage from "@/app/admin/uploads/page";
+
+const UPLOAD = {
+  book_id: 42,
+  title: "Dune",
+  filename: "dune.epub",
+  file_size: 524288,
+  format: "epub",
+  uploaded_at: "2026-04-01T12:00:00",
+  uploader_email: "alice@example.com",
+  uploader_name: "Alice",
+};
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+async function renderPage() {
+  render(<UploadsPage />);
+  await flushPromises();
+  await waitFor(() =>
+    expect(screen.queryByRole("status", { name: "Loading uploads" })).not.toBeInTheDocument(),
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAdminFetch.mockResolvedValue([UPLOAD]);
+});
+
+// ── clearFilter ───────────────────────────────────────────────────────────────
+
+test("clicking Clear filter resets filter and reloads without user_id", async () => {
+  mockAdminFetch.mockImplementation((path: string) => {
+    if (path.includes("user_id=")) return Promise.resolve([UPLOAD]);
+    return Promise.resolve([UPLOAD]);
+  });
+
+  await renderPage();
+
+  // Apply a filter first so activeFilter is set and Clear button appears
+  const input = screen.getByLabelText("User ID filter");
+  await userEvent.type(input, "7");
+  await userEvent.click(screen.getByRole("button", { name: /filter uploads/i }));
+
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: /clear filter/i })).toBeInTheDocument(),
+  );
+
+  mockAdminFetch.mockClear();
+  await userEvent.click(screen.getByRole("button", { name: /clear filter/i }));
+
+  // Should call adminFetch with plain /admin/uploads (no user_id)
+  await waitFor(() =>
+    expect(mockAdminFetch).toHaveBeenCalledWith("/admin/uploads"),
+  );
+
+  // Clear filter button disappears after clearing
+  await waitFor(() =>
+    expect(screen.queryByRole("button", { name: /clear filter/i })).not.toBeInTheDocument(),
+  );
+});
+
+// ── Open button ───────────────────────────────────────────────────────────────
+
+test("clicking Open navigates to /reader/:book_id", async () => {
+  await renderPage();
+
+  await userEvent.click(screen.getByRole("button", { name: /Open Dune/i }));
+
+  expect(mockPush).toHaveBeenCalledWith("/reader/42");
+});

--- a/frontend/src/__tests__/AdminUsersCoverage.test.tsx
+++ b/frontend/src/__tests__/AdminUsersCoverage.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Coverage tests for app/admin/users/page.tsx — functions not covered by existing tests.
+ * Closes #1987 — targets: Dismiss error onClick (line 86), getMe .catch (line 46).
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockAdminFetch = jest.fn();
+const mockGetMe = jest.fn();
+
+jest.mock("@/lib/adminFetch", () => ({
+  adminFetch: (...args: unknown[]) => mockAdminFetch(...args),
+}));
+jest.mock("@/lib/api", () => ({
+  getMe: (...args: unknown[]) => mockGetMe(...args),
+}));
+
+let UsersPage: React.ComponentType;
+beforeAll(async () => {
+  const mod = await import("@/app/admin/users/page");
+  UsersPage = mod.default;
+});
+
+const USERS = [
+  {
+    id: 1,
+    email: "alice@example.com",
+    name: "Alice",
+    picture: "",
+    role: "user",
+    approved: 1,
+    created_at: "2024-01-01",
+  },
+];
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetMe.mockResolvedValue({ id: 99 });
+  mockAdminFetch.mockResolvedValue(USERS);
+});
+
+// ── Dismiss actError ──────────────────────────────────────────────────────────
+
+test("clicking Dismiss error clears the actError alert", async () => {
+  // First load, then action fails, then reload
+  mockAdminFetch
+    .mockResolvedValueOnce(USERS)          // initial load
+    .mockRejectedValueOnce(new Error("Delete failed")); // action throws
+
+  render(<UsersPage />);
+  await flushPromises();
+
+  // Trigger an inline error via delete
+  const delBtn = await screen.findByRole("button", { name: /^Delete Alice/i });
+  await userEvent.click(delBtn);
+  const yesBtn = await screen.findByRole("button", { name: /confirm delete/i });
+  await userEvent.click(yesBtn);
+
+  await waitFor(() =>
+    expect(screen.getByRole("alert")).toHaveTextContent("Delete failed"),
+  );
+
+  // Dismiss the error
+  await userEvent.click(screen.getByRole("button", { name: /dismiss error/i }));
+
+  await waitFor(() =>
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
+  );
+});
+
+// ── getMe .catch silences rejection ──────────────────────────────────────────
+
+test("getMe rejection on mount is silently swallowed", async () => {
+  mockGetMe.mockRejectedValue(new Error("Token expired"));
+  mockAdminFetch.mockResolvedValue(USERS);
+
+  render(<UsersPage />);
+  await flushPromises();
+
+  // Page renders normally — the getMe error did not propagate
+  expect(await screen.findByText("Alice")).toBeInTheDocument();
+});

--- a/frontend/src/__tests__/BookCardCoverage.test.tsx
+++ b/frontend/src/__tests__/BookCardCoverage.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * Coverage tests for components/BookCard.tsx — functions not covered by existing tests.
+ * Closes #1987 — targets: onMouseLeave shadow reset (line 38), onBlur shadow reset (line 40).
+ */
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import BookCard from "@/components/BookCard";
+
+const BOOK = {
+  id: 1,
+  title: "The Call of the Wild",
+  authors: ["Jack London"],
+  cover: null,
+  gutenberg_id: 215,
+  language: "en",
+};
+
+test("onMouseLeave resets box-shadow to --shadow-card after hover", () => {
+  const { getByTestId } = render(<BookCard book={BOOK} onClick={jest.fn()} />);
+  const btn = getByTestId("book-card");
+
+  fireEvent.mouseEnter(btn);
+  expect(btn.style.boxShadow).toBe("var(--shadow-card-hover)");
+
+  fireEvent.mouseLeave(btn);
+  expect(btn.style.boxShadow).toBe("var(--shadow-card)");
+});
+
+test("onBlur resets box-shadow to --shadow-card after focus", () => {
+  const { getByTestId } = render(<BookCard book={BOOK} onClick={jest.fn()} />);
+  const btn = getByTestId("book-card");
+
+  fireEvent.focus(btn);
+  expect(btn.style.boxShadow).toBe("var(--shadow-card-hover)");
+
+  fireEvent.blur(btn);
+  expect(btn.style.boxShadow).toBe("var(--shadow-card)");
+});

--- a/frontend/src/__tests__/ProvidersCoverage.test.tsx
+++ b/frontend/src/__tests__/ProvidersCoverage.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Coverage tests for app/providers.tsx — functions not covered by existing tests.
+ * Closes #1987 — targets: anonymous .catch(() => {}) on getMe rejection (line 31).
+ */
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+
+const mockUseSession = jest.fn();
+jest.mock("next-auth/react", () => ({
+  SessionProvider: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  useSession: (...args: unknown[]) => mockUseSession(...args),
+}));
+
+const mockReplace = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  usePathname: () => "/",
+}));
+
+const mockSetAuthToken = jest.fn();
+const mockMarkSessionSettled = jest.fn();
+const mockGetMe = jest.fn();
+jest.mock("@/lib/api", () => ({
+  setAuthToken: (...args: unknown[]) => mockSetAuthToken(...args),
+  markSessionSettled: (...args: unknown[]) => mockMarkSessionSettled(...args),
+  getMe: (...args: unknown[]) => mockGetMe(...args),
+}));
+
+let Providers: React.ComponentType<{ children: React.ReactNode }>;
+beforeAll(async () => {
+  const mod = await import("@/app/providers");
+  Providers = mod.Providers;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseSession.mockReturnValue({
+    data: { backendToken: "tok", backendUser: { id: 1 } },
+    status: "authenticated",
+  });
+});
+
+test("getMe rejection is silently swallowed — no unhandled promise rejection", async () => {
+  mockGetMe.mockRejectedValue(new Error("Network failure"));
+
+  // Should not throw
+  render(
+    <Providers>
+      <span>child</span>
+    </Providers>,
+  );
+
+  // Give the rejected promise a tick to settle
+  await waitFor(() => expect(mockGetMe).toHaveBeenCalled());
+
+  // No redirect — the catch swallowed the error
+  expect(mockReplace).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## What changed

4 new test files covering small function-coverage gaps across the frontend:

| File | New tests | Gap covered |
|---|---|---|
| `BookCardCoverage.test.tsx` | 2 | `onMouseLeave` + `onBlur` shadow-reset handlers in `BookCard.tsx` |
| `ProvidersCoverage.test.tsx` | 1 | `.catch(() => {})` on `getMe` rejection in `providers.tsx` |
| `AdminUploadsCoverage.test.tsx` | 2 | `clearFilter()` function + Open button `router.push` in `admin/uploads/page.tsx` |
| `AdminUsersCoverage.test.tsx` | 2 | Dismiss-error `onClick` + `getMe` `.catch` on mount in `admin/users/page.tsx` |

## Why

Istanbul counted these anonymous arrow functions as uncovered even though all surrounding lines were hit. Targeting them directly brings function coverage on these files from 83–88% up to 100%.

## Test plan

- All 7 new tests pass individually
- Full suite: 2979 tests pass (frontend), 1942 pass (backend)

Closes #1987
