### PR TITLE
test: render NotFound and Loading pages for 0% coverage gap (closes #2016)

### DIFF
--- a/frontend/src/__tests__/Loading.render.test.tsx
+++ b/frontend/src/__tests__/Loading.render.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * Regression tests for #2016 — app/loading.tsx has 0% runtime coverage.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import Loading from "@/app/loading";
+
+test("renders a loading status region", () => {
+  render(<Loading />);
+  expect(screen.getByRole("status")).toBeInTheDocument();
+});
+
+test("has an accessible label for the loading state", () => {
+  render(<Loading />);
+  expect(screen.getByRole("status")).toHaveAttribute("aria-label", "Loading page");
+});
+
+test("has sr-only text for screen readers", () => {
+  render(<Loading />);
+  expect(screen.getByText(/loading page/i)).toBeInTheDocument();
+});

--- a/frontend/src/__tests__/NotFound.render.test.tsx
+++ b/frontend/src/__tests__/NotFound.render.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * Regression tests for #2016 — app/not-found.tsx has 0% runtime coverage.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("next/link", () => {
+  const Link = ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) => (
+    <a href={href} className={className}>{children}</a>
+  );
+  Link.displayName = "Link";
+  return { __esModule: true, default: Link };
+});
+
+import NotFound from "@/app/not-found";
+
+test("renders the Page not found heading", () => {
+  render(<NotFound />);
+  expect(screen.getByRole("heading", { name: /page not found/i })).toBeInTheDocument();
+});
+
+test("renders a link to the library (Browse books → /)", () => {
+  render(<NotFound />);
+  const link = screen.getByRole("link", { name: /browse books/i });
+  expect(link).toHaveAttribute("href", "/");
+});
+
+test("has a main landmark", () => {
+  render(<NotFound />);
+  expect(screen.getByRole("main")).toBeInTheDocument();
+});


### PR DESCRIPTION
## What changed

Added render tests for two uncovered Next.js special pages:

- `frontend/src/__tests__/NotFound.render.test.tsx` — 3 tests: heading text, library link href, main landmark
- `frontend/src/__tests__/Loading.render.test.tsx` — 3 tests: role=status present, aria-label value, sr-only text

## Why

Issue #2016: both `app/not-found.tsx` and `app/loading.tsx` showed 0% function coverage in the Istanbul report. The pages themselves are correct (reviewed in the audit), but without render tests Istanbul never sees them execute.

## Test plan

- [x] 6 new tests, all pass
- [x] Full suite: 3028 tests pass (494 suites)
- [x] No production code changed

Closes #2016
