### PR TITLE
fix: use role="alertdialog" for confirmation prompts in admin/books and QueueTab (closes #1999)

### DIFF
--- a/frontend/src/__tests__/AriaModalDialogs.test.tsx
+++ b/frontend/src/__tests__/AriaModalDialogs.test.tsx
@@ -1,6 +1,7 @@
 /**
- * Regression test for #1995 — confirmation dialogs in admin/books and QueueTab
- * must include aria-modal="true" so screen readers treat them as modal.
+ * Regression tests for #1995 and #1999 — confirmation dialogs in admin/books and QueueTab
+ * must use role="alertdialog" (announced immediately as an assertive live region) with
+ * aria-modal="true" so screen readers cannot navigate behind the dialog.
  */
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
@@ -46,7 +47,7 @@ beforeAll(async () => {
 beforeEach(() => jest.clearAllMocks());
 afterEach(() => jest.restoreAllMocks());
 
-test("admin/books confirm dialog has aria-modal='true'", async () => {
+test("admin/books confirm dialog has role='alertdialog' and aria-modal='true' (#1995, #1999)", async () => {
   mockAdminFetch.mockResolvedValue([BOOK]);
 
   render(<AdminBooksPage />);
@@ -56,6 +57,8 @@ test("admin/books confirm dialog has aria-modal='true'", async () => {
   // Click the Delete button to open the confirmation dialog
   await userEvent.click(screen.getByRole("button", { name: /delete moby dick/i }));
 
-  const dialog = screen.getByRole("dialog", { name: /confirm action/i });
+  // role="alertdialog" causes screen readers to announce the prompt immediately
+  // aria-modal="true" prevents virtual cursor from escaping into background content
+  const dialog = screen.getByRole("alertdialog", { name: /confirm action/i });
   expect(dialog).toHaveAttribute("aria-modal", "true");
 });

--- a/frontend/src/__tests__/QueueTab.branches.test.tsx
+++ b/frontend/src/__tests__/QueueTab.branches.test.tsx
@@ -566,8 +566,8 @@ describe("QueueTab.branches — worker start/stop", () => {
     const stopBtn = screen.getByRole("button", { name: /^stop$/i });
     await userEvent.click(stopBtn);
 
-    // Inline dialog appears — cancel it
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    // Inline alertdialog appears — cancel it
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: /cancel action/i }));
 
     // Should NOT call stop endpoint since we cancelled

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -251,7 +251,7 @@ export default function BooksPage() {
       )}
 
       {pendingConfirm && (
-        <div role="dialog" aria-modal="true" aria-label="Confirm action" className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm flex items-start gap-3">
+        <div role="alertdialog" aria-modal="true" aria-label="Confirm action" className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm flex items-start gap-3">
           <p className="flex-1 text-amber-900">{pendingConfirm.message}</p>
           <div className="flex gap-2 shrink-0">
             <button

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -504,7 +504,7 @@ export default function QueueTab({ adminFetch }: Props) {
       )}
 
       {pendingConfirm && (
-        <div role="dialog" aria-modal="true" aria-label="Confirm action" className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm flex items-start gap-3">
+        <div role="alertdialog" aria-modal="true" aria-label="Confirm action" className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm flex items-start gap-3">
           <p className="flex-1 text-amber-900">{pendingConfirm.message}</p>
           <div className="flex gap-2 shrink-0">
             <button


### PR DESCRIPTION
## What changed

Changed `role="dialog"` to `role="alertdialog"` on the inline confirmation prompts in:
- `src/app/admin/books/page.tsx` — book delete/retranslate/move confirmation
- `src/components/QueueTab.tsx` — queue action confirmation

Both retain `aria-modal="true"` to prevent the virtual cursor from escaping to background content.

Also updates `QueueTab.branches.test.tsx` to query `role="alertdialog"` (matching the fix).

## Why

`role="alertdialog"` is the correct ARIA role for inline prompts that interrupt the user and require a response. Unlike `role="dialog"`, `alertdialog` creates an implicit assertive live region — screen readers announce the prompt immediately when it appears, without requiring programmatic focus movement. This makes the confirmation visible to screen reader users (VoiceOver, NVDA, JAWS) who would otherwise not know the confirmation appeared.

`role="dialog"` + no focus management = screen reader users see a blank area with no prompt. `role="alertdialog"` = prompt is announced immediately.

## Test plan

- [x] `AriaModalDialogs.test.tsx` — verifies `role="alertdialog"` and `aria-modal="true"` on the admin/books confirmation dialog
- [x] `QueueTab.branches.test.tsx` updated — queries `alertdialog` role; Stop button inline confirmation test still passes
- [x] Full frontend suite: 489 suites / 3008 tests pass (includes rebased #1998 content)

Closes #1999
