### PR TITLE
fix: add aria-modal="true" to confirmation dialogs in admin/books and QueueTab (closes #1995)

### DIFF
--- a/frontend/src/__tests__/AriaModalDialogs.test.tsx
+++ b/frontend/src/__tests__/AriaModalDialogs.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Regression test for #1995 — confirmation dialogs in admin/books and QueueTab
+ * must include aria-modal="true" so screen readers treat them as modal.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// ── admin/books confirmation dialog ──────────────────────────────────────────
+
+const mockAdminFetch = jest.fn();
+jest.mock("@/lib/adminFetch", () => ({
+  adminFetch: (...args: unknown[]) => mockAdminFetch(...args),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("@/components/SeedPopularButton", () => {
+  const Seed = () => <button>Seed popular</button>;
+  Seed.displayName = "SeedPopularButton";
+  return { __esModule: true, default: Seed };
+});
+
+const BOOK = {
+  id: 1,
+  title: "Moby Dick",
+  authors: ["Herman Melville"],
+  languages: ["en"],
+  download_count: 100,
+  text_length: 50000,
+  word_count: 9000,
+  translations: {},
+  queue: {},
+};
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+let AdminBooksPage: React.ComponentType;
+beforeAll(async () => {
+  const mod = await import("@/app/admin/books/page");
+  AdminBooksPage = mod.default;
+});
+
+beforeEach(() => jest.clearAllMocks());
+afterEach(() => jest.restoreAllMocks());
+
+test("admin/books confirm dialog has aria-modal='true'", async () => {
+  mockAdminFetch.mockResolvedValue([BOOK]);
+
+  render(<AdminBooksPage />);
+  await flushPromises();
+  await waitFor(() => screen.getByText("Moby Dick"));
+
+  // Click the Delete button to open the confirmation dialog
+  await userEvent.click(screen.getByRole("button", { name: /delete moby dick/i }));
+
+  const dialog = screen.getByRole("dialog", { name: /confirm action/i });
+  expect(dialog).toHaveAttribute("aria-modal", "true");
+});

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -251,7 +251,7 @@ export default function BooksPage() {
       )}
 
       {pendingConfirm && (
-        <div role="dialog" aria-label="Confirm action" className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm flex items-start gap-3">
+        <div role="dialog" aria-modal="true" aria-label="Confirm action" className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm flex items-start gap-3">
           <p className="flex-1 text-amber-900">{pendingConfirm.message}</p>
           <div className="flex gap-2 shrink-0">
             <button

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -504,7 +504,7 @@ export default function QueueTab({ adminFetch }: Props) {
       )}
 
       {pendingConfirm && (
-        <div role="dialog" aria-label="Confirm action" className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm flex items-start gap-3">
+        <div role="dialog" aria-modal="true" aria-label="Confirm action" className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm flex items-start gap-3">
           <p className="flex-1 text-amber-900">{pendingConfirm.message}</p>
           <div className="flex gap-2 shrink-0">
             <button


### PR DESCRIPTION
## What changed

Added `aria-modal="true"` to two confirmation dialogs that already had `role="dialog"` but were missing the `aria-modal` attribute:

- `src/app/admin/books/page.tsx` line 254 — book deletion/retranslation confirm dialog
- `src/components/QueueTab.tsx` line 507 — translation queue action confirm dialog

## Why

Without `aria-modal="true"`, screen readers (VoiceOver, NVDA, JAWS) do not know the dialog is modal. Virtual cursor may escape into background content, violating WCAG 2.1 criterion 4.1.2 (Name, Role, Value). The fix is a one-attribute addition per dialog.

## Test plan

- [x] `AriaModalDialogs.test.tsx` — regression test: opens the admin/books Delete confirm dialog and asserts `aria-modal="true"` is present
- [x] Full frontend suite: 488 suites / 3007 tests pass

Closes #1995
