### PR TITLE
fix(ux): add focus-visible ring to login OAuth buttons for WCAG 2.4.7 (closes #2162)

### DIFF
--- a/frontend/src/__tests__/LoginFocusRing.test.ts
+++ b/frontend/src/__tests__/LoginFocusRing.test.ts
@@ -1,0 +1,18 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "../app/login/page.tsx"),
+  "utf8",
+);
+
+describe("login page OAuth button focus rings (closes #2162)", () => {
+  it("Google button has focus-visible ring for WCAG 2.4.7", () => {
+    expect(src).toMatch(/Continue with Google[\s\S]*?focus-visible:ring-2|focus-visible:ring-2[\s\S]*?Continue with Google/);
+  });
+
+  it("all OAuth buttons use focus-visible:ring-2 (checked by count ≥ 3)", () => {
+    const matches = src.match(/focus-visible:ring-2/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -32,7 +32,7 @@ function LoginForm() {
           <div className="space-y-3">
             <button
               onClick={() => signIn("google", { callbackUrl })}
-              className="w-full flex items-center justify-center gap-3 bg-white border border-stone-300 text-stone-700 rounded-lg px-4 min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-stone-50 transition-colors shadow-sm"
+              className="w-full flex items-center justify-center gap-3 bg-white border border-stone-300 text-stone-700 rounded-lg px-4 min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-stone-50 transition-colors shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2"
             >
               <svg width="18" height="18" viewBox="0 0 48 48" aria-hidden="true">
                 <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
@@ -46,7 +46,7 @@ function LoginForm() {
 
             <button
               onClick={() => signIn("github", { callbackUrl })}
-              className="w-full flex items-center justify-center gap-3 bg-stone-800 text-white rounded-lg px-4 min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-stone-900 transition-colors shadow-sm"
+              className="w-full flex items-center justify-center gap-3 bg-stone-800 text-white rounded-lg px-4 min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-stone-900 transition-colors shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-stone-800"
             >
               <svg width="18" height="18" viewBox="0 0 24 24" fill="white" aria-hidden="true">
                 <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
@@ -56,7 +56,7 @@ function LoginForm() {
 
             <button
               onClick={() => signIn("apple", { callbackUrl })}
-              className="w-full flex items-center justify-center gap-3 bg-black text-white rounded-lg px-4 min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-stone-900 transition-colors shadow-sm"
+              className="w-full flex items-center justify-center gap-3 bg-black text-white rounded-lg px-4 min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-stone-900 transition-colors shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
             >
               <svg width="18" height="18" viewBox="0 0 24 24" fill="white" aria-hidden="true">
                 <path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.54 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701"/>


### PR DESCRIPTION
## What changed

Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2` to all three OAuth login buttons. The GitHub button also gets `focus-visible:ring-offset-stone-800` and the Apple button gets `focus-visible:ring-offset-black` so the amber ring appears with a gap that contrasts cleanly against each button's dark background.

## Why

The GitHub (`bg-stone-800`) and Apple (`bg-black`) buttons had no explicit focus style. Browser-default dark outlines are nearly invisible on dark backgrounds, violating WCAG 2.4.7 (Focus Visible, Level AA). Google's button was also inconsistent with the rest of the app's amber ring system.

Using `focus-visible:` ensures the ring appears only on keyboard navigation (not mouse click), matching the design pattern used across all other interactive elements in the app.

## Test plan

- `frontend/src/__tests__/LoginFocusRing.test.ts` — 2 new static-analysis tests: one asserts `focus-visible:ring-2` appears in the Google button context, another asserts at least 3 occurrences of `focus-visible:ring-2` (one per button).
- All 3360 frontend tests pass.

Closes #2162
