### PR TITLE
ux: focus-visible ring on search empty-state CTA Links

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -212,7 +212,8 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.14 | AnnotationToolbar missing useScrollLock — body scroll locked while note editor open — closes #2216 (PR #2217) | ✅ Done |
 | 2026-04-29 | 11.15 | focus-visible ring to not-found and error page CTA links — closes #2218 (PR #2219) | ✅ Done |
 | 2026-04-29 | 11.16 | focus-visible ring to &lt;summary&gt; disclosures in QueueTab and SeedPopularButton — closes #2220 (PR #2221) | ✅ Done |
-| 2026-04-29 | 11.17 | dark-mode WCAG AA contrast for text-stone-600/700/500 — closes #2223 | 🔄 In progress |
+| 2026-04-29 | 11.17 | dark-mode WCAG AA contrast for text-stone-600/700/500 — closes #2223 (PR #2224) | ✅ Done |
+| 2026-04-29 | 11.18 | focus-visible ring on search empty-state CTA Links (both no-query and no-results states) — closes #2225 | 🔄 In progress |
 
 ---
 

--- a/frontend/src/__tests__/SearchEmptyStateFocusRing.test.ts
+++ b/frontend/src/__tests__/SearchEmptyStateFocusRing.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Static-analysis test: the search page's no-results empty state CTA Link
+ * must carry focus-visible:ring classes consistent with the design system.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "../app/search/page.tsx"),
+  "utf-8"
+);
+
+describe("Search empty-state CTA focus ring", () => {
+  it("Browse books Link has focus:outline-none", () => {
+    // Find the Link near "Browse books" and assert focus styles
+    const idx = src.indexOf("Browse books");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 400), idx + 50);
+    expect(window).toContain("focus:outline-none");
+  });
+
+  it("Browse books Link has focus-visible:ring-2", () => {
+    const idx = src.indexOf("Browse books");
+    const window = src.slice(Math.max(0, idx - 400), idx + 50);
+    expect(window).toContain("focus-visible:ring-2");
+  });
+
+  it("Browse books Link has focus-visible:ring-amber-400", () => {
+    const idx = src.indexOf("Browse books");
+    const window = src.slice(Math.max(0, idx - 400), idx + 50);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -157,7 +157,7 @@ function SearchResultsInner() {
           <p className="text-sm mt-2">Start typing in the search bar above.</p>
           <Link
             href="/"
-            className="mt-5 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
+            className="mt-5 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
           >
             Browse books <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
           </Link>
@@ -187,7 +187,7 @@ function SearchResultsInner() {
           <p className="text-sm mt-2">Try a shorter or different word.</p>
           <Link
             href="/"
-            className="mt-5 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0"
+            className="mt-5 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
           >
             Browse books <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
           </Link>


### PR DESCRIPTION
## What changed

Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700` to the two "Browse books" `<Link>` CTAs in `src/app/search/page.tsx`:
- Empty/no-query state (shown before the user types anything)
- No-results state (shown when a search yields 0 matches)

Both were rendering the browser's default blue focus outline instead of the amber design-system ring that every other primary CTA uses.

## Why

WCAG 2.4.7 (Focus Visible) requires keyboard focus to be clearly visible. Inconsistent ring styling also breaks the amber design language established across the whole app.

## Test plan

- [x] New static-analysis test `SearchEmptyStateFocusRing.test.ts` — 3 assertions confirm `focus:outline-none`, `focus-visible:ring-2`, and `focus-visible:ring-amber-400` are present on the "Browse books" Link
- [x] Full frontend suite: 3576 tests, 584 suites — all pass

Closes #2225
