### PR TITLE
ux: add focus-visible rings to AuthPromptModal and notes chapter link (closes #2204)

### DIFF
--- a/frontend/src/__tests__/AuthAndNotesFocusRings.test.ts
+++ b/frontend/src/__tests__/AuthAndNotesFocusRings.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Regression tests for #2204: focus-visible rings on AuthPromptModal sign-in
+ * link and notes page InsightRow chapter reader link (WCAG 2.4.7).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const authSrc = fs.readFileSync(
+  path.join(__dirname, "../components/AuthPromptModal.tsx"),
+  "utf8"
+);
+const notesSrc = fs.readFileSync(
+  path.join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("AuthPromptModal anchor focus ring (closes #2204)", () => {
+  it("Sign in link has focus-visible ring", () => {
+    const idx = authSrc.indexOf("/api/auth/signin");
+    expect(idx).toBeGreaterThan(-1);
+    const window = authSrc.slice(idx, idx + 300);
+    expect(window).toContain("focus-visible:ring-2");
+  });
+});
+
+describe("Notes page InsightRow chapter link focus ring (closes #2204)", () => {
+  it("Chapter reader link has focus-visible ring", () => {
+    // Unique anchor: only the InsightRow link uses encodeURIComponent(ann.sentence_text)
+    const idx = notesSrc.indexOf("encodeURIComponent(ann.sentence_text)");
+    expect(idx).toBeGreaterThan(-1);
+    const window = notesSrc.slice(idx, idx + 320);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -135,7 +135,7 @@ function AnnotationCard({
         <div className="flex items-center gap-3 mt-2">
           <a
             href={`/reader/${bookId}?chapter=${ann.chapter_index}&sentence=${encodeURIComponent(ann.sentence_text)}`}
-            className="inline-flex items-center gap-1 text-xs text-amber-700 hover:text-amber-800 hover:underline transition-colors"
+            className="inline-flex items-center gap-1 text-xs text-amber-700 hover:text-amber-800 hover:underline transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
           >
             <ArrowRightIcon className="w-3 h-3 shrink-0" /> {chapterLabel(chapters, ann.chapter_index)}
           </a>

--- a/frontend/src/components/AuthPromptModal.tsx
+++ b/frontend/src/components/AuthPromptModal.tsx
@@ -40,7 +40,7 @@ export default function AuthPromptModal({ open, feature, onClose }: Props) {
         </p>
         <a
           href="/api/auth/signin"
-          className="flex items-center justify-center w-full min-h-[44px] md:min-h-0 bg-amber-700 hover:bg-amber-800 text-white text-center rounded-xl font-medium transition-colors"
+          className="flex items-center justify-center w-full min-h-[44px] md:min-h-0 bg-amber-700 hover:bg-amber-800 text-white text-center rounded-xl font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
         >
           Sign in
         </a>


### PR DESCRIPTION
## What changed

Added `focus-visible` keyboard focus rings to 2 anchor links that were missed in prior sweeps:

1. **`components/AuthPromptModal.tsx`** — "Sign in" button-styled anchor on amber-700 background. Added white ring with amber-700 offset (`focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700`) to match the pattern used for other dark-background anchors.

2. **`app/notes/[bookId]/page.tsx` line 138** — Chapter reader link in `AnnotationCard` component (the `InsightCard` reader link at line 198 already had a ring from PR #2202; this link in the sibling `AnnotationCard` was missed). Added standard `focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded`.

## Why

WCAG 2.4.7 requires all keyboard-focusable elements to have visible focus indicators. These two links were tab-focusable but visually indistinguishable when focused.

## Test plan

- [x] New test file `frontend/src/__tests__/AuthAndNotesFocusRings.test.ts` with 2 static-analysis assertions — one per fixed link
- [x] All 3535 frontend tests pass

Closes #2204

[ ] Docs updated (if applicable)
