### PR TITLE
ux: lock body scroll when modals/drawers open via useScrollLock hook (closes #2210)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -202,6 +202,10 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.4 | WCAG 2.4.7: AnnotationsSidebar + InsightChat buttons (PR #2197, closes #2196) | ✅ Done |
 | 2026-04-29 | 11.5 | WCAG 2.4.7: BookCard remove + VocabWordTooltip save + upload chapter remove (PR #2199, closes #2198) | ✅ Done |
 | 2026-04-29 | 11.6 | WCAG 2.4.7: 6 inline anchor links (reader sign-in × 3, vocab export URL, InsightChat Gemini links × 2) — closes #2200 | ✅ Done |
+| 2026-04-29 | 11.7 | WCAG 2.4.7: 16 remaining anchor links across reader, notes, profile, import, vocabulary, VocabWordTooltip, AnnotationsSidebar, BookDetailModal — closes #2202 (PR #2203) | ✅ Done |
+| 2026-04-29 | 11.8 | WCAG 2.4.7: AuthPromptModal sign-in link + notes InsightCard chapter reader link — closes #2204 (PR #2205) | ✅ Done |
+| 2026-04-29 | 11.9 | useFocusTrap branch coverage 76.5% → 94.1%: empty-dialog, container-focus, inert filtering, shift-middle — closes #2206 (PR #2207) | ✅ Done |
+| 2026-04-29 | 11.10 | SearchBar mobile overflow fix: replace inline-flex + min-w-[14rem] with flex flex-1 + flex-1 min-w-0 — closes #2208 (PR #2209) | ✅ Done |
 
 ---
 

--- a/frontend/src/__tests__/ScrollLockModals.test.ts
+++ b/frontend/src/__tests__/ScrollLockModals.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Regression tests for #2210: modals and drawers must lock body scroll
+ * while open so the background page doesn't scroll behind the overlay.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const hookSrc = fs.readFileSync(
+  path.join(__dirname, "../lib/useScrollLock.ts"),
+  "utf8"
+);
+const bookModalSrc = fs.readFileSync(
+  path.join(__dirname, "../components/BookDetailModal.tsx"),
+  "utf8"
+);
+const authModalSrc = fs.readFileSync(
+  path.join(__dirname, "../components/AuthPromptModal.tsx"),
+  "utf8"
+);
+const sidebarSrc = fs.readFileSync(
+  path.join(__dirname, "../components/AnnotationsSidebar.tsx"),
+  "utf8"
+);
+const wordDrawerSrc = fs.readFileSync(
+  path.join(__dirname, "../components/WordActionDrawer.tsx"),
+  "utf8"
+);
+
+describe("useScrollLock hook (closes #2210)", () => {
+  it("sets document.body.style.overflow to hidden when locked", () => {
+    expect(hookSrc).toContain("overflow");
+    expect(hookSrc).toContain("hidden");
+  });
+
+  it("restores overflow on cleanup", () => {
+    expect(hookSrc).toContain("return () =>");
+  });
+});
+
+describe("Modal scroll lock usage (closes #2210)", () => {
+  it("BookDetailModal imports useScrollLock", () => {
+    expect(bookModalSrc).toContain("useScrollLock");
+  });
+
+  it("AuthPromptModal imports useScrollLock", () => {
+    expect(authModalSrc).toContain("useScrollLock");
+  });
+
+  it("AnnotationsSidebar imports useScrollLock", () => {
+    expect(sidebarSrc).toContain("useScrollLock");
+  });
+
+  it("WordActionDrawer imports useScrollLock", () => {
+    expect(wordDrawerSrc).toContain("useScrollLock");
+  });
+});

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import type { Annotation } from "@/lib/api";
 import { ArrowRightIcon, NoteIcon, EditIcon, CloseIcon, EmptyNotesIcon } from "@/components/Icons";
 import { useFocusTrap } from "@/lib/useFocusTrap";
+import { useScrollLock } from "@/lib/useScrollLock";
 
 const COLOR_BADGE: Record<string, string> = {
   yellow: "bg-yellow-100 border-yellow-300 text-yellow-800",
@@ -34,6 +35,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
   const [open, setOpen] = useState(false);
   const drawerRef = useRef<HTMLDivElement>(null);
   useFocusTrap(drawerRef, open);
+  useScrollLock(open);
 
   // Group by chapter
   const byChapter = annotations.reduce<Record<number, Annotation[]>>((acc, a) => {

--- a/frontend/src/components/AuthPromptModal.tsx
+++ b/frontend/src/components/AuthPromptModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useRef } from "react";
 import { useFocusTrap } from "@/lib/useFocusTrap";
+import { useScrollLock } from "@/lib/useScrollLock";
 
 interface Props {
   open: boolean;
@@ -11,6 +12,7 @@ interface Props {
 export default function AuthPromptModal({ open, feature, onClose }: Props) {
   const dialogRef = useRef<HTMLDivElement>(null);
   useFocusTrap(dialogRef, open);
+  useScrollLock(open);
 
   useEffect(() => {
     if (!open) return;

--- a/frontend/src/components/BookDetailModal.tsx
+++ b/frontend/src/components/BookDetailModal.tsx
@@ -5,6 +5,7 @@ import { RecentBook } from "@/lib/recentBooks";
 import { getSettings } from "@/lib/settings";
 import { BookCoverPlaceholderIcon, CloseIcon, CheckIcon, ArrowUpRightIcon } from "@/components/Icons";
 import { useFocusTrap } from "@/lib/useFocusTrap";
+import { useScrollLock } from "@/lib/useScrollLock";
 
 const LANG_NAMES: Record<string, string> = {
   en: "English", de: "German", fr: "French", es: "Spanish",
@@ -25,6 +26,7 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
   const translationLang = getSettings().translationLang;
   const dialogRef = useRef<HTMLDivElement>(null);
   useFocusTrap(dialogRef);
+  useScrollLock(true);
 
   useEffect(() => {
     getBookTranslationStatus(book.id, translationLang)

--- a/frontend/src/components/WordActionDrawer.tsx
+++ b/frontend/src/components/WordActionDrawer.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState } from "react";
 import { SpeakerIcon, SaveIcon, NoteIcon, CheckCircleIcon, CloseIcon } from "@/components/Icons";
 import { useFocusTrap } from "@/lib/useFocusTrap";
+import { useScrollLock } from "@/lib/useScrollLock";
 
 interface Definition {
   partOfSpeech: string;
@@ -45,6 +46,7 @@ export default function WordActionDrawer({
   const [saved, setSaved] = useState(false);
   const drawerRef = useRef<HTMLDivElement>(null);
   useFocusTrap(drawerRef, !!action);
+  useScrollLock(!!action);
 
   const word = action?.word ?? "";
 

--- a/frontend/src/lib/useScrollLock.ts
+++ b/frontend/src/lib/useScrollLock.ts
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+
+export function useScrollLock(locked: boolean) {
+  useEffect(() => {
+    if (!locked) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [locked]);
+}


### PR DESCRIPTION
## What changed

Added a `lib/useScrollLock.ts` hook and applied it to 4 modal/drawer components so the document body scroll is locked while any overlay is open.

### New hook: `useScrollLock(locked: boolean)`

```ts
export function useScrollLock(locked: boolean) {
  useEffect(() => {
    if (!locked) return;
    const prev = document.body.style.overflow;
    document.body.style.overflow = "hidden";
    return () => { document.body.style.overflow = prev; };
  }, [locked]);
}
```

Restores the previous `overflow` value on cleanup so nesting or rapid toggling doesn't leave the body in a broken state.

### Applied to:
- `BookDetailModal` — `useScrollLock(true)` (always-mounted when shown)
- `AuthPromptModal` — `useScrollLock(open)` 
- `AnnotationsSidebar` — `useScrollLock(open)`
- `WordActionDrawer` — `useScrollLock(!!action)`

## Why

When any of these overlays opens, the background page was scrollable. Users on mobile could accidentally scroll past the content they were interacting with, and the visual context behind the modal shifted unexpectedly. Locking body scroll while an overlay is open is a standard, expected modal behavior.

## Test plan

- [x] New test file `ScrollLockModals.test.ts` with 6 static-analysis assertions — hook has `overflow: hidden` and cleanup, and each of the 4 components imports `useScrollLock`
- [x] All 3545 frontend tests pass

Closes #2210

[ ] Docs updated (if applicable)
