### PR TITLE
test: cover 3 single-function gaps — BookDetailModal catch, TypographyPanel Escape, admin/audio dismiss (closes #1989)

### DIFF
--- a/frontend/src/__tests__/AdminAudioCoverage.test.tsx
+++ b/frontend/src/__tests__/AdminAudioCoverage.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Coverage tests for app/admin/audio/page.tsx — functions not covered by existing tests.
+ * Closes #1989 — targets: Dismiss error onClick (line 84).
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockAdminFetch = jest.fn();
+jest.mock("@/lib/adminFetch", () => ({
+  adminFetch: (...args: unknown[]) => mockAdminFetch(...args),
+}));
+
+const AUDIO = [
+  {
+    book_id: 1,
+    chapter_index: 0,
+    provider: "google",
+    voice: "en-US-Standard-A",
+    chunks: 5,
+    size_mb: 2.1,
+    created_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+let AudioPage: React.ComponentType;
+beforeAll(async () => {
+  const mod = await import("@/app/admin/audio/page");
+  AudioPage = mod.default;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAdminFetch.mockResolvedValue(AUDIO);
+});
+
+async function renderPage() {
+  render(<AudioPage />);
+  await flushPromises();
+  await waitFor(() =>
+    expect(screen.queryByRole("status", { name: "Loading audio jobs" })).not.toBeInTheDocument(),
+  );
+}
+
+test("clicking Dismiss error clears the actError alert", async () => {
+  // First call: initial load; second call (delete action): reject; third call would be reload
+  mockAdminFetch
+    .mockResolvedValueOnce(AUDIO)
+    .mockRejectedValueOnce(new Error("Delete failed"))
+    .mockResolvedValueOnce([]);
+
+  await renderPage();
+
+  // Trigger an inline error by attempting to delete a chapter
+  const deleteBtn = screen.getByRole("button", { name: /delete audio for book 1/i });
+  await userEvent.click(deleteBtn);
+
+  await waitFor(() =>
+    expect(screen.getByRole("alert")).toHaveTextContent("Delete failed"),
+  );
+
+  // Dismiss the error
+  await userEvent.click(screen.getByRole("button", { name: /dismiss error/i }));
+
+  await waitFor(() =>
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
+  );
+});

--- a/frontend/src/__tests__/BookDetailModalCoverage3.test.tsx
+++ b/frontend/src/__tests__/BookDetailModalCoverage3.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Coverage tests for components/BookDetailModal.tsx — functions not covered by existing tests.
+ * Closes #1989 — targets: .catch(() => {}) on getBookTranslationStatus rejection (line 30).
+ */
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+
+jest.mock("@/lib/api", () => ({
+  getBookTranslationStatus: jest.fn(),
+}));
+
+jest.mock("@/lib/settings", () => ({
+  getSettings: jest.fn(() => ({ translationLang: "de" })),
+}));
+
+import * as api from "@/lib/api";
+import BookDetailModal from "@/components/BookDetailModal";
+import type { BookMeta } from "@/lib/api";
+
+const mockGetTranslationStatus = api.getBookTranslationStatus as jest.MockedFunction<
+  typeof api.getBookTranslationStatus
+>;
+
+const BOOK: BookMeta = {
+  id: 99,
+  title: "The Stranger",
+  authors: ["Albert Camus"],
+  languages: ["fr"],
+  subjects: [],
+  download_count: 1000,
+  cover: "",
+};
+
+test("getBookTranslationStatus rejection is silently swallowed — no throw", async () => {
+  mockGetTranslationStatus.mockRejectedValue(new Error("Network error"));
+
+  render(
+    <BookDetailModal book={BOOK} onClose={jest.fn()} onRead={jest.fn()} />,
+  );
+
+  await waitFor(() => expect(mockGetTranslationStatus).toHaveBeenCalled());
+  // If the .catch(() => {}) is missing, this would throw an unhandled rejection.
+  // The test passing confirms the catch is in place.
+});

--- a/frontend/src/__tests__/TypographyPanelCoverage2.test.tsx
+++ b/frontend/src/__tests__/TypographyPanelCoverage2.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Coverage tests for components/TypographyPanel.tsx — functions not covered by existing tests.
+ * Closes #1989 — targets: onKey function (line 105) — the Escape keydown handler that
+ * the existing EscapeDismiss test only checks via static source inspection, never fires.
+ */
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import TypographyPanel from "@/components/TypographyPanel";
+
+jest.mock("@/lib/settings", () => ({
+  saveSettings: jest.fn(),
+}));
+
+const DEFAULT_PROPS = {
+  fontSize: "base" as const,
+  lineHeight: "normal" as const,
+  contentWidth: "normal" as const,
+  fontFamily: "serif" as const,
+  paragraphFocus: false,
+  onFontSize: jest.fn(),
+  onLineHeight: jest.fn(),
+  onContentWidth: jest.fn(),
+  onFontFamily: jest.fn(),
+  onParagraphFocus: jest.fn(),
+  onClose: jest.fn(),
+};
+
+afterEach(() => jest.clearAllMocks());
+
+test("pressing Escape calls onClose via the document keydown listener", () => {
+  render(<TypographyPanel {...DEFAULT_PROPS} />);
+
+  fireEvent.keyDown(document, { key: "Escape" });
+
+  expect(DEFAULT_PROPS.onClose).toHaveBeenCalledTimes(1);
+});
+
+test("pressing a non-Escape key does not call onClose", () => {
+  render(<TypographyPanel {...DEFAULT_PROPS} />);
+
+  fireEvent.keyDown(document, { key: "Enter" });
+
+  expect(DEFAULT_PROPS.onClose).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## What changed

3 new test files targeting exactly 1 uncovered function each:

| File | Target | Root cause of gap |
|---|---|---|
| `BookDetailModalCoverage3.test.tsx` | `.catch(() => {})` on `getBookTranslationStatus` rejection (line 30) | All existing tests mock a resolved value; rejection path never fired |
| `TypographyPanelCoverage2.test.tsx` | `onKey` Escape handler (line 105) | Existing `EscapeDismiss` test does static source inspection only, never dispatches a real keydown event |
| `AdminAudioCoverage.test.tsx` | Dismiss error `onClick` (line 84) | No existing test triggers an `actError` then dismisses it |

## Why

Function coverage on these components was at 90–91% due to anonymous callback functions that Istanbul counts separately. These tests drive it to 100%.

## Test plan

- 4 new tests, all pass locally
- Full suite: 2981 frontend tests pass; 1942 backend tests pass

Closes #1989
