### PR TITLE
test: cover function gaps in AnnotationsSidebar, upload/page, notes/page (closes #1993)

### DIFF
--- a/frontend/src/__tests__/AnnotationsSidebarCoverage3.test.tsx
+++ b/frontend/src/__tests__/AnnotationsSidebarCoverage3.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Coverage tests for components/AnnotationsSidebar.tsx — functions not covered by existing tests.
+ * Closes #1993 — targets:
+ *   FN:56  onKey — Escape keydown handler (document listener, only active when sidebar is open)
+ *   FN:138 onKeyDown — keyboard activation (Enter / Space) on annotation card
+ */
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AnnotationsSidebar from "@/components/AnnotationsSidebar";
+import type { Annotation } from "@/lib/api";
+
+function makeAnnotation(overrides: Partial<Annotation> = {}): Annotation {
+  return {
+    id: 1, book_id: 1, chapter_index: 0,
+    sentence_text: "Some selected sentence.", note_text: "A note.", color: "yellow",
+    ...overrides,
+  };
+}
+
+const BASE_PROPS = {
+  annotations: [] as Annotation[],
+  totalCount: 0,
+  onJump: jest.fn(),
+  onEdit: jest.fn(),
+  loading: false,
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+// ── onKey — Escape closes the sidebar (FN:56) ─────────────────────────────────
+
+test("pressing Escape while sidebar is open closes it", async () => {
+  render(<AnnotationsSidebar {...BASE_PROPS} />);
+
+  // Open sidebar
+  await userEvent.click(screen.getByTestId("annotations-toggle"));
+  expect(screen.getByTestId("annotations-sidebar")).toBeInTheDocument();
+
+  // Fire Escape — onKey function should set open to false
+  fireEvent.keyDown(document, { key: "Escape" });
+
+  expect(screen.queryByTestId("annotations-sidebar")).not.toBeInTheDocument();
+});
+
+test("Escape keydown is a no-op when the sidebar is already closed", () => {
+  render(<AnnotationsSidebar {...BASE_PROPS} />);
+  // Sidebar is closed — listener not attached, so this should be a no-op
+  fireEvent.keyDown(document, { key: "Escape" });
+  expect(screen.queryByTestId("annotations-sidebar")).not.toBeInTheDocument();
+});
+
+// ── onKeyDown — Enter / Space activates annotation card (FN:138) ──────────────
+
+test("pressing Enter on an annotation card calls onJump and closes the sidebar", async () => {
+  const ann = makeAnnotation({ id: 42 });
+  render(
+    <AnnotationsSidebar
+      {...BASE_PROPS}
+      annotations={[ann]}
+      totalCount={1}
+    />,
+  );
+
+  // Open sidebar
+  await userEvent.click(screen.getByTestId("annotations-toggle"));
+
+  // Find annotation card (role="button") and fire Enter
+  const card = screen.getByRole("button", {
+    name: /jump to annotation/i,
+  });
+  fireEvent.keyDown(card, { key: "Enter" });
+
+  expect(BASE_PROPS.onJump).toHaveBeenCalledWith(ann);
+  expect(screen.queryByTestId("annotations-sidebar")).not.toBeInTheDocument();
+});
+
+test("pressing Space on an annotation card calls onJump and closes the sidebar", async () => {
+  const ann = makeAnnotation({ id: 43 });
+  render(
+    <AnnotationsSidebar
+      {...BASE_PROPS}
+      annotations={[ann]}
+      totalCount={1}
+    />,
+  );
+
+  await userEvent.click(screen.getByTestId("annotations-toggle"));
+
+  const card = screen.getByRole("button", { name: /jump to annotation/i });
+  fireEvent.keyDown(card, { key: " " });
+
+  expect(BASE_PROPS.onJump).toHaveBeenCalledWith(ann);
+  expect(screen.queryByTestId("annotations-sidebar")).not.toBeInTheDocument();
+});
+
+test("pressing Tab on an annotation card does NOT call onJump", async () => {
+  const ann = makeAnnotation({ id: 44 });
+  render(
+    <AnnotationsSidebar
+      {...BASE_PROPS}
+      annotations={[ann]}
+      totalCount={1}
+    />,
+  );
+
+  await userEvent.click(screen.getByTestId("annotations-toggle"));
+
+  const card = screen.getByRole("button", { name: /jump to annotation/i });
+  fireEvent.keyDown(card, { key: "Tab" });
+
+  expect(BASE_PROPS.onJump).not.toHaveBeenCalled();
+});

--- a/frontend/src/__tests__/NotesPageCoverage3.test.tsx
+++ b/frontend/src/__tests__/NotesPageCoverage3.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Coverage tests for app/notes/page.tsx — functions not covered by existing tests.
+ * Closes #1993 — targets:
+ *   FN:184 "Browse books" onClick (empty-state, books.length === 0) → router.push("/")
+ *   FN:196 "Clear search" onClick (filtered empty state) → setSearch("")
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: jest.fn() }),
+}));
+
+jest.mock("next-auth/react", () => ({
+  useSession: jest.fn().mockReturnValue({ data: { backendToken: "tok" }, status: "authenticated" }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getAllAnnotations: jest.fn(),
+  getAllInsights: jest.fn(),
+  getVocabulary: jest.fn(),
+}));
+
+import * as api from "@/lib/api";
+import NotesPage from "@/app/notes/page";
+
+const mockGetAllAnnotations = api.getAllAnnotations as jest.MockedFunction<typeof api.getAllAnnotations>;
+const mockGetAllInsights = api.getAllInsights as jest.MockedFunction<typeof api.getAllInsights>;
+const mockGetVocabulary = api.getVocabulary as jest.MockedFunction<typeof api.getVocabulary>;
+
+const flushPromises = () => new Promise<void>((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetAllAnnotations.mockResolvedValue([]);
+  mockGetAllInsights.mockResolvedValue([]);
+  mockGetVocabulary.mockResolvedValue([]);
+});
+
+// ── "Browse books" button onClick (FN:184) ────────────────────────────────────
+
+test("clicking 'Browse books' in empty state navigates to / via router.push", async () => {
+  // All APIs return empty arrays → books.length === 0 → empty state shown
+  render(<NotesPage />);
+  await waitFor(() => flushPromises());
+
+  const browseBtn = await screen.findByRole("button", { name: /browse books/i });
+  await userEvent.click(browseBtn);
+
+  expect(mockPush).toHaveBeenCalledWith("/");
+});
+
+// ── "Clear search" button onClick (FN:196) ────────────────────────────────────
+
+test("clicking 'Clear search' in filtered empty state resets search and shows books again", async () => {
+  // Seed one book so that search can produce a no-match state
+  mockGetAllAnnotations.mockResolvedValue([
+    {
+      id: 1, book_id: 10, chapter_index: 0,
+      sentence_text: "Hello world.", note_text: "", color: "yellow",
+      book_title: "Moby Dick",
+      created_at: "2026-01-01T00:00:00",
+    } as Parameters<typeof mockGetAllAnnotations.mockResolvedValue>[0][0],
+  ]);
+
+  render(<NotesPage />);
+
+  // Wait for book to appear
+  await screen.findByText("Moby Dick");
+
+  // Type a search term that matches nothing
+  const searchInput = screen.getByPlaceholderText(/search books/i);
+  await userEvent.type(searchInput, "zzznomatch");
+
+  // The book should now be filtered out and "Clear search" button appears
+  await waitFor(() => {
+    expect(screen.queryByText("Moby Dick")).not.toBeInTheDocument();
+  });
+
+  const clearBtn = screen.getByRole("button", { name: /clear search/i });
+  await userEvent.click(clearBtn);
+
+  // After clearing, the book re-appears
+  await screen.findByText("Moby Dick");
+});

--- a/frontend/src/__tests__/UploadPageCoverage2.test.tsx
+++ b/frontend/src/__tests__/UploadPageCoverage2.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Coverage tests for app/upload/page.tsx — functions not covered by existing tests.
+ * Closes #1993 — targets:
+ *   FN:24  .catch(() => {}) on getUploadQuota rejection
+ *   FN:151 drop-zone div onClick handler
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  useParams: () => ({}),
+}));
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ status: "authenticated", data: { backendToken: "tok" } }),
+}));
+
+const mockGetUploadQuota = jest.fn();
+const mockUploadBook = jest.fn();
+jest.mock("@/lib/api", () => ({
+  getUploadQuota: (...args: unknown[]) => mockGetUploadQuota(...args),
+  uploadBook: (...args: unknown[]) => mockUploadBook(...args),
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+      this.name = "ApiError";
+    }
+  },
+}));
+
+import UploadPage from "@/app/upload/page";
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+const QUOTA = { used: 0, max: 10 };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetUploadQuota.mockResolvedValue(QUOTA);
+  mockUploadBook.mockResolvedValue({ book_id: 1 });
+});
+
+// ── getUploadQuota .catch (FN:24) ─────────────────────────────────────────────
+
+test("getUploadQuota rejection is silently swallowed — component renders without throw", async () => {
+  mockGetUploadQuota.mockRejectedValue(new Error("Network error"));
+
+  render(<UploadPage />);
+  await flushPromises();
+
+  // If .catch(() => {}) is missing this throws an unhandled rejection.
+  // Component should still render the upload UI.
+  expect(screen.getByRole("button", { name: /upload a book file/i })).toBeInTheDocument();
+});
+
+// ── drop-zone onClick (FN:151) ────────────────────────────────────────────────
+
+test("clicking the drop-zone button triggers the hidden file input click", async () => {
+  render(<UploadPage />);
+  await flushPromises();
+
+  // Spy on HTMLInputElement.prototype.click so we can verify it's called
+  const clickSpy = jest.spyOn(HTMLInputElement.prototype, "click").mockImplementation(() => {});
+
+  const dropZone = screen.getByRole("button", { name: /upload a book file/i });
+  await userEvent.click(dropZone);
+
+  expect(clickSpy).toHaveBeenCalled();
+  clickSpy.mockRestore();
+});
+
+test("clicking the drop-zone does nothing when uploading is in progress", async () => {
+  // Make upload take a long time so uploading stays true
+  mockUploadBook.mockReturnValue(new Promise(() => {}));
+
+  render(<UploadPage />);
+  await flushPromises();
+
+  // Upload a file to put component in uploading state
+  const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+  const file = new File(["x"], "book.txt", { type: "text/plain" });
+  await userEvent.upload(fileInput, file);
+
+  // Now the component is in uploading state — drop-zone onClick is guarded by !uploading
+  const clickSpy = jest.spyOn(HTMLInputElement.prototype, "click").mockImplementation(() => {});
+  const dropZone = screen.getByRole("button", { name: /upload a book file/i });
+  await userEvent.click(dropZone);
+
+  // click() should NOT be called because the guard `!uploading` is false
+  expect(clickSpy).not.toHaveBeenCalled();
+  clickSpy.mockRestore();
+});


### PR DESCRIPTION
## What changed

Adds three test files targeting function-level coverage gaps identified via lcov analysis:

- **AnnotationsSidebarCoverage3** — covers `onKey` Escape document listener (FN:56) and `onKeyDown` Enter/Space on annotation cards (FN:138)
- **UploadPageCoverage2** — covers `.catch(() => {})` on `getUploadQuota` rejection (FN:24) and drop-zone `onClick` triggering hidden file input (FN:151)
- **NotesPageCoverage3** — covers "Browse books" `router.push("/")` in empty state (FN:184) and "Clear search" `setSearch("")` in filtered-no-match state (FN:196)

## Why

These 6 anonymous functions were uncovered by Istanbul function coverage after PRs #1988, #1990, #1992 merged. Each is a real interactive handler (keyboard navigation, error resilience, empty-state CTAs) that deserved a runtime test.

## Test plan

- [x] AnnotationsSidebarCoverage3: Escape closes sidebar, Escape no-op when closed, Enter activates card, Space activates card, Tab ignored
- [x] UploadPageCoverage2: quota rejection swallowed, drop-zone click triggers file input, drop-zone click no-ops while uploading
- [x] NotesPageCoverage3: Browse books navigates to `/`, Clear search restores results
- [x] Full frontend suite: 487 suites / 3006 tests pass

Closes #1993
