### PR TITLE
fix(ux): add list semantics to search results sections (closes #2045)

### DIFF
--- a/frontend/src/__tests__/SearchPageListSemantics.test.tsx
+++ b/frontend/src/__tests__/SearchPageListSemantics.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Regression test for #2045: search results sections must use list semantics
+ * so screen readers can announce item counts and navigation position.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+
+const mockSearchParams = { get: (k: string) => (k === "q" ? "Pride" : null) };
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const mockSearchFn = jest.fn();
+jest.mock("@/lib/api", () => ({
+  searchInAppContent: (...args: unknown[]) => mockSearchFn(...args),
+}));
+
+jest.mock("next/link", () => {
+  const Link = ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) => (
+    <a href={href} className={className}>{children}</a>
+  );
+  Link.displayName = "Link";
+  return { __esModule: true, default: Link };
+});
+
+import SearchPage from "@/app/search/page";
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+function makeAnnotation(id: number) {
+  return {
+    type: "annotation" as const,
+    book_id: id,
+    book_title: `Book ${id}`,
+    chapter_index: 0,
+    chapter_title: `Chapter ${id}`,
+    snippet: "Some text",
+    note_text: "A note",
+  };
+}
+
+beforeEach(() => {
+  mockSearchFn.mockReset();
+});
+
+test("search result section renders as a list element", async () => {
+  mockSearchFn.mockResolvedValue({
+    query: "Pride",
+    total: 3,
+    results: [makeAnnotation(1), makeAnnotation(2), makeAnnotation(3)],
+  });
+
+  render(<SearchPage />);
+  await flushPromises();
+
+  await waitFor(() => {
+    const list = screen.getByRole("list", { name: /annotations/i });
+    expect(list).toBeInTheDocument();
+  });
+
+  const items = screen.getAllByRole("listitem");
+  expect(items.length).toBeGreaterThanOrEqual(3);
+});

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -90,11 +90,13 @@ function ResultsSection({ title, items }: { title: string; items: InAppSearchRes
       <h2 className="text-sm uppercase tracking-wide text-stone-500">
         {title} · {items.length}
       </h2>
-      <div className="grid gap-3">
+      <ul role="list" aria-label={title} className="grid gap-3 list-none p-0 m-0">
         {items.map((r, i) => (
-          <ResultCard key={`${r.type}-${i}`} r={r} />
+          <li key={`${r.type}-${i}`}>
+            <ResultCard r={r} />
+          </li>
         ))}
-      </div>
+      </ul>
     </section>
   );
 }


### PR DESCRIPTION
## What changed

The in-app search results page (`/search`) rendered each result section's items in a plain `<div className="grid gap-3">` container. Screen readers could not announce item counts or navigation position within the result lists (Annotations, Vocabulary, Chapters).

Replaced with `<ul role="list" aria-label={title}>` + `<li>` wrappers in the shared `ResultsSection` component, so all three section types get the fix automatically.

## Why

WCAG 2.1 SC 1.3.1 — list structure (item count, current position) must be conveyed programmatically to assistive technology. Same class of issue as #2041 and #2043.

## Test plan

- New regression test `SearchPageListSemantics.test.tsx`:
  - Mocks `searchInAppContent` with 3 annotation results
  - Verifies `role="list"` with `aria-label="Annotations"` is present
  - Verifies ≥ 3 `listitem` children
- Full frontend suite: 3132/3132 pass

Closes #2045
