### PR TITLE
fix(ux): responsive touch-target resets for admin pages and SelectionToolbar (closes #2150)

### DIFF
--- a/frontend/src/__tests__/TouchTargetsAdmin.test.ts
+++ b/frontend/src/__tests__/TouchTargetsAdmin.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Regression tests for #2150 — third batch of responsive touch-target resets.
+ * Admin pages and SelectionToolbar must pair min-h-[44px] with md:min-h-0.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+function readSrc(rel: string) {
+  return fs.readFileSync(path.join(__dirname, "..", rel), "utf8");
+}
+
+function checkFile(rel: string, label: string) {
+  describe(`${label} (closes #2150)`, () => {
+    const src = readSrc(rel);
+
+    it("every min-h-[44px] is paired with md:min-h-0", () => {
+      const lines = src.split("\n");
+      const violations: string[] = [];
+      lines.forEach((line, i) => {
+        if (line.includes("min-h-[44px]") && !line.includes("md:min-h-0") && !line.includes("lg:min-h-0")) {
+          violations.push(`line ${i + 1}: ${line.trim()}`);
+        }
+      });
+      expect(violations).toEqual([]);
+    });
+
+    it("every min-w-[44px] is paired with md:min-w-0", () => {
+      const lines = src.split("\n");
+      const violations: string[] = [];
+      lines.forEach((line, i) => {
+        if (line.includes("min-w-[44px]") && !line.includes("md:min-w-0") && !line.includes("lg:min-w-0")) {
+          violations.push(`line ${i + 1}: ${line.trim()}`);
+        }
+      });
+      expect(violations).toEqual([]);
+    });
+  });
+}
+
+checkFile("app/admin/books/page.tsx", "AdminBooksPage");
+checkFile("app/admin/uploads/page.tsx", "AdminUploadsPage");
+checkFile("app/admin/layout.tsx", "AdminLayout");
+checkFile("app/admin/audio/page.tsx", "AdminAudioPage");
+checkFile("app/admin/users/page.tsx", "AdminUsersPage");
+checkFile("components/SelectionToolbar.tsx", "SelectionToolbar");

--- a/frontend/src/app/admin/audio/page.tsx
+++ b/frontend/src/app/admin/audio/page.tsx
@@ -65,7 +65,7 @@ export default function AudioPage() {
         <button
           type="button"
           onClick={load}
-          className="inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 transition-colors"
+          className="inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 transition-colors"
         >
           <RetryIcon className="w-4 h-4" aria-hidden="true" />
           Retry
@@ -105,7 +105,7 @@ export default function AudioPage() {
               act(() => adminFetch(`/admin/audio/${a.book_id}/${a.chapter_index}`, { method: "DELETE" }))
             }
             aria-label={`Delete audio for Book ${a.book_id}, Chapter ${a.chapter_index + 1}`}
-            className="text-xs px-2 py-1 rounded border border-red-200 text-red-600 min-h-[44px]"
+            className="text-xs px-2 py-1 rounded border border-red-200 text-red-600 min-h-[44px] md:min-h-0"
           >
             Delete
           </button>

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -330,7 +330,7 @@ export default function BooksPage() {
         <button
           onClick={handleImport}
           disabled={importing || !importId.trim()}
-          className="rounded-lg bg-amber-700 text-white px-4 py-2 min-h-[44px] text-sm hover:bg-amber-800 disabled:opacity-50"
+          className="rounded-lg bg-amber-700 text-white px-4 py-2 min-h-[44px] md:min-h-0 text-sm hover:bg-amber-800 disabled:opacity-50"
         >
           {importing ? "Importing…" : "Import Book"}
         </button>
@@ -374,7 +374,7 @@ export default function BooksPage() {
                     setExpandedBookId(isExpanded ? null : b.id);
                     setExpandedLang(null);
                   }}
-                  className="text-stone-500 hover:text-amber-700 flex items-center min-h-[44px] min-w-[44px] justify-center"
+                  className="text-stone-500 hover:text-amber-700 flex items-center min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 justify-center"
                   title={isExpanded ? `Collapse ${b.title}` : `Expand ${b.title}`}
                   aria-label={isExpanded ? `Collapse ${b.title}` : `Expand ${b.title}`}
                   aria-expanded={isExpanded}
@@ -460,7 +460,7 @@ export default function BooksPage() {
                               disabled={retryingFailed === retryKey}
                               title={`Retry ${failed} failed ${lang} chapter${failed === 1 ? "" : "s"}`}
                               aria-label={`Retry ${failed} failed ${lang} chapter${failed === 1 ? "" : "s"}`}
-                              className="text-xs px-1 rounded border border-red-300 text-red-600 hover:bg-red-50 disabled:opacity-50 inline-flex items-center min-h-[44px] min-w-[44px] justify-center"
+                              className="text-xs px-1 rounded border border-red-300 text-red-600 hover:bg-red-50 disabled:opacity-50 inline-flex items-center min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 justify-center"
                             >
                               <RetryIcon className={`w-3 h-3 ${retryingFailed === retryKey ? "animate-spin" : ""}`} />
                             </button>
@@ -474,7 +474,7 @@ export default function BooksPage() {
                 <button
                   onClick={() => router.push(`/reader/${b.id}`)}
                   aria-label={`Open reader for ${b.title}`}
-                  className="text-xs text-amber-700 hover:text-amber-800 shrink-0 min-h-[44px] flex items-center"
+                  className="text-xs text-amber-700 hover:text-amber-800 shrink-0 min-h-[44px] md:min-h-0 flex items-center"
                 >
                   Open
                 </button>
@@ -496,7 +496,7 @@ export default function BooksPage() {
                   onClick={() => queueLanguageForBook(b, newLangInput[b.id] ?? "zh")}
                   disabled={queueingLangFor?.startsWith(`${b.id}:`)}
                   aria-label={`Translate ${b.title} into ${QUEUE_LANG_OPTIONS.find((o) => o.code === (newLangInput[b.id] ?? "zh"))?.label ?? (newLangInput[b.id] ?? "zh")}`}
-                  className="text-xs px-2 py-1 rounded border border-emerald-300 text-emerald-700 hover:bg-emerald-50 shrink-0 disabled:opacity-50 min-h-[44px]"
+                  className="text-xs px-2 py-1 rounded border border-emerald-300 text-emerald-700 hover:bg-emerald-50 shrink-0 disabled:opacity-50 min-h-[44px] md:min-h-0"
                 >
                   {queueingLangFor?.startsWith(`${b.id}:`) ? "Queueing…" : "+ Translate"}
                 </button>
@@ -509,7 +509,7 @@ export default function BooksPage() {
                     })
                   }
                   aria-label={`Delete ${b.title}`}
-                  className="text-xs px-2 py-1 rounded border border-red-200 text-red-600 shrink-0 min-h-[44px]"
+                  className="text-xs px-2 py-1 rounded border border-red-200 text-red-600 shrink-0 min-h-[44px] md:min-h-0"
                 >
                   Delete
                 </button>
@@ -536,7 +536,7 @@ export default function BooksPage() {
                             <div className="px-3 py-2 flex items-center gap-2">
                               <button
                                 onClick={() => setExpandedLang(isLangExpanded ? null : bulkKey)}
-                                className="text-xs text-stone-500 hover:text-amber-700 flex items-center min-h-[44px] min-w-[44px] justify-center"
+                                className="text-xs text-stone-500 hover:text-amber-700 flex items-center min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 justify-center"
                                 aria-label={isLangExpanded ? `Collapse ${lang} translations` : `Expand ${lang} translations`}
                                 aria-expanded={isLangExpanded}
                               >
@@ -570,7 +570,7 @@ export default function BooksPage() {
                                   })
                                 }
                                 aria-label={`Retranslate all ${lang} chapters of ${b.title}`}
-                                className="ml-auto text-xs px-2 py-1 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-50 min-h-[44px]"
+                                className="ml-auto text-xs px-2 py-1 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-50 min-h-[44px] md:min-h-0"
                               >
                                 {bulkRetranslating === bulkKey ? "Retranslating…" : "Retranslate all"}
                               </button>
@@ -587,7 +587,7 @@ export default function BooksPage() {
                                   })
                                 }
                                 aria-label={`Delete all ${lang} translations for ${b.title}`}
-                                className="text-xs px-2 py-1 rounded border border-red-200 text-red-600 min-h-[44px]"
+                                className="text-xs px-2 py-1 rounded border border-red-200 text-red-600 min-h-[44px] md:min-h-0"
                               >
                                 Delete all
                               </button>
@@ -632,7 +632,7 @@ export default function BooksPage() {
                                             onClick={() => handleMove(t, moveInput[rowKey] ?? "")}
                                             disabled={moving === rowKey || !(moveInput[rowKey] ?? "").trim()}
                                             aria-label={`Move Ch. ${t.chapter_index + 1} ${t.target_language} translation`}
-                                            className="px-2 py-0.5 rounded border border-sky-300 text-sky-700 hover:bg-sky-50 disabled:opacity-50 min-h-[44px]"
+                                            className="px-2 py-0.5 rounded border border-sky-300 text-sky-700 hover:bg-sky-50 disabled:opacity-50 min-h-[44px] md:min-h-0"
                                           >
                                             {moving === rowKey ? "…" : "Move"}
                                           </button>
@@ -640,7 +640,7 @@ export default function BooksPage() {
                                             onClick={() => handleRetranslate(t)}
                                             disabled={retranslating === rowKey}
                                             aria-label={`Retranslate Ch. ${t.chapter_index + 1} ${t.target_language}`}
-                                            className="px-2 py-0.5 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-50 min-h-[44px]"
+                                            className="px-2 py-0.5 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-50 min-h-[44px] md:min-h-0"
                                           >
                                             {retranslating === rowKey ? "…" : "Retranslate"}
                                           </button>
@@ -654,7 +654,7 @@ export default function BooksPage() {
                                               )
                                             }
                                             aria-label={`Delete Ch. ${t.chapter_index + 1} ${t.target_language} translation`}
-                                            className="px-2 py-0.5 rounded border border-red-200 text-red-600 min-h-[44px]"
+                                            className="px-2 py-0.5 rounded border border-red-200 text-red-600 min-h-[44px] md:min-h-0"
                                           >
                                             Delete
                                           </button>

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -75,11 +75,11 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   return (
     <main id="main-content" className="min-h-screen bg-parchment">
       <header className="border-b border-amber-200 bg-white/60 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
-        <button onClick={() => router.push("/")} className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] flex items-center gap-1">
+        <button onClick={() => router.push("/")} className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] md:min-h-0 flex items-center gap-1">
           <ArrowLeftIcon className="w-4 h-4" aria-hidden="true" /> Library
         </button>
         <h1 className="font-serif font-bold text-ink text-lg md:text-xl">Admin Panel</h1>
-        <button onClick={loadStats} className="ml-auto text-sm text-amber-700 hover:text-amber-900 min-h-[44px] flex items-center gap-1">
+        <button onClick={loadStats} className="ml-auto text-sm text-amber-700 hover:text-amber-900 min-h-[44px] md:min-h-0 flex items-center gap-1">
           <RetryIcon className="w-4 h-4" aria-hidden="true" /> Refresh
         </button>
       </header>

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -113,7 +113,7 @@ export default function UploadsPage() {
         />
         <button
           onClick={handleFilter}
-          className="rounded-lg bg-amber-700 text-white px-4 py-2 min-h-[44px] text-sm hover:bg-amber-800"
+          className="rounded-lg bg-amber-700 text-white px-4 py-2 min-h-[44px] md:min-h-0 text-sm hover:bg-amber-800"
           aria-label="Filter uploads"
         >
           Filter
@@ -121,7 +121,7 @@ export default function UploadsPage() {
         {activeFilter && (
           <button
             onClick={clearFilter}
-            className="text-sm text-amber-700 hover:text-amber-900 min-h-[44px] flex items-center"
+            className="text-sm text-amber-700 hover:text-amber-900 min-h-[44px] md:min-h-0 flex items-center"
           >
             <CloseIcon className="w-3.5 h-3.5 inline" aria-hidden="true" /> Clear filter (user {activeFilter})
           </button>
@@ -171,7 +171,7 @@ export default function UploadsPage() {
                       <button
                         onClick={() => router.push(`/reader/${u.book_id}`)}
                         aria-label={`Open ${u.title}`}
-                        className="text-xs text-amber-700 hover:text-amber-800 min-h-[44px] flex items-center"
+                        className="text-xs text-amber-700 hover:text-amber-800 min-h-[44px] md:min-h-0 flex items-center"
                       >
                         Open
                       </button>

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -67,7 +67,7 @@ export default function UsersPage() {
         <button
           type="button"
           onClick={load}
-          className="inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 transition-colors"
+          className="inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 transition-colors"
         >
           <RetryIcon className="w-4 h-4" aria-hidden="true" />
           Retry

--- a/frontend/src/components/SelectionToolbar.tsx
+++ b/frontend/src/components/SelectionToolbar.tsx
@@ -124,7 +124,7 @@ export default function SelectionToolbar({ onRead, onHighlight, onNote, onChat, 
     setSelection(null);
   }
 
-  const btnClass = "flex items-center gap-1.5 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-white/10 active:bg-white/20 transition-colors min-h-[44px]";
+  const btnClass = "flex items-center gap-1.5 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-white/10 active:bg-white/20 transition-colors min-h-[44px] md:min-h-0";
 
   return (
     <div


### PR DESCRIPTION
## What changed

21 `min-h-[44px]` and 3 `min-w-[44px]` instances across 6 files lacked `md:min-h-0` / `md:min-w-0`, causing admin buttons to be taller than content requires on desktop.

**Files fixed:**
- `app/admin/books/page.tsx` — 12 min-h + 3 min-w
- `app/admin/uploads/page.tsx` — 3 min-h
- `app/admin/layout.tsx` — 2 min-h
- `app/admin/audio/page.tsx` — 2 min-h
- `app/admin/users/page.tsx` — 1 min-h
- `components/SelectionToolbar.tsx` — 1 min-h (string constant `btnClass`)

## Why

CLAUDE.md: "Touch targets minimum 44×44px on mobile only. Use `min-h-[44px] md:min-h-0` so desktop chrome keeps its natural compact size." This is the third and final cleanup pass completing all remaining violations after PRs #2141 and #2149.

## Test plan

New `TouchTargetsAdmin.test.ts` with 12 tests (2 per file): every `min-h-[44px]` paired with `md:min-h-0` and every `min-w-[44px]` paired with `md:min-w-0`. Full suite: 3346 tests pass.

Closes #2150

## Docs follow-up

N/A — admin-only visual sizing change, no user-visible behaviour change.
