### PR TITLE
ux: add focus-visible rings to inline anchor links (closes #2200)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -196,6 +196,12 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 10.8 | Docs: decks tutorial added covering manual/smart modes and flashcard filtering (PR #2118, closes #2117) | ✅ Done |
 | 2026-04-29 | 10.9 | Docs: in-app search tutorial added covering annotations, vocabulary, and chapter search (PR #2120, closes #2119) | ✅ Done |
 | 2026-04-29 | 10.10 | Login page: `document.title` set to "Sign In — Book Reader AI", WCAG 2.4.2 (PR #2122, closes #2121) | ✅ Done |
+| 2026-04-29 | 11.1 | WCAG 2.4.7 focus-visible ring sweep: reader toolbar + page components (PRs #2186, #2184, #2182) | ✅ Done |
+| 2026-04-29 | 11.2 | WCAG 2.4.7: vocab, notes, flashcard page buttons (PR #2192, closes #2191) | ✅ Done |
+| 2026-04-29 | 11.3 | WCAG 2.4.7: all 20 homepage buttons (PR #2194, closes #2193) | ✅ Done |
+| 2026-04-29 | 11.4 | WCAG 2.4.7: AnnotationsSidebar + InsightChat buttons (PR #2197, closes #2196) | ✅ Done |
+| 2026-04-29 | 11.5 | WCAG 2.4.7: BookCard remove + VocabWordTooltip save + upload chapter remove (PR #2199, closes #2198) | ✅ Done |
+| 2026-04-29 | 11.6 | WCAG 2.4.7: 6 inline anchor links (reader sign-in × 3, vocab export URL, InsightChat Gemini links × 2) — closes #2200 | ✅ Done |
 
 ---
 

--- a/frontend/src/__tests__/AnchorFocusRings.test.ts
+++ b/frontend/src/__tests__/AnchorFocusRings.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression tests for #2200: focus-visible rings on inline anchor links.
+ * Six <a> elements were missing keyboard focus indicators (WCAG 2.4.7).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const readerSrc = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+const vocabSrc = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8"
+);
+
+const chatSrc = fs.readFileSync(
+  path.join(__dirname, "../components/InsightChat.tsx"),
+  "utf8"
+);
+
+describe("Reader page anchor focus rings (closes #2200)", () => {
+  it("Button-styled Sign in anchor has focus ring", () => {
+    // className contains unique segment; focus-visible:ring-amber-400 is ~190 chars forward
+    const idx = readerSrc.indexOf("shrink-0 ml-auto md:ml-0 px-3 py-1.5 rounded-lg border border-amber-300");
+    expect(idx).toBeGreaterThan(-1);
+    const window = readerSrc.slice(idx, idx + 260);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Banner Sign in inline anchor has focus ring", () => {
+    // Anchor on the unique surrounding text; className comes after href
+    const idx = readerSrc.indexOf("Translation requires an account.");
+    expect(idx).toBeGreaterThan(-1);
+    const window = readerSrc.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Vocab panel Sign in inline anchor has focus ring", () => {
+    // className comes before "Sign in</a> to translate" — look backward
+    const idx = readerSrc.indexOf("Sign in</a> to translate this chapter.");
+    expect(idx).toBeGreaterThan(-1);
+    const window = readerSrc.slice(Math.max(0, idx - 150), idx + 10);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("Vocabulary page anchor focus ring (closes #2200)", () => {
+  it("Obsidian export URL link has focus ring", () => {
+    // className contains break-all; focus-visible is added after it
+    const idx = vocabSrc.indexOf("text-amber-700 underline break-all");
+    expect(idx).toBeGreaterThan(-1);
+    const window = vocabSrc.slice(idx, idx + 150);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("InsightChat Gemini API key anchor focus rings (closes #2200)", () => {
+  it("Gemini key notice anchor (first) has focus ring", () => {
+    // First occurrence ends with Gemini API key</a>{" "}
+    const idx = chatSrc.indexOf('Gemini API key</a>{" "}');
+    expect(idx).toBeGreaterThan(-1);
+    const window = chatSrc.slice(Math.max(0, idx - 150), idx + 10);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Gemini key chat-panel anchor (second) has focus ring", () => {
+    // Second occurrence ends with Gemini API key</a>.
+    const idx = chatSrc.indexOf("Gemini API key</a>.");
+    expect(idx).toBeGreaterThan(-1);
+    const window = chatSrc.slice(Math.max(0, idx - 150), idx + 10);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1301,7 +1301,7 @@ export default function ReaderPage() {
           ) : (
             <a
               href="/api/auth/signin"
-              className="shrink-0 ml-auto md:ml-0 px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-xs font-medium transition-colors min-h-[44px] md:min-h-0 flex items-center"
+              className="shrink-0 ml-auto md:ml-0 px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-xs font-medium transition-colors min-h-[44px] md:min-h-0 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               Sign in
             </a>
@@ -1337,7 +1337,7 @@ export default function ReaderPage() {
         <div className="bg-amber-50 border-b border-amber-300 px-4 py-2 text-xs text-amber-800 flex items-center gap-2">
           <span>
             Translation requires an account.{" "}
-            <a href="/api/auth/signin" className="underline font-medium hover:text-amber-900">
+            <a href="/api/auth/signin" className="underline font-medium hover:text-amber-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded">
               Sign in
             </a>{" "}
             to translate this chapter.
@@ -2070,7 +2070,7 @@ export default function ReaderPage() {
                           </>
                         ) : (
                           <p className="text-xs text-amber-700">
-                            <a href="/api/auth/signin" className="underline font-medium">Sign in</a> to translate this chapter.
+                            <a href="/api/auth/signin" className="underline font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded">Sign in</a> to translate this chapter.
                           </p>
                         )}
                       </div>

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -495,7 +495,7 @@ function VocabularyPageContent() {
         {exportMsg && (
           <div className="border border-amber-300 bg-amber-50 rounded-xl px-4 py-3 text-sm text-ink">
             {exportMsg.startsWith("http") ? (
-              <>Exported! <a href={exportMsg} target="_blank" rel="noopener noreferrer" className="text-amber-700 underline break-all">{exportMsg}</a></>
+              <>Exported! <a href={exportMsg} target="_blank" rel="noopener noreferrer" className="text-amber-700 underline break-all focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded">{exportMsg}</a></>
             ) : (
               <span className="text-red-600">{exportMsg}</span>
             )}

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -416,7 +416,7 @@ export default function InsightChat({
       {!hasGeminiKey && (
         <div className="px-3 py-2 bg-amber-50 border-b border-amber-100 text-xs text-amber-800">
           Insights require a{" "}
-          <a href="/profile" target="_blank" rel="noopener noreferrer" className="underline font-medium">Gemini API key</a>{" "}
+          <a href="/profile" target="_blank" rel="noopener noreferrer" className="underline font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded">Gemini API key</a>{" "}
           — free from Google AI Studio.
         </div>
       )}
@@ -583,7 +583,7 @@ export default function InsightChat({
         {!hasGeminiKey && (
           <div className="bg-amber-50 border border-amber-100 rounded-lg px-3 py-2 mb-2 text-xs text-amber-800">
             Chat requires a{" "}
-            <a href="/profile" target="_blank" rel="noopener noreferrer" className="underline font-medium">Gemini API key</a>.
+            <a href="/profile" target="_blank" rel="noopener noreferrer" className="underline font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded">Gemini API key</a>.
           </div>
         )}
 


### PR DESCRIPTION
## What changed

Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded` to 6 inline `<a>` links that had no keyboard focus indicator:

| File | Description |
|---|---|
| `app/reader/[bookId]/page.tsx` | Button-styled "Sign in" anchor in header |
| `app/reader/[bookId]/page.tsx` | Inline "Sign in" link in translation banner |
| `app/reader/[bookId]/page.tsx` | Inline "Sign in" link in vocab panel |
| `app/vocabulary/page.tsx` | Obsidian export URL link |
| `components/InsightChat.tsx` | "Gemini API key" link (×2) |

## Why

WCAG 2.4.7 (Focus Visible) — keyboard users could not see which link was focused when tabbing through these elements. Buttons were already fixed in prior PRs (#2192–#2199); this completes the sweep for anchor tags.

## Test plan

- New `AnchorFocusRings.test.ts` with 6 static-analysis assertions (fail before, pass after)
- Full Jest suite: 3518 tests pass
- Tab through reader page, vocabulary page, InsightChat — all links now show amber focus ring
