### PR TITLE
fix(ux): add visible close button to WordActionDrawer modal

### DIFF
--- a/frontend/src/__tests__/WordActionDrawerCloseButton.test.ts
+++ b/frontend/src/__tests__/WordActionDrawerCloseButton.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Regression test for #2069: WordActionDrawer must have a visible close button
+ * with an aria-label so keyboard and screen-reader users can dismiss it.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/WordActionDrawer.tsx"),
+  "utf8"
+);
+
+describe("WordActionDrawer close button (WCAG 2.1.1, closes #2069)", () => {
+  it("imports CloseIcon", () => {
+    expect(src).toMatch(/CloseIcon/);
+  });
+
+  it("has a close button with aria-label", () => {
+    expect(src).toMatch(/aria-label="Close word lookup"/);
+  });
+
+  it("close button uses CloseIcon", () => {
+    const block = src.match(
+      /aria-label="Close word lookup"[\s\S]{0,200}CloseIcon|CloseIcon[\s\S]{0,200}aria-label="Close word lookup"/
+    );
+    expect(block).not.toBeNull();
+  });
+});

--- a/frontend/src/components/WordActionDrawer.tsx
+++ b/frontend/src/components/WordActionDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { SpeakerIcon, SaveIcon, NoteIcon, CheckCircleIcon } from "@/components/Icons";
+import { SpeakerIcon, SaveIcon, NoteIcon, CheckCircleIcon, CloseIcon } from "@/components/Icons";
 
 interface Definition {
   partOfSpeech: string;
@@ -129,9 +129,16 @@ export default function WordActionDrawer({
         aria-label={`Word lookup: ${word}`}
         className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl border-t border-amber-200 max-h-[60vh] overflow-y-auto safe-bottom animate-slide-up focus:outline-none"
       >
-        {/* Drag handle */}
-        <div className="flex justify-center py-2">
-          <div className="w-10 h-1 bg-amber-200 rounded-full" />
+        {/* Drag handle + close button */}
+        <div className="flex items-center justify-between px-4 py-2">
+          <div className="w-10 h-1 bg-amber-200 rounded-full mx-auto" />
+          <button
+            onClick={onClose}
+            aria-label="Close word lookup"
+            className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg text-stone-500 hover:text-ink hover:bg-amber-50 transition-colors -mr-1"
+          >
+            <CloseIcon className="w-4 h-4" aria-hidden="true" />
+          </button>
         </div>
 
         <div className="px-5 pb-5 space-y-3">


### PR DESCRIPTION
## What changed

Added a visible close button to `WordActionDrawer.tsx`:
- Imported `CloseIcon` from `@/components/Icons`
- Changed the drag-handle row from `flex justify-center` to `flex items-center justify-between` to accommodate the close button on the right
- Added `<button aria-label="Close word lookup" onClick={onClose}>` with `CloseIcon` and 44×44px touch target

## Why

Issue #2069: The word-lookup drawer opened by tapping a word in the reader had no visible close affordance — only backdrop click and Escape key. This matches the same WCAG 2.1.1 (Keyboard) violation fixed for the vocabulary DefinitionSheet in PR #2064.

## Test plan

- [x] `frontend/src/__tests__/WordActionDrawerCloseButton.test.ts` — 3 new static-analysis tests verifying `CloseIcon` import, `aria-label="Close word lookup"`, and CloseIcon proximity to the label
- [x] Full frontend suite: 3179 tests passed, 519 suites

Closes #2069
