### PR TITLE
docs(ux): annotations tutorial — highlight, note, and review flow (closes #2089)

### DIFF
--- a/docs/tutorials/annotations.md
+++ b/docs/tutorials/annotations.md
@@ -1,0 +1,44 @@
+# Highlight and annotate while reading
+
+The annotation system lets you mark up sentences while you read — add color-coded highlights, attach written notes, and review everything later on the Notes page.
+
+## Create a highlight
+
+**On desktop:** click any sentence in the reader. A small toolbar appears beneath the selected sentence with color swatches (yellow, green, blue, pink, purple). Click a color to save a highlight.
+
+**On mobile:** long-press a sentence to open the same toolbar.
+
+The highlight is saved automatically and synced to your account. Highlighted sentences appear color-coded the next time you open the chapter.
+
+## Add a written note
+
+1. Click (or long-press) a sentence to open the annotation toolbar.
+2. Click the **Note** icon (pencil icon) in the toolbar.
+3. The toolbar expands to show a text field. Type your note.
+4. Click **Save** to attach the note to that sentence.
+
+A small dot appears next to annotated sentences. Click the dot to read the note inline without leaving the text.
+
+## Change or delete an annotation
+
+Click a highlighted sentence to re-open the toolbar. The same color swatches appear — click a different color to change it, or click the **Delete** (trash) icon to remove the highlight and any attached note.
+
+## View all annotations in the sidebar
+
+Open the **Notes** tab in the reader sidebar (click the **Notes** button in the right toolbar, or press **N**). All highlights and notes for the current chapter appear here, in reading order.
+
+Switch chapters to see annotations from other parts of the book.
+
+## Review annotations across all books
+
+Go to [Notes](/notes) in the main navigation. This page lists every book you have annotated, with counts for highlights, notes, and saved vocabulary. Click a book to expand its annotations and AI insights.
+
+## Export annotations
+
+From the Notes page, click **Export** to download your annotations as a JSON file. You can also configure Obsidian export in your profile to push annotations directly to your Obsidian vault — see [Export vocabulary to Obsidian](obsidian-export.md) for setup instructions.
+
+## Tips
+
+- **Color coding:** use different colors to tag annotations by type (e.g. yellow for vocabulary, blue for plot, green for favorite passages).
+- **Inline reading:** the small dot next to an annotated sentence lets you read your note without leaving the text flow — hover (desktop) or tap (mobile) to expand it.
+- **Keyboard shortcut:** press **N** in the reader to toggle the Notes sidebar.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -11,3 +11,4 @@ Step-by-step walkthroughs for the most common workflows. Tutorials are written a
 - **[Add your own EPUB](epub-upload.md)** — upload a .epub or .txt file, review chapter splits, and start reading.
 - **[Review vocabulary with flashcards](flashcards.md)** — save words while reading, then review them with spaced repetition.
 - **[Read without distractions (Focus mode)](focus-mode.md)** — hide the UI chrome and read with keyboard navigation and paragraph focus.
+- **[Highlight and annotate while reading](annotations.md)** — color-code sentences, attach notes, and review everything on the Notes page.


### PR DESCRIPTION
## What changed

Added `docs/tutorials/annotations.md` — a new tutorial covering the annotations/note-taking flow. Updated `docs/tutorials/index.md` to link to it.

## Why

The tutorials site covered reading, translation, queue, EPUB upload, flashcards, and focus mode — but had no entry for the annotation system. A new reader would not discover on their own that they can long-press sentences to highlight them, attach written notes, or review everything on the Notes page. The flow is non-obvious enough to warrant a tutorial (same bar as focus-mode.md).

## What the tutorial covers

- Creating a highlight (desktop click / mobile long-press)
- Adding a written note
- Changing or deleting an annotation
- Viewing annotations in the reader sidebar
- Notes page for cross-book review
- Export (JSON + Obsidian integration)
- Color-coding tips and keyboard shortcut

## Test plan

- [x] Docs-only change — no source code modified
- [x] Full frontend suite: 3207 tests passed
- [x] `annotations.md` links correctly from `index.md`

Closes #2089

🤖 Generated with [Claude Code](https://claude.com/claude-code)
