### PR TITLE
fix(ux): responsive touch targets in TypographyPanel (closes #2130)

### DIFF
--- a/frontend/src/__tests__/TypographyPanelResponsiveTouchTarget.test.tsx
+++ b/frontend/src/__tests__/TypographyPanelResponsiveTouchTarget.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Regression test for #2130 — TypographyPanel segmented controls must use
+ * min-h-[44px] md:min-h-0 so desktop chrome stays compact.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import TypographyPanel from "@/components/TypographyPanel";
+import type { FontSize, LineHeight, ContentWidth, FontFamily } from "@/lib/settings";
+
+jest.mock("@/lib/settings", () => ({
+  saveSettings: jest.fn(),
+}));
+
+const DEFAULT_PROPS = {
+  fontSize: "base" as FontSize,
+  lineHeight: "normal" as LineHeight,
+  contentWidth: "normal" as ContentWidth,
+  fontFamily: "serif" as FontFamily,
+  paragraphFocus: false,
+  onFontSize: jest.fn(),
+  onLineHeight: jest.fn(),
+  onContentWidth: jest.fn(),
+  onFontFamily: jest.fn(),
+  onParagraphFocus: jest.fn(),
+  onClose: jest.fn(),
+};
+
+test("SegmentedControl buttons include md:min-h-0 for compact desktop size", () => {
+  const { container } = render(<TypographyPanel {...DEFAULT_PROPS} />);
+  const segmentBtns = Array.from(container.querySelectorAll("button")).filter(
+    (btn) => btn.classList.contains("flex-1") && !btn.hasAttribute("role"),
+  );
+  expect(segmentBtns.length).toBeGreaterThan(0);
+  segmentBtns.forEach((btn) => {
+    expect(btn.className).toContain("md:min-h-0");
+  });
+});
+
+test("paragraph focus toggle includes md:min-h-0 and md:min-w-0", () => {
+  render(<TypographyPanel {...DEFAULT_PROPS} />);
+  const toggle = screen.getByRole("switch", { name: /paragraph focus/i });
+  expect(toggle.className).toContain("md:min-h-0");
+  expect(toggle.className).toContain("md:min-w-0");
+});

--- a/frontend/src/components/TypographyPanel.tsx
+++ b/frontend/src/components/TypographyPanel.tsx
@@ -62,7 +62,7 @@ function SegmentedControl<T extends string>({
           key={opt.value}
           onClick={() => onChange(opt.value)}
           aria-pressed={value === opt.value}
-          className={`flex-1 px-2 py-1.5 min-h-[44px] text-xs font-medium transition-colors flex items-center justify-center ${
+          className={`flex-1 px-2 py-1.5 min-h-[44px] md:min-h-0 text-xs font-medium transition-colors flex items-center justify-center ${
             value === opt.value
               ? "bg-amber-700 text-white"
               : "bg-white text-amber-700 hover:bg-amber-50"
@@ -176,7 +176,7 @@ export default function TypographyPanel({
               onParagraphFocus(next);
               saveSettings({ paragraphFocus: next });
             }}
-            className="min-h-[44px] min-w-[44px] flex items-center justify-center -mr-1.5"
+            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center -mr-1.5"
             role="switch"
             aria-label="Paragraph focus"
             aria-checked={paragraphFocus}


### PR DESCRIPTION
## What changed

`TypographyPanel`'s `SegmentedControl` buttons and the paragraph-focus toggle now use `min-h-[44px] md:min-h-0` (and `min-w-[44px] md:min-w-0` for the square toggle) instead of unconditional `min-h-[44px]`.

## Why

CLAUDE.md graphic design rules require `min-h-[44px] md:min-h-0` for elements visible on both mobile and desktop so desktop chrome stays compact. Without `md:min-h-0`, each button row was forced to 44px on desktop, making the panel ~80px taller than needed.

## Test plan

- [x] New regression test `TypographyPanelResponsiveTouchTarget.test.tsx` asserts `md:min-h-0` on SegmentedControl buttons and toggle
- [x] Existing `TypographyPanelTouchTarget.test.tsx` still asserts `min-h-[44px]` present (mobile targets still enforced)
- [x] Full frontend suite: 3263 tests pass

Closes #2130
