### PR TITLE
fix(ux): add focus-visible ring to tabpanels for WCAG 2.4.7 (closes #2158)

### DIFF
--- a/frontend/src/__tests__/TabPanelFocusRing.test.ts
+++ b/frontend/src/__tests__/TabPanelFocusRing.test.ts
@@ -1,0 +1,26 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "../app/page.tsx"),
+  "utf8",
+);
+
+describe("home page tabpanel focus rings (closes #2158)", () => {
+  it("tabpanel-library has a focus-visible ring for WCAG 2.4.7", () => {
+    expect(src).toMatch(/tabpanel-library[^>]*focus-visible:ring-2/);
+  });
+
+  it("tabpanel-discover has a focus-visible ring for WCAG 2.4.7", () => {
+    expect(src).toMatch(/tabpanel-discover[^>]*focus-visible:ring-2/);
+  });
+
+  it("tabpanel-library does not silently suppress all focus indicators", () => {
+    // outline-none alone (without a replacement ring) is the violation
+    expect(src).not.toMatch(/tabpanel-library[^>]*focus:outline-none(?![^>]*focus-visible:ring)/);
+  });
+
+  it("tabpanel-discover does not silently suppress all focus indicators", () => {
+    expect(src).not.toMatch(/tabpanel-discover[^>]*focus:outline-none(?![^>]*focus-visible:ring)/);
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -303,7 +303,7 @@ export default function Home() {
 
         {/* ════════════ Home Tab ════════════ */}
         {tab === "library" && (
-          <div id="tabpanel-library" role="tabpanel" aria-labelledby="tab-library" tabIndex={0} className="space-y-8 focus:outline-none">
+          <div id="tabpanel-library" role="tabpanel" aria-labelledby="tab-library" tabIndex={0} className="space-y-8 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 rounded-sm">
 
             {/* Greeting */}
             {status === "authenticated" && session?.backendUser?.name && (
@@ -463,7 +463,7 @@ export default function Home() {
 
         {/* ════════════ Discover Tab ════════════ */}
         {tab === "discover" && (
-          <div id="tabpanel-discover" role="tabpanel" aria-labelledby="tab-discover" tabIndex={0} className="space-y-10 focus:outline-none">
+          <div id="tabpanel-discover" role="tabpanel" aria-labelledby="tab-discover" tabIndex={0} className="space-y-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 rounded-sm">
 
             {/* ── Landing hero (unauthenticated visitors only) ── */}
             {status === "unauthenticated" && (


### PR DESCRIPTION
## What changed

Both `role="tabpanel"` containers on the home page now include `focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2` alongside the existing `focus:outline-none`. A `rounded-sm` class was added so the ring renders cleanly.

## Why

WCAG 2.4.7 (Focus Visible, Level AA) requires every keyboard-focusable element to have a visible focus indicator. Both tabpanels have `tabIndex={0}`, meaning keyboard users can Tab into them — but `focus:outline-none` with no replacement ring made the focus invisible. Using `focus-visible:` (not `focus:`) ensures the ring appears only for keyboard navigation, not on mouse click.

## Test plan

- `frontend/src/__tests__/TabPanelFocusRing.test.ts` — 4 new static-analysis tests assert both tabpanels have `focus-visible:ring-2` and neither relies solely on `focus:outline-none`.
- All 3356 frontend tests pass (`npm test --no-coverage --ci`).
- All 1941 backend tests pass.

Closes #2158
