### PR TITLE
fix(ux): empty alt on decorative profile avatar images (closes #2085)

### DIFF
--- a/frontend/src/__tests__/ProfileAvatarAlt.test.ts
+++ b/frontend/src/__tests__/ProfileAvatarAlt.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression test for #2085 — profile avatar images inside aria-labeled buttons
+ * must have alt="" so screen readers don't announce "profile" redundantly.
+ *
+ * WCAG 1.1.1: decorative images must have empty alt text.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const homeSrc = fs.readFileSync(
+  path.join(__dirname, "../app/page.tsx"),
+  "utf8",
+);
+
+const readerSrc = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Profile avatar alt text (closes #2085)", () => {
+  it("home page profile picture has alt=\"\" not alt=\"profile\"", () => {
+    expect(homeSrc).not.toContain('alt="profile"');
+  });
+
+  it("reader page profile picture has alt=\"\" not alt=\"profile\"", () => {
+    expect(readerSrc).not.toContain('alt="profile"');
+  });
+
+  it("home page profile img has empty alt", () => {
+    expect(homeSrc).toContain('src={session.backendUser.picture}');
+    const idx = homeSrc.indexOf('src={session.backendUser.picture}');
+    const window = homeSrc.slice(Math.max(0, idx - 20), idx + 100);
+    expect(window).toContain('alt=""');
+  });
+
+  it("reader page profile img has empty alt", () => {
+    expect(readerSrc).toContain('src={session.backendUser.picture}');
+    const idx = readerSrc.indexOf('src={session.backendUser.picture}');
+    const window = readerSrc.slice(Math.max(0, idx - 20), idx + 100);
+    expect(window).toContain('alt=""');
+  });
+});

--- a/frontend/src/__tests__/ReaderPage.branches.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches.test.tsx
@@ -815,7 +815,7 @@ describe("ReaderPage.branches — profile picture display", () => {
     await flushPromises();
 
     await waitFor(() => {
-      const img = document.querySelector("img[alt='profile']");
+      const img = document.querySelector("img[alt='']");
       expect(img).toBeInTheDocument();
     });
   });

--- a/frontend/src/__tests__/ReaderPage.branches2.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches2.test.tsx
@@ -1512,7 +1512,7 @@ describe("ReaderPage.branches2 — profile avatar variants", () => {
     await flushPromises();
 
     await waitFor(() => {
-      expect(document.querySelector("img[alt='profile']")).toBeInTheDocument();
+      expect(document.querySelector("img[alt='']")).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -200,7 +200,7 @@ export default function Home() {
               >
                 {session?.backendUser?.picture ? (
                   // eslint-disable-next-line @next/next/no-img-element
-                  <img src={session.backendUser.picture} alt="profile" className="w-full h-full object-cover" />
+                  <img src={session.backendUser.picture} alt="" className="w-full h-full object-cover" />
                 ) : (
                   <span className="w-full h-full flex items-center justify-center bg-amber-100 text-amber-700 text-sm font-bold">
                     {session?.backendUser?.name?.[0] ?? "?"}

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1291,7 +1291,7 @@ export default function ReaderPage() {
             >
               {session.backendUser?.picture ? (
                 // eslint-disable-next-line @next/next/no-img-element
-                <img src={session.backendUser.picture} alt="profile" className="w-full h-full object-cover" />
+                <img src={session.backendUser.picture} alt="" className="w-full h-full object-cover" />
               ) : (
                 <span className="w-full h-full flex items-center justify-center bg-amber-100 text-amber-700 text-xs font-bold">
                   {session.backendUser?.name?.[0] ?? "?"}


### PR DESCRIPTION
## What changed

Profile avatar `<img>` elements inside `aria-label`-bearing `<button>` tags now use `alt=""` instead of `alt="profile"`.

## Why

WCAG 1.1.1 (Non-text Content): when a decorative image is inside a control that already has an accessible name via `aria-label`, the image's `alt` must be empty. With `alt="profile"`, screen readers would announce "profile" *in addition to* the button's aria-label (e.g. "Bob profile button"), redundantly double-reading the purpose.

Fixes two locations:
- `src/app/page.tsx` (home page header avatar button)
- `src/app/reader/[bookId]/page.tsx` (reader header avatar button)

## Test plan

- [x] New regression test `ProfileAvatarAlt.test.ts` — 4 assertions: neither page contains `alt="profile"`, both contain `alt=""` adjacent to `src={session.backendUser.picture}`
- [x] Updated `ReaderPage.branches.test.tsx` and `ReaderPage.branches2.test.tsx` selectors from `img[alt='profile']` → `img[alt='']` to stay consistent
- [x] Full frontend suite: 3205 tests passed
- [x] Full backend suite: 1941 passed, 1 skipped

Closes #2085

🤖 Generated with [Claude Code](https://claude.com/claude-code)
