### PR TITLE
fix(ux): add focus-visible rings to user-facing page files (closes #2185)

### DIFF
--- a/frontend/src/__tests__/ImportUploadChaptersTouchTargets.test.ts
+++ b/frontend/src/__tests__/ImportUploadChaptersTouchTargets.test.ts
@@ -39,7 +39,7 @@ describe("Import and upload-chapters flow touch targets (closes #838)", () => {
   });
 
   it("Confirm & Start Reading button has min-h-[44px]", () => {
-    checkBefore(chaptersPage, "Confirm & Start Reading", 400);
+    checkBefore(chaptersPage, "Confirm & Start Reading", 600);
   });
 
   it("Try another file button has min-h-[44px]", () => {

--- a/frontend/src/__tests__/PagesFocusRings.test.ts
+++ b/frontend/src/__tests__/PagesFocusRings.test.ts
@@ -1,0 +1,121 @@
+import fs from "fs";
+import path from "path";
+
+const errorPage = fs.readFileSync(
+  path.resolve(__dirname, "../app/error.tsx"), "utf8");
+const pendingPage = fs.readFileSync(
+  path.resolve(__dirname, "../app/pending/page.tsx"), "utf8");
+const uploadPage = fs.readFileSync(
+  path.resolve(__dirname, "../app/upload/page.tsx"), "utf8");
+const chaptersPage = fs.readFileSync(
+  path.resolve(__dirname, "../app/upload/[bookId]/chapters/page.tsx"), "utf8");
+const importPage = fs.readFileSync(
+  path.resolve(__dirname, "../app/import/[bookId]/page.tsx"), "utf8");
+
+describe("error.tsx button focus rings (closes #2185)", () => {
+  it("Try again button (amber-700 bg) has focus ring with offset", () => {
+    const idx = errorPage.indexOf("reset()");
+    expect(idx).toBeGreaterThan(-1);
+    const window = errorPage.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-amber-400");
+    expect(window).toContain("ring-offset-amber-700");
+  });
+});
+
+describe("pending/page.tsx button focus rings (closes #2185)", () => {
+  it("Sign out button has red focus ring", () => {
+    const idx = pendingPage.indexOf("Sign out");
+    expect(idx).toBeGreaterThan(-1);
+    const window = pendingPage.slice(Math.max(0, idx - 300), idx + 20);
+    expect(window).toContain("focus-visible:ring-red-400");
+  });
+});
+
+describe("upload/page.tsx button focus rings (closes #2185)", () => {
+  it("Sign in button (amber-700 bg) has focus ring with offset", () => {
+    // Skip the isAuthenticated check branch, find the sign-in button
+    const idx = uploadPage.indexOf('router.push("/login")');
+    expect(idx).toBeGreaterThan(-1);
+    const window = uploadPage.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-amber-400");
+    expect(window).toContain("ring-offset-amber-700");
+  });
+
+  it("Back button has focus ring", () => {
+    const idx = uploadPage.indexOf('router.push("/")');
+    expect(idx).toBeGreaterThan(-1);
+    const window = uploadPage.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("upload/[bookId]/chapters/page.tsx button focus rings (closes #2185)", () => {
+  it("error retry button (amber-700 bg) has focus ring with offset", () => {
+    // Skip function definition and useEffect — find onClick={loadChapters}
+    const def1 = chaptersPage.indexOf("loadChapters");
+    const def2 = chaptersPage.indexOf("loadChapters", def1 + 1);
+    const idx = chaptersPage.indexOf("loadChapters", def2 + 1);
+    expect(idx).toBeGreaterThan(-1);
+    const window = chaptersPage.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-amber-400");
+    expect(window).toContain("ring-offset-amber-700");
+  });
+
+  it("Back button in header has focus ring", () => {
+    const idx = chaptersPage.indexOf("ArrowLeftIcon");
+    // Skip import — find usage in JSX
+    const usageIdx = chaptersPage.indexOf("ArrowLeftIcon", idx + 1);
+    expect(usageIdx).toBeGreaterThan(-1);
+    const window = chaptersPage.slice(Math.max(0, usageIdx - 300), usageIdx + 20);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Save/Import button (amber-700 bg) has focus ring with offset", () => {
+    // Skip function definition — find onClick={handleConfirm}
+    const defIdx = chaptersPage.indexOf("handleConfirm");
+    const idx = chaptersPage.indexOf("handleConfirm", defIdx + 1);
+    expect(idx).toBeGreaterThan(-1);
+    const window = chaptersPage.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-amber-400");
+    expect(window).toContain("ring-offset-amber-700");
+  });
+});
+
+describe("import/[bookId]/page.tsx button focus rings (closes #2185)", () => {
+  it("Start import button (amber-700 bg) has focus ring with offset", () => {
+    // Skip function definition — find onClick={startImport}
+    const defIdx = importPage.indexOf("startImport");
+    const idx = importPage.indexOf("startImport", defIdx + 1);
+    expect(idx).toBeGreaterThan(-1);
+    const window = importPage.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-amber-400");
+    expect(window).toContain("ring-offset-amber-700");
+  });
+
+  it("Skip button has focus ring", () => {
+    // Skip = router.push(nextUrl) in the Skip button, find the JSX button text
+    const idx = importPage.indexOf("Skip");
+    expect(idx).toBeGreaterThan(-1);
+    const window = importPage.slice(Math.max(0, idx - 400), idx + 20);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Start reading now button (amber-700 bg) has focus ring with offset", () => {
+    // Skip function definition — find onClick={skipToReading}
+    const defIdx = importPage.indexOf("skipToReading");
+    const idx = importPage.indexOf("skipToReading", defIdx + 1);
+    expect(idx).toBeGreaterThan(-1);
+    const window = importPage.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-amber-400");
+    expect(window).toContain("ring-offset-amber-700");
+  });
+
+  it("Cancel button has focus ring", () => {
+    // Skip function definition — find onClick={cancel}
+    const defIdx = importPage.indexOf("cancel");
+    const idx = importPage.indexOf("cancel", defIdx + 1);
+    expect(idx).toBeGreaterThan(-1);
+    const window = importPage.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -25,7 +25,7 @@ export default function ErrorPage({ error, reset }: Props) {
           <button
             type="button"
             onClick={() => reset()}
-            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
+            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
           >
             <RetryIcon className="w-4 h-4" aria-hidden="true" /> Try again
           </button>

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -196,13 +196,13 @@ export default function BookImportPage() {
               <div className="flex gap-2 pt-2">
                 <button
                   onClick={startImport}
-                  className="flex-1 rounded-lg bg-amber-700 text-white min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-amber-800 flex items-center justify-center"
+                  className="flex-1 rounded-lg bg-amber-700 text-white min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-amber-800 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
                 >
                   Start import
                 </button>
                 <button
                   onClick={() => router.push(nextUrl)}
-                  className="rounded-lg border border-amber-300 text-amber-700 px-4 min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-amber-50 flex items-center"
+                  className="rounded-lg border border-amber-300 text-amber-700 px-4 min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-amber-50 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                 >
                   Skip
                 </button>
@@ -320,14 +320,14 @@ export default function BookImportPage() {
               {canStartReading && (
                 <button
                   onClick={skipToReading}
-                  className="flex-1 rounded-lg bg-amber-700 text-white min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-amber-800 flex items-center justify-center"
+                  className="flex-1 rounded-lg bg-amber-700 text-white min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-amber-800 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
                 >
                   Start reading now
                 </button>
               )}
               <button
                 onClick={cancel}
-                className="rounded-lg border border-stone-300 text-stone-600 px-4 min-h-[44px] md:min-h-0 text-sm hover:bg-stone-50 flex items-center"
+                className="rounded-lg border border-stone-300 text-stone-600 px-4 min-h-[44px] md:min-h-0 text-sm hover:bg-stone-50 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
               >
                 Cancel
               </button>

--- a/frontend/src/app/pending/page.tsx
+++ b/frontend/src/app/pending/page.tsx
@@ -38,7 +38,7 @@ export default function PendingApprovalPage() {
         <p className="text-xs text-stone-600 mb-4">Checking automatically every 30 seconds…</p>
         <button
           onClick={() => signOut({ callbackUrl: "/login" })}
-          className="text-sm text-red-600 hover:text-red-800 min-h-[44px] md:min-h-0 flex items-center justify-center mx-auto"
+          className="text-sm text-red-600 hover:text-red-800 min-h-[44px] md:min-h-0 flex items-center justify-center mx-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
         >
           Sign out
         </button>

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -98,7 +98,7 @@ export default function ChapterEditorPage() {
             <button
               type="button"
               onClick={loadChapters}
-              className="inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 transition-colors"
+              className="inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
             >
               <RetryIcon className="w-4 h-4" aria-hidden="true" />
               Retry
@@ -106,7 +106,7 @@ export default function ChapterEditorPage() {
             <button
               type="button"
               onClick={() => router.push("/upload")}
-              className="px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg border border-amber-300 text-amber-700 text-sm hover:bg-amber-50 transition-colors"
+              className="px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg border border-amber-300 text-amber-700 text-sm hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               Try another file
             </button>
@@ -126,7 +126,7 @@ export default function ChapterEditorPage() {
           <div className="flex items-center gap-3">
             <button
               onClick={() => router.push("/upload")}
-              className="text-sm text-amber-700 hover:text-amber-800 transition-colors min-h-[44px] md:min-h-0 flex items-center"
+              className="text-sm text-amber-700 hover:text-amber-800 transition-colors min-h-[44px] md:min-h-0 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               <ArrowLeftIcon className="w-4 h-4 inline" aria-hidden="true" /> Back
             </button>
@@ -138,7 +138,7 @@ export default function ChapterEditorPage() {
           <button
             onClick={handleConfirm}
             disabled={confirming || chapters.length === 0}
-            className="rounded-lg bg-amber-700 px-5 min-h-[44px] md:min-h-0 text-white text-sm font-medium hover:bg-amber-800 disabled:opacity-50 transition-colors flex items-center gap-2"
+            className="rounded-lg bg-amber-700 px-5 min-h-[44px] md:min-h-0 text-white text-sm font-medium hover:bg-amber-800 disabled:opacity-50 transition-colors flex items-center gap-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
           >
             {confirming && (
               <span className="w-3.5 h-3.5 border-2 border-white/40 border-t-white rounded-full animate-spin" aria-hidden="true" />

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -77,7 +77,7 @@ export default function UploadPage() {
           </p>
           <button
             onClick={() => router.push("/login")}
-            className="rounded-lg bg-amber-700 px-6 min-h-[44px] md:min-h-0 flex items-center text-white font-medium hover:bg-amber-800 transition-colors"
+            className="rounded-lg bg-amber-700 px-6 min-h-[44px] md:min-h-0 flex items-center text-white font-medium hover:bg-amber-800 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
           >
             Sign in
           </button>
@@ -105,7 +105,7 @@ export default function UploadPage() {
         <div className="max-w-2xl mx-auto flex items-center gap-3">
           <button
             onClick={() => router.push("/")}
-            className="text-sm text-amber-700 hover:text-amber-800 transition-colors min-h-[44px] md:min-h-0 flex items-center"
+            className="text-sm text-amber-700 hover:text-amber-800 transition-colors min-h-[44px] md:min-h-0 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <ArrowLeftIcon className="w-4 h-4 inline" aria-hidden="true" /> Back
           </button>


### PR DESCRIPTION
## What changed

Added `focus:outline-none focus-visible:ring-2` focus rings to all interactive buttons in user-facing page files that were missing keyboard focus indicators (WCAG 2.4.7):

- **`error.tsx`**: Try again button (amber-700 bg with ring offset)
- **`pending/page.tsx`**: Sign out button (red ring, destructive action)
- **`upload/page.tsx`**: Sign in button (amber-700 bg with offset), Back button
- **`upload/[bookId]/chapters/page.tsx`**: error retry (amber-700), Try another file, Back header button, Confirm & Start Reading (amber-700)
- **`import/[bookId]/page.tsx`**: Start import (amber-700), Skip, Start reading now (amber-700), Cancel

## Why

Page-level files were missed in the previous focus ring audit (PRs #2177, #2179, #2182, #2184), which covered components. This completes WCAG 2.4.7 keyboard focus visibility across the full frontend.

## Test plan

- [x] 11 new static-analysis assertions in `PagesFocusRings.test.ts` — all pass
- [x] Updated `ImportUploadChaptersTouchTargets.test.ts` window size (400→600) for "Confirm & Start Reading" whose className grew due to focus ring addition
- [x] Full suite: 3472 tests pass

Closes #2185
