### PR TITLE
fix(ux): auto-redirect pending page when account is approved (closes #2099)

### DIFF
--- a/frontend/src/__tests__/PendingPage.test.tsx
+++ b/frontend/src/__tests__/PendingPage.test.tsx
@@ -8,6 +8,15 @@ jest.mock("next-auth/react", () => ({
   signOut: jest.fn(),
 }));
 
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getMe: jest.fn().mockResolvedValue({ approved: false }),
+}));
+
 import { signOut } from "next-auth/react";
 import PendingApprovalPage from "@/app/pending/page";
 
@@ -15,6 +24,7 @@ const mockSignOut = signOut as jest.MockedFunction<typeof signOut>;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockPush.mockReset();
 });
 
 test("renders heading and description text", () => {

--- a/frontend/src/__tests__/PendingPagePolling.test.ts
+++ b/frontend/src/__tests__/PendingPagePolling.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Regression test for #2099 — pending approval page must poll for approval
+ * status and redirect automatically when account is approved, instead of
+ * leaving users stuck on a static page indefinitely.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/pending/page.tsx"),
+  "utf8",
+);
+
+describe("Pending approval page auto-poll (closes #2099)", () => {
+  it("imports getMe to poll approval status", () => {
+    expect(src).toContain("getMe");
+  });
+
+  it("uses setInterval to poll periodically", () => {
+    expect(src).toContain("setInterval");
+  });
+
+  it("checks the approved field from getMe response", () => {
+    expect(src).toContain("approved");
+  });
+
+  it("redirects on approval", () => {
+    // Should either router.push('/') or window.location
+    const hasRouterPush = src.includes('router.push("/")') || src.includes("router.push('/')");
+    const hasWindowLoc = src.includes("window.location");
+    expect(hasRouterPush || hasWindowLoc).toBe(true);
+  });
+
+  it("clears the interval on unmount (no memory leak)", () => {
+    expect(src).toContain("clearInterval");
+  });
+});

--- a/frontend/src/app/pending/page.tsx
+++ b/frontend/src/app/pending/page.tsx
@@ -1,12 +1,30 @@
 "use client";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { signOut } from "next-auth/react";
+import { useRouter } from "next/navigation";
 import { ClockIcon } from "@/components/Icons";
+import { getMe } from "@/lib/api";
 
 export default function PendingApprovalPage() {
+  const router = useRouter();
+
+  const checkApproval = useCallback(async () => {
+    try {
+      const user = await getMe();
+      if (user.approved) {
+        router.push("/");
+      }
+    } catch {
+      // silently ignore — user stays on page if the check fails
+    }
+  }, [router]);
+
   useEffect(() => {
     document.title = "Account Pending — Book Reader AI";
-  }, []);
+    checkApproval();
+    const interval = setInterval(checkApproval, 30_000);
+    return () => clearInterval(interval);
+  }, [checkApproval]);
 
   return (
     <main id="main-content" className="min-h-screen bg-parchment flex items-center justify-center px-4">
@@ -17,6 +35,7 @@ export default function PendingApprovalPage() {
           Your account is waiting for admin approval. You&apos;ll be able to use the
           app once an administrator approves your account.
         </p>
+        <p className="text-xs text-stone-400 mb-4">Checking automatically every 30 seconds…</p>
         <button
           onClick={() => signOut({ callbackUrl: "/login" })}
           className="text-sm text-red-600 hover:text-red-800 min-h-[44px] flex items-center justify-center mx-auto"


### PR DESCRIPTION
## What

The pending-approval page (`/pending`) was a UX dead-end. If an admin approved a user's account while they were sitting on that page, nothing happened — the user saw "Account Pending" indefinitely and had to manually reload or navigate away to discover they'd been approved.

## Fix

- Added a 30-second polling loop via `getMe()` in a `useEffect`
- On `approved === true`, immediately redirects to `/` via `router.push`
- Polls once on mount too (catches the case where the user lands on `/pending` after already being approved)
- Clears the interval on unmount (no memory leak)
- Added a subtle "Checking automatically every 30 seconds…" note so users know the page isn't stuck

## Changes

- `frontend/src/app/pending/page.tsx`: polling + redirect logic
- `frontend/src/__tests__/PendingPagePolling.test.ts`: new regression test (5 assertions: getMe imported, setInterval present, `approved` checked, redirect wired, clearInterval present)
- `frontend/src/__tests__/PendingPage.test.tsx`: added `next/navigation` and `@/lib/api` mocks so existing tests pass with the new hooks

## Test plan

- New `PendingPagePolling.test.ts`: 5/5 passing
- Full frontend suite: 530 suites / 3216 tests passing

Closes #2099
