### PR TITLE
docs(ux): add / keyboard shortcut to search tutorial

### DIFF
--- a/docs/tutorials/search.md
+++ b/docs/tutorials/search.md
@@ -6,6 +6,8 @@ The search feature lets you find anything you've saved or read — annotations y
 
 Click the **search bar** in the top navigation (the magnifying-glass icon on mobile). You can also navigate directly to `/search`.
 
+**Keyboard shortcut:** Press `/` from any page (when you're not already typing) to jump directly to the search bar. Press **Escape** to close it without searching.
+
 The search bar appears on all pages — type your query and press **Enter** to go to the results page.
 
 ## What gets searched

--- a/frontend/src/__tests__/SearchTutorial.test.ts
+++ b/frontend/src/__tests__/SearchTutorial.test.ts
@@ -39,6 +39,10 @@ describe("Search tutorial (closes #2119)", () => {
     expect(tutorial).toMatch(/no.{0,10}result|no.{0,10}match/i);
   });
 
+  it("documents the / keyboard shortcut", () => {
+    expect(tutorial).toMatch(/keyboard shortcut|press.*\//i);
+  });
+
   it("is linked from the tutorial index", () => {
     expect(index).toContain("search.md");
   });


### PR DESCRIPTION
## What changed

Added the `/` keyboard shortcut and `Escape` to dismiss to the search tutorial (`docs/tutorials/search.md`). Also added a regression test assertion verifying the shortcut is documented.

## Why

The search tutorial (PR #2120) covered how to click the search icon and navigate to results, but omitted the `/` global keyboard shortcut that opens search from any page. This is the primary power-user path to search and its absence from the tutorial was a discoverability gap.

## Test plan

- [x] `SearchTutorial.test.ts` — 8 tests pass including new assertion for keyboard shortcut text
- [x] Full frontend suite: 3255/3255 pass
