### PR TITLE
chore(docs): document flashcard and search keyboard shortcuts in reader-interaction-design

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -191,6 +191,11 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 10.3 | Docs: vocabulary word-saving tutorial added (PR #2098, closes #2097) | ✅ Done |
 | 2026-04-29 | 10.4 | Pending approval page: 30s polling via getMe() + auto-redirect on approved=true (PR #2100, closes #2099) | ✅ Done |
 | 2026-04-29 | 10.5 | Home/library page: added `document.title` in useEffect for WCAG 2.4.2 compliance (PR #2104, closes #2103) | ✅ Done |
+| 2026-04-29 | 10.6 | Flashcards: 1/2/3/4 keyboard shortcuts for grading + Space/Enter to flip; key hints shown on grade buttons (PR #2114, closes #2113) | ✅ Done |
+| 2026-04-29 | 10.7 | Import page: `document.title` updates to book name once SSE meta event fires, WCAG 2.4.2 (PR #2116, closes #2115) | ✅ Done |
+| 2026-04-29 | 10.8 | Docs: decks tutorial added covering manual/smart modes and flashcard filtering (PR #2118, closes #2117) | ✅ Done |
+| 2026-04-29 | 10.9 | Docs: in-app search tutorial added covering annotations, vocabulary, and chapter search (PR #2120, closes #2119) | ✅ Done |
+| 2026-04-29 | 10.10 | Login page: `document.title` set to "Sign In — Book Reader AI", WCAG 2.4.2 (PR #2122, closes #2121) | ✅ Done |
 
 ---
 

--- a/docs/reader-interaction-design.md
+++ b/docs/reader-interaction-design.md
@@ -136,6 +136,8 @@ When multiple interactions are triggered simultaneously, resolve in this order:
 
 ## 6. Keyboard Shortcuts (Desktop)
 
+### Reader (`/reader/[bookId]`)
+
 | Key | Action |
 |-----|--------|
 | `←` `→` | Prev / next chapter |
@@ -143,6 +145,24 @@ When multiple interactions are triggered simultaneously, resolve in this order:
 | `Space` | Play / pause TTS |
 | `Escape` | Close open panel (AnnotationToolbar / QuickHighlightPanel / TypographyPanel) |
 | `?` | Toggle shortcuts help |
+
+### Flashcards (`/vocabulary/flashcards`)
+
+| Key | Action |
+|-----|--------|
+| `Space` / `Enter` | Flip card (show answer) |
+| `1` | Grade: Again (repeat immediately) |
+| `2` | Grade: Hard |
+| `3` | Grade: Good |
+| `4` | Grade: Easy |
+
+Keys are guarded — they do not fire when focus is inside an INPUT, SELECT, or TEXTAREA.
+
+### Global
+
+| Key | Action |
+|-----|--------|
+| `/` | Open header search bar (from any page, when not typing) |
 
 ---
 


### PR DESCRIPTION
## What changed

Updated `docs/reader-interaction-design.md` section 6 (Keyboard Shortcuts) to:
- Split the reader shortcuts into a named subsection
- Add a new **Flashcards** subsection documenting Space/Enter to flip and 1/2/3/4 grading keys (landed in PR #2114)
- Add a **Global** subsection documenting the `/` key to open search (landed in PR #2046)

## Why

New interaction patterns must be noted in `reader-interaction-design.md` per the UI/UX docs policy in CLAUDE.md. This was deferred from PR #2114.

## Test plan

- [x] Docs-only change — no code modified
