### PR TITLE
test: render all Icons with default props to cover default-arg branches (closes #2031)

### DIFF
--- a/frontend/src/__tests__/Icons.default.test.tsx
+++ b/frontend/src/__tests__/Icons.default.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Smoke-render every icon in components/Icons.tsx with no props (closes #2031).
+ *
+ * Istanbul tracks a `default-arg` branch for each icon's `className` default
+ * parameter. All icon usages in the codebase pass `className` explicitly, so
+ * the "use default value" path is never hit. Rendering with no props here
+ * exercises all 50 default-arg branches and pushes Icons.tsx to ~100% branches.
+ */
+import React from "react";
+import { render } from "@testing-library/react";
+import {
+  FireIcon,
+  SpeakerIcon,
+  ArrowRightIcon,
+  HighlightIcon,
+  NoteIcon,
+  ChatIcon,
+  BookOpenIcon,
+  GlobeIcon,
+  BookmarkIcon,
+  PlayIcon,
+  PauseIcon,
+  CloseIcon,
+  SunIcon,
+  MoonIcon,
+  SepiaIcon,
+  ArrowLeftIcon,
+  WordIcon,
+  SummaryIcon,
+  ExportIcon,
+  EditIcon,
+  TrashIcon,
+  ChevronRightIcon,
+  CheckIcon,
+  CheckCircleIcon,
+  RetryIcon,
+  InsightIcon,
+  VocabIcon,
+  EmptyNotesIcon,
+  BookCoverPlaceholderIcon,
+  EmptyVocabIcon,
+  EmptyUploadIcon,
+  AlertCircleIcon,
+  CircleDotIcon,
+  PaperclipIcon,
+  SaveIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  KeyboardIcon,
+  FocusIcon,
+  UploadIcon,
+  FlashcardIcon,
+  GridViewIcon,
+  ListViewIcon,
+  ArrowUpRightIcon,
+  SearchIcon,
+  SettingsIcon,
+  DeckIcon,
+  ClockIcon,
+  ArrowUpIcon,
+  PlusIcon,
+} from "@/components/Icons";
+
+const ALL_ICONS = [
+  FireIcon, SpeakerIcon, ArrowRightIcon, HighlightIcon, NoteIcon,
+  ChatIcon, BookOpenIcon, GlobeIcon, BookmarkIcon, PlayIcon,
+  PauseIcon, CloseIcon, SunIcon, MoonIcon, SepiaIcon,
+  ArrowLeftIcon, WordIcon, SummaryIcon, ExportIcon, EditIcon,
+  TrashIcon, ChevronRightIcon, CheckIcon, CheckCircleIcon, RetryIcon,
+  InsightIcon, VocabIcon, EmptyNotesIcon, BookCoverPlaceholderIcon, EmptyVocabIcon,
+  EmptyUploadIcon, AlertCircleIcon, CircleDotIcon, PaperclipIcon, SaveIcon,
+  ChevronDownIcon, ChevronUpIcon, KeyboardIcon, FocusIcon, UploadIcon,
+  FlashcardIcon, GridViewIcon, ListViewIcon, ArrowUpRightIcon, SearchIcon,
+  SettingsIcon, DeckIcon, ClockIcon, ArrowUpIcon, PlusIcon,
+];
+
+test.each(ALL_ICONS)("renders %s with default className (no props — hits default-arg branch)", (Icon) => {
+  expect(() => render(<Icon />)).not.toThrow();
+});


### PR DESCRIPTION
## What
Smoke-render every icon in `components/Icons.tsx` with no props (closes #2031).

Istanbul tracks a `default-arg` branch for each icon's `className` default parameter. All 50 icons are called throughout the codebase with an explicit `className` prop, so the "use default value" path was never exercised — leaving Icons.tsx at 2% branch coverage (1/51 branches).

The new test file renders each of the 50 exported icons with no props, triggering the default-arg branch for every icon. `BookmarkIcon` also has a `fill = "none"` default which was already covered (1879 hits from production usage).

## Result
`components/Icons.tsx` branch coverage: **2% → 100%** (51/51 branches).

## Test plan
- [x] 50 new tests pass (`Icons.default.test.tsx`) — one per icon
- [x] Full frontend suite: 3101 tests pass
- [x] Backend pytest: running (no backend changes)
- [x] Coverage verified: 51/51 branches hit after this test runs in isolation

Closes #2031
