### PR TITLE
fix(ux): add focus-visible:ring rings to reader page, QueueTab, WordActionDrawer, SentenceActionPopup (closes #2176)

### DIFF
--- a/frontend/src/__tests__/CloseIconReplaceTimes.test.ts
+++ b/frontend/src/__tests__/CloseIconReplaceTimes.test.ts
@@ -22,7 +22,7 @@ const adminAudio = read("../app/admin/audio/page.tsx");
  */
 function dismissButtonBodies(src: string): string[] {
   const results: string[] = [];
-  const re = /aria-label="Dismiss[^"]*"[\s\S]{0,300}?<\/button>/g;
+  const re = /aria-label="Dismiss[^"]*"[\s\S]{0,450}?<\/button>/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(src)) !== null) {
     results.push(m[0]);

--- a/frontend/src/__tests__/QueueTabChainTouchTargets.test.ts
+++ b/frontend/src/__tests__/QueueTabChainTouchTargets.test.ts
@@ -15,7 +15,7 @@ function checkAround(anchor: string, radius = 300): void {
 
 describe("QueueTab model-chain button touch targets (closes #850)", () => {
   it("Save chain button has min-h-[44px]", () => {
-    checkAround('"Saving…" : "Save chain"', 550);
+    checkAround('"Saving…" : "Save chain"', 1100);
   });
 
   it("preset card buttons have min-h-[44px]", () => {

--- a/frontend/src/__tests__/ReaderComponentsFocusRing.test.ts
+++ b/frontend/src/__tests__/ReaderComponentsFocusRing.test.ts
@@ -1,0 +1,129 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const sentencePopup = fs.readFileSync(
+  path.join(__dirname, "../components/SentenceActionPopup.tsx"),
+  "utf8"
+);
+const wordDrawer = fs.readFileSync(
+  path.join(__dirname, "../components/WordActionDrawer.tsx"),
+  "utf8"
+);
+const queueTab = fs.readFileSync(
+  path.join(__dirname, "../components/QueueTab.tsx"),
+  "utf8"
+);
+const readerPage = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("SentenceActionPopup focus rings (closes #2176)", () => {
+  it("Read button has focus-visible ring with stone-800 offset (dark bg)", () => {
+    const idx = sentencePopup.indexOf("onRead()");
+    expect(idx).toBeGreaterThan(-1);
+    const window = sentencePopup.slice(idx, idx + 450);
+    expect(window).toContain("focus-visible:ring-amber-400");
+    expect(window).toContain("ring-offset-stone-800");
+  });
+
+  it("Note button has focus-visible ring with stone-800 offset", () => {
+    const idx = sentencePopup.indexOf("onNote()");
+    expect(idx).toBeGreaterThan(-1);
+    const window = sentencePopup.slice(idx, idx + 450);
+    expect(window).toContain("focus-visible:ring-amber-400");
+    expect(window).toContain("ring-offset-stone-800");
+  });
+});
+
+describe("WordActionDrawer focus rings (closes #2176)", () => {
+  it("Close button has focus-visible ring", () => {
+    const idx = wordDrawer.indexOf("Close word lookup");
+    expect(idx).toBeGreaterThan(-1);
+    const window = wordDrawer.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Read sentence button has focus-visible ring", () => {
+    const idx = wordDrawer.indexOf("onReadSentence(action.sentenceText");
+    expect(idx).toBeGreaterThan(-1);
+    const window = wordDrawer.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Save word button has focus-visible ring", () => {
+    const idx = wordDrawer.indexOf("onSaveWord(action.word");
+    expect(idx).toBeGreaterThan(-1);
+    const window = wordDrawer.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("QueueTab focus rings (closes #2176)", () => {
+  it("Confirm dialog Confirm button has focus-visible ring", () => {
+    // Skip the dialog div's aria-label; find the button's aria-label (2nd occurrence)
+    const first = queueTab.indexOf("aria-label=\"Confirm action\"");
+    const idx = queueTab.indexOf("aria-label=\"Confirm action\"", first + 1);
+    expect(idx).toBeGreaterThan(-1);
+    const window = queueTab.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Confirm dialog Cancel button has focus-visible ring", () => {
+    const idx = queueTab.indexOf("aria-label=\"Cancel action\"");
+    expect(idx).toBeGreaterThan(-1);
+    const window = queueTab.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Stop worker button has focus-visible ring", () => {
+    const idx = queueTab.indexOf("onClick={stopWorker}");
+    expect(idx).toBeGreaterThan(-1);
+    const window = queueTab.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-red-400");
+  });
+
+  it("Queue items retry button has focus-visible ring", () => {
+    const idx = queueTab.indexOf("retry(it)");
+    expect(idx).toBeGreaterThan(-1);
+    const window = queueTab.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Queue items delete button has focus-visible ring (red)", () => {
+    const idx = queueTab.indexOf("remove(it)");
+    expect(idx).toBeGreaterThan(-1);
+    const window = queueTab.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-red-400");
+  });
+});
+
+describe("Reader page focus rings (closes #2176)", () => {
+  it("Library back button has focus-visible ring", () => {
+    const idx = readerPage.indexOf('router.push("/")');
+    expect(idx).toBeGreaterThan(-1);
+    const window = readerPage.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Dismiss banner button has focus-visible ring", () => {
+    const idx = readerPage.indexOf("setGeminiReminderVisible(false)");
+    expect(idx).toBeGreaterThan(-1);
+    const window = readerPage.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Typography settings button (header) has focus-visible ring", () => {
+    const idx = readerPage.indexOf("aria-label=\"Typography settings\"");
+    expect(idx).toBeGreaterThan(-1);
+    const window = readerPage.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Focus mode toggle button has focus-visible ring", () => {
+    const idx = readerPage.indexOf("aria-label=\"Focus mode\"");
+    expect(idx).toBeGreaterThan(-1);
+    const window = readerPage.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});

--- a/frontend/src/__tests__/ReaderPageUnicodeIcons.test.ts
+++ b/frontend/src/__tests__/ReaderPageUnicodeIcons.test.ts
@@ -41,7 +41,7 @@ describe("Reader page Unicode icon replacements", () => {
   });
 
   it("Library back button uses ArrowLeftIcon", () => {
-    expect(src).toMatch(/router\.push\("\/"\)[\s\S]{0,200}<ArrowLeftIcon/);
+    expect(src).toMatch(/router\.push\("\/"\)[\s\S]{0,350}<ArrowLeftIcon/);
   });
 
   it("chapter navigation uses ArrowLeftIcon", () => {

--- a/frontend/src/__tests__/WordActionDrawerCloseButton.test.ts
+++ b/frontend/src/__tests__/WordActionDrawerCloseButton.test.ts
@@ -21,7 +21,7 @@ describe("WordActionDrawer close button (WCAG 2.1.1, closes #2069)", () => {
 
   it("close button uses CloseIcon", () => {
     const block = src.match(
-      /aria-label="Close word lookup"[\s\S]{0,300}CloseIcon|CloseIcon[\s\S]{0,300}aria-label="Close word lookup"/
+      /aria-label="Close word lookup"[\s\S]{0,400}CloseIcon|CloseIcon[\s\S]{0,400}aria-label="Close word lookup"/
     );
     expect(block).not.toBeNull();
   });

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -878,7 +878,7 @@ export default function ReaderPage() {
           </span>
           <button
             onClick={() => setGeminiReminderVisible(false)}
-            className="shrink-0 text-amber-700 hover:text-amber-900 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 flex items-center justify-center"
+            className="shrink-0 text-amber-700 hover:text-amber-900 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 flex items-center justify-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             aria-label="Dismiss"
           >
             <CloseIcon aria-hidden="true" className="w-4 h-4" />
@@ -894,7 +894,7 @@ export default function ReaderPage() {
               aria-label="Previous chapter"
               onClick={() => chapterIndex > 0 && goToChapter(chapterIndex - 1)}
               disabled={chapterIndex === 0}
-              className="inline-flex items-center gap-1 px-2 py-1 rounded-full hover:bg-amber-50 disabled:opacity-30 transition-colors min-h-[44px] md:min-h-0"
+              className="inline-flex items-center gap-1 px-2 py-1 rounded-full hover:bg-amber-50 disabled:opacity-30 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             ><ArrowLeftIcon className="w-3 h-3" aria-hidden="true" /> Prev</button>
             <span className="text-stone-400 mx-0.5" aria-hidden="true">|</span>
             <span
@@ -908,14 +908,14 @@ export default function ReaderPage() {
               aria-label="Next chapter"
               onClick={() => chapterIndex < chapters.length - 1 && goToChapter(chapterIndex + 1)}
               disabled={chapterIndex === chapters.length - 1}
-              className="inline-flex items-center gap-1 px-2 py-1 rounded-full hover:bg-amber-50 disabled:opacity-30 transition-colors min-h-[44px] md:min-h-0"
+              className="inline-flex items-center gap-1 px-2 py-1 rounded-full hover:bg-amber-50 disabled:opacity-30 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >Next <ArrowRightIcon className="w-3 h-3" aria-hidden="true" /></button>
             {paragraphFocus && (
               <>
                 <span className="text-stone-400 mx-0.5" aria-hidden="true">|</span>
                 <button
                   onClick={ttsIsPlaying ? undefined : readFocusedParagraph}
-                  className="inline-flex items-center gap-1 px-2 py-1 rounded-full hover:bg-amber-50 transition-colors min-h-[44px] md:min-h-0"
+                  className="inline-flex items-center gap-1 px-2 py-1 rounded-full hover:bg-amber-50 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                   aria-label={ttsIsPlaying ? "Playing paragraph" : "Read focused paragraph"}
                   title={ttsIsPlaying ? "Playing…" : "Read focused paragraph"}
                 >
@@ -933,13 +933,13 @@ export default function ReaderPage() {
               aria-label="Typography settings"
               aria-expanded={showTypographyPanel}
               aria-controls="typography-panel"
-              className="px-2 py-1 rounded-full hover:bg-amber-50 transition-colors font-bold min-h-[44px] md:min-h-0"
+              className="px-2 py-1 rounded-full hover:bg-amber-50 transition-colors font-bold min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
               title="Typography"
             >Aa</button>
             <span className="text-stone-400 mx-0.5" aria-hidden="true">|</span>
             <button
               onClick={() => setFocusMode(false)}
-              className="inline-flex items-center gap-1 px-2 py-1 rounded-full hover:bg-red-50 text-stone-600 hover:text-red-600 transition-colors min-h-[44px] md:min-h-0"
+              className="inline-flex items-center gap-1 px-2 py-1 rounded-full hover:bg-red-50 text-stone-600 hover:text-red-600 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
               aria-label="Exit focus mode"
               title="Exit focus mode (F)"
             ><CloseIcon className="w-3 h-3" aria-hidden="true" /> Focus</button>
@@ -956,7 +956,7 @@ export default function ReaderPage() {
           <button
             onClick={() => router.push("/")}
             aria-label="Library"
-            className="text-amber-700 hover:text-amber-900 text-sm shrink-0 min-h-[44px] md:min-h-0 flex items-center"
+            className="text-amber-700 hover:text-amber-900 text-sm shrink-0 min-h-[44px] md:min-h-0 flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <ArrowLeftIcon className="w-4 h-4 shrink-0" aria-hidden="true" /><span className="hidden sm:inline ml-1">Library</span>
           </button>
@@ -1061,7 +1061,7 @@ export default function ReaderPage() {
               aria-label="Typography settings"
               aria-expanded={showTypographyPanel}
               aria-controls="typography-panel"
-              className={`flex shrink-0 items-center gap-1 px-2 py-1 min-h-[44px] md:min-h-0 rounded-lg border text-xs font-bold transition-colors ${
+              className={`flex shrink-0 items-center gap-1 px-2 py-1 min-h-[44px] md:min-h-0 rounded-lg border text-xs font-bold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 ${
                 showTypographyPanel || paragraphFocus
                   ? "bg-amber-100 border-amber-400 text-amber-800"
                   : "border-amber-300 hover:bg-amber-100 text-amber-700"
@@ -1230,7 +1230,7 @@ export default function ReaderPage() {
             title="Focus mode (F)"
             aria-label="Focus mode"
             aria-pressed={focusMode}
-            className={`hidden md:flex shrink-0 items-center gap-1.5 px-2 lg:px-3 py-1.5 min-h-[44px] md:min-h-0 rounded-lg border text-xs font-medium transition-colors ${
+            className={`hidden md:flex shrink-0 items-center gap-1.5 px-2 lg:px-3 py-1.5 min-h-[44px] md:min-h-0 rounded-lg border text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 ${
               focusMode
                 ? "bg-amber-700 text-white border-amber-700"
                 : "border-amber-300 text-amber-700 hover:bg-amber-50"

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -527,7 +527,7 @@ export default function QueueTab({ adminFetch }: Props) {
                 await fn();
               }}
               aria-label="Confirm action"
-              className="px-3 py-1.5 rounded border border-amber-500 bg-amber-100 text-amber-800 hover:bg-amber-200 text-xs font-medium"
+              className="px-3 py-1.5 rounded border border-amber-500 bg-amber-100 text-amber-800 hover:bg-amber-200 text-xs font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               Confirm
             </button>
@@ -535,7 +535,7 @@ export default function QueueTab({ adminFetch }: Props) {
               type="button"
               onClick={() => setPendingConfirm(null)}
               aria-label="Cancel action"
-              className="px-3 py-1.5 rounded border border-stone-200 text-stone-600 hover:bg-stone-50 text-xs"
+              className="px-3 py-1.5 rounded border border-stone-200 text-stone-600 hover:bg-stone-50 text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               Cancel
             </button>
@@ -550,7 +550,7 @@ export default function QueueTab({ adminFetch }: Props) {
             type="button"
             onClick={() => setActError(null)}
             aria-label="Dismiss error"
-            className="shrink-0 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 flex items-center justify-center text-red-500 hover:text-red-700"
+            className="shrink-0 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 flex items-center justify-center text-red-500 hover:text-red-700 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
           >
             <CloseIcon className="w-4 h-4" aria-hidden="true" />
           </button>
@@ -564,7 +564,7 @@ export default function QueueTab({ adminFetch }: Props) {
             type="button"
             onClick={() => setToast(null)}
             aria-label="Dismiss message"
-            className="shrink-0 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 flex items-center justify-center text-emerald-500 hover:text-emerald-700"
+            className="shrink-0 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 flex items-center justify-center text-emerald-500 hover:text-emerald-700 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <CloseIcon className="w-4 h-4" aria-hidden="true" />
           </button>
@@ -603,7 +603,7 @@ export default function QueueTab({ adminFetch }: Props) {
             <button
               onClick={stopWorker}
               disabled={togglingWorker !== null}
-              className="text-xs px-3 py-1 rounded border border-red-200 text-red-600 hover:bg-red-50 disabled:opacity-50 inline-flex items-center gap-1.5 min-h-[44px] md:min-h-0"
+              className="text-xs px-3 py-1 rounded border border-red-200 text-red-600 hover:bg-red-50 disabled:opacity-50 inline-flex items-center gap-1.5 min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
             >
               {togglingWorker === "stop" && (
                 <span
@@ -618,7 +618,7 @@ export default function QueueTab({ adminFetch }: Props) {
             <button
               onClick={startWorker}
               disabled={togglingWorker !== null}
-              className="text-xs px-3 py-1 rounded border border-emerald-300 text-emerald-700 hover:bg-emerald-50 disabled:opacity-50 inline-flex items-center gap-1.5 min-h-[44px] md:min-h-0"
+              className="text-xs px-3 py-1 rounded border border-emerald-300 text-emerald-700 hover:bg-emerald-50 disabled:opacity-50 inline-flex items-center gap-1.5 min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               {togglingWorker === "start" && (
                 <span
@@ -772,14 +772,14 @@ export default function QueueTab({ adminFetch }: Props) {
           <button
             onClick={runPlan}
             disabled={planning || dryRunning}
-            className="text-sm px-3 py-1.5 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-40 min-h-[44px] md:min-h-0"
+            className="text-sm px-3 py-1.5 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-40 min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             {planning ? "Planning…" : "Show plan"}
           </button>
           <button
             onClick={runDryRun}
             disabled={dryRunning || planning}
-            className="text-sm px-3 py-1.5 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-40 min-h-[44px] md:min-h-0"
+            className="text-sm px-3 py-1.5 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-40 min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             {dryRunning ? "Translating…" : "Dry run (preview quality)"}
           </button>
@@ -893,7 +893,7 @@ export default function QueueTab({ adminFetch }: Props) {
                   })
                 }
                 disabled={saving}
-                className="text-xs px-3 py-1 rounded bg-amber-700 text-white disabled:opacity-50 min-h-[44px] md:min-h-0"
+                className="text-xs px-3 py-1 rounded bg-amber-700 text-white disabled:opacity-50 min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
               >
                 Save
               </button>
@@ -920,7 +920,7 @@ export default function QueueTab({ adminFetch }: Props) {
                   setApiKey("");
                 }}
                 disabled={saving || !apiKey}
-                className="text-xs px-3 py-1 rounded bg-amber-700 text-white disabled:opacity-50 min-h-[44px] md:min-h-0"
+                className="text-xs px-3 py-1 rounded bg-amber-700 text-white disabled:opacity-50 min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
               >
                 Save
               </button>
@@ -933,7 +933,7 @@ export default function QueueTab({ adminFetch }: Props) {
                     })
                   }
                   aria-label="Clear Gemini API key"
-                  className="text-xs px-2 py-1 rounded border border-red-200 text-red-600 min-h-[44px] md:min-h-0"
+                  className="text-xs px-2 py-1 rounded border border-red-200 text-red-600 min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
                 >
                   Clear
                 </button>
@@ -971,7 +971,7 @@ export default function QueueTab({ adminFetch }: Props) {
                     );
                   }}
                   disabled={saving || chain.length === 0}
-                  className="text-xs px-3 min-h-[44px] md:min-h-0 rounded bg-amber-700 text-white disabled:opacity-50 inline-flex items-center gap-1.5"
+                  className="text-xs px-3 min-h-[44px] md:min-h-0 rounded bg-amber-700 text-white disabled:opacity-50 inline-flex items-center gap-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
                 >
                   {saving && (
                     <span
@@ -1015,7 +1015,7 @@ export default function QueueTab({ adminFetch }: Props) {
                       key={p.id}
                       onClick={() => setChain([...p.chain])}
                       aria-pressed={active}
-                      className={`text-left p-2 min-h-[44px] md:min-h-0 rounded-lg border transition-colors ${
+                      className={`text-left p-2 min-h-[44px] md:min-h-0 rounded-lg border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 ${
                         active
                           ? "border-amber-500 bg-amber-100/60"
                           : "border-amber-200 bg-white hover:bg-amber-50"
@@ -1096,7 +1096,7 @@ export default function QueueTab({ adminFetch }: Props) {
                           setChain(copy);
                         }}
                         disabled={idx === 0}
-                        className="text-xs min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-600 hover:text-amber-700 disabled:opacity-30"
+                        className="text-xs min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-600 hover:text-amber-700 disabled:opacity-30 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                         title={`Move ${labelForModel(m)} up`}
                         aria-label={`Move ${labelForModel(m)} up`}
                       >
@@ -1110,7 +1110,7 @@ export default function QueueTab({ adminFetch }: Props) {
                           setChain(copy);
                         }}
                         disabled={idx === chain.length - 1}
-                        className="text-xs min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-600 hover:text-amber-700 disabled:opacity-30"
+                        className="text-xs min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-600 hover:text-amber-700 disabled:opacity-30 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                         title={`Move ${labelForModel(m)} down`}
                         aria-label={`Move ${labelForModel(m)} down`}
                       >
@@ -1119,7 +1119,7 @@ export default function QueueTab({ adminFetch }: Props) {
                     </div>
                     <button
                       onClick={() => setChain(chain.filter((_, i) => i !== idx))}
-                      className="text-xs min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded border border-red-200 text-red-600 shrink-0"
+                      className="text-xs min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded border border-red-200 text-red-600 shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
                       title={`Remove ${labelForModel(m)} from chain`}
                       aria-label={`Remove ${labelForModel(m)} from chain`}
                     >
@@ -1145,7 +1145,7 @@ export default function QueueTab({ adminFetch }: Props) {
                     <button
                       key={opt.value || "default"}
                       onClick={() => setChain([...chain, opt.value])}
-                      className={`text-xs px-2 py-1 rounded border font-mono min-h-[44px] md:min-h-0 ${
+                      className={`text-xs px-2 py-1 rounded border font-mono min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 ${
                         opt.recommended
                           ? "border-emerald-300 text-emerald-700 hover:bg-emerald-50"
                           : "border-stone-200 text-stone-600 hover:bg-stone-50"
@@ -1176,7 +1176,7 @@ export default function QueueTab({ adminFetch }: Props) {
                     setCustomModel("");
                   }}
                   disabled={!customModel.trim()}
-                  className="text-xs px-2 py-1 rounded border border-amber-300 text-amber-700 disabled:opacity-40 min-h-[44px] md:min-h-0"
+                  className="text-xs px-2 py-1 rounded border border-amber-300 text-amber-700 disabled:opacity-40 min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                 >
                   + Add custom
                 </button>
@@ -1188,7 +1188,7 @@ export default function QueueTab({ adminFetch }: Props) {
         <div className="flex gap-2 pt-2 border-t border-amber-100">
           <button
             onClick={enqueueAll}
-            className="text-xs px-3 py-1.5 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 min-h-[44px] md:min-h-0"
+            className="text-xs px-3 py-1.5 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             Queue every book for all configured languages
           </button>
@@ -1334,7 +1334,7 @@ export default function QueueTab({ adminFetch }: Props) {
               key={f}
               onClick={() => setItemFilter(f)}
               aria-pressed={itemFilter === f}
-              className={`text-xs px-2 py-0.5 min-h-[44px] md:min-h-0 flex items-center rounded ${
+              className={`text-xs px-2 py-0.5 min-h-[44px] md:min-h-0 flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-inset ${
                 itemFilter === f ? "bg-amber-700 text-white" : "text-amber-700 hover:bg-amber-50"
               }`}
             >
@@ -1345,7 +1345,7 @@ export default function QueueTab({ adminFetch }: Props) {
           <button
             onClick={clearAll}
             disabled={items.length === 0}
-            className="text-xs px-2 py-0.5 min-h-[44px] md:min-h-0 flex items-center rounded border border-red-200 text-red-600 hover:bg-red-50 disabled:opacity-40"
+            className="text-xs px-2 py-0.5 min-h-[44px] md:min-h-0 flex items-center rounded border border-red-200 text-red-600 hover:bg-red-50 disabled:opacity-40 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
             title={itemFilter === "all" ? "Clear entire queue" : `Clear all ${itemFilter}`}
           >
             {itemFilter === "all" ? "Clear queue" : `Clear ${itemFilter}`}
@@ -1410,7 +1410,7 @@ export default function QueueTab({ adminFetch }: Props) {
                     <button
                       onClick={() => retry(it)}
                       aria-label={`Retry ${it.book_title || `book ${it.book_id}`} ch${it.chapter_index + 1} → ${it.target_language}`}
-                      className="px-1.5 py-0.5 rounded border border-amber-300 text-amber-700 min-h-[44px] md:min-h-0 flex items-center"
+                      className="px-1.5 py-0.5 rounded border border-amber-300 text-amber-700 min-h-[44px] md:min-h-0 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                     >
                       Retry
                     </button>
@@ -1418,7 +1418,7 @@ export default function QueueTab({ adminFetch }: Props) {
                   <button
                     onClick={() => remove(it)}
                     aria-label={`Remove ${it.book_title || `book ${it.book_id}`} ch${it.chapter_index + 1} → ${it.target_language} from queue`}
-                    className="px-1.5 py-0.5 rounded border border-red-200 text-red-600 min-h-[44px] md:min-h-0 flex items-center"
+                    className="px-1.5 py-0.5 rounded border border-red-200 text-red-600 min-h-[44px] md:min-h-0 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
                   >
                     Del
                   </button>

--- a/frontend/src/components/SentenceActionPopup.tsx
+++ b/frontend/src/components/SentenceActionPopup.tsx
@@ -51,14 +51,14 @@ export default function SentenceActionPopup({ sentenceText: _sentenceText, posit
     >
       <button
         onClick={() => { onRead(); onClose(); }}
-        className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px] md:min-h-0"
+        className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 focus-visible:ring-offset-stone-800"
       >
         <SpeakerIcon className="w-3.5 h-3.5 shrink-0" /> Read
       </button>
       {onNote && (
         <button
           onClick={() => { onNote(); onClose(); }}
-          className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px] md:min-h-0"
+          className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 focus-visible:ring-offset-stone-800"
         >
           <NoteIcon className="w-3.5 h-3.5 shrink-0" /> Note
         </button>
@@ -66,7 +66,7 @@ export default function SentenceActionPopup({ sentenceText: _sentenceText, posit
       {onChat && (
         <button
           onClick={() => { onChat(); onClose(); }}
-          className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px] md:min-h-0"
+          className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 focus-visible:ring-offset-stone-800"
         >
           <ChatIcon className="w-3.5 h-3.5 shrink-0" /> Chat
         </button>

--- a/frontend/src/components/WordActionDrawer.tsx
+++ b/frontend/src/components/WordActionDrawer.tsx
@@ -137,7 +137,7 @@ export default function WordActionDrawer({
           <button
             onClick={onClose}
             aria-label="Close word lookup"
-            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-600 hover:text-ink hover:bg-amber-50 transition-colors -mr-1"
+            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-600 hover:text-ink hover:bg-amber-50 transition-colors -mr-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <CloseIcon className="w-4 h-4" aria-hidden="true" />
           </button>
@@ -195,7 +195,7 @@ export default function WordActionDrawer({
                   onReadSentence(action.sentenceText, action.segmentStartTime);
                   onClose();
                 }}
-                className="flex-1 flex items-center justify-center gap-1.5 min-h-[48px] rounded-xl bg-amber-50 border border-amber-200 text-amber-800 text-sm font-medium hover:bg-amber-100 transition-colors"
+                className="flex-1 flex items-center justify-center gap-1.5 min-h-[48px] rounded-xl bg-amber-50 border border-amber-200 text-amber-800 text-sm font-medium hover:bg-amber-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
               >
                 <SpeakerIcon className="w-4 h-4 shrink-0" /> Read
               </button>
@@ -209,7 +209,7 @@ export default function WordActionDrawer({
                   }
                 }}
                 disabled={saved}
-                className={`flex-1 flex items-center justify-center gap-1.5 min-h-[48px] rounded-xl border text-sm font-medium transition-colors ${
+                className={`flex-1 flex items-center justify-center gap-1.5 min-h-[48px] rounded-xl border text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 ${
                   saved
                     ? "bg-green-50 border-green-200 text-green-700"
                     : "bg-amber-50 border-amber-200 text-amber-800 hover:bg-amber-100"
@@ -224,7 +224,7 @@ export default function WordActionDrawer({
                   onAnnotate(action.sentenceText, action.chapterIndex);
                   onClose();
                 }}
-                className="flex-1 flex items-center justify-center gap-1.5 min-h-[48px] rounded-xl bg-amber-50 border border-amber-200 text-amber-800 text-sm font-medium hover:bg-amber-100 transition-colors"
+                className="flex-1 flex items-center justify-center gap-1.5 min-h-[48px] rounded-xl bg-amber-50 border border-amber-200 text-amber-800 text-sm font-medium hover:bg-amber-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
               >
                 <NoteIcon className="w-4 h-4 shrink-0" /> Note
               </button>


### PR DESCRIPTION
## What changed

Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400` amber design system focus rings to all interactive buttons in the reader experience components:

- **`app/reader/[bookId]/page.tsx`** — Library back, Dismiss banner, Focus mode HUD (Prev/Next/Read-para/Typography/Exit), header Typography settings, Focus mode toggle
- **`components/QueueTab.tsx`** — Confirm/Cancel dialog, Dismiss error/message (red ring), Stop/Start worker, Show plan/Dry run, Save settings (ring-offset-amber-700), Save chain, preset cards, Move up/down, Remove from chain (red), Add to chain, Add custom, Queue every book, filter pills (ring-inset), Clear queue (red), Retry, Del (red)
- **`components/WordActionDrawer.tsx`** — Close, Read, Save, Annotate action buttons
- **`components/SentenceActionPopup.tsx`** — Read, Note, Chat buttons on dark stone-800 background (ring-offset-stone-800)

## Why

WCAG 2.4.7 Focus Visible: keyboard users had no visible focus indicator on any button in the reader flow, the most-used part of the app. These four files had zero `focus-visible` classes before this PR.

## Test plan

- [x] New static-analysis test `ReaderComponentsFocusRing.test.ts` (14 assertions) verifies rings on key buttons in all four files
- [x] Expanded windows in 4 existing tests that broke due to longer classNames: `QueueTabChainTouchTargets`, `WordActionDrawerCloseButton`, `ReaderPageUnicodeIcons`, `CloseIconReplaceTimes`
- [x] Full suite: 3414 frontend tests pass

Closes #2176
