### PR TITLE
fix(ux): add list semantics to reader sidebar annotation and vocab panels (closes #2053)

### DIFF
--- a/frontend/src/__tests__/ReaderSidebarListSemantics.test.ts
+++ b/frontend/src/__tests__/ReaderSidebarListSemantics.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf-8"
+);
+
+describe("reader/[bookId]/page.tsx sidebar list semantics (WCAG 1.3.1)", () => {
+  it("renderCard returns <li> wrapper", () => {
+    const fnMatch = src.match(/const renderCard = \(ann[\s\S]*?^                \);/m);
+    expect(fnMatch).not.toBeNull();
+    expect(fnMatch![0]).toContain("<li key={ann.id}>");
+    expect(fnMatch![0]).toContain("</li>");
+  });
+
+  it("filteredNotes.map(renderCard) is wrapped in <ul role=\"list\">", () => {
+    expect(src).toMatch(/<ul role="list"[^>]*>\s*\{filteredNotes\.map\(renderCard\)\}/);
+  });
+
+  it("annotations.filter(...).map(renderCard) is wrapped in <ul role=\"list\">", () => {
+    // Find all <ul role="list"> blocks that contain map(renderCard) — multiline
+    const ulBlocks = src.match(/<ul role="list"[\s\S]*?<\/ul>/g) || [];
+    const containsFilterMap = ulBlocks.some(
+      (block) => block.includes(".filter(") && block.includes(".map(renderCard)")
+    );
+    expect(containsFilterMap).toBe(true);
+  });
+
+  it("filteredVocab.map is inside <ul role=\"list\">", () => {
+    expect(src).toMatch(/<ul role="list"[^>]*aria-label="Vocabulary"[^>]*>/);
+    const vocabMatch = src.match(/<ul role="list"[^>]*aria-label="Vocabulary"[^>]*>[\s\S]*?filteredVocab\.map/);
+    expect(vocabMatch).not.toBeNull();
+  });
+
+  it("vocab items wrapped in <li key={w.id}>", () => {
+    expect(src).toMatch(/<li key=\{w\.id\}>/);
+  });
+
+  it("bottom notes expand panel uses <ul role=\"list\"> around annotation buttons", () => {
+    // The annotations.map in the bottom panel should be in a <ul role="list">
+    const bottomMatch = src.match(/<ul role="list"[^>]*aria-label="Annotations"[^>]*>[\s\S]*?<li key=\{ann\.id\}>\s*<button[\s\S]*?setNotesExpanded\(false\)/);
+    expect(bottomMatch).not.toBeNull();
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1767,8 +1767,8 @@ export default function ReaderPage() {
                   pink: "bg-pink-100 border-pink-300 text-pink-800",
                 };
                 const renderCard = (ann: (typeof annotations)[0]) => (
+                  <li key={ann.id}>
                   <div
-                    key={ann.id}
                     role="button"
                     tabIndex={0}
                     aria-label={`Jump to annotation: ${ann.sentence_text.slice(0, 60)}`}
@@ -1821,6 +1821,7 @@ export default function ReaderPage() {
                       </p>
                     )}
                   </div>
+                  </li>
                 );
                 return (
                   <div className="flex-1 overflow-y-auto p-4 space-y-3">
@@ -1851,9 +1852,9 @@ export default function ReaderPage() {
                         <p className="mt-1 text-xs">Long-press a sentence to add one.</p>
                       </div>
                     ) : notesView === "chapter" ? (
-                      <div className="space-y-2">
+                      <ul role="list" aria-label="Annotations" className="space-y-2 list-none p-0 m-0">
                         {filteredNotes.map(renderCard)}
-                      </div>
+                      </ul>
                     ) : (
                       <>
                         {Object.keys(
@@ -1875,9 +1876,9 @@ export default function ReaderPage() {
                                 <span>Chapter {ch + 1}</span>
                               </button>
                               {!isCollapsed && (
-                                <div className="space-y-2">
+                                <ul role="list" aria-label="Annotations" className="space-y-2 list-none p-0 m-0">
                                   {annotations.filter((a) => a.chapter_index === ch).map(renderCard)}
-                                </div>
+                                </ul>
                               )}
                             </div>
                           );
@@ -1940,7 +1941,7 @@ export default function ReaderPage() {
                         <p className="mt-1 text-xs">Select text to save words to vocabulary.</p>
                       </div>
                     ) : (
-                      <div className="space-y-2">
+                      <ul role="list" aria-label="Vocabulary" className="space-y-2 list-none p-0 m-0">
                         {filteredVocab.map((w) => {
                           const lemma = w.lemma || w.word;
                           const isForm = w.lemma && w.lemma.toLowerCase() !== w.word.toLowerCase();
@@ -1948,7 +1949,8 @@ export default function ReaderPage() {
                             ? w.occurrences.filter((o) => o.book_id === Number(bookId) && o.chapter_index === chapterIndex)
                             : w.occurrences.filter((o) => o.book_id === Number(bookId));
                           return (
-                            <div key={w.id} className="rounded-lg bg-amber-50 border border-amber-200 overflow-hidden">
+                            <li key={w.id}>
+                            <div className="rounded-lg bg-amber-50 border border-amber-200 overflow-hidden">
                               {/* Lemma header */}
                               <button
                                 onClick={() => router.push(`/vocabulary?word=${encodeURIComponent(w.word)}`)}
@@ -1982,9 +1984,10 @@ export default function ReaderPage() {
                                 </button>
                               ))}
                             </div>
+                            </li>
                           );
                         })}
-                      </div>
+                      </ul>
                     )}
                   </div>
                 );
@@ -2267,10 +2270,10 @@ export default function ReaderPage() {
                   <p className="text-xs mt-1">Long-press text to add one.</p>
                 </div>
               ) : (
-                <div className="space-y-1.5">
+                <ul role="list" aria-label="Annotations" className="space-y-1.5 list-none p-0 m-0">
                   {annotations.map((ann) => (
+                    <li key={ann.id}>
                     <button
-                      key={ann.id}
                       onClick={() => {
                         if (ann.chapter_index !== chapterIndex) {
                           goToChapter(ann.chapter_index);
@@ -2288,8 +2291,9 @@ export default function ReaderPage() {
                         <div className="text-stone-500 mt-0.5 line-clamp-1 italic">{ann.note_text}</div>
                       )}
                     </button>
+                    </li>
                   ))}
-                </div>
+                </ul>
               )}
             </div>
           )}


### PR DESCRIPTION
## What changed

`reader/[bookId]/page.tsx` rendered annotation and vocabulary lists in the reader sidebar inside plain `<div>` containers, giving assistive technologies no list semantics (WCAG 2.1 SC 1.3.1 Info and Relationships). Four instances fixed:

1. **Chapter-view notes panel** (`filteredNotes.map(renderCard)`) → `<ul role="list">`
2. **All-view notes panel by chapter** (`annotations.filter(...).map(renderCard)`) → `<ul role="list">`
3. **Vocabulary panel** (`filteredVocab.map(...)`) → `<ul role="list">` with `<li key={w.id}>`
4. **Bottom notes expand panel** (`annotations.map(<button>)`) → `<ul role="list">` with `<li key={ann.id}>`

`renderCard` now returns `<li key={ann.id}><div role="button">...</div></li>` — the key moved from the inner `div` to the `li`.

## Why

This is the 6th in the WCAG list-semantics series:
- #2042 — homepage book grids
- #2044 — notes/decks index  
- #2046 — search results
- #2048 — vocabulary word groups
- #2052 — notes/[bookId] detail page
- **#2054 (this PR)** — reader sidebar panels

Safari/WebKit removes list semantics from `<ul>` when `list-style: none` is applied; `role="list"` is required for cross-browser AT support. Bare `<div>` containers have no list semantics at all.

## Test plan

- [x] New static analysis test `ReaderSidebarListSemantics.test.ts` (6 assertions)
- [x] Full frontend suite: 3148 tests pass (511 suites, including all merged-in tests)

Closes #2053
