### PR TITLE
fix(ux): align profile button title tooltip with aria-label (closes #2144)

### DIFF
--- a/frontend/src/__tests__/HomePage.test.tsx
+++ b/frontend/src/__tests__/HomePage.test.tsx
@@ -191,7 +191,7 @@ describe("HomePage — signed-in state", () => {
   it("navigates to /profile when profile button is clicked", async () => {
     const user = userEvent.setup();
     await renderHome();
-    const profileBtn = screen.getByTitle("Alice");
+    const profileBtn = screen.getByTitle("Alice — Profile & Settings");
     await user.click(profileBtn);
     expect(mockPush).toHaveBeenCalledWith("/profile");
   });

--- a/frontend/src/__tests__/ProfileButtonTitle.test.ts
+++ b/frontend/src/__tests__/ProfileButtonTitle.test.ts
@@ -1,0 +1,18 @@
+/**
+ * Regression test for #2144 — profile button title tooltip must match
+ * the aria-label pattern (include action context, not just the user's name).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(join(__dirname, "../app/page.tsx"), "utf-8");
+
+test("profile button title includes Profile & Settings (not just user name)", () => {
+  // title should use the same template pattern as aria-label
+  expect(src).toMatch(/title=\{`\$\{.*backendUser.*\}.*Profile.*Settings`\}/);
+});
+
+test("profile button title does not use name-only pattern", () => {
+  const badPattern = /title=\{session\?\.backendUser\?\.name\s*\?\?\s*"Profile/;
+  expect(src).not.toMatch(badPattern);
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -198,7 +198,7 @@ export default function Home() {
             ) : (
               <button
                 onClick={() => router.push("/profile")}
-                title={session?.backendUser?.name ?? "Profile & Settings"}
+                title={`${session?.backendUser?.name ?? "Profile"} — Profile & Settings`}
                 aria-label={`${session?.backendUser?.name ?? "Profile"} — Profile & Settings`}
                 className="min-w-[44px] md:min-w-0 min-h-[44px] md:min-h-0 w-11 h-11 md:w-9 md:h-9 rounded-full overflow-hidden border border-amber-200 hover:border-amber-400 transition-colors"
               >


### PR DESCRIPTION
## What changed

After #2143 updated the `aria-label` on the profile avatar button to include action context ("Alice — Profile & Settings"), the `title` tooltip was left behind:

```tsx
// Before (inconsistent)
title={session?.backendUser?.name ?? "Profile & Settings"}
aria-label={`${session?.backendUser?.name ?? "Profile"} — Profile & Settings`}

// After (aligned)
title={`${session?.backendUser?.name ?? "Profile"} — Profile & Settings`}
aria-label={`${session?.backendUser?.name ?? "Profile"} — Profile & Settings`}
```

Sighted users hovering the profile picture tooltip now see "Alice — Profile & Settings" instead of just "Alice", making the button's purpose clear on hover.

**File:** `frontend/src/app/page.tsx` line 201

## Why

`title` and `aria-label` should be consistent. A tooltip that says only "Alice" gives no hint the button navigates to profile settings — the sighted user tooltip experience was worse than the accessible name experience.

## Test plan

- New `ProfileButtonTitle.test.ts` — 2 tests: template pattern present, name-only pattern absent
- Updated `HomePage.test.tsx` — click test now finds button by `"Alice — Profile & Settings"` title
- Full frontend suite: **3277 tests, 0 failures**

- [ ] Docs updated (if applicable)
