### PR TITLE
fix(ux): add focus-visible rings to admin nav buttons and VocabWordTooltip close (closes #2164)

### DIFF
--- a/frontend/src/__tests__/AdminFocusRing.test.ts
+++ b/frontend/src/__tests__/AdminFocusRing.test.ts
@@ -1,0 +1,37 @@
+import fs from "fs";
+import path from "path";
+
+const adminLayout = fs.readFileSync(
+  path.resolve(__dirname, "../app/admin/layout.tsx"),
+  "utf8",
+);
+
+const vocabTooltip = fs.readFileSync(
+  path.resolve(__dirname, "../components/VocabWordTooltip.tsx"),
+  "utf8",
+);
+
+describe("admin layout button focus rings (closes #2164)", () => {
+  it("Library back button has a focus-visible ring for WCAG 2.4.7", () => {
+    expect(adminLayout).toMatch(/router\.push\("\/"\)[\s\S]*?focus-visible:ring-2|focus-visible:ring-2[\s\S]*?router\.push\("\/"\)/);
+  });
+
+  it("Refresh button has a focus-visible ring for WCAG 2.4.7", () => {
+    expect(adminLayout).toMatch(/loadStats[\s\S]*?focus-visible:ring-2|focus-visible:ring-2[\s\S]*?loadStats/);
+  });
+
+  it("admin nav tabs (Links) have a focus-visible ring for WCAG 2.4.7", () => {
+    expect(adminLayout).toMatch(/TABS\.map[\s\S]*?focus-visible:ring-2/);
+  });
+
+  it("all three admin focusable controls have focus-visible:ring-2 (count ≥ 3)", () => {
+    const matches = adminLayout.match(/focus-visible:ring-2/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("VocabWordTooltip close button focus ring (closes #2164)", () => {
+  it("close button has a focus-visible ring for WCAG 2.4.7", () => {
+    expect(vocabTooltip).toMatch(/Close word definition[\s\S]*?focus-visible:ring-2|focus-visible:ring-2[\s\S]*?Close word definition/);
+  });
+});

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -75,11 +75,11 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   return (
     <main id="main-content" className="min-h-screen bg-parchment">
       <header className="border-b border-amber-200 bg-white/60 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
-        <button onClick={() => router.push("/")} className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] md:min-h-0 flex items-center gap-1">
+        <button onClick={() => router.push("/")} className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] md:min-h-0 flex items-center gap-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1">
           <ArrowLeftIcon className="w-4 h-4" aria-hidden="true" /> Library
         </button>
         <h1 className="font-serif font-bold text-ink text-lg md:text-xl">Admin Panel</h1>
-        <button onClick={loadStats} className="ml-auto text-sm text-amber-700 hover:text-amber-900 min-h-[44px] md:min-h-0 flex items-center gap-1">
+        <button onClick={loadStats} className="ml-auto text-sm text-amber-700 hover:text-amber-900 min-h-[44px] md:min-h-0 flex items-center gap-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1">
           <RetryIcon className="w-4 h-4" aria-hidden="true" /> Refresh
         </button>
       </header>
@@ -97,7 +97,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
               href={href}
               prefetch
               aria-current={current === key ? "page" : undefined}
-              className={`px-3 md:px-4 py-2.5 md:py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap min-h-[44px] md:min-h-0 flex items-center ${
+              className={`px-3 md:px-4 py-2.5 md:py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap min-h-[44px] md:min-h-0 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-0 rounded-t ${
                 current === key
                   ? "border-amber-700 text-amber-900"
                   : "border-transparent text-amber-700 hover:text-amber-900"

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -82,7 +82,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
       {/* Header */}
       <div className="flex items-center justify-between px-3 pt-2.5 pb-1.5 border-b border-amber-100">
         <span id="vocab-tooltip-title" className="font-semibold text-ink text-sm">{word}</span>
-        <button onClick={onClose} aria-label="Close word definition" className="text-stone-600 hover:text-stone-700 p-0.5 rounded transition-colors min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center"><CloseIcon className="w-3.5 h-3.5" /></button>
+        <button onClick={onClose} aria-label="Close word definition" className="text-stone-600 hover:text-stone-700 p-0.5 rounded transition-colors min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"><CloseIcon className="w-3.5 h-3.5" /></button>
       </div>
 
       {/* Body */}


### PR DESCRIPTION
## What changed

Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400` to three interactive controls in the admin panel and the vocabulary tooltip that were missing keyboard focus indicators:

- `admin/layout.tsx` — Library back button and Refresh button now have amber focus rings
- `admin/layout.tsx` — Admin section tab `<Link>` elements now have focus rings (added `rounded-t` for clean ring shape)
- `components/VocabWordTooltip.tsx` — Close button now has a focus ring

## Why

WCAG 2.4.7 (Focus Visible) requires all keyboard-focusable controls to show a visible focus indicator. These buttons had `hover:` styles but no `focus-visible:ring`, so keyboard-only users received no visual cue on where focus was.

## Test plan

- [x] New static-analysis test `AdminFocusRing.test.ts` — 5 assertions covering all four affected controls; confirmed failing before the fix, passing after
- [x] Full frontend suite: 3363 tests pass (556 suites)
- [x] Full backend suite: passed

Closes #2164
