### PR TITLE
ux: fix SearchBar mobile overflow — replace min-w-[14rem] with flex-1 (closes #2208)

### DIFF
--- a/frontend/src/__tests__/SearchBarMobileLayout.test.ts
+++ b/frontend/src/__tests__/SearchBarMobileLayout.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Regression test for #2208: SearchBar expanded form must not use a fixed
+ * min-width on the input that forces horizontal overflow on narrow mobile screens.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/SearchBar.tsx"),
+  "utf8"
+);
+
+describe("SearchBar mobile layout (closes #2208)", () => {
+  it("input does not use fixed min-w-[14rem] that overflows narrow screens", () => {
+    expect(src).not.toContain("min-w-[14rem]");
+  });
+
+  it("input uses flex-1 so it grows within available container space", () => {
+    const idx = src.indexOf("placeholder:text-stone-600");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 200), idx + 30);
+    expect(window).toContain("flex-1");
+  });
+});

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -75,7 +75,7 @@ export function SearchBar() {
         e.preventDefault();
         submit();
       }}
-      className="inline-flex items-center gap-2 min-h-[44px] md:min-h-0 px-2 border border-amber-200 rounded-md bg-parchment animate-fade-in focus-within:ring-2 focus-within:ring-amber-400 focus-within:border-amber-400"
+      className="flex flex-1 items-center gap-2 min-h-[44px] md:min-h-0 px-2 border border-amber-200 rounded-md bg-parchment animate-fade-in focus-within:ring-2 focus-within:ring-amber-400 focus-within:border-amber-400"
     >
       <SearchIcon className="w-4 h-4 text-ink" />
       <input
@@ -87,7 +87,7 @@ export function SearchBar() {
         placeholder="Search notes, vocabulary, chapters…"
         aria-label="Search your content"
         maxLength={200}
-        className="bg-transparent outline-none min-w-[14rem] py-1 text-sm text-ink placeholder:text-stone-600"
+        className="bg-transparent outline-none flex-1 min-w-0 py-1 text-sm text-ink placeholder:text-stone-600"
       />
       <button
         type="button"


### PR DESCRIPTION
## What changed

Fixed `components/SearchBar.tsx` expanded form overflowing the viewport on narrow mobile screens.

**Before:** The form used `inline-flex` (takes only content width, can exceed viewport) and the input had `min-w-[14rem]` (fixed 224px minimum).

**After:** The form uses `flex flex-1` (fills available space in the header row) and the input uses `flex-1 min-w-0` (grows within the form without enforcing a fixed floor).

```diff
- className="inline-flex items-center gap-2 ..."
+ className="flex flex-1 items-center gap-2 ..."

- className="bg-transparent outline-none min-w-[14rem] ..."
+ className="bg-transparent outline-none flex-1 min-w-0 ..."
```

## Why

On phones narrower than ~360px, or when the header already contains other elements (profile button, sign-in button), the expanded search form's `inline-flex` + `min-w-[14rem]` could push the total header width past the viewport, forcing horizontal scroll. The `flex-1` approach lets the search form fill whatever space the header flex row allows without imposing a fixed minimum.

## Test plan

- [x] New static-analysis test `SearchBarMobileLayout.test.ts` asserts `min-w-[14rem]` is gone and `flex-1` is present on the input
- [x] All 17 existing SearchBar tests pass
- [x] All 3537 frontend tests pass

Closes #2208

[ ] Docs updated (if applicable)
