### PR TITLE
fix(ux): add semantic h2 and CTA to search page initial empty state (closes #2095)

### DIFF
--- a/frontend/src/__tests__/SearchPageEmptyState.test.ts
+++ b/frontend/src/__tests__/SearchPageEmptyState.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Regression test for #2095 — search page initial empty state must have
+ * a semantic <h2> heading (not <p>) and a CTA button pointing to "/".
+ * WCAG 1.3.1: info conveyed visually should be programmatically determinable.
+ * CLAUDE.md: every empty state needs a headline, sub-text, and a primary CTA.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/search/page.tsx"),
+  "utf8",
+);
+
+describe("Search page initial empty state (closes #2095)", () => {
+  it("initial empty state uses a semantic heading element, not <p>", () => {
+    // The initial empty state block starts with !q.trim()
+    const idx = src.indexOf("{!q.trim() &&");
+    expect(idx).toBeGreaterThan(-1);
+    // Grab the block: 600 chars after the marker
+    const block = src.slice(idx, idx + 600);
+    // Should contain h2 for the title
+    expect(block).toContain("<h2");
+    // Should NOT use <p> for the visible title text
+    const titleIdx = block.indexOf("Search your notes");
+    expect(titleIdx).toBeGreaterThan(-1);
+    const tagBefore = block.slice(Math.max(0, titleIdx - 80), titleIdx);
+    expect(tagBefore).not.toMatch(/<p\b/);
+  });
+
+  it("initial empty state contains a CTA link to the home page", () => {
+    const idx = src.indexOf("{!q.trim() &&");
+    const block = src.slice(idx, idx + 800);
+    // Should have a link/button pointing to "/"
+    expect(block).toContain('href="/"');
+  });
+});

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -153,8 +153,14 @@ function SearchResultsInner() {
       {!q.trim() && (
         <div className="text-center text-stone-500 py-16">
           <SearchIcon className="w-10 h-10 mx-auto mb-2 text-stone-400" aria-hidden="true" />
-          <p className="font-serif text-lg text-ink">Search your notes, vocabulary, and uploads</p>
-          <p className="text-sm mt-2">Start typing in the search bar.</p>
+          <h2 className="font-serif text-lg text-ink">Search your notes, vocabulary, and uploads</h2>
+          <p className="text-sm mt-2">Start typing in the search bar above.</p>
+          <Link
+            href="/"
+            className="mt-5 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px]"
+          >
+            Browse books <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
+          </Link>
         </div>
       )}
 


### PR DESCRIPTION
## What

The search page initial empty state (shown before any query is typed) had two issues:
1. The visually prominent title text was a `<p>` element instead of a semantic `<h2>` — screen reader users navigating by headings (H key in NVDA/JAWS) got no heading landmark despite the visual styling
2. No primary CTA button — CLAUDE.md empty-state design rules require every empty state to have a CTA

## Changes

- `frontend/src/app/search/page.tsx`: Changed title `<p>` → `<h2>` and added "Browse books" link button
- Zero visual change to the "no matches" state (already had CTA and correct structure)

## Why

WCAG 1.3.1 — info and relationships conveyed visually must be programmatically determinable. A large serif title that looks like a heading should be a heading.

## Test plan

- New regression test `SearchPageEmptyState.test.ts`: verifies `<h2` is used for the title and `href="/"` CTA is present in the initial empty state block
- Full frontend suite: 529 suites / 3211 tests passing

Closes #2095
