### PR TITLE
fix(ux): show error alert when vocabulary word delete fails (closes #2134)

### DIFF
--- a/frontend/src/__tests__/VocabDeleteError.test.tsx
+++ b/frontend/src/__tests__/VocabDeleteError.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * Regression test for #2134 — silent error in vocabulary delete.
+ * When deleteVocabularyWord throws, the user must see an error message
+ * with role="alert" (not a silent catch-and-ignore).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8",
+);
+
+test("handleDelete catch block sets an error state instead of silently ignoring", () => {
+  // The catch block must not be a no-op comment — it should call a setter
+  const catchIdx = src.indexOf("async function handleDelete");
+  expect(catchIdx).toBeGreaterThan(-1);
+  const fnSrc = src.slice(catchIdx, catchIdx + 400);
+  // Must NOT contain bare "// ignore" with nothing else in the catch block
+  expect(fnSrc).not.toMatch(/catch\s*\{[\s\n]*\/\/ ignore[\s\n]*\}/);
+  // Must contain a setState call in the catch block
+  expect(fnSrc).toMatch(/catch[\s\S]{0,60}set[A-Z][a-zA-Z]+\(/);
+});
+
+test("vocabulary page has a role=alert element for delete errors", () => {
+  expect(src).toMatch(/role="alert"/);
+  // The alert must be connected to a delete-related error state (not just fetchError)
+  const alertIdx = src.search(/role="alert"[^>]*>[^<]*deleteError/);
+  // Also accept the JSX pattern where deleteError is rendered inside the alert div
+  const hasDeleteErrorAlert =
+    alertIdx > -1 ||
+    (() => {
+      // Find all role="alert" occurrences and check if deleteError is nearby
+      let i = 0;
+      while (i < src.length) {
+        const found = src.indexOf('role="alert"', i);
+        if (found === -1) break;
+        const region = src.slice(found, found + 200);
+        if (region.includes("deleteError")) return true;
+        i = found + 1;
+      }
+      return false;
+    })();
+  expect(hasDeleteErrorAlert).toBe(true);
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -229,6 +229,7 @@ function VocabularyPageContent() {
   const [exportMsg, setExportMsg] = useState<string | null>(null);
   const [exporting, setExporting] = useState(false);
   const [deleting, setDeleting] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [sortMode, setSortMode] = useState<SortMode>("alpha");
   const [activeWord, setActiveWord] = useState<{ word: string; lang: string | null } | null>(null);
@@ -322,12 +323,13 @@ function VocabularyPageContent() {
   }, [targetWord, loading]);
 
   async function handleDelete(word: string) {
+    setDeleteError(null);
     setDeleting(word);
     try {
       await deleteVocabularyWord(word);
       setWords((prev) => prev.filter((w) => w.word !== word));
     } catch {
-      // ignore
+      setDeleteError("Failed to delete. Please try again.");
     } finally {
       setDeleting(null);
     }
@@ -480,6 +482,14 @@ function VocabularyPageContent() {
           {exporting ? "Exporting…" : (<><ArrowUpRightIcon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" /><span className="hidden sm:inline">Export all to Obsidian</span><span className="sm:hidden">Export</span></>)}
         </button>
       </header>
+
+      {deleteError && (
+        <div role="alert" aria-atomic="true" className="mx-6 mt-4">
+          <div className="border border-red-300 bg-red-50 rounded-xl px-4 py-3 text-sm text-red-700">
+            {deleteError}
+          </div>
+        </div>
+      )}
 
       <div role="status" aria-live="polite" aria-atomic="true" className="mx-6 mt-4">
         {exportMsg && (


### PR DESCRIPTION
## What changed
- `handleDelete` in `frontend/src/app/vocabulary/page.tsx` previously had `catch { // ignore }` — delete failures were invisible to the user.
- Now sets `deleteError` state in the catch block and renders a `role="alert"` banner so both sighted users and screen readers see the failure.
- Clears `deleteError` at the start of each new delete attempt.

## Why
Silent error handling on a destructive action (word deletion) is a UX violation — users have no way to know the delete failed and may retry or assume success incorrectly.

## Test plan
- New regression test `VocabDeleteError.test.tsx` (static file analysis):
  1. Asserts `handleDelete` catch block is not a bare `// ignore` no-op
  2. Asserts a `role="alert"` element exists that renders `deleteError`
- Full frontend suite: 3265 tests pass

Closes #2134
