### PR TITLE
docs: add TTS tutorial (closes #2109)

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -15,3 +15,4 @@ Step-by-step walkthroughs for the most common workflows. Tutorials are written a
 - **[Highlight and annotate while reading](annotations.md)** — color-code sentences, attach notes, and review everything on the Notes page.
 - **[Track your reading progress](reading-stats.md)** — reading streak, activity heatmap, and cumulative stats on the home page.
 - **[Ask questions with AI Insights](ai-insights.md)** — chat sidebar that knows your chapter, with context attachment and multi-language support.
+- **[Listen with text-to-speech](tts.md)** — play any chapter aloud, control voice, speed, and seek position, and read individual sentences or paragraphs.

--- a/docs/tutorials/tts.md
+++ b/docs/tutorials/tts.md
@@ -1,0 +1,52 @@
+# Listen to your book with text-to-speech
+
+Book Reader AI can read any chapter aloud using AI-generated speech. No API key is required — the feature works out of the box using a free text-to-speech engine, with higher-quality audio available when you have a Gemini key.
+
+## Start listening
+
+Open any chapter. At the bottom of the reader you'll see the audio bar with a **Read** button. Click it to start playback. The button changes to **Pause** while audio is playing — click it again to pause.
+
+Press **Space** anywhere in the reader to toggle play/pause without reaching for the mouse.
+
+## Controls
+
+The audio bar contains everything you need:
+
+| Control | What it does |
+|---|---|
+| **Read / Pause** | Start or pause chapter audio |
+| **F / M** | Toggle between Female and Male voice |
+| **Seek bar** | Scrub to any point in the chapter — drag the slider or click a position |
+| **Speed slider** | Change playback speed from 0.5× (slow) to 2× (fast) |
+
+The seek bar only appears once audio has finished loading. The current time and total duration are shown on either side.
+
+## Resume where you left off
+
+Your playback position is saved automatically. If you navigate away and return to the chapter, clicking **Read** picks up from where you paused — even after closing the browser.
+
+## Read a single paragraph
+
+If you have **Paragraph focus** enabled (via Typography settings or Focus mode), a **Read para** button appears next to the chapter navigation bar. Click it to play just the focused paragraph without starting the full chapter audio.
+
+The paragraph reader uses the same voice and quality settings as the full chapter player.
+
+## Read a highlighted sentence
+
+Click any sentence in the reader to open the sentence toolbar. Click the **Read** (speaker) button in the toolbar to play just that sentence. If the chapter was already playing, it pauses during the sentence and resumes automatically when it finishes.
+
+## Voice quality
+
+| Situation | Engine used |
+|---|---|
+| No Gemini key | Microsoft Edge TTS (free, no account needed) |
+| Gemini key saved | Google Gemini TTS (higher quality, natural intonation) |
+
+To add your Gemini key for better quality, go to **Profile → Gemini API Key**. See [Enable AI translation](ai-translation.md) for key setup steps.
+
+## Tips
+
+- **Speed up non-fiction, slow down poetry.** Drag the speed slider to 1.5× for informational chapters; drop to 0.75× for verse or dense passages.
+- **Switch chapters without losing the thread.** Audio stops on chapter change; press **Read** again on the new chapter to continue listening.
+- **Use the seek bar to re-listen.** If a passage went by too fast, drag the seek handle backward to replay it.
+- **Mix reading and listening.** Click a sentence to open its toolbar and get a translation or note while audio is paused — the position is preserved.

--- a/frontend/src/__tests__/TTSTutorial.test.ts
+++ b/frontend/src/__tests__/TTSTutorial.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression test for #2109 — TTS tutorial must exist and cover key sections.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const tutorial = fs.readFileSync(
+  path.join(__dirname, "../../../docs/tutorials/tts.md"),
+  "utf8",
+);
+
+const index = fs.readFileSync(
+  path.join(__dirname, "../../../docs/tutorials/index.md"),
+  "utf8",
+);
+
+describe("TTS tutorial (closes #2109)", () => {
+  it("covers core playback controls", () => {
+    expect(tutorial).toContain("Read");
+    expect(tutorial).toContain("Pause");
+    expect(tutorial).toContain("Space");
+  });
+
+  it("covers voice gender toggle", () => {
+    expect(tutorial).toContain("Female");
+    expect(tutorial).toContain("Male");
+  });
+
+  it("covers seek and speed controls", () => {
+    expect(tutorial).toContain("seek");
+    expect(tutorial).toContain("speed");
+  });
+
+  it("covers paragraph and sentence reading", () => {
+    expect(tutorial).toContain("paragraph");
+    expect(tutorial).toContain("sentence");
+  });
+
+  it("mentions position persistence", () => {
+    expect(tutorial).toContain("saved automatically");
+  });
+
+  it("is linked from the tutorial index", () => {
+    expect(index).toContain("tts.md");
+  });
+});


### PR DESCRIPTION
## What changed

- Added `docs/tutorials/tts.md` — full tutorial for the text-to-speech feature covering: starting playback, voice gender toggle (F/M), seek bar, speed control (0.5×–2×), position persistence, paragraph-level reading (Focus mode "Read para" button), sentence-level reading (SelectionToolbar Read button), and voice quality tiers (Edge TTS free vs Gemini TTS with key).
- Updated `docs/tutorials/index.md` with the new entry.
- Added `frontend/src/__tests__/TTSTutorial.test.ts` — 6 regression tests confirming the tutorial exists and covers all key sections.

## Why

TTS is one of the most discoverable features (Read button is always visible at the bottom of the reader), but had no tutorial. Users had no guidance on voice switching, seek, paragraph/sentence reading, or the free-vs-Gemini quality distinction.

## Test plan

- [x] `TTSTutorial.test.ts` — 6 tests pass (tutorial file exists, covers controls/gender/seek/speed/persistence/paragraph/sentence reading, linked from index)
- [x] Full frontend suite: 532 suites, 3224 tests pass

Closes #2109

## Docs follow-up

n/a — this PR *is* the doc update.
