### PR TITLE
fix(ux): add list semantics to vocabulary word groups (closes #2047)

### DIFF
--- a/frontend/src/__tests__/VocabWordGroupsListSemantics.test.ts
+++ b/frontend/src/__tests__/VocabWordGroupsListSemantics.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Regression test for #2047: vocabulary page word groups must use list
+ * semantics so screen readers can announce item counts and position.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8",
+);
+
+test("vocabulary word groups container is a <ul> not a <div>", () => {
+  // The word groups are rendered via sectionGroups.map(...)
+  // They must be inside a <ul role="list"> for screen reader item counts.
+  const mapIdx = src.indexOf("sectionGroups.map(");
+  expect(mapIdx).toBeGreaterThan(-1);
+
+  // Look back 300 chars from the map call to find the container opening tag
+  const snippet = src.slice(Math.max(0, mapIdx - 300), mapIdx + 20);
+  expect(snippet).toMatch(/<ul[^>]*role="list"/);
+  expect(snippet).not.toMatch(/<div[^>]*space-y-4[^>]*>\s*$/);
+});
+
+test("each vocabulary word group is wrapped in a <li>", () => {
+  // The renderGroup function result should be wrapped in <li key={...}>
+  const mapIdx = src.indexOf("sectionGroups.map(");
+  expect(mapIdx).toBeGreaterThan(-1);
+
+  const snippet = src.slice(mapIdx, mapIdx + 200);
+  expect(snippet).toMatch(/<li/);
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -357,7 +357,6 @@ function VocabularyPageContent() {
     );
     return (
       <div
-        key={group.lemma}
         ref={target ? highlightRef : undefined}
         className={`rounded-xl border p-4 transition-colors ${
           target
@@ -640,9 +639,11 @@ function VocabularyPageContent() {
                     {heading}
                   </h2>
                 )}
-                <div className="space-y-4">
-                  {sectionGroups.map(renderGroup)}
-                </div>
+                <ul role="list" className="space-y-4 list-none p-0 m-0">
+                  {sectionGroups.map((group) => (
+                    <li key={group.lemma}>{renderGroup(group)}</li>
+                  ))}
+                </ul>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## What changed

The vocabulary page rendered word groups inside a plain `<div className="space-y-4">` container, preventing screen readers from announcing item counts or navigation position within the word group list.

Replaced with `<ul role="list" className="space-y-4 list-none p-0 m-0">` + `<li key={group.lemma}>` wrappers. The `key` was moved from inside `renderGroup` to the outer `<li>` (cleaner and correct). Pattern is identical to #2041, #2043, #2045.

## Why

WCAG 2.1 SC 1.3.1 — list structure (item count, current position) must be conveyed programmatically. Safari/WebKit also strips list semantics from `<ul>` with `list-style: none`, so the explicit `role="list"` ensures cross-browser screen reader support.

## Test plan

- New regression test `VocabWordGroupsListSemantics.test.ts` (static source analysis):
  - Verifies `sectionGroups.map` is inside a `<ul role="list">` context
  - Verifies each item is wrapped in `<li>`
- Full frontend suite: 3135/3135 pass

Closes #2047
