### PR TITLE
fix(ux): add ARIA landmark role to reader sidebar panel (closes #2075)

### DIFF
--- a/frontend/src/__tests__/ReaderSidebarLandmark.test.ts
+++ b/frontend/src/__tests__/ReaderSidebarLandmark.test.ts
@@ -1,0 +1,27 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Reader sidebar ARIA landmark (closes #2075)", () => {
+  it('sidebar container has role="complementary"', () => {
+    expect(src).toContain('role="complementary"');
+  });
+
+  it("sidebar container has an aria-label", () => {
+    const idx = src.indexOf('role="complementary"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 50), idx + 300);
+    expect(window).toMatch(/aria-label=/);
+  });
+
+  it("sidebar aria-label references sidebarTab for dynamic naming", () => {
+    const idx = src.indexOf('role="complementary"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 50), idx + 300);
+    expect(window).toContain("sidebarTab");
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1726,6 +1726,9 @@ export default function ReaderPage() {
 
         {/* Insight/Vocab/Translate sidebar — desktop only */}
         <div
+          role="complementary"
+          aria-label={`${({ chat: "Insight", translate: "Translation", summary: "Summary", notes: "Notes", vocab: "Vocabulary" } as const)[sidebarTab]} panel`}
+          aria-hidden={!sidebarOpen}
           style={sidebarOpen ? { width: sidebarWidth } : { width: 0 }}
           className="hidden md:flex flex-col overflow-hidden shrink-0 border-l border-amber-200 transition-[width] duration-200"
         >


### PR DESCRIPTION
## What changed

Added `role="complementary"` and a dynamic `aria-label` to the reader sidebar container div in `frontend/src/app/reader/[bookId]/page.tsx`. The label reflects the active tab (e.g. "Insight panel", "Translation panel", "Notes panel", "Summary panel", "Vocabulary panel"). Also added `aria-hidden={!sidebarOpen}` so the collapsed sidebar is invisible to assistive technology.

## Why

WCAG 1.3.6 (Identify Purpose) and 2.4.1 (Bypass Blocks): the reader sidebar holds significant interactive content (chat, translation, notes, vocabulary) but had no ARIA landmark role. Screen-reader users navigating by landmarks (JAWS `R`, NVDA `D`, VoiceOver landmark list) could not jump directly to it — they had to tab through the entire chapter text first. Adding `role="complementary"` creates the `aside` landmark; the dynamic `aria-label` disambiguates it from any other complementary regions on the page.

## Test plan

New test file `ReaderSidebarLandmark.test.ts` (3 static-source tests):
- Verifies `role="complementary"` is present
- Verifies an `aria-label` attribute appears on the same element
- Verifies the label references `sidebarTab` (dynamic, not hardcoded)

Full suite: 522 test suites, 3189 tests — all pass.

Closes #2075

## Docs follow-up

- [ ] Docs updated (if applicable)
