### PR TITLE
fix(ux): announce deleting state to screen readers on notes delete buttons

### DIFF
--- a/frontend/src/__tests__/NotesDeleteButtonAriaBusy.test.ts
+++ b/frontend/src/__tests__/NotesDeleteButtonAriaBusy.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Regression test for #2065: delete buttons on notes page must announce
+ * the "deleting" state to screen readers via aria-busy and a dynamic aria-label.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Notes page delete buttons announce deleting state (closes #2065)", () => {
+  it("annotation delete button has aria-busy={isDeleting}", () => {
+    expect(src).toMatch(/aria-busy=\{isDeleting\}/);
+  });
+
+  it("annotation delete button label changes when isDeleting is true", () => {
+    expect(src).toMatch(/isDeleting\s*\?\s*["']Deleting[^"']*["']/);
+  });
+
+  it("insight delete button has aria-busy={isDeleting}", () => {
+    // Both AnnotationCard and InsightCard must have aria-busy
+    const matches = src.match(/aria-busy=\{isDeleting\}/g);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -150,11 +150,12 @@ function AnnotationCard({
           <button
             onClick={onDelete}
             disabled={isDeleting}
+            aria-busy={isDeleting}
             className="text-red-500 hover:text-red-600 disabled:opacity-40 transition-colors p-1 min-h-[44px] flex items-center justify-center"
             title="Delete annotation"
-            aria-label={`Delete annotation: ${ann.sentence_text.slice(0, 60)}`}
+            aria-label={isDeleting ? "Deleting annotation…" : `Delete annotation: ${ann.sentence_text.slice(0, 60)}`}
           >
-            {isDeleting ? <RetryIcon className="w-3.5 h-3.5 animate-spin" /> : <TrashIcon className="w-3.5 h-3.5" />}
+            {isDeleting ? <RetryIcon className="w-3.5 h-3.5 animate-spin" aria-hidden="true" /> : <TrashIcon className="w-3.5 h-3.5" aria-hidden="true" />}
           </button>
         </div>
       )}
@@ -202,11 +203,12 @@ function InsightCard({
         <button
           onClick={onDelete}
           disabled={isDeleting}
+          aria-busy={isDeleting}
           className="text-red-500 hover:text-red-600 disabled:opacity-40 transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
           title="Delete insight"
-          aria-label={`Delete insight: ${ins.question.slice(0, 60)}`}
+          aria-label={isDeleting ? "Deleting insight…" : `Delete insight: ${ins.question.slice(0, 60)}`}
         >
-          {isDeleting ? <RetryIcon className="w-3.5 h-3.5 animate-spin" /> : <TrashIcon className="w-3.5 h-3.5" />}
+          {isDeleting ? <RetryIcon className="w-3.5 h-3.5 animate-spin" aria-hidden="true" /> : <TrashIcon className="w-3.5 h-3.5" aria-hidden="true" />}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## What changed

Updated the delete buttons in `AnnotationCard` and `InsightCard` on the notes page (`frontend/src/app/notes/[bookId]/page.tsx`) to properly announce their deleting state to assistive technology:

- Added `aria-busy={isDeleting}` to both delete buttons
- Made `aria-label` conditional: `"Deleting annotation…"` / `"Deleting insight…"` while in progress, falling back to the descriptive label at rest
- Added `aria-hidden="true"` to the icon children (both TrashIcon and RetryIcon) since the button label already conveys the action

## Why

Issue #2065: The buttons switched from `TrashIcon` to a spinning `RetryIcon` when deletion was in progress, but the `aria-label` stayed at `"Delete annotation: [text]"`. Screen readers had no way to know the operation started. This violates WCAG 4.1.3 (Status Messages).

## Test plan

- [x] `frontend/src/__tests__/NotesDeleteButtonAriaBusy.test.ts` — 3 new static-analysis tests verifying `aria-busy={isDeleting}`, dynamic label on `isDeleting`, and both buttons get `aria-busy`
- [x] Full frontend suite: 3169 tests passed, 516 suites

Closes #2065
