### PR TITLE
fix(ux): add aria-expanded and aria-controls to SeedPopularButton toggle buttons

### DIFF
--- a/frontend/src/__tests__/SeedPopularButtonAriaExpanded.test.ts
+++ b/frontend/src/__tests__/SeedPopularButtonAriaExpanded.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Regression test for #2067: SeedPopularButton expand/collapse buttons
+ * must have aria-expanded so screen readers know the panel state.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/SeedPopularButton.tsx"),
+  "utf8"
+);
+
+describe("SeedPopularButton expand/collapse aria-expanded (closes #2067)", () => {
+  it("Show progress button has aria-expanded={false}", () => {
+    expect(src).toMatch(/aria-expanded=\{false\}/);
+  });
+
+  it("Hide button has aria-expanded={true}", () => {
+    expect(src).toMatch(/aria-expanded=\{true\}/);
+  });
+
+  it("expandable panel has an id for aria-controls", () => {
+    expect(src).toMatch(/id="seed-progress-panel"/);
+  });
+
+  it("buttons reference the panel via aria-controls", () => {
+    expect(src).toMatch(/aria-controls="seed-progress-panel"/);
+  });
+});

--- a/frontend/src/components/SeedPopularButton.tsx
+++ b/frontend/src/components/SeedPopularButton.tsx
@@ -138,6 +138,8 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
         {state && state.status !== "idle" && !expanded && !pendingStart && (
           <button
             onClick={() => setExpanded(true)}
+            aria-expanded={false}
+            aria-controls="seed-progress-panel"
             className="text-xs text-amber-700 hover:text-amber-900 min-h-[44px] flex items-center"
           >
             Show progress
@@ -146,6 +148,8 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
         {state && state.status !== "idle" && expanded && !running && !pendingStart && (
           <button
             onClick={() => setExpanded(false)}
+            aria-expanded={true}
+            aria-controls="seed-progress-panel"
             className="text-xs text-stone-500 hover:text-stone-700 min-h-[44px] flex items-center"
           >
             Hide
@@ -154,7 +158,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
       </div>
 
       {expanded && state && state.status !== "idle" && (
-        <div className="bg-amber-50/60 border border-amber-200 rounded-xl p-4 text-sm space-y-2">
+        <div id="seed-progress-panel" className="bg-amber-50/60 border border-amber-200 rounded-xl p-4 text-sm space-y-2">
           <div className="flex items-baseline justify-between">
             <span className="font-medium text-ink">Seed popular books</span>
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## What changed

Added `aria-expanded` and `aria-controls` to the "Show progress" and "Hide" toggle buttons in `SeedPopularButton.tsx`, and added `id="seed-progress-panel"` to the expandable panel div.

- "Show progress" button: `aria-expanded={false}`, `aria-controls="seed-progress-panel"`
- "Hide" button: `aria-expanded={true}`, `aria-controls="seed-progress-panel"`
- Panel div: `id="seed-progress-panel"`

## Why

Issue #2067: Screen reader users had no programmatic way to tell whether the seed job progress panel was expanded or collapsed. WCAG 4.1.2 (Name, Role, Value) requires that the state of user interface components can be programmatically determined. The `aria-expanded` attribute communicates the toggle state; `aria-controls` links the button to the controlled region.

## Test plan

- [x] `frontend/src/__tests__/SeedPopularButtonAriaExpanded.test.ts` — 4 new tests verifying `aria-expanded={false}`, `aria-expanded={true}`, panel id, and `aria-controls`
- [x] Full frontend suite: 3173 tests passed, 517 suites

Closes #2067
