### PR TITLE
ux: add focus-visible ring to summary disclosure elements

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -210,6 +210,8 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.12 | Add hover title tooltip to truncated book title/author in BookCard, Continue Reading banner, Popular Classics list — closes #2212 (PR #2213) | ✅ Done |
 | 2026-04-29 | 11.13 | Add loading="lazy" to 7 remote img elements (book covers, user avatars) across 5 files — closes #2214 (PR #2215) | ✅ Done |
 | 2026-04-29 | 11.14 | AnnotationToolbar missing useScrollLock — body scroll locked while note editor open — closes #2216 (PR #2217) | ✅ Done |
+| 2026-04-29 | 11.15 | focus-visible ring to not-found and error page CTA links — closes #2218 (PR #2219) | ✅ Done |
+| 2026-04-29 | 11.16 | focus-visible ring to &lt;summary&gt; disclosures in QueueTab and SeedPopularButton — closes #2220 | 🔄 In progress |
 
 ---
 

--- a/frontend/src/__tests__/SummaryFocusRings.test.ts
+++ b/frontend/src/__tests__/SummaryFocusRings.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Static-analysis tests: <summary> elements used as keyboard-focusable
+ * disclosures must carry the design-system focus-visible ring classes.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = (rel: string) =>
+  fs.readFileSync(
+    path.resolve(__dirname, "../components", rel),
+    "utf-8"
+  );
+
+describe("summary element focus rings", () => {
+  it("QueueTab activity-log summary has focus-visible:ring", () => {
+    const content = src("QueueTab.tsx");
+    const idx = content.indexOf("Activity log");
+    expect(idx).toBeGreaterThan(-1);
+    const window = content.slice(Math.max(0, idx - 300), idx + 50);
+    expect(window).toContain("focus-visible:ring");
+  });
+
+  it("QueueTab activity-log summary has focus:outline-none", () => {
+    const content = src("QueueTab.tsx");
+    const idx = content.indexOf("Activity log");
+    const window = content.slice(Math.max(0, idx - 300), idx + 50);
+    expect(window).toContain("focus:outline-none");
+  });
+
+  it("SeedPopularButton recent-events summary has focus-visible:ring", () => {
+    const content = src("SeedPopularButton.tsx");
+    const idx = content.indexOf("Recent events");
+    expect(idx).toBeGreaterThan(-1);
+    const window = content.slice(Math.max(0, idx - 300), idx + 50);
+    expect(window).toContain("focus-visible:ring");
+  });
+
+  it("SeedPopularButton recent-events summary has focus:outline-none", () => {
+    const content = src("SeedPopularButton.tsx");
+    const idx = content.indexOf("Recent events");
+    const window = content.slice(Math.max(0, idx - 300), idx + 50);
+    expect(window).toContain("focus:outline-none");
+  });
+});

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -680,7 +680,7 @@ export default function QueueTab({ adminFetch }: Props) {
 
         {s?.log && s.log.length > 0 && (
           <details>
-            <summary className="text-xs text-amber-700 cursor-pointer">
+            <summary className="text-xs text-amber-700 cursor-pointer rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1">
               Activity log ({s.log.length})
             </summary>
             <ul role="list" className="mt-1 text-xs space-y-1 max-h-60 overflow-y-auto list-none p-0 m-0">

--- a/frontend/src/components/SeedPopularButton.tsx
+++ b/frontend/src/components/SeedPopularButton.tsx
@@ -258,7 +258,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
 
           {state.log.length > 0 && (
             <details className="mt-2">
-              <summary className="text-xs text-amber-700 cursor-pointer">
+              <summary className="text-xs text-amber-700 cursor-pointer rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1">
                 Recent events ({state.log.length})
               </summary>
               <ul role="list" className="mt-1 text-xs space-y-0.5 max-h-40 overflow-y-auto list-none p-0 m-0">


### PR DESCRIPTION
## What changed
Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded` to the `<summary>` disclosure elements in `QueueTab` and `SeedPopularButton`.

## Why
`<summary>` elements are keyboard-focusable interactive controls. Both instances had `cursor-pointer` but no explicit focus ring, so keyboard users would see the browser-default blue outline instead of the app's amber design-system ring — inconsistent with every other interactive element.

## Test plan
- [x] 4 static-analysis tests in `SummaryFocusRings.test.ts` assert `focus:outline-none` and `focus-visible:ring` are present on each summary element
- [x] Full frontend suite: 3569 tests, 582 suites — all passing

Closes #2220
