### PR TITLE
fix(ux): add focus-visible ring to SelectionToolbar buttons for WCAG 2.4.7 (closes #2160)

### DIFF
--- a/frontend/src/__tests__/SelectionToolbarFocusRing.test.ts
+++ b/frontend/src/__tests__/SelectionToolbarFocusRing.test.ts
@@ -1,0 +1,18 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "../components/SelectionToolbar.tsx"),
+  "utf8",
+);
+
+describe("SelectionToolbar button focus rings (closes #2160)", () => {
+  it("btnClass includes a focus-visible ring for WCAG 2.4.7", () => {
+    expect(src).toMatch(/btnClass\s*=\s*["'][^"']*focus-visible:ring-2[^"']*/);
+  });
+
+  it("btnClass does not silently suppress focus with only outline-none", () => {
+    // If outline-none is present, a ring must accompany it
+    expect(src).not.toMatch(/btnClass\s*=\s*["'][^"']*focus:outline-none(?![^"']*focus-visible:ring)/);
+  });
+});

--- a/frontend/src/components/SelectionToolbar.tsx
+++ b/frontend/src/components/SelectionToolbar.tsx
@@ -124,7 +124,7 @@ export default function SelectionToolbar({ onRead, onHighlight, onNote, onChat, 
     setSelection(null);
   }
 
-  const btnClass = "flex items-center gap-1.5 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-white/10 active:bg-white/20 transition-colors min-h-[44px] md:min-h-0";
+  const btnClass = "flex items-center gap-1.5 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-white/10 active:bg-white/20 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 focus-visible:ring-offset-stone-800";
 
   return (
     <div


### PR DESCRIPTION
## What changed

Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 focus-visible:ring-offset-stone-800` to the shared `btnClass` constant in `SelectionToolbar.tsx`.

## Why

The five action buttons (Read, Highlight, Note, Chat, Word) on the selection toolbar had hover and active styles but no `focus-visible` indicator. The toolbar appears on a `bg-stone-800/95` backdrop — without a contrasting ring, keyboard users who Tab into the toolbar see no visible focus cue, violating WCAG 2.4.7 (Focus Visible, Level AA).

Using `focus-visible:` instead of `focus:` ensures the ring appears only for keyboard navigation, not on mouse click. The `ring-offset-stone-800` makes the amber ring pop against the dark backdrop.

## Test plan

- `frontend/src/__tests__/SelectionToolbarFocusRing.test.ts` — 2 new static-analysis tests assert `btnClass` includes `focus-visible:ring-2` and doesn't suppress focus without a replacement ring.
- All 3358 frontend tests pass.

Closes #2160
