### PR TITLE
fix(ux): announce vocabulary filter word count to screen readers (closes #2073)

### DIFF
--- a/frontend/src/__tests__/VocabFilterAriaLive.test.ts
+++ b/frontend/src/__tests__/VocabFilterAriaLive.test.ts
@@ -1,0 +1,25 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Vocabulary filter word count aria-live (closes #2073)", () => {
+  it("word count span has aria-live=\"polite\"", () => {
+    expect(src).toContain('aria-live="polite"');
+  });
+
+  it("word count span has aria-atomic=\"true\"", () => {
+    expect(src).toContain('aria-atomic="true"');
+  });
+
+  it("aria-live and aria-atomic are near the word count", () => {
+    const idx = src.indexOf('aria-live="polite"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 100), idx + 200);
+    expect(window).toContain("filteredVocab.length");
+    expect(window).toContain('aria-atomic="true"');
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1927,7 +1927,7 @@ export default function ReaderPage() {
                       ))}
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-xs text-stone-500">
+                      <span className="text-xs text-stone-500" aria-live="polite" aria-atomic="true">
                         {filteredVocab.length} word{filteredVocab.length !== 1 ? "s" : ""}
                       </span>
                       <button onClick={() => router.push("/vocabulary")} className="text-xs text-amber-700 hover:text-amber-800 font-medium min-h-[44px] flex items-center gap-1">


### PR DESCRIPTION
## What changed

Added `aria-live="polite"` and `aria-atomic="true"` to the word count span in the reader sidebar vocabulary tab (`frontend/src/app/reader/[bookId]/page.tsx` ~line 1930).

## Why

WCAG 4.1.3 (Status Messages) requires that dynamic content updates be conveyed to assistive technology without moving focus. When users toggle the filter between "This chapter" and "All chapters", the word count and the vocabulary list change, but screen-reader users received no announcement. The `aria-live="polite"` attribute causes the updated count to be read after the current utterance finishes; `aria-atomic="true"` ensures the full count string is read rather than individual words.

## Test plan

New test file `VocabFilterAriaLive.test.ts` (3 tests):
- Verifies `aria-live="polite"` is present in the source
- Verifies `aria-atomic="true"` is present in the source
- Verifies both attributes appear adjacent to `filteredVocab.length` (not somewhere unrelated)

Full suite: 521 test suites, 3186 tests — all pass.

Closes #2073

## Docs follow-up

- [ ] Docs updated (if applicable)
