### PR TITLE
test: cover lib/settings.ts SSR-guard branches (closes #2015)

### DIFF
--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -2,8 +2,11 @@ import "@testing-library/jest-dom";
 import { TextEncoder, TextDecoder } from "util";
 import { ReadableStream } from "stream/web";
 
-// jsdom doesn't implement layout APIs used by InsightChat
-window.HTMLElement.prototype.scrollIntoView = jest.fn();
+// jsdom doesn't implement layout APIs used by InsightChat.
+// Guard so @jest-environment node tests can load this setup file without throwing.
+if (typeof window !== "undefined") {
+  window.HTMLElement.prototype.scrollIntoView = jest.fn();
+}
 
 // jsdom also lacks some streaming Web APIs that importBookStream uses
 if (typeof global.TextEncoder === "undefined") global.TextEncoder = TextEncoder;

--- a/frontend/src/__tests__/settings.ssr.test.ts
+++ b/frontend/src/__tests__/settings.ssr.test.ts
@@ -1,0 +1,22 @@
+/**
+ * @jest-environment node
+ *
+ * Covers the two SSR-guard branches in lib/settings.ts (lines 43 and 53):
+ *   if (typeof window === "undefined") return { ...DEFAULTS };
+ *   if (typeof window === "undefined") return;
+ *
+ * These can only be hit in a node environment where window is not defined.
+ * Closes #2015.
+ */
+import { getSettings, saveSettings } from "@/lib/settings";
+
+test("getSettings returns defaults in SSR (window undefined)", () => {
+  const s = getSettings();
+  expect(s.insightLang).toBe("en");
+  expect(s.ttsGender).toBe("female");
+  expect(s.translationEnabled).toBe(false);
+});
+
+test("saveSettings is a no-op in SSR (window undefined, does not throw)", () => {
+  expect(() => saveSettings({ insightLang: "de" })).not.toThrow();
+});


### PR DESCRIPTION
## What changed

- `frontend/jest.setup.js`: guarded `window.HTMLElement.prototype.scrollIntoView` behind `typeof window !== "undefined"` so tests using `@jest-environment node` can load the setup file without throwing a ReferenceError.
- `frontend/src/__tests__/settings.ssr.test.ts`: new test file with `@jest-environment node` that hits the two uncovered SSR-guard branches in `lib/settings.ts` (lines 43 and 53):
  - `getSettings` returns defaults when window is undefined (SSR)
  - `saveSettings` is a no-op when window is undefined (SSR)

## Why

`lib/settings.ts` had 66.7% branch coverage. The 2 missing branches are intentional SSR guards (`if (typeof window === "undefined") return ...`). These can only be exercised in a Node.js environment, but the shared jest.setup.js accessed `window` unconditionally, blocking `@jest-environment node` usage. Guarding that line is a safe, backward-compatible change — jsdom tests are unaffected.

## Test plan

- `npm --prefix frontend test -- --no-coverage --ci` — 496 suites, 3035 tests, all pass
- `lib/settings.ts` coverage: lines 100%, branches 100% (was 66.7%)

Closes #2015

## Docs follow-up

N/A — internal test infrastructure change only.
