### PR TITLE
fix(ux): add focus-visible rings to remaining components (closes #2183)

### DIFF
--- a/frontend/src/__tests__/AuthPromptModalTouchTargets.test.ts
+++ b/frontend/src/__tests__/AuthPromptModalTouchTargets.test.ts
@@ -17,7 +17,7 @@ describe("AuthPromptModal touch targets (closes #835)", () => {
   it("Maybe later button has min-h-[44px]", () => {
     const idx = src.indexOf("Maybe later");
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(Math.max(0, idx - 200), idx + 20);
+    const window = src.slice(Math.max(0, idx - 300), idx + 20);
     expect(window).toContain("min-h-[44px]");
   });
 });

--- a/frontend/src/__tests__/BookDetailModalTouchTarget.test.ts
+++ b/frontend/src/__tests__/BookDetailModalTouchTarget.test.ts
@@ -36,7 +36,7 @@ describe("BookDetailModal touch targets (closes #811)", () => {
   it("Start/Continue Reading CTA button has min-h-[44px]", () => {
     const idx = src.indexOf("Start Reading");
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(Math.max(0, idx - 300), idx + 20);
+    const window = src.slice(Math.max(0, idx - 450), idx + 20);
     expect(window).toContain("min-h-[44px]");
   });
 });

--- a/frontend/src/__tests__/RemainingComponentsFocusRing.test.ts
+++ b/frontend/src/__tests__/RemainingComponentsFocusRing.test.ts
@@ -1,0 +1,188 @@
+import fs from "fs";
+import path from "path";
+
+const quickHighlightPanel = fs.readFileSync(
+  path.resolve(__dirname, "../components/QuickHighlightPanel.tsx"), "utf8");
+const searchBar = fs.readFileSync(
+  path.resolve(__dirname, "../components/SearchBar.tsx"), "utf8");
+const chapterSummary = fs.readFileSync(
+  path.resolve(__dirname, "../components/ChapterSummary.tsx"), "utf8");
+const authPromptModal = fs.readFileSync(
+  path.resolve(__dirname, "../components/AuthPromptModal.tsx"), "utf8");
+const bookDetailModal = fs.readFileSync(
+  path.resolve(__dirname, "../components/BookDetailModal.tsx"), "utf8");
+const tagEditor = fs.readFileSync(
+  path.resolve(__dirname, "../components/TagEditor.tsx"), "utf8");
+const sentenceReader = fs.readFileSync(
+  path.resolve(__dirname, "../components/SentenceReader.tsx"), "utf8");
+const seedPopularButton = fs.readFileSync(
+  path.resolve(__dirname, "../components/SeedPopularButton.tsx"), "utf8");
+
+describe("QuickHighlightPanel button focus rings (closes #2183)", () => {
+  it("color picker button has focus ring", () => {
+    const idx = quickHighlightPanel.indexOf("onClick={() => handleColor");
+    expect(idx).toBeGreaterThan(-1);
+    const window = quickHighlightPanel.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("add note button has focus ring", () => {
+    const idx = quickHighlightPanel.indexOf('"Add note"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = quickHighlightPanel.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("delete highlight button has red focus ring", () => {
+    const idx = quickHighlightPanel.indexOf('"Delete highlight"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = quickHighlightPanel.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-red-400");
+  });
+});
+
+describe("SearchBar button focus rings (closes #2183)", () => {
+  it("open search button has focus ring", () => {
+    const idx = searchBar.indexOf('"Open search"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = searchBar.slice(idx, idx + 350);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("close search button has focus ring", () => {
+    const idx = searchBar.indexOf('"Close search"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = searchBar.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("ChapterSummary button focus rings (closes #2183)", () => {
+  it("generate/refresh button has focus ring", () => {
+    const idx = chapterSummary.indexOf('"Regenerate summary"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = chapterSummary.slice(idx, idx + 250);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("error retry button has red focus ring", () => {
+    // JSX text content has no quotes in source
+    const idx = chapterSummary.indexOf("Try again");
+    expect(idx).toBeGreaterThan(-1);
+    const window = chapterSummary.slice(Math.max(0, idx - 300), idx + 20);
+    expect(window).toContain("focus-visible:ring-red-400");
+  });
+
+  it("generate CTA button has focus ring", () => {
+    // JSX text content has no quotes in source
+    const idx = chapterSummary.indexOf("Generate Summary");
+    expect(idx).toBeGreaterThan(-1);
+    const window = chapterSummary.slice(Math.max(0, idx - 300), idx + 20);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("AuthPromptModal button focus rings (closes #2183)", () => {
+  it("maybe later button has focus ring", () => {
+    // JSX text content has no quotes in source
+    const idx = authPromptModal.indexOf("Maybe later");
+    expect(idx).toBeGreaterThan(-1);
+    const window = authPromptModal.slice(Math.max(0, idx - 300), idx + 20);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("BookDetailModal button focus rings (closes #2183)", () => {
+  it("close button has focus ring", () => {
+    const idx = bookDetailModal.indexOf('"Close book details"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = bookDetailModal.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("read/start button (amber-700 bg) has focus ring with offset", () => {
+    const idx = bookDetailModal.indexOf("onClick={onRead}");
+    expect(idx).toBeGreaterThan(-1);
+    const window = bookDetailModal.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+    expect(window).toContain("ring-offset-amber-700");
+  });
+});
+
+describe("TagEditor button focus rings (closes #2183)", () => {
+  it("remove tag button has focus ring", () => {
+    // aria-label is a template literal: `Remove tag ${tag}` — use substring
+    const idx = tagEditor.indexOf("onClick={() => handleRemove");
+    expect(idx).toBeGreaterThan(-1);
+    const window = tagEditor.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("add tag button has focus ring", () => {
+    const idx = tagEditor.indexOf('"Add tag"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = tagEditor.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("SentenceReader button focus rings (closes #2183)", () => {
+  it("note dot toggle button has focus ring", () => {
+    const idx = sentenceReader.indexOf("e.stopPropagation(); setExpandedNoteFlatIdx(");
+    expect(idx).toBeGreaterThan(-1);
+    const window = sentenceReader.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("SeedPopularButton button focus rings (closes #2183)", () => {
+  it("confirm seed button has focus ring", () => {
+    const idx = seedPopularButton.indexOf('"Confirm seed popular books"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = seedPopularButton.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("cancel seed button has focus ring", () => {
+    const idx = seedPopularButton.indexOf('"Cancel seed"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = seedPopularButton.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("start seeding button has focus ring", () => {
+    const idx = seedPopularButton.indexOf("setPendingStart(true)");
+    expect(idx).toBeGreaterThan(-1);
+    const window = seedPopularButton.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("show progress button has focus ring", () => {
+    // first occurrence of aria-controls is the show-progress button
+    const idx = seedPopularButton.indexOf('aria-controls="seed-progress-panel"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = seedPopularButton.slice(idx, idx + 250);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("stop button has red focus ring", () => {
+    const idx = seedPopularButton.indexOf("setPendingStop(true)");
+    expect(idx).toBeGreaterThan(-1);
+    const window = seedPopularButton.slice(idx, idx + 250);
+    expect(window).toContain("focus-visible:ring-red-400");
+  });
+
+  it("confirm stop button has red focus ring", () => {
+    const idx = seedPopularButton.indexOf('"Confirm stop seed job"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = seedPopularButton.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-red-400");
+  });
+
+  it("cancel stop button has focus ring", () => {
+    const idx = seedPopularButton.indexOf('"Cancel stop"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = seedPopularButton.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});

--- a/frontend/src/__tests__/UndoToastChapterSummaryTouchTargets.test.ts
+++ b/frontend/src/__tests__/UndoToastChapterSummaryTouchTargets.test.ts
@@ -28,14 +28,14 @@ describe("UndoToast and ChapterSummary touch targets (closes #833)", () => {
   it("ChapterSummary Try-again error button has min-h-[44px]", () => {
     const idx = summary.indexOf("Try again");
     expect(idx).toBeGreaterThan(-1);
-    const window = summary.slice(Math.max(0, idx - 200), idx + 50);
+    const window = summary.slice(Math.max(0, idx - 300), idx + 50);
     expect(window).toContain("min-h-[44px]");
   });
 
   it("ChapterSummary Generate Summary CTA has min-h-[44px]", () => {
     const idx = summary.indexOf("Generate Summary");
     expect(idx).toBeGreaterThan(-1);
-    const window = summary.slice(Math.max(0, idx - 200), idx + 50);
+    const window = summary.slice(Math.max(0, idx - 300), idx + 50);
     expect(window).toContain("min-h-[44px]");
   });
 });

--- a/frontend/src/components/AuthPromptModal.tsx
+++ b/frontend/src/components/AuthPromptModal.tsx
@@ -46,7 +46,7 @@ export default function AuthPromptModal({ open, feature, onClose }: Props) {
         </a>
         <button
           onClick={onClose}
-          className="flex items-center justify-center w-full min-h-[44px] md:min-h-0 text-sm text-stone-600 mt-2 hover:text-stone-700 transition-colors"
+          className="flex items-center justify-center w-full min-h-[44px] md:min-h-0 text-sm text-stone-600 mt-2 hover:text-stone-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
         >
           Maybe later
         </button>

--- a/frontend/src/components/BookDetailModal.tsx
+++ b/frontend/src/components/BookDetailModal.tsx
@@ -96,7 +96,7 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
           <button
             onClick={onClose}
             aria-label="Close book details"
-            className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-full text-stone-600 hover:bg-stone-100 hover:text-stone-700 transition-colors"
+            className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-full text-stone-600 hover:bg-stone-100 hover:text-stone-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <CloseIcon className="w-4 h-4" />
           </button>
@@ -135,7 +135,7 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
         {/* Primary CTA */}
         <button
           onClick={onRead}
-          className="w-full rounded-xl bg-amber-700 text-white py-3 min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-amber-800 transition-colors"
+          className="w-full rounded-xl bg-amber-700 text-white py-3 min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-amber-800 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
         >
           {recentBook
             ? `Continue Reading — Ch. ${recentBook.lastChapter + 1}`

--- a/frontend/src/components/ChapterSummary.tsx
+++ b/frontend/src/components/ChapterSummary.tsx
@@ -89,7 +89,7 @@ export default function ChapterSummary({
           <button
             onClick={load}
             title="Regenerate summary"
-            className="text-xs text-amber-700 hover:text-amber-800 hover:underline transition-colors min-h-[44px] md:min-h-0 flex items-center px-1"
+            className="text-xs text-amber-700 hover:text-amber-800 hover:underline transition-colors min-h-[44px] md:min-h-0 flex items-center px-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             {summary ? <><RetryIcon className="w-3 h-3 inline" aria-hidden="true" /> Refresh</> : "Generate"}
           </button>
@@ -118,7 +118,7 @@ export default function ChapterSummary({
             <p className="text-xs text-red-700">{error}</p>
             <button
               onClick={load}
-              className="mt-1 text-xs font-medium text-red-600 hover:underline min-h-[44px] md:min-h-0 flex items-center"
+              className="mt-1 text-xs font-medium text-red-600 hover:underline min-h-[44px] md:min-h-0 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
             >
               Try again
             </button>
@@ -140,7 +140,7 @@ export default function ChapterSummary({
             <p className="text-sm">Get a quick overview of this chapter before continuing.</p>
             <button
               onClick={load}
-              className="mt-2 px-4 min-h-[44px] md:min-h-0 flex items-center rounded-lg bg-amber-100 hover:bg-amber-200 text-amber-800 text-sm font-medium transition-colors"
+              className="mt-2 px-4 min-h-[44px] md:min-h-0 flex items-center rounded-lg bg-amber-100 hover:bg-amber-200 text-amber-800 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               Generate Summary
             </button>

--- a/frontend/src/components/QuickHighlightPanel.tsx
+++ b/frontend/src/components/QuickHighlightPanel.tsx
@@ -113,7 +113,7 @@ export default function QuickHighlightPanel({
           onClick={() => handleColor(c.key)}
           disabled={busy}
           aria-label={c.label}
-          className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center disabled:opacity-50"
+          className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
         >
           <span
             className={`w-7 h-7 rounded-full ${c.bg} border-2 transition-all hover:scale-110 ${
@@ -128,7 +128,7 @@ export default function QuickHighlightPanel({
           onClick={onOpenNote}
           disabled={busy}
           aria-label="Add note"
-          className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-600 hover:text-stone-700 disabled:opacity-50 transition-colors"
+          className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-600 hover:text-stone-700 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
         >
           <span className="w-7 h-7 rounded-full bg-stone-100 border border-stone-300 flex items-center justify-center hover:bg-stone-200 transition-colors">
             <NoteIcon className="w-3.5 h-3.5" />
@@ -141,7 +141,7 @@ export default function QuickHighlightPanel({
           onClick={handleDelete}
           disabled={busy}
           aria-label="Delete highlight"
-          className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-red-500 disabled:opacity-50 transition-colors"
+          className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-red-500 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
         >
           <span className="w-7 h-7 rounded-full bg-red-50 border border-red-200 flex items-center justify-center hover:bg-red-100 transition-colors">
             <TrashIcon className="w-3.5 h-3.5" />

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -61,7 +61,7 @@ export function SearchBar() {
           setOpen(true);
           focusInput();
         }}
-        className="inline-flex items-center justify-center min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 rounded-md text-ink hover:bg-amber-100 transition-colors"
+        className="inline-flex items-center justify-center min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 rounded-md text-ink hover:bg-amber-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
       >
         <SearchIcon className="w-5 h-5" />
       </button>
@@ -96,7 +96,7 @@ export function SearchBar() {
           setQuery("");
           setOpen(false);
         }}
-        className="text-xs text-stone-600 hover:text-ink min-h-[44px] md:min-h-0 flex items-center"
+        className="text-xs text-stone-600 hover:text-ink min-h-[44px] md:min-h-0 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
       >
         Esc
       </button>

--- a/frontend/src/components/SeedPopularButton.tsx
+++ b/frontend/src/components/SeedPopularButton.tsx
@@ -113,7 +113,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
               type="button"
               onClick={confirmStart}
               aria-label="Confirm seed popular books"
-              className="rounded-lg border border-emerald-300 text-emerald-700 px-3 py-1.5 min-h-[44px] md:min-h-0 text-sm hover:bg-emerald-50"
+              className="rounded-lg border border-emerald-300 text-emerald-700 px-3 py-1.5 min-h-[44px] md:min-h-0 text-sm hover:bg-emerald-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               Yes, start
             </button>
@@ -121,7 +121,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
               type="button"
               onClick={() => setPendingStart(false)}
               aria-label="Cancel seed"
-              className="rounded-lg border border-stone-200 text-stone-600 px-3 py-1.5 min-h-[44px] md:min-h-0 text-sm hover:bg-stone-50"
+              className="rounded-lg border border-stone-200 text-stone-600 px-3 py-1.5 min-h-[44px] md:min-h-0 text-sm hover:bg-stone-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               Cancel
             </button>
@@ -130,7 +130,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
           <button
             onClick={() => setPendingStart(true)}
             disabled={running}
-            className="rounded-lg border border-amber-300 text-amber-700 px-4 py-2 min-h-[44px] md:min-h-0 text-sm hover:bg-amber-50 disabled:opacity-50"
+            className="rounded-lg border border-amber-300 text-amber-700 px-4 py-2 min-h-[44px] md:min-h-0 text-sm hover:bg-amber-50 disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             {running ? "Seeding…" : "Seed all popular books"}
           </button>
@@ -140,7 +140,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
             onClick={() => setExpanded(true)}
             aria-expanded={false}
             aria-controls="seed-progress-panel"
-            className="text-xs text-amber-700 hover:text-amber-900 min-h-[44px] md:min-h-0 flex items-center"
+            className="text-xs text-amber-700 hover:text-amber-900 min-h-[44px] md:min-h-0 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             Show progress
           </button>
@@ -150,7 +150,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
             onClick={() => setExpanded(false)}
             aria-expanded={true}
             aria-controls="seed-progress-panel"
-            className="text-xs text-stone-600 hover:text-stone-700 min-h-[44px] md:min-h-0 flex items-center"
+            className="text-xs text-stone-600 hover:text-stone-700 min-h-[44px] md:min-h-0 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             Hide
           </button>
@@ -175,7 +175,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
                 <button
                   type="button"
                   onClick={() => setPendingStop(true)}
-                  className="text-xs text-red-600 hover:text-red-800 min-h-[44px] md:min-h-0 flex items-center"
+                  className="text-xs text-red-600 hover:text-red-800 min-h-[44px] md:min-h-0 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
                 >
                   Stop
                 </button>
@@ -187,7 +187,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
                     type="button"
                     onClick={confirmStop}
                     aria-label="Confirm stop seed job"
-                    className="text-xs px-2 py-1 rounded border border-red-400 bg-red-50 text-red-700 min-h-[44px] md:min-h-0 flex items-center"
+                    className="text-xs px-2 py-1 rounded border border-red-400 bg-red-50 text-red-700 min-h-[44px] md:min-h-0 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
                   >
                     Yes
                   </button>
@@ -195,7 +195,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
                     type="button"
                     onClick={() => setPendingStop(false)}
                     aria-label="Cancel stop"
-                    className="text-xs px-2 py-1 rounded border border-stone-200 text-stone-600 min-h-[44px] md:min-h-0 flex items-center"
+                    className="text-xs px-2 py-1 rounded border border-stone-200 text-stone-600 min-h-[44px] md:min-h-0 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                   >
                     No
                   </button>

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -800,7 +800,7 @@ export default function SentenceReader({
               {noteAnnotation?.note_text && (
                 <button
                   onClick={(e) => { e.stopPropagation(); setExpandedNoteFlatIdx((prev) => prev === seg.flatIdx ? null : seg.flatIdx); }}
-                  className="inline-flex items-center justify-center ml-0.5 align-middle cursor-pointer min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 -m-[19px] p-[19px]"
+                  className="inline-flex items-center justify-center ml-0.5 align-middle cursor-pointer min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 -m-[19px] p-[19px] focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                   aria-label={`Toggle note for: ${seg.text.slice(0, 60)}`}
                   aria-expanded={expandedNoteFlatIdx === seg.flatIdx}
                 >

--- a/frontend/src/components/TagEditor.tsx
+++ b/frontend/src/components/TagEditor.tsx
@@ -126,7 +126,7 @@ export default function TagEditor({
             onClick={() => handleRemove(tag)}
             disabled={busy === tag}
             aria-label={`Remove tag ${tag}`}
-            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-full hover:bg-amber-100 disabled:opacity-50 transition-colors"
+            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-full hover:bg-amber-100 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <CloseIcon className="w-3 h-3" />
           </button>
@@ -154,7 +154,7 @@ export default function TagEditor({
           type="button"
           onClick={() => setAdding(true)}
           aria-label="Add tag"
-          className="inline-flex items-center gap-0.5 rounded-full border border-dashed border-amber-300 px-2 py-0.5 min-h-[44px] md:min-h-0 text-xs text-amber-700 hover:bg-amber-50 transition-colors"
+          className="inline-flex items-center gap-0.5 rounded-full border border-dashed border-amber-300 px-2 py-0.5 min-h-[44px] md:min-h-0 text-xs text-amber-700 hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           data-testid={`add-tag-${vocabularyId}`}
         >
           <span aria-hidden="true">+</span>


### PR DESCRIPTION
## What changed

Added `focus:outline-none focus-visible:ring-2` rings to all remaining interactive buttons across 8 components that were missing keyboard focus indicators (WCAG 2.4.7):

- **QuickHighlightPanel**: color picker (amber), add note (amber), delete highlight (red)
- **SearchBar**: open search button (amber), close/Esc button (amber)
- **ChapterSummary**: generate/refresh (amber), error retry (red), generate CTA (amber)
- **AuthPromptModal**: "Maybe later" button (amber)
- **BookDetailModal**: close button (amber), read/start CTA (amber with amber-700 offset)
- **TagEditor**: remove tag (amber), add tag (amber)
- **SentenceReader**: note dot toggle (amber)
- **SeedPopularButton**: all 8 buttons (amber for safe actions, red for destructive)

## Why

Keyboard-only users had no visible focus indicator on any of these buttons, violating WCAG 2.4.7. This completes the focus ring audit started in #2176, #2178, and #2180.

## Test plan

- [x] 21 new static-analysis assertions in `RemainingComponentsFocusRing.test.ts` — all pass
- [x] Updated 3 pre-existing tests whose backward-look windows were too small after className growth (`AuthPromptModalTouchTargets`, `BookDetailModalTouchTarget`, `UndoToastChapterSummaryTouchTargets`)
- [x] Full suite: 3461 tests pass

Closes #2183
