### PR TITLE
ux: add focus-visible rings to BookCard remove, VocabWordTooltip save, and upload chapter remove (closes #2198)

### DIFF
--- a/frontend/src/__tests__/BookCardVocabUploadFocusRings.test.ts
+++ b/frontend/src/__tests__/BookCardVocabUploadFocusRings.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression tests for #2198: focus-visible rings on BookCard remove,
+ * VocabWordTooltip save, and upload chapter remove buttons.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const bookCardSrc = fs.readFileSync(
+  path.join(__dirname, "../components/BookCard.tsx"),
+  "utf8"
+);
+
+const vocabTooltipSrc = fs.readFileSync(
+  path.join(__dirname, "../components/VocabWordTooltip.tsx"),
+  "utf8"
+);
+
+const uploadSrc = fs.readFileSync(
+  path.join(__dirname, "../app/upload/[bookId]/chapters/page.tsx"),
+  "utf8"
+);
+
+describe("BookCard focus rings (closes #2198)", () => {
+  it("Remove book button has focus ring", () => {
+    // className comes after aria-label — look forward
+    const idx = bookCardSrc.indexOf("aria-label={`Remove");
+    expect(idx).toBeGreaterThan(-1);
+    const window = bookCardSrc.slice(idx, idx + 420);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("VocabWordTooltip focus rings (closes #2198)", () => {
+  it("Save to vocab button has focus ring", () => {
+    // className comes before button label text — look backward
+    const idx = vocabTooltipSrc.indexOf("Save to vocab");
+    expect(idx).toBeGreaterThan(-1);
+    const window = vocabTooltipSrc.slice(Math.max(0, idx - 460), idx + 20);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("Upload chapters focus rings (closes #2198)", () => {
+  it("Remove chapter button has focus ring", () => {
+    // className comes after aria-label — look forward
+    const idx = uploadSrc.indexOf("Remove chapter");
+    expect(idx).toBeGreaterThan(-1);
+    const window = uploadSrc.slice(idx, idx + 380);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -202,7 +202,7 @@ export default function ChapterEditorPage() {
                   <button
                     aria-label={`Remove chapter ${i + 1}`}
                     onClick={(e) => { e.stopPropagation(); handleRemove(i); }}
-                    className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded text-stone-600 hover:text-red-600 hover:bg-red-50 transition-colors"
+                    className="shrink-0 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded text-stone-600 hover:text-red-600 hover:bg-red-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                   >
                     <TrashIcon className="w-3.5 h-3.5" />
                   </button>

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -23,7 +23,7 @@ export default function BookCard({ book, onClick, badge, onRemove }: Props) {
           }}
           title={`Remove ${book.title} from library`}
           aria-label={`Remove ${book.title} from library`}
-          className="absolute top-0 right-0 z-10 min-w-[44px] md:min-w-0 min-h-[44px] md:min-h-0 inline-flex items-center justify-center rounded-full bg-white/80 text-stone-600 border border-amber-200 text-sm hover:bg-red-50 hover:text-red-600 hover:border-red-200 transition-colors"
+          className="absolute top-0 right-0 z-10 min-w-[44px] md:min-w-0 min-h-[44px] md:min-h-0 inline-flex items-center justify-center rounded-full bg-white/80 text-stone-600 border border-amber-200 text-sm hover:bg-red-50 hover:text-red-600 hover:border-red-200 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
         >
           <CloseIcon className="w-3.5 h-3.5" />
         </button>

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -130,7 +130,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
         <button
           onClick={handleSave}
           disabled={saved}
-          className={`text-xs font-medium px-3 py-1 min-h-[44px] md:min-h-0 rounded-lg transition-colors flex items-center justify-center ${
+          className={`text-xs font-medium px-3 py-1 min-h-[44px] md:min-h-0 rounded-lg transition-colors flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700 ${
             saved
               ? "bg-stone-100 text-stone-600 cursor-default"
               : "bg-amber-700 text-white hover:bg-amber-800"


### PR DESCRIPTION
## What changed

Adds `focus-visible:ring-2 focus-visible:ring-amber-400` to 3 buttons missing WCAG 2.4.7 focus indicators:

- **`BookCard.tsx`** — "Remove book" overlay button (×) on library page book cards
- **`VocabWordTooltip.tsx`** — "Save to vocab" button in the reader vocab tooltip (uses `ring-offset-amber-700` since it has a solid amber-700 background)
- **`upload/[bookId]/chapters/page.tsx`** — "Remove chapter" trash icon button in upload chapters list

## Why

Issue #2198 — keyboard users had no visible focus indicator on these three buttons. Discovered during UX accessibility audit after completing #2193/#2196.

## Test plan

- Added `BookCardVocabUploadFocusRings.test.ts` with 3 static-analysis assertions
- Full frontend suite: 3507 tests pass

Closes #2198

- [ ] Docs updated (if applicable)
