### PR TITLE
docs(ux): add reading-stats tutorial (closes #2105)

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -13,3 +13,4 @@ Step-by-step walkthroughs for the most common workflows. Tutorials are written a
 - **[Review vocabulary with flashcards](flashcards.md)** — save words while reading, then review them with spaced repetition.
 - **[Read without distractions (Focus mode)](focus-mode.md)** — hide the UI chrome and read with keyboard navigation and paragraph focus.
 - **[Highlight and annotate while reading](annotations.md)** — color-code sentences, attach notes, and review everything on the Notes page.
+- **[Track your reading progress](reading-stats.md)** — reading streak, activity heatmap, and cumulative stats on the home page.

--- a/docs/tutorials/reading-stats.md
+++ b/docs/tutorials/reading-stats.md
@@ -1,0 +1,55 @@
+# Track your reading progress
+
+Book Reader AI tracks how much you read each day and shows your stats on the home page — your reading streak, total books opened, vocabulary words saved, and a 365-day activity heatmap.
+
+## Where to find your stats
+
+Open the home page (click **My Library** or navigate to `/`). Below the **Continue reading** button and above your book grid, you'll see a **Your Progress** section with stat cards.
+
+If the section isn't visible, check that you are signed in — stats are per-account and only appear after your first reading session.
+
+## Reading streak
+
+The flame icon (🔥) card shows how many days in a row you have read. A day counts toward your streak when you open any chapter — even briefly navigating to a chapter is enough to record a reading event.
+
+- **Current streak:** days in a row up to and including today.
+- **Longest streak:** your all-time personal best, visible in the expanded activity panel.
+
+The streak resets if you skip a full calendar day without opening a chapter. Yesterday still counts, so an early morning or late evening read is enough to keep the chain going.
+
+## Stat cards
+
+| Card | What it counts |
+|---|---|
+| **Day streak** | Consecutive days with at least one chapter opened |
+| **Books started** | Total distinct books you have opened (any chapter) |
+| **Words saved** | Total vocabulary words saved across all books |
+| **Annotations** | Total highlights and notes saved across all books |
+
+## Activity heatmap
+
+Click **Show activity** (top-right of the Your Progress section) to expand the 365-day activity grid.
+
+Each square represents one calendar day. The colour intensity shows how many reading events were recorded that day:
+
+| Colour | Events |
+|---|---|
+| Light grey | 0 — no reading |
+| Light amber | 1–2 events |
+| Medium amber | 3–5 events |
+| Dark amber | 6–10 events |
+| Deep amber | 11+ events |
+
+Month labels appear along the top. Hover a square (desktop) to see the exact date and event count.
+
+## What counts as a reading event
+
+One reading event is recorded each time you **navigate to a chapter** — clicking a chapter in the table of contents, pressing the Next/Previous chapter buttons, or opening the reader for the first time. Every new chapter you open adds an event for that day.
+
+Events are tied to your account, so reading on a phone and a desktop both contribute to the same heatmap.
+
+## Tips
+
+- **Build the habit first, then the streak.** Even opening one chapter a day keeps the streak alive — you don't need to read for a long time.
+- **Check your longest streak.** Open the activity panel to see your longest streak displayed below the heatmap alongside the count of active reading days in the past year.
+- **Vocabulary and annotations count separately.** The words-saved and annotation counts grow independently of your streak — you can save words while reading and they accumulate in the stats even on days when your streak is already counted.


### PR DESCRIPTION
## What changed

Added `docs/tutorials/reading-stats.md` — a new tutorial covering the reading statistics feature visible on the home page. Updated `docs/tutorials/index.md` to link the new tutorial.

## Why

The reading stats panel (streak counter, activity heatmap, total books/annotations/words) is hidden behind a collapsible section on the home page and has no tutorial. A new user has no way to discover what the stats mean, what triggers a reading event, or how the streak is counted.

## What the tutorial covers

- Where to find the stats section (home page → Your Progress)
- What each stat card counts (streak, books started, words saved, annotations)
- How the 365-day activity heatmap works (colour intensity → events per day)
- What counts as a reading event (navigating to any chapter)
- Tips for building a reading habit

## Test plan

- [x] Frontend tests pass (3218/3218)
- [x] `docs/tutorials/reading-stats.md` exists and accurately describes the current UI (verified against `page.tsx` and `ReadingStats.tsx`)
- [x] `docs/tutorials/index.md` links the new tutorial

Closes #2105
