### PR TITLE
docs(ux): add vocabulary word-saving tutorial (closes #2097)

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -9,6 +9,7 @@ Step-by-step walkthroughs for the most common workflows. Tutorials are written a
 - **[Set up the reading queue](queue.md)** — background pre-translation while you read.
 - **[Export vocabulary to Obsidian](obsidian-export.md)** — push saved words into your Obsidian vault via GitHub.
 - **[Add your own EPUB](epub-upload.md)** — upload a .epub or .txt file, review chapter splits, and start reading.
+- **[Save vocabulary words while reading](vocabulary.md)** — double-click or long-press a word to save it, then review on the Vocabulary page.
 - **[Review vocabulary with flashcards](flashcards.md)** — save words while reading, then review them with spaced repetition.
 - **[Read without distractions (Focus mode)](focus-mode.md)** — hide the UI chrome and read with keyboard navigation and paragraph focus.
 - **[Highlight and annotate while reading](annotations.md)** — color-code sentences, attach notes, and review everything on the Notes page.

--- a/docs/tutorials/vocabulary.md
+++ b/docs/tutorials/vocabulary.md
@@ -1,0 +1,38 @@
+# Save vocabulary words while reading
+
+The vocabulary system lets you save words you encounter while reading, look up their definitions, and review them later with flashcards or spaced repetition.
+
+## Save a word while reading
+
+**On desktop:** double-click any word to select it, then click **Word** in the toolbar that appears. A definition panel opens with the word's meaning, translation, and a **Save** button. Click **Save** to add the word to your vocabulary list.
+
+**On mobile:** long-press a word (hold for about half a second). The word-action drawer slides up from the bottom. Tap **Save** to add the word, or **Define** to look up the definition first.
+
+A small confirmation toast appears briefly to confirm the save.
+
+## View your saved words
+
+Go to **Vocabulary** in the main navigation. All saved words appear here, grouped by language and sorted by how recently you saved them.
+
+Each word entry shows:
+- The base form (lemma) of the word
+- The book and chapter where you saved it
+- A **Delete** button to remove it
+
+## Filter and search your vocabulary
+
+Use the language filter tabs at the top of the Vocabulary page to view words from a specific target language. The search bar filters by word or root form.
+
+## Add words to a flashcard deck
+
+From the Vocabulary page, click **Flashcards** (top right) to open the flashcard review flow. You can also create a named deck on the **Decks** page and add vocabulary words to it for spaced-repetition review — see [Review vocabulary with flashcards](flashcards.md) for the full workflow.
+
+## Export vocabulary
+
+From the Vocabulary page, click **Export** to download your word list as a JSON file. To push vocabulary directly to Obsidian, configure the GitHub integration in your profile — see [Export vocabulary to Obsidian](obsidian-export.md).
+
+## Tips
+
+- **Highlighted words:** words you have saved appear lightly underlined in the reader so you can see at a glance which words you already know.
+- **Desktop shortcut:** double-clicking a word selects exactly one word and immediately shows the SelectionToolbar — faster than click-drag for single words.
+- **Save without defining:** on mobile you can tap **Save** directly in the drawer without opening the definition, which keeps your reading flow.


### PR DESCRIPTION
## What

Adds a vocabulary word-saving tutorial covering the complete flow from reader to vocabulary list to flashcard deck. This is one of the core differentiating features of the app but completely non-discoverable for new users — no tutorial existed.

## Coverage

- **Desktop path**: double-click word → SelectionToolbar "Word" → VocabWordTooltip → Save
- **Mobile path**: long-press word → WordActionDrawer → Save
- Viewing saved words on the Vocabulary page
- Filtering/searching vocabulary
- Adding words to flashcard decks (links to flashcards tutorial)
- Export to JSON / Obsidian (links to obsidian-export tutorial)
- Tips: highlighted-word indicator, skip-define shortcut on mobile

## Changes

- `docs/tutorials/vocabulary.md`: new tutorial
- `docs/tutorials/index.md`: linked between foundational reading and flashcard review tutorials

Closes #2097
