### PR TITLE
ux: add focus-visible ring to reader Gemini reminder banner button (closes #2229)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -214,7 +214,8 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.16 | focus-visible ring to &lt;summary&gt; disclosures in QueueTab and SeedPopularButton — closes #2220 (PR #2221) | ✅ Done |
 | 2026-04-29 | 11.17 | dark-mode WCAG AA contrast for text-stone-600/700/500 — closes #2223 (PR #2224) | ✅ Done |
 | 2026-04-29 | 11.18 | focus-visible ring on search empty-state CTA Links (both no-query and no-results states) — closes #2225 (PR #2226) | ✅ Done |
-| 2026-04-29 | 11.19 | fix admin Retry button touch target: min-h-[36px] → min-h-[44px] md:min-h-0 in uploads and books admin pages — closes #2227 | 🔄 In progress |
+| 2026-04-29 | 11.19 | fix admin Retry button touch target: min-h-[36px] → min-h-[44px] md:min-h-0 in uploads and books admin pages — closes #2227 (PR #2228) | ✅ Done |
+| 2026-04-29 | 11.20 | focus-visible ring on reader Gemini reminder banner "Add your free Gemini API key" button — closes #2229 | 🔄 In progress |
 
 ---
 

--- a/frontend/src/__tests__/ReaderGeminiBannerFocusRing.test.ts
+++ b/frontend/src/__tests__/ReaderGeminiBannerFocusRing.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Static-analysis test: reader Gemini reminder banner "Add your free Gemini API key"
+ * button must have a focus-visible ring for keyboard accessibility (WCAG 2.4.7).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf-8",
+);
+
+describe("Reader Gemini banner focus ring", () => {
+  it("'Add your free Gemini API key' button exists", () => {
+    expect(src).toContain("Add your free Gemini API key");
+  });
+
+  it("button has focus:outline-none", () => {
+    const idx = src.indexOf("Add your free Gemini API key");
+    const window = src.slice(Math.max(0, idx - 300), idx + 50);
+    expect(window).toContain("focus:outline-none");
+  });
+
+  it("button has focus-visible:ring-2", () => {
+    const idx = src.indexOf("Add your free Gemini API key");
+    const window = src.slice(Math.max(0, idx - 300), idx + 50);
+    expect(window).toContain("focus-visible:ring-2");
+  });
+
+  it("button has focus-visible:ring-amber-400", () => {
+    const idx = src.indexOf("Add your free Gemini API key");
+    const window = src.slice(Math.max(0, idx - 300), idx + 50);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -870,7 +870,7 @@ export default function ReaderPage() {
             AI features require your own Gemini API key.{" "}
             <button
               onClick={() => { window.open("/profile", "_blank"); }}
-              className="underline font-medium hover:text-amber-900 min-h-[44px] md:min-h-0 inline-flex items-center"
+              className="underline font-medium hover:text-amber-900 min-h-[44px] md:min-h-0 inline-flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               Add your free Gemini API key
             </button>{" "}


### PR DESCRIPTION
## What changed

Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded` to the "Add your free Gemini API key" button inside the reader page Gemini reminder banner (`app/reader/[bookId]/page.tsx` line 873).

## Why

The button was missing a keyboard focus indicator. When users tab to this button, no visible ring appeared — a WCAG 2.4.7 (Focus Visible) and WCAG 2.4.11 (Focus Appearance) violation.

## Test plan

- Added `ReaderGeminiBannerFocusRing.test.ts` (static-analysis): asserts the button className includes `focus:outline-none`, `focus-visible:ring-2`, and `focus-visible:ring-amber-400`
- All 3583 frontend tests pass

Closes #2229
