### PR TITLE
fix(ux): fix WCAG AA contrast on pending page hint text (closes #2128)

### DIFF
--- a/frontend/src/__tests__/PendingPageContrast.test.tsx
+++ b/frontend/src/__tests__/PendingPageContrast.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * Regression test for #2128 — pending page hint text must not use
+ * text-stone-400 (contrast ~2.1:1 on parchment — fails WCAG AA).
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("next-auth/react", () => ({
+  signOut: jest.fn(),
+}));
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+jest.mock("@/lib/api", () => ({
+  getMe: jest.fn(() => new Promise(() => {})),
+}));
+
+import PendingApprovalPage from "@/app/pending/page";
+
+test("hint text does not use text-stone-400 (WCAG AA contrast failure)", () => {
+  const { container } = render(<PendingApprovalPage />);
+  const hint = screen.getByText(/checking automatically/i);
+  expect(hint.className).not.toContain("text-stone-400");
+});
+
+test("hint text uses a color class with sufficient contrast", () => {
+  render(<PendingApprovalPage />);
+  const hint = screen.getByText(/checking automatically/i);
+  // stone-500 (3.88:1 on white) or darker passes WCAG AA for supplementary text
+  // stone-600 (~6.6:1 on parchment) is the preferred choice
+  expect(hint.className).toMatch(/text-stone-[5-9]00|text-amber-[7-9]00|text-ink/);
+});

--- a/frontend/src/app/pending/page.tsx
+++ b/frontend/src/app/pending/page.tsx
@@ -35,7 +35,7 @@ export default function PendingApprovalPage() {
           Your account is waiting for admin approval. You&apos;ll be able to use the
           app once an administrator approves your account.
         </p>
-        <p className="text-xs text-stone-400 mb-4">Checking automatically every 30 seconds…</p>
+        <p className="text-xs text-stone-600 mb-4">Checking automatically every 30 seconds…</p>
         <button
           onClick={() => signOut({ callbackUrl: "/login" })}
           className="text-sm text-red-600 hover:text-red-800 min-h-[44px] flex items-center justify-center mx-auto"


### PR DESCRIPTION
## What changed

Changed `text-stone-400` → `text-stone-600` on the hint text "Checking automatically every 30 seconds…" on the pending approval page (`/pending`).

## Why

Stone-400 (#a8a29e) on the parchment background (#f5f0e8) yields ~2.1:1 contrast ratio — well below WCAG AA's 4.5:1 requirement for `text-xs` (12px) normal text.

Stone-600 (#57534e) on parchment yields ~6.6:1, passing WCAG AAA. All other `text-stone-400` instances in the codebase are decorative elements with `aria-hidden="true"` and are not affected.

## Test plan

- [ ] `PendingPageContrast.test.tsx` — 2 new tests verify the hint does not use `text-stone-400` and uses a class with sufficient contrast
- [ ] Full suite: 3259/3259 pass

Closes #2128
