### PR TITLE
fix(ux): add list semantics to book grids for screen reader item counts (closes #2041)

### DIFF
--- a/frontend/src/__tests__/HomePage.listSemantics.test.tsx
+++ b/frontend/src/__tests__/HomePage.listSemantics.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Regression test for #2041: book grids must use list semantics so
+ * screen readers can announce item counts and navigation position.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ status: "unauthenticated", data: null }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+function makeBook(id: number) {
+  return {
+    id,
+    title: `Book ${id}`,
+    authors: [`Author ${id}`],
+    subjects: [],
+    languages: ["en"],
+    download_count: id * 100,
+    cover_url: null,
+  };
+}
+
+const BOOKS = Array.from({ length: 3 }, (_, i) => makeBook(i + 1));
+
+const mockGetPopularBooks = jest.fn().mockResolvedValue({ books: BOOKS, total: 3 });
+const mockGetMe = jest.fn().mockResolvedValue({ role: "user" });
+const mockSearchBooks = jest.fn().mockResolvedValue({ books: BOOKS });
+const mockGetReadingProgress = jest.fn().mockResolvedValue([]);
+const mockGetUserStats = jest.fn().mockResolvedValue(null);
+
+jest.mock("@/lib/api", () => ({
+  getPopularBooks: (...args: unknown[]) => mockGetPopularBooks(...args),
+  getMe: (...args: unknown[]) => mockGetMe(...args),
+  searchBooks: (...args: unknown[]) => mockSearchBooks(...args),
+  getReadingProgress: (...args: unknown[]) => mockGetReadingProgress(...args),
+  getUserStats: (...args: unknown[]) => mockGetUserStats(...args),
+}));
+
+jest.mock("@/lib/recentBooks", () => ({
+  getRecentBooks: () => [],
+  removeRecentBook: jest.fn(),
+  recordRecentBook: jest.fn(),
+}));
+
+jest.mock("@/components/BookCard", () => {
+  const BookCard = ({ book }: { book: { id: number; title: string } }) => (
+    <div data-testid={`book-card-${book.id}`}>{book.title}</div>
+  );
+  BookCard.displayName = "BookCard";
+  return BookCard;
+});
+
+jest.mock("@/components/BookDetailModal", () => {
+  const BookDetailModal = () => null;
+  BookDetailModal.displayName = "BookDetailModal";
+  return BookDetailModal;
+});
+
+jest.mock("@/components/UndoToast", () => {
+  const UndoToast = () => null;
+  UndoToast.displayName = "UndoToast";
+  return UndoToast;
+});
+
+jest.mock("@/components/ReadingStats", () => {
+  const ReadingStats = () => null;
+  ReadingStats.displayName = "ReadingStats";
+  return ReadingStats;
+});
+
+jest.mock("@/components/SeedPopularButton", () => {
+  const SeedPopularButton = () => null;
+  SeedPopularButton.displayName = "SeedPopularButton";
+  return SeedPopularButton;
+});
+
+import Home from "@/app/page";
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetPopularBooks.mockResolvedValue({ books: BOOKS, total: 3 });
+  mockSearchBooks.mockResolvedValue({ books: BOOKS });
+});
+
+test("Popular Classics grid renders as a list element", async () => {
+  render(<Home />);
+  await flushPromises();
+
+  // After popular books load, the grid container should be a <ul> with role=list
+  const list = await screen.findByRole("list", { name: /popular classics/i });
+  expect(list).toBeInTheDocument();
+  // All book cards should be inside list items
+  const items = screen.getAllByRole("listitem");
+  expect(items.length).toBeGreaterThanOrEqual(3);
+});
+
+test("search results grid renders as a list element", async () => {
+  render(<Home />);
+  await flushPromises();
+
+  const searchInput = screen.getByRole("textbox", { name: /search by title or author/i });
+  const user = userEvent.setup();
+  await user.type(searchInput, "Pride");
+  await user.keyboard("{Enter}");
+
+  await waitFor(() => {
+    expect(screen.getByRole("list", { name: /search results/i })).toBeInTheDocument();
+  });
+  const items = screen.getAllByRole("listitem");
+  expect(items.length).toBeGreaterThanOrEqual(3);
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -638,11 +638,13 @@ export default function Home() {
               )}
 
               {!searching && searchResults.length > 0 && (
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+                <ul role="list" aria-label="Search results" className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 list-none p-0 m-0">
                   {searchResults.map((book) => (
-                    <BookCard key={book.id} book={book} onClick={() => handleBookClick(book)} />
+                    <li key={book.id}>
+                      <BookCard book={book} onClick={() => handleBookClick(book)} />
+                    </li>
                   ))}
-                </div>
+                </ul>
               )}
 
               {!searching && searchedQuery && searchResults.length === 0 && !searchError && (
@@ -730,43 +732,46 @@ export default function Home() {
               {!popularLoading && popularBooks.length > 0 && (
                 <>
                   {popularView === "grid" ? (
-                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+                    <ul role="list" aria-label="Popular Classics" className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 list-none p-0 m-0">
                       {popularBooks.map((book) => (
-                        <BookCard key={book.id} book={book} onClick={() => handleBookClick(book)} />
+                        <li key={book.id}>
+                          <BookCard book={book} onClick={() => handleBookClick(book)} />
+                        </li>
                       ))}
-                    </div>
+                    </ul>
                   ) : (
-                    <div className="divide-y divide-amber-100 border border-amber-200 rounded-xl overflow-hidden bg-white">
+                    <ul role="list" aria-label="Popular Classics" className="divide-y divide-amber-100 border border-amber-200 rounded-xl overflow-hidden bg-white list-none p-0 m-0">
                       {popularBooks.map((book, idx) => (
-                        <button
-                          key={book.id}
-                          onClick={() => handleBookClick(book)}
-                          aria-label={`Open ${book.title}${book.authors.length ? ` by ${book.authors.join(", ")}` : ""}`}
-                          className="flex items-center gap-3 w-full px-4 py-3 text-left hover:bg-amber-50 transition-colors"
-                        >
-                          <span className="text-xs text-stone-500 w-7 text-right shrink-0 tabular-nums">
-                            {(popularPage - 1) * PER_PAGE + idx + 1}
-                          </span>
-                          {book.cover ? (
-                            // eslint-disable-next-line @next/next/no-img-element
-                            <img src={book.cover} alt="" className="w-9 h-14 object-cover rounded shrink-0" />
-                          ) : (
-                            <div className="w-9 h-14 bg-gradient-to-br from-amber-50 to-amber-100 border border-amber-100 rounded shrink-0 flex items-center justify-center">
-                              <BookCoverPlaceholderIcon className="w-5 h-7 text-amber-500" />
-                            </div>
-                          )}
-                          <div className="flex-1 min-w-0">
-                            <p className="font-serif text-sm font-semibold text-ink truncate">{book.title}</p>
-                            <p className="text-xs text-amber-700 truncate">{book.authors.join(", ")}</p>
-                          </div>
-                          {book.download_count > 0 ? (
-                            <span className="text-xs text-stone-500 shrink-0 tabular-nums">
-                              {book.download_count.toLocaleString()}
+                        <li key={book.id}>
+                          <button
+                            onClick={() => handleBookClick(book)}
+                            aria-label={`Open ${book.title}${book.authors.length ? ` by ${book.authors.join(", ")}` : ""}`}
+                            className="flex items-center gap-3 w-full px-4 py-3 text-left hover:bg-amber-50 transition-colors"
+                          >
+                            <span className="text-xs text-stone-500 w-7 text-right shrink-0 tabular-nums">
+                              {(popularPage - 1) * PER_PAGE + idx + 1}
                             </span>
-                          ) : null}
-                        </button>
+                            {book.cover ? (
+                              // eslint-disable-next-line @next/next/no-img-element
+                              <img src={book.cover} alt="" className="w-9 h-14 object-cover rounded shrink-0" />
+                            ) : (
+                              <div className="w-9 h-14 bg-gradient-to-br from-amber-50 to-amber-100 border border-amber-100 rounded shrink-0 flex items-center justify-center">
+                                <BookCoverPlaceholderIcon className="w-5 h-7 text-amber-500" />
+                              </div>
+                            )}
+                            <div className="flex-1 min-w-0">
+                              <p className="font-serif text-sm font-semibold text-ink truncate">{book.title}</p>
+                              <p className="text-xs text-amber-700 truncate">{book.authors.join(", ")}</p>
+                            </div>
+                            {book.download_count > 0 ? (
+                              <span className="text-xs text-stone-500 shrink-0 tabular-nums">
+                                {book.download_count.toLocaleString()}
+                              </span>
+                            ) : null}
+                          </button>
+                        </li>
                       ))}
-                    </div>
+                    </ul>
                   )}
 
                   {/* Pagination */}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -392,24 +392,25 @@ export default function Home() {
                     Your Library
                   </h2>
                 )}
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+                <ul role="list" aria-label="Your Library" className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 list-none p-0 m-0">
                   {recentBooks.map((book) => (
-                    <BookCard
-                      key={book.id}
-                      book={book}
-                      onClick={() => handleBookClick(book)}
-                      badge={`Ch. ${book.lastChapter + 1} · ${timeAgo(book.lastRead)}`}
-                      onRemove={() => {
-                        if (removedBookToast) {
-                          setRemovedBookToast(null);
-                        }
-                        removeRecentBook(book.id);
-                        setRecentBooks(getRecentBooks());
-                        setRemovedBookToast(book);
-                      }}
-                    />
+                    <li key={book.id}>
+                      <BookCard
+                        book={book}
+                        onClick={() => handleBookClick(book)}
+                        badge={`Ch. ${book.lastChapter + 1} · ${timeAgo(book.lastRead)}`}
+                        onRemove={() => {
+                          if (removedBookToast) {
+                            setRemovedBookToast(null);
+                          }
+                          removeRecentBook(book.id);
+                          setRecentBooks(getRecentBooks());
+                          setRemovedBookToast(book);
+                        }}
+                      />
+                    </li>
                   ))}
-                </div>
+                </ul>
               </section>
             ) : (
               <div className="text-center py-20">


### PR DESCRIPTION
## What changed
Replaced plain `<div>` containers in the Popular Classics and search results book grids with `<ul role="list">` / `<li>` structure.

- **Search results grid**: `<div class="grid ...">` → `<ul role="list" aria-label="Search results" class="grid ...">`
- **Popular Classics grid view**: same pattern, `aria-label="Popular Classics"`
- **Popular Classics list view**: `<div class="divide-y ...">` → `<ul role="list" aria-label="Popular Classics">` with each row's button inside a `<li>`

The `role="list"` attribute is required to restore list semantics that Tailwind's `list-none` + `p-0` CSS can strip in Safari/WebKit (known browser bug).

## Why
WCAG 2.1 SC 1.3.1 — screen readers could not announce item counts ("list, 10 items") or position ("item 3 of 10") when navigating these grids, because they had no list structure (closes #2041).

## Test plan
- [x] New `HomePage.listSemantics.test.tsx` — 2 tests: popular books grid has `role="list"` with labelled container, search results grid has same
- [x] Full frontend suite: 3127 tests pass
