### PR TITLE
fix(ux): add focus-visible rings to TTSControls and InsightChat (closes #2180)

### DIFF
--- a/frontend/src/__tests__/InsightChatContextToggleAria.test.ts
+++ b/frontend/src/__tests__/InsightChatContextToggleAria.test.ts
@@ -15,7 +15,7 @@ describe("InsightChat context expand/collapse aria-labels (closes #1007)", () =>
     const contextChipSrc = src.slice(contextChipIdx, nextComponentIdx);
     const btnIdx = contextChipSrc.indexOf('onClick={() => setExpanded');
     expect(btnIdx).toBeGreaterThan(-1);
-    const btnWindow = contextChipSrc.slice(Math.max(0, btnIdx - 20), btnIdx + 300);
+    const btnWindow = contextChipSrc.slice(Math.max(0, btnIdx - 20), btnIdx + 400);
     expect(btnWindow).toContain("aria-label");
   });
 

--- a/frontend/src/__tests__/TTSInsightChatFocusRing.test.ts
+++ b/frontend/src/__tests__/TTSInsightChatFocusRing.test.ts
@@ -1,0 +1,106 @@
+import fs from "fs";
+import path from "path";
+
+const tts = fs.readFileSync(
+  path.resolve(__dirname, "../components/TTSControls.tsx"),
+  "utf8",
+);
+const chat = fs.readFileSync(
+  path.resolve(__dirname, "../components/InsightChat.tsx"),
+  "utf8",
+);
+
+describe("TTSControls button focus rings (closes #2180)", () => {
+  it("Cancel loading button has focus ring", () => {
+    // Skip function definition; find the onClick usage
+    const defIdx = tts.indexOf("cancelLoad");
+    const idx = tts.indexOf("cancelLoad", defIdx + 1);
+    expect(idx).toBeGreaterThan(-1);
+    const window = tts.slice(idx, idx + 350);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Pause button (playing state) has focus ring", () => {
+    // data-tts-play first occurrence is the pause button
+    const idx = tts.indexOf("data-tts-play");
+    expect(idx).toBeGreaterThan(-1);
+    const window = tts.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Read/Resume button (paused state, amber-700 bg) has focus ring with offset", () => {
+    const first = tts.indexOf("data-tts-play");
+    const idx = tts.indexOf("data-tts-play", first + 1);
+    expect(idx).toBeGreaterThan(-1);
+    const window = tts.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-amber-400");
+    expect(window).toContain("ring-offset-amber-700");
+  });
+
+  it("Error retry button has red focus ring", () => {
+    const idx = tts.indexOf('status === "error"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = tts.slice(idx, idx + 500);
+    expect(window).toContain("focus-visible:ring-red-400");
+  });
+
+  it("Gender toggle button has focus ring", () => {
+    // Skip function definition; find the onClick usage
+    const defIdx = tts.indexOf("toggleGender");
+    const idx = tts.indexOf("toggleGender", defIdx + 1);
+    expect(idx).toBeGreaterThan(-1);
+    const window = tts.slice(idx, idx + 500);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("InsightChat button focus rings (closes #2180)", () => {
+  it("Font size toggle button has focus ring", () => {
+    // Look forward from the onClick body (chatFontSize toggle logic)
+    const idx = chat.indexOf('chatFontSize === "xs" ? "sm" : "xs"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = chat.slice(idx, idx + 600);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Refresh insight button has focus ring", () => {
+    // aria-label="Append a fresh insight" comes before className — need extra window
+    const idx = chat.indexOf('"Append a fresh insight"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = chat.slice(idx, idx + 450);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Load earlier messages button has focus ring", () => {
+    // Skip function definition; find onClick usage
+    const defIdx = chat.indexOf("loadEarlier");
+    const idx = chat.indexOf("loadEarlier", defIdx + 1);
+    expect(idx).toBeGreaterThan(-1);
+    const window = chat.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Send message button has focus ring", () => {
+    // className comes before aria-label="Send message" — look back
+    const idx = chat.indexOf('aria-label="Send message"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = chat.slice(Math.max(0, idx - 350), idx + 20);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Toggle context button has focus ring", () => {
+    // className comes before aria-label="Toggle context" — look back
+    const idx = chat.indexOf('"Toggle context"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = chat.slice(Math.max(0, idx - 300), idx + 20);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Remove context button has focus ring", () => {
+    // onClick={onRemove} comes before className — look forward
+    const idx = chat.indexOf("onClick={onRemove}");
+    expect(idx).toBeGreaterThan(-1);
+    const window = chat.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -76,7 +76,7 @@ function ContextChip({
           {needsToggle && (
             <button
               onClick={() => setExpanded((v) => !v)}
-              className="ml-1.5 text-amber-700 hover:text-amber-900 font-medium not-italic min-h-[44px] md:min-h-0 inline-flex items-center"
+              className="ml-1.5 text-amber-700 hover:text-amber-900 font-medium not-italic min-h-[44px] md:min-h-0 inline-flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
               aria-label="Toggle context"
               aria-expanded={expanded}
             >
@@ -87,7 +87,7 @@ function ContextChip({
         {onRemove && (
           <button
             onClick={onRemove}
-            className="shrink-0 text-amber-600 hover:text-amber-700 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center"
+            className="shrink-0 text-amber-600 hover:text-amber-700 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             title="Remove context"
             aria-label="Remove context"
           >
@@ -393,7 +393,7 @@ export default function InsightChat({
           }}
           title={`Toggle font size (${chatFontSize === "xs" ? "small" : "medium"})`}
           aria-label={chatFontSize === "xs" ? "Increase chat font size" : "Decrease chat font size"}
-          className={`shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded text-xs font-bold transition-colors ${
+          className={`shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded text-xs font-bold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 ${
             chatFontSize === "sm"
               ? "bg-amber-100 text-amber-800 hover:bg-amber-200"
               : "text-stone-600 hover:bg-stone-200 hover:text-stone-700"
@@ -406,7 +406,7 @@ export default function InsightChat({
           title={hasGeminiKey ? "Append a fresh insight" : "Gemini API key required"}
           aria-label="Append a fresh insight"
           disabled={!hasGeminiKey}
-          className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded hover:bg-stone-200 text-stone-600 hover:text-stone-700 disabled:opacity-40 disabled:cursor-not-allowed"
+          className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded hover:bg-stone-200 text-stone-600 hover:text-stone-700 disabled:opacity-40 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
         >
           <RetryIcon className="w-3.5 h-3.5" />
         </button>
@@ -433,7 +433,7 @@ export default function InsightChat({
         {hasEarlier && (
           <button
             onClick={loadEarlier}
-            className="w-full text-xs text-stone-600 hover:text-stone-800 py-1.5 min-h-[44px] md:min-h-0 rounded-lg border border-stone-200 hover:bg-stone-50 transition-colors inline-flex items-center justify-center gap-1.5"
+            className="w-full text-xs text-stone-600 hover:text-stone-800 py-1.5 min-h-[44px] md:min-h-0 rounded-lg border border-stone-200 hover:bg-stone-50 transition-colors inline-flex items-center justify-center gap-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <ArrowUpIcon className="w-3 h-3" />
             <span>Load earlier ({loadedFrom} more)</span>
@@ -606,7 +606,7 @@ export default function InsightChat({
           <button
             onClick={sendMessage}
             disabled={chatLoading || !input.trim() || !hasGeminiKey}
-            className="rounded-xl bg-amber-600 p-2 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-white hover:bg-amber-700 disabled:opacity-40 shrink-0 transition-colors"
+            className="rounded-xl bg-amber-600 p-2 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-white hover:bg-amber-700 disabled:opacity-40 shrink-0 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-600"
             aria-label="Send message"
             title="Send (Enter)"
           >

--- a/frontend/src/components/TTSControls.tsx
+++ b/frontend/src/components/TTSControls.tsx
@@ -410,7 +410,7 @@ export default function TTSControls({
         {status === "loading" ? (
           <button
             onClick={cancelLoad}
-            className="rounded-lg bg-amber-300 text-amber-900 px-4 py-2.5 md:py-1.5 text-sm flex items-center gap-2 hover:bg-amber-400 min-h-[44px] md:min-h-0"
+            className="rounded-lg bg-amber-300 text-amber-900 px-4 py-2.5 md:py-1.5 text-sm flex items-center gap-2 hover:bg-amber-400 min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             aria-label="Cancel audio loading"
           >
             <span className="w-3 h-3 border-2 border-amber-700/40 border-t-amber-800 rounded-full animate-spin" aria-hidden="true" />
@@ -421,7 +421,7 @@ export default function TTSControls({
           <button
             data-tts-play
             onClick={pause}
-            className="rounded-lg bg-amber-200 text-amber-900 px-4 py-2.5 md:py-1.5 text-sm hover:bg-amber-300 min-h-[44px] md:min-h-0 flex items-center gap-1.5"
+            className="rounded-lg bg-amber-200 text-amber-900 px-4 py-2.5 md:py-1.5 text-sm hover:bg-amber-300 min-h-[44px] md:min-h-0 flex items-center gap-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <PauseIcon className="w-3.5 h-3.5" aria-hidden="true" />
             Pause
@@ -430,7 +430,7 @@ export default function TTSControls({
           <button
             data-tts-play
             onClick={play}
-            className="rounded-lg bg-amber-700 text-white px-4 py-2.5 md:py-1.5 text-sm hover:bg-amber-800 min-h-[44px] md:min-h-0 flex items-center gap-1.5"
+            className="rounded-lg bg-amber-700 text-white px-4 py-2.5 md:py-1.5 text-sm hover:bg-amber-800 min-h-[44px] md:min-h-0 flex items-center gap-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
           >
             <PlayIcon className="w-3.5 h-3.5" aria-hidden="true" />
             Read
@@ -438,7 +438,7 @@ export default function TTSControls({
         ) : status === "error" ? (
           <button
             onClick={play}
-            className="rounded-lg bg-red-100 text-red-800 border border-red-300 px-3 py-2.5 md:py-1.5 text-sm hover:bg-red-200 min-h-[44px] md:min-h-0 flex items-center gap-1.5"
+            className="rounded-lg bg-red-100 text-red-800 border border-red-300 px-3 py-2.5 md:py-1.5 text-sm hover:bg-red-200 min-h-[44px] md:min-h-0 flex items-center gap-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
             title={errorMsg || "Audio failed"}
           >
             <RetryIcon className="w-3.5 h-3.5" aria-hidden="true" />
@@ -460,7 +460,7 @@ export default function TTSControls({
         onClick={toggleGender}
         title={`Voice: ${gender}. Click to switch.`}
         aria-label={`Voice: ${gender === "female" ? "Female" : "Male"}. Click to switch.`}
-        className="text-xs px-3 py-2 md:px-2 md:py-1 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 transition-colors min-h-[44px] md:min-h-0 font-medium"
+        className="text-xs px-3 py-2 md:px-2 md:py-1 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 transition-colors min-h-[44px] md:min-h-0 font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
         disabled={status === "loading"}
       >
         {gender === "female" ? "F" : "M"}


### PR DESCRIPTION
## What changed

Added WCAG 2.4.7-compliant `focus-visible` rings to all interactive buttons in `TTSControls` and `InsightChat`:

**TTSControls:**
- Cancel audio loading button: amber ring
- Pause button: amber ring
- Play/Resume button (amber-700 bg): amber ring with `ring-offset-amber-700`
- Error retry button: red ring
- Gender toggle button: amber ring

**InsightChat:**
- Toggle context ("more"/"less") button: amber ring
- Remove context (close icon) button: amber ring
- Font size toggle button (template literal className): amber ring
- Refresh insight button: amber ring
- Load earlier messages button: amber ring
- Send message button (amber-600 bg): amber ring with `ring-offset-amber-600`

## Why

Keyboard-only and AT users had no visible focus indicator on the TTS playback controls and the chat toolbar, failing WCAG 2.4.7 (issue #2180). Two existing test windows widened (300→400) to accommodate the longer classNames.

## Test plan

- [x] `TTSInsightChatFocusRing.test.ts` — 11 static-analysis assertions, all passing
- [x] `InsightChatContextToggleAria.test.ts` window 300→400 (kept passing)
- [x] Full frontend suite: 3440 tests passing
- [x] Closes #2180

