### PR TITLE
ux: add focus-visible rings to AnnotationsSidebar and InsightChat buttons (closes #2196)

### DIFF
--- a/frontend/src/__tests__/AnnotationsInsightChatFocusRings.test.ts
+++ b/frontend/src/__tests__/AnnotationsInsightChatFocusRings.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Regression tests for #2196: focus-visible rings on AnnotationsSidebar and InsightChat buttons.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const sidebarSrc = fs.readFileSync(
+  path.join(__dirname, "../components/AnnotationsSidebar.tsx"),
+  "utf8"
+);
+
+const chatSrc = fs.readFileSync(
+  path.join(__dirname, "../components/InsightChat.tsx"),
+  "utf8"
+);
+
+describe("AnnotationsSidebar focus rings (closes #2196)", () => {
+  it("Toggle notes panel button has focus ring", () => {
+    // className comes after aria-label — look forward
+    const idx = sidebarSrc.indexOf("Toggle notes panel");
+    expect(idx).toBeGreaterThan(-1);
+    const window = sidebarSrc.slice(idx, idx + 350);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Close annotations sidebar button has focus ring", () => {
+    const idx = sidebarSrc.indexOf("Close annotations sidebar");
+    expect(idx).toBeGreaterThan(-1);
+    const window = sidebarSrc.slice(Math.max(0, idx - 300), idx + 20);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Edit annotation button has focus ring", () => {
+    const idx = sidebarSrc.indexOf("Edit annotation:");
+    expect(idx).toBeGreaterThan(-1);
+    const window = sidebarSrc.slice(Math.max(0, idx - 300), idx + 20);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("InsightChat focus rings (closes #2196)", () => {
+  it("Save to notes button has focus ring", () => {
+    // className comes after the save-key text — look forward
+    const idx = chatSrc.indexOf("Save to notes");
+    expect(idx).toBeGreaterThan(-1);
+    const window = chatSrc.slice(idx, idx + 220);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Toggle context more/less button has focus ring", () => {
+    const idx = chatSrc.indexOf("Toggle context");
+    expect(idx).toBeGreaterThan(-1);
+    const window = chatSrc.slice(Math.max(0, idx - 300), idx + 20);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});

--- a/frontend/src/__tests__/InsightChatContextToggleAria.test.ts
+++ b/frontend/src/__tests__/InsightChatContextToggleAria.test.ts
@@ -27,7 +27,7 @@ describe("InsightChat context expand/collapse aria-labels (closes #1007)", () =>
     // Search for the onClick={onToggle} button, then check nearby for aria-label
     const onClickIdx = msgCtxSrc.indexOf("onClick={onToggle}");
     expect(onClickIdx).toBeGreaterThan(-1);
-    const btnWindow = msgCtxSrc.slice(Math.max(0, onClickIdx - 20), onClickIdx + 200);
+    const btnWindow = msgCtxSrc.slice(Math.max(0, onClickIdx - 20), onClickIdx + 320);
     expect(btnWindow).toContain("aria-label");
   });
 

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -70,7 +70,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
         aria-expanded={open}
         aria-label="Toggle notes panel"
         title="Annotations"
-        className="relative shrink-0 flex items-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-xs font-medium transition-colors min-h-[44px] md:min-h-0"
+        className="relative shrink-0 flex items-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-xs font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
         data-testid="annotations-toggle"
       >
         <NoteIcon className="w-3.5 h-3.5" /> Notes
@@ -96,7 +96,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
             <h2 id="annotations-heading" className="font-serif font-semibold text-ink text-sm">Annotations</h2>
             <button
               onClick={() => setOpen(false)}
-              className="text-stone-600 hover:text-stone-700 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg transition-colors"
+              className="text-stone-600 hover:text-stone-700 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
               aria-label="Close annotations sidebar"
             >
               <CloseIcon className="w-4 h-4" />
@@ -157,7 +157,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
                             )}
                             <button
                               onClick={(e) => { e.stopPropagation(); onEdit(ann); setOpen(false); }}
-                              className="opacity-60 hover:opacity-100 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center"
+                              className="opacity-60 hover:opacity-100 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                               title="Edit annotation"
                               aria-label={`Edit annotation: ${ann.sentence_text.slice(0, 60)}`}
                             >

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -537,7 +537,7 @@ export default function InsightChat({
                         onSaveInsight(prevUserMsg.content, msg.content, prevUserMsg.context);
                       }}
                       title={isSaved ? "Already saved" : "Save to notes"}
-                      className={`mt-1.5 flex items-center gap-1 min-h-[44px] md:min-h-0 text-[11px] transition-colors ${
+                      className={`mt-1.5 flex items-center gap-1 min-h-[44px] md:min-h-0 text-[11px] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded ${
                         isSaved
                           ? "text-stone-600 cursor-default"
                           : "text-stone-600 hover:text-amber-700"
@@ -639,7 +639,7 @@ function MsgContextBlock({
         {needsToggle && (
           <button
             onClick={onToggle}
-            className="ml-1.5 text-amber-700 hover:text-amber-900 font-medium not-italic min-h-[44px] md:min-h-0 inline-flex items-center"
+            className="ml-1.5 text-amber-700 hover:text-amber-900 font-medium not-italic min-h-[44px] md:min-h-0 inline-flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
             aria-label="Toggle context"
             aria-expanded={expanded}
           >


### PR DESCRIPTION
## What changed

Adds `focus-visible:ring-2 focus-visible:ring-amber-400` focus rings to 5 buttons in core reader components that were missing them (WCAG 2.4.7):

**AnnotationsSidebar.tsx**
- "Toggle notes panel" button (opens/closes the annotations drawer)
- "Close annotations sidebar" button (inside the drawer)
- "Edit annotation" per-annotation action button

**InsightChat.tsx**
- "Save to notes" button on AI responses
- "Toggle context more/less" inline button

Also updates `InsightChatContextToggleAria.test.ts` window size (200→320) that was displaced by the longer className string.

## Why

Issue #2196 — keyboard users in the reader had no visible focus indicator on the annotations panel and insight chat action buttons.

## Test plan

- Added `AnnotationsInsightChatFocusRings.test.ts` with 5 static-analysis assertions
- Fixed 1 displaced window in `InsightChatContextToggleAria.test.ts`
- Full frontend suite: 3509 tests pass

Closes #2196

- [ ] Docs updated (if applicable)
