### PR TITLE
fix(ux): responsive touch targets on home page header and search pills (closes #2132)

### DIFF
--- a/frontend/src/__tests__/HomeResponsiveTouchTargets.test.ts
+++ b/frontend/src/__tests__/HomeResponsiveTouchTargets.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Regression test for #2132 — home page interactive elements that have
+ * explicit responsive desktop sizing must also include md:min-h-0 so the
+ * mobile 44px touch target doesn't override the desktop size.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/page.tsx"),
+  "utf8",
+);
+
+test("sign-in button: md:py-1.5 desktop padding paired with md:min-h-0", () => {
+  // The button has md:py-1.5 to be compact on desktop.
+  // It must also have md:min-h-0 or the min-h-[44px] overrides the padding.
+  expect(src).toContain("md:py-1.5");
+  // Find the className containing md:py-1.5 and verify md:min-h-0 is present
+  const match = src.match(/className="[^"]*md:py-1\.5[^"]*"/);
+  expect(match).not.toBeNull();
+  expect(match![0]).toContain("md:min-h-0");
+});
+
+test("profile avatar: md:w-9 md:h-9 desktop sizing paired with md:min-h-0 md:min-w-0", () => {
+  // The avatar has md:w-9 md:h-9 to be 36px square on desktop.
+  // Without md:min-h-0, the min-h-[44px] makes it non-square (44px × 36px).
+  const match = src.match(/className="[^"]*md:w-9 md:h-9[^"]*"/);
+  expect(match).not.toBeNull();
+  expect(match![0]).toContain("md:min-h-0");
+  expect(match![0]).toContain("md:min-w-0");
+});
+
+test("Gutenberg quick-search pills include md:min-h-0 for compact desktop pills", () => {
+  // Pills styled with text-xs py-1 should be compact on desktop.
+  const match = src.match(/className="[^"]*text-xs rounded-full border border-amber-300 px-3 py-1[^"]*"/);
+  expect(match).not.toBeNull();
+  expect(match![0]).toContain("md:min-h-0");
+});
+
+test("popular-books category filter tags include md:min-h-0", () => {
+  // Category tag pills with text-xs py-1 should also be compact on desktop.
+  const match = src.match(/`[^`]*text-xs rounded-full px-3 py-1 min-h-\[44px\][^`]*`/);
+  expect(match).not.toBeNull();
+  expect(match![0]).toContain("md:min-h-0");
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -191,7 +191,7 @@ export default function Home() {
             {status === "unauthenticated" ? (
               <button
                 onClick={() => router.push("/login")}
-                className="rounded-lg border border-amber-300 px-4 py-2.5 md:py-1.5 text-sm font-medium text-amber-700 hover:bg-amber-50 transition-colors min-h-[44px]"
+                className="rounded-lg border border-amber-300 px-4 py-2.5 md:py-1.5 text-sm font-medium text-amber-700 hover:bg-amber-50 transition-colors min-h-[44px] md:min-h-0"
               >
                 Sign in
               </button>
@@ -200,7 +200,7 @@ export default function Home() {
                 onClick={() => router.push("/profile")}
                 title={session?.backendUser?.name ?? "Profile & Settings"}
                 aria-label={session?.backendUser?.name ?? "Profile & Settings"}
-                className="min-w-[44px] min-h-[44px] w-11 h-11 md:w-9 md:h-9 rounded-full overflow-hidden border border-amber-200 hover:border-amber-400 transition-colors"
+                className="min-w-[44px] md:min-w-0 min-h-[44px] md:min-h-0 w-11 h-11 md:w-9 md:h-9 rounded-full overflow-hidden border border-amber-200 hover:border-amber-400 transition-colors"
               >
                 {session?.backendUser?.picture ? (
                   // eslint-disable-next-line @next/next/no-img-element
@@ -621,7 +621,7 @@ export default function Home() {
                 {FEATURED.map((f) => (
                   <button
                     key={f.query}
-                    className="text-xs rounded-full border border-amber-300 px-3 py-1 min-h-[44px] text-amber-800 hover:bg-amber-100 transition-colors"
+                    className="text-xs rounded-full border border-amber-300 px-3 py-1 min-h-[44px] md:min-h-0 text-amber-800 hover:bg-amber-100 transition-colors"
                     onClick={() => { setQuery(f.query); setLang(f.lang); handleSearch(f.query, f.lang); }}
                     disabled={searching}
                   >
@@ -691,7 +691,7 @@ export default function Home() {
                         key={l.code}
                         onClick={() => handlePopularLangChange(l.code)}
                         aria-pressed={popularLang === l.code}
-                        className={`text-xs rounded-full px-3 py-1 min-h-[44px] border transition-colors ${
+                        className={`text-xs rounded-full px-3 py-1 min-h-[44px] md:min-h-0 border transition-colors ${
                           popularLang === l.code
                             ? "bg-amber-700 text-white border-amber-700"
                             : "border-amber-300 text-amber-700 hover:bg-amber-50"


### PR DESCRIPTION
## What changed

Four interactive elements on the home page that already had responsive desktop sizing were missing `md:min-h-0`, so the mobile 44px touch target silently overrode their desktop size:

| Element | Had | Missing |
|---|---|---|
| Sign-in button | `md:py-1.5` | `md:min-h-0` |
| Profile avatar | `md:w-9 md:h-9` | `md:min-h-0 md:min-w-0` |
| Gutenberg quick-search pills | `text-xs py-1` | `md:min-h-0` |
| Popular-books language filter pills | `text-xs py-1` | `md:min-h-0` |

## Why

CLAUDE.md graphic design rules require `min-h-[44px] md:min-h-0` for elements visible on both mobile and desktop. Without `md:min-h-0`, the profile avatar was non-square on desktop (44px tall × 36px wide) and the sign-in button ignored its own `md:py-1.5` compact padding.

## Test plan

- [x] New regression test `HomeResponsiveTouchTargets.test.ts` asserts all four elements have `md:min-h-0`
- [x] Full frontend suite: 3265 tests pass

Closes #2132
