### PR TITLE
ux: add aria-disabled to upload dropzone when quota full or uploading (closes #2231)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -215,7 +215,8 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.17 | dark-mode WCAG AA contrast for text-stone-600/700/500 — closes #2223 (PR #2224) | ✅ Done |
 | 2026-04-29 | 11.18 | focus-visible ring on search empty-state CTA Links (both no-query and no-results states) — closes #2225 (PR #2226) | ✅ Done |
 | 2026-04-29 | 11.19 | fix admin Retry button touch target: min-h-[36px] → min-h-[44px] md:min-h-0 in uploads and books admin pages — closes #2227 (PR #2228) | ✅ Done |
-| 2026-04-29 | 11.20 | focus-visible ring on reader Gemini reminder banner "Add your free Gemini API key" button — closes #2229 | 🔄 In progress |
+| 2026-04-29 | 11.20 | focus-visible ring on reader Gemini reminder banner "Add your free Gemini API key" button — closes #2229 (PR #2230) | ✅ Done |
+| 2026-04-29 | 11.21 | upload dropzone role=button missing aria-disabled when quota full or uploading — closes #2231 | 🔄 In progress |
 
 ---
 

--- a/frontend/src/__tests__/UploadDropzoneAriaDisabled.test.ts
+++ b/frontend/src/__tests__/UploadDropzoneAriaDisabled.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Static-analysis test: the upload dropzone (role=button) must include
+ * aria-disabled to communicate its disabled state to screen readers when
+ * quota is full or a file is being uploaded (WCAG 4.1.2 Name, Role, Value).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "../app/upload/page.tsx"),
+  "utf-8",
+);
+
+describe("Upload dropzone aria-disabled", () => {
+  it("dropzone has role=button", () => {
+    expect(src).toContain('role="button"');
+  });
+
+  it("dropzone has aria-disabled attribute", () => {
+    // The aria-disabled must appear near the role=button anchor
+    const idx = src.indexOf('role="button"');
+    const window = src.slice(Math.max(0, idx - 20), idx + 300);
+    expect(window).toContain("aria-disabled");
+  });
+});

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -147,6 +147,7 @@ export default function UploadPage() {
         <div
           role="button"
           aria-label="Upload a book file"
+          aria-disabled={quotaFull || uploading}
           tabIndex={0}
           onClick={() => !uploading && !quotaFull && fileInputRef.current?.click()}
           onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && !uploading && !quotaFull && fileInputRef.current?.click()}


### PR DESCRIPTION
## What changed

Added `aria-disabled={quotaFull || uploading}` to the upload dropzone (`role="button"`) in `app/upload/page.tsx`.

## Why

When the upload quota is full or a file is being uploaded, the dropzone is visually disabled (opacity-50, cursor-not-allowed) but lacked `aria-disabled`. Screen readers announced it as an active button with no indication of its unavailable state — a WCAG 4.1.2 (Name, Role, Value) violation.

With `aria-disabled`, screen readers announce the control as "dimmed" / "unavailable" when appropriate.

## Test plan

- Added `UploadDropzoneAriaDisabled.test.ts` (static-analysis): asserts `aria-disabled` appears next to the `role="button"` dropzone
- All 3581 frontend tests pass

Closes #2231
