### PR TITLE
fix(ux): responsive touch-target resets for remaining 11 pages/components (closes #2140)

### DIFF
--- a/frontend/src/__tests__/InsightChatSendCloseTouchTargets.test.ts
+++ b/frontend/src/__tests__/InsightChatSendCloseTouchTargets.test.ts
@@ -23,13 +23,13 @@ describe("InsightChat send/close touch targets (closes #847)", () => {
   it("send button has min-h-[44px]", () => {
     const idx = src.indexOf("Send (Enter)");
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(Math.max(0, idx - 200), idx + 20);
+    const window = src.slice(Math.max(0, idx - 400), idx + 20);
     expect(window).toContain("min-h-[44px]");
   });
 
   it("send button has min-w-[44px]", () => {
     const idx = src.indexOf("Send (Enter)");
-    const window = src.slice(Math.max(0, idx - 200), idx + 20);
+    const window = src.slice(Math.max(0, idx - 400), idx + 20);
     expect(window).toContain("min-w-[44px]");
   });
 

--- a/frontend/src/__tests__/RemainingTouchTargets.test.ts
+++ b/frontend/src/__tests__/RemainingTouchTargets.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression test for #2140 — all remaining pages and components must pair
+ * min-h-[44px] with md:min-h-0 (and min-w-[44px] with md:min-w-0).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const SRC = path.join(__dirname, "..");
+
+function readFile(rel: string) {
+  return fs.readFileSync(path.join(SRC, rel), "utf8");
+}
+
+function checkFile(rel: string, label: string) {
+  const src = readFile(rel);
+
+  const doubleH = Array.from(src.matchAll(/className="([^"]*)"/g), (m) => m[1]).filter(
+    (cls) => cls.includes("min-h-[44px]"),
+  );
+  const tmplH = Array.from(src.matchAll(/className=\{`([^`]*)`\}/gs), (m) => m[1]).filter(
+    (cls) => cls.includes("min-h-[44px]"),
+  );
+  for (const cls of [...doubleH, ...tmplH]) {
+    const ok = cls.includes("md:min-h-0") || cls.includes("lg:min-h-0");
+    if (!ok) {
+      throw new Error(
+        `${label}: found min-h-[44px] without md:min-h-0 in className:\n  ${cls.slice(0, 120)}`,
+      );
+    }
+  }
+
+  const doubleW = Array.from(src.matchAll(/className="([^"]*)"/g), (m) => m[1]).filter(
+    (cls) => cls.includes("min-w-[44px]"),
+  );
+  const tmplW = Array.from(src.matchAll(/className=\{`([^`]*)`\}/gs), (m) => m[1]).filter(
+    (cls) => cls.includes("min-w-[44px]"),
+  );
+  for (const cls of [...doubleW, ...tmplW]) {
+    const ok = cls.includes("md:min-w-0") || cls.includes("lg:min-w-0");
+    if (!ok) {
+      throw new Error(
+        `${label}: found min-w-[44px] without md:min-w-0 in className:\n  ${cls.slice(0, 120)}`,
+      );
+    }
+  }
+}
+
+const FILES: [string, string][] = [
+  ["app/vocabulary/page.tsx", "VocabularyPage"],
+  ["app/notes/page.tsx", "NotesPage"],
+  ["app/notes/[bookId]/page.tsx", "NotesDetailPage"],
+  ["app/search/page.tsx", "SearchPage"],
+  ["app/profile/page.tsx", "ProfilePage"],
+  ["app/decks/page.tsx", "DecksPage"],
+  ["app/decks/new/page.tsx", "DecksNewPage"],
+  ["components/SentenceReader.tsx", "SentenceReader"],
+  ["components/BookCard.tsx", "BookCard"],
+  ["components/InsightChat.tsx", "InsightChat"],
+  ["components/TagEditor.tsx", "TagEditor"],
+];
+
+for (const [rel, label] of FILES) {
+  test(`${label}: every min-h-[44px] paired with md:min-h-0, every min-w-[44px] with md:min-w-0`, () => {
+    checkFile(rel, label);
+  });
+}

--- a/frontend/src/__tests__/VocabularyDefinitionSheetClose.test.ts
+++ b/frontend/src/__tests__/VocabularyDefinitionSheetClose.test.ts
@@ -13,7 +13,7 @@ describe("VocabularyPage DefinitionSheet accessibility (WCAG 2.1.1)", () => {
   });
 
   it("close button uses CloseIcon", () => {
-    const closeButtonBlock = vocab.match(/aria-label="Close definition"[\s\S]{0,200}CloseIcon|CloseIcon[\s\S]{0,200}aria-label="Close definition"/);
+    const closeButtonBlock = vocab.match(/aria-label="Close definition"[\s\S]{0,300}CloseIcon|CloseIcon[\s\S]{0,300}aria-label="Close definition"/);
     expect(closeButtonBlock).not.toBeNull();
   });
 });

--- a/frontend/src/app/decks/new/page.tsx
+++ b/frontend/src/app/decks/new/page.tsx
@@ -76,7 +76,7 @@ export default function DecksNewPage() {
       <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
         <button
           onClick={() => router.push("/decks")}
-          className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] flex items-center"
+          className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] md:min-h-0 flex items-center"
         >
           <ArrowLeftIcon className="w-4 h-4 shrink-0" /> Decks
         </button>
@@ -279,7 +279,7 @@ export default function DecksNewPage() {
               type="submit"
               disabled={submitting}
               data-testid="deck-submit-btn"
-              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] disabled:opacity-50"
+              className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 disabled:opacity-50"
             >
               <DeckIcon className="w-4 h-4" />
               {submitting ? "Creating…" : "Create deck"}
@@ -287,7 +287,7 @@ export default function DecksNewPage() {
             <button
               type="button"
               onClick={() => router.push("/decks")}
-              className="text-sm text-amber-700 hover:text-amber-900 min-h-[44px] px-3"
+              className="text-sm text-amber-700 hover:text-amber-900 min-h-[44px] md:min-h-0 px-3"
             >
               Cancel
             </button>

--- a/frontend/src/app/decks/page.tsx
+++ b/frontend/src/app/decks/page.tsx
@@ -62,7 +62,7 @@ export default function DecksPage() {
       <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
         <button
           onClick={() => router.push("/")}
-          className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] flex items-center"
+          className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] md:min-h-0 flex items-center"
         >
           <ArrowLeftIcon className="w-4 h-4 shrink-0" /> Library
         </button>
@@ -106,7 +106,7 @@ export default function DecksPage() {
             <button
               type="button"
               onClick={loadDecks}
-              className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px]"
+              className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
             >
               <RetryIcon className="w-4 h-4" aria-hidden="true" />
               Try again
@@ -127,7 +127,7 @@ export default function DecksPage() {
               type="button"
               onClick={() => router.push("/decks/new")}
               data-testid="decks-empty-new-btn"
-              className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px]"
+              className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
             >
               <DeckIcon className="w-4 h-4" />
               New deck

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -45,7 +45,7 @@ function CollapseHeading({
       <button
         onClick={onToggle}
         aria-expanded={!isCollapsed}
-        className={`w-full flex items-center gap-2 text-left group min-h-[44px] ${
+        className={`w-full flex items-center gap-2 text-left group min-h-[44px] md:min-h-0 ${
           level === 2 ? "pb-1.5 border-b border-amber-200" : ""
         }`}
       >
@@ -113,13 +113,13 @@ function AnnotationCard({
           <div className="flex gap-2">
             <button
               onClick={onSave}
-              className="px-3 py-1 text-xs bg-amber-700 text-white rounded-lg hover:bg-amber-800 transition-colors min-h-[44px]"
+              className="px-3 py-1 text-xs bg-amber-700 text-white rounded-lg hover:bg-amber-800 transition-colors min-h-[44px] md:min-h-0"
             >
               Save
             </button>
             <button
               onClick={onCancel}
-              className="px-3 py-1 text-xs text-stone-500 hover:text-stone-700 transition-colors min-h-[44px]"
+              className="px-3 py-1 text-xs text-stone-500 hover:text-stone-700 transition-colors min-h-[44px] md:min-h-0"
             >
               Cancel
             </button>
@@ -141,7 +141,7 @@ function AnnotationCard({
           </a>
           <button
             onClick={onEdit}
-            className="text-stone-500 hover:text-stone-700 transition-colors p-1 min-h-[44px] flex items-center justify-center"
+            className="text-stone-500 hover:text-stone-700 transition-colors p-1 min-h-[44px] md:min-h-0 flex items-center justify-center"
             title="Edit note"
             aria-label={`Edit annotation: ${ann.sentence_text.slice(0, 60)}`}
           >
@@ -151,7 +151,7 @@ function AnnotationCard({
             onClick={onDelete}
             disabled={isDeleting}
             aria-busy={isDeleting}
-            className="text-red-500 hover:text-red-600 disabled:opacity-40 transition-colors p-1 min-h-[44px] flex items-center justify-center"
+            className="text-red-500 hover:text-red-600 disabled:opacity-40 transition-colors p-1 min-h-[44px] md:min-h-0 flex items-center justify-center"
             title="Delete annotation"
             aria-label={isDeleting ? "Deleting annotation…" : `Delete annotation: ${ann.sentence_text.slice(0, 60)}`}
           >
@@ -204,7 +204,7 @@ function InsightCard({
           onClick={onDelete}
           disabled={isDeleting}
           aria-busy={isDeleting}
-          className="text-red-500 hover:text-red-600 disabled:opacity-40 transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
+          className="text-red-500 hover:text-red-600 disabled:opacity-40 transition-colors min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center"
           title="Delete insight"
           aria-label={isDeleting ? "Deleting insight…" : `Delete insight: ${ins.question.slice(0, 60)}`}
         >
@@ -659,7 +659,7 @@ export default function BookNotesPage() {
         <div className="max-w-3xl mx-auto flex items-center gap-3 flex-wrap">
           <button
             onClick={() => router.push("/notes")}
-            className="text-amber-700 hover:text-amber-900 text-sm font-medium shrink-0 min-h-[44px] flex items-center"
+            className="text-amber-700 hover:text-amber-900 text-sm font-medium shrink-0 min-h-[44px] md:min-h-0 flex items-center"
           >
             <ArrowLeftIcon className="w-3.5 h-3.5 mr-1 inline" aria-hidden="true" />Notes
           </button>
@@ -675,7 +675,7 @@ export default function BookNotesPage() {
             <button
               onClick={toggleCollapseAll}
               aria-expanded={!isAllCollapsed}
-              className="text-xs text-stone-500 hover:text-stone-600 shrink-0 transition-colors min-h-[44px]"
+              className="text-xs text-stone-500 hover:text-stone-600 shrink-0 transition-colors min-h-[44px] md:min-h-0"
             >
               {isAllCollapsed ? "Expand all" : "Collapse all"}
             </button>
@@ -688,7 +688,7 @@ export default function BookNotesPage() {
                 key={m}
                 onClick={() => setViewMode(m)}
                 aria-pressed={viewMode === m}
-                className={`px-3 py-1.5 min-h-[44px] transition-colors ${
+                className={`px-3 py-1.5 min-h-[44px] md:min-h-0 transition-colors ${
                   viewMode === m
                     ? "bg-amber-700 text-white"
                     : "text-amber-700 hover:bg-amber-50"
@@ -703,7 +703,7 @@ export default function BookNotesPage() {
           <button
             onClick={handleExport}
             disabled={exporting}
-            className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 min-h-[44px] rounded-lg bg-amber-700 text-white text-xs font-medium hover:bg-amber-800 disabled:opacity-50 transition-colors"
+            className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 min-h-[44px] md:min-h-0 rounded-lg bg-amber-700 text-white text-xs font-medium hover:bg-amber-800 disabled:opacity-50 transition-colors"
           >
             {exporting ? "Exporting…" : <><ArrowUpRightIcon className="w-3.5 h-3.5 inline" aria-hidden="true" /> Export</>}
           </button>
@@ -736,7 +736,7 @@ export default function BookNotesPage() {
             <button
               type="button"
               onClick={loadData}
-              className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px]"
+              className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
             >
               <RetryIcon className="w-4 h-4" aria-hidden="true" />
               Try again
@@ -749,7 +749,7 @@ export default function BookNotesPage() {
             <p className="text-sm">Annotate sentences, save AI insights, or add words to vocabulary while reading.</p>
             <button
               onClick={() => router.push(`/reader/${bookId}`)}
-              className="mt-4 px-5 py-2 min-h-[44px] rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 inline-flex items-center gap-1"
+              className="mt-4 px-5 py-2 min-h-[44px] md:min-h-0 rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 inline-flex items-center gap-1"
             >
               Open reader <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
             </button>

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -113,7 +113,7 @@ export default function NotesOverviewPage() {
         <div className="max-w-3xl mx-auto flex items-center gap-4">
           <button
             onClick={() => router.push("/")}
-            className="text-amber-700 hover:text-amber-900 text-sm font-medium shrink-0 min-h-[44px] flex items-center"
+            className="text-amber-700 hover:text-amber-900 text-sm font-medium shrink-0 min-h-[44px] md:min-h-0 flex items-center"
           >
             <ArrowLeftIcon className="w-3.5 h-3.5 mr-1 inline" aria-hidden="true" />Library
           </button>
@@ -166,7 +166,7 @@ export default function NotesOverviewPage() {
             <button
               type="button"
               onClick={loadNotes}
-              className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px]"
+              className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
             >
               <RetryIcon className="w-4 h-4" aria-hidden="true" />
               Try again
@@ -182,7 +182,7 @@ export default function NotesOverviewPage() {
                 <button
                   type="button"
                   onClick={() => router.push("/")}
-                  className="mt-5 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px]"
+                  className="mt-5 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
                 >
                   Browse books <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
                 </button>
@@ -194,7 +194,7 @@ export default function NotesOverviewPage() {
                 <button
                   type="button"
                   onClick={() => setSearch("")}
-                  className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px]"
+                  className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
                 >
                   Clear search
                 </button>

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -197,7 +197,7 @@ export default function ProfilePage() {
       <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-6 py-4 flex items-center gap-4">
         <button
           onClick={() => router.push("/")}
-          className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] flex items-center"
+          className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] md:min-h-0 flex items-center"
         >
           <ArrowLeftIcon className="w-3.5 h-3.5 mr-1 inline" aria-hidden="true" />Library
         </button>
@@ -225,14 +225,14 @@ export default function ProfilePage() {
           <div className="mt-6 flex items-center gap-4">
             <button
               onClick={() => signOut({ callbackUrl: "/login" })}
-              className="text-sm text-red-600 hover:text-red-800 min-h-[44px] flex items-center"
+              className="text-sm text-red-600 hover:text-red-800 min-h-[44px] md:min-h-0 flex items-center"
             >
               Sign out
             </button>
             {isAdmin && (
               <button
                 onClick={() => router.push("/admin")}
-                className="text-sm text-amber-700 hover:text-amber-900 underline min-h-[44px] flex items-center"
+                className="text-sm text-amber-700 hover:text-amber-900 underline min-h-[44px] md:min-h-0 flex items-center"
               >
                 Admin Panel
               </button>
@@ -249,8 +249,8 @@ export default function ProfilePage() {
           >
             <div className="animate-pulse space-y-3" aria-hidden="true">
               <div className="h-5 w-32 bg-amber-100 rounded" />
-              <div className="h-12 bg-amber-100 rounded-xl min-h-[44px]" />
-              <div className="h-12 bg-amber-100 rounded-xl min-h-[44px]" />
+              <div className="h-12 bg-amber-100 rounded-xl min-h-[44px] md:min-h-0" />
+              <div className="h-12 bg-amber-100 rounded-xl min-h-[44px] md:min-h-0" />
             </div>
           </section>
         ) : dueDecks.length > 0 ? (
@@ -263,7 +263,7 @@ export default function ProfilePage() {
                     type="button"
                     onClick={() => gotoFlashcardsForDeck(d.id)}
                     aria-label={`Review ${d.due_today} due card${d.due_today !== 1 ? "s" : ""} in ${d.name}`}
-                    className="w-full flex items-center gap-3 rounded-xl border border-amber-200 bg-white px-4 py-2 hover:border-amber-400 hover:bg-amber-50 transition-colors min-h-[44px]"
+                    className="w-full flex items-center gap-3 rounded-xl border border-amber-200 bg-white px-4 py-2 hover:border-amber-400 hover:bg-amber-50 transition-colors min-h-[44px] md:min-h-0"
                   >
                     <DeckIcon className="w-4 h-4 text-amber-700 shrink-0" />
                     <span className="font-serif text-ink truncate flex-1 min-w-0 text-left">
@@ -311,7 +311,7 @@ export default function ProfilePage() {
               <button
                 onClick={handleRemoveKey}
                 disabled={removingKey}
-                className="text-sm text-red-600 hover:text-red-800 disabled:opacity-50 min-h-[44px] flex items-center"
+                className="text-sm text-red-600 hover:text-red-800 disabled:opacity-50 min-h-[44px] md:min-h-0 flex items-center"
               >
                 {removingKey ? "Removing…" : "Remove key"}
               </button>
@@ -331,7 +331,7 @@ export default function ProfilePage() {
               <button
                 onClick={handleSaveKey}
                 disabled={savingKey || !keyInput.trim()}
-                className="rounded-lg bg-amber-700 text-white px-5 py-2 min-h-[44px] text-sm hover:bg-amber-800 disabled:opacity-50 transition-colors"
+                className="rounded-lg bg-amber-700 text-white px-5 py-2 min-h-[44px] md:min-h-0 text-sm hover:bg-amber-800 disabled:opacity-50 transition-colors"
               >
                 {savingKey ? "Saving…" : "Save key"}
               </button>
@@ -385,7 +385,7 @@ export default function ProfilePage() {
                       <button
                         onClick={handleRemoveObsidianToken}
                         disabled={obsidianSaving}
-                        className="text-xs text-red-600 hover:text-red-700 underline disabled:opacity-50 min-h-[44px] inline-flex items-center"
+                        className="text-xs text-red-600 hover:text-red-700 underline disabled:opacity-50 min-h-[44px] md:min-h-0 inline-flex items-center"
                       >
                         Remove
                       </button>
@@ -436,7 +436,7 @@ export default function ProfilePage() {
               <button
                 onClick={handleSaveObsidian}
                 disabled={obsidianSaving}
-                className="rounded-lg bg-amber-700 text-white px-5 py-2 min-h-[44px] text-sm hover:bg-amber-800 disabled:opacity-50 transition-colors"
+                className="rounded-lg bg-amber-700 text-white px-5 py-2 min-h-[44px] md:min-h-0 text-sm hover:bg-amber-800 disabled:opacity-50 transition-colors"
               >
                 {obsidianSaving ? "Saving…" : "Save Obsidian settings"}
               </button>
@@ -574,7 +574,7 @@ export default function ProfilePage() {
           </div>
           <button
             onClick={savePreferences}
-            className={`w-full rounded-lg py-2.5 min-h-[44px] text-sm font-medium transition-colors ${
+            className={`w-full rounded-lg py-2.5 min-h-[44px] md:min-h-0 text-sm font-medium transition-colors ${
               prefsSaved
                 ? "bg-green-600 text-white"
                 : "bg-amber-700 text-white hover:bg-amber-800"

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -157,7 +157,7 @@ function SearchResultsInner() {
           <p className="text-sm mt-2">Start typing in the search bar above.</p>
           <Link
             href="/"
-            className="mt-5 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px]"
+            className="mt-5 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
           >
             Browse books <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
           </Link>
@@ -187,7 +187,7 @@ function SearchResultsInner() {
           <p className="text-sm mt-2">Try a shorter or different word.</p>
           <Link
             href="/"
-            className="mt-5 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px]"
+            className="mt-5 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
           >
             Browse books <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
           </Link>
@@ -211,7 +211,7 @@ export default function SearchPage() {
       <div className="flex items-center gap-4 mb-6">
         <Link
           href="/"
-          className="text-amber-700 hover:text-amber-900 text-sm font-medium shrink-0 min-h-[44px] flex items-center"
+          className="text-amber-700 hover:text-amber-900 text-sm font-medium shrink-0 min-h-[44px] md:min-h-0 flex items-center"
         >
           <ArrowLeftIcon className="w-3.5 h-3.5 mr-1 inline" aria-hidden="true" />Library
         </Link>

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -166,7 +166,7 @@ function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
           <button
             onClick={onClose}
             aria-label="Close definition"
-            className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg text-stone-500 hover:text-ink hover:bg-amber-50 transition-colors -mr-1"
+            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-500 hover:text-ink hover:bg-amber-50 transition-colors -mr-1"
           >
             <CloseIcon className="w-4 h-4" aria-hidden="true" />
           </button>
@@ -379,7 +379,7 @@ function VocabularyPageContent() {
           <div className="flex items-center gap-2 flex-wrap">
             <button
               onClick={() => setActiveWord({ word: group.lemma, lang: group.language })}
-              className="font-serif font-semibold text-ink text-base hover:text-amber-700 transition-colors text-left min-h-[44px] flex items-center"
+              className="font-serif font-semibold text-ink text-base hover:text-amber-700 transition-colors text-left min-h-[44px] md:min-h-0 flex items-center"
             >
               {group.lemma}
             </button>
@@ -452,7 +452,7 @@ function VocabularyPageContent() {
       <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
         <button
           onClick={() => router.push("/")}
-          className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] flex items-center"
+          className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] md:min-h-0 flex items-center"
         >
           <ArrowLeftIcon className="w-4 h-4 shrink-0" /> Library
         </button>
@@ -528,7 +528,7 @@ function VocabularyPageContent() {
                   onClick={() => setSortMode(value)}
                   aria-pressed={sortMode === value}
                   data-testid={`sort-${value}`}
-                  className={`flex-1 px-2 py-2 text-xs font-medium transition-colors min-h-[44px] ${
+                  className={`flex-1 px-2 py-2 text-xs font-medium transition-colors min-h-[44px] md:min-h-0 ${
                     sortMode === value
                       ? "bg-amber-700 text-white"
                       : "bg-white text-amber-700 hover:bg-amber-50"
@@ -553,7 +553,7 @@ function VocabularyPageContent() {
               onClick={() => setSelectedTag(null)}
               aria-pressed={selectedTag === null}
               data-testid="tag-filter-all"
-              className={`shrink-0 min-h-[44px] px-3 rounded-full text-xs font-medium border transition-colors ${
+              className={`shrink-0 min-h-[44px] md:min-h-0 px-3 rounded-full text-xs font-medium border transition-colors ${
                 selectedTag === null
                   ? "bg-amber-700 text-white border-amber-700"
                   : "bg-white text-amber-700 border-amber-200 hover:bg-amber-50"
@@ -570,7 +570,7 @@ function VocabularyPageContent() {
                   onClick={() => setSelectedTag(active ? null : tag)}
                   aria-pressed={active}
                   data-testid={`tag-filter-${tag}`}
-                  className={`shrink-0 min-h-[44px] px-3 rounded-full text-xs font-medium border transition-colors ${
+                  className={`shrink-0 min-h-[44px] md:min-h-0 px-3 rounded-full text-xs font-medium border transition-colors ${
                     active
                       ? "bg-amber-700 text-white border-amber-700"
                       : "bg-white text-amber-700 border-amber-200 hover:bg-amber-50"
@@ -601,7 +601,7 @@ function VocabularyPageContent() {
             <button
               type="button"
               onClick={loadVocab}
-              className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px]"
+              className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
             >
               <RetryIcon className="w-4 h-4" aria-hidden="true" />
               Try again
@@ -615,7 +615,7 @@ function VocabularyPageContent() {
             <button
               type="button"
               onClick={() => router.push("/")}
-              className="mt-4 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px]"
+              className="mt-4 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
             >
               Browse books <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
             </button>
@@ -630,7 +630,7 @@ function VocabularyPageContent() {
                 <button
                   type="button"
                   onClick={() => setSelectedTag(null)}
-                  className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px]"
+                  className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
                 >
                   Clear tag filter
                 </button>
@@ -642,7 +642,7 @@ function VocabularyPageContent() {
                 <button
                   type="button"
                   onClick={() => setSearch("")}
-                  className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px]"
+                  className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
                 >
                   Clear search
                 </button>

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -23,7 +23,7 @@ export default function BookCard({ book, onClick, badge, onRemove }: Props) {
           }}
           title={`Remove ${book.title} from library`}
           aria-label={`Remove ${book.title} from library`}
-          className="absolute top-0 right-0 z-10 min-w-[44px] min-h-[44px] inline-flex items-center justify-center rounded-full bg-white/80 text-stone-500 border border-amber-200 text-sm hover:bg-red-50 hover:text-red-600 hover:border-red-200 transition-colors"
+          className="absolute top-0 right-0 z-10 min-w-[44px] md:min-w-0 min-h-[44px] md:min-h-0 inline-flex items-center justify-center rounded-full bg-white/80 text-stone-500 border border-amber-200 text-sm hover:bg-red-50 hover:text-red-600 hover:border-red-200 transition-colors"
         >
           <CloseIcon className="w-3.5 h-3.5" />
         </button>

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -76,7 +76,7 @@ function ContextChip({
           {needsToggle && (
             <button
               onClick={() => setExpanded((v) => !v)}
-              className="ml-1.5 text-amber-700 hover:text-amber-900 font-medium not-italic min-h-[44px] inline-flex items-center"
+              className="ml-1.5 text-amber-700 hover:text-amber-900 font-medium not-italic min-h-[44px] md:min-h-0 inline-flex items-center"
               aria-label="Toggle context"
               aria-expanded={expanded}
             >
@@ -87,7 +87,7 @@ function ContextChip({
         {onRemove && (
           <button
             onClick={onRemove}
-            className="shrink-0 text-amber-600 hover:text-amber-700 min-h-[44px] min-w-[44px] flex items-center justify-center"
+            className="shrink-0 text-amber-600 hover:text-amber-700 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center"
             title="Remove context"
             aria-label="Remove context"
           >
@@ -393,7 +393,7 @@ export default function InsightChat({
           }}
           title={`Toggle font size (${chatFontSize === "xs" ? "small" : "medium"})`}
           aria-label={chatFontSize === "xs" ? "Increase chat font size" : "Decrease chat font size"}
-          className={`shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded text-xs font-bold transition-colors ${
+          className={`shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded text-xs font-bold transition-colors ${
             chatFontSize === "sm"
               ? "bg-amber-100 text-amber-800 hover:bg-amber-200"
               : "text-stone-500 hover:bg-stone-200 hover:text-stone-700"
@@ -406,7 +406,7 @@ export default function InsightChat({
           title={hasGeminiKey ? "Append a fresh insight" : "Gemini API key required"}
           aria-label="Append a fresh insight"
           disabled={!hasGeminiKey}
-          className="shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded hover:bg-stone-200 text-stone-500 hover:text-stone-700 disabled:opacity-40 disabled:cursor-not-allowed"
+          className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded hover:bg-stone-200 text-stone-500 hover:text-stone-700 disabled:opacity-40 disabled:cursor-not-allowed"
         >
           <RetryIcon className="w-3.5 h-3.5" />
         </button>
@@ -433,7 +433,7 @@ export default function InsightChat({
         {hasEarlier && (
           <button
             onClick={loadEarlier}
-            className="w-full text-xs text-stone-600 hover:text-stone-800 py-1.5 min-h-[44px] rounded-lg border border-stone-200 hover:bg-stone-50 transition-colors inline-flex items-center justify-center gap-1.5"
+            className="w-full text-xs text-stone-600 hover:text-stone-800 py-1.5 min-h-[44px] md:min-h-0 rounded-lg border border-stone-200 hover:bg-stone-50 transition-colors inline-flex items-center justify-center gap-1.5"
           >
             <ArrowUpIcon className="w-3 h-3" />
             <span>Load earlier ({loadedFrom} more)</span>
@@ -537,7 +537,7 @@ export default function InsightChat({
                         onSaveInsight(prevUserMsg.content, msg.content, prevUserMsg.context);
                       }}
                       title={isSaved ? "Already saved" : "Save to notes"}
-                      className={`mt-1.5 flex items-center gap-1 min-h-[44px] text-[11px] transition-colors ${
+                      className={`mt-1.5 flex items-center gap-1 min-h-[44px] md:min-h-0 text-[11px] transition-colors ${
                         isSaved
                           ? "text-stone-500 cursor-default"
                           : "text-stone-600 hover:text-amber-700"
@@ -606,7 +606,7 @@ export default function InsightChat({
           <button
             onClick={sendMessage}
             disabled={chatLoading || !input.trim() || !hasGeminiKey}
-            className="rounded-xl bg-amber-600 p-2 min-h-[44px] min-w-[44px] flex items-center justify-center text-white hover:bg-amber-700 disabled:opacity-40 shrink-0 transition-colors"
+            className="rounded-xl bg-amber-600 p-2 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-white hover:bg-amber-700 disabled:opacity-40 shrink-0 transition-colors"
             aria-label="Send message"
             title="Send (Enter)"
           >
@@ -639,7 +639,7 @@ function MsgContextBlock({
         {needsToggle && (
           <button
             onClick={onToggle}
-            className="ml-1.5 text-amber-700 hover:text-amber-900 font-medium not-italic min-h-[44px] inline-flex items-center"
+            className="ml-1.5 text-amber-700 hover:text-amber-900 font-medium not-italic min-h-[44px] md:min-h-0 inline-flex items-center"
             aria-label="Toggle context"
             aria-expanded={expanded}
           >

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -800,7 +800,7 @@ export default function SentenceReader({
               {noteAnnotation?.note_text && (
                 <button
                   onClick={(e) => { e.stopPropagation(); setExpandedNoteFlatIdx((prev) => prev === seg.flatIdx ? null : seg.flatIdx); }}
-                  className="inline-flex items-center justify-center ml-0.5 align-middle cursor-pointer min-h-[44px] min-w-[44px] -m-[19px] p-[19px]"
+                  className="inline-flex items-center justify-center ml-0.5 align-middle cursor-pointer min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 -m-[19px] p-[19px]"
                   aria-label={`Toggle note for: ${seg.text.slice(0, 60)}`}
                   aria-expanded={expandedNoteFlatIdx === seg.flatIdx}
                 >

--- a/frontend/src/components/TagEditor.tsx
+++ b/frontend/src/components/TagEditor.tsx
@@ -126,7 +126,7 @@ export default function TagEditor({
             onClick={() => handleRemove(tag)}
             disabled={busy === tag}
             aria-label={`Remove tag ${tag}`}
-            className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-full hover:bg-amber-100 disabled:opacity-50 transition-colors"
+            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-full hover:bg-amber-100 disabled:opacity-50 transition-colors"
           >
             <CloseIcon className="w-3 h-3" />
           </button>
@@ -154,7 +154,7 @@ export default function TagEditor({
           type="button"
           onClick={() => setAdding(true)}
           aria-label="Add tag"
-          className="inline-flex items-center gap-0.5 rounded-full border border-dashed border-amber-300 px-2 py-0.5 min-h-[44px] text-xs text-amber-700 hover:bg-amber-50 transition-colors"
+          className="inline-flex items-center gap-0.5 rounded-full border border-dashed border-amber-300 px-2 py-0.5 min-h-[44px] md:min-h-0 text-xs text-amber-700 hover:bg-amber-50 transition-colors"
           data-testid={`add-tag-${vocabularyId}`}
         >
           <span aria-hidden="true">+</span>


### PR DESCRIPTION
## What changed

Adds `md:min-h-0` / `md:min-w-0` resets alongside every bare `min-h-[44px]` / `min-w-[44px]` across the 11 remaining pages and components that were not covered by PRs #2131, #2133, #2137, or #2139:

- `app/vocabulary/page.tsx` — 10 elements
- `app/notes/page.tsx` — 4 elements
- `app/notes/[bookId]/page.tsx` — 13 elements
- `app/search/page.tsx` — 3 elements
- `app/profile/page.tsx` — 11 elements
- `app/decks/page.tsx` — 3 elements
- `app/decks/new/page.tsx` — 3 elements
- `components/SentenceReader.tsx` — 2 elements
- `components/BookCard.tsx` — 2 elements
- `components/InsightChat.tsx` — 12 elements
- `components/TagEditor.tsx` — 3 elements

Also expands the static-analysis look-back windows in `InsightChatSendCloseTouchTargets.test.ts` (200 → 400 chars) and `VocabularyDefinitionSheetClose.test.ts` (200 → 300 chars) — adding `md:min-h-0 md:min-w-0` made the class strings longer, pushing the anchor strings just outside the old windows.

## Why

The CLAUDE.md rule requires `min-h-[44px] md:min-h-0` so mobile touch targets remain 44 px while desktop chrome keeps its natural compact size. 67 violations remained after the earlier per-file PRs (closes #2140).

## Test plan

- New `RemainingTouchTargets.test.ts` — 11 static-analysis tests (one per file), all green
- Full frontend suite: **3282 tests, 0 failures**
- Existing `InsightChatSendCloseTouchTargets` and `VocabularyDefinitionSheetClose` tests continue to pass with the widened windows

- [ ] Docs updated (if applicable)
