### PR TITLE
ux: add focus-visible rings to vocab, notes, and flashcard buttons (closes #2191)

### DIFF
--- a/frontend/src/__tests__/VocabNotesFlashcardFocusRings.test.ts
+++ b/frontend/src/__tests__/VocabNotesFlashcardFocusRings.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Regression tests for #2191: focus-visible rings on vocabulary, notes,
+ * and flashcard page interactive buttons.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const vocabPage = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8"
+);
+const notesBookPage = fs.readFileSync(
+  path.join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf8"
+);
+const flashcardsPage = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/flashcards/page.tsx"),
+  "utf8"
+);
+
+describe("Vocabulary page focus rings (closes #2191)", () => {
+  it("Sort mode buttons (inside overflow-hidden container) have focus ring with ring-inset", () => {
+    const idx = vocabPage.indexOf('sort-mode-control"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = vocabPage.slice(idx, idx + 500);
+    expect(window).toContain("focus-visible:ring-amber-400");
+    expect(window).toContain("focus-visible:ring-inset");
+  });
+
+  it("Tag filter buttons have focus ring", () => {
+    // data-testid="tag-filter-all" is the stable anchor; className comes before it
+    const idx = vocabPage.indexOf('data-testid="tag-filter-all"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = vocabPage.slice(Math.max(0, idx - 150), idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("Notes book page focus rings (closes #2191)", () => {
+  it("Delete insight button has red focus ring (destructive action)", () => {
+    const idx = notesBookPage.indexOf('"Delete insight"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = notesBookPage.slice(Math.max(0, idx - 300), idx + 50);
+    expect(window).toContain("focus-visible:ring-red-400");
+  });
+});
+
+describe("Flashcards page focus rings (closes #2191)", () => {
+  it("Retry button (amber-700 bg) has focus ring with amber-700 offset", () => {
+    // Use onClick=loadData as anchor (unique to this button)
+    const idx = flashcardsPage.indexOf("onClick={loadData}");
+    expect(idx).toBeGreaterThan(-1);
+    const window = flashcardsPage.slice(idx, idx + 360);
+    expect(window).toContain("focus-visible:ring-amber-400");
+    expect(window).toContain("ring-offset-amber-700");
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -204,7 +204,7 @@ function InsightCard({
           onClick={onDelete}
           disabled={isDeleting}
           aria-busy={isDeleting}
-          className="text-red-500 hover:text-red-600 disabled:opacity-40 transition-colors min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center"
+          className="text-red-500 hover:text-red-600 disabled:opacity-40 transition-colors min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
           title="Delete insight"
           aria-label={isDeleting ? "Deleting insight…" : `Delete insight: ${ins.question.slice(0, 60)}`}
         >

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -242,7 +242,7 @@ export default function FlashcardsPage() {
             <button
               type="button"
               onClick={loadData}
-              className="mt-1 inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 transition-colors"
+              className="mt-1 inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
             >
               <RetryIcon className="w-4 h-4" aria-hidden="true" />
               Retry

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -528,7 +528,7 @@ function VocabularyPageContent() {
                   onClick={() => setSortMode(value)}
                   aria-pressed={sortMode === value}
                   data-testid={`sort-${value}`}
-                  className={`flex-1 px-2 py-2 text-xs font-medium transition-colors min-h-[44px] md:min-h-0 ${
+                  className={`flex-1 px-2 py-2 text-xs font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-inset ${
                     sortMode === value
                       ? "bg-amber-700 text-white"
                       : "bg-white text-amber-700 hover:bg-amber-50"
@@ -553,7 +553,7 @@ function VocabularyPageContent() {
               onClick={() => setSelectedTag(null)}
               aria-pressed={selectedTag === null}
               data-testid="tag-filter-all"
-              className={`shrink-0 min-h-[44px] md:min-h-0 px-3 rounded-full text-xs font-medium border transition-colors ${
+              className={`shrink-0 min-h-[44px] md:min-h-0 px-3 rounded-full text-xs font-medium border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 ${
                 selectedTag === null
                   ? "bg-amber-700 text-white border-amber-700"
                   : "bg-white text-amber-700 border-amber-200 hover:bg-amber-50"
@@ -570,7 +570,7 @@ function VocabularyPageContent() {
                   onClick={() => setSelectedTag(active ? null : tag)}
                   aria-pressed={active}
                   data-testid={`tag-filter-${tag}`}
-                  className={`shrink-0 min-h-[44px] md:min-h-0 px-3 rounded-full text-xs font-medium border transition-colors ${
+                  className={`shrink-0 min-h-[44px] md:min-h-0 px-3 rounded-full text-xs font-medium border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 ${
                     active
                       ? "bg-amber-700 text-white border-amber-700"
                       : "bg-white text-amber-700 border-amber-200 hover:bg-amber-50"


### PR DESCRIPTION
## What changed

Added `focus:outline-none focus-visible:ring-2` focus rings to 4 groups of interactive buttons across 3 pages that were missing WCAG 2.4.7 focus indicators:

**`vocabulary/page.tsx`**
- Sort mode buttons (inside `overflow-hidden` container): use `focus-visible:ring-inset` so the ring renders inside the clipping boundary
- Tag filter buttons (All + per-tag pill buttons): standard `focus-visible:ring-amber-400 focus-visible:ring-offset-1`

**`notes/[bookId]/page.tsx`**
- Delete insight button: `focus-visible:ring-red-400` (destructive action pattern)

**`vocabulary/flashcards/page.tsx`**
- Retry button (amber-700 background): `focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700`

## Why

WCAG 2.4.7 Focus Visible: all keyboard-focusable interactive elements must have a visible focus indicator. These were found in a UX audit of non-reader pages after completing the reader page focus ring pass (PR #2186, #2188).

## Test plan

- Added `frontend/src/__tests__/VocabNotesFlashcardFocusRings.test.ts` with 4 static-analysis assertions
- All 4 new tests pass
- Full suite: 3495/3495 tests pass (569 suites)

Closes #2191
