### PR TITLE
docs: flashcard SRS tutorial (closes #2018)

### DIFF
--- a/docs/tutorials/flashcards.md
+++ b/docs/tutorials/flashcards.md
@@ -1,0 +1,67 @@
+# Review vocabulary with flashcards
+
+Book Reader AI includes a spaced-repetition (SRS) flashcard system built around the words you save while reading. Words you save get added to a review queue; the system schedules them so you see each word again just before you're likely to forget it.
+
+## Prerequisites
+
+- You are signed in.
+- You have saved at least one vocabulary word while reading (see step 1 below).
+
+## 1. Save words while reading
+
+Flashcards are created automatically from the words you save in the reader.
+
+1. Open any book chapter in the reader.
+2. Tap (mobile) or click (desktop) a word you want to learn.
+3. The word lookup panel appears with the word's definition.
+4. Click **Save** to add the word to your vocabulary.
+
+Repeat for any word you encounter. Saved words appear in your **Vocabulary** list and are automatically scheduled for flashcard review.
+
+## 2. Open the flashcard review session
+
+1. Go to **Vocabulary** (nav → Vocabulary, or `/vocabulary`).
+2. Click the **Flashcards** button in the top-right of the header.
+
+You are taken to the Flashcard review page. The header shows how many cards are due today and your current streak.
+
+### Optional: filter by deck
+
+If you have created vocabulary decks (via Vocabulary → Decks), you can select a specific deck from the dropdown at the top of the flashcard page to review only words from that deck. Leave it on **All decks** to review everything due today.
+
+## 3. Review your cards
+
+Each card shows a word on the front. The back contains the definition and example sentences from your reading context.
+
+1. Read the word on the front.
+2. Try to recall the definition before flipping.
+3. Click or tap the card (or press **Space**) to flip it and see the definition.
+4. Rate how well you remembered it by clicking one of four buttons:
+
+| Button | Keyboard | When to use |
+|---|---|---|
+| **Again** | `1` | You had no idea or got it completely wrong |
+| **Hard** | `2` | You remembered, but it took a lot of effort |
+| **Good** | `3` | You remembered with some effort — the normal choice |
+| **Easy** | `4` | Instantly recalled, no hesitation |
+
+The system (SM-2 algorithm) uses your rating to schedule the next review. Words rated **Again** come back very soon; words rated **Easy** are pushed weeks into the future.
+
+## 4. Finish the session
+
+When all due cards have been reviewed, a completion screen shows your session stats: cards reviewed, accuracy, and streak.
+
+Click **Done** to return to your Vocabulary list, or **Review again** to run through all the cards from scratch.
+
+## Tips
+
+- **Daily habit beats marathon sessions.** The SRS algorithm is calibrated for short daily sessions (~10–20 cards). Reviewing 5 cards today is more effective than reviewing 50 cards once a week.
+- **Context helps retention.** Words are shown with the sentence and chapter they came from. Use that context — don't just memorize the definition in isolation.
+- **Add hard words sooner.** If you're reading and a word looks important, save it even before you look it up. The sooner it enters the queue, the more review repetitions it accumulates.
+- **Decks for targeted study.** Create a deck for a single book or language and filter the flashcard session to that deck if you want to focus.
+
+## Troubleshooting
+
+- **"No cards due"** — either you haven't saved any words yet (see step 1), or today's review has already been completed. Check the **Next review** date on the Vocabulary page — it shows when your next batch is due.
+- **A card keeps coming back immediately** — you rated it **Again**. This is normal; the system will keep showing it until you rate it at least **Hard**. Try reading the example sentence closely to reinforce the meaning.
+- **Words from deleted books still appear** — vocabulary words are stored independently of books. You can delete them individually from the Vocabulary list (tap the word, then click **Delete**).

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -9,3 +9,4 @@ Step-by-step walkthroughs for the most common workflows. Tutorials are written a
 - **[Set up the reading queue](queue.md)** — background pre-translation while you read.
 - **[Export vocabulary to Obsidian](obsidian-export.md)** — push saved words into your Obsidian vault via GitHub.
 - **[Add your own EPUB](epub-upload.md)** — upload a .epub or .txt file, review chapter splits, and start reading.
+- **[Review vocabulary with flashcards](flashcards.md)** — save words while reading, then review them with spaced repetition.


### PR DESCRIPTION
## What changed

- Created `docs/tutorials/flashcards.md` — complete walkthrough for the vocabulary SRS flashcard system: saving words while reading, opening the review session, rating cards (Again/Hard/Good/Easy), the SM-2 scheduling algorithm, tips for effective study, and troubleshooting.
- Updated `docs/tutorials/index.md` — added flashcards to "Available now" (6th tutorial).

## Why

Issue #2018: CLAUDE.md explicitly lists flashcards as a user-visible flow "a new reader would not discover on their own." There was no tutorial documenting the save-words → flashcard-review → SRS cycle. The feature has been implemented and tested (coverage improved in prior PRs) but was never documented for end users.

## Test plan

- [x] Frontend suite: 3027 tests pass (doc-only change, no code touched)
- [x] Tutorial prose verified against `app/vocabulary/flashcards/page.tsx` — grades (Again=0, Hard=2, Good=3, Easy=5), keyboard shortcuts (Space to flip, 1-4 to rate), deck filtering

Closes #2018
