### PR TITLE
docs: add typography panel tutorial (closes #2111)

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -16,3 +16,4 @@ Step-by-step walkthroughs for the most common workflows. Tutorials are written a
 - **[Track your reading progress](reading-stats.md)** — reading streak, activity heatmap, and cumulative stats on the home page.
 - **[Ask questions with AI Insights](ai-insights.md)** — chat sidebar that knows your chapter, with context attachment and multi-language support.
 - **[Listen with text-to-speech](tts.md)** — play any chapter aloud, control voice, speed, and seek position, and read individual sentences or paragraphs.
+- **[Customize the reading layout](typography.md)** — font size, font family, line spacing, column width, and paragraph focus — all saved automatically.

--- a/docs/tutorials/typography.md
+++ b/docs/tutorials/typography.md
@@ -1,0 +1,52 @@
+# Customize the reading layout
+
+The typography panel lets you adjust how text appears on the page — size, font, spacing, and column width. All settings save automatically and persist across sessions and devices.
+
+## Open the typography panel
+
+Click the **Aa** button in the reader toolbar (desktop) or in the Focus mode HUD. The panel appears as a popover below the button with four controls and a toggle. Press **Esc** or click anywhere outside to close it.
+
+## Font size
+
+Four sizes: **S**, **M**, **L**, **XL**. M is the default for most users. Use L or XL if you read on a large monitor or prefer less time with your eyes tracking across long lines. Use S to fit more text on screen.
+
+## Font family
+
+| Option | When to use |
+|---|---|
+| **Serif** (default) | Sustained reading — novels, essays, long chapters. The stroke variations reduce eye fatigue over long sessions. |
+| **Sans** | Technical content, short reference material, or personal preference. |
+
+## Line spacing
+
+| Option | Effect |
+|---|---|
+| **Tight** | Less whitespace between lines — denser, more lines per screen. |
+| **Normal** (default) | Balanced for most reading contexts. |
+| **Relaxed** | More whitespace — useful for dense prose or when you find the default hard to track. |
+
+## Content width
+
+| Option | Effect |
+|---|---|
+| **Narrow** | Short lines (~55 characters) — easier to track for sustained reading, common in books. |
+| **Normal** (default) | ~70-character lines — works well for most content. |
+| **Wide** | Longer lines — useful on large monitors or for reference scanning, not sustained reading. |
+
+Typographers generally recommend 45–75 characters per line for comfortable reading. **Narrow** and **Normal** both fall in that range.
+
+## Paragraph focus
+
+The **Paragraph focus** toggle at the bottom of the panel highlights the paragraph you are hovering and dims the rest. It also adds a **Read para** button to the reader navigation bar, which reads the focused paragraph aloud.
+
+Paragraph focus pairs well with Focus mode — enable both for a distraction-free, single-paragraph reading experience.
+
+- Paragraph focus is **per-session** for which paragraph is active, but the **on/off preference** is saved and persists.
+- When using TTS playback, paragraph focus controls which paragraph the **Read para** button plays.
+
+## Tips
+
+- **Start with the defaults.** M size, Serif font, Normal spacing, and Normal width are calibrated for average screen sizes. Adjust one at a time to see the effect.
+- **Narrow + Relaxed** is a good combination for dense 19th-century prose — shorter lines with more space reduces the effort of tracking across the page.
+- **Paragraph focus without Focus mode** works too — you don't need to enable the full Focus mode to get the paragraph highlight.
+- **Settings sync across chapters.** Change the font once; it applies everywhere in the reader.

--- a/frontend/src/__tests__/TypographyTutorial.test.ts
+++ b/frontend/src/__tests__/TypographyTutorial.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression test for #2111 — typography tutorial must exist and cover key controls.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const tutorial = fs.readFileSync(
+  path.join(__dirname, "../../../docs/tutorials/typography.md"),
+  "utf8",
+);
+
+const index = fs.readFileSync(
+  path.join(__dirname, "../../../docs/tutorials/index.md"),
+  "utf8",
+);
+
+describe("Typography panel tutorial (closes #2111)", () => {
+  it("covers font size control", () => {
+    expect(tutorial).toContain("Font size");
+  });
+
+  it("covers font family (serif/sans)", () => {
+    expect(tutorial).toContain("Serif");
+    expect(tutorial).toContain("Sans");
+  });
+
+  it("covers line spacing", () => {
+    expect(tutorial).toContain("spacing");
+  });
+
+  it("covers content width", () => {
+    expect(tutorial).toContain("width");
+  });
+
+  it("covers paragraph focus toggle", () => {
+    expect(tutorial).toContain("Paragraph focus");
+  });
+
+  it("mentions settings persistence", () => {
+    expect(tutorial).toContain("persist");
+  });
+
+  it("is linked from the tutorial index", () => {
+    expect(index).toContain("typography.md");
+  });
+});


### PR DESCRIPTION
## What changed

- Added `docs/tutorials/typography.md` — full tutorial for the typography panel covering: how to open it (Aa button), font size options (S/M/L/XL), font family (Serif vs Sans with context for when to use each), line spacing (Tight/Normal/Relaxed), content width (Narrow/Normal/Wide with character-count guidance), and paragraph focus toggle (including its relationship to Focus mode and TTS "Read para").
- Updated `docs/tutorials/index.md` with the new entry.
- Added `frontend/src/__tests__/TypographyTutorial.test.ts` — 7 regression tests confirming the tutorial exists and covers all key controls.

## Why

The typography panel is a significant reader customization feature — four independent controls plus a toggle — but had no documentation. Users who click "Aa" discover it by accident and have no context for what each setting does or when to change it.

## Test plan

- [x] `TypographyTutorial.test.ts` — 7 tests pass (tutorial file exists, covers font size/family/spacing/width/paragraph focus/persistence, linked from index)
- [x] Full frontend suite: 533 suites, 3231 tests pass

Closes #2111

## Docs follow-up

n/a — this PR is the doc update.
