### PR TITLE
fix(ux): add roving tabIndex and arrow-key nav to homepage tablist (closes #2049)

### DIFF
--- a/frontend/src/__tests__/HomeTablistKeyboard.test.tsx
+++ b/frontend/src/__tests__/HomeTablistKeyboard.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Regression test for #2049: homepage tablist must implement the WAI-ARIA
+ * tab pattern — roving tabIndex and arrow-key keyboard navigation.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ status: "unauthenticated", data: null }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const mockGetPopularBooks = jest.fn().mockResolvedValue({ books: [], total: 0 });
+const mockGetMe = jest.fn().mockResolvedValue({ role: "user" });
+const mockSearchBooks = jest.fn().mockResolvedValue({ books: [] });
+const mockGetReadingProgress = jest.fn().mockResolvedValue([]);
+const mockGetUserStats = jest.fn().mockResolvedValue(null);
+
+jest.mock("@/lib/api", () => ({
+  getPopularBooks: (...args: unknown[]) => mockGetPopularBooks(...args),
+  getMe: (...args: unknown[]) => mockGetMe(...args),
+  searchBooks: (...args: unknown[]) => mockSearchBooks(...args),
+  getReadingProgress: (...args: unknown[]) => mockGetReadingProgress(...args),
+  getUserStats: (...args: unknown[]) => mockGetUserStats(...args),
+}));
+
+jest.mock("@/lib/recentBooks", () => ({
+  getRecentBooks: () => [],
+  removeRecentBook: jest.fn(),
+  recordRecentBook: jest.fn(),
+}));
+
+jest.mock("@/components/BookCard", () => {
+  const BookCard = () => null;
+  BookCard.displayName = "BookCard";
+  return BookCard;
+});
+
+jest.mock("@/components/BookDetailModal", () => {
+  const BookDetailModal = () => null;
+  BookDetailModal.displayName = "BookDetailModal";
+  return BookDetailModal;
+});
+
+jest.mock("@/components/UndoToast", () => {
+  const UndoToast = () => null;
+  UndoToast.displayName = "UndoToast";
+  return UndoToast;
+});
+
+jest.mock("@/components/ReadingStats", () => {
+  const ReadingStats = () => null;
+  ReadingStats.displayName = "ReadingStats";
+  return ReadingStats;
+});
+
+jest.mock("@/components/SeedPopularButton", () => {
+  const SeedPopularButton = () => null;
+  SeedPopularButton.displayName = "SeedPopularButton";
+  return SeedPopularButton;
+});
+
+import Home from "@/app/page";
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+test("selected tab has tabIndex 0, unselected tabs have tabIndex -1", async () => {
+  render(<Home />);
+  await flushPromises();
+
+  const tabs = screen.getAllByRole("tab");
+  const selectedTab = tabs.find((t) => t.getAttribute("aria-selected") === "true");
+  const unselectedTabs = tabs.filter((t) => t.getAttribute("aria-selected") !== "true");
+
+  expect(selectedTab).toHaveAttribute("tabindex", "0");
+  for (const t of unselectedTabs) {
+    expect(t).toHaveAttribute("tabindex", "-1");
+  }
+});
+
+test("ArrowRight on Discover tab wraps focus back to Home tab", async () => {
+  render(<Home />);
+  await flushPromises();
+
+  const homeTab = screen.getByRole("tab", { name: /home/i });
+  const discoverTab = screen.getByRole("tab", { name: /discover/i });
+
+  const user = userEvent.setup();
+  await user.click(discoverTab);
+  await user.keyboard("{ArrowRight}");
+
+  expect(document.activeElement).toBe(homeTab);
+});
+
+test("ArrowLeft on Home tab wraps focus back to Discover tab", async () => {
+  render(<Home />);
+  await flushPromises();
+
+  const homeTab = screen.getByRole("tab", { name: /home/i });
+  const discoverTab = screen.getByRole("tab", { name: /discover/i });
+
+  const user = userEvent.setup();
+  await user.click(homeTab);
+  await user.keyboard("{ArrowLeft}");
+
+  expect(document.activeElement).toBe(discoverTab);
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -40,6 +40,7 @@ function timeAgo(ms: number): string {
 }
 
 type Tab = "library" | "discover";
+const TAB_ORDER: Tab[] = ["library", "discover"];
 
 export default function Home() {
   const router = useRouter();
@@ -214,7 +215,23 @@ export default function Home() {
       {/* Tab bar */}
       <div className="border-b border-amber-200 bg-white/40 backdrop-blur">
         <div className="max-w-5xl mx-auto px-4 md:px-6 flex gap-1 items-center overflow-x-auto scrollbar-none" style={{ scrollbarWidth: "none" }}>
-          <div role="tablist" aria-label="Main navigation" className="flex gap-1 items-center">
+          <div
+            role="tablist"
+            aria-label="Main navigation"
+            className="flex gap-1 items-center"
+            onKeyDown={(e) => {
+              const idx = TAB_ORDER.indexOf(tab);
+              if (e.key === "ArrowRight") {
+                const next = TAB_ORDER[(idx + 1) % TAB_ORDER.length];
+                setTab(next);
+                document.getElementById(`tab-${next}`)?.focus();
+              } else if (e.key === "ArrowLeft") {
+                const prev = TAB_ORDER[(idx - 1 + TAB_ORDER.length) % TAB_ORDER.length];
+                setTab(prev);
+                document.getElementById(`tab-${prev}`)?.focus();
+              }
+            }}
+          >
           {([
             { key: "library" as Tab, label: "Home", count: recentBooks.length || undefined },
             { key: "discover" as Tab, label: "Discover" },
@@ -225,6 +242,7 @@ export default function Home() {
               role="tab"
               aria-selected={tab === key}
               aria-controls={`tabpanel-${key}`}
+              tabIndex={tab === key ? 0 : -1}
               onClick={() => setTab(key)}
               className={`px-5 py-3 min-h-[44px] text-sm font-medium border-b-2 transition-colors ${
                 tab === key


### PR DESCRIPTION
## What changed

The homepage navigation tablist (`role="tablist"`) with Home and Discover tabs was missing two required WAI-ARIA tab pattern behaviors:

1. **Roving `tabIndex`**: Selected tab now gets `tabIndex={0}`, unselected tabs get `tabIndex={-1}`. This prevents extra Tab key stops on unselected tabs.

2. **Arrow-key navigation**: An `onKeyDown` handler on the `<div role="tablist">` moves focus and selection with ArrowLeft/ArrowRight (wrapping from last to first and vice versa).

Also added a `TAB_ORDER` constant to make the key order explicit and the handler deterministic.

## Why

- **WCAG 2.1 SC 2.1.1 Keyboard** — all functionality must be keyboard accessible  
- **WAI-ARIA Authoring Practices 1.1 — Tabs Pattern** — requires roving tabindex and arrow-key navigation within a tablist

## Test plan

- 3 new regression tests in `HomeTablistKeyboard.test.tsx`:
  - Selected tab has `tabindex="0"`, all others have `tabindex="-1"`
  - ArrowRight on last tab wraps focus to first tab
  - ArrowLeft on first tab wraps focus to last tab
- Full frontend suite: 3137/3137 pass

Closes #2049
