### PR TITLE
fix(ux): descriptive aria-labels on all dialog close buttons (closes #2071)

### DIFF
--- a/frontend/src/__tests__/AnnotationsSidebar.coverage2.test.tsx
+++ b/frontend/src/__tests__/AnnotationsSidebar.coverage2.test.tsx
@@ -33,7 +33,7 @@ test("close (✕) button closes the sidebar", async () => {
   await userEvent.click(screen.getByTestId("annotations-toggle"));
   expect(screen.getByTestId("annotations-sidebar")).toBeInTheDocument();
 
-  fireEvent.click(screen.getByRole("button", { name: "Close" }));
+  fireEvent.click(screen.getByRole("button", { name: "Close annotations sidebar" }));
   expect(screen.queryByTestId("annotations-sidebar")).not.toBeInTheDocument();
 });
 

--- a/frontend/src/__tests__/AnnotationsSidebarTouchTargets.test.ts
+++ b/frontend/src/__tests__/AnnotationsSidebarTouchTargets.test.ts
@@ -8,14 +8,14 @@ const src = fs.readFileSync(
 
 describe("AnnotationsSidebar touch targets (closes #806)", () => {
   it("Close button has min-h-[44px]", () => {
-    const idx = src.indexOf('aria-label="Close"');
+    const idx = src.indexOf('aria-label="Close annotations sidebar"');
     expect(idx).toBeGreaterThan(-1);
     const window = src.slice(Math.max(0, idx - 300), idx + 100);
     expect(window).toContain("min-h-[44px]");
   });
 
   it("Close button has min-w-[44px]", () => {
-    const idx = src.indexOf('aria-label="Close"');
+    const idx = src.indexOf('aria-label="Close annotations sidebar"');
     expect(idx).toBeGreaterThan(-1);
     const window = src.slice(Math.max(0, idx - 300), idx + 100);
     expect(window).toContain("min-w-[44px]");

--- a/frontend/src/__tests__/BookDetailModalTouchTarget.test.ts
+++ b/frontend/src/__tests__/BookDetailModalTouchTarget.test.ts
@@ -8,25 +8,25 @@ const src = fs.readFileSync(
 
 describe("BookDetailModal touch targets (closes #811)", () => {
   it("Close button has aria-label", () => {
-    expect(src).toContain('aria-label="Close"');
+    expect(src).toContain('aria-label="Close book details"');
   });
 
   it("Close button has min-h-[44px]", () => {
-    const idx = src.indexOf('aria-label="Close"');
+    const idx = src.indexOf('aria-label="Close book details"');
     expect(idx).toBeGreaterThan(-1);
     const window = src.slice(Math.max(0, idx - 200), idx + 100);
     expect(window).toContain("min-h-[44px]");
   });
 
   it("Close button has min-w-[44px]", () => {
-    const idx = src.indexOf('aria-label="Close"');
+    const idx = src.indexOf('aria-label="Close book details"');
     expect(idx).toBeGreaterThan(-1);
     const window = src.slice(Math.max(0, idx - 200), idx + 100);
     expect(window).toContain("min-w-[44px]");
   });
 
   it("Close button does not use hard-coded w-8 h-8", () => {
-    const idx = src.indexOf('aria-label="Close"');
+    const idx = src.indexOf('aria-label="Close book details"');
     expect(idx).toBeGreaterThan(-1);
     const window = src.slice(Math.max(0, idx - 200), idx + 100);
     expect(window).not.toMatch(/\bw-8\b/);

--- a/frontend/src/__tests__/DialogCloseButtonLabels.test.ts
+++ b/frontend/src/__tests__/DialogCloseButtonLabels.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Regression test for #2071: close buttons in dialogs must have descriptive
+ * aria-labels so screen reader users can identify what will be closed.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const toolbar = fs.readFileSync(
+  path.join(__dirname, "../components/AnnotationToolbar.tsx"),
+  "utf8"
+);
+const tooltip = fs.readFileSync(
+  path.join(__dirname, "../components/VocabWordTooltip.tsx"),
+  "utf8"
+);
+const sidebar = fs.readFileSync(
+  path.join(__dirname, "../components/AnnotationsSidebar.tsx"),
+  "utf8"
+);
+const modal = fs.readFileSync(
+  path.join(__dirname, "../components/BookDetailModal.tsx"),
+  "utf8"
+);
+
+describe("Dialog close buttons have descriptive aria-labels (closes #2071)", () => {
+  it("AnnotationToolbar close button is not generic 'Close'", () => {
+    expect(toolbar).not.toMatch(/aria-label="Close"(?![\s\S]*annotation)/);
+    expect(toolbar).toMatch(/aria-label="Close note editor"/);
+  });
+
+  it("VocabWordTooltip close button is not generic 'Close'", () => {
+    expect(tooltip).not.toMatch(/aria-label="Close"(?![\s\S]*word)/);
+    expect(tooltip).toMatch(/aria-label="Close word definition"/);
+  });
+
+  it("AnnotationsSidebar close button is not generic 'Close'", () => {
+    expect(sidebar).not.toMatch(/aria-label="Close"(?![\s\S]*sidebar)/);
+    expect(sidebar).toMatch(/aria-label="Close annotations sidebar"/);
+  });
+
+  it("BookDetailModal close button is not generic 'Close'", () => {
+    expect(modal).not.toMatch(/aria-label="Close"(?![\s\S]*book)/);
+    expect(modal).toMatch(/aria-label="Close book details"/);
+  });
+});

--- a/frontend/src/__tests__/VocabWordTooltipCloseTouchTarget.test.tsx
+++ b/frontend/src/__tests__/VocabWordTooltipCloseTouchTarget.test.tsx
@@ -27,7 +27,7 @@ const BASE = {
 test("close button has min-h-[44px] and min-w-[44px]", () => {
   render(<VocabWordTooltip {...BASE} />);
 
-  const closeBtn = document.querySelector("button[aria-label='Close']") as HTMLButtonElement | null;
+  const closeBtn = document.querySelector("button[aria-label='Close word definition']") as HTMLButtonElement | null;
   expect(closeBtn).not.toBeNull();
   expect(closeBtn!.className).toContain("min-h-[44px]");
   expect(closeBtn!.className).toContain("min-w-[44px]");

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -122,7 +122,7 @@ export default function AnnotationToolbar({
           </div>
           <button
             onClick={onClose}
-            aria-label="Close"
+            aria-label="Close note editor"
             className="rounded-lg p-1.5 min-h-[44px] min-w-[44px] flex items-center justify-center text-stone-500 hover:text-stone-700 hover:bg-amber-50 transition-colors"
           >
             <CloseIcon className="w-4 h-4" />

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -95,7 +95,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
             <button
               onClick={() => setOpen(false)}
               className="text-stone-500 hover:text-stone-700 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg transition-colors"
-              aria-label="Close"
+              aria-label="Close annotations sidebar"
             >
               <CloseIcon className="w-4 h-4" />
             </button>

--- a/frontend/src/components/BookDetailModal.tsx
+++ b/frontend/src/components/BookDetailModal.tsx
@@ -93,7 +93,7 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
           </div>
           <button
             onClick={onClose}
-            aria-label="Close"
+            aria-label="Close book details"
             className="shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-full text-stone-500 hover:bg-stone-100 hover:text-stone-700 transition-colors"
           >
             <CloseIcon className="w-4 h-4" />

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -80,7 +80,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
       {/* Header */}
       <div className="flex items-center justify-between px-3 pt-2.5 pb-1.5 border-b border-amber-100">
         <span id="vocab-tooltip-title" className="font-semibold text-ink text-sm">{word}</span>
-        <button onClick={onClose} aria-label="Close" className="text-stone-500 hover:text-stone-700 p-0.5 rounded transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"><CloseIcon className="w-3.5 h-3.5" /></button>
+        <button onClick={onClose} aria-label="Close word definition" className="text-stone-500 hover:text-stone-700 p-0.5 rounded transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"><CloseIcon className="w-3.5 h-3.5" /></button>
       </div>
 
       {/* Body */}


### PR DESCRIPTION
## What changed

Replace generic `aria-label="Close"` on modal/dialog close buttons with specific, descriptive labels across four components:

- `BookDetailModal` → `"Close book details"`
- `AnnotationsSidebar` → `"Close annotations sidebar"`
- `VocabWordTooltip` → `"Close word definition"`
- `AnnotationToolbar` → `"Close note editor"`

## Why

WCAG 2.4.6 (Headings and Labels) and 4.1.2 (Name, Role, Value) require that controls have labels that describe their purpose in context. A screen-reader user hearing multiple "Close" buttons in the same view cannot distinguish between them. The descriptive labels make it immediately clear what each button closes.

## Test plan

- New test file `DialogCloseButtonLabels.test.ts` (4 tests) statically verifies all four descriptive labels are present in each component source.
- Updated four existing test files that matched the old generic `"Close"` label:
  - `BookDetailModalTouchTarget.test.ts`
  - `AnnotationsSidebarTouchTargets.test.ts`
  - `VocabWordTooltipCloseTouchTarget.test.tsx`
  - `AnnotationsSidebar.coverage2.test.tsx`
- Full suite: 519 test suites, 3183 tests — all pass.

Closes #2071

## Docs follow-up

- [ ] Docs updated (if applicable)
