### PR TITLE
fix(ux): null-guard active_language in admin translating badge aria-label (closes #2146)

### DIFF
--- a/frontend/src/__tests__/AdminTranslatingBadgeAriaLabel.test.ts
+++ b/frontend/src/__tests__/AdminTranslatingBadgeAriaLabel.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Regression test for #2146 — admin books page "translating" badge
+ * must not produce aria-label="Translating to null" when active_language is null.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/admin/books/page.tsx"),
+  "utf8",
+);
+
+describe("Admin books translating badge aria-label null-safety (closes #2146)", () => {
+  it("aria-label uses null-guard so active_language=null never produces 'Translating to null'", () => {
+    // Must use a ternary or ?? to guard against null active_language
+    const nullGuardPattern =
+      /aria-label=\{.*active_language.*\?.*Translating to.*:.*Translating/s;
+    expect(src).toMatch(nullGuardPattern);
+  });
+
+  it("visible text uses null-guard so active_language=null is not rendered literally", () => {
+    // The visible "translating → {b.active_language}" must also be guarded
+    // Pattern: active_language should be conditional in the visible text node too
+    const rawNullRisk = /translating → \{b\.active_language\}/;
+    expect(src).not.toMatch(rawNullRisk);
+  });
+});

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -389,9 +389,9 @@ export default function BooksPage() {
                       <span
                         className="text-xs px-1.5 py-0.5 rounded-full bg-emerald-100 text-emerald-700 animate-pulse"
                         role="status"
-                        aria-label={`Translating to ${b.active_language}`}
+                        aria-label={b.active_language ? `Translating to ${b.active_language}` : "Translating"}
                       >
-                        translating → {b.active_language}
+                        translating{b.active_language ? ` → ${b.active_language}` : ""}
                       </span>
                     )}
                   </div>


### PR DESCRIPTION
## What changed

`app/admin/books/page.tsx`: When a book's `active_language` field is `null` (typed `string | null`), the "translating" badge was producing:
- `aria-label="Translating to null"` — broken screen-reader announcement  
- Visible text "translating → null" — literal "null" shown in the UI

Fixed both with a null-guard ternary:
- `aria-label={b.active_language ? \`Translating to ${b.active_language}\` : "Translating"}`
- Visible: `translating{b.active_language ? \` → ${b.active_language}\` : ""}`

## Why

WCAG 2.4.6: headings and labels must describe their topic/purpose. "Translating to null" is a broken label. This can occur whenever the server starts a translation job before the `active_language` field is populated in the response.

## Test plan

New `AdminTranslatingBadgeAriaLabel.test.ts`:
- Asserts aria-label uses a null-guard ternary
- Asserts the unguarded `{b.active_language}` interpolation is no longer directly in the visible text node

Full suite: 3279 tests pass.

Closes #2146

## Docs follow-up

N/A — admin-only UI change, no tutorial or FEATURES.md entry needed.
