### PR TITLE
test: cover useFocusTrap empty-dialog, container-focus, inert and shift-middle branches (closes #2206)

### DIFF
--- a/frontend/src/__tests__/FocusTrap.test.tsx
+++ b/frontend/src/__tests__/FocusTrap.test.tsx
@@ -4,9 +4,10 @@
  *
  * Tests that Tab wraps from last to first focusable element,
  * and Shift+Tab wraps from first to last.
+ * Branch coverage for #2206: empty dialog, dialog-element active, inert filtering.
  */
 import React, { useRef } from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useFocusTrap } from "@/lib/useFocusTrap";
 
@@ -20,6 +21,31 @@ function TestDialog({ enabled = true }: { enabled?: boolean }) {
         <button data-testid="first">First</button>
         <button data-testid="second">Second</button>
         <button data-testid="last">Last</button>
+      </div>
+    </div>
+  );
+}
+
+function EmptyDialog() {
+  const ref = useRef<HTMLDivElement>(null);
+  useFocusTrap(ref);
+  return (
+    <div ref={ref} role="dialog" aria-modal="true" tabIndex={-1} data-testid="empty-dialog">
+      <span>No focusable children</span>
+    </div>
+  );
+}
+
+function InertDialog() {
+  const ref = useRef<HTMLDivElement>(null);
+  useFocusTrap(ref);
+  return (
+    <div ref={ref} role="dialog" aria-modal="true" tabIndex={-1}>
+      {/* visible button is the only real focusable element */}
+      <button data-testid="real">Real</button>
+      {/* inert subtree — its button should be excluded from trap */}
+      <div inert="" aria-hidden="true">
+        <button data-testid="inert-btn">Hidden</button>
       </div>
     </div>
   );
@@ -57,5 +83,44 @@ describe("useFocusTrap (closes #2083)", () => {
     await user.tab();
     // focus moves to outside button (natural tab order)
     expect(document.activeElement).not.toBe(screen.getByTestId("first"));
+  });
+
+  it("Shift+Tab from middle element does not wrap (closes #2206)", async () => {
+    const user = userEvent.setup();
+    render(<TestDialog />);
+    screen.getByTestId("second").focus();
+    await user.tab({ shift: true });
+    // active is "second" — neither first nor dialog container — so no wrap, focus moves to "first"
+    expect(document.activeElement).toBe(screen.getByTestId("first"));
+  });
+
+  it("prevents Tab when dialog has no focusable children (closes #2206)", () => {
+    render(<EmptyDialog />);
+    const dialog = screen.getByTestId("empty-dialog");
+    dialog.focus();
+    const event = new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true });
+    dialog.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("Shift+Tab from dialog container element wraps to last focusable (closes #2206)", () => {
+    render(<TestDialog />);
+    // Focus the dialog container div (tabIndex={-1}) directly — not a child button
+    const dialog = document.querySelector('[role="dialog"]') as HTMLElement;
+    dialog.focus();
+    expect(document.activeElement).toBe(dialog);
+    // Fire keydown directly so our listener (not userEvent's simulation) handles it
+    fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true, bubbles: true, cancelable: true });
+    expect(document.activeElement).toBe(screen.getByTestId("last"));
+  });
+
+  it("excludes inert subtree elements from focus cycle (closes #2206)", async () => {
+    const user = userEvent.setup();
+    render(<InertDialog />);
+    const real = screen.getByTestId("real");
+    real.focus();
+    // Tab from the only real focusable should wrap back to itself (not the inert button)
+    await user.tab();
+    expect(document.activeElement).toBe(real);
   });
 });


### PR DESCRIPTION
## What changed

Extended `frontend/src/__tests__/FocusTrap.test.tsx` with 4 additional test cases that cover 3 previously-untested branches in `lib/useFocusTrap.ts`, raising branch coverage from 76.5% → 94.1%.

### New tests

1. **Shift+Tab from middle element** — exercises the false-branch of `if (active === first || active === el)` (shift key pressed but active element is neither the first nor the dialog container → no wrap, normal focus movement)

2. **Prevents Tab in empty dialog** — exercises `if (focusable.length === 0)` (dialog with no focusable children → `e.preventDefault()` + early return)

3. **Shift+Tab from dialog container itself** — exercises `active === el` condition using `fireEvent.keyDown` directly so our listener (not userEvent's built-in simulation) handles the event; verifies focus wraps to last

4. **Inert subtree filtering** — exercises `.filter((n) => !n.closest("[inert]"))` by rendering a dialog with one real button and one button inside an `[inert]` subtree; Tab from the real button wraps back to itself, proving the inert button was excluded

## Why

Branch coverage gap filed as #2206. The three uncovered branches all represent real defensive code paths (empty dialog guard, focus-on-container edge case, inert filtering) that could silently break without tests.

## Test plan

- [x] All 3539 frontend tests pass (`npm test -- --no-coverage --ci`)
- [x] `useFocusTrap.ts` branch coverage: 76.5% → 94.1% (only line 19 null-ref safety guard remains uncoverable without DOM manipulation tricks)

Closes #2206

[ ] Docs updated (if applicable)
