### PR TITLE
fix(ux): add focus-visible rings to AnnotationToolbar buttons for WCAG 2.4.7 (closes #2168)

### DIFF
--- a/frontend/src/__tests__/AnnotationToolbarFocusRing.test.ts
+++ b/frontend/src/__tests__/AnnotationToolbarFocusRing.test.ts
@@ -1,0 +1,30 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "../components/AnnotationToolbar.tsx"),
+  "utf8",
+);
+
+describe("AnnotationToolbar button focus rings (closes #2168)", () => {
+  it("close button has focus-visible:ring-2 for WCAG 2.4.7", () => {
+    expect(src).toMatch(/Close note editor[\s\S]*?focus-visible:ring-2|focus-visible:ring-2[\s\S]*?Close note editor/);
+  });
+
+  it("color radio buttons have focus-visible:ring-2 for WCAG 2.4.7", () => {
+    expect(src).toMatch(/role="radio"[\s\S]*?focus-visible:ring-2|focus-visible:ring-2[\s\S]*?role="radio"/);
+  });
+
+  it("save button has focus-visible:ring-2 for WCAG 2.4.7", () => {
+    expect(src).toMatch(/handleSave[\s\S]*?focus-visible:ring-2|focus-visible:ring-2[\s\S]*?handleSave/);
+  });
+
+  it("delete button has focus-visible:ring-2 for WCAG 2.4.7", () => {
+    expect(src).toMatch(/Delete note[\s\S]*?focus-visible:ring-2|focus-visible:ring-2[\s\S]*?Delete note/);
+  });
+
+  it("all four AnnotationToolbar buttons use focus-visible:ring-2 (count ≥ 4)", () => {
+    const matches = src.match(/focus-visible:ring-2/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -125,7 +125,7 @@ export default function AnnotationToolbar({
           <button
             onClick={onClose}
             aria-label="Close note editor"
-            className="rounded-lg p-1.5 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-600 hover:text-stone-700 hover:bg-amber-50 transition-colors"
+            className="rounded-lg p-1.5 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-600 hover:text-stone-700 hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <CloseIcon className="w-4 h-4" />
           </button>
@@ -150,7 +150,7 @@ export default function AnnotationToolbar({
                   onClick={() => setColor(c.key)}
                   aria-label={c.label}
                   aria-checked={color === c.key}
-                  className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center"
+                  className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                 >
                   <span
                     className={`w-8 h-8 rounded-full ${c.bg} border-2 transition-all duration-150 hover:scale-110 inline-block ${
@@ -188,7 +188,7 @@ export default function AnnotationToolbar({
             <button
               onClick={handleSave}
               disabled={saving}
-              className="flex-1 rounded-xl bg-amber-700 text-white text-sm font-medium py-2.5 min-h-[44px] md:min-h-0 hover:bg-amber-800 disabled:opacity-50 transition-colors"
+              className="flex-1 rounded-xl bg-amber-700 text-white text-sm font-medium py-2.5 min-h-[44px] md:min-h-0 hover:bg-amber-800 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
             >
               {saving ? "Saving…" : existingAnnotation ? "Update" : "Save note"}
             </button>
@@ -197,7 +197,7 @@ export default function AnnotationToolbar({
                 onClick={handleDelete}
                 disabled={deleting}
                 aria-label="Delete note"
-                className="rounded-xl border border-red-200 text-red-500 px-3 py-2.5 min-h-[44px] md:min-h-0 hover:bg-red-50 disabled:opacity-50 transition-colors flex items-center justify-center"
+                className="rounded-xl border border-red-200 text-red-500 px-3 py-2.5 min-h-[44px] md:min-h-0 hover:bg-red-50 disabled:opacity-50 transition-colors flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
               >
                 <TrashIcon className="w-4 h-4" />
               </button>


### PR DESCRIPTION
## What changed

Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400` to four interactive buttons in `AnnotationToolbar.tsx`:

- **Close button**: `ring-offset-1` for gap against the parchment panel background
- **Color picker radio buttons**: `rounded-full ring-offset-1` — ring wraps the outer hit-target, not the inner color swatch
- **Save/Update button**: `ring-offset-2 ring-offset-amber-700` — amber ring sits outside the dark amber background with a contrasting offset
- **Delete button**: `ring-red-400 ring-offset-1` — uses red ring to match the button's destructive red color scheme

## Why

WCAG 2.4.7 (Focus Visible) — keyboard users who open the annotation modal (by selecting text → clicking Note) had no visible focus indicator on any of the four buttons inside it. All had `hover:` styles but no `focus-visible:ring`.

## Test plan

- [x] New static-analysis test `AnnotationToolbarFocusRing.test.ts` — 5 assertions covering all four controls; confirmed failing before fix, all passing after
- [x] Full frontend suite: 3368 tests (558 suites) pass
- [x] Backend suite passed

Closes #2168
