### PR TITLE
feat(ux): add 1/2/3/4 keyboard shortcuts for flashcard grading (closes #2113)

### DIFF
--- a/frontend/src/__tests__/FlashcardKeyboardShortcuts.test.ts
+++ b/frontend/src/__tests__/FlashcardKeyboardShortcuts.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Regression test for #2113 — flashcard page must implement 1/2/3/4 keyboard
+ * shortcuts for grading after flipping the card.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/flashcards/page.tsx"),
+  "utf8",
+);
+
+describe("Flashcard keyboard shortcuts (closes #2113)", () => {
+  it("has a global keydown listener via addEventListener", () => {
+    expect(src).toContain("addEventListener");
+    expect(src).toContain("keydown");
+  });
+
+  it("maps key '1' to grade 0 (Again)", () => {
+    expect(src).toContain('"1": 0');
+  });
+
+  it("maps key '2' to grade 2 (Hard)", () => {
+    expect(src).toContain('"2": 2');
+  });
+
+  it("maps key '3' to grade 3 (Good)", () => {
+    expect(src).toContain('"3": 3');
+  });
+
+  it("maps key '4' to grade 5 (Easy)", () => {
+    expect(src).toContain('"4": 5');
+  });
+
+  it("guards against typing in form controls", () => {
+    expect(src).toContain("INPUT");
+    expect(src).toContain("SELECT");
+    expect(src).toContain("TEXTAREA");
+  });
+
+  it("shows key hint numbers on grade buttons", () => {
+    expect(src).toContain("i + 1");
+  });
+});

--- a/frontend/src/__tests__/FlashcardsCoverage.test.tsx
+++ b/frontend/src/__tests__/FlashcardsCoverage.test.tsx
@@ -85,7 +85,7 @@ test("grading first card of two advances to second card instead of showing done"
 
   // Flip and grade first card
   await userEvent.click(screen.getByText("Show answer"));
-  await userEvent.click(screen.getByRole("button", { name: "Good" }));
+  await userEvent.click(screen.getByRole("button", { name: /Good/i }));
 
   // Should advance to second card, not show "All done"
   await waitFor(() => screen.getByText("stoic"));
@@ -107,7 +107,7 @@ test("card counter shows correct position after advancing", async () => {
   expect(counter).toBeInTheDocument();
 
   await userEvent.click(screen.getByText("Show answer"));
-  await userEvent.click(screen.getByRole("button", { name: "Again" }));
+  await userEvent.click(screen.getByRole("button", { name: /Again/i }));
 
   // Now showing card 2 of 2
   await waitFor(() => screen.getByText("stoic"));
@@ -218,7 +218,7 @@ test("pressing Enter on card flips it to reveal answer side", async () => {
   await userEvent.keyboard("{Enter}");
 
   // Grade buttons now visible
-  await waitFor(() => screen.getByRole("button", { name: "Good" }));
+  await waitFor(() => screen.getByRole("button", { name: /Good/i }));
   expect(screen.queryByText("Show answer")).not.toBeInTheDocument();
 });
 
@@ -233,7 +233,7 @@ test("pressing Space on card flips it to reveal answer side", async () => {
   card.focus();
   await userEvent.keyboard(" ");
 
-  await waitFor(() => screen.getByRole("button", { name: "Good" }));
+  await waitFor(() => screen.getByRole("button", { name: /Good/i }));
 });
 
 // ── Done state with selected deck ─────────────────────────────────────────────
@@ -266,7 +266,7 @@ test("done state shows deck-specific message when a deck is selected", async () 
 
   // Grade the card
   await userEvent.click(screen.getByText("Show answer"));
-  await userEvent.click(screen.getByRole("button", { name: "Easy" }));
+  await userEvent.click(screen.getByRole("button", { name: /Easy/i }));
 
   // Done state should show deck-specific message
   await waitFor(() => screen.getByText(/all done for today/i));

--- a/frontend/src/__tests__/FlashcardsCoverage2.test.tsx
+++ b/frontend/src/__tests__/FlashcardsCoverage2.test.tsx
@@ -82,7 +82,7 @@ test("clicking the card div directly toggles flipped state via onClick (line 251
   await userEvent.click(card);
 
   // After click, grade buttons appear (flipped=true)
-  await waitFor(() => screen.getByRole("button", { name: "Good" }));
+  await waitFor(() => screen.getByRole("button", { name: /Good/i }));
 });
 
 // ── line 252: card onKeyDown — Enter / Space flip card back ──────────────────
@@ -93,7 +93,7 @@ test("Enter keydown on card div invokes onKeyDown handler and flips card (line 2
 
   // Flip to the definition side first via "Show answer" button so the card is in flipped=true state
   await userEvent.click(screen.getByText("Show answer"));
-  await waitFor(() => screen.getByRole("button", { name: "Good" }));
+  await waitFor(() => screen.getByRole("button", { name: /Good/i }));
 
   // Now the card is flipped — pressing Enter should flip it back via onKeyDown
   const card = screen.getByRole("button", { name: /press to flip back/i });
@@ -101,7 +101,7 @@ test("Enter keydown on card div invokes onKeyDown handler and flips card (line 2
 
   // Card flipped back — grade buttons gone, "Show answer" visible again
   await waitFor(() => screen.getByText("Show answer"));
-  expect(screen.queryByRole("button", { name: "Good" })).not.toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: /Good/i })).not.toBeInTheDocument();
 });
 
 test("Space keydown on card div invokes onKeyDown handler and flips card (line 251, #2003)", async () => {
@@ -109,7 +109,7 @@ test("Space keydown on card div invokes onKeyDown handler and flips card (line 2
   await waitFor(() => screen.getByText("ephemeral"));
 
   await userEvent.click(screen.getByText("Show answer"));
-  await waitFor(() => screen.getByRole("button", { name: "Good" }));
+  await waitFor(() => screen.getByRole("button", { name: /Good/i }));
 
   const card = screen.getByRole("button", { name: /press to flip back/i });
   fireEvent.keyDown(card, { key: " " });
@@ -125,7 +125,7 @@ test("non-activating key on card does not flip it (line 251 branch, #2003)", asy
   fireEvent.keyDown(card, { key: "Tab" });
 
   // Grade buttons should NOT appear — card stays unflipped
-  expect(screen.queryByRole("button", { name: "Good" })).not.toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: /Good/i })).not.toBeInTheDocument();
   expect(screen.getByText("Show answer")).toBeInTheDocument();
 });
 

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -131,6 +131,28 @@ export default function FlashcardsPage() {
     }
   }, [currentCard, currentIndex, cards.length, submitting]);
 
+  // Keyboard shortcuts: Space/Enter → flip; 1/2/3/4 → grade (Again/Hard/Good/Easy)
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.target instanceof HTMLElement && ["INPUT", "SELECT", "TEXTAREA"].includes(e.target.tagName)) return;
+      if (e.key === " " || e.key === "Enter") {
+        if (!flipped && currentCard && !done) {
+          e.preventDefault();
+          setFlipped(true);
+        }
+      } else if (flipped && !submitting && currentCard) {
+        const gradeMap: Record<string, number> = { "1": 0, "2": 2, "3": 3, "4": 5 };
+        const grade = gradeMap[e.key];
+        if (grade !== undefined) {
+          e.preventDefault();
+          handleGrade(grade);
+        }
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [flipped, currentCard, done, submitting, handleGrade]);
+
   if (status === "loading" || loading) {
     return (
       <div role="status" aria-label="Loading flashcards" className="min-h-screen bg-parchment flex items-center justify-center">
@@ -286,14 +308,16 @@ export default function FlashcardsPage() {
             {/* Grade buttons — shown after flip */}
             {flipped && (
               <div className="grid grid-cols-4 gap-2 animate-fade-in">
-                {GRADES.map(({ label, value, className }) => (
+                {GRADES.map(({ label, value, className }, i) => (
                   <button
                     key={value}
                     onClick={() => handleGrade(value)}
                     disabled={submitting}
-                    className={`py-3 rounded-xl border font-medium text-sm transition-colors min-h-[44px] disabled:opacity-50 ${className}`}
+                    aria-label={`${label} (key ${i + 1})`}
+                    className={`py-3 rounded-xl border font-medium text-sm transition-colors min-h-[44px] disabled:opacity-50 flex flex-col items-center justify-center gap-0.5 ${className}`}
                   >
-                    {label}
+                    <span>{label}</span>
+                    <span className="text-[10px] opacity-60 font-normal">{i + 1}</span>
                   </button>
                 ))}
               </div>


### PR DESCRIPTION
## What changed

Implements the 1/2/3/4 keyboard shortcuts for flashcard grading that were already documented in the tutorial but never built into the page.

- **Space / Enter** — flip the card (when unflipped)
- **1** — Again (grade 0), **2** — Hard (grade 2), **3** — Good (grade 3), **4** — Easy (grade 5) — active only after the card is flipped
- Guard: shortcuts are skipped when focus is inside an `INPUT`, `SELECT`, or `TEXTAREA` (prevents the deck selector from triggering grades)
- Grade buttons now show a small key-number hint (`1`/`2`/`3`/`4`) and carry updated `aria-label`s (`"Again (key 1)"` etc.) for screen readers

## Why

The flashcard tutorial at `docs/tutorials/flashcards.md` explicitly described keyboard shortcuts as a feature, but `page.tsx` had no `keydown` listener — the shortcuts silently did nothing.

## Test plan

- New regression suite `FlashcardKeyboardShortcuts.test.ts` (7 tests): verifies `addEventListener`/`keydown` presence, all four grade-key mappings, form-control guard, and key-hint rendering
- Updated `FlashcardsCoverage.test.tsx` and `FlashcardsCoverage2.test.tsx`: changed button queries from exact name `"Good"` to regex `/Good/i` to match new `aria-label` pattern
- All 534 frontend test suites pass (3238 tests)

Closes #2113
