### PR TITLE
fix(ux): add focus-visible:ring amber rings to vocabulary, decks/[id], notes/[id], DeckCard, UndoToast (closes #2174)

### DIFF
--- a/frontend/src/__tests__/ErrorStateRetryButton.test.ts
+++ b/frontend/src/__tests__/ErrorStateRetryButton.test.ts
@@ -22,7 +22,7 @@ const notesBookSrc = fs.readFileSync(notesBookSrcPath, "utf8");
 
 // ── Vocabulary page ────────────────────────────────────────────────────────
 const vocabErrorBlock =
-  vocabSrc.match(/fetchError \?[\s\S]{0,800}Try again/)?.[0] ?? "";
+  vocabSrc.match(/fetchError \?[\s\S]{0,1000}Try again/)?.[0] ?? "";
 
 describe("vocabulary page error state", () => {
   it("error block contains 'Try again' button", () => {
@@ -54,7 +54,7 @@ describe("notes index page error state", () => {
 
 // ── Notes book page ────────────────────────────────────────────────────────
 const notesBookErrorBlock =
-  notesBookSrc.match(/fetchError \?[\s\S]{0,800}Try again/)?.[0] ?? "";
+  notesBookSrc.match(/fetchError \?[\s\S]{0,1000}Try again/)?.[0] ?? "";
 
 describe("notes book page error state", () => {
   it("error block contains 'Try again' button", () => {

--- a/frontend/src/__tests__/NotesBookIdTouchTargets.test.ts
+++ b/frontend/src/__tests__/NotesBookIdTouchTargets.test.ts
@@ -33,7 +33,7 @@ describe("notes/[bookId] page touch targets (closes #849)", () => {
   it("empty-state Open reader button has min-h-[44px]", () => {
     const idx = src.indexOf("Open reader");
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(Math.max(0, idx - 200), idx + 20);
+    const window = src.slice(Math.max(0, idx - 350), idx + 20);
     expect(window).toContain("min-h-[44px]");
   });
 });

--- a/frontend/src/__tests__/VocabDeckNotesFocusRing.test.ts
+++ b/frontend/src/__tests__/VocabDeckNotesFocusRing.test.ts
@@ -1,0 +1,76 @@
+import fs from "fs";
+import path from "path";
+
+const vocabPage = fs.readFileSync(
+  path.resolve(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8",
+);
+const deckDetailPage = fs.readFileSync(
+  path.resolve(__dirname, "../app/decks/[deckId]/page.tsx"),
+  "utf8",
+);
+const notesBookPage = fs.readFileSync(
+  path.resolve(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf8",
+);
+const deckCard = fs.readFileSync(
+  path.resolve(__dirname, "../components/DeckCard.tsx"),
+  "utf8",
+);
+const undoToast = fs.readFileSync(
+  path.resolve(__dirname, "../components/UndoToast.tsx"),
+  "utf8",
+);
+
+describe("vocabulary page button focus rings (closes #2174)", () => {
+  it("Library back button has focus-visible:ring-2", () => {
+    expect(vocabPage).toMatch(/router\.push\("\/"\)[\s\S]{0,300}?focus-visible:ring-2|focus-visible:ring-2[\s\S]{0,300}?router\.push\("\/"\)/);
+  });
+
+  it("Flashcards button has focus-visible:ring-2", () => {
+    expect(vocabPage).toMatch(/flashcards[\s\S]{0,300}?focus-visible:ring-2|focus-visible:ring-2[\s\S]{0,300}?flashcards/i);
+  });
+
+  it("close definition button has focus-visible:ring-2", () => {
+    expect(vocabPage).toMatch(/Close definition[\s\S]{0,300}?focus-visible:ring-2|focus-visible:ring-2[\s\S]{0,300}?Close definition/);
+  });
+
+  it("vocabulary page has at least 5 focus-visible:ring-2 instances", () => {
+    const matches = vocabPage.match(/focus-visible:ring-2/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(5);
+  });
+});
+
+describe("decks/[deckId] page button focus rings (closes #2174)", () => {
+  it("Decks back button has focus-visible:ring-2", () => {
+    expect(deckDetailPage).toMatch(/router\.push\("\/decks"\)[\s\S]{0,300}?focus-visible:ring-2|focus-visible:ring-2[\s\S]{0,300}?router\.push\("\/decks"\)/);
+  });
+
+  it("deck detail page has at least 4 focus-visible:ring-2 instances", () => {
+    const matches = deckDetailPage.match(/focus-visible:ring-2/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe("notes/[bookId] page button focus rings (closes #2174)", () => {
+  it("notes book page has at least 4 focus-visible:ring-2 instances", () => {
+    const matches = notesBookPage.match(/focus-visible:ring-2/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe("DeckCard component button focus rings (closes #2174)", () => {
+  it("open deck button has focus-visible:ring-2", () => {
+    expect(deckCard).toMatch(/Open deck[\s\S]{0,300}?focus-visible:ring-2|focus-visible:ring-2[\s\S]{0,300}?Open deck/);
+  });
+
+  it("delete deck button has focus-visible:ring-2", () => {
+    expect(deckCard).toMatch(/Delete deck[\s\S]{0,300}?focus-visible:ring-2|focus-visible:ring-2[\s\S]{0,300}?Delete deck/);
+  });
+});
+
+describe("UndoToast component button focus rings (closes #2174)", () => {
+  it("Undo button has focus-visible:ring-2", () => {
+    expect(undoToast).toMatch(/handleUndo[\s\S]{0,300}?focus-visible:ring-2|focus-visible:ring-2[\s\S]{0,300}?handleUndo/);
+  });
+});

--- a/frontend/src/__tests__/VocabularyDefinitionSheetClose.test.ts
+++ b/frontend/src/__tests__/VocabularyDefinitionSheetClose.test.ts
@@ -13,7 +13,7 @@ describe("VocabularyPage DefinitionSheet accessibility (WCAG 2.1.1)", () => {
   });
 
   it("close button uses CloseIcon", () => {
-    const closeButtonBlock = vocab.match(/aria-label="Close definition"[\s\S]{0,300}CloseIcon|CloseIcon[\s\S]{0,300}aria-label="Close definition"/);
+    const closeButtonBlock = vocab.match(/aria-label="Close definition"[\s\S]{0,450}CloseIcon|CloseIcon[\s\S]{0,450}aria-label="Close definition"/);
     expect(closeButtonBlock).not.toBeNull();
   });
 });

--- a/frontend/src/app/decks/[deckId]/page.tsx
+++ b/frontend/src/app/decks/[deckId]/page.tsx
@@ -131,7 +131,7 @@ export default function DeckDetailPage() {
       <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
         <button
           onClick={() => router.push("/decks")}
-          className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] md:min-h-0 flex items-center"
+          className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] md:min-h-0 flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
         >
           <ArrowLeftIcon className="w-4 h-4 shrink-0" /> Decks
         </button>
@@ -152,7 +152,7 @@ export default function DeckDetailPage() {
             onClick={() => setPickerOpen(true)}
             aria-label="Add word to deck"
             disabled={candidateWords.length === 0}
-            className="flex items-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium transition-colors min-h-[44px] md:min-h-0 shrink-0"
+            className="flex items-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium transition-colors min-h-[44px] md:min-h-0 shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <PlusIcon className="w-4 h-4" />
             <span className="hidden sm:inline">Add word</span>
@@ -186,7 +186,7 @@ export default function DeckDetailPage() {
               <button
                 type="button"
                 onClick={loadDeck}
-                className="inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 transition-colors"
+                className="inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
               >
                 <RetryIcon className="w-4 h-4" aria-hidden="true" />
                 Retry
@@ -194,7 +194,7 @@ export default function DeckDetailPage() {
               <button
                 type="button"
                 onClick={() => router.push("/decks")}
-                className="px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg border border-amber-300 text-amber-700 text-sm hover:bg-amber-50 transition-colors"
+                className="px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg border border-amber-300 text-amber-700 text-sm hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
               >
                 Back to decks
               </button>
@@ -227,7 +227,7 @@ export default function DeckDetailPage() {
                     type="button"
                     onClick={() => setPickerOpen(true)}
                     disabled={candidateWords.length === 0}
-                    className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
+                    className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
                   >
                     <PlusIcon className="w-4 h-4" />
                     Add word
@@ -236,7 +236,7 @@ export default function DeckDetailPage() {
                   <button
                     type="button"
                     onClick={() => router.push("/decks")}
-                    className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
+                    className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                   >
                     <ArrowLeftIcon className="w-4 h-4" />
                     Back to decks
@@ -268,7 +268,7 @@ export default function DeckDetailPage() {
                         type="button"
                         onClick={() => handleRemove(w.id)}
                         aria-label={`Remove ${w.word} from deck`}
-                        className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-600 hover:text-red-600 hover:bg-red-50 transition-colors"
+                        className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-600 hover:text-red-600 hover:bg-red-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
                       >
                         <TrashIcon className="w-4 h-4" />
                       </button>
@@ -368,7 +368,7 @@ function AddWordPicker({ candidates, onClose, onAdd }: AddWordPickerProps) {
             type="button"
             onClick={onClose}
             aria-label="Close add-word picker"
-            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-600 hover:text-ink hover:bg-amber-100 transition-colors"
+            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-600 hover:text-ink hover:bg-amber-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <CloseIcon className="w-4 h-4" />
           </button>
@@ -409,7 +409,7 @@ function AddWordPicker({ candidates, onClose, onAdd }: AddWordPickerProps) {
                       onAdd(w.id);
                     }}
                     aria-label={`Add ${w.word} to deck`}
-                    className="w-full flex items-center justify-between gap-3 rounded-lg border border-amber-200 bg-white px-3 py-2 text-left hover:border-amber-400 hover:bg-amber-50 transition-colors min-h-[44px] md:min-h-0"
+                    className="w-full flex items-center justify-between gap-3 rounded-lg border border-amber-200 bg-white px-3 py-2 text-left hover:border-amber-400 hover:bg-amber-50 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                   >
                     <span className="font-serif text-ink truncate flex-1 min-w-0">
                       {w.word}

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -45,7 +45,7 @@ function CollapseHeading({
       <button
         onClick={onToggle}
         aria-expanded={!isCollapsed}
-        className={`w-full flex items-center gap-2 text-left group min-h-[44px] md:min-h-0 ${
+        className={`w-full flex items-center gap-2 text-left group min-h-[44px] md:min-h-0 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-inset ${
           level === 2 ? "pb-1.5 border-b border-amber-200" : ""
         }`}
       >
@@ -113,13 +113,13 @@ function AnnotationCard({
           <div className="flex gap-2">
             <button
               onClick={onSave}
-              className="px-3 py-1 text-xs bg-amber-700 text-white rounded-lg hover:bg-amber-800 transition-colors min-h-[44px] md:min-h-0"
+              className="px-3 py-1 text-xs bg-amber-700 text-white rounded-lg hover:bg-amber-800 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
             >
               Save
             </button>
             <button
               onClick={onCancel}
-              className="px-3 py-1 text-xs text-stone-600 hover:text-stone-700 transition-colors min-h-[44px] md:min-h-0"
+              className="px-3 py-1 text-xs text-stone-600 hover:text-stone-700 transition-colors min-h-[44px] md:min-h-0 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               Cancel
             </button>
@@ -141,7 +141,7 @@ function AnnotationCard({
           </a>
           <button
             onClick={onEdit}
-            className="text-stone-600 hover:text-stone-700 transition-colors p-1 min-h-[44px] md:min-h-0 flex items-center justify-center"
+            className="text-stone-600 hover:text-stone-700 transition-colors p-1 min-h-[44px] md:min-h-0 flex items-center justify-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             title="Edit note"
             aria-label={`Edit annotation: ${ann.sentence_text.slice(0, 60)}`}
           >
@@ -151,7 +151,7 @@ function AnnotationCard({
             onClick={onDelete}
             disabled={isDeleting}
             aria-busy={isDeleting}
-            className="text-red-500 hover:text-red-600 disabled:opacity-40 transition-colors p-1 min-h-[44px] md:min-h-0 flex items-center justify-center"
+            className="text-red-500 hover:text-red-600 disabled:opacity-40 transition-colors p-1 min-h-[44px] md:min-h-0 flex items-center justify-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
             title="Delete annotation"
             aria-label={isDeleting ? "Deleting annotation…" : `Delete annotation: ${ann.sentence_text.slice(0, 60)}`}
           >
@@ -659,7 +659,7 @@ export default function BookNotesPage() {
         <div className="max-w-3xl mx-auto flex items-center gap-3 flex-wrap">
           <button
             onClick={() => router.push("/notes")}
-            className="text-amber-700 hover:text-amber-900 text-sm font-medium shrink-0 min-h-[44px] md:min-h-0 flex items-center"
+            className="text-amber-700 hover:text-amber-900 text-sm font-medium shrink-0 min-h-[44px] md:min-h-0 flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <ArrowLeftIcon className="w-3.5 h-3.5 mr-1 inline" aria-hidden="true" />Notes
           </button>
@@ -675,7 +675,7 @@ export default function BookNotesPage() {
             <button
               onClick={toggleCollapseAll}
               aria-expanded={!isAllCollapsed}
-              className="text-xs text-stone-600 hover:text-stone-700 shrink-0 transition-colors min-h-[44px] md:min-h-0"
+              className="text-xs text-stone-600 hover:text-stone-700 shrink-0 transition-colors min-h-[44px] md:min-h-0 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               {isAllCollapsed ? "Expand all" : "Collapse all"}
             </button>
@@ -688,7 +688,7 @@ export default function BookNotesPage() {
                 key={m}
                 onClick={() => setViewMode(m)}
                 aria-pressed={viewMode === m}
-                className={`px-3 py-1.5 min-h-[44px] md:min-h-0 transition-colors ${
+                className={`px-3 py-1.5 min-h-[44px] md:min-h-0 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-inset ${
                   viewMode === m
                     ? "bg-amber-700 text-white"
                     : "text-amber-700 hover:bg-amber-50"
@@ -703,7 +703,7 @@ export default function BookNotesPage() {
           <button
             onClick={handleExport}
             disabled={exporting}
-            className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 min-h-[44px] md:min-h-0 rounded-lg bg-amber-700 text-white text-xs font-medium hover:bg-amber-800 disabled:opacity-50 transition-colors"
+            className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 min-h-[44px] md:min-h-0 rounded-lg bg-amber-700 text-white text-xs font-medium hover:bg-amber-800 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
           >
             {exporting ? "Exporting…" : <><ArrowUpRightIcon className="w-3.5 h-3.5 inline" aria-hidden="true" /> Export</>}
           </button>
@@ -736,7 +736,7 @@ export default function BookNotesPage() {
             <button
               type="button"
               onClick={loadData}
-              className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
+              className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               <RetryIcon className="w-4 h-4" aria-hidden="true" />
               Try again
@@ -749,7 +749,7 @@ export default function BookNotesPage() {
             <p className="text-sm">Annotate sentences, save AI insights, or add words to vocabulary while reading.</p>
             <button
               onClick={() => router.push(`/reader/${bookId}`)}
-              className="mt-4 px-5 py-2 min-h-[44px] md:min-h-0 rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 inline-flex items-center gap-1"
+              className="mt-4 px-5 py-2 min-h-[44px] md:min-h-0 rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 inline-flex items-center gap-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
             >
               Open reader <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
             </button>

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -166,7 +166,7 @@ function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
           <button
             onClick={onClose}
             aria-label="Close definition"
-            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-600 hover:text-ink hover:bg-amber-50 transition-colors -mr-1"
+            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-600 hover:text-ink hover:bg-amber-50 transition-colors -mr-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <CloseIcon className="w-4 h-4" aria-hidden="true" />
           </button>
@@ -379,7 +379,7 @@ function VocabularyPageContent() {
           <div className="flex items-center gap-2 flex-wrap">
             <button
               onClick={() => setActiveWord({ word: group.lemma, lang: group.language })}
-              className="font-serif font-semibold text-ink text-base hover:text-amber-700 transition-colors text-left min-h-[44px] md:min-h-0 flex items-center"
+              className="font-serif font-semibold text-ink text-base hover:text-amber-700 transition-colors text-left min-h-[44px] md:min-h-0 flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               {group.lemma}
             </button>
@@ -404,7 +404,7 @@ function VocabularyPageContent() {
                 onClick={() => handleDelete(f.word)}
                 disabled={deleting === f.word}
                 aria-label={`Delete ${f.word}`}
-                className="text-xs text-red-600 hover:text-red-800 disabled:opacity-50 transition-colors min-h-[44px] md:min-h-0 flex items-center px-2"
+                className="text-xs text-red-600 hover:text-red-800 disabled:opacity-50 transition-colors min-h-[44px] md:min-h-0 flex items-center px-2 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
                 data-testid={`delete-${f.word}`}
               >
                 {deleting === f.word ? "…" : "Delete"}
@@ -452,7 +452,7 @@ function VocabularyPageContent() {
       <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
         <button
           onClick={() => router.push("/")}
-          className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] md:min-h-0 flex items-center"
+          className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] md:min-h-0 flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
         >
           <ArrowLeftIcon className="w-4 h-4 shrink-0" /> Library
         </button>
@@ -467,7 +467,7 @@ function VocabularyPageContent() {
         <button
           onClick={() => router.push("/vocabulary/flashcards")}
           aria-label="Flashcards"
-          className="flex items-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 shrink-0"
+          className="flex items-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           data-testid="flashcards-btn"
         >
           <FlashcardIcon className="w-4 h-4" />
@@ -476,7 +476,7 @@ function VocabularyPageContent() {
         <button
           onClick={() => handleExport()}
           disabled={exporting || words.length === 0}
-          className="flex items-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors disabled:opacity-50 min-h-[44px] md:min-h-0 shrink-0"
+          className="flex items-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors disabled:opacity-50 min-h-[44px] md:min-h-0 shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           data-testid="export-all-btn"
         >
           {exporting ? "Exporting…" : (<><ArrowUpRightIcon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" /><span className="hidden sm:inline">Export all to Obsidian</span><span className="sm:hidden">Export</span></>)}
@@ -601,7 +601,7 @@ function VocabularyPageContent() {
             <button
               type="button"
               onClick={loadVocab}
-              className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
+              className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               <RetryIcon className="w-4 h-4" aria-hidden="true" />
               Try again
@@ -615,7 +615,7 @@ function VocabularyPageContent() {
             <button
               type="button"
               onClick={() => router.push("/")}
-              className="mt-4 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
+              className="mt-4 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
             >
               Browse books <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
             </button>
@@ -630,7 +630,7 @@ function VocabularyPageContent() {
                 <button
                   type="button"
                   onClick={() => setSelectedTag(null)}
-                  className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
+                  className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                 >
                   Clear tag filter
                 </button>
@@ -642,7 +642,7 @@ function VocabularyPageContent() {
                 <button
                   type="button"
                   onClick={() => setSearch("")}
-                  className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
+                  className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                 >
                   Clear search
                 </button>

--- a/frontend/src/components/DeckCard.tsx
+++ b/frontend/src/components/DeckCard.tsx
@@ -60,7 +60,7 @@ export default function DeckCard({ deck, onClick, onDelete }: DeckCardProps) {
             onClick={onClick}
             aria-label={`Open deck ${deck.name}`}
             data-testid={`deck-card-link-${deck.id}`}
-            className="min-w-0 flex-1 text-left hover:opacity-80 transition-opacity"
+            className="min-w-0 flex-1 text-left hover:opacity-80 transition-opacity rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             {cardContent}
           </button>
@@ -73,7 +73,7 @@ export default function DeckCard({ deck, onClick, onDelete }: DeckCardProps) {
             onClick={() => onDelete(deck.id)}
             aria-label={`Delete deck ${deck.name}`}
             data-testid={`deck-delete-${deck.id}`}
-            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-600 hover:text-red-600 transition-colors shrink-0"
+            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-600 hover:text-red-600 transition-colors shrink-0 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
           >
             <TrashIcon className="w-4 h-4" />
           </button>

--- a/frontend/src/components/UndoToast.tsx
+++ b/frontend/src/components/UndoToast.tsx
@@ -38,7 +38,7 @@ export default function UndoToast({ message, onUndo, onDone }: Props) {
       <span>{message}</span>
       <button
         onClick={handleUndo}
-        className="font-semibold text-amber-300 hover:text-amber-200 transition-colors shrink-0 min-h-[44px] md:min-h-0 flex items-center px-1"
+        className="font-semibold text-amber-300 hover:text-amber-200 transition-colors shrink-0 min-h-[44px] md:min-h-0 flex items-center px-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-stone-800"
       >
         Undo
       </button>


### PR DESCRIPTION
## What changed

Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400` amber design system rings to buttons across five areas that were using browser-default focus outlines.

**vocabulary/page.tsx** — Library back, close definition sheet, Flashcards, Export, word title buttons, delete word (ring-red-400), Try again, Browse books, Clear tag/search filter

**decks/[deckId]/page.tsx** — Decks back, Add word header, Retry (ring-offset-amber-700), Back to decks, empty-state Add/Back buttons, remove word (ring-red-400), close AddWordPicker dialog, picker word rows

**notes/[bookId]/page.tsx** — Notes back, collapse toggle (ring-inset for full-width), view mode segmented control (ring-inset), Export, Try again, Open reader, Save/Cancel inline edit, Edit annotation, Delete annotation (ring-red-400)

**DeckCard.tsx** — open deck button, delete deck button (ring-red-400)

**UndoToast.tsx** — Undo button (ring-offset-stone-800 for dark toast bg)

## Why

Design consistency (P3, #2174): all other pages/components in the app use the amber `focus-visible:ring` design system pattern; these pages were exceptions relying on browser-default blue outlines on keyboard focus.

## Test plan

- New static-analysis test `VocabDeckNotesFocusRing.test.ts` (10 assertions) verifies each area has ≥ expected `focus-visible:ring-2` count and key buttons are covered.
- Expanded look-back/look-ahead windows in `ErrorStateRetryButton.test.ts`, `NotesBookIdTouchTargets.test.ts`, and `VocabularyDefinitionSheetClose.test.ts` to account for added className content.
- Full frontend suite: **3400 tests pass**, 562 suites.

Closes #2174
