### PR TITLE
fix(ux): set document.title on home/library page (closes #2103)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -186,6 +186,11 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 9.6 | Homepage tablist: roving tabIndex + ArrowLeft/Right keyboard nav (PR #2050) | ✅ Done |
 | 2026-04-29 | 9.7 | Notes/[bookId]: `<ul role="list">` on annotation and insight lists — all 6 map sites (PR #2052) | ✅ Done |
 | 2026-04-29 | 9.8 | Reader sidebar: `<ul role="list">` on annotation panels + vocab panel + bottom notes expand (PR #2054) | ✅ Done |
+| 2026-04-29 | 10.1 | Admin books: aria-label on queue-status symbol span + aria-hidden on inner symbol (PR #2094, closes #2093) | ✅ Done |
+| 2026-04-29 | 10.2 | Search page: `<p>` → `<h2>` + Browse books CTA in initial empty state (PR #2096, closes #2095) | ✅ Done |
+| 2026-04-29 | 10.3 | Docs: vocabulary word-saving tutorial added (PR #2098, closes #2097) | ✅ Done |
+| 2026-04-29 | 10.4 | Pending approval page: 30s polling via getMe() + auto-redirect on approved=true (PR #2100, closes #2099) | ✅ Done |
+| 2026-04-29 | 10.5 | Home/library page: added `document.title` in useEffect for WCAG 2.4.2 compliance (PR #2104, closes #2103) | ✅ Done |
 
 ---
 

--- a/frontend/src/__tests__/HomePageDocumentTitle.test.ts
+++ b/frontend/src/__tests__/HomePageDocumentTitle.test.ts
@@ -1,0 +1,17 @@
+/**
+ * Regression test for #2103 — home/library page must set document.title on
+ * mount so the browser tab updates correctly after client-side navigation.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/page.tsx"),
+  "utf8",
+);
+
+describe("Home page document.title (closes #2103)", () => {
+  it("sets document.title to 'My Library — Book Reader AI'", () => {
+    expect(src).toContain('document.title = "My Library — Book Reader AI"');
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -57,6 +57,10 @@ export default function Home() {
   const [removedBookToast, setRemovedBookToast] = useState<RecentBook | null>(null);
 
   useEffect(() => {
+    document.title = "My Library — Book Reader AI";
+  }, []);
+
+  useEffect(() => {
     const books = getRecentBooks();
     setRecentBooks(books);
     if (books.length === 0) setTab("discover");


### PR DESCRIPTION
## What changed

Added `document.title = "My Library — Book Reader AI"` in a `useEffect` in `app/page.tsx`.

## Why

The home/library page was the only client-component page not setting `document.title`. After client-side navigation to `/` (e.g., from Vocabulary → Library), the browser tab title remained stale from the previous page. Every other page (`/vocabulary`, `/decks`, `/profile`, `/search`, `/notes`, `/upload`, `/reader/...`) already sets `document.title` in `useEffect`. The reader page even resets to `"My Library — Book Reader AI"` in its cleanup function — making the omission on the home page itself clear.

**WCAG 2.4.2 (Page Titled):** screen reader users rely on accurate page titles to identify their current location.

## Test plan

- New static-source test `HomePageDocumentTitle.test.ts` asserts the string is present
- 531 test suites, 3217 tests pass

Closes #2103
