### PR TITLE
fix(ux): add close button to vocabulary DefinitionSheet modal

### DIFF
--- a/frontend/src/__tests__/VocabularyDefinitionSheetClose.test.ts
+++ b/frontend/src/__tests__/VocabularyDefinitionSheetClose.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const vocab = readFileSync(join(__dirname, "../app/vocabulary/page.tsx"), "utf-8");
+
+describe("VocabularyPage DefinitionSheet accessibility (WCAG 2.1.1)", () => {
+  it("DefinitionSheet imports CloseIcon", () => {
+    expect(vocab).toMatch(/CloseIcon/);
+  });
+
+  it("DefinitionSheet has a close button with aria-label", () => {
+    expect(vocab).toMatch(/aria-label="Close definition"/);
+  });
+
+  it("close button uses CloseIcon", () => {
+    const closeButtonBlock = vocab.match(/aria-label="Close definition"[\s\S]{0,200}CloseIcon|CloseIcon[\s\S]{0,200}aria-label="Close definition"/);
+    expect(closeButtonBlock).not.toBeNull();
+  });
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -13,7 +13,7 @@ import {
   VocabularyWord,
   WordDefinition,
 } from "@/lib/api";
-import { EmptyVocabIcon, ArrowLeftIcon, ArrowRightIcon, FlashcardIcon, ArrowUpRightIcon, AlertCircleIcon, RetryIcon } from "@/components/Icons";
+import { EmptyVocabIcon, ArrowLeftIcon, ArrowRightIcon, FlashcardIcon, ArrowUpRightIcon, AlertCircleIcon, RetryIcon, CloseIcon } from "@/components/Icons";
 import TagEditor from "@/components/TagEditor";
 
 type SortMode = "alpha" | "language" | "book" | "recent";
@@ -159,10 +159,17 @@ function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
         aria-label="Word definition"
         className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl border-t border-amber-200 max-h-[60vh] overflow-y-auto animate-slide-up focus:outline-none"
       >
-        <div className="flex justify-center py-2">
-          <div className="w-10 h-1 bg-amber-200 rounded-full" />
+        <div className="flex items-center justify-between px-4 py-2 border-b border-amber-100">
+          <div className="w-10 h-1 bg-amber-200 rounded-full mx-auto" />
+          <button
+            onClick={onClose}
+            aria-label="Close definition"
+            className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg text-stone-500 hover:text-ink hover:bg-amber-50 transition-colors -mr-1"
+          >
+            <CloseIcon className="w-4 h-4" aria-hidden="true" />
+          </button>
         </div>
-        <div className="px-5 pb-6 space-y-3">
+        <div className="px-5 pb-6 space-y-3 pt-3">
           <div className="flex items-baseline justify-between gap-2">
             <span className="font-serif font-bold text-ink text-xl">{word}</span>
             {def && def.lemma !== word && (


### PR DESCRIPTION
## What changed

Added a visible close button to the `DefinitionSheet` modal in the vocabulary page (`frontend/src/app/vocabulary/page.tsx`).

- Imported `CloseIcon` from `@/components/Icons`
- Added a close button (`aria-label="Close definition"`) in the modal header, right-aligned alongside the drag handle
- Button meets 44×44px touch target requirement (`min-h-[44px] min-w-[44px]`)

## Why

Issue #2063: The DefinitionSheet (bottom sheet showing word definitions) had no visible close button, only a drag handle. Keyboard and assistive-technology users had no way to dismiss it without pressing Escape (which also isn't obvious). WCAG 2.1.1 (Keyboard) requires all functionality to be available via keyboard through visible affordances.

## Test plan

- [x] `frontend/src/__tests__/VocabularyDefinitionSheetClose.test.ts` — 3 new static-analysis tests verifying `CloseIcon` import, `aria-label="Close definition"`, and icon proximity to the aria-label
- [x] Full frontend suite: 3169 tests passed
- [x] Full backend suite: 1941 passed, 1 skipped

Closes #2063
