### PR TITLE
ux: add focus-visible rings to all homepage buttons (closes #2193)

### DIFF
--- a/frontend/src/__tests__/HomepageFocusRings.test.ts
+++ b/frontend/src/__tests__/HomepageFocusRings.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Regression tests for #2193: focus-visible rings on homepage (library page) buttons.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/page.tsx"),
+  "utf8"
+);
+
+describe("Homepage header buttons focus rings (closes #2193)", () => {
+  it("Sign in button (unauthenticated header) has focus ring", () => {
+    // Use router.push('/login') in header context
+    const idx = src.indexOf("router.push(\"/login\")");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Profile avatar button (overflow-hidden) has ring-inset", () => {
+    // className comes after aria-label — look forward from first "Profile & Settings"
+    const idx = src.indexOf("Profile & Settings");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 430);
+    expect(window).toContain("focus-visible:ring-amber-400");
+    expect(window).toContain("focus-visible:ring-inset");
+  });
+});
+
+describe("Homepage tab bar focus rings (closes #2193)", () => {
+  it("Home/Discover tab buttons have focus ring", () => {
+    const idx = src.indexOf("tabpanel-${key}");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 400);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Upload tab button has focus ring", () => {
+    const idx = src.indexOf("router.push(\"/upload\")");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("Homepage discover section focus rings (closes #2193)", () => {
+  it("Sign in free hero button (amber-700) has ring with amber-700 offset", () => {
+    const idx = src.indexOf("Sign in free");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 300), idx + 20);
+    expect(window).toContain("focus-visible:ring-amber-400");
+    expect(window).toContain("ring-offset-amber-700");
+  });
+
+  it("Search button (amber-700) has ring with amber-700 offset", () => {
+    // className is ~458 chars before "Searching" button label — look 500 chars back
+    const idx = src.indexOf("\"Searching\"");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 500), idx + 20);
+    expect(window).toContain("focus-visible:ring-amber-400");
+    expect(window).toContain("ring-offset-amber-700");
+  });
+
+  it("Popular language filter buttons have focus ring", () => {
+    const idx = src.indexOf("popularLang === l.code");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Grid/List view toggle buttons have focus ring", () => {
+    const idx = src.indexOf("aria-label=\"Grid view\"");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Pagination Previous/Next buttons have focus ring", () => {
+    const idx = src.indexOf("aria-label=\"Previous page of popular books\"");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 350);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});

--- a/frontend/src/__tests__/HomepageNavCtaTouchTargets.test.ts
+++ b/frontend/src/__tests__/HomepageNavCtaTouchTargets.test.ts
@@ -27,22 +27,22 @@ describe("Home page tab-nav and CTA touch targets (closes #853)", () => {
   });
 
   it("Discover Books CTA has min-h-[44px]", () => {
-    checkAround("Discover Books");
+    checkAround("Discover Books", 300);
   });
 
   it("Sign in free hero CTA has min-h-[44px]", () => {
-    checkAround("Sign in free");
+    checkAround("Sign in free", 320);
   });
 
   it("Browse library hero CTA has min-h-[44px]", () => {
-    checkAround("Browse library");
+    checkAround("Browse library", 320);
   });
 
   it("Search button has min-h-[44px]", () => {
     // anchor on searching state text, className is nearby
     const idx = src.indexOf('"Searching" : "Search"');
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(Math.max(0, idx - 550), idx + 20);
+    const window = src.slice(Math.max(0, idx - 660), idx + 20);
     expect(window).toContain("min-h-[44px]");
   });
 });

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -191,7 +191,7 @@ export default function Home() {
             {status === "unauthenticated" ? (
               <button
                 onClick={() => router.push("/login")}
-                className="rounded-lg border border-amber-300 px-4 py-2.5 md:py-1.5 text-sm font-medium text-amber-700 hover:bg-amber-50 transition-colors min-h-[44px] md:min-h-0"
+                className="rounded-lg border border-amber-300 px-4 py-2.5 md:py-1.5 text-sm font-medium text-amber-700 hover:bg-amber-50 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
               >
                 Sign in
               </button>
@@ -200,7 +200,7 @@ export default function Home() {
                 onClick={() => router.push("/profile")}
                 title={`${session?.backendUser?.name ?? "Profile"} — Profile & Settings`}
                 aria-label={`${session?.backendUser?.name ?? "Profile"} — Profile & Settings`}
-                className="min-w-[44px] md:min-w-0 min-h-[44px] md:min-h-0 w-11 h-11 md:w-9 md:h-9 rounded-full overflow-hidden border border-amber-200 hover:border-amber-400 transition-colors"
+                className="min-w-[44px] md:min-w-0 min-h-[44px] md:min-h-0 w-11 h-11 md:w-9 md:h-9 rounded-full overflow-hidden border border-amber-200 hover:border-amber-400 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-inset"
               >
                 {session?.backendUser?.picture ? (
                   // eslint-disable-next-line @next/next/no-img-element
@@ -248,7 +248,7 @@ export default function Home() {
               aria-controls={`tabpanel-${key}`}
               tabIndex={tab === key ? 0 : -1}
               onClick={() => setTab(key)}
-              className={`px-5 py-3 min-h-[44px] md:min-h-0 text-sm font-medium border-b-2 transition-colors ${
+              className={`px-5 py-3 min-h-[44px] md:min-h-0 text-sm font-medium border-b-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 ${
                 tab === key
                   ? "border-amber-700 text-amber-900"
                   : "border-transparent text-amber-700 hover:text-amber-900"
@@ -264,7 +264,7 @@ export default function Home() {
           {status === "authenticated" && (
             <button
               onClick={() => router.push("/upload")}
-              className="px-5 py-3 min-h-[44px] md:min-h-0 text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 transition-colors"
+              className="px-5 py-3 min-h-[44px] md:min-h-0 text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               Upload
             </button>
@@ -272,7 +272,7 @@ export default function Home() {
           {status === "authenticated" && (
             <button
               onClick={() => router.push("/notes")}
-              className="px-5 py-3 min-h-[44px] md:min-h-0 text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 transition-colors"
+              className="px-5 py-3 min-h-[44px] md:min-h-0 text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               Your Notes
             </button>
@@ -280,7 +280,7 @@ export default function Home() {
           {status === "authenticated" && (
             <button
               onClick={() => router.push("/vocabulary")}
-              className="px-5 py-3 min-h-[44px] md:min-h-0 text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 transition-colors"
+              className="px-5 py-3 min-h-[44px] md:min-h-0 text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               Your Word List
             </button>
@@ -290,7 +290,7 @@ export default function Home() {
             <button
               onClick={() => router.push("/admin")}
               data-testid="admin-tab"
-              className="px-5 py-3 min-h-[44px] md:min-h-0 text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 flex items-center gap-1.5"
+              className="px-5 py-3 min-h-[44px] md:min-h-0 text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 flex items-center gap-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               <SettingsIcon className="w-3.5 h-3.5" />
               Admin
@@ -359,7 +359,7 @@ export default function Home() {
                     onClick={() => setStatsExpanded((v) => !v)}
                     aria-expanded={statsExpanded}
                     aria-controls="stats-activity-panel"
-                    className="text-xs text-amber-700 hover:text-amber-800 transition-colors min-h-[44px] md:min-h-0 px-2 flex items-center"
+                    className="text-xs text-amber-700 hover:text-amber-800 transition-colors min-h-[44px] md:min-h-0 px-2 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                   >
                     {statsExpanded ? "Hide activity" : "Show activity"}
                   </button>
@@ -452,7 +452,7 @@ export default function Home() {
                 </p>
                 <button
                   onClick={() => setTab("discover")}
-                  className="rounded-lg bg-amber-700 px-6 py-2.5 min-h-[44px] md:min-h-0 text-white font-medium hover:bg-amber-800 transition-colors shadow-sm"
+                  className="rounded-lg bg-amber-700 px-6 py-2.5 min-h-[44px] md:min-h-0 text-white font-medium hover:bg-amber-800 transition-colors shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
                 >
                   Discover Books
                 </button>
@@ -479,13 +479,13 @@ export default function Home() {
                   <div className="flex flex-col sm:flex-row gap-3 justify-center items-center">
                     <button
                       onClick={() => router.push("/login")}
-                      className="rounded-lg bg-amber-700 px-7 py-3 min-h-[44px] md:min-h-0 text-white font-semibold text-base hover:bg-amber-800 transition-colors shadow-sm min-w-[160px]"
+                      className="rounded-lg bg-amber-700 px-7 py-3 min-h-[44px] md:min-h-0 text-white font-semibold text-base hover:bg-amber-800 transition-colors shadow-sm min-w-[160px] focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
                     >
                       Sign in free
                     </button>
                     <button
                       onClick={() => document.getElementById("discover-search")?.scrollIntoView({ behavior: "smooth" })}
-                      className="rounded-lg border border-amber-300 px-7 py-3 min-h-[44px] md:min-h-0 text-amber-800 font-medium text-base hover:bg-amber-50 transition-colors min-w-[160px] flex items-center justify-center gap-2"
+                      className="rounded-lg border border-amber-300 px-7 py-3 min-h-[44px] md:min-h-0 text-amber-800 font-medium text-base hover:bg-amber-50 transition-colors min-w-[160px] flex items-center justify-center gap-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                     >
                       Browse library <ArrowRightIcon className="w-4 h-4" />
                     </button>
@@ -604,7 +604,7 @@ export default function Home() {
                     <option value="es">Spanish</option>
                   </select>
                   <button
-                    className="rounded-lg bg-amber-700 px-5 py-2.5 min-h-[44px] md:min-h-0 text-white font-medium hover:bg-amber-800 disabled:opacity-50 flex items-center justify-center gap-2 flex-1 sm:flex-none"
+                    className="rounded-lg bg-amber-700 px-5 py-2.5 min-h-[44px] md:min-h-0 text-white font-medium hover:bg-amber-800 disabled:opacity-50 flex items-center justify-center gap-2 flex-1 sm:flex-none focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
                     onClick={() => handleSearch()}
                     disabled={searching}
                   >
@@ -621,7 +621,7 @@ export default function Home() {
                 {FEATURED.map((f) => (
                   <button
                     key={f.query}
-                    className="text-xs rounded-full border border-amber-300 px-3 py-1 min-h-[44px] md:min-h-0 text-amber-800 hover:bg-amber-100 transition-colors"
+                    className="text-xs rounded-full border border-amber-300 px-3 py-1 min-h-[44px] md:min-h-0 text-amber-800 hover:bg-amber-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                     onClick={() => { setQuery(f.query); setLang(f.lang); handleSearch(f.query, f.lang); }}
                     disabled={searching}
                   >
@@ -691,7 +691,7 @@ export default function Home() {
                         key={l.code}
                         onClick={() => handlePopularLangChange(l.code)}
                         aria-pressed={popularLang === l.code}
-                        className={`text-xs rounded-full px-3 py-1 min-h-[44px] md:min-h-0 border transition-colors ${
+                        className={`text-xs rounded-full px-3 py-1 min-h-[44px] md:min-h-0 border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 ${
                           popularLang === l.code
                             ? "bg-amber-700 text-white border-amber-700"
                             : "border-amber-300 text-amber-700 hover:bg-amber-50"
@@ -708,7 +708,7 @@ export default function Home() {
                     title="Grid view"
                     aria-label="Grid view"
                     aria-pressed={popularView === "grid"}
-                    className={`p-1.5 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded transition-colors ${popularView === "grid" ? "bg-amber-100 text-amber-800" : "text-amber-600 hover:text-amber-700"}`}
+                    className={`p-1.5 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 ${popularView === "grid" ? "bg-amber-100 text-amber-800" : "text-amber-600 hover:text-amber-700"}`}
                   >
                     <GridViewIcon className="w-4 h-4" />
                   </button>
@@ -717,7 +717,7 @@ export default function Home() {
                     title="List view"
                     aria-label="List view"
                     aria-pressed={popularView === "list"}
-                    className={`p-1.5 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded transition-colors ${popularView === "list" ? "bg-amber-100 text-amber-800" : "text-amber-600 hover:text-amber-700"}`}
+                    className={`p-1.5 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 ${popularView === "list" ? "bg-amber-100 text-amber-800" : "text-amber-600 hover:text-amber-700"}`}
                   >
                     <ListViewIcon className="w-4 h-4" />
                   </button>
@@ -771,7 +771,7 @@ export default function Home() {
                           <button
                             onClick={() => handleBookClick(book)}
                             aria-label={`Open ${book.title}${book.authors.length ? ` by ${book.authors.join(", ")}` : ""}`}
-                            className="flex items-center gap-3 w-full px-4 py-3 text-left hover:bg-amber-50 transition-colors"
+                            className="flex items-center gap-3 w-full px-4 py-3 text-left hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-inset"
                           >
                             <span className="text-xs text-stone-600 w-7 text-right shrink-0 tabular-nums">
                               {(popularPage - 1) * PER_PAGE + idx + 1}
@@ -806,7 +806,7 @@ export default function Home() {
                         onClick={() => setPopularPage((p) => p - 1)}
                         disabled={popularPage === 1}
                         aria-label="Previous page of popular books"
-                        className="px-4 py-2.5 md:py-1.5 text-sm rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors min-h-[44px] md:min-h-0"
+                        className="px-4 py-2.5 md:py-1.5 text-sm rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                       >
                         <ArrowLeftIcon className="w-4 h-4 inline" aria-hidden="true" /> Prev
                       </button>
@@ -823,7 +823,7 @@ export default function Home() {
                         onClick={() => setPopularPage((p) => p + 1)}
                         disabled={popularPage >= Math.ceil(popularTotal / PER_PAGE)}
                         aria-label="Next page of popular books"
-                        className="px-4 py-2.5 md:py-1.5 text-sm rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors min-h-[44px] md:min-h-0"
+                        className="px-4 py-2.5 md:py-1.5 text-sm rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                       >
                         Next <ArrowRightIcon className="w-4 h-4 inline" aria-hidden="true" />
                       </button>
@@ -840,7 +840,7 @@ export default function Home() {
                   <button
                     type="button"
                     onClick={loadPopularBooks}
-                    className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
+                    className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                   >
                     <RetryIcon className="w-4 h-4" aria-hidden="true" />
                     Try again
@@ -863,7 +863,7 @@ export default function Home() {
                       el?.focus();
                       el?.scrollIntoView({ behavior: "smooth", block: "center" });
                     }}
-                    className="mt-1 inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors"
+                    className="mt-1 inline-flex items-center gap-1.5 px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                   >
                     Search for a book
                   </button>


### PR DESCRIPTION
## What changed

Adds `focus-visible:ring-2 focus-visible:ring-amber-400` focus rings to all 20 interactive buttons on the homepage (`app/page.tsx`) that were missing them, fixing WCAG 2.4.7 (Focus Visible) violations:

- **Header**: Sign-in button, Profile avatar button (`ring-inset` due to `overflow-hidden` container)
- **Tab bar**: Home, Discover, Upload, Notes, Word List, Admin tabs
- **Home tab CTAs**: Show activity toggle, Discover Books (amber-700 offset)
- **Discover hero**: Sign in free (amber-700 offset), Browse library
- **Discover search**: Search button (amber-700 offset), quick search pills, language filter pills
- **Discover results**: Grid/List view toggles, book list items (`ring-inset`), Pagination Prev/Next, Try again, Search for a book

Also fixes `HomepageNavCtaTouchTargets.test.ts` window sizes (4 tests) that broke because the longer className strings pushed `min-h-[44px]` beyond the original 200-char radius.

## Why

Issue #2193 — keyboard users had no visible focus indicator on any homepage button.

## Test plan

- Added `HomepageFocusRings.test.ts` with 9 static-analysis assertions covering each button group
- Fixed 4 window-size regressions in `HomepageNavCtaTouchTargets.test.ts`
- Full frontend suite: 3504 tests pass

Closes #2193

- [ ] Docs updated (if applicable)
