### PR TITLE
fix(ux): responsive touch-target resets for 23 pages/components batch 2 (closes #2148)

### DIFF
--- a/frontend/src/__tests__/TouchTargetsBatch2.test.ts
+++ b/frontend/src/__tests__/TouchTargetsBatch2.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Regression tests for #2148 — second batch of responsive touch-target resets.
+ * Every min-h-[44px] in these files must be paired with md:min-h-0.
+ * Every min-w-[44px] must be paired with md:min-w-0.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+function readSrc(rel: string) {
+  return fs.readFileSync(path.join(__dirname, "..", rel), "utf8");
+}
+
+function checkFile(rel: string, label: string) {
+  describe(`${label} (closes #2148)`, () => {
+    const src = readSrc(rel);
+
+    it("every min-h-[44px] is paired with md:min-h-0", () => {
+      const lines = src.split("\n");
+      const violations: string[] = [];
+      lines.forEach((line, i) => {
+        if (line.includes("min-h-[44px]") && !line.includes("md:min-h-0") && !line.includes("lg:min-h-0")) {
+          violations.push(`line ${i + 1}: ${line.trim()}`);
+        }
+      });
+      expect(violations).toEqual([]);
+    });
+
+    it("every min-w-[44px] is paired with md:min-w-0", () => {
+      const lines = src.split("\n");
+      const violations: string[] = [];
+      lines.forEach((line, i) => {
+        if (line.includes("min-w-[44px]") && !line.includes("md:min-w-0") && !line.includes("lg:min-w-0")) {
+          violations.push(`line ${i + 1}: ${line.trim()}`);
+        }
+      });
+      expect(violations).toEqual([]);
+    });
+  });
+}
+
+checkFile("app/vocabulary/flashcards/page.tsx", "FlashcardsPage");
+checkFile("app/decks/[deckId]/page.tsx", "DeckDetailPage");
+checkFile("app/import/[bookId]/page.tsx", "ImportPage");
+checkFile("app/error.tsx", "ErrorPage");
+checkFile("app/not-found.tsx", "NotFoundPage");
+checkFile("app/login/page.tsx", "LoginPage");
+checkFile("app/pending/page.tsx", "PendingPage");
+checkFile("app/upload/page.tsx", "UploadPage");
+checkFile("app/upload/[bookId]/chapters/page.tsx", "UploadChaptersPage");
+checkFile("app/page.tsx", "HomePage");
+checkFile("components/WordActionDrawer.tsx", "WordActionDrawer");
+checkFile("components/VocabWordTooltip.tsx", "VocabWordTooltip");
+checkFile("components/DeckCard.tsx", "DeckCard");
+checkFile("components/UndoToast.tsx", "UndoToast");
+checkFile("components/BookDetailModal.tsx", "BookDetailModal");
+checkFile("components/AuthPromptModal.tsx", "AuthPromptModal");
+checkFile("components/SentenceActionPopup.tsx", "SentenceActionPopup");
+checkFile("components/SearchBar.tsx", "SearchBar");
+checkFile("components/AnnotationToolbar.tsx", "AnnotationToolbar");
+checkFile("components/AnnotationsSidebar.tsx", "AnnotationsSidebar");
+checkFile("components/ChapterSummary.tsx", "ChapterSummary");
+checkFile("components/QuickHighlightPanel.tsx", "QuickHighlightPanel");
+checkFile("components/SeedPopularButton.tsx", "SeedPopularButton");

--- a/frontend/src/__tests__/WordActionDrawerCloseButton.test.ts
+++ b/frontend/src/__tests__/WordActionDrawerCloseButton.test.ts
@@ -21,7 +21,7 @@ describe("WordActionDrawer close button (WCAG 2.1.1, closes #2069)", () => {
 
   it("close button uses CloseIcon", () => {
     const block = src.match(
-      /aria-label="Close word lookup"[\s\S]{0,200}CloseIcon|CloseIcon[\s\S]{0,200}aria-label="Close word lookup"/
+      /aria-label="Close word lookup"[\s\S]{0,300}CloseIcon|CloseIcon[\s\S]{0,300}aria-label="Close word lookup"/
     );
     expect(block).not.toBeNull();
   });

--- a/frontend/src/app/decks/[deckId]/page.tsx
+++ b/frontend/src/app/decks/[deckId]/page.tsx
@@ -131,7 +131,7 @@ export default function DeckDetailPage() {
       <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
         <button
           onClick={() => router.push("/decks")}
-          className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] flex items-center"
+          className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] md:min-h-0 flex items-center"
         >
           <ArrowLeftIcon className="w-4 h-4 shrink-0" /> Decks
         </button>
@@ -186,7 +186,7 @@ export default function DeckDetailPage() {
               <button
                 type="button"
                 onClick={loadDeck}
-                className="inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 transition-colors"
+                className="inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 transition-colors"
               >
                 <RetryIcon className="w-4 h-4" aria-hidden="true" />
                 Retry
@@ -194,7 +194,7 @@ export default function DeckDetailPage() {
               <button
                 type="button"
                 onClick={() => router.push("/decks")}
-                className="px-4 py-2 min-h-[44px] rounded-lg border border-amber-300 text-amber-700 text-sm hover:bg-amber-50 transition-colors"
+                className="px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg border border-amber-300 text-amber-700 text-sm hover:bg-amber-50 transition-colors"
               >
                 Back to decks
               </button>
@@ -227,7 +227,7 @@ export default function DeckDetailPage() {
                     type="button"
                     onClick={() => setPickerOpen(true)}
                     disabled={candidateWords.length === 0}
-                    className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium transition-colors min-h-[44px]"
+                    className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
                   >
                     <PlusIcon className="w-4 h-4" />
                     Add word
@@ -236,7 +236,7 @@ export default function DeckDetailPage() {
                   <button
                     type="button"
                     onClick={() => router.push("/decks")}
-                    className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px]"
+                    className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
                   >
                     <ArrowLeftIcon className="w-4 h-4" />
                     Back to decks
@@ -268,7 +268,7 @@ export default function DeckDetailPage() {
                         type="button"
                         onClick={() => handleRemove(w.id)}
                         aria-label={`Remove ${w.word} from deck`}
-                        className="shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg text-stone-500 hover:text-red-600 hover:bg-red-50 transition-colors"
+                        className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-500 hover:text-red-600 hover:bg-red-50 transition-colors"
                       >
                         <TrashIcon className="w-4 h-4" />
                       </button>
@@ -368,7 +368,7 @@ function AddWordPicker({ candidates, onClose, onAdd }: AddWordPickerProps) {
             type="button"
             onClick={onClose}
             aria-label="Close add-word picker"
-            className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg text-stone-500 hover:text-ink hover:bg-amber-100 transition-colors"
+            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-500 hover:text-ink hover:bg-amber-100 transition-colors"
           >
             <CloseIcon className="w-4 h-4" />
           </button>
@@ -409,7 +409,7 @@ function AddWordPicker({ candidates, onClose, onAdd }: AddWordPickerProps) {
                       onAdd(w.id);
                     }}
                     aria-label={`Add ${w.word} to deck`}
-                    className="w-full flex items-center justify-between gap-3 rounded-lg border border-amber-200 bg-white px-3 py-2 text-left hover:border-amber-400 hover:bg-amber-50 transition-colors min-h-[44px]"
+                    className="w-full flex items-center justify-between gap-3 rounded-lg border border-amber-200 bg-white px-3 py-2 text-left hover:border-amber-400 hover:bg-amber-50 transition-colors min-h-[44px] md:min-h-0"
                   >
                     <span className="font-serif text-ink truncate flex-1 min-w-0">
                       {w.word}

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -20,13 +20,13 @@ export default function ErrorPage({ error, reset }: Props) {
           <button
             type="button"
             onClick={() => reset()}
-            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px]"
+            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
           >
             <RetryIcon className="w-4 h-4" aria-hidden="true" /> Try again
           </button>
           <Link
             href="/"
-            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px]"
+            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
           >
             <ArrowLeftIcon className="w-4 h-4" aria-hidden="true" /> Library
           </Link>

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -196,13 +196,13 @@ export default function BookImportPage() {
               <div className="flex gap-2 pt-2">
                 <button
                   onClick={startImport}
-                  className="flex-1 rounded-lg bg-amber-700 text-white min-h-[44px] text-sm font-medium hover:bg-amber-800 flex items-center justify-center"
+                  className="flex-1 rounded-lg bg-amber-700 text-white min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-amber-800 flex items-center justify-center"
                 >
                   Start import
                 </button>
                 <button
                   onClick={() => router.push(nextUrl)}
-                  className="rounded-lg border border-amber-300 text-amber-700 px-4 min-h-[44px] text-sm font-medium hover:bg-amber-50 flex items-center"
+                  className="rounded-lg border border-amber-300 text-amber-700 px-4 min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-amber-50 flex items-center"
                 >
                   Skip
                 </button>
@@ -295,7 +295,7 @@ export default function BookImportPage() {
               </p>
               <a
                 href="/api/auth/signin"
-                className="inline-flex items-center rounded-lg bg-amber-700 text-white px-5 min-h-[44px] text-sm font-medium hover:bg-amber-800"
+                className="inline-flex items-center rounded-lg bg-amber-700 text-white px-5 min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-amber-800"
               >
                 Sign in
               </a>
@@ -320,14 +320,14 @@ export default function BookImportPage() {
               {canStartReading && (
                 <button
                   onClick={skipToReading}
-                  className="flex-1 rounded-lg bg-amber-700 text-white min-h-[44px] text-sm font-medium hover:bg-amber-800 flex items-center justify-center"
+                  className="flex-1 rounded-lg bg-amber-700 text-white min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-amber-800 flex items-center justify-center"
                 >
                   Start reading now
                 </button>
               )}
               <button
                 onClick={cancel}
-                className="rounded-lg border border-stone-300 text-stone-600 px-4 min-h-[44px] text-sm hover:bg-stone-50 flex items-center"
+                className="rounded-lg border border-stone-300 text-stone-600 px-4 min-h-[44px] md:min-h-0 text-sm hover:bg-stone-50 flex items-center"
               >
                 Cancel
               </button>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -32,7 +32,7 @@ function LoginForm() {
           <div className="space-y-3">
             <button
               onClick={() => signIn("google", { callbackUrl })}
-              className="w-full flex items-center justify-center gap-3 bg-white border border-stone-300 text-stone-700 rounded-lg px-4 min-h-[44px] text-sm font-medium hover:bg-stone-50 transition-colors shadow-sm"
+              className="w-full flex items-center justify-center gap-3 bg-white border border-stone-300 text-stone-700 rounded-lg px-4 min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-stone-50 transition-colors shadow-sm"
             >
               <svg width="18" height="18" viewBox="0 0 48 48" aria-hidden="true">
                 <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
@@ -46,7 +46,7 @@ function LoginForm() {
 
             <button
               onClick={() => signIn("github", { callbackUrl })}
-              className="w-full flex items-center justify-center gap-3 bg-stone-800 text-white rounded-lg px-4 min-h-[44px] text-sm font-medium hover:bg-stone-900 transition-colors shadow-sm"
+              className="w-full flex items-center justify-center gap-3 bg-stone-800 text-white rounded-lg px-4 min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-stone-900 transition-colors shadow-sm"
             >
               <svg width="18" height="18" viewBox="0 0 24 24" fill="white" aria-hidden="true">
                 <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
@@ -56,7 +56,7 @@ function LoginForm() {
 
             <button
               onClick={() => signIn("apple", { callbackUrl })}
-              className="w-full flex items-center justify-center gap-3 bg-black text-white rounded-lg px-4 min-h-[44px] text-sm font-medium hover:bg-stone-900 transition-colors shadow-sm"
+              className="w-full flex items-center justify-center gap-3 bg-black text-white rounded-lg px-4 min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-stone-900 transition-colors shadow-sm"
             >
               <svg width="18" height="18" viewBox="0 0 24 24" fill="white" aria-hidden="true">
                 <path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.54 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701"/>

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -15,7 +15,7 @@ export default function NotFound() {
         </p>
         <Link
           href="/"
-          className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px]"
+          className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
         >
           Browse books <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
         </Link>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -248,7 +248,7 @@ export default function Home() {
               aria-controls={`tabpanel-${key}`}
               tabIndex={tab === key ? 0 : -1}
               onClick={() => setTab(key)}
-              className={`px-5 py-3 min-h-[44px] text-sm font-medium border-b-2 transition-colors ${
+              className={`px-5 py-3 min-h-[44px] md:min-h-0 text-sm font-medium border-b-2 transition-colors ${
                 tab === key
                   ? "border-amber-700 text-amber-900"
                   : "border-transparent text-amber-700 hover:text-amber-900"
@@ -264,7 +264,7 @@ export default function Home() {
           {status === "authenticated" && (
             <button
               onClick={() => router.push("/upload")}
-              className="px-5 py-3 min-h-[44px] text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 transition-colors"
+              className="px-5 py-3 min-h-[44px] md:min-h-0 text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 transition-colors"
             >
               Upload
             </button>
@@ -272,7 +272,7 @@ export default function Home() {
           {status === "authenticated" && (
             <button
               onClick={() => router.push("/notes")}
-              className="px-5 py-3 min-h-[44px] text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 transition-colors"
+              className="px-5 py-3 min-h-[44px] md:min-h-0 text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 transition-colors"
             >
               Your Notes
             </button>
@@ -280,7 +280,7 @@ export default function Home() {
           {status === "authenticated" && (
             <button
               onClick={() => router.push("/vocabulary")}
-              className="px-5 py-3 min-h-[44px] text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 transition-colors"
+              className="px-5 py-3 min-h-[44px] md:min-h-0 text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 transition-colors"
             >
               Your Word List
             </button>
@@ -290,7 +290,7 @@ export default function Home() {
             <button
               onClick={() => router.push("/admin")}
               data-testid="admin-tab"
-              className="px-5 py-3 min-h-[44px] text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 flex items-center gap-1.5"
+              className="px-5 py-3 min-h-[44px] md:min-h-0 text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 flex items-center gap-1.5"
             >
               <SettingsIcon className="w-3.5 h-3.5" />
               Admin
@@ -359,7 +359,7 @@ export default function Home() {
                     onClick={() => setStatsExpanded((v) => !v)}
                     aria-expanded={statsExpanded}
                     aria-controls="stats-activity-panel"
-                    className="text-xs text-amber-700 hover:text-amber-800 transition-colors min-h-[44px] px-2 flex items-center"
+                    className="text-xs text-amber-700 hover:text-amber-800 transition-colors min-h-[44px] md:min-h-0 px-2 flex items-center"
                   >
                     {statsExpanded ? "Hide activity" : "Show activity"}
                   </button>
@@ -452,7 +452,7 @@ export default function Home() {
                 </p>
                 <button
                   onClick={() => setTab("discover")}
-                  className="rounded-lg bg-amber-700 px-6 py-2.5 min-h-[44px] text-white font-medium hover:bg-amber-800 transition-colors shadow-sm"
+                  className="rounded-lg bg-amber-700 px-6 py-2.5 min-h-[44px] md:min-h-0 text-white font-medium hover:bg-amber-800 transition-colors shadow-sm"
                 >
                   Discover Books
                 </button>
@@ -479,13 +479,13 @@ export default function Home() {
                   <div className="flex flex-col sm:flex-row gap-3 justify-center items-center">
                     <button
                       onClick={() => router.push("/login")}
-                      className="rounded-lg bg-amber-700 px-7 py-3 min-h-[44px] text-white font-semibold text-base hover:bg-amber-800 transition-colors shadow-sm min-w-[160px]"
+                      className="rounded-lg bg-amber-700 px-7 py-3 min-h-[44px] md:min-h-0 text-white font-semibold text-base hover:bg-amber-800 transition-colors shadow-sm min-w-[160px]"
                     >
                       Sign in free
                     </button>
                     <button
                       onClick={() => document.getElementById("discover-search")?.scrollIntoView({ behavior: "smooth" })}
-                      className="rounded-lg border border-amber-300 px-7 py-3 min-h-[44px] text-amber-800 font-medium text-base hover:bg-amber-50 transition-colors min-w-[160px] flex items-center justify-center gap-2"
+                      className="rounded-lg border border-amber-300 px-7 py-3 min-h-[44px] md:min-h-0 text-amber-800 font-medium text-base hover:bg-amber-50 transition-colors min-w-[160px] flex items-center justify-center gap-2"
                     >
                       Browse library <ArrowRightIcon className="w-4 h-4" />
                     </button>
@@ -604,7 +604,7 @@ export default function Home() {
                     <option value="es">Spanish</option>
                   </select>
                   <button
-                    className="rounded-lg bg-amber-700 px-5 py-2.5 min-h-[44px] text-white font-medium hover:bg-amber-800 disabled:opacity-50 flex items-center justify-center gap-2 flex-1 sm:flex-none"
+                    className="rounded-lg bg-amber-700 px-5 py-2.5 min-h-[44px] md:min-h-0 text-white font-medium hover:bg-amber-800 disabled:opacity-50 flex items-center justify-center gap-2 flex-1 sm:flex-none"
                     onClick={() => handleSearch()}
                     disabled={searching}
                   >
@@ -708,7 +708,7 @@ export default function Home() {
                     title="Grid view"
                     aria-label="Grid view"
                     aria-pressed={popularView === "grid"}
-                    className={`p-1.5 min-h-[44px] min-w-[44px] flex items-center justify-center rounded transition-colors ${popularView === "grid" ? "bg-amber-100 text-amber-800" : "text-amber-600 hover:text-amber-700"}`}
+                    className={`p-1.5 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded transition-colors ${popularView === "grid" ? "bg-amber-100 text-amber-800" : "text-amber-600 hover:text-amber-700"}`}
                   >
                     <GridViewIcon className="w-4 h-4" />
                   </button>
@@ -717,7 +717,7 @@ export default function Home() {
                     title="List view"
                     aria-label="List view"
                     aria-pressed={popularView === "list"}
-                    className={`p-1.5 min-h-[44px] min-w-[44px] flex items-center justify-center rounded transition-colors ${popularView === "list" ? "bg-amber-100 text-amber-800" : "text-amber-600 hover:text-amber-700"}`}
+                    className={`p-1.5 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded transition-colors ${popularView === "list" ? "bg-amber-100 text-amber-800" : "text-amber-600 hover:text-amber-700"}`}
                   >
                     <ListViewIcon className="w-4 h-4" />
                   </button>
@@ -840,7 +840,7 @@ export default function Home() {
                   <button
                     type="button"
                     onClick={loadPopularBooks}
-                    className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px]"
+                    className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
                   >
                     <RetryIcon className="w-4 h-4" aria-hidden="true" />
                     Try again
@@ -863,7 +863,7 @@ export default function Home() {
                       el?.focus();
                       el?.scrollIntoView({ behavior: "smooth", block: "center" });
                     }}
-                    className="mt-1 inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors"
+                    className="mt-1 inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors"
                   >
                     Search for a book
                   </button>

--- a/frontend/src/app/pending/page.tsx
+++ b/frontend/src/app/pending/page.tsx
@@ -38,7 +38,7 @@ export default function PendingApprovalPage() {
         <p className="text-xs text-stone-600 mb-4">Checking automatically every 30 seconds…</p>
         <button
           onClick={() => signOut({ callbackUrl: "/login" })}
-          className="text-sm text-red-600 hover:text-red-800 min-h-[44px] flex items-center justify-center mx-auto"
+          className="text-sm text-red-600 hover:text-red-800 min-h-[44px] md:min-h-0 flex items-center justify-center mx-auto"
         >
           Sign out
         </button>

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -98,7 +98,7 @@ export default function ChapterEditorPage() {
             <button
               type="button"
               onClick={loadChapters}
-              className="inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 transition-colors"
+              className="inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 transition-colors"
             >
               <RetryIcon className="w-4 h-4" aria-hidden="true" />
               Retry
@@ -106,7 +106,7 @@ export default function ChapterEditorPage() {
             <button
               type="button"
               onClick={() => router.push("/upload")}
-              className="px-4 py-2 min-h-[44px] rounded-lg border border-amber-300 text-amber-700 text-sm hover:bg-amber-50 transition-colors"
+              className="px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg border border-amber-300 text-amber-700 text-sm hover:bg-amber-50 transition-colors"
             >
               Try another file
             </button>
@@ -126,7 +126,7 @@ export default function ChapterEditorPage() {
           <div className="flex items-center gap-3">
             <button
               onClick={() => router.push("/upload")}
-              className="text-sm text-amber-700 hover:text-amber-800 transition-colors min-h-[44px] flex items-center"
+              className="text-sm text-amber-700 hover:text-amber-800 transition-colors min-h-[44px] md:min-h-0 flex items-center"
             >
               <ArrowLeftIcon className="w-4 h-4 inline" aria-hidden="true" /> Back
             </button>
@@ -138,7 +138,7 @@ export default function ChapterEditorPage() {
           <button
             onClick={handleConfirm}
             disabled={confirming || chapters.length === 0}
-            className="rounded-lg bg-amber-700 px-5 min-h-[44px] text-white text-sm font-medium hover:bg-amber-800 disabled:opacity-50 transition-colors flex items-center gap-2"
+            className="rounded-lg bg-amber-700 px-5 min-h-[44px] md:min-h-0 text-white text-sm font-medium hover:bg-amber-800 disabled:opacity-50 transition-colors flex items-center gap-2"
           >
             {confirming && (
               <span className="w-3.5 h-3.5 border-2 border-white/40 border-t-white rounded-full animate-spin" aria-hidden="true" />
@@ -202,7 +202,7 @@ export default function ChapterEditorPage() {
                   <button
                     aria-label={`Remove chapter ${i + 1}`}
                     onClick={(e) => { e.stopPropagation(); handleRemove(i); }}
-                    className="shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded text-stone-500 hover:text-red-600 hover:bg-red-50 transition-colors"
+                    className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded text-stone-500 hover:text-red-600 hover:bg-red-50 transition-colors"
                   >
                     <TrashIcon className="w-3.5 h-3.5" />
                   </button>

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -77,7 +77,7 @@ export default function UploadPage() {
           </p>
           <button
             onClick={() => router.push("/login")}
-            className="rounded-lg bg-amber-700 px-6 min-h-[44px] flex items-center text-white font-medium hover:bg-amber-800 transition-colors"
+            className="rounded-lg bg-amber-700 px-6 min-h-[44px] md:min-h-0 flex items-center text-white font-medium hover:bg-amber-800 transition-colors"
           >
             Sign in
           </button>
@@ -105,7 +105,7 @@ export default function UploadPage() {
         <div className="max-w-2xl mx-auto flex items-center gap-3">
           <button
             onClick={() => router.push("/")}
-            className="text-sm text-amber-700 hover:text-amber-800 transition-colors min-h-[44px] flex items-center"
+            className="text-sm text-amber-700 hover:text-amber-800 transition-colors min-h-[44px] md:min-h-0 flex items-center"
           >
             <ArrowLeftIcon className="w-4 h-4 inline" aria-hidden="true" /> Back
           </button>

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -174,7 +174,7 @@ export default function FlashcardsPage() {
           <button
             onClick={() => router.push("/vocabulary")}
             aria-label="Back to vocabulary"
-            className="p-2 rounded-lg hover:bg-amber-100 transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
+            className="p-2 rounded-lg hover:bg-amber-100 transition-colors min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center"
           >
             <ArrowLeftIcon className="w-5 h-5 text-ink" />
           </button>
@@ -206,7 +206,7 @@ export default function FlashcardsPage() {
                 setSelectedDeckId(next);
                 persistLastDeckId(next);
               }}
-              className="flex-1 min-h-[44px] rounded-lg border border-amber-200 bg-white px-3 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-amber-300"
+              className="flex-1 min-h-[44px] md:min-h-0 rounded-lg border border-amber-200 bg-white px-3 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-amber-300"
             >
               <option value="">All decks</option>
               {decks.map((d) => (
@@ -242,7 +242,7 @@ export default function FlashcardsPage() {
             <button
               type="button"
               onClick={loadData}
-              className="mt-1 inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 transition-colors"
+              className="mt-1 inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 transition-colors"
             >
               <RetryIcon className="w-4 h-4" aria-hidden="true" />
               Retry
@@ -262,7 +262,7 @@ export default function FlashcardsPage() {
             </p>
             <button
               onClick={() => router.push("/vocabulary")}
-              className="mt-2 px-5 py-2.5 bg-amber-700 text-white rounded-lg font-medium hover:bg-amber-800 transition-colors min-h-[44px]"
+              className="mt-2 px-5 py-2.5 bg-amber-700 text-white rounded-lg font-medium hover:bg-amber-800 transition-colors min-h-[44px] md:min-h-0"
             >
               Back to Vocabulary
             </button>
@@ -314,7 +314,7 @@ export default function FlashcardsPage() {
                     onClick={() => handleGrade(value)}
                     disabled={submitting}
                     aria-label={`${label} (key ${i + 1})`}
-                    className={`py-3 rounded-xl border font-medium text-sm transition-colors min-h-[44px] disabled:opacity-50 flex flex-col items-center justify-center gap-0.5 ${className}`}
+                    className={`py-3 rounded-xl border font-medium text-sm transition-colors min-h-[44px] md:min-h-0 disabled:opacity-50 flex flex-col items-center justify-center gap-0.5 ${className}`}
                   >
                     <span>{label}</span>
                     <span className="text-[10px] opacity-60 font-normal">{i + 1}</span>
@@ -329,7 +329,7 @@ export default function FlashcardsPage() {
                 <button
                   onClick={() => setFlipped(true)}
                   aria-label="Show answer (Space or Enter)"
-                  className="px-6 py-3 bg-amber-700 text-white rounded-xl font-medium hover:bg-amber-800 transition-colors min-h-[44px] flex flex-col items-center gap-0.5"
+                  className="px-6 py-3 bg-amber-700 text-white rounded-xl font-medium hover:bg-amber-800 transition-colors min-h-[44px] md:min-h-0 flex flex-col items-center gap-0.5"
                 >
                   <span>Show answer</span>
                   <span className="text-[10px] opacity-60 font-normal">Space / Enter</span>

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -125,7 +125,7 @@ export default function AnnotationToolbar({
           <button
             onClick={onClose}
             aria-label="Close note editor"
-            className="rounded-lg p-1.5 min-h-[44px] min-w-[44px] flex items-center justify-center text-stone-500 hover:text-stone-700 hover:bg-amber-50 transition-colors"
+            className="rounded-lg p-1.5 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-500 hover:text-stone-700 hover:bg-amber-50 transition-colors"
           >
             <CloseIcon className="w-4 h-4" />
           </button>
@@ -150,7 +150,7 @@ export default function AnnotationToolbar({
                   onClick={() => setColor(c.key)}
                   aria-label={c.label}
                   aria-checked={color === c.key}
-                  className="min-h-[44px] min-w-[44px] flex items-center justify-center"
+                  className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center"
                 >
                   <span
                     className={`w-8 h-8 rounded-full ${c.bg} border-2 transition-all duration-150 hover:scale-110 inline-block ${
@@ -188,7 +188,7 @@ export default function AnnotationToolbar({
             <button
               onClick={handleSave}
               disabled={saving}
-              className="flex-1 rounded-xl bg-amber-700 text-white text-sm font-medium py-2.5 min-h-[44px] hover:bg-amber-800 disabled:opacity-50 transition-colors"
+              className="flex-1 rounded-xl bg-amber-700 text-white text-sm font-medium py-2.5 min-h-[44px] md:min-h-0 hover:bg-amber-800 disabled:opacity-50 transition-colors"
             >
               {saving ? "Saving…" : existingAnnotation ? "Update" : "Save note"}
             </button>
@@ -197,7 +197,7 @@ export default function AnnotationToolbar({
                 onClick={handleDelete}
                 disabled={deleting}
                 aria-label="Delete note"
-                className="rounded-xl border border-red-200 text-red-500 px-3 py-2.5 min-h-[44px] hover:bg-red-50 disabled:opacity-50 transition-colors flex items-center justify-center"
+                className="rounded-xl border border-red-200 text-red-500 px-3 py-2.5 min-h-[44px] md:min-h-0 hover:bg-red-50 disabled:opacity-50 transition-colors flex items-center justify-center"
               >
                 <TrashIcon className="w-4 h-4" />
               </button>

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -96,7 +96,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
             <h2 id="annotations-heading" className="font-serif font-semibold text-ink text-sm">Annotations</h2>
             <button
               onClick={() => setOpen(false)}
-              className="text-stone-500 hover:text-stone-700 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg transition-colors"
+              className="text-stone-500 hover:text-stone-700 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg transition-colors"
               aria-label="Close annotations sidebar"
             >
               <CloseIcon className="w-4 h-4" />
@@ -157,7 +157,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
                             )}
                             <button
                               onClick={(e) => { e.stopPropagation(); onEdit(ann); setOpen(false); }}
-                              className="opacity-60 hover:opacity-100 min-h-[44px] min-w-[44px] flex items-center justify-center"
+                              className="opacity-60 hover:opacity-100 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center"
                               title="Edit annotation"
                               aria-label={`Edit annotation: ${ann.sentence_text.slice(0, 60)}`}
                             >

--- a/frontend/src/components/AuthPromptModal.tsx
+++ b/frontend/src/components/AuthPromptModal.tsx
@@ -40,13 +40,13 @@ export default function AuthPromptModal({ open, feature, onClose }: Props) {
         </p>
         <a
           href="/api/auth/signin"
-          className="flex items-center justify-center w-full min-h-[44px] bg-amber-700 hover:bg-amber-800 text-white text-center rounded-xl font-medium transition-colors"
+          className="flex items-center justify-center w-full min-h-[44px] md:min-h-0 bg-amber-700 hover:bg-amber-800 text-white text-center rounded-xl font-medium transition-colors"
         >
           Sign in
         </a>
         <button
           onClick={onClose}
-          className="flex items-center justify-center w-full min-h-[44px] text-sm text-stone-500 mt-2 hover:text-stone-700 transition-colors"
+          className="flex items-center justify-center w-full min-h-[44px] md:min-h-0 text-sm text-stone-500 mt-2 hover:text-stone-700 transition-colors"
         >
           Maybe later
         </button>

--- a/frontend/src/components/BookDetailModal.tsx
+++ b/frontend/src/components/BookDetailModal.tsx
@@ -96,7 +96,7 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
           <button
             onClick={onClose}
             aria-label="Close book details"
-            className="shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-full text-stone-500 hover:bg-stone-100 hover:text-stone-700 transition-colors"
+            className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-full text-stone-500 hover:bg-stone-100 hover:text-stone-700 transition-colors"
           >
             <CloseIcon className="w-4 h-4" />
           </button>
@@ -135,7 +135,7 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
         {/* Primary CTA */}
         <button
           onClick={onRead}
-          className="w-full rounded-xl bg-amber-700 text-white py-3 min-h-[44px] text-sm font-medium hover:bg-amber-800 transition-colors"
+          className="w-full rounded-xl bg-amber-700 text-white py-3 min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-amber-800 transition-colors"
         >
           {recentBook
             ? `Continue Reading — Ch. ${recentBook.lastChapter + 1}`

--- a/frontend/src/components/ChapterSummary.tsx
+++ b/frontend/src/components/ChapterSummary.tsx
@@ -89,7 +89,7 @@ export default function ChapterSummary({
           <button
             onClick={load}
             title="Regenerate summary"
-            className="text-xs text-amber-700 hover:text-amber-800 hover:underline transition-colors min-h-[44px] flex items-center px-1"
+            className="text-xs text-amber-700 hover:text-amber-800 hover:underline transition-colors min-h-[44px] md:min-h-0 flex items-center px-1"
           >
             {summary ? <><RetryIcon className="w-3 h-3 inline" aria-hidden="true" /> Refresh</> : "Generate"}
           </button>
@@ -118,7 +118,7 @@ export default function ChapterSummary({
             <p className="text-xs text-red-700">{error}</p>
             <button
               onClick={load}
-              className="mt-1 text-xs font-medium text-red-600 hover:underline min-h-[44px] flex items-center"
+              className="mt-1 text-xs font-medium text-red-600 hover:underline min-h-[44px] md:min-h-0 flex items-center"
             >
               Try again
             </button>
@@ -140,7 +140,7 @@ export default function ChapterSummary({
             <p className="text-sm">Get a quick overview of this chapter before continuing.</p>
             <button
               onClick={load}
-              className="mt-2 px-4 min-h-[44px] flex items-center rounded-lg bg-amber-100 hover:bg-amber-200 text-amber-800 text-sm font-medium transition-colors"
+              className="mt-2 px-4 min-h-[44px] md:min-h-0 flex items-center rounded-lg bg-amber-100 hover:bg-amber-200 text-amber-800 text-sm font-medium transition-colors"
             >
               Generate Summary
             </button>

--- a/frontend/src/components/DeckCard.tsx
+++ b/frontend/src/components/DeckCard.tsx
@@ -73,7 +73,7 @@ export default function DeckCard({ deck, onClick, onDelete }: DeckCardProps) {
             onClick={() => onDelete(deck.id)}
             aria-label={`Delete deck ${deck.name}`}
             data-testid={`deck-delete-${deck.id}`}
-            className="min-h-[44px] min-w-[44px] flex items-center justify-center text-stone-500 hover:text-red-600 transition-colors shrink-0"
+            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-500 hover:text-red-600 transition-colors shrink-0"
           >
             <TrashIcon className="w-4 h-4" />
           </button>

--- a/frontend/src/components/QuickHighlightPanel.tsx
+++ b/frontend/src/components/QuickHighlightPanel.tsx
@@ -113,7 +113,7 @@ export default function QuickHighlightPanel({
           onClick={() => handleColor(c.key)}
           disabled={busy}
           aria-label={c.label}
-          className="min-h-[44px] min-w-[44px] flex items-center justify-center disabled:opacity-50"
+          className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center disabled:opacity-50"
         >
           <span
             className={`w-7 h-7 rounded-full ${c.bg} border-2 transition-all hover:scale-110 ${
@@ -128,7 +128,7 @@ export default function QuickHighlightPanel({
           onClick={onOpenNote}
           disabled={busy}
           aria-label="Add note"
-          className="min-h-[44px] min-w-[44px] flex items-center justify-center text-stone-500 hover:text-stone-700 disabled:opacity-50 transition-colors"
+          className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-500 hover:text-stone-700 disabled:opacity-50 transition-colors"
         >
           <span className="w-7 h-7 rounded-full bg-stone-100 border border-stone-300 flex items-center justify-center hover:bg-stone-200 transition-colors">
             <NoteIcon className="w-3.5 h-3.5" />
@@ -141,7 +141,7 @@ export default function QuickHighlightPanel({
           onClick={handleDelete}
           disabled={busy}
           aria-label="Delete highlight"
-          className="min-h-[44px] min-w-[44px] flex items-center justify-center text-red-500 disabled:opacity-50 transition-colors"
+          className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-red-500 disabled:opacity-50 transition-colors"
         >
           <span className="w-7 h-7 rounded-full bg-red-50 border border-red-200 flex items-center justify-center hover:bg-red-100 transition-colors">
             <TrashIcon className="w-3.5 h-3.5" />

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -61,7 +61,7 @@ export function SearchBar() {
           setOpen(true);
           focusInput();
         }}
-        className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded-md text-ink hover:bg-amber-100 transition-colors"
+        className="inline-flex items-center justify-center min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 rounded-md text-ink hover:bg-amber-100 transition-colors"
       >
         <SearchIcon className="w-5 h-5" />
       </button>
@@ -75,7 +75,7 @@ export function SearchBar() {
         e.preventDefault();
         submit();
       }}
-      className="inline-flex items-center gap-2 min-h-[44px] px-2 border border-amber-200 rounded-md bg-parchment animate-fade-in"
+      className="inline-flex items-center gap-2 min-h-[44px] md:min-h-0 px-2 border border-amber-200 rounded-md bg-parchment animate-fade-in"
     >
       <SearchIcon className="w-4 h-4 text-ink" />
       <input
@@ -96,7 +96,7 @@ export function SearchBar() {
           setQuery("");
           setOpen(false);
         }}
-        className="text-xs text-stone-500 hover:text-ink min-h-[44px] flex items-center"
+        className="text-xs text-stone-500 hover:text-ink min-h-[44px] md:min-h-0 flex items-center"
       >
         Esc
       </button>

--- a/frontend/src/components/SeedPopularButton.tsx
+++ b/frontend/src/components/SeedPopularButton.tsx
@@ -130,7 +130,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
           <button
             onClick={() => setPendingStart(true)}
             disabled={running}
-            className="rounded-lg border border-amber-300 text-amber-700 px-4 py-2 min-h-[44px] text-sm hover:bg-amber-50 disabled:opacity-50"
+            className="rounded-lg border border-amber-300 text-amber-700 px-4 py-2 min-h-[44px] md:min-h-0 text-sm hover:bg-amber-50 disabled:opacity-50"
           >
             {running ? "Seeding…" : "Seed all popular books"}
           </button>
@@ -140,7 +140,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
             onClick={() => setExpanded(true)}
             aria-expanded={false}
             aria-controls="seed-progress-panel"
-            className="text-xs text-amber-700 hover:text-amber-900 min-h-[44px] flex items-center"
+            className="text-xs text-amber-700 hover:text-amber-900 min-h-[44px] md:min-h-0 flex items-center"
           >
             Show progress
           </button>
@@ -150,7 +150,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
             onClick={() => setExpanded(false)}
             aria-expanded={true}
             aria-controls="seed-progress-panel"
-            className="text-xs text-stone-500 hover:text-stone-700 min-h-[44px] flex items-center"
+            className="text-xs text-stone-500 hover:text-stone-700 min-h-[44px] md:min-h-0 flex items-center"
           >
             Hide
           </button>
@@ -175,7 +175,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
                 <button
                   type="button"
                   onClick={() => setPendingStop(true)}
-                  className="text-xs text-red-600 hover:text-red-800 min-h-[44px] flex items-center"
+                  className="text-xs text-red-600 hover:text-red-800 min-h-[44px] md:min-h-0 flex items-center"
                 >
                   Stop
                 </button>

--- a/frontend/src/components/SentenceActionPopup.tsx
+++ b/frontend/src/components/SentenceActionPopup.tsx
@@ -51,14 +51,14 @@ export default function SentenceActionPopup({ sentenceText: _sentenceText, posit
     >
       <button
         onClick={() => { onRead(); onClose(); }}
-        className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px]"
+        className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px] md:min-h-0"
       >
         <SpeakerIcon className="w-3.5 h-3.5 shrink-0" /> Read
       </button>
       {onNote && (
         <button
           onClick={() => { onNote(); onClose(); }}
-          className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px]"
+          className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px] md:min-h-0"
         >
           <NoteIcon className="w-3.5 h-3.5 shrink-0" /> Note
         </button>
@@ -66,7 +66,7 @@ export default function SentenceActionPopup({ sentenceText: _sentenceText, posit
       {onChat && (
         <button
           onClick={() => { onChat(); onClose(); }}
-          className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px]"
+          className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px] md:min-h-0"
         >
           <ChatIcon className="w-3.5 h-3.5 shrink-0" /> Chat
         </button>

--- a/frontend/src/components/UndoToast.tsx
+++ b/frontend/src/components/UndoToast.tsx
@@ -38,7 +38,7 @@ export default function UndoToast({ message, onUndo, onDone }: Props) {
       <span>{message}</span>
       <button
         onClick={handleUndo}
-        className="font-semibold text-amber-300 hover:text-amber-200 transition-colors shrink-0 min-h-[44px] flex items-center px-1"
+        className="font-semibold text-amber-300 hover:text-amber-200 transition-colors shrink-0 min-h-[44px] md:min-h-0 flex items-center px-1"
       >
         Undo
       </button>

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -82,7 +82,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
       {/* Header */}
       <div className="flex items-center justify-between px-3 pt-2.5 pb-1.5 border-b border-amber-100">
         <span id="vocab-tooltip-title" className="font-semibold text-ink text-sm">{word}</span>
-        <button onClick={onClose} aria-label="Close word definition" className="text-stone-500 hover:text-stone-700 p-0.5 rounded transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"><CloseIcon className="w-3.5 h-3.5" /></button>
+        <button onClick={onClose} aria-label="Close word definition" className="text-stone-500 hover:text-stone-700 p-0.5 rounded transition-colors min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center"><CloseIcon className="w-3.5 h-3.5" /></button>
       </div>
 
       {/* Body */}
@@ -130,7 +130,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
         <button
           onClick={handleSave}
           disabled={saved}
-          className={`text-xs font-medium px-3 py-1 min-h-[44px] rounded-lg transition-colors flex items-center justify-center ${
+          className={`text-xs font-medium px-3 py-1 min-h-[44px] md:min-h-0 rounded-lg transition-colors flex items-center justify-center ${
             saved
               ? "bg-stone-100 text-stone-600 cursor-default"
               : "bg-amber-700 text-white hover:bg-amber-800"

--- a/frontend/src/components/WordActionDrawer.tsx
+++ b/frontend/src/components/WordActionDrawer.tsx
@@ -137,7 +137,7 @@ export default function WordActionDrawer({
           <button
             onClick={onClose}
             aria-label="Close word lookup"
-            className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg text-stone-500 hover:text-ink hover:bg-amber-50 transition-colors -mr-1"
+            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-500 hover:text-ink hover:bg-amber-50 transition-colors -mr-1"
           >
             <CloseIcon className="w-4 h-4" aria-hidden="true" />
           </button>


### PR DESCRIPTION
## What changed

78 `min-h-[44px]` and 18 `min-w-[44px]` instances across 23 files lacked `md:min-h-0` / `md:min-w-0`, making buttons render taller than content requires on desktop.

**Pages fixed (10):** `vocabulary/flashcards`, `decks/[deckId]`, `import/[bookId]`, `error`, `not-found`, `login`, `pending`, `upload`, `upload/[bookId]/chapters`, `page.tsx` (home)

**Components fixed (13):** `WordActionDrawer`, `VocabWordTooltip`, `DeckCard`, `UndoToast`, `BookDetailModal`, `AuthPromptModal`, `SentenceActionPopup`, `SearchBar`, `AnnotationToolbar`, `AnnotationsSidebar`, `ChapterSummary`, `QuickHighlightPanel`, `SeedPopularButton`

Also expands `WordActionDrawerCloseButton` test lookback window 200→300 chars to accommodate the longer className after the responsive resets were added.

## Why

CLAUDE.md graphic design rules: "Touch targets minimum 44×44px on mobile only. Use `min-h-[44px] md:min-h-0` so desktop chrome keeps its natural compact size." Bare `min-h-[44px]` without the reset inflates desktop button heights unnecessarily.

## Test plan

New `TouchTargetsBatch2.test.ts` with 46 tests (2 per file): every `min-h-[44px]` paired with `md:min-h-0` and every `min-w-[44px]` paired with `md:min-w-0`. Full suite: 3334 tests pass.

Closes #2148

## Docs follow-up

N/A — no user-visible behaviour change, only visual sizing on desktop.
