### PR TITLE
ux: add focus-visible ring to not-found and error page CTA links

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -206,6 +206,10 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.8 | WCAG 2.4.7: AuthPromptModal sign-in link + notes InsightCard chapter reader link — closes #2204 (PR #2205) | ✅ Done |
 | 2026-04-29 | 11.9 | useFocusTrap branch coverage 76.5% → 94.1%: empty-dialog, container-focus, inert filtering, shift-middle — closes #2206 (PR #2207) | ✅ Done |
 | 2026-04-29 | 11.10 | SearchBar mobile overflow fix: replace inline-flex + min-w-[14rem] with flex flex-1 + flex-1 min-w-0 — closes #2208 (PR #2209) | ✅ Done |
+| 2026-04-29 | 11.11 | Body scroll lock hook (useScrollLock) applied to BookDetailModal, AnnotationsSidebar, WordActionDrawer, AuthPromptModal — closes #2210 (PR #2211) | ✅ Done |
+| 2026-04-29 | 11.12 | Add hover title tooltip to truncated book title/author in BookCard, Continue Reading banner, Popular Classics list — closes #2212 (PR #2213) | ✅ Done |
+| 2026-04-29 | 11.13 | Add loading="lazy" to 7 remote img elements (book covers, user avatars) across 5 files — closes #2214 (PR #2215) | ✅ Done |
+| 2026-04-29 | 11.14 | AnnotationToolbar missing useScrollLock — body scroll locked while note editor open — closes #2216 (PR #2217) | ✅ Done |
 
 ---
 

--- a/frontend/src/__tests__/ErrorPageFocusRings.test.ts
+++ b/frontend/src/__tests__/ErrorPageFocusRings.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Static-analysis tests: CTA links in not-found and error pages must have
+ * explicit focus-visible ring classes for consistent keyboard focus styling,
+ * matching every other interactive element in the app.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const appRoot = path.resolve(__dirname, "../app");
+
+describe("Error/NotFound page CTA focus rings", () => {
+  it("not-found.tsx Browse books link has focus-visible:ring", () => {
+    const src = fs.readFileSync(path.join(appRoot, "not-found.tsx"), "utf-8");
+    // Find the Link element with amber-700 background
+    const idx = src.indexOf("bg-amber-700");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 200);
+    expect(window).toContain("focus-visible:ring");
+  });
+
+  it("not-found.tsx Browse books link has focus:outline-none", () => {
+    const src = fs.readFileSync(path.join(appRoot, "not-found.tsx"), "utf-8");
+    const idx = src.indexOf("bg-amber-700");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 200);
+    expect(window).toContain("focus:outline-none");
+  });
+
+  it("error.tsx Library link has focus-visible:ring", () => {
+    const src = fs.readFileSync(path.join(appRoot, "error.tsx"), "utf-8");
+    // Find the Library link (has ArrowLeftIcon and href="/")
+    const idx = src.indexOf("border-amber-300");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 200);
+    expect(window).toContain("focus-visible:ring");
+  });
+
+  it("error.tsx Library link has focus:outline-none", () => {
+    const src = fs.readFileSync(path.join(appRoot, "error.tsx"), "utf-8");
+    const idx = src.indexOf("border-amber-300");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 200);
+    expect(window).toContain("focus:outline-none");
+  });
+});

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -31,7 +31,7 @@ export default function ErrorPage({ error, reset }: Props) {
           </button>
           <Link
             href="/"
-            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
+            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <ArrowLeftIcon className="w-4 h-4" aria-hidden="true" /> Library
           </Link>

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -15,7 +15,7 @@ export default function NotFound() {
         </p>
         <Link
           href="/"
-          className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
+          className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
         >
           Browse books <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
         </Link>


### PR DESCRIPTION
## What changed
Added `focus:outline-none focus-visible:ring-2` keyboard focus styles to the CTA links in `not-found.tsx` and `error.tsx`, matching the focus ring treatment on every other interactive element in the app.

- `not-found.tsx` "Browse books" link (amber-700 bg): `focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700`
- `error.tsx` "Library" link (outlined variant): `focus-visible:ring-amber-400 focus-visible:ring-offset-1`

## Why
Both error-state pages were missing explicit keyboard focus indicators, violating WCAG 2.4.7. The amber-700 background CTA had especially poor contrast with the browser-default dark focus outline.

## Test plan
- [x] 4 static-analysis tests in `ErrorPageFocusRings.test.ts` assert each class is present on the correct element
- [x] Full frontend test suite: 3565 tests, 581 suites — all passing

Closes #2218

## Docs follow-up
None needed — focus ring polish only.
