### PR TITLE
fix(ux): add ARIA live region to Popular Classics pagination (closes #2039)

### DIFF
--- a/frontend/src/__tests__/HomePage.paginationAria.test.tsx
+++ b/frontend/src/__tests__/HomePage.paginationAria.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Regression test for #2039: Popular Classics pagination must announce
+ * page changes to screen readers via a live region on the page counter.
+ * Buttons must have descriptive aria-labels.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ status: "unauthenticated", data: null }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+function makeBook(id: number) {
+  return {
+    id,
+    title: `Book ${id}`,
+    authors: [`Author ${id}`],
+    subjects: [],
+    languages: ["en"],
+    download_count: id * 100,
+    cover_url: null,
+  };
+}
+
+const BOOKS_PAGE_1 = Array.from({ length: 10 }, (_, i) => makeBook(i + 1));
+
+const mockGetPopularBooks = jest.fn();
+const mockGetMe = jest.fn().mockResolvedValue({ role: "user" });
+const mockSearchBooks = jest.fn();
+const mockGetReadingProgress = jest.fn().mockResolvedValue([]);
+const mockGetUserStats = jest.fn().mockResolvedValue(null);
+
+jest.mock("@/lib/api", () => ({
+  getPopularBooks: (...args: unknown[]) => mockGetPopularBooks(...args),
+  getMe: (...args: unknown[]) => mockGetMe(...args),
+  searchBooks: (...args: unknown[]) => mockSearchBooks(...args),
+  getReadingProgress: (...args: unknown[]) => mockGetReadingProgress(...args),
+  getUserStats: (...args: unknown[]) => mockGetUserStats(...args),
+}));
+
+jest.mock("@/lib/recentBooks", () => ({
+  getRecentBooks: () => [],
+  removeRecentBook: jest.fn(),
+  recordRecentBook: jest.fn(),
+}));
+
+jest.mock("@/components/BookCard", () => {
+  const BookCard = ({ book }: { book: { id: number; title: string } }) => (
+    <div data-testid={`book-card-${book.id}`}>{book.title}</div>
+  );
+  BookCard.displayName = "BookCard";
+  return BookCard;
+});
+
+jest.mock("@/components/BookDetailModal", () => {
+  const BookDetailModal = () => null;
+  BookDetailModal.displayName = "BookDetailModal";
+  return BookDetailModal;
+});
+
+jest.mock("@/components/UndoToast", () => {
+  const UndoToast = () => null;
+  UndoToast.displayName = "UndoToast";
+  return UndoToast;
+});
+
+jest.mock("@/components/ReadingStats", () => {
+  const ReadingStats = () => null;
+  ReadingStats.displayName = "ReadingStats";
+  return ReadingStats;
+});
+
+jest.mock("@/components/SeedPopularButton", () => {
+  const SeedPopularButton = () => null;
+  SeedPopularButton.displayName = "SeedPopularButton";
+  return SeedPopularButton;
+});
+
+import Home from "@/app/page";
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Return total > 50 to trigger pagination controls
+  mockGetPopularBooks.mockResolvedValue({ books: BOOKS_PAGE_1, total: 60 });
+});
+
+test("pagination page counter has role=status for screen reader announcements", async () => {
+  render(<Home />);
+  await flushPromises();
+
+  const pageCounter = await screen.findByRole("status", { name: /page 1 of/i });
+  expect(pageCounter).toBeInTheDocument();
+});
+
+test("Prev button has descriptive aria-label", async () => {
+  render(<Home />);
+  await flushPromises();
+
+  await screen.findByRole("button", { name: /previous page of popular books/i });
+});
+
+test("Next button has descriptive aria-label", async () => {
+  render(<Home />);
+  await flushPromises();
+
+  await screen.findByRole("button", { name: /next page of popular books/i });
+});
+
+test("clicking Next loads page 2 and page counter updates", async () => {
+  const BOOKS_PAGE_2 = Array.from({ length: 10 }, (_, i) => makeBook(i + 51));
+  mockGetPopularBooks
+    .mockResolvedValueOnce({ books: BOOKS_PAGE_1, total: 60 })
+    .mockResolvedValueOnce({ books: BOOKS_PAGE_2, total: 60 });
+
+  render(<Home />);
+  await flushPromises();
+
+  const nextBtn = await screen.findByRole("button", { name: /next page of popular books/i });
+  const user = userEvent.setup();
+  await user.click(nextBtn);
+
+  await waitFor(() => {
+    expect(screen.getByRole("status", { name: /page 2 of/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/HomepagePaginationUnicodeIcons.test.ts
+++ b/frontend/src/__tests__/HomepagePaginationUnicodeIcons.test.ts
@@ -23,8 +23,9 @@ describe("Homepage pagination Unicode icon replacements", () => {
   });
 
   it("Prev button uses ArrowLeftIcon", () => {
-    const prevIdx = src.indexOf("Prev");
-    const snippet = src.slice(Math.max(0, prevIdx - 100), prevIdx + 10);
+    // Search for the button content "/> Prev" and check ArrowLeftIcon precedes it
+    const prevIdx = src.indexOf("/> Prev");
+    const snippet = src.slice(Math.max(0, prevIdx - 80), prevIdx + 10);
     expect(snippet).toMatch(/ArrowLeftIcon/);
   });
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -775,16 +775,24 @@ export default function Home() {
                       <button
                         onClick={() => setPopularPage((p) => p - 1)}
                         disabled={popularPage === 1}
+                        aria-label="Previous page of popular books"
                         className="px-4 py-2.5 md:py-1.5 text-sm rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors min-h-[44px] md:min-h-0"
                       >
                         <ArrowLeftIcon className="w-4 h-4 inline" aria-hidden="true" /> Prev
                       </button>
-                      <span className="text-sm text-amber-700">
+                      <span
+                        role="status"
+                        aria-live="polite"
+                        aria-atomic="true"
+                        aria-label={`Page ${popularPage} of ${Math.ceil(popularTotal / PER_PAGE)}`}
+                        className="text-sm text-amber-700"
+                      >
                         Page {popularPage} of {Math.ceil(popularTotal / PER_PAGE)}
                       </span>
                       <button
                         onClick={() => setPopularPage((p) => p + 1)}
                         disabled={popularPage >= Math.ceil(popularTotal / PER_PAGE)}
+                        aria-label="Next page of popular books"
                         className="px-4 py-2.5 md:py-1.5 text-sm rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors min-h-[44px] md:min-h-0"
                       >
                         Next <ArrowRightIcon className="w-4 h-4 inline" aria-hidden="true" />


### PR DESCRIPTION
## What changed
- Added `role="status" aria-live="polite" aria-atomic="true"` to the Popular Classics page counter span so screen readers announce the new page when Prev/Next is clicked (WCAG 2.1 SC 4.1.3 Status Messages)
- Added `aria-label="Previous page of popular books"` and `aria-label="Next page of popular books"` to pagination buttons so their purpose is clear out of context
- Updated `HomepagePaginationUnicodeIcons.test.ts` to use `"> Prev"` as the anchor string (the old `indexOf("Prev")` matched "Previous" in the new aria-label)

## Why
Screen readers gave no feedback when paginating through popular books — the page counter text changed but wasn't announced, leaving keyboard-only users with no confirmation that the page changed (closes #2039).

## Test plan
- [x] New regression test `HomePage.paginationAria.test.tsx` — 4 tests covering: role=status presence, button aria-labels, page counter update on Next click
- [x] Existing `HomepagePaginationUnicodeIcons` suite still passes (5 tests)
- [x] Full frontend suite: 3129 tests pass
