### PR TITLE
ux: dark-mode WCAG AA contrast for text-stone-600/700/500

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -211,7 +211,8 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.13 | Add loading="lazy" to 7 remote img elements (book covers, user avatars) across 5 files — closes #2214 (PR #2215) | ✅ Done |
 | 2026-04-29 | 11.14 | AnnotationToolbar missing useScrollLock — body scroll locked while note editor open — closes #2216 (PR #2217) | ✅ Done |
 | 2026-04-29 | 11.15 | focus-visible ring to not-found and error page CTA links — closes #2218 (PR #2219) | ✅ Done |
-| 2026-04-29 | 11.16 | focus-visible ring to &lt;summary&gt; disclosures in QueueTab and SeedPopularButton — closes #2220 | 🔄 In progress |
+| 2026-04-29 | 11.16 | focus-visible ring to &lt;summary&gt; disclosures in QueueTab and SeedPopularButton — closes #2220 (PR #2221) | ✅ Done |
+| 2026-04-29 | 11.17 | dark-mode WCAG AA contrast for text-stone-600/700/500 — closes #2223 | 🔄 In progress |
 
 ---
 

--- a/frontend/src/__tests__/DarkModeStoneContrast.test.ts
+++ b/frontend/src/__tests__/DarkModeStoneContrast.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Static-analysis tests: dark mode must override text-stone-600/700/500 so
+ * secondary text passes WCAG AA contrast on dark card backgrounds.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const globalsCss = fs.readFileSync(
+  path.resolve(__dirname, "../app/globals.css"),
+  "utf-8"
+);
+
+describe("Dark mode stone text contrast overrides", () => {
+  it('overrides text-stone-600 in dark mode', () => {
+    expect(globalsCss).toContain('[data-theme="dark"] .text-stone-600');
+  });
+
+  it('overrides text-stone-700 in dark mode', () => {
+    expect(globalsCss).toContain('[data-theme="dark"] .text-stone-700');
+  });
+
+  it('overrides text-stone-500 in dark mode', () => {
+    expect(globalsCss).toContain('[data-theme="dark"] .text-stone-500');
+  });
+
+  it('stone-600 dark override is a light color (not original dark value)', () => {
+    const idx = globalsCss.indexOf('[data-theme="dark"] .text-stone-600');
+    const window = globalsCss.slice(idx, idx + 80);
+    // Must not be the original stone-600 (#57534e) — must be lighter
+    expect(window).not.toContain('#57534e');
+    expect(window).toContain('color:');
+  });
+});

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -51,6 +51,12 @@ body, [data-theme="light"] {
 [data-theme="dark"] .hover\:bg-amber-100:hover { background-color: #2e2e4a; }
 [data-theme="dark"] .hover\:bg-amber-50:hover { background-color: #252540; }
 [data-theme="dark"] .highlighted-sentence { background-color: #5c4a1e; }
+/* Secondary text: stone-600/700 on dark surfaces fails WCAG AA — lift to ~stone-400 */
+[data-theme="dark"] .text-stone-600 { color: #a8a29e; }
+[data-theme="dark"] .text-stone-700 { color: #b5b1ad; }
+[data-theme="dark"] .text-stone-500 { color: #a8a29e; }
+[data-theme="dark"] .hover\:text-stone-700:hover { color: #b5b1ad; }
+[data-theme="dark"] .hover\:text-stone-600:hover { color: #a8a29e; }
 [data-theme="dark"] input, [data-theme="dark"] select {
   background-color: #252540;
   color: #e0dcd4;


### PR DESCRIPTION
## What changed
Added dark-mode CSS overrides in `globals.css` for `text-stone-600`, `text-stone-700`, `text-stone-500`, and their hover variants, mapping them to lighter equivalents (`#a8a29e` / `#b5b1ad`).

## Why
`text-stone-600` (#57534e) is used for secondary text in ~295 places across the frontend. In dark mode, `bg-white` renders as `#252540` — giving stone-600 text only ~2.1:1 contrast ratio, well below the WCAG AA minimum of 4.5:1. The new light values provide ~5.7:1 and ~7:1 contrast respectively.

## Test plan
- [x] 4 static-analysis tests in `DarkModeStoneContrast.test.ts` verify all three overrides exist and the stone-600 override is not the original dark value
- [x] Full frontend suite: 3573 tests, 583 suites — all passing

Closes #2223
