### PR TITLE
fix: move focus into alertdialog container on open, restore on close (closes #2001)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -176,6 +176,8 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-28 | 8.4 | Import and chapter-editor error banners: AlertCircleIcon added | ✅ Done |
 | 2026-04-28 | 8.5 | Admin tables: title attributes on truncated book/user/file text | ✅ Done |
 | 2026-04-28 | 8.6 | Admin dismiss error/message buttons: 44×44px mobile touch targets | ✅ Done |
+| 2026-04-28 | 8.7 | Admin/QueueTab confirm dialogs: role="alertdialog" + aria-modal (PR #2000) | ✅ Done |
+| 2026-04-28 | 8.8 | Admin/QueueTab confirm dialogs: focus on container open, restore on close (PR #2002) | ✅ Done |
 
 ---
 

--- a/frontend/src/__tests__/ConfirmDialogFocusMgmt.test.tsx
+++ b/frontend/src/__tests__/ConfirmDialogFocusMgmt.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Regression tests for #2001 — confirmation dialogs in admin/books and QueueTab
+ * must move keyboard focus into the dialog container when opened (WCAG 2.1 SC 2.4.3)
+ * and restore it to the triggering element when closed.
+ *
+ * The dialog container uses tabIndex={-1} (not the Confirm button) so that
+ * pressing Enter to open the dialog does NOT accidentally auto-confirm.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// ── Shared mocks ──────────────────────────────────────────────────────────────
+
+const mockAdminFetch = jest.fn();
+jest.mock("@/lib/adminFetch", () => ({
+  adminFetch: (...args: unknown[]) => mockAdminFetch(...args),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("@/components/SeedPopularButton", () => {
+  const Seed = () => <button>Seed popular</button>;
+  Seed.displayName = "SeedPopularButton";
+  return { __esModule: true, default: Seed };
+});
+
+const BOOK = {
+  id: 1,
+  title: "Moby Dick",
+  authors: ["Herman Melville"],
+  languages: ["en"],
+  download_count: 100,
+  text_length: 50000,
+  word_count: 9000,
+  translations: {},
+  queue: {},
+};
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+// ── admin/books focus management ─────────────────────────────────────────────
+
+let AdminBooksPage: React.ComponentType;
+beforeAll(async () => {
+  const mod = await import("@/app/admin/books/page");
+  AdminBooksPage = mod.default;
+});
+
+beforeEach(() => jest.clearAllMocks());
+afterEach(() => jest.restoreAllMocks());
+
+test("admin/books: opening confirm dialog moves focus into dialog container (#2001)", async () => {
+  mockAdminFetch.mockResolvedValue([BOOK]);
+
+  render(<AdminBooksPage />);
+  await flushPromises();
+  await waitFor(() => screen.getByText("Moby Dick"));
+
+  const deleteBtn = screen.getByRole("button", { name: /delete moby dick/i });
+  await userEvent.click(deleteBtn);
+
+  // Dialog container must have focus — not the button inside it
+  const dialog = screen.getByRole("alertdialog", { name: /confirm action/i });
+  expect(dialog).toHaveFocus();
+});
+
+test("admin/books: cancelling confirm dialog restores focus to trigger (#2001)", async () => {
+  mockAdminFetch.mockResolvedValue([BOOK]);
+
+  render(<AdminBooksPage />);
+  await flushPromises();
+  await waitFor(() => screen.getByText("Moby Dick"));
+
+  const deleteBtn = screen.getByRole("button", { name: /delete moby dick/i });
+  await userEvent.click(deleteBtn);
+
+  // Cancel — focus should return to Delete button
+  await userEvent.click(screen.getByRole("button", { name: /cancel action/i }));
+  expect(deleteBtn).toHaveFocus();
+});
+
+// ── QueueTab focus management ─────────────────────────────────────────────────
+
+import QueueTab from "@/components/QueueTab";
+
+const BASE_SETTINGS = {
+  enabled: true,
+  has_api_key: true,
+  auto_translate_languages: ["zh"],
+  rpm: 1000,
+  rpd: 10000,
+  model: "gemini-2.5-flash",
+  model_chain: ["gemini-2.5-flash"],
+  max_output_tokens: 7500,
+};
+
+const RUNNING_STATUS = {
+  running: true,
+  state: {
+    enabled: true,
+    idle: false,
+    current_book_id: null,
+    current_book_title: "",
+    current_target_language: "",
+    current_batch_size: 0,
+    last_completed_at: null,
+    last_error: "",
+    started_at: null,
+    requests_made: 0,
+    chapters_done: 0,
+    chapters_failed: 0,
+    waiting_reason: "",
+    log: [],
+  },
+  counts: { pending: 2, running: 0, done: 5, failed: 1 },
+};
+
+const NO_COST = {
+  pending_items: 0,
+  pending_books: 0,
+  estimated_input_tokens: 0,
+  estimated_output_tokens: 0,
+  per_model: [],
+};
+
+function makeQueueFetch(overrides: Record<string, unknown> = {}) {
+  return jest.fn((path: string) => {
+    if (path === "/admin/queue/status") return Promise.resolve(overrides.status ?? RUNNING_STATUS);
+    if (path === "/admin/queue/settings") return Promise.resolve(BASE_SETTINGS);
+    if (path.startsWith("/admin/queue/items")) return Promise.resolve([]);
+    if (path === "/admin/queue/cost-estimate") return Promise.resolve(NO_COST);
+    return Promise.resolve({});
+  });
+}
+
+test("QueueTab: opening confirm dialog moves focus into dialog container (#2001)", async () => {
+  const adminFetch = makeQueueFetch();
+  render(<QueueTab adminFetch={adminFetch} />);
+  await waitFor(() => expect(screen.queryByText(/loading queue/i)).not.toBeInTheDocument(), { timeout: 3000 });
+
+  const stopBtn = screen.getByRole("button", { name: /^stop$/i });
+  await userEvent.click(stopBtn);
+
+  const dialog = screen.getByRole("alertdialog", { name: /confirm action/i });
+  expect(dialog).toHaveFocus();
+});
+
+test("QueueTab: cancelling confirm dialog restores focus to trigger (#2001)", async () => {
+  const adminFetch = makeQueueFetch();
+  render(<QueueTab adminFetch={adminFetch} />);
+  await waitFor(() => expect(screen.queryByText(/loading queue/i)).not.toBeInTheDocument(), { timeout: 3000 });
+
+  const stopBtn = screen.getByRole("button", { name: /^stop$/i });
+  await userEvent.click(stopBtn);
+
+  await userEvent.click(screen.getByRole("button", { name: /cancel action/i }));
+  expect(stopBtn).toHaveFocus();
+});

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { adminFetch } from "@/lib/adminFetch";
 import SeedPopularButton from "@/components/SeedPopularButton";
@@ -58,6 +58,8 @@ export default function BooksPage() {
     message: string;
     fn: () => void | Promise<void>;
   } | null>(null);
+  const confirmContainerRef = useRef<HTMLDivElement>(null);
+  const confirmTriggerRef = useRef<HTMLElement | null>(null);
   const [importId, setImportId] = useState("");
   const [importing, setImporting] = useState(false);
   const [expandedBookId, setExpandedBookId] = useState<number | null>(null);
@@ -93,6 +95,16 @@ export default function BooksPage() {
   useEffect(() => {
     load();
   }, [load]);
+
+  useEffect(() => {
+    if (pendingConfirm) {
+      confirmTriggerRef.current = document.activeElement as HTMLElement;
+      confirmContainerRef.current?.focus();
+    } else if (confirmTriggerRef.current) {
+      confirmTriggerRef.current.focus();
+      confirmTriggerRef.current = null;
+    }
+  }, [pendingConfirm]);
 
   async function act(fn: () => Promise<unknown>) {
     try {
@@ -251,7 +263,7 @@ export default function BooksPage() {
       )}
 
       {pendingConfirm && (
-        <div role="alertdialog" aria-modal="true" aria-label="Confirm action" className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm flex items-start gap-3">
+        <div ref={confirmContainerRef} role="alertdialog" aria-modal="true" aria-label="Confirm action" tabIndex={-1} className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm flex items-start gap-3 outline-none">
           <p className="flex-1 text-amber-900">{pendingConfirm.message}</p>
           <div className="flex gap-2 shrink-0">
             <button

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -140,6 +140,8 @@ export default function QueueTab({ adminFetch }: Props) {
     message: string;
     fn: () => void | Promise<void>;
   } | null>(null);
+  const confirmContainerRef = useRef<HTMLDivElement>(null);
+  const confirmTriggerRef = useRef<HTMLElement | null>(null);
   const [saving, setSaving] = useState(false);
   // Per-section loading flags so a slow fetch spins only its own panel
   // instead of freezing the whole tab. Each is set true at the start of
@@ -295,6 +297,16 @@ export default function QueueTab({ adminFetch }: Props) {
     refreshItems(itemFilter);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [itemFilter]);
+
+  useEffect(() => {
+    if (pendingConfirm) {
+      confirmTriggerRef.current = document.activeElement as HTMLElement;
+      confirmContainerRef.current?.focus();
+    } else if (confirmTriggerRef.current) {
+      confirmTriggerRef.current.focus();
+      confirmTriggerRef.current = null;
+    }
+  }, [pendingConfirm]);
 
   async function saveSettings(
     patch: Record<string, unknown>,
@@ -504,7 +516,7 @@ export default function QueueTab({ adminFetch }: Props) {
       )}
 
       {pendingConfirm && (
-        <div role="alertdialog" aria-modal="true" aria-label="Confirm action" className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm flex items-start gap-3">
+        <div ref={confirmContainerRef} role="alertdialog" aria-modal="true" aria-label="Confirm action" tabIndex={-1} className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm flex items-start gap-3 outline-none">
           <p className="flex-1 text-amber-900">{pendingConfirm.message}</p>
           <div className="flex gap-2 shrink-0">
             <button


### PR DESCRIPTION
## What changed

- `admin/books/page.tsx` and `components/QueueTab.tsx`: added `useRef` + `useEffect` focus management on the alertdialog confirm prompt
  - When the dialog opens, focus moves to the dialog **container div** (`tabIndex={-1}`, not the Confirm button) so Enter key does not accidentally auto-confirm
  - When the dialog closes (Confirm or Cancel), focus returns to the element that triggered it
  - `outline-none` on the focusable div suppresses the default focus ring since the dialog already has a visible amber border

## Why

WCAG 2.1 SC 2.4.3 (Focus Order) requires that keyboard focus move inside a dialog when it opens. Without this, keyboard users must Tab forward through all the page content to reach the Confirm/Cancel buttons.

Using the container div (not the Confirm button) as the focus target avoids the Enter-auto-confirm trap: if focus landed on Confirm, the same Enter key that triggered the dialog would immediately fire Confirm.

## Test plan

- `ConfirmDialogFocusMgmt.test.tsx` (new): 4 tests
  - admin/books: dialog container has focus after Delete button click
  - admin/books: Delete button has focus after Cancel
  - QueueTab: dialog container has focus after Stop button click
  - QueueTab: Stop button has focus after Cancel
- Full suite: 3012 frontend tests + 1942 backend tests — all pass

Closes #2001
