### PR TITLE
fix(ux): add aria-pressed and role=group to popular language filter buttons (closes #2079)

### DIFF
--- a/frontend/src/__tests__/PopularLangFilterAriaPressed.test.ts
+++ b/frontend/src/__tests__/PopularLangFilterAriaPressed.test.ts
@@ -1,0 +1,27 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/page.tsx"),
+  "utf8"
+);
+
+describe("Popular language filter buttons aria-pressed (closes #2079)", () => {
+  it("filter button has aria-pressed attribute", () => {
+    expect(src).toContain("aria-pressed={popularLang === l.code}");
+  });
+
+  it("filter button container has role=group", () => {
+    const idx = src.indexOf("POPULAR_LANGS.map");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 300), idx + 50);
+    expect(window).toContain('role="group"');
+  });
+
+  it("filter button container has aria-label", () => {
+    const idx = src.indexOf("POPULAR_LANGS.map");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 300), idx + 50);
+    expect(window).toContain('aria-label="Filter by language"');
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -680,11 +680,12 @@ export default function Home() {
               <div className="flex flex-wrap items-center justify-between gap-y-3 mb-4">
                 <div className="flex items-center gap-2">
                   <h2 className="font-serif font-semibold text-ink text-lg">Popular Classics</h2>
-                  <div className="flex gap-1.5">
+                  <div role="group" aria-label="Filter by language" className="flex gap-1.5">
                     {POPULAR_LANGS.map((l) => (
                       <button
                         key={l.code}
                         onClick={() => handlePopularLangChange(l.code)}
+                        aria-pressed={popularLang === l.code}
                         className={`text-xs rounded-full px-3 py-1 min-h-[44px] border transition-colors ${
                           popularLang === l.code
                             ? "bg-amber-700 text-white border-amber-700"


### PR DESCRIPTION
## What changed

Added `aria-pressed` state and `role="group"` grouping to the "Popular Classics" language filter buttons on the home page (`frontend/src/app/page.tsx`).

## Why

WCAG 2.1 SC 4.1.2 (Name, Role, Value) requires that UI controls expose their state to assistive technology. The language filter buttons (All / English / Russian / Deutsch / Français) visually highlighted the active selection via background colour, but conveyed no state via ARIA — a screen reader user had no way to know which filter was currently active.

Fix:
- `aria-pressed={popularLang === l.code}` on each button — announces the toggled state
- `role="group" aria-label="Filter by language"` on the container — groups the buttons semantically

## Test plan

- New test file: `PopularLangFilterAriaPressed.test.ts` — 3 static-source assertions verifying `aria-pressed`, `role="group"`, and `aria-label="Filter by language"` are present adjacent to the `POPULAR_LANGS.map` render
- Full Jest suite: 523 suites / 3192 tests passed

Closes #2079
