### PR TITLE
fix(ux): profile button aria-label includes action context (closes #2142)

### DIFF
--- a/frontend/src/__tests__/HomepageProfileAriaTouch.test.ts
+++ b/frontend/src/__tests__/HomepageProfileAriaTouch.test.ts
@@ -16,8 +16,9 @@ const iconsSrc = fs.readFileSync(
 );
 
 describe("Homepage profile button a11y (#585)", () => {
-  it("profile button has aria-label", () => {
-    expect(pageSrc).toMatch(/aria-label=\{session\?\.backendUser\?\.name/);
+  it("profile button has aria-label referencing user name", () => {
+    // Template literal includes name and action context (closes #2142)
+    expect(pageSrc).toMatch(/aria-label=\{`\$\{session\?\.backendUser\?\.name/);
   });
 
   it("profile button is at least 44px on mobile (w-11)", () => {

--- a/frontend/src/__tests__/ProfileButtonAriaLabel.test.ts
+++ b/frontend/src/__tests__/ProfileButtonAriaLabel.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Regression test for #2142 — profile button aria-label must include
+ * action context ("Profile & Settings"), not just the user's name.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(join(__dirname, "../app/page.tsx"), "utf-8");
+
+describe("Home page profile button aria-label (closes #2142)", () => {
+  it("aria-label template includes Profile & Settings alongside user name", () => {
+    // Should use a template that concatenates name with a descriptive suffix
+    expect(src).toMatch(/aria-label=\{`\$\{.*backendUser.*\}.*Profile.*Settings`\}/);
+  });
+
+  it("aria-label does not use name-only pattern", () => {
+    // Old bad pattern: aria-label={session?.backendUser?.name ?? "..."}
+    // with ONLY the name (no concatenation of action context)
+    const badPattern = /aria-label=\{session\?\.backendUser\?\.name\s*\?\?\s*"Profile/;
+    expect(src).not.toMatch(badPattern);
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -199,7 +199,7 @@ export default function Home() {
               <button
                 onClick={() => router.push("/profile")}
                 title={session?.backendUser?.name ?? "Profile & Settings"}
-                aria-label={session?.backendUser?.name ?? "Profile & Settings"}
+                aria-label={`${session?.backendUser?.name ?? "Profile"} — Profile & Settings`}
                 className="min-w-[44px] md:min-w-0 min-h-[44px] md:min-h-0 w-11 h-11 md:w-9 md:h-9 rounded-full overflow-hidden border border-amber-200 hover:border-amber-400 transition-colors"
               >
                 {session?.backendUser?.picture ? (


### PR DESCRIPTION
## What changed

The profile avatar button on the home page used:

```tsx
aria-label={session?.backendUser?.name ?? "Profile & Settings"}
```

When logged in, this resolves to just the user's name (e.g. `"Alice"`), so screen readers announce *"Alice, button"* — no indication the button navigates to profile or settings. Only the unauthenticated fallback was descriptive.

Changed to a template literal that includes both name and purpose:

```tsx
aria-label={`${session?.backendUser?.name ?? "Profile"} — Profile & Settings`}
```

**File:** `frontend/src/app/page.tsx` line 202

## Why

WCAG 2.1 SC 4.1.2 (Name, Role, Value) — interactive controls must have an accessible name that conveys their purpose. "Alice" conveys identity but not the action (navigate to profile/settings).

## Test plan

- New `ProfileButtonAriaLabel.test.ts` — 2 tests: template includes "Profile & Settings", old name-only pattern is gone
- Updated `HomepageProfileAriaTouch.test.ts` to match the new template literal form (was checking for the old `session?.backendUser?.name` pattern directly)
- Full frontend suite: **3275 tests, 0 failures**

- [ ] Docs updated (if applicable)
