### PR TITLE
fix: add role="alert" to chapter load error in reader page (closes #1997)

### DIFF
--- a/frontend/src/__tests__/ReaderChapterErrorAlert.test.ts
+++ b/frontend/src/__tests__/ReaderChapterErrorAlert.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Regression test for #1997 — chapter load error div must have role="alert"
+ * so screen readers announce it when the error state is dynamically rendered.
+ *
+ * This is a source-level check for a static markup attribute: role="alert"
+ * on a conditionally-rendered div is not a runtime behaviour that requires
+ * component rendering to verify — it's a guaranteed-present attribute check.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+test("chapter load error container has role='alert'", () => {
+  // Find the error state block — it contains "Failed to load chapter"
+  const idx = src.indexOf("Failed to load chapter");
+  expect(idx).toBeGreaterThan(-1);
+
+  // Walk back to the opening div of this block (within 300 chars)
+  const context = src.slice(Math.max(0, idx - 300), idx);
+
+  // The nearest <div before the error heading must include role="alert"
+  const lastDivIdx = context.lastIndexOf("<div");
+  const divToHeading = context.slice(lastDivIdx);
+  expect(divToHeading).toContain('role="alert"');
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1398,7 +1398,7 @@ export default function ReaderPage() {
                 ))}
               </div>
             ) : error ? (
-              <div className="max-w-prose mx-auto text-center py-16 px-4">
+              <div role="alert" className="max-w-prose mx-auto text-center py-16 px-4">
                 <BookOpenIcon className="w-10 h-10 text-amber-300 mx-auto mb-4" aria-hidden="true" />
                 <h2 className="font-serif text-lg text-ink mb-2">Failed to load chapter</h2>
                 <p className="text-sm text-stone-500 mb-6">{error}</p>


### PR DESCRIPTION
## What changed

Added `role="alert"` to the chapter load error container in `src/app/reader/[bookId]/page.tsx` (line ~1401).

## Why

When a chapter fails to load, the error state ("Failed to load chapter") is rendered dynamically without a page reload. Without `role="alert"`, screen readers (VoiceOver, NVDA, JAWS) do not announce the error — blind users would see a blank reading area with no explanation. This violates WCAG 2.1 criterion 4.1.3 (Status Messages).

The one-character fix ensures the error is announced immediately when it appears, consistent with the `role="alert"` pattern used throughout the rest of the codebase for dynamic error states.

## Test plan

- [x] `ReaderChapterErrorAlert.test.ts` — source check confirms `role="alert"` is present on the div immediately before the "Failed to load chapter" heading
- [x] Full frontend suite: 488 suites / 3007 tests pass

Closes #1997
