### PR TITLE
fix(ux): lift secondary text from stone-500 to stone-600 for WCAG AA 1.4.3 (closes #2154)

### DIFF
--- a/frontend/src/__tests__/BookDetailSubjectChipContrast.test.ts
+++ b/frontend/src/__tests__/BookDetailSubjectChipContrast.test.ts
@@ -11,12 +11,11 @@ const src = fs.readFileSync(
 );
 
 describe("BookDetailModal subject chip contrast (closes #1667)", () => {
-  it("no className combines base bg-stone-100 with base text-stone-500", () => {
+  it("no className combines base bg-stone-100 with base text-stone-500 (4.23:1, fails AA)", () => {
     // Walk every className=\"…\" string and check whether it has both
-    // bg-stone-100 AND text-stone-500 as space-separated *base* tokens
-    // (not hover:bg-stone-100 / hover:text-stone-500). The pre-fix chip
-    // matched; the close button on line 97 uses hover:bg-stone-100 only,
-    // so it does not match.
+    // bg-stone-100 AND text-stone-500 as space-separated *base* tokens.
+    // text-stone-500 on bg-stone-100 is ~4.23:1 — fails WCAG AA.
+    // The correct token is text-stone-600 (6.72:1 on stone-100).
     const re = /className="([^"]*)"/g;
     for (const m of src.matchAll(re)) {
       const tokens = m[1].split(/\s+/);

--- a/frontend/src/__tests__/ComponentsContrastWave6.test.ts
+++ b/frontend/src/__tests__/ComponentsContrastWave6.test.ts
@@ -11,38 +11,44 @@ const deckCard        = readSrc("DeckCard.tsx");
 const chapterSummary  = readSrc("ChapterSummary.tsx");
 
 describe("Component contrast wave 6 (closes #1362)", () => {
-  it("ReadingStats heatmap month labels use text-stone-500 not text-stone-400", () => {
+  it("ReadingStats heatmap month labels use text-stone-600 not text-stone-400", () => {
     expect(readingStats).not.toContain("text-[9px] text-stone-400");
-    expect(readingStats).toContain("text-[9px] text-stone-500");
+    expect(readingStats).not.toContain("text-[9px] text-stone-500");
+    expect(readingStats).toContain("text-[9px] text-stone-600");
   });
 
-  it("ReadingStats legend Less/More use text-stone-500 not text-stone-400", () => {
+  it("ReadingStats legend Less/More use text-stone-600 not text-stone-400", () => {
     expect(readingStats).not.toContain('"text-[9px] text-stone-400 mr-1"');
     expect(readingStats).not.toContain('"text-[9px] text-stone-400 ml-1"');
   });
 
-  it("AnnotationToolbar (optional) hint uses text-stone-500 not text-stone-400", () => {
+  it("AnnotationToolbar (optional) hint uses text-stone-600 not text-stone-400", () => {
     expect(annotationTb).not.toContain('"text-stone-400">(optional)');
-    expect(annotationTb).toContain('"text-stone-500">(optional)');
+    expect(annotationTb).not.toContain('"text-stone-500">(optional)');
+    expect(annotationTb).toContain('"text-stone-600">(optional)');
   });
 
-  it("VocabWordTooltip Base form label uses text-stone-500 not text-stone-400 (2.65:1 fail)", () => {
+  it("VocabWordTooltip Base form label uses text-stone-600 not text-stone-400 (WCAG AA)", () => {
     expect(vocabTooltip).not.toContain("text-[11px] text-stone-400");
-    expect(vocabTooltip).toContain("text-[11px] text-stone-500");
+    expect(vocabTooltip).not.toContain("text-[11px] text-stone-500");
+    expect(vocabTooltip).toContain("text-[11px] text-stone-600");
   });
 
-  it("VocabWordTooltip Close button uses text-stone-500 (WCAG 1.4.11 non-text 3:1)", () => {
+  it("VocabWordTooltip Close button uses text-stone-600 (WCAG AA 4.5:1 on parchment)", () => {
     expect(vocabTooltip).not.toContain('"text-stone-400 hover:text-stone-600');
-    expect(vocabTooltip).toContain("text-stone-500 hover:text-stone-700");
+    expect(vocabTooltip).not.toContain('"text-stone-500 hover:text-stone-700');
+    expect(vocabTooltip).toContain("text-stone-600 hover:text-stone-700");
   });
 
-  it("DeckCard delete icon uses text-stone-500 not text-stone-400 (WCAG 1.4.11)", () => {
+  it("DeckCard delete icon uses text-stone-600 not text-stone-400 (WCAG AA)", () => {
     expect(deckCard).not.toContain("text-stone-400 hover:text-red-600");
-    expect(deckCard).toContain("text-stone-500 hover:text-red-600");
+    expect(deckCard).not.toContain("text-stone-500 hover:text-red-600");
+    expect(deckCard).toContain("text-stone-600 hover:text-red-600");
   });
 
-  it("ChapterSummary empty state uses text-stone-500 not text-stone-400", () => {
+  it("ChapterSummary empty state uses text-stone-600 not text-stone-400", () => {
     expect(chapterSummary).not.toContain("text-center text-stone-400");
-    expect(chapterSummary).toContain("text-center text-stone-500");
+    expect(chapterSummary).not.toContain("text-center text-stone-500");
+    expect(chapterSummary).toContain("text-center text-stone-600");
   });
 });

--- a/frontend/src/__tests__/ContrastWave7.test.ts
+++ b/frontend/src/__tests__/ContrastWave7.test.ts
@@ -10,27 +10,31 @@ const adminBooks    = readApp("admin/books/page.tsx");
 const searchPage    = readApp("search/page.tsx");
 
 describe("Contrast wave 7 (closes #1364)", () => {
-  it("decks/new label hints use text-stone-500 not text-stone-400", () => {
+  it("decks/new label hints use text-stone-600 not text-stone-400", () => {
     expect(decksNew).not.toContain('"text-stone-400 font-normal"');
-    expect(decksNew).toContain('"text-stone-500 font-normal"');
+    expect(decksNew).not.toContain('"text-stone-500 font-normal"');
+    expect(decksNew).toContain('"text-stone-600 font-normal"');
   });
 
-  it("admin/uploads date cell uses text-stone-500 not text-stone-400", () => {
+  it("admin/uploads date cell uses text-stone-600 not text-stone-400", () => {
     expect(adminUploads).not.toContain("text-stone-400 whitespace-nowrap");
-    expect(adminUploads).toContain("text-stone-500 whitespace-nowrap");
+    expect(adminUploads).not.toContain("text-stone-500 whitespace-nowrap");
+    expect(adminUploads).toContain("text-stone-600 whitespace-nowrap");
   });
 
-  it("admin/books expand toggle uses text-stone-500 not text-stone-400 (WCAG 1.4.11)", () => {
+  it("admin/books expand toggle uses text-stone-600 not text-stone-400 (WCAG AA)", () => {
     expect(adminBooks).not.toContain("text-stone-400 hover:text-amber-700");
-    expect(adminBooks).toContain("text-stone-500 hover:text-amber-700");
+    expect(adminBooks).not.toContain("text-stone-500 hover:text-amber-700");
+    expect(adminBooks).toContain("text-stone-600 hover:text-amber-700");
   });
 
-  it("admin/books translation size label uses text-stone-500 not text-stone-400", () => {
+  it("admin/books translation size label uses text-stone-600 not text-stone-400", () => {
     expect(adminBooks).not.toContain('"text-stone-400 flex-1"');
-    expect(adminBooks).toContain('"text-stone-500 flex-1"');
+    expect(adminBooks).not.toContain('"text-stone-500 flex-1"');
+    expect(adminBooks).toContain('"text-stone-600 flex-1"');
   });
 
   it("search page empty-state SearchIcon has aria-hidden (decorative, exempt from 1.4.11)", () => {
-    expect(searchPage).toContain('text-stone-400" aria-hidden="true"');
+    expect(searchPage).toMatch(/text-stone-\d+" aria-hidden="true"/);
   });
 });

--- a/frontend/src/__tests__/ContrastWave8.test.ts
+++ b/frontend/src/__tests__/ContrastWave8.test.ts
@@ -19,76 +19,89 @@ const profilePage = src("app/profile/page.tsx");
 describe("Contrast wave 8 (closes #1369)", () => {
   // ─── Text contrast (WCAG 1.4.3) ────────────────────────────────────────
 
-  it("upload page Tips heading uses text-stone-500 not text-stone-400", () => {
+  it("upload page Tips heading uses text-stone-600 not text-stone-400 (WCAG AA on parchment)", () => {
     expect(uploadPage).not.toContain('text-stone-400">Tips');
-    expect(uploadPage).toContain('text-stone-500">Tips');
+    expect(uploadPage).not.toContain('text-stone-500">Tips');
+    expect(uploadPage).toContain('text-stone-600">Tips');
   });
 
-  it("chapters page detected count uses text-stone-500 not text-stone-400", () => {
+  it("chapters page detected count uses text-stone-600 not text-stone-400 (WCAG AA on parchment)", () => {
     expect(chaptersPage).not.toContain("text-sm font-normal text-stone-400");
-    expect(chaptersPage).toContain("text-sm font-normal text-stone-500");
+    expect(chaptersPage).not.toContain("text-sm font-normal text-stone-500");
+    expect(chaptersPage).toContain("text-sm font-normal text-stone-600");
   });
 
-  it("chapters page Preview heading uses text-stone-500 not text-stone-400", () => {
+  it("chapters page Preview heading uses text-stone-600 not text-stone-400 (WCAG AA on parchment)", () => {
     expect(chaptersPage).not.toContain("text-stone-400 mb-3");
-    expect(chaptersPage).toContain("text-stone-500 mb-3");
+    expect(chaptersPage).not.toContain("text-stone-500 mb-3");
+    expect(chaptersPage).toContain("text-stone-600 mb-3");
   });
 
-  it("chapters page ellipsis uses text-stone-500 not text-stone-400", () => {
+  it("chapters page ellipsis uses text-stone-600 not text-stone-400 (WCAG AA on parchment)", () => {
     expect(chaptersPage).not.toContain('"text-stone-400">…');
-    expect(chaptersPage).toContain('"text-stone-500">…');
+    expect(chaptersPage).not.toContain('"text-stone-500">…');
+    expect(chaptersPage).toContain('"text-stone-600">…');
   });
 
-  it("chapters page empty state uses text-stone-500 not text-stone-400", () => {
+  it("chapters page empty state uses text-stone-600 not text-stone-400 (WCAG AA on parchment)", () => {
     expect(chaptersPage).not.toContain("text-sm text-stone-400 text-center mt-8");
-    expect(chaptersPage).toContain("text-sm text-stone-500 text-center mt-8");
+    expect(chaptersPage).not.toContain("text-sm text-stone-500 text-center mt-8");
+    expect(chaptersPage).toContain("text-sm text-stone-600 text-center mt-8");
   });
 
-  it("import page footer note uses text-stone-500 not text-stone-400", () => {
+  it("import page footer note uses text-stone-600 not text-stone-400 (WCAG AA on parchment)", () => {
     expect(importPage).not.toContain("text-xs text-stone-400 mt-4");
-    expect(importPage).toContain("text-xs text-stone-500 mt-4");
+    expect(importPage).not.toContain("text-xs text-stone-500 mt-4");
+    expect(importPage).toContain("text-xs text-stone-600 mt-4");
   });
 
-  it("login page footer note uses text-stone-500 not text-stone-400", () => {
+  it("login page footer note uses text-stone-600 not text-stone-400 (WCAG AA on parchment)", () => {
     expect(loginPage).not.toContain("text-xs text-stone-400 mt-6");
-    expect(loginPage).toContain("text-xs text-stone-500 mt-6");
+    expect(loginPage).not.toContain("text-xs text-stone-500 mt-6");
+    expect(loginPage).toContain("text-xs text-stone-600 mt-6");
   });
 
-  it("SentenceReader not-loaded word uses text-stone-500 not text-stone-400", () => {
+  it("SentenceReader not-loaded word uses text-stone-600 not text-stone-400 (WCAG AA on parchment)", () => {
     expect(sentenceReader).not.toContain(': "text-stone-400";');
-    expect(sentenceReader).toContain(': "text-stone-500";');
+    expect(sentenceReader).not.toContain(': "text-stone-500";');
+    expect(sentenceReader).toContain(': "text-stone-600"');
   });
 
   // ─── Icon button contrast (WCAG 1.4.11) ────────────────────────────────
 
-  it("AnnotationToolbar close button uses text-stone-500 not text-stone-400 (WCAG 1.4.11)", () => {
+  it("AnnotationToolbar close button uses text-stone-600 not text-stone-400 (WCAG 1.4.11)", () => {
     expect(annotationToolbar).not.toContain("text-stone-400 hover:text-stone-600 hover:bg-amber-50");
-    expect(annotationToolbar).toContain("text-stone-500 hover:text-stone-700 hover:bg-amber-50");
+    expect(annotationToolbar).not.toContain("text-stone-500 hover:text-stone-700 hover:bg-amber-50");
+    expect(annotationToolbar).toContain("text-stone-600 hover:text-stone-700 hover:bg-amber-50");
   });
 
-  it("AnnotationsSidebar close button uses text-stone-500 not text-stone-400 (WCAG 1.4.11)", () => {
+  it("AnnotationsSidebar close button uses text-stone-600 not text-stone-400 (WCAG 1.4.11)", () => {
     expect(annotationsSidebar).not.toContain('"text-stone-400 hover:text-stone-600 min-h-[44px]');
-    expect(annotationsSidebar).toContain('"text-stone-500 hover:text-stone-700 min-h-[44px]');
+    expect(annotationsSidebar).not.toContain('"text-stone-500 hover:text-stone-700 min-h-[44px]');
+    expect(annotationsSidebar).toContain('"text-stone-600 hover:text-stone-700 min-h-[44px]');
   });
 
-  it("BookDetailModal close button uses text-stone-500 not text-stone-400 (WCAG 1.4.11)", () => {
+  it("BookDetailModal close button uses text-stone-600 not text-stone-400 (WCAG 1.4.11)", () => {
     expect(bookDetailModal).not.toContain("text-stone-400 hover:bg-stone-100 hover:text-stone-600");
-    expect(bookDetailModal).toContain("text-stone-500 hover:bg-stone-100 hover:text-stone-700");
+    expect(bookDetailModal).not.toContain("text-stone-500 hover:bg-stone-100 hover:text-stone-700");
+    expect(bookDetailModal).toContain("text-stone-600 hover:bg-stone-100 hover:text-stone-700");
   });
 
-  it("notes edit button uses text-stone-500 not text-stone-400 (WCAG 1.4.11)", () => {
+  it("notes edit button uses text-stone-600 not text-stone-400 (WCAG 1.4.11)", () => {
     expect(notesBookPage).not.toContain("text-stone-400 hover:text-stone-600 transition-colors p-1");
-    expect(notesBookPage).toContain("text-stone-500 hover:text-stone-700 transition-colors p-1");
+    expect(notesBookPage).not.toContain("text-stone-500 hover:text-stone-700 transition-colors p-1");
+    expect(notesBookPage).toContain("text-stone-600 hover:text-stone-700 transition-colors p-1");
   });
 
-  it("deck member trash button uses text-stone-500 not text-stone-400 (WCAG 1.4.11)", () => {
+  it("deck member trash button uses text-stone-600 not text-stone-400 (WCAG 1.4.11)", () => {
     expect(deckIdPage).not.toContain("rounded-lg text-stone-400 hover:text-red-600");
-    expect(deckIdPage).toContain("rounded-lg text-stone-500 hover:text-red-600");
+    expect(deckIdPage).not.toContain("rounded-lg text-stone-500 hover:text-red-600");
+    expect(deckIdPage).toContain("rounded-lg text-stone-600 hover:text-red-600");
   });
 
   // ─── Decorative icon: aria-hidden ──────────────────────────────────────
 
   it("profile ChevronRight in deck button has aria-hidden (decorative, exempt from 1.4.11)", () => {
-    expect(profilePage).toContain('text-stone-400 shrink-0" aria-hidden="true"');
+    expect(profilePage).toMatch(/text-stone-\d+ shrink-0" aria-hidden="true"/);
   });
 });

--- a/frontend/src/__tests__/ReaderContrast.test.ts
+++ b/frontend/src/__tests__/ReaderContrast.test.ts
@@ -20,14 +20,16 @@ describe("Reader page contrast (closes #1356)", () => {
     expect(readerSrc).toContain("text-stone-600 hover:text-stone-800");
   });
 
-  it("keyboard shortcuts heading uses text-stone-500 not text-stone-400", () => {
+  it("keyboard shortcuts heading uses text-stone-600 not text-stone-400 (WCAG AA on parchment)", () => {
     expect(readerSrc).not.toContain("tracking-widest text-stone-400");
-    expect(readerSrc).toContain("tracking-widest text-stone-500");
+    expect(readerSrc).not.toContain("tracking-widest text-stone-500");
+    expect(readerSrc).toContain("tracking-widest text-stone-600");
   });
 
-  it("cache status spans use text-stone-500 not text-stone-400", () => {
+  it("cache status spans use text-stone-600 not text-stone-400 (WCAG AA on parchment)", () => {
     expect(readerSrc).not.toContain('"text-stone-400">Loaded from cache');
-    expect(readerSrc).toContain('"text-stone-500">Loaded from cache');
+    expect(readerSrc).not.toContain('"text-stone-500">Loaded from cache');
+    expect(readerSrc).toContain('"text-stone-600">Loaded from cache');
   });
 
   it("separator pipe spans all have aria-hidden=true", () => {

--- a/frontend/src/__tests__/ReaderPage.branches3.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches3.test.tsx
@@ -561,7 +561,7 @@ describe("ReaderPage.branches3 — vocab sidebar occurrence filtering", () => {
 
     // In "book" view, chapter labels appear (line 1428: vocabView === "book")
     await waitFor(() => {
-      const chLabels = document.querySelectorAll("span[class*='text-stone-500']");
+      const chLabels = document.querySelectorAll("span[class*='text-stone-600']");
       expect(chLabels.length).toBeGreaterThan(0);
     });
   });

--- a/frontend/src/app/admin/audio/page.tsx
+++ b/frontend/src/app/admin/audio/page.tsx
@@ -61,7 +61,7 @@ export default function AudioPage() {
       <div role="alert" className="flex flex-col items-center gap-3 py-16 text-center">
         <AlertCircleIcon className="w-10 h-10 text-red-300" aria-hidden="true" />
         <p className="font-serif text-lg text-ink">Failed to load audio.</p>
-        <p className="text-sm text-stone-500">{error}</p>
+        <p className="text-sm text-stone-600">{error}</p>
         <button
           type="button"
           onClick={load}
@@ -96,7 +96,7 @@ export default function AudioPage() {
             <div className="text-sm text-ink">
               Book {a.book_id}, Ch. {a.chapter_index + 1}
             </div>
-            <div className="text-xs text-stone-500">
+            <div className="text-xs text-stone-600">
               {a.provider}/{a.voice} · {a.chunks} chunks · {a.size_mb} MB
             </div>
           </div>

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -348,7 +348,7 @@ export default function BooksPage() {
           aria-label="Filter books"
         />
         {searchQuery && (
-          <span role="status" aria-live="polite" aria-atomic="true" className="text-xs text-stone-500">
+          <span role="status" aria-live="polite" aria-atomic="true" className="text-xs text-stone-600">
             {books.filter((b) =>
               fuzzyMatchAny(searchQuery, [b.title, ...(b.authors || []), b.id]),
             ).length}{" "}
@@ -374,7 +374,7 @@ export default function BooksPage() {
                     setExpandedBookId(isExpanded ? null : b.id);
                     setExpandedLang(null);
                   }}
-                  className="text-stone-500 hover:text-amber-700 flex items-center min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 justify-center"
+                  className="text-stone-600 hover:text-amber-700 flex items-center min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 justify-center"
                   title={isExpanded ? `Collapse ${b.title}` : `Expand ${b.title}`}
                   aria-label={isExpanded ? `Collapse ${b.title}` : `Expand ${b.title}`}
                   aria-expanded={isExpanded}
@@ -395,7 +395,7 @@ export default function BooksPage() {
                       </span>
                     )}
                   </div>
-                  <div className="text-xs text-stone-500">
+                  <div className="text-xs text-stone-600">
                     ID: {b.id} · {b.languages?.join(", ")}
                     {" · "}
                     {((b.text_length || 0) / 1000).toFixed(0)}K chars
@@ -406,7 +406,7 @@ export default function BooksPage() {
 
                 <div className="flex flex-wrap gap-1 items-center">
                   {allLangs.length === 0 ? (
-                    <span className="text-xs text-stone-500">no translations</span>
+                    <span className="text-xs text-stone-600">no translations</span>
                   ) : (
                     allLangs.map((lang) => {
                       const count = b.translations?.[lang] || 0;
@@ -518,7 +518,7 @@ export default function BooksPage() {
               {isExpanded && (
                 <div className="px-4 pb-4 pt-1 bg-amber-50/40 border-t border-amber-100">
                   {translatedLangs.length === 0 ? (
-                    <p className="text-xs text-stone-500 italic">
+                    <p className="text-xs text-stone-600 italic">
                       No translations cached yet. Use the + Translate button above to queue a language.
                     </p>
                   ) : (
@@ -536,14 +536,14 @@ export default function BooksPage() {
                             <div className="px-3 py-2 flex items-center gap-2">
                               <button
                                 onClick={() => setExpandedLang(isLangExpanded ? null : bulkKey)}
-                                className="text-xs text-stone-500 hover:text-amber-700 flex items-center min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 justify-center"
+                                className="text-xs text-stone-600 hover:text-amber-700 flex items-center min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 justify-center"
                                 aria-label={isLangExpanded ? `Collapse ${lang} translations` : `Expand ${lang} translations`}
                                 aria-expanded={isLangExpanded}
                               >
                                 {isLangExpanded ? <ChevronDownIcon className="w-3 h-3" /> : <ChevronRightIcon className="w-3 h-3" />}
                               </button>
                               <span className="text-sm font-medium text-ink">{lang}</span>
-                              <span className="text-xs text-stone-500">
+                              <span className="text-xs text-stone-600">
                                 · {count} chapter{count === 1 ? "" : "s"} cached
                               </span>
 
@@ -596,7 +596,7 @@ export default function BooksPage() {
                             {isLangExpanded && (
                               <div className="border-t border-amber-100 divide-y divide-amber-50 max-h-80 overflow-y-auto">
                                 {chapterRows.length === 0 ? (
-                                  <p className="text-xs text-stone-500 px-3 py-2">
+                                  <p className="text-xs text-stone-600 px-3 py-2">
                                     (Chapter-level details load from the translations list — reload if empty.)
                                   </p>
                                 ) : (
@@ -609,8 +609,8 @@ export default function BooksPage() {
                                           key={rowKey}
                                           className="px-3 py-1.5 flex items-center gap-2 text-xs"
                                         >
-                                          <span className="text-stone-500 w-16">Ch. {t.chapter_index + 1}</span>
-                                          <span className="text-stone-500 flex-1">
+                                          <span className="text-stone-600 w-16">Ch. {t.chapter_index + 1}</span>
+                                          <span className="text-stone-600 flex-1">
                                             {(t.size_chars / 1000).toFixed(1)}K chars
                                           </span>
                                           <input

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -126,14 +126,14 @@ export default function UploadsPage() {
             <CloseIcon className="w-3.5 h-3.5 inline" aria-hidden="true" /> Clear filter (user {activeFilter})
           </button>
         )}
-        <span className="ml-auto text-xs text-stone-500">{uploads.length} upload{uploads.length !== 1 ? "s" : ""}</span>
+        <span className="ml-auto text-xs text-stone-600">{uploads.length} upload{uploads.length !== 1 ? "s" : ""}</span>
       </div>
 
       {uploads.length === 0 ? (
         <div className="bg-white rounded-xl border border-amber-200 px-4 py-12 text-center">
           <EmptyUploadIcon className="mx-auto mb-3 w-10 h-10 text-amber-200" />
           <p className="font-serif text-ink mb-1">No uploads yet</p>
-          <p className="text-sm text-stone-500">
+          <p className="text-sm text-stone-600">
             {activeFilter ? `No uploads found for user ${activeFilter}.` : "No books have been uploaded by users."}
           </p>
         </div>
@@ -156,17 +156,17 @@ export default function UploadsPage() {
                 {uploads.map((u) => (
                   <tr key={`${u.book_id}-${u.filename}`} className="hover:bg-amber-50/40">
                     <td className="px-4 py-2.5 font-medium text-ink max-w-[200px] truncate" title={u.title}>{u.title}</td>
-                    <td className="px-4 py-2.5 text-stone-500 max-w-[160px] truncate" title={u.filename}>{u.filename}</td>
+                    <td className="px-4 py-2.5 text-stone-600 max-w-[160px] truncate" title={u.filename}>{u.filename}</td>
                     <td className="px-4 py-2.5">
                       <span className="text-xs px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-200">
                         {u.format}
                       </span>
                     </td>
-                    <td className="px-4 py-2.5 text-stone-500 whitespace-nowrap">{fmt_size(u.file_size)}</td>
-                    <td className="px-4 py-2.5 text-stone-500 max-w-[160px] truncate" title={u.uploader_email}>
+                    <td className="px-4 py-2.5 text-stone-600 whitespace-nowrap">{fmt_size(u.file_size)}</td>
+                    <td className="px-4 py-2.5 text-stone-600 max-w-[160px] truncate" title={u.uploader_email}>
                       {u.uploader_email}
                     </td>
-                    <td className="px-4 py-2.5 text-stone-500 whitespace-nowrap">{fmt_date(u.uploaded_at)}</td>
+                    <td className="px-4 py-2.5 text-stone-600 whitespace-nowrap">{fmt_date(u.uploaded_at)}</td>
                     <td className="px-4 py-2.5">
                       <button
                         onClick={() => router.push(`/reader/${u.book_id}`)}

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -63,7 +63,7 @@ export default function UsersPage() {
       <div role="alert" className="flex flex-col items-center gap-3 py-16 text-center">
         <AlertCircleIcon className="w-10 h-10 text-red-300" aria-hidden="true" />
         <p className="font-serif text-lg text-ink">Failed to load users.</p>
-        <p className="text-sm text-stone-500">{error}</p>
+        <p className="text-sm text-stone-600">{error}</p>
         <button
           type="button"
           onClick={load}
@@ -112,7 +112,7 @@ export default function UsersPage() {
                   <span className="text-xs bg-orange-100 text-orange-800 px-1.5 py-0.5 rounded">pending</span>
                 )}
               </div>
-              <p className="text-xs text-stone-500 truncate" title={u.email}>{u.email}</p>
+              <p className="text-xs text-stone-600 truncate" title={u.email}>{u.email}</p>
             </div>
             {u.id !== myId && (
               <div className="flex gap-1 items-center">
@@ -168,7 +168,7 @@ export default function UsersPage() {
                 )}
               </div>
             )}
-            {u.id === myId && <span className="text-xs text-stone-500">You</span>}
+            {u.id === myId && <span className="text-xs text-stone-600">You</span>}
           </li>
         ))}
       </ul>

--- a/frontend/src/app/decks/[deckId]/page.tsx
+++ b/frontend/src/app/decks/[deckId]/page.tsx
@@ -140,7 +140,7 @@ export default function DeckDetailPage() {
             {deck?.name ?? "Deck"}
           </h1>
           {deck && (
-            <p className="text-xs text-stone-500 mt-0.5">
+            <p className="text-xs text-stone-600 mt-0.5">
               {deck.members.length} word{deck.members.length !== 1 ? "s" : ""}
               {deck.mode === "smart" ? " · smart" : ""}
             </p>
@@ -181,7 +181,7 @@ export default function DeckDetailPage() {
             <p className="font-serif text-lg text-ink mt-1">
               Could not load deck.
             </p>
-            <p className="text-sm text-stone-500">Check your connection and try again.</p>
+            <p className="text-sm text-stone-600">Check your connection and try again.</p>
             <div className="flex items-center justify-center gap-3 mt-1">
               <button
                 type="button"
@@ -214,10 +214,10 @@ export default function DeckDetailPage() {
                 className="text-center mt-16 flex flex-col items-center gap-3"
               >
                 <DeckIcon className="w-14 h-14 text-amber-300" />
-                <p className="font-serif text-lg text-stone-500 mt-1">
+                <p className="font-serif text-lg text-stone-600 mt-1">
                   No words in this deck yet.
                 </p>
-                <p className="text-sm text-stone-500 max-w-xs">
+                <p className="text-sm text-stone-600 max-w-xs">
                   {isManual
                     ? "Add words from your vocabulary to study them as a focused set."
                     : "This smart deck has no matching words yet — saved vocabulary that matches the rules will appear here."}
@@ -259,7 +259,7 @@ export default function DeckDetailPage() {
                       {w.word}
                     </span>
                     {w.language && (
-                      <span className="text-xs uppercase tracking-wide text-stone-500 shrink-0">
+                      <span className="text-xs uppercase tracking-wide text-stone-600 shrink-0">
                         {w.language}
                       </span>
                     )}
@@ -268,7 +268,7 @@ export default function DeckDetailPage() {
                         type="button"
                         onClick={() => handleRemove(w.id)}
                         aria-label={`Remove ${w.word} from deck`}
-                        className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-500 hover:text-red-600 hover:bg-red-50 transition-colors"
+                        className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-600 hover:text-red-600 hover:bg-red-50 transition-colors"
                       >
                         <TrashIcon className="w-4 h-4" />
                       </button>
@@ -368,7 +368,7 @@ function AddWordPicker({ candidates, onClose, onAdd }: AddWordPickerProps) {
             type="button"
             onClick={onClose}
             aria-label="Close add-word picker"
-            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-500 hover:text-ink hover:bg-amber-100 transition-colors"
+            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-600 hover:text-ink hover:bg-amber-100 transition-colors"
           >
             <CloseIcon className="w-4 h-4" />
           </button>
@@ -392,11 +392,11 @@ function AddWordPicker({ candidates, onClose, onAdd }: AddWordPickerProps) {
 
         <div className="flex-1 overflow-y-auto px-4 py-3">
           {candidates.length === 0 ? (
-            <p className="text-sm text-stone-500 text-center py-6">
+            <p className="text-sm text-stone-600 text-center py-6">
               All your saved words are already in this deck.
             </p>
           ) : filtered.length === 0 ? (
-            <p className="text-sm text-stone-500 text-center py-6">
+            <p className="text-sm text-stone-600 text-center py-6">
               No matches.
             </p>
           ) : (
@@ -415,7 +415,7 @@ function AddWordPicker({ candidates, onClose, onAdd }: AddWordPickerProps) {
                       {w.word}
                     </span>
                     {w.language && (
-                      <span className="text-xs uppercase tracking-wide text-stone-500 shrink-0">
+                      <span className="text-xs uppercase tracking-wide text-stone-600 shrink-0">
                         {w.language}
                       </span>
                     )}

--- a/frontend/src/app/decks/new/page.tsx
+++ b/frontend/src/app/decks/new/page.tsx
@@ -113,7 +113,7 @@ export default function DecksNewPage() {
               htmlFor="deck-description"
               className="block text-sm font-medium text-ink mb-1"
             >
-              Description <span className="text-stone-500 font-normal">(optional)</span>
+              Description <span className="text-stone-600 font-normal">(optional)</span>
             </label>
             <textarea
               id="deck-description"
@@ -142,7 +142,7 @@ export default function DecksNewPage() {
                 />
                 <span className="text-sm">
                   <span className="font-medium text-ink block">Manual</span>
-                  <span className="text-stone-500">
+                  <span className="text-stone-600">
                     Pick members by hand. You add and remove words one at a time.
                   </span>
                 </span>
@@ -159,7 +159,7 @@ export default function DecksNewPage() {
                 />
                 <span className="text-sm">
                   <span className="font-medium text-ink block">Smart</span>
-                  <span className="text-stone-500">
+                  <span className="text-stone-600">
                     Rule-based — membership recomputed at query time from your saved vocabulary.
                   </span>
                 </span>
@@ -173,7 +173,7 @@ export default function DecksNewPage() {
               className="rounded-xl border border-amber-200 bg-amber-50/40 p-4 space-y-4"
             >
               <legend className="px-2 text-sm font-medium text-ink">
-                Rules <span className="text-stone-500 font-normal">(leave blank to match everything)</span>
+                Rules <span className="text-stone-600 font-normal">(leave blank to match everything)</span>
               </legend>
 
               <div>
@@ -181,7 +181,7 @@ export default function DecksNewPage() {
                   htmlFor="deck-rule-language"
                   className="block text-sm font-medium text-ink mb-1"
                 >
-                  Language <span className="text-stone-500 font-normal">(e.g. de, en, zh)</span>
+                  Language <span className="text-stone-600 font-normal">(e.g. de, en, zh)</span>
                 </label>
                 <input
                   id="deck-rule-language"
@@ -199,7 +199,7 @@ export default function DecksNewPage() {
                   htmlFor="deck-rule-tags-any"
                   className="block text-sm font-medium text-ink mb-1"
                 >
-                  Tags any of <span className="text-stone-500 font-normal">(comma-separated)</span>
+                  Tags any of <span className="text-stone-600 font-normal">(comma-separated)</span>
                 </label>
                 <input
                   id="deck-rule-tags-any"
@@ -216,7 +216,7 @@ export default function DecksNewPage() {
                   htmlFor="deck-rule-tags-all"
                   className="block text-sm font-medium text-ink mb-1"
                 >
-                  Tags all of <span className="text-stone-500 font-normal">(comma-separated)</span>
+                  Tags all of <span className="text-stone-600 font-normal">(comma-separated)</span>
                 </label>
                 <input
                   id="deck-rule-tags-all"

--- a/frontend/src/app/decks/page.tsx
+++ b/frontend/src/app/decks/page.tsx
@@ -69,7 +69,7 @@ export default function DecksPage() {
         <div className="flex-1 min-w-0">
           <h1 className="font-serif font-bold text-ink truncate">Decks</h1>
           {!loading && !fetchError && (
-            <p className="text-xs text-stone-500 mt-0.5">
+            <p className="text-xs text-stone-600 mt-0.5">
               {decks.length} deck{decks.length !== 1 ? "s" : ""}
             </p>
           )}
@@ -99,7 +99,7 @@ export default function DecksPage() {
             </div>
           </div>
         ) : fetchError ? (
-          <div role="alert" className="text-center text-stone-500 mt-16 flex flex-col items-center gap-2">
+          <div role="alert" className="text-center text-stone-600 mt-16 flex flex-col items-center gap-2">
             <AlertCircleIcon className="w-12 h-12 text-red-300 mx-auto mb-1" aria-hidden="true" />
             <p className="font-serif text-lg text-red-700 mt-1">Failed to load decks.</p>
             <p className="text-sm">Check your connection and try again.</p>
@@ -118,8 +118,8 @@ export default function DecksPage() {
             className="text-center mt-16 flex flex-col items-center gap-3"
           >
             <DeckIcon className="w-14 h-14 text-amber-300" />
-            <p className="font-serif text-lg text-stone-500 mt-1">No study decks yet.</p>
-            <p className="text-sm text-stone-500 max-w-xs">
+            <p className="font-serif text-lg text-stone-600 mt-1">No study decks yet.</p>
+            <p className="text-sm text-stone-600 max-w-xs">
               Build focused review lists from your saved vocabulary. Start with a manual
               deck — pick a few words and study just them.
             </p>

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -13,7 +13,7 @@ export default function ErrorPage({ error, reset }: Props) {
       <div role="alert" className="text-center max-w-sm">
         <AlertCircleIcon className="w-14 h-14 mx-auto mb-4 text-red-400" aria-hidden="true" />
         <h1 className="font-serif text-2xl font-bold text-ink mb-2">Something went wrong</h1>
-        <p className="text-sm text-stone-500 mb-6">
+        <p className="text-sm text-stone-600 mb-6">
           {error.message || "An unexpected error occurred. Try again, or head back to the library."}
         </p>
         <div className="flex items-center justify-center gap-3">

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -277,7 +277,7 @@ export default function BookImportPage() {
                         </div>
                       )}
                     {s.message && s.status === "active" && (
-                      <p className="ml-7 mt-1 text-xs text-stone-500 truncate">
+                      <p className="ml-7 mt-1 text-xs text-stone-600 truncate">
                         {s.message}
                       </p>
                     )}
@@ -335,7 +335,7 @@ export default function BookImportPage() {
           )}
         </div>
 
-        <p className="text-center text-xs text-stone-500 mt-4">
+        <p className="text-center text-xs text-stone-600 mt-4">
           Translations are cached — other readers of the same book share the
           result.
         </p>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -25,7 +25,7 @@ function LoginForm() {
         {/* Card */}
         <div className="bg-white rounded-2xl shadow-sm border border-amber-100 p-8">
           <h2 className="font-serif text-xl font-semibold text-ink mb-1">Sign in</h2>
-          <p className="text-sm text-stone-500 mb-8">
+          <p className="text-sm text-stone-600 mb-8">
             Sign in to access your library and AI features.
           </p>
 
@@ -66,7 +66,7 @@ function LoginForm() {
           </div>
         </div>
 
-        <p className="text-center text-xs text-stone-500 mt-6">
+        <p className="text-center text-xs text-stone-600 mt-6">
           Your reading data stays on your own device.
         </p>
       </div>

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -10,7 +10,7 @@ export default function NotFound() {
       <div className="text-center max-w-sm">
         <BookOpenIcon className="w-14 h-14 mx-auto mb-4 text-amber-300" aria-hidden="true" />
         <h1 className="font-serif text-2xl font-bold text-ink mb-2">Page not found</h1>
-        <p className="text-sm text-stone-500 mb-6">
+        <p className="text-sm text-stone-600 mb-6">
           The page you&rsquo;re looking for doesn&rsquo;t exist or has been moved.
         </p>
         <Link

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -119,7 +119,7 @@ function AnnotationCard({
             </button>
             <button
               onClick={onCancel}
-              className="px-3 py-1 text-xs text-stone-500 hover:text-stone-700 transition-colors min-h-[44px] md:min-h-0"
+              className="px-3 py-1 text-xs text-stone-600 hover:text-stone-700 transition-colors min-h-[44px] md:min-h-0"
             >
               Cancel
             </button>
@@ -141,7 +141,7 @@ function AnnotationCard({
           </a>
           <button
             onClick={onEdit}
-            className="text-stone-500 hover:text-stone-700 transition-colors p-1 min-h-[44px] md:min-h-0 flex items-center justify-center"
+            className="text-stone-600 hover:text-stone-700 transition-colors p-1 min-h-[44px] md:min-h-0 flex items-center justify-center"
             title="Edit note"
             aria-label={`Edit annotation: ${ann.sentence_text.slice(0, 60)}`}
           >
@@ -183,7 +183,7 @@ function InsightCard({
   return (
     <div className="my-3 space-y-1.5">
       {ins.context_text && (
-        <blockquote className="border-l-4 border-amber-200 pl-4 italic text-stone-500 text-sm leading-relaxed">
+        <blockquote className="border-l-4 border-amber-200 pl-4 italic text-stone-600 text-sm leading-relaxed">
           &ldquo;{truncate(ins.context_text, 200)}&rdquo;
         </blockquote>
       )}
@@ -234,7 +234,7 @@ function VocabRow({
         >
           {word}
         </a>{" "}
-        <span className="text-stone-500 text-xs">({chapterLabel(chapters, occurrence.chapter_index)})</span>
+        <span className="text-stone-600 text-xs">({chapterLabel(chapters, occurrence.chapter_index)})</span>
         {" — "}
         <a
           href={readerHref}
@@ -665,7 +665,7 @@ export default function BookNotesPage() {
           </button>
 
           <div className="flex-1 min-w-0">
-            <p className="text-xs text-stone-500 truncate">
+            <p className="text-xs text-stone-600 truncate">
               {annCount} annotations · {insCount} insights · {vocCount} words
             </p>
           </div>
@@ -675,7 +675,7 @@ export default function BookNotesPage() {
             <button
               onClick={toggleCollapseAll}
               aria-expanded={!isAllCollapsed}
-              className="text-xs text-stone-500 hover:text-stone-600 shrink-0 transition-colors min-h-[44px] md:min-h-0"
+              className="text-xs text-stone-600 hover:text-stone-700 shrink-0 transition-colors min-h-[44px] md:min-h-0"
             >
               {isAllCollapsed ? "Expand all" : "Collapse all"}
             </button>
@@ -729,7 +729,7 @@ export default function BookNotesPage() {
             <span className="w-6 h-6 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
           </div>
         ) : fetchError ? (
-          <div role="alert" className="text-center text-stone-500 mt-20 flex flex-col items-center gap-2">
+          <div role="alert" className="text-center text-stone-600 mt-20 flex flex-col items-center gap-2">
             <AlertCircleIcon className="w-12 h-12 text-red-300 mx-auto mb-1" aria-hidden="true" />
             <p className="font-serif text-lg text-red-700 mt-1">Failed to load notes.</p>
             <p className="text-sm">Check your connection and try again.</p>
@@ -743,7 +743,7 @@ export default function BookNotesPage() {
             </button>
           </div>
         ) : annCount + insCount + vocCount === 0 ? (
-          <div className="text-center py-24 text-stone-500">
+          <div className="text-center py-24 text-stone-600">
             <EmptyNotesIcon className="w-16 h-16 mx-auto mb-3 text-amber-300" aria-hidden="true" />
             <p className="font-serif text-lg text-ink mb-1">No notes yet</p>
             <p className="text-sm">Annotate sentences, save AI insights, or add words to vocabulary while reading.</p>
@@ -760,7 +760,7 @@ export default function BookNotesPage() {
               <div className="mb-6">
                 <h1 className="text-2xl font-serif font-bold text-ink">{meta.title}</h1>
                 {(meta.authors ?? []).length > 0 && (
-                  <p className="text-sm text-stone-500 italic mt-0.5">{meta.authors.join(", ")}</p>
+                  <p className="text-sm text-stone-600 italic mt-0.5">{meta.authors.join(", ")}</p>
                 )}
               </div>
             )}

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -159,7 +159,7 @@ export default function NotesOverviewPage() {
             <span className="w-6 h-6 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
           </div>
         ) : fetchError ? (
-          <div role="alert" className="text-center text-stone-500 mt-20 flex flex-col items-center gap-2">
+          <div role="alert" className="text-center text-stone-600 mt-20 flex flex-col items-center gap-2">
             <AlertCircleIcon className="w-12 h-12 text-red-300 mx-auto mb-1" aria-hidden="true" />
             <p className="font-serif text-lg text-red-700 mt-1">Failed to load notes.</p>
             <p className="text-sm">Check your connection and try again.</p>
@@ -173,7 +173,7 @@ export default function NotesOverviewPage() {
             </button>
           </div>
         ) : filtered.length === 0 ? (
-          <div className="text-center py-20 text-stone-500">
+          <div className="text-center py-20 text-stone-600">
             <EmptyNotesIcon className="w-14 h-14 mx-auto mb-4 text-amber-400/60" />
             {books.length === 0 ? (
               <>
@@ -189,7 +189,7 @@ export default function NotesOverviewPage() {
               </>
             ) : (
               <>
-                <p className="font-serif text-lg text-stone-500 mt-1">No books match &ldquo;{search}&rdquo;</p>
+                <p className="font-serif text-lg text-stone-600 mt-1">No books match &ldquo;{search}&rdquo;</p>
                 <p className="text-sm">Try a different search term.</p>
                 <button
                   type="button"
@@ -236,7 +236,7 @@ export default function NotesOverviewPage() {
                     </div>
                   </div>
                   <div className="shrink-0 text-right">
-                    <span className="text-xs text-stone-500">{timeAgo(book.lastActivity)}</span>
+                    <span className="text-xs text-stone-600">{timeAgo(book.lastActivity)}</span>
                     <p className="text-amber-600 group-hover:text-amber-800 mt-0.5"><ArrowRightIcon className="w-5 h-5" aria-hidden="true" /></p>
                   </div>
                 </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -315,7 +315,7 @@ export default function Home() {
             {/* Continue Reading */}
             {recentBooks.length > 0 && (
               <section>
-                <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-500 mb-2">
+                <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-600 mb-2">
                   Continue Reading
                 </h2>
                 <button
@@ -339,7 +339,7 @@ export default function Home() {
                   <div className="flex-1 min-w-0">
                     <p className="font-serif font-semibold text-sm text-ink line-clamp-1">{recentBooks[0].title}</p>
                     <p className="text-xs text-amber-700 mt-0.5 line-clamp-1">{recentBooks[0].authors?.join(", ")}</p>
-                    <p className="text-xs text-stone-500 mt-1">
+                    <p className="text-xs text-stone-600 mt-1">
                       Chapter {recentBooks[0].lastChapter + 1} · {timeAgo(recentBooks[0].lastRead)}
                     </p>
                   </div>
@@ -352,7 +352,7 @@ export default function Home() {
             {status === "authenticated" && userStats && (
               <section>
                 <div className="flex items-center gap-2 mb-3">
-                  <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-500 flex-1">
+                  <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-600 flex-1">
                     Your Progress
                   </h2>
                   <button
@@ -371,7 +371,7 @@ export default function Home() {
                       <FireIcon className="w-5 h-5 text-amber-600 shrink-0" />
                       <div>
                         <p className="text-lg font-bold text-amber-900 leading-none">{userStats.streak}</p>
-                        <p className="text-[10px] text-stone-500 mt-0.5">day streak</p>
+                        <p className="text-[10px] text-stone-600 mt-0.5">day streak</p>
                       </div>
                     </div>
                   )}
@@ -379,21 +379,21 @@ export default function Home() {
                     <BookOpenIcon className="w-5 h-5 text-amber-600 shrink-0" />
                     <div>
                       <p className="text-lg font-bold text-stone-800 leading-none">{userStats.totals.books_started}</p>
-                      <p className="text-[10px] text-stone-500 mt-0.5">books started</p>
+                      <p className="text-[10px] text-stone-600 mt-0.5">books started</p>
                     </div>
                   </div>
                   <div className="bg-white rounded-xl border border-amber-100 px-4 py-3 flex items-center gap-3">
                     <VocabIcon className="w-5 h-5 text-amber-600 shrink-0" />
                     <div>
                       <p className="text-lg font-bold text-stone-800 leading-none">{userStats.totals.vocabulary_words}</p>
-                      <p className="text-[10px] text-stone-500 mt-0.5">words saved</p>
+                      <p className="text-[10px] text-stone-600 mt-0.5">words saved</p>
                     </div>
                   </div>
                   <div className="bg-white rounded-xl border border-amber-100 px-4 py-3 flex items-center gap-3">
                     <NoteIcon className="w-5 h-5 text-amber-600 shrink-0" />
                     <div>
                       <p className="text-lg font-bold text-stone-800 leading-none">{userStats.totals.annotations}</p>
-                      <p className="text-[10px] text-stone-500 mt-0.5">annotations</p>
+                      <p className="text-[10px] text-stone-600 mt-0.5">annotations</p>
                     </div>
                   </div>
                 </div>
@@ -411,7 +411,7 @@ export default function Home() {
             {recentBooks.length > 0 ? (
               <section>
                 {recentBooks.length > 1 && (
-                  <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-500 mb-3">
+                  <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-600 mb-3">
                     Your Library
                   </h2>
                 )}
@@ -773,7 +773,7 @@ export default function Home() {
                             aria-label={`Open ${book.title}${book.authors.length ? ` by ${book.authors.join(", ")}` : ""}`}
                             className="flex items-center gap-3 w-full px-4 py-3 text-left hover:bg-amber-50 transition-colors"
                           >
-                            <span className="text-xs text-stone-500 w-7 text-right shrink-0 tabular-nums">
+                            <span className="text-xs text-stone-600 w-7 text-right shrink-0 tabular-nums">
                               {(popularPage - 1) * PER_PAGE + idx + 1}
                             </span>
                             {book.cover ? (
@@ -789,7 +789,7 @@ export default function Home() {
                               <p className="text-xs text-amber-700 truncate">{book.authors.join(", ")}</p>
                             </div>
                             {book.download_count > 0 ? (
-                              <span className="text-xs text-stone-500 shrink-0 tabular-nums">
+                              <span className="text-xs text-stone-600 shrink-0 tabular-nums">
                                 {book.download_count.toLocaleString()}
                               </span>
                             ) : null}
@@ -836,7 +836,7 @@ export default function Home() {
                 <div role="alert" className="text-center py-10 flex flex-col items-center gap-2">
                   <AlertCircleIcon className="w-10 h-10 text-red-300 mx-auto" aria-hidden="true" />
                   <p className="font-serif text-base text-red-700">Failed to load books.</p>
-                  <p className="text-sm text-stone-500">Check your connection and try again.</p>
+                  <p className="text-sm text-stone-600">Check your connection and try again.</p>
                   <button
                     type="button"
                     onClick={loadPopularBooks}
@@ -852,7 +852,7 @@ export default function Home() {
                 <div className="text-center py-10 flex flex-col items-center gap-3">
                   <BookOpenIcon className="w-12 h-12 text-amber-300 mx-auto" aria-hidden="true" />
                   <p className="font-serif text-lg text-ink">No popular books yet</p>
-                  <p className="text-sm text-stone-500 max-w-xs">
+                  <p className="text-sm text-stone-600 max-w-xs">
                     Popular classics from Project Gutenberg haven&apos;t been loaded yet.
                     Search above to find any title or author.
                   </p>

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -219,7 +219,7 @@ export default function ProfilePage() {
             )}
             <div>
               <p className="font-medium text-ink">{user?.name}</p>
-              <p className="text-sm text-stone-500">{user?.email}</p>
+              <p className="text-sm text-stone-600">{user?.email}</p>
             </div>
           </div>
           <div className="mt-6 flex items-center gap-4">
@@ -281,12 +281,12 @@ export default function ProfilePage() {
         ) : null}
 
         {/* Section label */}
-        <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-500 px-1">AI &amp; Integrations</h2>
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-600 px-1">AI &amp; Integrations</h2>
 
         {/* ── Gemini API key ──────────────────────────────────────────────── */}
         <section className="bg-white rounded-2xl border border-amber-100 p-6">
           <h2 className="font-serif text-lg font-semibold text-ink mb-1">Gemini API Key</h2>
-          <p className="text-sm text-stone-500 mb-5">
+          <p className="text-sm text-stone-600 mb-5">
             Add your own key from{" "}
             <a
               href="https://aistudio.google.com/app/apikey"
@@ -355,7 +355,7 @@ export default function ProfilePage() {
             >
               <div>
                 <span className="font-serif text-lg font-semibold text-ink">Obsidian Export</span>
-                <p className="text-xs text-stone-500 mt-0.5">
+                <p className="text-xs text-stone-600 mt-0.5">
                   {hasObsidianToken
                     ? "GitHub token configured — vault sync ready"
                     : "Configure GitHub integration to push vocab to Obsidian"}
@@ -400,7 +400,7 @@ export default function ProfilePage() {
                   onChange={(e) => setObsidianToken(e.target.value)}
                   className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-amber-400 placeholder:text-stone-600"
                 />
-                <p className="text-xs text-stone-500 mt-1">
+                <p className="text-xs text-stone-600 mt-1">
                   Requires <code>contents:write</code> permission on your vault repo.
                 </p>
               </div>
@@ -449,13 +449,13 @@ export default function ProfilePage() {
         </section>
 
         {/* Section label */}
-        <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-500 px-1">Reader Preferences</h2>
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-600 px-1">Reader Preferences</h2>
 
         {/* ── Preferences ─────────────────────────────────────────────────── */}
         <section className="bg-white rounded-2xl border border-amber-100 p-6 space-y-6">
           <div>
             <h2 className="font-serif text-lg font-semibold text-ink">Preferences</h2>
-            <p className="text-sm text-stone-500 mt-1">
+            <p className="text-sm text-stone-600 mt-1">
               Defaults applied across the reader. You can still override most of these per-session.
             </p>
           </div>
@@ -475,7 +475,7 @@ export default function ProfilePage() {
                 <option key={l.code} value={l.code}>{l.label}</option>
               ))}
             </select>
-            <p className="text-xs text-stone-500 mt-1">
+            <p className="text-xs text-stone-600 mt-1">
               Language used for chapter insights and follow-up chat responses.
             </p>
           </div>
@@ -495,7 +495,7 @@ export default function ProfilePage() {
                 <option key={l.code} value={l.code}>{l.label}</option>
               ))}
             </select>
-            <p className="text-xs text-stone-500 mt-1">
+            <p className="text-xs text-stone-600 mt-1">
               Target language when the translation panel is enabled.
             </p>
           </div>
@@ -505,7 +505,7 @@ export default function ProfilePage() {
             <label className="block text-sm font-medium text-ink mb-1.5">
               Text-to-speech voice
             </label>
-            <p className="text-xs text-stone-500 mb-2">
+            <p className="text-xs text-stone-600 mb-2">
               Uses Microsoft Edge TTS (free, no API key required).
             </p>
             <div className="flex gap-2">
@@ -561,7 +561,7 @@ export default function ProfilePage() {
                   />
                   <div className="flex-1">
                     <div className="text-sm font-medium text-ink">{opt.label}</div>
-                    <div className="text-xs text-stone-500 mt-0.5">{opt.hint}</div>
+                    <div className="text-xs text-stone-600 mt-0.5">{opt.hint}</div>
                   </div>
                 </label>
               ))}

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -939,7 +939,7 @@ export default function ReaderPage() {
             <span className="text-stone-400 mx-0.5" aria-hidden="true">|</span>
             <button
               onClick={() => setFocusMode(false)}
-              className="inline-flex items-center gap-1 px-2 py-1 rounded-full hover:bg-red-50 text-stone-500 hover:text-red-600 transition-colors min-h-[44px] md:min-h-0"
+              className="inline-flex items-center gap-1 px-2 py-1 rounded-full hover:bg-red-50 text-stone-600 hover:text-red-600 transition-colors min-h-[44px] md:min-h-0"
               aria-label="Exit focus mode"
               title="Exit focus mode (F)"
             ><CloseIcon className="w-3 h-3" aria-hidden="true" /> Focus</button>
@@ -1258,7 +1258,7 @@ export default function ReaderPage() {
             </button>
             {showShortcuts && (
               <div id="shortcuts-panel" role="region" aria-label="Keyboard shortcuts" className="absolute right-0 top-full mt-2 w-56 bg-white border border-amber-200 rounded-xl shadow-lg z-50 p-3 animate-fade-in">
-                <p className="text-[10px] font-semibold uppercase tracking-widest text-stone-500 mb-2">Keyboard Shortcuts</p>
+                <p className="text-[10px] font-semibold uppercase tracking-widest text-stone-600 mb-2">Keyboard Shortcuts</p>
                 <div className="space-y-1.5">
                   {[
                     { keys: ["Space"], label: "Play / Pause TTS" },
@@ -1268,7 +1268,7 @@ export default function ReaderPage() {
                     { keys: ["Esc"], label: "Close panels" },
                   ].map(({ keys, label }) => (
                     <div key={label} className="flex items-center justify-between gap-2">
-                      <span className="text-xs text-stone-500">{label}</span>
+                      <span className="text-xs text-stone-600">{label}</span>
                       <div className="flex items-center gap-1 shrink-0">
                         {keys.map((k) => (
                           <kbd key={k} className="inline-flex items-center justify-center min-w-[22px] h-5 px-1 rounded border border-stone-200 bg-stone-50 text-[10px] font-mono text-stone-600">{k}</kbd>
@@ -1404,7 +1404,7 @@ export default function ReaderPage() {
               <div role="alert" className="max-w-prose mx-auto text-center py-16 px-4">
                 <BookOpenIcon className="w-10 h-10 text-amber-300 mx-auto mb-4" aria-hidden="true" />
                 <h2 className="font-serif text-lg text-ink mb-2">Failed to load chapter</h2>
-                <p className="text-sm text-stone-500 mb-6">{error}</p>
+                <p className="text-sm text-stone-600 mb-6">{error}</p>
                 <div className="flex items-center justify-center gap-3">
                   <button
                     onClick={retryChapterLoad}
@@ -1852,9 +1852,9 @@ export default function ReaderPage() {
                         <span className="w-5 h-5 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
                       </div>
                     ) : filteredNotes.length === 0 ? (
-                      <div className="text-center text-stone-500 mt-10 text-sm">
+                      <div className="text-center text-stone-600 mt-10 text-sm">
                         <NoteIcon className="w-8 h-8 mx-auto mb-2 opacity-40" />
-                        <p className="font-serif text-lg text-stone-500 mt-1">{notesView === "chapter" ? "No annotations in this chapter" : "No annotations yet"}</p>
+                        <p className="font-serif text-lg text-stone-600 mt-1">{notesView === "chapter" ? "No annotations in this chapter" : "No annotations yet"}</p>
                         <p className="mt-1 text-xs">Long-press a sentence to add one.</p>
                       </div>
                     ) : notesView === "chapter" ? (
@@ -1870,7 +1870,7 @@ export default function ReaderPage() {
                           return (
                             <div key={ch}>
                               <button
-                                className="flex items-center gap-1 w-full text-left text-xs font-semibold text-stone-500 uppercase tracking-wide min-h-[44px] md:min-h-0"
+                                className="flex items-center gap-1 w-full text-left text-xs font-semibold text-stone-600 uppercase tracking-wide min-h-[44px] md:min-h-0"
                                 aria-expanded={!isCollapsed}
                                 onClick={() => setCollapsedNoteChapters((prev) => {
                                   const next = new Set(prev);
@@ -1901,7 +1901,7 @@ export default function ReaderPage() {
                       </a>
                       <a
                         href="/notes"
-                        className="text-xs text-stone-500 hover:text-stone-700 transition-colors"
+                        className="text-xs text-stone-600 hover:text-stone-700 transition-colors"
                       >
                         All books
                       </a>
@@ -1933,7 +1933,7 @@ export default function ReaderPage() {
                       ))}
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-xs text-stone-500" aria-live="polite" aria-atomic="true">
+                      <span className="text-xs text-stone-600" aria-live="polite" aria-atomic="true">
                         {filteredVocab.length} word{filteredVocab.length !== 1 ? "s" : ""}
                       </span>
                       <button onClick={() => router.push("/vocabulary")} className="text-xs text-amber-700 hover:text-amber-800 font-medium min-h-[44px] md:min-h-0 flex items-center gap-1">
@@ -1941,9 +1941,9 @@ export default function ReaderPage() {
                       </button>
                     </div>
                     {filteredVocab.length === 0 ? (
-                      <div className="text-center text-stone-500 mt-10 text-sm">
+                      <div className="text-center text-stone-600 mt-10 text-sm">
                         <EmptyVocabIcon className="w-10 h-10 text-stone-300 mx-auto mb-2" />
-                        <p className="font-serif text-lg text-stone-500 mt-1">{vocabView === "chapter" ? "No vocabulary in this chapter" : "No vocabulary saved yet"}</p>
+                        <p className="font-serif text-lg text-stone-600 mt-1">{vocabView === "chapter" ? "No vocabulary in this chapter" : "No vocabulary saved yet"}</p>
                         <p className="mt-1 text-xs">Select text to save words to vocabulary.</p>
                       </div>
                     ) : (
@@ -1984,9 +1984,9 @@ export default function ReaderPage() {
                                   className="w-full text-left border-t border-amber-200 px-3 py-1.5 hover:bg-amber-100 transition-colors min-h-[44px] md:min-h-0 flex items-center"
                                 >
                                   {vocabView === "book" && (
-                                    <span className="text-[10px] text-stone-500 mr-1">Ch.{occ.chapter_index + 1}</span>
+                                    <span className="text-[10px] text-stone-600 mr-1">Ch.{occ.chapter_index + 1}</span>
                                   )}
-                                  <span className="text-xs text-stone-500 italic line-clamp-2">&ldquo;{occ.sentence_text}&rdquo;</span>
+                                  <span className="text-xs text-stone-600 italic line-clamp-2">&ldquo;{occ.sentence_text}&rdquo;</span>
                                 </button>
                               ))}
                             </div>
@@ -2093,9 +2093,9 @@ export default function ReaderPage() {
                         )}
                         {!translationLoading && (
                           translationUsedProvider === "cache" ? (
-                            <span className="text-stone-500">Loaded from cache</span>
+                            <span className="text-stone-600">Loaded from cache</span>
                           ) : translationUsedProvider.startsWith("cache · ") ? (
-                            <span className="text-stone-500">From cache · <span className="font-mono">{translationUsedProvider.slice(8)}</span></span>
+                            <span className="text-stone-600">From cache · <span className="font-mono">{translationUsedProvider.slice(8)}</span></span>
                           ) : translationUsedProvider === "translated" ? (
                             <span className="text-green-700">Translated</span>
                           ) : translationUsedProvider.startsWith("translated · ") ? (
@@ -2136,7 +2136,7 @@ export default function ReaderPage() {
                                 {enqueueingBook ? "Queueing…" : `Translate remaining ${notStarted}`}
                               </button>
                               {hasGeminiKey === true && !enqueueingBook && (
-                                <p className="mt-1 text-xs text-stone-500 text-center" aria-label="Rough cost estimate for queuing remaining chapters">
+                                <p className="mt-1 text-xs text-stone-600 text-center" aria-label="Rough cost estimate for queuing remaining chapters">
                                   Rough estimate: {queueTotalCostLabel(current?.text, notStarted)}
                                 </p>
                               )}
@@ -2270,7 +2270,7 @@ export default function ReaderPage() {
           {session?.backendToken && notesExpanded && (
             <div className="bg-white/95 backdrop-blur border-t border-amber-200 px-3 py-2 max-h-60 overflow-y-auto animate-slide-up">
               {annotations.length === 0 ? (
-                <div className="text-center text-stone-500 py-4 text-sm">
+                <div className="text-center text-stone-600 py-4 text-sm">
                   <NoteIcon className="w-6 h-6 mx-auto mb-1 opacity-40" />
                   <p>No annotations yet.</p>
                   <p className="text-xs mt-1">Long-press text to add one.</p>
@@ -2294,7 +2294,7 @@ export default function ReaderPage() {
                     >
                       <div className="text-ink line-clamp-2">{ann.sentence_text}</div>
                       {ann.note_text && (
-                        <div className="text-stone-500 mt-0.5 line-clamp-1 italic">{ann.note_text}</div>
+                        <div className="text-stone-600 mt-0.5 line-clamp-1 italic">{ann.note_text}</div>
                       )}
                     </button>
                     </li>

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -30,7 +30,7 @@ function AnnotationCard({ r }: { r: Extract<InAppSearchResult, { type: "annotati
     >
       <div className="flex items-baseline justify-between gap-2 mb-1">
         <div className="font-serif text-base text-ink">{r.book_title || `Book #${r.book_id}`}</div>
-        <div className="text-xs text-stone-500">Annotation · Ch.&nbsp;{r.chapter_index + 1}</div>
+        <div className="text-xs text-stone-600">Annotation · Ch.&nbsp;{r.chapter_index + 1}</div>
       </div>
       <SnippetHtml snippet={r.snippet} />
       {r.note_text ? (
@@ -50,7 +50,7 @@ function VocabularyCard({ r }: { r: Extract<InAppSearchResult, { type: "vocabula
     >
       <div className="flex items-baseline justify-between gap-2 mb-1">
         <div className="font-serif text-base text-ink">{r.word}</div>
-        <div className="text-xs text-stone-500">Vocabulary · Ch.&nbsp;{r.chapter_index + 1}</div>
+        <div className="text-xs text-stone-600">Vocabulary · Ch.&nbsp;{r.chapter_index + 1}</div>
       </div>
       <SnippetHtml snippet={r.snippet} />
       <div className="mt-2 text-xs text-stone-600">in {r.book_title || `Book #${r.book_id}`}</div>
@@ -70,7 +70,7 @@ function ChapterCard({ r }: { r: Extract<InAppSearchResult, { type: "chapter" }>
         <div className="font-serif text-base text-ink">
           {r.book_title || `Book #${r.book_id}`} — {r.chapter_title || `Chapter ${r.chapter_index + 1}`}
         </div>
-        <div className="text-xs text-stone-500">Chapter</div>
+        <div className="text-xs text-stone-600">Chapter</div>
       </div>
       <SnippetHtml snippet={r.snippet} />
     </Link>
@@ -87,7 +87,7 @@ function ResultsSection({ title, items }: { title: string; items: InAppSearchRes
   if (!items.length) return null;
   return (
     <section className="space-y-3">
-      <h2 className="text-sm uppercase tracking-wide text-stone-500">
+      <h2 className="text-sm uppercase tracking-wide text-stone-600">
         {title} · {items.length}
       </h2>
       <ul role="list" aria-label={title} className="grid gap-3 list-none p-0 m-0">
@@ -151,7 +151,7 @@ function SearchResultsInner() {
       </div>
 
       {!q.trim() && (
-        <div className="text-center text-stone-500 py-16">
+        <div className="text-center text-stone-600 py-16">
           <SearchIcon className="w-10 h-10 mx-auto mb-2 text-stone-400" aria-hidden="true" />
           <h2 className="font-serif text-lg text-ink">Search your notes, vocabulary, and uploads</h2>
           <p className="text-sm mt-2">Start typing in the search bar above.</p>
@@ -181,7 +181,7 @@ function SearchResultsInner() {
       )}
 
       {!loading && !error && data && data.total === 0 && (
-        <div className="text-center text-stone-500 py-12">
+        <div className="text-center text-stone-600 py-12">
           <SearchIcon className="w-10 h-10 mx-auto mb-2 text-stone-400" aria-hidden="true" />
           <p className="font-serif text-lg text-ink">No matches for &ldquo;{q}&rdquo;.</p>
           <p className="text-sm mt-2">Try a shorter or different word.</p>

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -93,7 +93,7 @@ export default function ChapterEditorPage() {
         <div role="alert" className="text-center max-w-sm">
           <AlertCircleIcon className="w-10 h-10 text-red-300 mx-auto mb-3" aria-hidden="true" />
           <p className="font-serif text-lg text-ink mb-2">Could not load chapters</p>
-          <p className="text-sm text-stone-500 mb-6">{error}</p>
+          <p className="text-sm text-stone-600 mb-6">{error}</p>
           <div className="flex items-center justify-center gap-3">
             <button
               type="button"
@@ -132,7 +132,7 @@ export default function ChapterEditorPage() {
             </button>
             <h1 className="font-serif text-lg font-semibold text-ink">
               Review Chapters
-              <span className="ml-2 text-sm font-normal text-stone-500">({chapters.length} detected)</span>
+              <span className="ml-2 text-sm font-normal text-stone-600">({chapters.length} detected)</span>
             </h1>
           </div>
           <button
@@ -192,7 +192,7 @@ export default function ChapterEditorPage() {
                         className={`text-xs px-1.5 py-0.5 rounded font-mono ${
                           wordWarn
                             ? "bg-amber-100 text-amber-700"
-                            : "bg-stone-100 text-stone-500"
+                            : "bg-stone-100 text-stone-600"
                         }`}
                       >
                         {ch.word_count.toLocaleString()} words
@@ -202,7 +202,7 @@ export default function ChapterEditorPage() {
                   <button
                     aria-label={`Remove chapter ${i + 1}`}
                     onClick={(e) => { e.stopPropagation(); handleRemove(i); }}
-                    className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded text-stone-500 hover:text-red-600 hover:bg-red-50 transition-colors"
+                    className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded text-stone-600 hover:text-red-600 hover:bg-red-50 transition-colors"
                   >
                     <TrashIcon className="w-3.5 h-3.5" />
                   </button>
@@ -217,17 +217,17 @@ export default function ChapterEditorPage() {
         <div className="bg-white rounded-xl border border-amber-100 p-5 overflow-y-auto">
           {selectedChapter ? (
             <>
-              <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-500 mb-3">Preview</h2>
+              <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-600 mb-3">Preview</h2>
               <p className="font-serif font-semibold text-ink mb-3">{selectedChapter.title}</p>
               <p className="text-sm text-stone-600 leading-relaxed whitespace-pre-wrap font-serif">
                 {selectedChapter.preview}
                 {selectedChapter.preview.length >= 300 && (
-                  <span className="text-stone-500">…</span>
+                  <span className="text-stone-600">…</span>
                 )}
               </p>
             </>
           ) : (
-            <p className="text-sm text-stone-500 text-center mt-8">Select a chapter to preview</p>
+            <p className="text-sm text-stone-600 text-center mt-8">Select a chapter to preview</p>
           )}
         </div>
       </div>

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -194,7 +194,7 @@ export default function UploadPage() {
 
         {/* Format hints */}
         <div className="rounded-xl border border-amber-100 bg-white/60 p-4 space-y-2">
-          <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-500">Tips</h2>
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-600">Tips</h2>
           <ul className="text-sm text-amber-800 space-y-1 list-disc list-inside">
             <li>Plain text (.txt) files work best when chapters start with &quot;Chapter I&quot;, &quot;CHAPTER 1&quot;, etc.</li>
             <li>EPUB files are parsed automatically using the book&apos;s built-in structure.</li>

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -183,7 +183,7 @@ export default function FlashcardsPage() {
             <h1 className="font-serif text-xl text-ink font-semibold">Flashcards</h1>
           </div>
           {stats && (
-            <span className="ml-auto text-sm text-stone-500">
+            <span className="ml-auto text-sm text-stone-600">
               {stats.reviewed_today} / {total} today
             </span>
           )}
@@ -238,7 +238,7 @@ export default function FlashcardsPage() {
           <div role="alert" className="flex flex-col items-center gap-3 py-16 text-center">
             <AlertCircleIcon className="w-10 h-10 text-red-300 mx-auto" aria-hidden="true" />
             <p className="font-serif text-lg text-ink">Failed to load flashcards.</p>
-            <p className="text-sm text-stone-500">Check your connection and try again.</p>
+            <p className="text-sm text-stone-600">Check your connection and try again.</p>
             <button
               type="button"
               onClick={loadData}
@@ -255,7 +255,7 @@ export default function FlashcardsPage() {
           <div className="flex flex-col items-center gap-4 py-16 text-center">
             <CheckIcon className="w-12 h-12 text-green-500" />
             <h2 className="font-serif text-2xl text-ink">All done for today!</h2>
-            <p className="text-sm text-stone-500">
+            <p className="text-sm text-stone-600">
               {selectedDeckId
                 ? `No more cards due in "${decks.find((d) => d.id === selectedDeckId)?.name ?? "this deck"}".`
                 : `You reviewed ${stats?.reviewed_today ?? 0} card${(stats?.reviewed_today ?? 0) !== 1 ? "s" : ""}. Come back tomorrow for more.`}
@@ -279,7 +279,7 @@ export default function FlashcardsPage() {
               className="cursor-pointer rounded-2xl border border-amber-200 bg-white p-8 min-h-[200px] flex flex-col items-center justify-center gap-3 hover:-translate-y-0.5 transition-all duration-200 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
               style={{ boxShadow: "var(--shadow-card)" }}
             >
-              <span className="text-xs text-stone-500 uppercase tracking-wide">
+              <span className="text-xs text-stone-600 uppercase tracking-wide">
                 {flipped ? "Context" : "Word"}
               </span>
               {!flipped ? (
@@ -293,15 +293,15 @@ export default function FlashcardsPage() {
                       {currentCard.context}
                     </p>
                   ) : (
-                    <p className="text-sm text-stone-500 italic">No context saved</p>
+                    <p className="text-sm text-stone-600 italic">No context saved</p>
                   )}
-                  <p className="text-xs text-stone-500 mt-2">
+                  <p className="text-xs text-stone-600 mt-2">
                     How well did you remember <span className="font-medium text-ink">{currentCard.word}</span>?
                   </p>
                 </div>
               )}
               {!flipped && (
-                <span className="text-xs text-stone-500 mt-2">tap to reveal</span>
+                <span className="text-xs text-stone-600 mt-2">tap to reveal</span>
               )}
             </div>
 
@@ -338,7 +338,7 @@ export default function FlashcardsPage() {
             )}
 
             {/* Card counter — role=status so screen readers announce position after grading */}
-            <p role="status" aria-live="polite" aria-atomic="true" className="text-center text-xs text-stone-500">
+            <p role="status" aria-live="polite" aria-atomic="true" className="text-center text-xs text-stone-600">
               {currentIndex + 1} of {cards.length} remaining
               {currentCard ? `: ${currentCard.word}` : ""}
             </p>

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -166,7 +166,7 @@ function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
           <button
             onClick={onClose}
             aria-label="Close definition"
-            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-500 hover:text-ink hover:bg-amber-50 transition-colors -mr-1"
+            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-600 hover:text-ink hover:bg-amber-50 transition-colors -mr-1"
           >
             <CloseIcon className="w-4 h-4" aria-hidden="true" />
           </button>
@@ -187,7 +187,7 @@ function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
           )}
 
           {!loading && (!def || def.definitions.length === 0) && (
-            <p className="text-sm text-stone-500 italic">No definition found.</p>
+            <p className="text-sm text-stone-600 italic">No definition found.</p>
           )}
 
           {def && def.definitions.length > 0 && (
@@ -384,7 +384,7 @@ function VocabularyPageContent() {
               {group.lemma}
             </button>
             {alternateForms.length > 0 && (
-              <span className="text-xs text-stone-500">
+              <span className="text-xs text-stone-600">
                 ({alternateForms.map((f) => f.word).join(", ")})
               </span>
             )}
@@ -427,9 +427,9 @@ function VocabularyPageContent() {
                     {occ.book_title}
                   </a>
                 ) : (
-                  <span className="text-stone-500 font-medium">(deleted book)</span>
+                  <span className="text-stone-600 font-medium">(deleted book)</span>
                 )}{" "}
-                <span className="text-stone-500">{`Ch.${occ.chapter_index + 1}`}</span>
+                <span className="text-stone-600">{`Ch.${occ.chapter_index + 1}`}</span>
                 {" — "}
                 <span className="italic">&ldquo;{occ.sentence_text}&rdquo;</span>
               </div>
@@ -459,7 +459,7 @@ function VocabularyPageContent() {
         <div className="flex-1 min-w-0">
           <h1 className="font-serif font-bold text-ink truncate">Vocabulary</h1>
           {!loading && (
-            <p className="text-xs text-stone-500 mt-0.5">
+            <p className="text-xs text-stone-600 mt-0.5">
               {words.length} word{words.length !== 1 ? "s" : ""} · {totalOccurrences} occurrence{totalOccurrences !== 1 ? "s" : ""}
             </p>
           )}
@@ -577,7 +577,7 @@ function VocabularyPageContent() {
                   }`}
                 >
                   {tag}
-                  <span className={`ml-1 ${active ? "opacity-80" : "text-stone-500"}`}>
+                  <span className={`ml-1 ${active ? "opacity-80" : "text-stone-600"}`}>
                     · {word_count}
                   </span>
                 </button>
@@ -594,7 +594,7 @@ function VocabularyPageContent() {
             ))}
           </div>
         ) : fetchError ? (
-          <div role="alert" className="text-center text-stone-500 mt-20 flex flex-col items-center gap-2">
+          <div role="alert" className="text-center text-stone-600 mt-20 flex flex-col items-center gap-2">
             <AlertCircleIcon className="w-12 h-12 text-red-300 mx-auto mb-1" aria-hidden="true" />
             <p className="font-serif text-lg text-red-700 mt-1">Failed to load vocabulary.</p>
             <p className="text-sm">Check your connection and try again.</p>
@@ -608,9 +608,9 @@ function VocabularyPageContent() {
             </button>
           </div>
         ) : words.length === 0 ? (
-          <div className="text-center text-stone-500 mt-20 flex flex-col items-center gap-2">
+          <div className="text-center text-stone-600 mt-20 flex flex-col items-center gap-2">
             <EmptyVocabIcon className="w-14 h-14 text-amber-300" />
-            <p className="font-serif text-lg text-stone-500 mt-1">No saved words yet.</p>
+            <p className="font-serif text-lg text-stone-600 mt-1">No saved words yet.</p>
             <p className="text-sm">Double-click any word while reading to save it here.</p>
             <button
               type="button"
@@ -621,11 +621,11 @@ function VocabularyPageContent() {
             </button>
           </div>
         ) : filtered.length === 0 ? (
-          <div className="text-center text-stone-500 mt-16 flex flex-col items-center gap-2">
+          <div className="text-center text-stone-600 mt-16 flex flex-col items-center gap-2">
             <EmptyVocabIcon className="w-14 h-14 text-amber-300" aria-hidden="true" />
             {selectedTag ? (
               <>
-                <p className="font-serif text-lg text-stone-500 mt-1">No words tagged &ldquo;{selectedTag}&rdquo;</p>
+                <p className="font-serif text-lg text-stone-600 mt-1">No words tagged &ldquo;{selectedTag}&rdquo;</p>
                 <p className="text-sm">This tag has no vocabulary words yet.</p>
                 <button
                   type="button"
@@ -637,7 +637,7 @@ function VocabularyPageContent() {
               </>
             ) : (
               <>
-                <p className="font-serif text-lg text-stone-500 mt-1">No words match &ldquo;{search}&rdquo;</p>
+                <p className="font-serif text-lg text-stone-600 mt-1">No words match &ldquo;{search}&rdquo;</p>
                 <p className="text-sm">Try a different search term.</p>
                 <button
                   type="button"

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -125,7 +125,7 @@ export default function AnnotationToolbar({
           <button
             onClick={onClose}
             aria-label="Close note editor"
-            className="rounded-lg p-1.5 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-500 hover:text-stone-700 hover:bg-amber-50 transition-colors"
+            className="rounded-lg p-1.5 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-600 hover:text-stone-700 hover:bg-amber-50 transition-colors"
           >
             <CloseIcon className="w-4 h-4" />
           </button>
@@ -139,7 +139,7 @@ export default function AnnotationToolbar({
 
           {/* Color picker */}
           <div>
-            <p className="text-xs text-stone-500 mb-2" aria-hidden="true">Highlight colour</p>
+            <p className="text-xs text-stone-600 mb-2" aria-hidden="true">Highlight colour</p>
             <div role="radiogroup" aria-label="Highlight colour" className="flex items-center gap-0.5">
               {COLORS.map((c) => (
                 <button
@@ -166,7 +166,7 @@ export default function AnnotationToolbar({
 
           {/* Note textarea */}
           <div>
-            <label htmlFor="annotation-note" className="block text-xs text-stone-500 mb-1.5">Note <span className="text-stone-500">(optional)</span></label>
+            <label htmlFor="annotation-note" className="block text-xs text-stone-600 mb-1.5">Note <span className="text-stone-600">(optional)</span></label>
             <textarea
               ref={textareaRef}
               id="annotation-note"

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -96,7 +96,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
             <h2 id="annotations-heading" className="font-serif font-semibold text-ink text-sm">Annotations</h2>
             <button
               onClick={() => setOpen(false)}
-              className="text-stone-500 hover:text-stone-700 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg transition-colors"
+              className="text-stone-600 hover:text-stone-700 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg transition-colors"
               aria-label="Close annotations sidebar"
             >
               <CloseIcon className="w-4 h-4" />
@@ -110,9 +110,9 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
                 <span className="w-5 h-5 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
               </div>
             ) : annotations.length === 0 ? (
-              <div className="text-center text-stone-500 mt-10 text-sm">
+              <div className="text-center text-stone-600 mt-10 text-sm">
                 <EmptyNotesIcon className="w-10 h-10 text-stone-300 mx-auto mb-2" />
-                <p className="font-serif text-lg text-stone-500 mt-1">No annotations yet</p>
+                <p className="font-serif text-lg text-stone-600 mt-1">No annotations yet</p>
                 <p className="mt-1 text-xs">Click a sentence and choose Note to add one.</p>
               </div>
             ) : (
@@ -125,7 +125,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
                 )}
               {chapters.map((ch) => (
                 <div key={ch}>
-                  <h3 className="text-xs font-semibold text-stone-500 uppercase tracking-wide mb-2">
+                  <h3 className="text-xs font-semibold text-stone-600 uppercase tracking-wide mb-2">
                     Chapter {ch + 1}
                   </h3>
                   <div className="space-y-2">
@@ -191,7 +191,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
             <a
               href="/notes"
               onClick={() => setOpen(false)}
-              className="inline-flex items-center text-xs text-stone-500 hover:text-stone-600 transition-colors min-h-[44px] md:min-h-0"
+              className="inline-flex items-center text-xs text-stone-600 hover:text-stone-700 transition-colors min-h-[44px] md:min-h-0"
             >
               All books
             </a>

--- a/frontend/src/components/AuthPromptModal.tsx
+++ b/frontend/src/components/AuthPromptModal.tsx
@@ -35,7 +35,7 @@ export default function AuthPromptModal({ open, feature, onClose }: Props) {
       <div className="absolute inset-0 bg-black/40" aria-hidden="true" onClick={onClose} />
       <div ref={dialogRef} tabIndex={-1} role="dialog" aria-modal="true" aria-label="Sign in required" className="relative bg-white rounded-t-2xl md:rounded-2xl shadow-xl p-6 w-full max-w-sm animate-slide-up focus:outline-none">
         <p className="font-serif text-lg text-ink mb-1">Sign in to {feature}</p>
-        <p className="text-sm text-stone-500 mb-5">
+        <p className="text-sm text-stone-600 mb-5">
           Create a free account or sign in to unlock this feature.
         </p>
         <a
@@ -46,7 +46,7 @@ export default function AuthPromptModal({ open, feature, onClose }: Props) {
         </a>
         <button
           onClick={onClose}
-          className="flex items-center justify-center w-full min-h-[44px] md:min-h-0 text-sm text-stone-500 mt-2 hover:text-stone-700 transition-colors"
+          className="flex items-center justify-center w-full min-h-[44px] md:min-h-0 text-sm text-stone-600 mt-2 hover:text-stone-700 transition-colors"
         >
           Maybe later
         </button>

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -23,7 +23,7 @@ export default function BookCard({ book, onClick, badge, onRemove }: Props) {
           }}
           title={`Remove ${book.title} from library`}
           aria-label={`Remove ${book.title} from library`}
-          className="absolute top-0 right-0 z-10 min-w-[44px] md:min-w-0 min-h-[44px] md:min-h-0 inline-flex items-center justify-center rounded-full bg-white/80 text-stone-500 border border-amber-200 text-sm hover:bg-red-50 hover:text-red-600 hover:border-red-200 transition-colors"
+          className="absolute top-0 right-0 z-10 min-w-[44px] md:min-w-0 min-h-[44px] md:min-h-0 inline-flex items-center justify-center rounded-full bg-white/80 text-stone-600 border border-amber-200 text-sm hover:bg-red-50 hover:text-red-600 hover:border-red-200 transition-colors"
         >
           <CloseIcon className="w-3.5 h-3.5" />
         </button>

--- a/frontend/src/components/BookDetailModal.tsx
+++ b/frontend/src/components/BookDetailModal.tsx
@@ -96,7 +96,7 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
           <button
             onClick={onClose}
             aria-label="Close book details"
-            className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-full text-stone-500 hover:bg-stone-100 hover:text-stone-700 transition-colors"
+            className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-full text-stone-600 hover:bg-stone-100 hover:text-stone-700 transition-colors"
           >
             <CloseIcon className="w-4 h-4" />
           </button>
@@ -144,7 +144,7 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
 
         <div className="flex items-center justify-between mt-3">
           {book.download_count > 0 && (
-            <p className="text-xs text-stone-500">
+            <p className="text-xs text-stone-600">
               {book.download_count.toLocaleString()} downloads
             </p>
           )}

--- a/frontend/src/components/ChapterSummary.tsx
+++ b/frontend/src/components/ChapterSummary.tsx
@@ -134,9 +134,9 @@ export default function ChapterSummary({
         )}
 
         {!summary && !loading && !error && (
-          <div className="flex flex-col items-center justify-center h-full text-center text-stone-500 gap-3 py-8">
+          <div className="flex flex-col items-center justify-center h-full text-center text-stone-600 gap-3 py-8">
             <SummaryIcon className="w-10 h-10 text-amber-300" />
-            <p className="font-serif text-lg text-stone-500 mt-1">Chapter Summary</p>
+            <p className="font-serif text-lg text-stone-600 mt-1">Chapter Summary</p>
             <p className="text-sm">Get a quick overview of this chapter before continuing.</p>
             <button
               onClick={load}

--- a/frontend/src/components/DeckCard.tsx
+++ b/frontend/src/components/DeckCard.tsx
@@ -26,9 +26,9 @@ export default function DeckCard({ deck, onClick, onDelete }: DeckCardProps) {
         </span>
       </div>
       {deck.description && (
-        <p className="text-sm text-stone-500 mt-1.5 line-clamp-2">{deck.description}</p>
+        <p className="text-sm text-stone-600 mt-1.5 line-clamp-2">{deck.description}</p>
       )}
-      <div className="mt-3 flex items-center gap-3 text-xs text-stone-500">
+      <div className="mt-3 flex items-center gap-3 text-xs text-stone-600">
         <span>
           <span
             data-testid={`deck-member-count-${deck.id}`}
@@ -73,7 +73,7 @@ export default function DeckCard({ deck, onClick, onDelete }: DeckCardProps) {
             onClick={() => onDelete(deck.id)}
             aria-label={`Delete deck ${deck.name}`}
             data-testid={`deck-delete-${deck.id}`}
-            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-500 hover:text-red-600 transition-colors shrink-0"
+            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-600 hover:text-red-600 transition-colors shrink-0"
           >
             <TrashIcon className="w-4 h-4" />
           </button>

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -396,7 +396,7 @@ export default function InsightChat({
           className={`shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded text-xs font-bold transition-colors ${
             chatFontSize === "sm"
               ? "bg-amber-100 text-amber-800 hover:bg-amber-200"
-              : "text-stone-500 hover:bg-stone-200 hover:text-stone-700"
+              : "text-stone-600 hover:bg-stone-200 hover:text-stone-700"
           }`}
         >
           {chatFontSize === "xs" ? "A" : "a"}
@@ -406,7 +406,7 @@ export default function InsightChat({
           title={hasGeminiKey ? "Append a fresh insight" : "Gemini API key required"}
           aria-label="Append a fresh insight"
           disabled={!hasGeminiKey}
-          className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded hover:bg-stone-200 text-stone-500 hover:text-stone-700 disabled:opacity-40 disabled:cursor-not-allowed"
+          className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded hover:bg-stone-200 text-stone-600 hover:text-stone-700 disabled:opacity-40 disabled:cursor-not-allowed"
         >
           <RetryIcon className="w-3.5 h-3.5" />
         </button>
@@ -539,7 +539,7 @@ export default function InsightChat({
                       title={isSaved ? "Already saved" : "Save to notes"}
                       className={`mt-1.5 flex items-center gap-1 min-h-[44px] md:min-h-0 text-[11px] transition-colors ${
                         isSaved
-                          ? "text-stone-500 cursor-default"
+                          ? "text-stone-600 cursor-default"
                           : "text-stone-600 hover:text-amber-700"
                       }`}
                     >

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -500,7 +500,7 @@ export default function QueueTab({ adminFetch }: Props) {
           <div className="h-4 w-3/4 bg-stone-100 rounded" />
           <div className="h-4 w-5/6 bg-stone-100 rounded" />
         </div>
-        <div className="text-center text-xs text-stone-500">
+        <div className="text-center text-xs text-stone-600">
           Loading queue…
         </div>
       </div>
@@ -594,7 +594,7 @@ export default function QueueTab({ adminFetch }: Props) {
                     }`
                 : "Worker stopped"}
             </div>
-            <div className="text-xs text-stone-500">
+            <div className="text-xs text-stone-600">
               {totalPending} pending · {totalRunning} running · {totalDone} done · {totalFailed} failed
               {s?.requests_made !== undefined && ` · ${s.requests_made} API calls this session`}
             </div>
@@ -721,29 +721,29 @@ export default function QueueTab({ adminFetch }: Props) {
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-center">
             <div className="rounded-lg bg-emerald-50 border border-emerald-100 px-3 py-2">
               <div className="text-lg font-bold text-emerald-700">{s.chapters_done}</div>
-              <div className="text-xs text-stone-500">Translated</div>
+              <div className="text-xs text-stone-600">Translated</div>
             </div>
             {(s.total_chapters ?? 0) > 0 && (
               <div className="rounded-lg bg-amber-50 border border-amber-100 px-3 py-2">
                 <div className="text-lg font-bold text-ink">{s.total_chapters}</div>
-                <div className="text-xs text-stone-500">Remaining</div>
+                <div className="text-xs text-stone-600">Remaining</div>
               </div>
             )}
             {(s.skipped_chapters ?? 0) > 0 && (
               <div className="rounded-lg bg-stone-50 border border-stone-100 px-3 py-2">
                 <div className="text-lg font-bold text-stone-600">{s.skipped_chapters}</div>
-                <div className="text-xs text-stone-500">Skipped</div>
+                <div className="text-xs text-stone-600">Skipped</div>
               </div>
             )}
             {s.chapters_failed > 0 && (
               <div className="rounded-lg bg-red-50 border border-red-100 px-3 py-2">
                 <div className="text-lg font-bold text-red-700">{s.chapters_failed}</div>
-                <div className="text-xs text-stone-500">Failed</div>
+                <div className="text-xs text-stone-600">Failed</div>
               </div>
             )}
           </div>
           {s.ended_at && (
-            <p className="text-xs text-stone-500 mt-2">Last completed {relTime(s.ended_at)}</p>
+            <p className="text-xs text-stone-600 mt-2">Last completed {relTime(s.ended_at)}</p>
           )}
         </div>
       )}
@@ -800,11 +800,11 @@ export default function QueueTab({ adminFetch }: Props) {
               ].map(({ label, value }) => (
                 <div key={label} className="rounded-lg bg-amber-50 border border-amber-100 px-3 py-2 text-center">
                   <div className="text-base font-bold text-ink">{value}</div>
-                  <div className="text-xs text-stone-500">{label}</div>
+                  <div className="text-xs text-stone-600">{label}</div>
                 </div>
               ))}
             </div>
-            <p className="text-xs text-stone-500 mb-2">
+            <p className="text-xs text-stone-600 mb-2">
               ~<strong>{planResult.estimated_minutes_at_rpm} min</strong> at configured RPM
               {" · "}~<strong>{planResult.estimated_days_at_rpd} days</strong> at RPD
             </p>
@@ -833,7 +833,7 @@ export default function QueueTab({ adminFetch }: Props) {
 
         {dryRunResult && Object.keys(dryRunResult.preview).length > 0 && (
           <div className="border-t border-amber-100 pt-3">
-            <p className="text-xs text-stone-500 mb-2">
+            <p className="text-xs text-stone-600 mb-2">
               Preview: <strong>{dryRunResult.preview_book_title || "book"}</strong>
               {" · "}{dryRunResult.total_chapters} chapters total across {dryRunResult.total_books} book(s)
             </p>
@@ -851,7 +851,7 @@ export default function QueueTab({ adminFetch }: Props) {
         )}
 
         {dryRunResult && Object.keys(dryRunResult.preview).length === 0 && (
-          <p className="text-xs text-stone-500">No chapters need translation for this language.</p>
+          <p className="text-xs text-stone-600">No chapters need translation for this language.</p>
         )}
       </div>
 
@@ -987,7 +987,7 @@ export default function QueueTab({ adminFetch }: Props) {
 
             {/* Live summary — show the configured chain and what the
                 worker is actually using at the moment. */}
-            <div className="text-[11px] text-stone-500 leading-relaxed">
+            <div className="text-[11px] text-stone-600 leading-relaxed">
               Active chain:{" "}
               {(settings?.model_chain ?? [])
                 .map((m, i) => `${i + 1}. ${labelForModel(m)}`)
@@ -1030,10 +1030,10 @@ export default function QueueTab({ adminFetch }: Props) {
                         )}
                       </div>
                       <div className="text-[11px] text-amber-700">{p.tagline}</div>
-                      <div className="text-[11px] text-stone-500 mt-1 leading-snug">
+                      <div className="text-[11px] text-stone-600 mt-1 leading-snug">
                         {p.description}
                       </div>
-                      <div className="text-xs font-mono text-stone-500 mt-1 truncate">
+                      <div className="text-xs font-mono text-stone-600 mt-1 truncate">
                         {p.chain.join(" → ")}
                       </div>
                     </button>
@@ -1056,7 +1056,7 @@ export default function QueueTab({ adminFetch }: Props) {
                         : "border-amber-200 bg-white"
                     }`}
                   >
-                    <div className="text-xs text-stone-500 font-mono w-6 shrink-0 pt-0.5">
+                    <div className="text-xs text-stone-600 font-mono w-6 shrink-0 pt-0.5">
                       {idx + 1}.
                     </div>
                     <div className="flex-1 min-w-0">
@@ -1073,18 +1073,18 @@ export default function QueueTab({ adminFetch }: Props) {
                           </span>
                         )}
                         {opt ? (
-                          <span className="text-[11px] text-stone-500">
+                          <span className="text-[11px] text-stone-600">
                             {opt.rpm} rpm · {opt.rpd} rpd · ≤
                             {opt.maxOutputTokens.toLocaleString()} tok
                           </span>
                         ) : (
-                          <span className="text-[11px] text-stone-500">
+                          <span className="text-[11px] text-stone-600">
                             custom — conservative defaults
                           </span>
                         )}
                       </div>
                       {opt?.note && (
-                        <div className="text-xs text-stone-500 mt-0.5">{opt.note}</div>
+                        <div className="text-xs text-stone-600 mt-0.5">{opt.note}</div>
                       )}
                     </div>
                     <div className="flex flex-col gap-0.5 shrink-0">
@@ -1096,7 +1096,7 @@ export default function QueueTab({ adminFetch }: Props) {
                           setChain(copy);
                         }}
                         disabled={idx === 0}
-                        className="text-xs min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-500 hover:text-amber-700 disabled:opacity-30"
+                        className="text-xs min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-600 hover:text-amber-700 disabled:opacity-30"
                         title={`Move ${labelForModel(m)} up`}
                         aria-label={`Move ${labelForModel(m)} up`}
                       >
@@ -1110,7 +1110,7 @@ export default function QueueTab({ adminFetch }: Props) {
                           setChain(copy);
                         }}
                         disabled={idx === chain.length - 1}
-                        className="text-xs min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-500 hover:text-amber-700 disabled:opacity-30"
+                        className="text-xs min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-600 hover:text-amber-700 disabled:opacity-30"
                         title={`Move ${labelForModel(m)} down`}
                         aria-label={`Move ${labelForModel(m)} down`}
                       >
@@ -1129,7 +1129,7 @@ export default function QueueTab({ adminFetch }: Props) {
                 );
               })}
               {chain.length === 0 && (
-                <div className="text-xs text-stone-500 italic">
+                <div className="text-xs text-stone-600 italic">
                   Chain is empty — add a model below.
                 </div>
               )}
@@ -1148,7 +1148,7 @@ export default function QueueTab({ adminFetch }: Props) {
                       className={`text-xs px-2 py-1 rounded border font-mono min-h-[44px] md:min-h-0 ${
                         opt.recommended
                           ? "border-emerald-300 text-emerald-700 hover:bg-emerald-50"
-                          : "border-stone-200 text-stone-500 hover:bg-stone-50"
+                          : "border-stone-200 text-stone-600 hover:bg-stone-50"
                       }`}
                       title={opt.note}
                     >
@@ -1199,7 +1199,7 @@ export default function QueueTab({ adminFetch }: Props) {
           across each model. Helps decide whether to route through pro vs flash.
           Shows its own spinner (not full-tab) because this is the slowest fetch. */}
       {loadingCost && !cost && (
-        <div role="status" className="bg-white rounded-xl border border-amber-200 p-4 flex items-center gap-2 text-sm text-stone-500">
+        <div role="status" className="bg-white rounded-xl border border-amber-200 p-4 flex items-center gap-2 text-sm text-stone-600">
           <Spinner />
           Computing cost estimate…
         </div>
@@ -1220,7 +1220,7 @@ export default function QueueTab({ adminFetch }: Props) {
                 Cost estimate (to drain queue)
                 {loadingCost && <Spinner />}
               </h3>
-              <span className="text-[11px] text-stone-500">
+              <span className="text-[11px] text-stone-600">
                 {cost.pending_items} pending across {cost.pending_books} book
                 {cost.pending_books === 1 ? "" : "s"} ·{" "}
                 ~{(cost.estimated_input_tokens / 1_000_000).toFixed(1)}M in /{" "}
@@ -1238,7 +1238,7 @@ export default function QueueTab({ adminFetch }: Props) {
                 </div>
                 <div className="flex flex-wrap gap-4 items-baseline">
                   <div>
-                    <div className="text-xs text-stone-500">if primary handles all</div>
+                    <div className="text-xs text-stone-600">if primary handles all</div>
                     <div className="text-lg font-semibold text-emerald-800">
                       ${(
                         byModel[activeChain[0]] ??
@@ -1248,7 +1248,7 @@ export default function QueueTab({ adminFetch }: Props) {
                     </div>
                   </div>
                   <div>
-                    <div className="text-xs text-stone-500">per book (avg)</div>
+                    <div className="text-xs text-stone-600">per book (avg)</div>
                     <div className="text-lg font-semibold text-emerald-800">
                       ${(
                         (byModel[activeChain[0]] ??
@@ -1259,7 +1259,7 @@ export default function QueueTab({ adminFetch }: Props) {
                   </div>
                   {activeChain.length > 1 && (
                     <div>
-                      <div className="text-xs text-stone-500">
+                      <div className="text-xs text-stone-600">
                         fallback min · {labelForModel(activeChain[activeChain.length - 1])}
                       </div>
                       <div className="text-lg font-semibold text-emerald-800">
@@ -1276,7 +1276,7 @@ export default function QueueTab({ adminFetch }: Props) {
             {/* Grid: all models, with total + per-book so admins can
                 compare any alternative to their current chain. */}
             <div>
-              <div className="text-[11px] text-stone-500 mb-1">
+              <div className="text-[11px] text-stone-600 mb-1">
                 All models — total / per-book
               </div>
               <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
@@ -1292,13 +1292,13 @@ export default function QueueTab({ adminFetch }: Props) {
                           : "border-amber-100"
                       }`}
                     >
-                      <div className="text-[11px] text-stone-500 font-mono truncate">
+                      <div className="text-[11px] text-stone-600 font-mono truncate">
                         {row.model}
                       </div>
                       <div className="text-sm font-semibold text-ink">
                         ${row.usd.toFixed(2)}
                       </div>
-                      <div className="text-xs text-stone-500">
+                      <div className="text-xs text-stone-600">
                         ${(row.usd / books).toFixed(3)}/book
                       </div>
                     </div>
@@ -1307,7 +1307,7 @@ export default function QueueTab({ adminFetch }: Props) {
               </div>
             </div>
 
-            <p className="text-[11px] text-stone-500">
+            <p className="text-[11px] text-stone-600">
               Rough estimate — assumes ~3 chars/token and 1:1 input-to-output ratio.
               Actual cost depends on tokenizer, chapter lengths, and batching.
               Chain advance on 429/quota means multiple models may contribute — the
@@ -1341,7 +1341,7 @@ export default function QueueTab({ adminFetch }: Props) {
               {f}
             </button>
           ))}
-          <span className="ml-auto text-xs text-stone-500">{items.length} shown</span>
+          <span className="ml-auto text-xs text-stone-600">{items.length} shown</span>
           <button
             onClick={clearAll}
             disabled={items.length === 0}
@@ -1352,7 +1352,7 @@ export default function QueueTab({ adminFetch }: Props) {
           </button>
         </div>
         {items.length === 0 ? (
-          <div role="status" className="px-4 py-8 text-center text-stone-500 text-sm flex items-center justify-center gap-2">
+          <div role="status" className="px-4 py-8 text-center text-stone-600 text-sm flex items-center justify-center gap-2">
             {loadingItems && <Spinner />}
             <span>{loadingItems ? "Loading items…" : "No items in this view."}</span>
           </div>
@@ -1381,21 +1381,21 @@ export default function QueueTab({ adminFetch }: Props) {
                 >
                   {it.book_title || `book ${it.book_id}`}
                 </span>
-                <span className="text-stone-500 font-mono shrink-0">
+                <span className="text-stone-600 font-mono shrink-0">
                   · ch {it.chapter_index + 1} → {it.target_language}
                 </span>
                 <span
-                  className="text-stone-500 shrink-0"
+                  className="text-stone-600 shrink-0"
                   title={`Queued ${it.created_at} by ${it.queued_by || "auto (save_book)"}`}
                 >
                   · {relTime(it.created_at)}
                   {" by "}
-                  <span className={it.queued_by ? "text-stone-500" : "italic"}>
+                  <span className={it.queued_by ? "text-stone-600" : "italic"}>
                     {it.queued_by || "auto"}
                   </span>
                 </span>
                 {it.attempts > 0 && (
-                  <span className="text-stone-500 shrink-0">· {it.attempts} attempts</span>
+                  <span className="text-stone-600 shrink-0">· {it.attempts} attempts</span>
                 )}
                 {it.last_error && (
                   <span

--- a/frontend/src/components/QuickHighlightPanel.tsx
+++ b/frontend/src/components/QuickHighlightPanel.tsx
@@ -128,7 +128,7 @@ export default function QuickHighlightPanel({
           onClick={onOpenNote}
           disabled={busy}
           aria-label="Add note"
-          className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-500 hover:text-stone-700 disabled:opacity-50 transition-colors"
+          className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-600 hover:text-stone-700 disabled:opacity-50 transition-colors"
         >
           <span className="w-7 h-7 rounded-full bg-stone-100 border border-stone-300 flex items-center justify-center hover:bg-stone-200 transition-colors">
             <NoteIcon className="w-3.5 h-3.5" />

--- a/frontend/src/components/ReadingStats.tsx
+++ b/frontend/src/components/ReadingStats.tsx
@@ -69,7 +69,7 @@ function StatCard({ label, value, icon }: StatCardProps) {
       <span className="text-amber-600">{icon}</span>
       <div>
         <p className="text-2xl font-bold text-stone-800">{value.toLocaleString()}</p>
-        <p className="text-xs text-stone-500 mt-0.5">{label}</p>
+        <p className="text-xs text-stone-600 mt-0.5">{label}</p>
       </div>
     </div>
   );
@@ -152,7 +152,7 @@ export default function ReadingStats({ active, heatmapOnly = false }: Props) {
       >
         <div className="flex items-center justify-between mb-3">
           <p className="text-sm font-medium text-stone-700">Activity — last year</p>
-          <p className="text-xs text-stone-500">
+          <p className="text-xs text-stone-600">
             {activeDays} active {activeDays === 1 ? "day" : "days"}
           </p>
         </div>
@@ -165,7 +165,7 @@ export default function ReadingStats({ active, heatmapOnly = false }: Props) {
           {weeks.map((_, wi) => {
             const m = months.find((m) => m.colStart === wi);
             return (
-              <div key={wi} className="text-[9px] text-stone-500 truncate">
+              <div key={wi} className="text-[9px] text-stone-600 truncate">
                 {m?.label ?? ""}
               </div>
             );
@@ -200,11 +200,11 @@ export default function ReadingStats({ active, heatmapOnly = false }: Props) {
 
         {/* Legend */}
         <div className="flex items-center gap-1 mt-2 justify-end">
-          <span className="text-[9px] text-stone-500 mr-1">Less</span>
+          <span className="text-[9px] text-stone-600 mr-1">Less</span>
           {["bg-stone-100", "bg-amber-200", "bg-amber-400", "bg-amber-600", "bg-amber-800"].map((c) => (
             <div key={c} className={`w-3 h-3 rounded-[2px] ${c}`} />
           ))}
-          <span className="text-[9px] text-stone-500 ml-1">More</span>
+          <span className="text-[9px] text-stone-600 ml-1">More</span>
         </div>
       </div>
     </div>

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -96,7 +96,7 @@ export function SearchBar() {
           setQuery("");
           setOpen(false);
         }}
-        className="text-xs text-stone-500 hover:text-ink min-h-[44px] md:min-h-0 flex items-center"
+        className="text-xs text-stone-600 hover:text-ink min-h-[44px] md:min-h-0 flex items-center"
       >
         Esc
       </button>

--- a/frontend/src/components/SeedPopularButton.tsx
+++ b/frontend/src/components/SeedPopularButton.tsx
@@ -150,7 +150,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
             onClick={() => setExpanded(false)}
             aria-expanded={true}
             aria-controls="seed-progress-panel"
-            className="text-xs text-stone-500 hover:text-stone-700 min-h-[44px] md:min-h-0 flex items-center"
+            className="text-xs text-stone-600 hover:text-stone-700 min-h-[44px] md:min-h-0 flex items-center"
           >
             Hide
           </button>
@@ -234,7 +234,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
               </div>
             </>
           ) : (
-            <p className="text-xs text-stone-500">
+            <p className="text-xs text-stone-600">
               {state.status === "running"
                 ? "Planning…"
                 : "No books need downloading."}

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -669,12 +669,12 @@ export default function SentenceReader({
           if (active) return "bg-amber-300 text-amber-950";
           if (disabled) {
             return loaded
-              ? "text-stone-500"
-              : "text-stone-500";
+              ? "text-stone-600"
+              : "text-stone-600";
           }
           return loaded
             ? "hover:bg-amber-50"
-            : "text-stone-500";
+            : "text-stone-600";
         };
 
         // Long press (500ms) → open word action drawer or annotation panel.

--- a/frontend/src/components/TTSControls.tsx
+++ b/frontend/src/components/TTSControls.tsx
@@ -535,7 +535,7 @@ export default function TTSControls({
               aria-hidden="true"
             />
           </div>
-          <p className="text-xs text-stone-500 mt-1 italic truncate">
+          <p className="text-xs text-stone-600 mt-1 italic truncate">
             &ldquo;{loadingState.preview}…&rdquo;
           </p>
         </div>

--- a/frontend/src/components/TypographyPanel.tsx
+++ b/frontend/src/components/TypographyPanel.tsx
@@ -202,7 +202,7 @@ export default function TypographyPanel({
 function Row({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="space-y-1.5">
-      <span className="text-xs text-stone-500 font-medium">{label}</span>
+      <span className="text-xs text-stone-600 font-medium">{label}</span>
       {children}
     </div>
   );

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -82,7 +82,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
       {/* Header */}
       <div className="flex items-center justify-between px-3 pt-2.5 pb-1.5 border-b border-amber-100">
         <span id="vocab-tooltip-title" className="font-semibold text-ink text-sm">{word}</span>
-        <button onClick={onClose} aria-label="Close word definition" className="text-stone-500 hover:text-stone-700 p-0.5 rounded transition-colors min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center"><CloseIcon className="w-3.5 h-3.5" /></button>
+        <button onClick={onClose} aria-label="Close word definition" className="text-stone-600 hover:text-stone-700 p-0.5 rounded transition-colors min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center"><CloseIcon className="w-3.5 h-3.5" /></button>
       </div>
 
       {/* Body */}
@@ -94,12 +94,12 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
           </div>
         )}
         {!loading && (!def || def.definitions.length === 0) && (
-          <p className="text-xs text-stone-500 italic">No definition found.</p>
+          <p className="text-xs text-stone-600 italic">No definition found.</p>
         )}
         {!loading && def && def.definitions.length > 0 && (
           <div className="space-y-2">
             {def.lemma && def.lemma !== word && (
-              <p className="text-[11px] text-stone-500">
+              <p className="text-[11px] text-stone-600">
                 Base form: <span className="font-medium text-stone-600">{def.lemma}</span>
               </p>
             )}

--- a/frontend/src/components/WordActionDrawer.tsx
+++ b/frontend/src/components/WordActionDrawer.tsx
@@ -137,7 +137,7 @@ export default function WordActionDrawer({
           <button
             onClick={onClose}
             aria-label="Close word lookup"
-            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-500 hover:text-ink hover:bg-amber-50 transition-colors -mr-1"
+            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-600 hover:text-ink hover:bg-amber-50 transition-colors -mr-1"
           >
             <CloseIcon className="w-4 h-4" aria-hidden="true" />
           </button>


### PR DESCRIPTION
## What changed

Replaces `text-stone-500` with `text-stone-600` for all secondary text across 39 frontend source files (pages + components).

## Why

`text-stone-500` (#78716c) on the app's `bg-parchment` (#f5f0e8) background produces a **4.23:1** contrast ratio — just below the WCAG AA 1.4.3 minimum of **4.5:1** for normal text. `text-stone-600` (#57534e) yields **6.72:1**, well above the threshold.

Two hover states that became no-ops after the replacement (`text-stone-600 hover:text-stone-600`) were corrected to `hover:text-stone-700` (AnnotationsSidebar "All books" link, notes/[bookId] "Collapse all" button).

## Test plan

- Updated 6 static-analysis test files (ContrastWave7, ContrastWave8, ComponentsContrastWave6, ReaderContrast, BookDetailSubjectChipContrast, ReaderPage.branches3) to assert the new floor value of `text-stone-600`
- All 3350 frontend tests pass (`npm test -- --no-coverage --ci`)
- No backend files touched

Closes #2154
