### PR TITLE
ux: add focus-visible rings to 16 remaining anchor links (closes #2202)

### DIFF
--- a/frontend/src/__tests__/RemainingAnchorFocusRings.test.ts
+++ b/frontend/src/__tests__/RemainingAnchorFocusRings.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Regression tests for #2202: focus-visible rings on 16 remaining anchor links
+ * that were missing keyboard focus indicators (WCAG 2.4.7).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const readerSrc = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+const notesSrc = fs.readFileSync(
+  path.join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf8"
+);
+const profileSrc = fs.readFileSync(
+  path.join(__dirname, "../app/profile/page.tsx"),
+  "utf8"
+);
+const importSrc = fs.readFileSync(
+  path.join(__dirname, "../app/import/[bookId]/page.tsx"),
+  "utf8"
+);
+const vocabSrc = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8"
+);
+const tooltipSrc = fs.readFileSync(
+  path.join(__dirname, "../components/VocabWordTooltip.tsx"),
+  "utf8"
+);
+const sidebarSrc = fs.readFileSync(
+  path.join(__dirname, "../components/AnnotationsSidebar.tsx"),
+  "utf8"
+);
+const modalSrc = fs.readFileSync(
+  path.join(__dirname, "../components/BookDetailModal.tsx"),
+  "utf8"
+);
+
+describe("Reader page remaining anchor focus rings (closes #2202)", () => {
+  it("Gutenberg icon link has focus ring", () => {
+    const idx = readerSrc.indexOf("gutenberg.org/ebooks/");
+    expect(idx).toBeGreaterThan(-1);
+    const window = readerSrc.slice(idx, idx + 280);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Obsidian export URL link has focus ring", () => {
+    const idx = readerSrc.indexOf("href={obsidianToast}");
+    expect(idx).toBeGreaterThan(-1);
+    const window = readerSrc.slice(idx, idx + 240);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Notes tab footer 'Book notes' link has focus ring", () => {
+    // Anchor by the ArrowRightIcon after "Book notes" text
+    const idx = readerSrc.indexOf("Book notes <ArrowRightIcon");
+    expect(idx).toBeGreaterThan(-1);
+    const window = readerSrc.slice(Math.max(0, idx - 200), idx + 30);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Notes tab footer 'All books' link has focus ring", () => {
+    // Look for the All books link in reader context (comes after 'Book notes' link)
+    const booksIdx = readerSrc.indexOf("Book notes <ArrowRightIcon");
+    const allBooksIdx = readerSrc.indexOf("All books\n", booksIdx);
+    expect(allBooksIdx).toBeGreaterThan(-1);
+    const window = readerSrc.slice(Math.max(0, allBooksIdx - 200), allBooksIdx + 30);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("Notes book page anchor focus rings (closes #2202)", () => {
+  it("Word (lemma) link has focus ring", () => {
+    const idx = notesSrc.indexOf("vocabulary?word=");
+    expect(idx).toBeGreaterThan(-1);
+    const window = notesSrc.slice(idx, idx + 240);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Sentence occurrence link has focus ring", () => {
+    const idx = notesSrc.indexOf("href={readerHref}");
+    expect(idx).toBeGreaterThan(-1);
+    const window = notesSrc.slice(idx, idx + 240);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("Profile page anchor focus ring (closes #2202)", () => {
+  it("Google AI Studio external link has focus ring", () => {
+    const idx = profileSrc.indexOf("aistudio.google.com");
+    expect(idx).toBeGreaterThan(-1);
+    const window = profileSrc.slice(idx, idx + 240);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("Import page anchor focus ring (closes #2202)", () => {
+  it("Button-styled sign-in anchor on import page has focus ring", () => {
+    // Find 'Sign in to read this book' then look for anchor ring
+    const idx = importSrc.indexOf("Sign in to read this book.");
+    expect(idx).toBeGreaterThan(-1);
+    const window = importSrc.slice(idx, idx + 330);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("Vocabulary page anchor focus rings (closes #2202)", () => {
+  it("Wiktionary inline link has focus ring", () => {
+    const idx = vocabSrc.indexOf("View on Wiktionary");
+    expect(idx).toBeGreaterThan(-1);
+    const window = vocabSrc.slice(Math.max(0, idx - 200), idx + 30);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Book title occurrence link has focus ring", () => {
+    // The book title link in word occurrence panels
+    const idx = vocabSrc.indexOf("{occ.book_title}");
+    expect(idx).toBeGreaterThan(-1);
+    const window = vocabSrc.slice(Math.max(0, idx - 200), idx + 30);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("VocabWordTooltip Wiktionary anchor focus ring (closes #2202)", () => {
+  it("Wiktionary link in tooltip has focus ring", () => {
+    const idx = tooltipSrc.indexOf("Wiktionary <ArrowUpRightIcon");
+    expect(idx).toBeGreaterThan(-1);
+    const window = tooltipSrc.slice(Math.max(0, idx - 200), idx + 30);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("AnnotationsSidebar anchor focus rings (closes #2202)", () => {
+  it("Annotation icon link (to notes page) has focus ring", () => {
+    const idx = sidebarSrc.indexOf("annotation-${ann.id}");
+    expect(idx).toBeGreaterThan(-1);
+    const window = sidebarSrc.slice(idx, idx + 360);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Footer 'Book notes' link has focus ring", () => {
+    // The "Book notes" text is inside the footer link
+    const idx = sidebarSrc.indexOf('"Book notes"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = sidebarSrc.slice(Math.max(0, idx - 250), idx + 30);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Footer 'All books' link has focus ring", () => {
+    // The "All books" text in the footer <a> element (plain text, no JS quotes)
+    const bookNotesIdx = sidebarSrc.indexOf('"Book notes"');
+    const allBooksIdx = sidebarSrc.indexOf("All books\n", bookNotesIdx);
+    expect(allBooksIdx).toBeGreaterThan(-1);
+    const window = sidebarSrc.slice(Math.max(0, allBooksIdx - 280), allBooksIdx + 30);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});
+
+describe("BookDetailModal anchor focus ring (closes #2202)", () => {
+  it("View on Project Gutenberg link has focus ring", () => {
+    const idx = modalSrc.indexOf("Project Gutenberg");
+    expect(idx).toBeGreaterThan(-1);
+    const window = modalSrc.slice(Math.max(0, idx - 200), idx + 30);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -295,7 +295,7 @@ export default function BookImportPage() {
               </p>
               <a
                 href="/api/auth/signin"
-                className="inline-flex items-center rounded-lg bg-amber-700 text-white px-5 min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-amber-800"
+                className="inline-flex items-center rounded-lg bg-amber-700 text-white px-5 min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-amber-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
               >
                 Sign in
               </a>

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -195,7 +195,7 @@ function InsightCard({
         {readerHref && (
           <a
             href={readerHref}
-            className="inline-flex items-center gap-1 text-xs text-amber-700 hover:text-amber-800 hover:underline transition-colors"
+            className="inline-flex items-center gap-1 text-xs text-amber-700 hover:text-amber-800 hover:underline transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
           >
             <ArrowRightIcon className="w-3 h-3 shrink-0" /> {chapterLabel(chapters, ins.chapter_index as number)}
           </a>
@@ -230,7 +230,7 @@ function VocabRow({
       <span>
         <a
           href={`/vocabulary?word=${encodeURIComponent(word)}`}
-          className="font-semibold text-amber-700 hover:text-amber-900 hover:underline"
+          className="font-semibold text-amber-700 hover:text-amber-900 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
         >
           {word}
         </a>{" "}
@@ -238,7 +238,7 @@ function VocabRow({
         {" — "}
         <a
           href={readerHref}
-          className="italic text-stone-600 hover:text-amber-700 hover:underline transition-colors"
+          className="italic text-stone-600 hover:text-amber-700 hover:underline transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
         >
           &ldquo;{truncate(occurrence.sentence_text, 90)}&rdquo;
         </a>

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -292,7 +292,7 @@ export default function ProfilePage() {
               href="https://aistudio.google.com/app/apikey"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-amber-700 underline"
+              className="text-amber-700 underline focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
             >
               Google AI Studio
             </a>{" "}

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -995,7 +995,7 @@ export default function ReaderPage() {
                       href={`https://www.gutenberg.org/ebooks/${meta.id}`}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="shrink-0 text-xs text-amber-700 hover:text-amber-800"
+                      className="shrink-0 text-xs text-amber-700 hover:text-amber-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
                       title="View on Project Gutenberg"
                       aria-label="View on Project Gutenberg"
                     ><ArrowUpRightIcon className="w-3 h-3" aria-hidden="true" /></a>
@@ -1662,7 +1662,7 @@ export default function ReaderPage() {
                     href={obsidianToast}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-amber-700 underline break-all"
+                    className="text-amber-700 underline break-all focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
                   >
                     {obsidianToast}
                   </a>
@@ -1895,13 +1895,13 @@ export default function ReaderPage() {
                     <div className="border-t border-amber-100 pb-2 pt-3 flex gap-3 justify-between shrink-0">
                       <a
                         href={`/notes/${bookId}`}
-                        className="text-xs text-amber-700 hover:text-amber-900 font-medium transition-colors"
+                        className="text-xs text-amber-700 hover:text-amber-900 font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
                       >
                         Book notes <ArrowRightIcon className="w-3 h-3 inline" aria-hidden="true" />
                       </a>
                       <a
                         href="/notes"
-                        className="text-xs text-stone-600 hover:text-stone-700 transition-colors"
+                        className="text-xs text-stone-600 hover:text-stone-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
                       >
                         All books
                       </a>

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -206,7 +206,7 @@ function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
               href={def.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-block text-xs text-amber-700 hover:text-amber-800 hover:underline"
+              className="inline-block text-xs text-amber-700 hover:text-amber-800 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
             >
               View on Wiktionary <ArrowUpRightIcon className="w-3 h-3 inline" aria-hidden="true" />
             </a>
@@ -422,7 +422,7 @@ function VocabularyPageContent() {
                 {occ.book_title ? (
                   <a
                     href={`/reader/${occ.book_id}?chapter=${occ.chapter_index}`}
-                    className="text-amber-700 font-medium hover:underline"
+                    className="text-amber-700 font-medium hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
                   >
                     {occ.book_title}
                   </a>

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -148,7 +148,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
                               <a
                                 href={`/notes/${bookId}#annotation-${ann.id}`}
                                 onClick={(e) => { e.stopPropagation(); setOpen(false); }}
-                                className="opacity-60 hover:opacity-100 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 flex items-center justify-center"
+                                className="opacity-60 hover:opacity-100 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
                                 title="View in notes page"
                                 aria-label="View in notes page"
                               >
@@ -184,14 +184,14 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
             <a
               href={bookId ? `/notes/${bookId}` : "/notes"}
               onClick={() => setOpen(false)}
-              className="inline-flex items-center gap-1 text-xs text-amber-700 hover:text-amber-900 font-medium transition-colors min-h-[44px] md:min-h-0"
+              className="inline-flex items-center gap-1 text-xs text-amber-700 hover:text-amber-900 font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
             >
               {bookId ? "Book notes" : "All notes"} <ArrowRightIcon className="w-3 h-3 shrink-0" />
             </a>
             <a
               href="/notes"
               onClick={() => setOpen(false)}
-              className="inline-flex items-center text-xs text-stone-600 hover:text-stone-700 transition-colors min-h-[44px] md:min-h-0"
+              className="inline-flex items-center text-xs text-stone-600 hover:text-stone-700 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
             >
               All books
             </a>

--- a/frontend/src/components/BookDetailModal.tsx
+++ b/frontend/src/components/BookDetailModal.tsx
@@ -152,7 +152,7 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
             href={`https://www.gutenberg.org/ebooks/${book.id}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-xs text-amber-700 hover:text-amber-800 hover:underline ml-auto"
+            className="text-xs text-amber-700 hover:text-amber-800 hover:underline ml-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
           >
             View on Project Gutenberg <ArrowUpRightIcon className="w-3 h-3 inline" aria-hidden="true" />
           </a>

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -122,7 +122,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
             href={def.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-[11px] text-amber-700 hover:text-amber-800"
+            className="text-[11px] text-amber-700 hover:text-amber-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
           >
             Wiktionary <ArrowUpRightIcon className="w-3 h-3 inline" aria-hidden="true" />
           </a>


### PR DESCRIPTION
## What changed

Added `focus-visible:ring-2 focus-visible:ring-amber-400` keyboard focus indicators to **16 remaining anchor links** across the frontend that were missing WCAG 2.4.7 focus visibility.

Files updated:
- `frontend/src/app/reader/[bookId]/page.tsx` — Gutenberg icon link, obsidianToast export link, "Book notes" + "All books" footer links in Notes tab
- `frontend/src/app/notes/[bookId]/page.tsx` — word/lemma vocabulary link, sentence occurrence reader link
- `frontend/src/app/profile/page.tsx` — Google AI Studio external link
- `frontend/src/app/import/[bookId]/page.tsx` — "Sign in" button-styled anchor (amber-700 offset variant)
- `frontend/src/app/vocabulary/page.tsx` — "View on Wiktionary" link, book title occurrence link
- `frontend/src/components/VocabWordTooltip.tsx` — Wiktionary link in tooltip footer
- `frontend/src/components/AnnotationsSidebar.tsx` — annotation icon link, footer "Book notes" + "All books" links
- `frontend/src/components/BookDetailModal.tsx` — "View on Project Gutenberg" link

## Why

WCAG 2.4.7 (Focus Visible) requires all keyboard-focusable elements to have a visible focus indicator. Anchor links were being focusable via Tab but visually indistinguishable from non-focused state, creating a barrier for keyboard-only and assistive-technology users.

## Test plan

- [x] New test file `frontend/src/__tests__/RemainingAnchorFocusRings.test.ts` with 15 static-analysis assertions — one per link pattern across all 8 affected files
- [x] All 3533 frontend tests pass (`npm test -- --no-coverage --ci`)
- [x] Backend suite 1941 tests pass

Closes #2202

[ ] Docs updated (if applicable)
