### PR TITLE
fix: upgrade Popular Classics empty state with icon, headline, and CTA (closes #2037)

### DIFF
--- a/frontend/src/__tests__/HomePage.popularerror.test.tsx
+++ b/frontend/src/__tests__/HomePage.popularerror.test.tsx
@@ -80,8 +80,8 @@ test("shows error state (not empty-state) when getPopularBooks fails", async () 
   render(<Home />);
   await flushPromises();
 
-  // Should NOT show the "no books available" empty state
-  expect(screen.queryByText(/No popular books available/i)).not.toBeInTheDocument();
+  // Should NOT show the "no books yet" empty state
+  expect(screen.queryByText(/No popular books yet/i)).not.toBeInTheDocument();
 
   // Should show an error state with retry
   expect(await screen.findByRole("alert")).toBeInTheDocument();
@@ -114,7 +114,7 @@ test("genuine empty response shows no-books message, not error state", async () 
   mockGetPopularBooks.mockResolvedValue({ books: [], total: 0 });
   render(<Home />);
 
-  expect(await screen.findByText(/No popular books available/i)).toBeInTheDocument();
+  expect(await screen.findByText(/No popular books yet/i)).toBeInTheDocument();
   expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   expect(screen.queryByRole("button", { name: /try again/i })).not.toBeInTheDocument();
 });

--- a/frontend/src/__tests__/HomePage.test.tsx
+++ b/frontend/src/__tests__/HomePage.test.tsx
@@ -365,12 +365,13 @@ describe("HomePage — Discover tab", () => {
     resolve!(makePopularResponse());
   });
 
-  it("shows 'No popular books available yet.' when list is empty", async () => {
+  it("shows proper empty state with icon, headline, and CTA when popular books list is empty", async () => {
     mockGetPopularBooks.mockResolvedValue({ books: [], total: 0, page: 1, per_page: 50 });
     await renderHome();
     await waitFor(() => {
-      expect(screen.getByText("No popular books available yet.")).toBeInTheDocument();
+      expect(screen.getByText("No popular books yet")).toBeInTheDocument();
     });
+    expect(screen.getByRole("button", { name: "Search for a book" })).toBeInTheDocument();
   });
 
   it("clicking a popular book opens BookDetailModal", async () => {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -806,9 +806,25 @@ export default function Home() {
               )}
 
               {!popularLoading && !popularError && popularBooks.length === 0 && (
-                <p className="text-center py-10 text-amber-700 text-sm">
-                  No popular books available yet.
-                </p>
+                <div className="text-center py-10 flex flex-col items-center gap-3">
+                  <BookOpenIcon className="w-12 h-12 text-amber-300 mx-auto" aria-hidden="true" />
+                  <p className="font-serif text-lg text-ink">No popular books yet</p>
+                  <p className="text-sm text-stone-500 max-w-xs">
+                    Popular classics from Project Gutenberg haven&apos;t been loaded yet.
+                    Search above to find any title or author.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const el = document.querySelector<HTMLInputElement>('[aria-label="Search by title or author"]');
+                      el?.focus();
+                      el?.scrollIntoView({ behavior: "smooth", block: "center" });
+                    }}
+                    className="mt-1 inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors"
+                  >
+                    Search for a book
+                  </button>
+                </div>
               )}
             </section>
           </div>


### PR DESCRIPTION
## What changed

Replaced the bare `<p>No popular books available yet.</p>` in the Discover tab's Popular Classics section with a proper design-rule compliant empty state:

- **BookOpenIcon** SVG illustration (from Icons.tsx, `aria-hidden="true"`)
- **`font-serif` headline** — "No popular books yet"
- **Explanatory sub-text** — tells the user why and what they can do
- **CTA button** — "Search for a book" that focuses and scrolls to the search input above

## Why

CLAUDE.md graphic design rules require every empty state to have: icon + font-serif headline + sub-text + CTA button. The old state had none of those — it was a plain small text paragraph with no visual weight or call to action.

## Test plan

- [x] Updated existing test in `HomePage.test.tsx` to assert new headline and CTA button are present
- [x] Updated `HomePage.popularerror.test.tsx` to match new empty-state text
- [x] Full frontend suite passes (3120 tests)
- [x] Backend tests passing

## Docs follow-up

No docs update needed — this is a pure empty-state polish change.

Closes #2037

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
