### PR TITLE
docs(ux): add in-app search tutorial (closes #2119)

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -18,3 +18,4 @@ Step-by-step walkthroughs for the most common workflows. Tutorials are written a
 - **[Ask questions with AI Insights](ai-insights.md)** — chat sidebar that knows your chapter, with context attachment and multi-language support.
 - **[Listen with text-to-speech](tts.md)** — play any chapter aloud, control voice, speed, and seek position, and read individual sentences or paragraphs.
 - **[Customize the reading layout](typography.md)** — font size, font family, line spacing, column width, and paragraph focus — all saved automatically.
+- **[Search your notes, vocabulary, and chapters](search.md)** — find anything you've saved or read from one search bar.

--- a/docs/tutorials/search.md
+++ b/docs/tutorials/search.md
@@ -1,0 +1,38 @@
+# Search your notes, vocabulary, and chapters
+
+The search feature lets you find anything you've saved or read — annotations you wrote, vocabulary words you collected, and content from your uploaded chapters — all from one place.
+
+## Open Search
+
+Click the **search bar** in the top navigation (the magnifying-glass icon on mobile). You can also navigate directly to `/search`.
+
+The search bar appears on all pages — type your query and press **Enter** to go to the results page.
+
+## What gets searched
+
+Search runs across three types of content at once:
+
+| Section | What it includes |
+|---|---|
+| **Annotations** | Every highlight and note you saved while reading. |
+| **Vocabulary** | Every word you saved with double-click or long-press. |
+| **Chapters** | The raw text of every chapter in your uploaded books. |
+
+Results are grouped by section so you can scan each type separately.
+
+## Read the results
+
+Each result card shows a short excerpt with the matching words **highlighted in bold**. The card also shows the book title and chapter number.
+
+**To go to the matching passage**, click or tap the result card. Annotation and chapter results open the reader at the right chapter. Vocabulary results open your vocabulary list.
+
+## No-results state
+
+If your search returns no match, the page shows a "No matches for …" message with a suggestion to try a shorter or different word. Full-text search matches whole words, so searching for `walk` does not automatically match `walking` — try the stem if you get no match.
+
+## Tips
+
+- **Short queries work better than long phrases.** One or two distinctive words are usually enough.
+- **Search is case-insensitive** — `Faust` and `faust` return the same results.
+- **Annotations search includes your note text** — if you attached a note to a highlight, the note content is searchable too.
+- **New content is indexed immediately** — highlights and saved words appear in search results as soon as you save them.

--- a/frontend/src/__tests__/SearchTutorial.test.ts
+++ b/frontend/src/__tests__/SearchTutorial.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Regression test for #2119 — Search tutorial must exist and cover key sections.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const tutorial = fs.readFileSync(
+  path.join(__dirname, "../../../docs/tutorials/search.md"),
+  "utf8",
+);
+
+const index = fs.readFileSync(
+  path.join(__dirname, "../../../docs/tutorials/index.md"),
+  "utf8",
+);
+
+describe("Search tutorial (closes #2119)", () => {
+  it("explains how to access search", () => {
+    expect(tutorial).toMatch(/search bar|search icon/i);
+  });
+
+  it("covers annotations search", () => {
+    expect(tutorial).toContain("Annotations");
+  });
+
+  it("covers vocabulary search", () => {
+    expect(tutorial).toContain("Vocabulary");
+  });
+
+  it("covers chapter content search", () => {
+    expect(tutorial).toContain("Chapters");
+  });
+
+  it("explains how to navigate to a result", () => {
+    expect(tutorial).toMatch(/click|tap/i);
+  });
+
+  it("covers the no-results state", () => {
+    expect(tutorial).toMatch(/no.{0,10}result|no.{0,10}match/i);
+  });
+
+  it("is linked from the tutorial index", () => {
+    expect(index).toContain("search.md");
+  });
+});


### PR DESCRIPTION
## What changed

Added `docs/tutorials/search.md` — a how-to tutorial for the in-app full-text search feature (`/search`) that was undiscoverable for new users. Also added a Jest regression test (`SearchTutorial.test.ts`) that verifies the tutorial covers all key sections.

## Why

The search bar is a power feature accessible from the reader header, but there was no documentation explaining what it searches (annotations, vocabulary, and chapter text), how to navigate to results, or what to do when no results appear. Closes #2119.

## Test plan

- [x] `SearchTutorial.test.ts` — 7 tests verify tutorial covers: search bar access, Annotations section, Vocabulary section, Chapters section, click-to-navigate, no-results state, and index link
- [x] Full frontend suite: 3248/3248 pass
