### PR TITLE
docs(ux): fix stale reader-interaction-design.md — Space shortcut and resolved issues (closes #2091)

### DIFF
--- a/docs/reader-interaction-design.md
+++ b/docs/reader-interaction-design.md
@@ -1,6 +1,6 @@
 # Reader Page — Interaction Design Model
 
-_Last updated: 2026-04-22_
+_Last updated: 2026-04-29_
 
 ## Overview
 
@@ -18,7 +18,7 @@ The reader page combines three overlapping input systems: **TTS playback**, **te
 | Drag to select text | Open SelectionToolbar | Not supported (touch pointer blocked) |
 | Long-press 400 ms | Open AnnotationToolbar (legacy) | Open AnnotationToolbar |
 | Swipe left / right | — | Navigate chapters |
-| Spacebar | (currently unbound) | — |
+| Spacebar | Play / Pause TTS | — |
 
 ---
 
@@ -140,7 +140,7 @@ When multiple interactions are triggered simultaneously, resolve in this order:
 |-----|--------|
 | `←` `→` | Prev / next chapter |
 | `F` | Toggle focus mode |
-| `Space` | Play / pause TTS (**not yet implemented — Issue #UX-006**) |
+| `Space` | Play / pause TTS |
 | `Escape` | Close open panel (AnnotationToolbar / QuickHighlightPanel / TypographyPanel) |
 | `?` | Toggle shortcuts help |
 
@@ -151,12 +151,12 @@ When multiple interactions are triggered simultaneously, resolve in this order:
 | ID | Title | Severity | Status |
 |----|-------|----------|--------|
 | #UX-001 | Mobile: no text selection path for sub-sentence highlight | Medium | Resolved (#364) |
-| #UX-002 | Empty / error state when chapters fail to load | High |
-| #UX-003 | SelectionToolbar "Read" plays simultaneously with chapter TTS | High |
-| #UX-004 | Pause chapter TTS when selection "Read" fires | High |
-| #UX-005 | Annotation delete has no undo or confirmation | Medium |
-| #UX-006 | Spacebar shortcut for TTS play/pause missing | Medium |
-| #UX-007 | Mobile bottom bar hidden when chapters fail to load | Medium |
+| #UX-002 | Empty / error state when chapters fail to load | High | Resolved |
+| #UX-003 | SelectionToolbar "Read" plays simultaneously with chapter TTS | High | Resolved |
+| #UX-004 | Pause chapter TTS when selection "Read" fires | High | Resolved |
+| #UX-005 | Annotation delete has no undo or confirmation | Medium | Resolved (UndoToast) |
+| #UX-006 | Spacebar shortcut for TTS play/pause missing | Medium | Resolved |
+| #UX-007 | Mobile bottom bar hidden when chapters fail to load | Medium | Resolved |
 
 ---
 


### PR DESCRIPTION
## What changed

Updated `docs/reader-interaction-design.md` to correct three stale entries introduced before Wave 8:

1. **Input Taxonomy table (line 21):** `Spacebar | (currently unbound)` → `Spacebar | Play / Pause TTS`
2. **Keyboard Shortcuts table (line 143):** removed the *(not yet implemented — Issue #UX-006)* qualifier from Space
3. **Known Issues table (lines 152-158):** all seven UX-001–007 issues marked `Resolved` (they were fixed across Waves 7–9 but the table was never updated)
4. **Last updated date:** bumped from 2026-04-22 to 2026-04-29

## Why

`reader-interaction-design.md` is the authoritative interaction spec for the reader. Stale entries cause confusion: the Spacebar shortcut has been live in `page.tsx` since at least Wave 8, but the doc still said it was unbound. The Known Issues section listed resolved items as open, making it hard to see what work actually remains.

## Test plan

- [x] Docs-only change — no source code modified
- [x] Full frontend suite: 3207 tests passed

Closes #2091

🤖 Generated with [Claude Code](https://claude.com/claude-code)
