### PR TITLE
fix(ux): set document title in error.tsx for WCAG 2.4.2 (closes #2156)

### DIFF
--- a/frontend/src/__tests__/ErrorPageTitle.test.ts
+++ b/frontend/src/__tests__/ErrorPageTitle.test.ts
@@ -1,0 +1,18 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "../app/error.tsx"),
+  "utf8",
+);
+
+describe("error.tsx document title (closes #2156)", () => {
+  it("sets document.title via useEffect for WCAG 2.4.2", () => {
+    expect(src).toMatch(/useEffect/);
+    expect(src).toMatch(/document\.title\s*=\s*["']Error/);
+  });
+
+  it("resets document.title on unmount so recovery navigates cleanly", () => {
+    expect(src).toMatch(/return\s*\(\)\s*=>\s*\{\s*document\.title\s*=/);
+  });
+});

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useEffect } from "react";
 import Link from "next/link";
 import { AlertCircleIcon, ArrowLeftIcon, RetryIcon } from "@/components/Icons";
 
@@ -8,6 +9,10 @@ interface Props {
 }
 
 export default function ErrorPage({ error, reset }: Props) {
+  useEffect(() => {
+    document.title = "Error — Book Reader AI";
+    return () => { document.title = "My Library — Book Reader AI"; };
+  }, []);
   return (
     <main id="main-content" className="min-h-screen bg-parchment flex items-center justify-center px-4">
       <div role="alert" className="text-center max-w-sm">


### PR DESCRIPTION
## What changed
`error.tsx` now sets `document.title = "Error — Book Reader AI"` via `useEffect` on mount, and resets it to `"My Library — Book Reader AI"` on unmount.

## Why
WCAG 2.4.2 requires every page/view to have a descriptive title. `error.tsx` is a `"use client"` component and cannot use Next.js static `metadata` export, so `useEffect` is the only supported mechanism. Without this fix, screen readers and browser tabs show no meaningful title when an error boundary triggers.

## Test plan
- `frontend/src/__tests__/ErrorPageTitle.test.ts` — two new static-analysis tests assert:
  1. `useEffect` is present and sets `document.title` to a string starting with `"Error"`
  2. The cleanup function resets `document.title` on unmount

- All 3352 existing tests pass (`npm test --no-coverage --ci`)

Closes #2156
