### PR TITLE
fix(ux): add focus-within ring to SearchBar for WCAG 2.4.7 Focus Visible (closes #2152)

### DIFF
--- a/frontend/src/__tests__/SearchBarFocusRing.test.ts
+++ b/frontend/src/__tests__/SearchBarFocusRing.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Regression test for #2152 — SearchBar form container must have a focus-within
+ * ring so keyboard users see a visible focus indicator when the input is focused.
+ * WCAG 2.4.7 (Focus Visible, Level AA).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/SearchBar.tsx"),
+  "utf8",
+);
+
+describe("SearchBar focus ring (closes #2152)", () => {
+  it("form container has focus-within:ring-2 for visible focus indicator", () => {
+    expect(src).toMatch(/focus-within:ring-2/);
+  });
+
+  it("form container has focus-within:ring-amber-400 to match design tokens", () => {
+    expect(src).toMatch(/focus-within:ring-amber-400/);
+  });
+});

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -75,7 +75,7 @@ export function SearchBar() {
         e.preventDefault();
         submit();
       }}
-      className="inline-flex items-center gap-2 min-h-[44px] md:min-h-0 px-2 border border-amber-200 rounded-md bg-parchment animate-fade-in"
+      className="inline-flex items-center gap-2 min-h-[44px] md:min-h-0 px-2 border border-amber-200 rounded-md bg-parchment animate-fade-in focus-within:ring-2 focus-within:ring-amber-400 focus-within:border-amber-400"
     >
       <SearchIcon className="w-4 h-4 text-ink" />
       <input


### PR DESCRIPTION
## What changed

`components/SearchBar.tsx`: the search `<input>` had `outline-none` with no visible focus alternative. The parent `<form>` container had a static `border border-amber-200` that never changed on focus.

Added `focus-within:ring-2 focus-within:ring-amber-400 focus-within:border-amber-400` to the form container so when the input is focused, the search bar gains a visible amber ring.

## Why

WCAG 2.4.7 (Focus Visible, Level AA): every keyboard-focusable component must have a visible focus indicator. Keyboard users navigating to the search bar had no visual feedback that it was focused.

## Test plan

New `SearchBarFocusRing.test.ts`:
- Asserts form container has `focus-within:ring-2`
- Asserts form container has `focus-within:ring-amber-400`

Full suite: 3348 tests pass.

Closes #2152

## Docs follow-up

N/A — visual-only change to focus state.
