### PR TITLE
docs(ux): add decks tutorial covering manual/smart modes and flashcard filtering (closes #2117)

### DIFF
--- a/docs/tutorials/decks.md
+++ b/docs/tutorials/decks.md
@@ -1,0 +1,58 @@
+# Organize vocabulary with decks
+
+Decks let you group saved vocabulary words into named collections — for example, "German verbs", "Chapter 3 words", or "Words I keep forgetting". When you study flashcards, you can filter to a single deck so you only see the cards that matter right now.
+
+## Open the Decks page
+
+Go to **Vocabulary → Decks** (the tab in the top navigation of the vocabulary page), or navigate directly to `/decks`. Your existing decks are listed there with a word count and how many cards are due today.
+
+## Create a deck
+
+1. Click **New deck** (top-right on the Decks page).
+2. Enter a **Name** — this is what appears in the deck selector on the Flashcards page.
+3. Optionally add a **Description** to remind yourself what this deck is for.
+4. Choose a **Mode**: Manual or Smart.
+5. Click **Create deck**.
+
+## Manual decks
+
+A Manual deck starts empty. You add and remove words one at a time from inside the deck.
+
+**To add words:**
+1. Open the deck (click its card).
+2. Click **Add word** (top-right).
+3. A picker shows all your saved vocabulary. Click any word to add it immediately.
+4. Close the picker when done.
+
+**To remove a word:** find it in the deck's word list and click the trash icon on its row.
+
+## Smart decks
+
+A Smart deck has no member list you manage by hand — membership is computed automatically from your saved vocabulary based on the rules you define. Every time you open the deck, it re-evaluates which words qualify.
+
+Available rules (leave any blank to match everything):
+
+| Rule | Effect |
+|---|---|
+| **Language** | Only include words saved with this language code (e.g. `de`, `zh`, `ja`). |
+| **Tags any of** | Include words tagged with at least one of the listed tags (comma-separated). |
+| **Tags all of** | Include only words that carry every listed tag. |
+| **Saved after / before** | Date range filter — only words saved within that window. |
+
+Example: a deck with Language `de` and Tags any of `verb, adjective` will always contain every German verb or adjective you save, without any manual curation.
+
+## Filter flashcards by deck
+
+On the **Flashcards** page, the **Deck:** selector (just below the header) lists all your decks. Choose one to study only the cards from that deck. The progress bar and "N of M remaining" counter reflect the filtered set. Your last-used deck is remembered across sessions.
+
+## Delete a deck
+
+Click the trash icon on a deck card. A brief undo toast appears — if you change your mind, tap **Undo** within a few seconds to restore the deck.
+
+Deleting a deck does not delete the vocabulary words inside it — they remain in your vocabulary list.
+
+## Tips
+
+- **Smart + tag workflow**: tag words as you save them (long-press on mobile, right-click on desktop), then create a Smart deck that matches that tag. New words are added automatically.
+- **One deck per book chapter**: create a Manual deck per chapter and add words as you encounter them. When you finish the chapter, study that deck for a targeted session.
+- **Deck due count**: the number in amber on each deck card is how many cards are due today in that deck — use it to prioritize which deck to study first.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -11,6 +11,7 @@ Step-by-step walkthroughs for the most common workflows. Tutorials are written a
 - **[Add your own EPUB](epub-upload.md)** — upload a .epub or .txt file, review chapter splits, and start reading.
 - **[Save vocabulary words while reading](vocabulary.md)** — double-click or long-press a word to save it, then review on the Vocabulary page.
 - **[Review vocabulary with flashcards](flashcards.md)** — save words while reading, then review them with spaced repetition.
+- **[Organize vocabulary with decks](decks.md)** — group saved words into named or rule-based decks and filter flashcard sessions by deck.
 - **[Read without distractions (Focus mode)](focus-mode.md)** — hide the UI chrome and read with keyboard navigation and paragraph focus.
 - **[Highlight and annotate while reading](annotations.md)** — color-code sentences, attach notes, and review everything on the Notes page.
 - **[Track your reading progress](reading-stats.md)** — reading streak, activity heatmap, and cumulative stats on the home page.

--- a/frontend/src/__tests__/DecksTutorial.test.ts
+++ b/frontend/src/__tests__/DecksTutorial.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression test for #2117 — Decks tutorial must exist and cover key sections.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const tutorial = fs.readFileSync(
+  path.join(__dirname, "../../../docs/tutorials/decks.md"),
+  "utf8",
+);
+
+const index = fs.readFileSync(
+  path.join(__dirname, "../../../docs/tutorials/index.md"),
+  "utf8",
+);
+
+describe("Decks tutorial (closes #2117)", () => {
+  it("explains how to create a deck", () => {
+    expect(tutorial).toContain("New deck");
+  });
+
+  it("covers manual deck mode", () => {
+    expect(tutorial).toContain("Manual");
+  });
+
+  it("covers smart deck mode with rules", () => {
+    expect(tutorial).toContain("Smart");
+    expect(tutorial).toContain("rule");
+  });
+
+  it("explains filtering flashcards by deck", () => {
+    expect(tutorial).toContain("Deck:");
+  });
+
+  it("explains how to add words to a deck", () => {
+    expect(tutorial).toContain("Add word");
+  });
+
+  it("is linked from the tutorial index", () => {
+    expect(index).toContain("decks.md");
+  });
+});


### PR DESCRIPTION
## What changed

- `docs/tutorials/decks.md` — new tutorial covering: opening the Decks page, creating a deck, Manual mode (adding/removing words by hand), Smart mode (rule-based with language/tag/date filters), filtering flashcards by deck, deleting a deck, and tips for effective use.
- `docs/tutorials/index.md` — added entry linking to the new tutorial.
- `frontend/src/__tests__/DecksTutorial.test.ts` — 6 regression tests verifying the tutorial covers core scenarios.

## Why

The Decks feature (`/decks`) had no tutorial. Users who wanted to organize vocabulary into subject-specific collections (e.g. "German verbs") or use smart rule-based decks had no documentation. The flashcards page's deck selector was also undocumented.

## Test plan

- All 6 `DecksTutorial` tests pass: create deck, Manual mode, Smart mode + rules, flashcard deck filter selector, Add word flow, index link
- All 536 frontend test suites pass (3247 tests)

Closes #2117
