### PR TITLE
fix(ux): add aria-controls to stats and shortcuts disclosure buttons (closes #2081)

### DIFF
--- a/frontend/src/__tests__/DisclosureAriaControls.test.ts
+++ b/frontend/src/__tests__/DisclosureAriaControls.test.ts
@@ -1,0 +1,42 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const homeSrc = fs.readFileSync(
+  path.join(__dirname, "../app/page.tsx"),
+  "utf8"
+);
+
+const readerSrc = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Disclosure button aria-controls (closes #2081)", () => {
+  describe("Home page stats toggle", () => {
+    it('stats toggle button has aria-controls="stats-activity-panel"', () => {
+      expect(homeSrc).toContain('aria-controls="stats-activity-panel"');
+    });
+
+    it('stats panel has id="stats-activity-panel"', () => {
+      expect(homeSrc).toContain('id="stats-activity-panel"');
+    });
+
+    it("aria-controls and id appear near aria-expanded statsExpanded usage", () => {
+      const idx = homeSrc.indexOf('aria-expanded={statsExpanded}');
+      expect(idx).toBeGreaterThan(-1);
+      const window = homeSrc.slice(idx, idx + 3000);
+      expect(window).toContain('aria-controls="stats-activity-panel"');
+      expect(window).toContain('id="stats-activity-panel"');
+    });
+  });
+
+  describe("Reader page shortcuts toggle", () => {
+    it('shortcuts toggle button has aria-controls="shortcuts-panel"', () => {
+      expect(readerSrc).toContain('aria-controls="shortcuts-panel"');
+    });
+
+    it('shortcuts panel has id="shortcuts-panel"', () => {
+      expect(readerSrc).toContain('id="shortcuts-panel"');
+    });
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -354,6 +354,7 @@ export default function Home() {
                   <button
                     onClick={() => setStatsExpanded((v) => !v)}
                     aria-expanded={statsExpanded}
+                    aria-controls="stats-activity-panel"
                     className="text-xs text-amber-700 hover:text-amber-800 transition-colors min-h-[44px] px-2 flex items-center"
                   >
                     {statsExpanded ? "Hide activity" : "Show activity"}
@@ -395,7 +396,7 @@ export default function Home() {
 
                 {/* Collapsible full activity view */}
                 {statsExpanded && (
-                  <div className="mt-4">
+                  <div id="stats-activity-panel" className="mt-4">
                     <ReadingStats active heatmapOnly />
                   </div>
                 )}

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1245,6 +1245,7 @@ export default function ReaderPage() {
               title="Keyboard shortcuts (?)"
               aria-label="Keyboard shortcuts"
               aria-expanded={showShortcuts}
+              aria-controls="shortcuts-panel"
               className={`flex shrink-0 items-center justify-center w-7 h-7 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 rounded-lg border text-xs font-medium transition-colors ${
                 showShortcuts
                   ? "bg-amber-100 border-amber-400 text-amber-800"
@@ -1254,7 +1255,7 @@ export default function ReaderPage() {
               <KeyboardIcon className="w-3.5 h-3.5" />
             </button>
             {showShortcuts && (
-              <div role="region" aria-label="Keyboard shortcuts" className="absolute right-0 top-full mt-2 w-56 bg-white border border-amber-200 rounded-xl shadow-lg z-50 p-3 animate-fade-in">
+              <div id="shortcuts-panel" role="region" aria-label="Keyboard shortcuts" className="absolute right-0 top-full mt-2 w-56 bg-white border border-amber-200 rounded-xl shadow-lg z-50 p-3 animate-fade-in">
                 <p className="text-[10px] font-semibold uppercase tracking-widest text-stone-500 mb-2">Keyboard Shortcuts</p>
                 <div className="space-y-1.5">
                   {[


### PR DESCRIPTION
## What changed

Added `aria-controls` + matching `id` attributes to two disclosure buttons that were missing them:

1. **Home page** (`frontend/src/app/page.tsx`): "Show/Hide activity" stats toggle button now has `aria-controls="stats-activity-panel"`, and the collapsible `ReadingStats` wrapper has `id="stats-activity-panel"`.

2. **Reader page** (`frontend/src/app/reader/[bookId]/page.tsx`): Keyboard shortcuts button now has `aria-controls="shortcuts-panel"`, and the shortcuts region has `id="shortcuts-panel"`.

## Why

WCAG 2.1 SC 4.1.2 (Name, Role, Value) requires disclosure controls to expose the relationship between the button and the panel it controls. Without `aria-controls`, screen readers know the expanded/collapsed state but cannot navigate directly from the button to its controlled panel.

## Test plan

- New test file: `DisclosureAriaControls.test.ts` — 5 static-source tests verifying `aria-controls` and matching `id` attributes are present on both pages
- Full Jest suite: 524 suites / 3197 tests passed

Closes #2081
