### PR TITLE
fix(ux): add list semantics to notes/[bookId] annotation and insight lists (closes #2051)

### DIFF
--- a/frontend/src/__tests__/NotesBookPageListSemantics.test.ts
+++ b/frontend/src/__tests__/NotesBookPageListSemantics.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf-8"
+);
+
+describe("notes/[bookId]/page.tsx list semantics (WCAG 1.3.1)", () => {
+  it("renderAnnotation returns <li> wrapper", () => {
+    const fnMatch = src.match(/function renderAnnotation[\s\S]*?^  \}/m);
+    expect(fnMatch).not.toBeNull();
+    expect(fnMatch![0]).toContain("<li key={ann.id}>");
+  });
+
+  it("renderInsight returns <li> wrapper", () => {
+    const fnMatch = src.match(/function renderInsight[\s\S]*?^  \}/m);
+    expect(fnMatch).not.toBeNull();
+    expect(fnMatch![0]).toContain("<li key={ins.id}>");
+  });
+
+  it("all renderAnnotation call sites are inside <ul role=\"list\">", () => {
+    const ulMatches = src.match(/<ul role="list"[^>]*>\s*\{[^}]*\.map\(renderAnnotation\)/g);
+    expect(ulMatches).not.toBeNull();
+    // 3 usages: byChapterAnn (section view), chAnns (chapter view)
+    // some may be combined; at minimum 2 <ul> wrappers
+    expect(ulMatches!.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("all renderInsight call sites are inside <ul role=\"list\">", () => {
+    const ulMatches = src.match(/<ul role="list"[^>]*>\s*\{[^}]*\.map\(renderInsight\)/g);
+    expect(ulMatches).not.toBeNull();
+    // 4 usages across section and chapter views
+    expect(ulMatches!.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("no <ul> is missing role=list around annotation or insight maps", () => {
+    // Every .map(renderAnnotation) and .map(renderInsight) must appear inside a <ul role="list"> block
+    const annUlWraps = (src.match(/<ul role="list"[\s\S]*?\.map\(renderAnnotation\)/g) || []).length;
+    const annTotalMaps = (src.match(/\.map\(renderAnnotation\)/g) || []).length;
+    expect(annUlWraps).toBe(annTotalMaps);
+
+    const insUlWraps = (src.match(/<ul role="list"[\s\S]*?\.map\(renderInsight\)/g) || []).length;
+    const insTotalMaps = (src.match(/\.map\(renderInsight\)/g) || []).length;
+    expect(insUlWraps).toBe(insTotalMaps);
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -415,33 +415,35 @@ export default function BookNotesPage() {
   // Shared rendering helpers
   function renderAnnotation(ann: Annotation) {
     return (
-      <AnnotationCard
-        key={ann.id}
-        ann={ann}
-        chapters={chapters}
-        bookId={bookId}
-        isEditing={editingId === ann.id}
-        editNote={editNote}
-        onEdit={() => startEdit(ann)}
-        onEditChange={setEditNote}
-        onSave={saveEdit}
-        onCancel={() => setEditingId(null)}
-        onDelete={() => handleDeleteAnnotation(ann.id)}
-        isDeleting={deletingAnns.has(ann.id)}
-      />
+      <li key={ann.id}>
+        <AnnotationCard
+          ann={ann}
+          chapters={chapters}
+          bookId={bookId}
+          isEditing={editingId === ann.id}
+          editNote={editNote}
+          onEdit={() => startEdit(ann)}
+          onEditChange={setEditNote}
+          onSave={saveEdit}
+          onCancel={() => setEditingId(null)}
+          onDelete={() => handleDeleteAnnotation(ann.id)}
+          isDeleting={deletingAnns.has(ann.id)}
+        />
+      </li>
     );
   }
 
   function renderInsight(ins: BookInsight) {
     return (
-      <InsightCard
-        key={ins.id}
-        ins={ins}
-        chapters={chapters}
-        bookId={bookId}
-        onDelete={() => handleDeleteInsight(ins.id)}
-        isDeleting={deletingIns.has(ins.id)}
-      />
+      <li key={ins.id}>
+        <InsightCard
+          ins={ins}
+          chapters={chapters}
+          bookId={bookId}
+          onDelete={() => handleDeleteInsight(ins.id)}
+          isDeleting={deletingIns.has(ins.id)}
+        />
+      </li>
     );
   }
 
@@ -484,9 +486,9 @@ export default function BookNotesPage() {
                       level={3}
                     />
                     {!collapsed.has(`ann-ch-${ch}`) && (
-                      <div className="pl-2">
+                      <ul role="list" aria-label="Annotations" className="pl-2 list-none p-0 m-0">
                         {byChapterAnn.get(ch)!.map(renderAnnotation)}
-                      </div>
+                      </ul>
                     )}
                   </div>
                 ))}
@@ -516,7 +518,9 @@ export default function BookNotesPage() {
                       level={3}
                     />
                     {!collapsed.has("ins-book") && (
-                      <div className="pl-2">{bookLevelIns.map(renderInsight)}</div>
+                      <ul role="list" aria-label="Insights" className="pl-2 list-none p-0 m-0">
+                        {bookLevelIns.map(renderInsight)}
+                      </ul>
                     )}
                   </div>
                 )}
@@ -530,9 +534,9 @@ export default function BookNotesPage() {
                       level={3}
                     />
                     {!collapsed.has(`ins-ch-${ch}`) && (
-                      <div className="pl-2">
+                      <ul role="list" aria-label="Insights" className="pl-2 list-none p-0 m-0">
                         {byChapterIns.get(ch)!.map(renderInsight)}
-                      </div>
+                      </ul>
                     )}
                   </div>
                 ))}
@@ -601,8 +605,16 @@ export default function BookNotesPage() {
               />
               {!collapsed.has(key) && (
                 <div className="pl-2 space-y-1">
-                  {chAnns.map(renderAnnotation)}
-                  {chIns.map(renderInsight)}
+                  {chAnns.length > 0 && (
+                    <ul role="list" aria-label="Annotations" className="list-none p-0 m-0">
+                      {chAnns.map(renderAnnotation)}
+                    </ul>
+                  )}
+                  {chIns.length > 0 && (
+                    <ul role="list" aria-label="Insights" className="list-none p-0 m-0">
+                      {chIns.map(renderInsight)}
+                    </ul>
+                  )}
                   {chVoc.length > 0 && (
                     <ul className="mt-2 ml-4 space-y-1 list-none">
                       {chVoc.map((v) => {
@@ -628,7 +640,9 @@ export default function BookNotesPage() {
               onToggle={() => toggleCollapse("ch-book")}
             />
             {!collapsed.has("ch-book") && (
-              <div className="pl-2">{bookLevelIns.map(renderInsight)}</div>
+              <ul role="list" aria-label="Insights" className="pl-2 list-none p-0 m-0">
+                {bookLevelIns.map(renderInsight)}
+              </ul>
             )}
           </section>
         )}


### PR DESCRIPTION
## What changed

`notes/[bookId]/page.tsx` had 6 places where annotation and insight lists were rendered using `.map(renderAnnotation)` / `.map(renderInsight)` inside plain `<div>` containers, giving assistive technologies no way to identify them as lists (WCAG 2.1 SC 1.3.1 Info and Relationships).

### Changes
- `renderAnnotation` and `renderInsight` now return `<li key={id}>` elements
- All 6 call sites wrapped in `<ul role="list" aria-label="Annotations"|"Insights">`
- Vocabulary words at line 607 were already using `<ul class="list-none">` — this PR brings annotations and insights to the same standard

This is the 5th in a series of list-semantics fixes: homepage (#2042), notes/decks index (#2044), search results (#2046), vocabulary word groups (#2048), and now notes/[bookId] detail page.

## Why

Safari/WebKit removes list semantics from `<ul>` when `list-style: none` is applied; `role="list"` is required for cross-browser AT support. Bare `<div>` containers have no list semantics at all.

## Test plan

- [x] New static analysis test `NotesBookPageListSemantics.test.ts` (5 assertions): `renderAnnotation` returns `<li>`, `renderInsight` returns `<li>`, all `renderAnnotation` map sites inside `<ul role="list">`, all `renderInsight` map sites inside `<ul role="list">`, count of wrapped calls matches total map calls
- [x] Full frontend suite: 3142 tests pass

Closes #2051

## Docs follow-up

Design Change Log in `docs/design-improvement-plan.md` updated (WCAG list-semantics series complete).
