### PR TITLE
fix(ux): add focus-visible rings to TypographyPanel controls for WCAG 2.4.7 (closes #2166)

### DIFF
--- a/frontend/src/__tests__/TypographyPanelFocusRing.test.ts
+++ b/frontend/src/__tests__/TypographyPanelFocusRing.test.ts
@@ -1,0 +1,22 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "../components/TypographyPanel.tsx"),
+  "utf8",
+);
+
+describe("TypographyPanel focus rings (closes #2166)", () => {
+  it("segmented-control buttons include focus-visible:ring-2 for WCAG 2.4.7", () => {
+    expect(src).toMatch(/aria-pressed[\s\S]*?focus-visible:ring-2|focus-visible:ring-2[\s\S]*?aria-pressed/);
+  });
+
+  it("toggle switch button includes focus-visible:ring-2 for WCAG 2.4.7", () => {
+    expect(src).toMatch(/role="switch"[\s\S]*?focus-visible:ring-2|focus-visible:ring-2[\s\S]*?role="switch"/);
+  });
+
+  it("does not silently suppress focus with only outline-none (no ring)", () => {
+    const outlineOnlyNoRing = /focus:outline-none(?![^"']*focus-visible:ring)/;
+    expect(src).not.toMatch(outlineOnlyNoRing);
+  });
+});

--- a/frontend/src/components/TypographyPanel.tsx
+++ b/frontend/src/components/TypographyPanel.tsx
@@ -62,7 +62,7 @@ function SegmentedControl<T extends string>({
           key={opt.value}
           onClick={() => onChange(opt.value)}
           aria-pressed={value === opt.value}
-          className={`flex-1 px-2 py-1.5 min-h-[44px] md:min-h-0 text-xs font-medium transition-colors flex items-center justify-center ${
+          className={`flex-1 px-2 py-1.5 min-h-[44px] md:min-h-0 text-xs font-medium transition-colors flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-inset ${
             value === opt.value
               ? "bg-amber-700 text-white"
               : "bg-white text-amber-700 hover:bg-amber-50"
@@ -176,7 +176,7 @@ export default function TypographyPanel({
               onParagraphFocus(next);
               saveSettings({ paragraphFocus: next });
             }}
-            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center -mr-1.5"
+            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center -mr-1.5 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             role="switch"
             aria-label="Paragraph focus"
             aria-checked={paragraphFocus}


### PR DESCRIPTION
## What changed

Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400` to two interactive control types in `TypographyPanel.tsx`:

- **Segmented-control buttons** (font family, font size, line height, column width): ring is `ring-inset` so it appears inside the grouped border container without disturbing the layout
- **Paragraph Focus toggle switch** (`role="switch"`): ring uses `ring-offset-1` so the amber ring is visible against the surrounding background

## Why

WCAG 2.4.7 (Focus Visible) — keyboard users who open the Aa typography panel in the reader had no visible indicator when tabbing through font/size/height controls or the paragraph-focus toggle. Both control types had `hover:` styles but no focus ring.

## Test plan

- [x] New static-analysis test `TypographyPanelFocusRing.test.ts` — 3 assertions covering both control types; confirmed failing before the fix, all passing after
- [x] Existing TypographyPanel tests all still pass (557 suites, 3363 tests)
- [x] Backend suite passed

Closes #2166
