### PR TITLE
fix(ux): add list semantics to upload chapter list and WordActionDrawer meanings (closes #2056)

### DIFF
--- a/frontend/src/__tests__/UploadChapterListSemantics.test.ts
+++ b/frontend/src/__tests__/UploadChapterListSemantics.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/upload/[bookId]/chapters/page.tsx"),
+  "utf-8"
+);
+
+describe("upload/[bookId]/chapters/page.tsx chapter list semantics (WCAG 1.3.1)", () => {
+  it("chapter list container uses <ul role=\"list\">", () => {
+    expect(src).toMatch(/<ul role="list" aria-label="Chapters"/);
+  });
+
+  it("each chapter wrapped in <li>", () => {
+    expect(src).toMatch(/<li key=\{ch\.original_index/);
+  });
+
+  it("chapters.map is inside <ul role=\"list\">", () => {
+    const ulMatch = src.match(/<ul role="list"[^>]*>[\s\S]*?chapters\.map/);
+    expect(ulMatch).not.toBeNull();
+  });
+
+  it("no bare <div> directly wraps chapters.map", () => {
+    // The pattern <div ...> immediately containing chapters.map without a ul wrapper
+    expect(src).not.toMatch(/<div[^>]*>\s*\{chapters\.map/);
+  });
+});

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -160,12 +160,12 @@ export default function ChapterEditorPage() {
       {/* Two-panel layout */}
       <div className="flex-1 max-w-5xl mx-auto w-full px-4 md:px-6 py-4 grid grid-cols-1 md:grid-cols-2 gap-4 min-h-0">
         {/* Left: chapter list */}
-        <div className="overflow-y-auto space-y-2 pr-1">
+        <ul role="list" aria-label="Chapters" className="overflow-y-auto space-y-2 pr-1 list-none p-0 m-0">
           {chapters.map((ch, i) => {
             const wordWarn = ch.word_count > 8000 || ch.word_count < 100;
             return (
+              <li key={ch.original_index + "-" + i}>
               <div
-                key={ch.original_index + "-" + i}
                 role="button"
                 tabIndex={0}
                 aria-label={`Chapter ${i + 1}: ${ch.title}${selected === i ? " (selected)" : ""}`}
@@ -208,9 +208,10 @@ export default function ChapterEditorPage() {
                   </button>
                 </div>
               </div>
+              </li>
             );
           })}
-        </div>
+        </ul>
 
         {/* Right: preview */}
         <div className="bg-white rounded-xl border border-amber-100 p-5 overflow-y-auto">

--- a/frontend/src/components/WordActionDrawer.tsx
+++ b/frontend/src/components/WordActionDrawer.tsx
@@ -156,18 +156,18 @@ export default function WordActionDrawer({
           )}
 
           {result && result.meanings.length > 0 && (
-            <div className="space-y-2">
+            <ul role="list" aria-label="Meanings" className="space-y-2 list-none p-0 m-0">
               {result.meanings.map((m, i) => (
-                <div key={i}>
+                <li key={i}>
                   <span className="text-xs font-medium text-amber-700 italic">{m.partOfSpeech}</span>
                   <ol className="list-decimal list-inside ml-1 mt-0.5 space-y-0.5">
                     {m.definitions.map((d, j) => (
                       <li key={j} className="text-ink text-sm leading-relaxed">{d.definition}</li>
                     ))}
                   </ol>
-                </div>
+                </li>
               ))}
-            </div>
+            </ul>
           )}
 
           {/* Translation context */}


### PR DESCRIPTION
## What changed

Two WCAG 1.3.1 list-semantics fixes:

### 1. `upload/[bookId]/chapters/page.tsx`
Chapter selection list changed from bare `<div className="overflow-y-auto space-y-2">` to `<ul role="list" aria-label="Chapters">`, with each `<div role="button">` wrapped in `<li key={...}>`. AT can now announce "list of N chapters" and navigate items with list shortcuts.

### 2. `components/WordActionDrawer.tsx`
Dictionary meanings list changed from bare `<div className="space-y-2">` to `<ul role="list" aria-label="Meanings">`, with each meaning group `<div key={i}>` wrapped in `<li>`. Inner definitions already used `<ol><li>` — this brings the outer grouping to the same standard.

## Why

Same WCAG 2.1 SC 1.3.1 (Info and Relationships) fix applied across the codebase since Wave 9. Safari/WebKit strips list semantics from `<ul>` with `list-style: none`; `role="list"` is required.

## Test plan

- [x] `UploadChapterListSemantics.test.ts` — 4 assertions: `<ul role="list" aria-label="Chapters">`, `<li key={ch.original_index...}>`, map inside `<ul>`, no bare `<div>` wrapping the map
- [x] Full frontend suite: 3152 tests pass (512 suites)

Closes #2056
