### PR TITLE
fix(ux): add list semantics to notes and decks index pages (closes #2043)

### DIFF
--- a/frontend/src/__tests__/NotesDecksListSemantics.test.tsx
+++ b/frontend/src/__tests__/NotesDecksListSemantics.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Regression test for #2043: notes and decks index pages must use list
+ * semantics so screen readers can announce item counts and navigation position.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+// ─── Notes page mocks ────────────────────────────────────────────────────────
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { backendToken: "token" }, status: "authenticated" }),
+}));
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: jest.fn() }),
+}));
+
+const mockGetAllAnnotations = jest.fn();
+const mockGetAllInsights = jest.fn();
+const mockGetVocabulary = jest.fn();
+const mockListDecks = jest.fn();
+
+jest.mock("@/lib/api", () => ({
+  getAllAnnotations: (...a: unknown[]) => mockGetAllAnnotations(...a),
+  getAllInsights: (...a: unknown[]) => mockGetAllInsights(...a),
+  getVocabulary: (...a: unknown[]) => mockGetVocabulary(...a),
+  listDecks: (...a: unknown[]) => mockListDecks(...a),
+  deleteDeck: jest.fn(),
+}));
+
+jest.mock("@/components/UndoToast", () => {
+  const UndoToast = () => null;
+  UndoToast.displayName = "UndoToast";
+  return UndoToast;
+});
+
+jest.mock("@/components/DeckCard", () => {
+  const DeckCard = ({ deck }: { deck: { id: number; name: string } }) => (
+    <div data-testid={`deck-${deck.id}`}>{deck.name}</div>
+  );
+  DeckCard.displayName = "DeckCard";
+  return DeckCard;
+});
+
+import NotesPage from "@/app/notes/page";
+import DecksPage from "@/app/decks/page";
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+function makeAnnotation(bookId: number, bookTitle: string) {
+  return {
+    id: bookId,
+    book_id: bookId,
+    chapter_index: 0,
+    sentence_text: "Some text",
+    note_text: "A note",
+    color: "yellow",
+    created_at: "2026-01-01T00:00:00",
+    book_title: bookTitle,
+    chapter_title: "Chapter 1",
+  };
+}
+
+function makeDeck(id: number) {
+  return {
+    id,
+    name: `Deck ${id}`,
+    description: "",
+    mode: "manual" as const,
+    rules_json: null,
+    created_at: "2026-01-01T00:00:00",
+    updated_at: "2026-01-01T00:00:00",
+    member_count: 5,
+    due_today: 1,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetAllInsights.mockResolvedValue([]);
+  mockGetVocabulary.mockResolvedValue([]);
+});
+
+test("notes page book list renders as a list element", async () => {
+  mockGetAllAnnotations.mockResolvedValue([
+    makeAnnotation(1, "Book One"),
+    makeAnnotation(2, "Book Two"),
+    makeAnnotation(3, "Book Three"),
+  ]);
+
+  render(<NotesPage />);
+  await flushPromises();
+
+  const list = await screen.findByRole("list", { name: /books with notes/i });
+  expect(list).toBeInTheDocument();
+  const items = screen.getAllByRole("listitem");
+  expect(items.length).toBeGreaterThanOrEqual(3);
+});
+
+test("decks page deck list renders as a list element", async () => {
+  mockListDecks.mockResolvedValue([makeDeck(1), makeDeck(2), makeDeck(3)]);
+
+  render(<DecksPage />);
+  await flushPromises();
+
+  const list = await screen.findByRole("list", { name: /your decks/i });
+  expect(list).toBeInTheDocument();
+  const items = screen.getAllByRole("listitem");
+  expect(items.length).toBeGreaterThanOrEqual(3);
+});

--- a/frontend/src/app/decks/page.tsx
+++ b/frontend/src/app/decks/page.tsx
@@ -134,16 +134,17 @@ export default function DecksPage() {
             </button>
           </div>
         ) : (
-          <div className="space-y-4">
+          <ul role="list" aria-label="Your decks" className="space-y-4 list-none p-0 m-0">
             {decks.map((d) => (
-              <DeckCard
-                key={d.id}
-                deck={d}
-                onClick={() => router.push(`/decks/${d.id}`)}
-                onDelete={handleDelete}
-              />
+              <li key={d.id}>
+                <DeckCard
+                  deck={d}
+                  onClick={() => router.push(`/decks/${d.id}`)}
+                  onDelete={handleDelete}
+                />
+              </li>
             ))}
-          </div>
+          </ul>
         )}
       </div>
 

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -202,10 +202,10 @@ export default function NotesOverviewPage() {
             )}
           </div>
         ) : (
-          <div className="space-y-3">
+          <ul role="list" aria-label="Books with notes" className="space-y-3 list-none p-0 m-0">
             {filtered.map((book) => (
+              <li key={book.bookId}>
               <button
-                key={book.bookId}
                 onClick={() => router.push(`/notes/${book.bookId}`)}
                 className="w-full text-left rounded-xl border border-amber-200 bg-white/80 px-5 py-4 hover:border-amber-400 hover:shadow-sm transition-all group"
               >
@@ -241,8 +241,9 @@ export default function NotesOverviewPage() {
                   </div>
                 </div>
               </button>
+              </li>
             ))}
-          </div>
+          </ul>
         )}
       </div>
     </main>


### PR DESCRIPTION
## What changed

The notes index page (`/notes`) and decks index page (`/decks`) rendered their item lists inside plain `<div>` containers. Screen readers could not announce item counts or navigation position within those lists.

Replaced the `<div className="space-y-*">` wrappers with `<ul role="list" aria-label="...">` + `<li>` wrappers on both pages, matching the identical pattern applied to homepage book grids in #2041.

## Why

WCAG 2.1 SC 1.3.1 — list structure (item count, current position) must be conveyed programmatically to assistive technology. Safari/WebKit also strips list semantics from `<ul>` elements styled with `list-style: none`, so the explicit `role="list"` is necessary for cross-browser screen reader support.

## Test plan

- Two new regression tests in `NotesDecksListSemantics.test.tsx`:
  - `notes page book list renders as a list element` — finds `role="list"` with `aria-label="Books with notes"`, verifies ≥ 3 `listitem` children
  - `decks page deck list renders as a list element` — finds `role="list"` with `aria-label="Your decks"`, verifies ≥ 3 `listitem` children
- Full frontend suite: 3131/3131 pass
- Full backend suite: 1941/1941 pass

Closes #2043
