### PR TITLE
ux: fix admin Retry button touch target from 36px to 44px (closes #2227)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -213,7 +213,8 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.15 | focus-visible ring to not-found and error page CTA links — closes #2218 (PR #2219) | ✅ Done |
 | 2026-04-29 | 11.16 | focus-visible ring to &lt;summary&gt; disclosures in QueueTab and SeedPopularButton — closes #2220 (PR #2221) | ✅ Done |
 | 2026-04-29 | 11.17 | dark-mode WCAG AA contrast for text-stone-600/700/500 — closes #2223 (PR #2224) | ✅ Done |
-| 2026-04-29 | 11.18 | focus-visible ring on search empty-state CTA Links (both no-query and no-results states) — closes #2225 | 🔄 In progress |
+| 2026-04-29 | 11.18 | focus-visible ring on search empty-state CTA Links (both no-query and no-results states) — closes #2225 (PR #2226) | ✅ Done |
+| 2026-04-29 | 11.19 | fix admin Retry button touch target: min-h-[36px] → min-h-[44px] md:min-h-0 in uploads and books admin pages — closes #2227 | 🔄 In progress |
 
 ---
 

--- a/frontend/src/__tests__/AdminRetryTouchTarget.test.ts
+++ b/frontend/src/__tests__/AdminRetryTouchTarget.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Static-analysis tests: admin error-state Retry buttons must use
+ * min-h-[44px] md:min-h-0 (not bare min-h-[36px]) for mobile touch targets.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+function src(file: string) {
+  return fs.readFileSync(path.resolve(__dirname, "../app", file), "utf-8");
+}
+
+describe("Admin Retry button touch targets", () => {
+  it("admin/uploads/page.tsx error Retry button uses min-h-[44px], not min-h-[36px]", () => {
+    const content = src("admin/uploads/page.tsx");
+    // Anchor on the border-red-300 class which appears only on the Retry button
+    const idx = content.indexOf("border-red-300 text-red-700");
+    expect(idx).toBeGreaterThan(-1);
+    const window = content.slice(Math.max(0, idx - 50), idx + 200);
+    expect(window).not.toContain("min-h-[36px]");
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("admin/uploads/page.tsx error Retry button uses md:min-h-0", () => {
+    const content = src("admin/uploads/page.tsx");
+    const idx = content.indexOf("border-red-300 text-red-700");
+    const window = content.slice(Math.max(0, idx - 50), idx + 200);
+    expect(window).toContain("md:min-h-0");
+  });
+
+  it("admin/books/page.tsx has no bare min-h-[36px] touch targets", () => {
+    const content = src("admin/books/page.tsx");
+    expect(content).not.toContain("min-h-[36px]");
+  });
+});

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -254,7 +254,7 @@ export default function BooksPage() {
           <button
             type="button"
             onClick={() => load()}
-            className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-red-300 text-red-700 hover:bg-red-100 text-xs font-medium transition-colors min-h-[36px] focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
+            className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-red-300 text-red-700 hover:bg-red-100 text-xs font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
           >
             <RetryIcon className="w-3.5 h-3.5" aria-hidden="true" />
             Retry

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -92,7 +92,7 @@ export default function UploadsPage() {
           <button
             type="button"
             onClick={() => load()}
-            className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-red-300 text-red-700 hover:bg-red-100 text-xs font-medium transition-colors min-h-[36px] focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
+            className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-red-300 text-red-700 hover:bg-red-100 text-xs font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
           >
             <RetryIcon className="w-3.5 h-3.5" aria-hidden="true" />
             Retry


### PR DESCRIPTION
## What changed

- `admin/uploads/page.tsx`: error-state Retry button `min-h-[36px]` → `min-h-[44px] md:min-h-0`
- `admin/books/page.tsx`: same fix (bare `min-h-[36px]` removed)

## Why

Mobile WCAG 2.5.5 touch target minimum is 44×44px. The error Retry buttons in both admin pages used `min-h-[36px]`, falling 8px short. Desktop keeps natural compact height via `md:min-h-0`.

## Test plan

- Added `AdminRetryTouchTarget.test.ts` (static-analysis): asserts the Retry button anchor (`border-red-300 text-red-700`) contains `min-h-[44px]` and `md:min-h-0`, and that `admin/books/page.tsx` has no bare `min-h-[36px]`
- All 3576 frontend tests pass

Closes #2227

## Docs follow-up

Design change log updated in `docs/design-improvement-plan.md` (entry 11.18).
