### PR TITLE
fix(ux): keyboard focus trap for all modal dialogs (closes #2083)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -319,6 +319,13 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 |------|--------|---------|----|
 | 2026-04-28 | Browser-default placeholder → `placeholder:text-stone-600` on 7 remaining inputs in QueueTab and admin pages | QueueTab.tsx, admin/uploads/page.tsx, admin/books/page.tsx | #1828 |
 
+## Wave 14 — Keyboard Focus Trap (2026-04-29)
+
+### ARIA APG Dialog Pattern — focus must stay within open modal
+| Date | Change | File(s) | PR |
+|------|--------|---------|----|
+| 2026-04-29 | Added `useFocusTrap` hook; applied to all 9 modal dialogs so Tab/Shift+Tab cycles within the dialog instead of escaping to background content | useFocusTrap.ts, AuthPromptModal.tsx, WordActionDrawer.tsx, BookDetailModal.tsx, VocabWordTooltip.tsx, AnnotationToolbar.tsx, AnnotationsSidebar.tsx, vocabulary/page.tsx, decks/[deckId]/page.tsx, reader/[bookId]/page.tsx | #2084 |
+
 ---
 
 

--- a/frontend/src/__tests__/FocusTrap.test.tsx
+++ b/frontend/src/__tests__/FocusTrap.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Regression test for #2083 — modal dialogs must trap keyboard focus within
+ * the dialog container while it is open (ARIA APG Dialog pattern).
+ *
+ * Tests that Tab wraps from last to first focusable element,
+ * and Shift+Tab wraps from first to last.
+ */
+import React, { useRef } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useFocusTrap } from "@/lib/useFocusTrap";
+
+function TestDialog({ enabled = true }: { enabled?: boolean }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useFocusTrap(ref, enabled);
+  return (
+    <div>
+      <button data-testid="outside">Outside button</button>
+      <div ref={ref} role="dialog" aria-modal="true" tabIndex={-1}>
+        <button data-testid="first">First</button>
+        <button data-testid="second">Second</button>
+        <button data-testid="last">Last</button>
+      </div>
+    </div>
+  );
+}
+
+describe("useFocusTrap (closes #2083)", () => {
+  it("Tab from last focusable wraps to first", async () => {
+    const user = userEvent.setup();
+    render(<TestDialog />);
+    screen.getByTestId("last").focus();
+    await user.tab();
+    expect(document.activeElement).toBe(screen.getByTestId("first"));
+  });
+
+  it("Shift+Tab from first focusable wraps to last", async () => {
+    const user = userEvent.setup();
+    render(<TestDialog />);
+    screen.getByTestId("first").focus();
+    await user.tab({ shift: true });
+    expect(document.activeElement).toBe(screen.getByTestId("last"));
+  });
+
+  it("Tab in the middle does not wrap", async () => {
+    const user = userEvent.setup();
+    render(<TestDialog />);
+    screen.getByTestId("first").focus();
+    await user.tab();
+    expect(document.activeElement).toBe(screen.getByTestId("second"));
+  });
+
+  it("does not trap when disabled", async () => {
+    const user = userEvent.setup();
+    render(<TestDialog enabled={false} />);
+    screen.getByTestId("last").focus();
+    await user.tab();
+    // focus moves to outside button (natural tab order)
+    expect(document.activeElement).not.toBe(screen.getByTestId("first"));
+  });
+});

--- a/frontend/src/app/decks/[deckId]/page.tsx
+++ b/frontend/src/app/decks/[deckId]/page.tsx
@@ -20,6 +20,7 @@ import {
   TrashIcon,
 } from "@/components/Icons";
 import UndoToast from "@/components/UndoToast";
+import { useFocusTrap } from "@/lib/useFocusTrap";
 
 export default function DeckDetailPage() {
   const { data: session } = useSession();
@@ -320,6 +321,8 @@ interface AddWordPickerProps {
 function AddWordPicker({ candidates, onClose, onAdd }: AddWordPickerProps) {
   const [query, setQuery] = useState("");
   const closeRef = useRef<HTMLButtonElement | null>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef);
 
   useEffect(() => {
     const prev = document.activeElement as HTMLElement | null;
@@ -346,6 +349,7 @@ function AddWordPicker({ candidates, onClose, onAdd }: AddWordPickerProps) {
       onClick={onClose}
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="add-word-picker-title"

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -19,6 +19,7 @@ import VocabWordTooltip from "@/components/VocabWordTooltip";
 import ChapterSummary from "@/components/ChapterSummary";
 import AuthPromptModal from "@/components/AuthPromptModal";
 import { SunIcon, MoonIcon, SepiaIcon, ChatIcon, GlobeIcon, NoteIcon, EditIcon, BookmarkIcon, BookOpenIcon, ExportIcon, SummaryIcon, PlayIcon, PauseIcon, CloseIcon, KeyboardIcon, FocusIcon, ArrowLeftIcon, ArrowRightIcon, ChevronDownIcon, ChevronRightIcon, EmptyVocabIcon, ArrowUpRightIcon } from "@/components/Icons";
+import { useFocusTrap } from "@/lib/useFocusTrap";
 
 // Gemini Flash pricing constants — used for total queue cost estimate in the translation sidebar.
 const FLASH_COST_PER_M = 2.5; // USD per 1M output tokens
@@ -177,6 +178,7 @@ export default function ReaderPage() {
 
   // Chat sheet (mobile bottom dialog) ref — needed for focus management
   const chatSheetRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(chatSheetRef, sidebarOpen || !!chatSheetText);
 
   // Move focus into the chat sheet when it opens; restore on close (WCAG 2.4.3)
   useEffect(() => {

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/api";
 import { EmptyVocabIcon, ArrowLeftIcon, ArrowRightIcon, FlashcardIcon, ArrowUpRightIcon, AlertCircleIcon, RetryIcon, CloseIcon } from "@/components/Icons";
 import TagEditor from "@/components/TagEditor";
+import { useFocusTrap } from "@/lib/useFocusTrap";
 
 type SortMode = "alpha" | "language" | "book" | "recent";
 
@@ -112,6 +113,7 @@ function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
   const [def, setDef] = useState<WordDefinition | null>(null);
   const [loading, setLoading] = useState(true);
   const ref = useRef<HTMLDivElement>(null);
+  useFocusTrap(ref);
 
   useEffect(() => {
     getWordDefinition(word, lang ?? undefined)

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState } from "react";
 import { createAnnotation, updateAnnotation, deleteAnnotation, Annotation } from "@/lib/api";
 import { CloseIcon, NoteIcon, TrashIcon } from "@/components/Icons";
+import { useFocusTrap } from "@/lib/useFocusTrap";
 
 const COLORS = [
   { key: "yellow", label: "Yellow", bg: "bg-yellow-400", border: "border-yellow-500", ring: "ring-yellow-400" },
@@ -40,6 +41,7 @@ export default function AnnotationToolbar({
   const [error, setError] = useState<string | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  useFocusTrap(panelRef);
 
   useEffect(() => {
     const prev = document.activeElement as HTMLElement | null;

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { Annotation } from "@/lib/api";
 import { ArrowRightIcon, NoteIcon, EditIcon, CloseIcon, EmptyNotesIcon } from "@/components/Icons";
+import { useFocusTrap } from "@/lib/useFocusTrap";
 
 const COLOR_BADGE: Record<string, string> = {
   yellow: "bg-yellow-100 border-yellow-300 text-yellow-800",
@@ -32,6 +33,7 @@ interface Props {
 export default function AnnotationsSidebar({ annotations, totalCount, onJump, onEdit, loading, bookId }: Props) {
   const [open, setOpen] = useState(false);
   const drawerRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(drawerRef, open);
 
   // Group by chapter
   const byChapter = annotations.reduce<Record<number, Annotation[]>>((acc, a) => {

--- a/frontend/src/components/AuthPromptModal.tsx
+++ b/frontend/src/components/AuthPromptModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useRef } from "react";
+import { useFocusTrap } from "@/lib/useFocusTrap";
 
 interface Props {
   open: boolean;
@@ -9,6 +10,7 @@ interface Props {
 
 export default function AuthPromptModal({ open, feature, onClose }: Props) {
   const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef, open);
 
   useEffect(() => {
     if (!open) return;

--- a/frontend/src/components/BookDetailModal.tsx
+++ b/frontend/src/components/BookDetailModal.tsx
@@ -4,6 +4,7 @@ import { BookMeta, getBookTranslationStatus, TranslationStatus } from "@/lib/api
 import { RecentBook } from "@/lib/recentBooks";
 import { getSettings } from "@/lib/settings";
 import { BookCoverPlaceholderIcon, CloseIcon, CheckIcon, ArrowUpRightIcon } from "@/components/Icons";
+import { useFocusTrap } from "@/lib/useFocusTrap";
 
 const LANG_NAMES: Record<string, string> = {
   en: "English", de: "German", fr: "French", es: "Spanish",
@@ -23,6 +24,7 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
   const [translationStatus, setTranslationStatus] = useState<TranslationStatus | null>(null);
   const translationLang = getSettings().translationLang;
   const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef);
 
   useEffect(() => {
     getBookTranslationStatus(book.id, translationLang)

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState } from "react";
 import { getWordDefinition, WordDefinition } from "@/lib/api";
 import { CloseIcon, CheckCircleIcon, ArrowUpRightIcon } from "@/components/Icons";
+import { useFocusTrap } from "@/lib/useFocusTrap";
 
 interface Props {
   word: string;
@@ -16,6 +17,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
   const [loading, setLoading] = useState(true);
   const [saved, setSaved] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  useFocusTrap(ref);
 
   useEffect(() => {
     setLoading(true);

--- a/frontend/src/components/WordActionDrawer.tsx
+++ b/frontend/src/components/WordActionDrawer.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
 import { SpeakerIcon, SaveIcon, NoteIcon, CheckCircleIcon, CloseIcon } from "@/components/Icons";
+import { useFocusTrap } from "@/lib/useFocusTrap";
 
 interface Definition {
   partOfSpeech: string;
@@ -43,6 +44,7 @@ export default function WordActionDrawer({
   const [error, setError] = useState("");
   const [saved, setSaved] = useState(false);
   const drawerRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(drawerRef, !!action);
 
   const word = action?.word ?? "";
 

--- a/frontend/src/lib/useFocusTrap.ts
+++ b/frontend/src/lib/useFocusTrap.ts
@@ -1,0 +1,49 @@
+import { RefObject, useEffect } from "react";
+
+const FOCUSABLE_SELECTORS = [
+  "button:not([disabled])",
+  "[href]",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
+export function useFocusTrap(
+  ref: RefObject<HTMLElement | null>,
+  enabled = true,
+) {
+  useEffect(() => {
+    if (!enabled) return;
+    const el = ref.current;
+    if (!el) return;
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== "Tab") return;
+      const focusable = Array.from(
+        el!.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS),
+      ).filter((n) => !n.closest("[inert]"));
+      if (focusable.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      if (e.shiftKey) {
+        if (active === first || active === el) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    el.addEventListener("keydown", onKeyDown);
+    return () => el.removeEventListener("keydown", onKeyDown);
+  }, [ref, enabled]);
+}


### PR DESCRIPTION
## What changed

Created `frontend/src/lib/useFocusTrap.ts` — a reusable `useFocusTrap(ref, enabled?)` hook that traps keyboard focus within a dialog container:
- Tab from the last focusable element wraps to the first
- Shift+Tab from the first wraps to the last
- Deactivates when `enabled` is false (dialog closed)

Applied the hook to all 9 `role="dialog"` modals in the app:
- `AuthPromptModal.tsx`
- `WordActionDrawer.tsx`
- `BookDetailModal.tsx`
- `VocabWordTooltip.tsx`
- `AnnotationToolbar.tsx`
- `AnnotationsSidebar.tsx`
- `vocabulary/page.tsx` (DefinitionSheet)
- `decks/[deckId]/page.tsx` (AddWordPicker)
- `reader/[bookId]/page.tsx` (mobile chat sheet)

## Why

Previously, pressing Tab inside any modal allowed focus to escape to background content behind the overlay backdrop. The [ARIA APG Dialog (Modal) Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) requires focus to stay within the dialog while it is open. This was a WCAG/keyboard-navigation failure affecting all modals.

## Test plan

- [x] New test `FocusTrap.test.tsx` — verifies Tab wraps last→first, Shift+Tab wraps first→last, mid-dialog Tab advances normally, disabled hook does not trap
- [x] Full Jest suite: 3201 tests pass
- [x] Updated `docs/design-improvement-plan.md` Change Log (Wave 14)

Closes #2083
