### PR TITLE
fix(ux): add aria-label to queue status symbols in admin books page (closes #2093)

### DIFF
--- a/frontend/src/__tests__/AdminBooksQueueStatusA11y.test.ts
+++ b/frontend/src/__tests__/AdminBooksQueueStatusA11y.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Regression test for #2093 — admin books page queue status symbols (▸·×)
+ * must have a screen-reader-accessible aria-label; the raw typographic
+ * characters should be wrapped in aria-hidden="true".
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/admin/books/page.tsx"),
+  "utf8",
+);
+
+describe("Admin books queue status accessibility (closes #2093)", () => {
+  it("queue status span has aria-label attribute", () => {
+    // Find the section containing the ▸ symbol (running indicator)
+    const idx = src.indexOf("▸${running}");
+    expect(idx).toBeGreaterThan(-1);
+    // Look back 600 chars for the opening span with aria-label
+    const window = src.slice(Math.max(0, idx - 600), idx + 10);
+    expect(window).toContain("aria-label");
+  });
+
+  it("symbol characters are wrapped in aria-hidden span", () => {
+    const idx = src.indexOf("▸${running}");
+    expect(idx).toBeGreaterThan(-1);
+    // Symbols should be inside an aria-hidden span
+    const window = src.slice(Math.max(0, idx - 200), idx + 10);
+    expect(window).toContain('aria-hidden="true"');
+  });
+});

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -436,10 +436,21 @@ export default function BooksPage() {
                           >
                             {lang} · {count}
                             {pending + running + failed > 0 && (
-                              <span className="ml-1 opacity-70">
-                                {running > 0 && `▸${running}`}
-                                {pending > 0 && `·${pending}`}
-                                {failed > 0 && `×${failed}`}
+                              <span
+                                className="ml-1 opacity-70"
+                                aria-label={[
+                                  running > 0 && `${running} running`,
+                                  pending > 0 && `${pending} pending`,
+                                  failed > 0 && `${failed} failed`,
+                                ]
+                                  .filter(Boolean)
+                                  .join(", ")}
+                              >
+                                <span aria-hidden="true">
+                                  {running > 0 && `▸${running}`}
+                                  {pending > 0 && `·${pending}`}
+                                  {failed > 0 && `×${failed}`}
+                                </span>
                               </span>
                             )}
                           </span>


### PR DESCRIPTION
## What

Admin books page queue status indicators used raw typographic symbols (▸ for running, · for pending, × for failed) without any accessible text alternative. Screen readers announced them as "TRIANGULAR BULLET 3 MIDDLE DOT 2 MULTIPLICATION SIGN 1" — meaningless to users relying on assistive technology.

## Why

WCAG 1.3.1 Info and Relationships — status information conveyed visually via symbol characters must have a programmatic text alternative.

## Change

- Wrapped `▸·×` symbols in `<span aria-hidden="true">` so screen readers skip them
- Added `aria-label` on the parent span with human-readable text: e.g. "3 running, 2 pending, 1 failed"
- Admin-only page; zero user-facing visual change

## Test plan

- New static-source regression test: `AdminBooksQueueStatusA11y.test.ts` — verifies `aria-label` attribute is present on the wrapping span and `aria-hidden="true"` is on the inner symbol span
- Full frontend suite: 528 suites / 3209 tests passing

Closes #2093
