### PR TITLE
ux: add amber focus ring to select elements (closes #2233)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -216,7 +216,8 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.18 | focus-visible ring on search empty-state CTA Links (both no-query and no-results states) — closes #2225 (PR #2226) | ✅ Done |
 | 2026-04-29 | 11.19 | fix admin Retry button touch target: min-h-[36px] → min-h-[44px] md:min-h-0 in uploads and books admin pages — closes #2227 (PR #2228) | ✅ Done |
 | 2026-04-29 | 11.20 | focus-visible ring on reader Gemini reminder banner "Add your free Gemini API key" button — closes #2229 (PR #2230) | ✅ Done |
-| 2026-04-29 | 11.21 | upload dropzone role=button missing aria-disabled when quota full or uploading — closes #2231 | 🔄 In progress |
+| 2026-04-29 | 11.21 | upload dropzone role=button missing aria-disabled when quota full or uploading — closes #2231 (PR #2232) | ✅ Done |
+| 2026-04-29 | 11.22 | select elements missing amber focus ring across admin/books, home, reader, QueueTab — closes #2233 | 🔄 In progress |
 
 ---
 

--- a/frontend/src/__tests__/AdminBooksAriaLabels.test.ts
+++ b/frontend/src/__tests__/AdminBooksAriaLabels.test.ts
@@ -17,8 +17,8 @@ describe("admin/books page form controls aria-label (closes #959)", () => {
   it("translation language select has aria-label", () => {
     const idx = src.indexOf('title="Pick a language to queue for translation"');
     expect(idx).toBeGreaterThan(-1);
-    // aria-label sits before a long className, look back 350 chars
-    const window = src.slice(Math.max(0, idx - 350), idx + 60);
+    // aria-label sits before a long className, look back 400 chars
+    const window = src.slice(Math.max(0, idx - 400), idx + 60);
     expect(window).toContain('aria-label="Translation language"');
   });
 

--- a/frontend/src/__tests__/SelectFocusRing.test.ts
+++ b/frontend/src/__tests__/SelectFocusRing.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Static-analysis test: select elements that are visible to keyboard users must
+ * carry the app's amber focus-ring classes for visual consistency (WCAG 2.4.7).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+function read(rel: string) {
+  return fs.readFileSync(path.resolve(__dirname, rel), "utf-8");
+}
+
+function assertSelectHasFocusRing(src: string, anchorText: string) {
+  const idx = src.indexOf(anchorText);
+  expect(idx).toBeGreaterThan(-1);
+  // Slice a window that covers the select's className attribute
+  const window = src.slice(idx, idx + 400);
+  expect(window).toContain("focus:outline-none");
+  expect(window).toContain("focus:ring-2");
+  expect(window).toContain("focus:ring-amber-400");
+}
+
+describe("Select focus ring — admin/books", () => {
+  const src = read("../app/admin/books/page.tsx");
+  it("translation language select has amber focus ring", () => {
+    assertSelectHasFocusRing(src, 'aria-label="Translation language"');
+  });
+});
+
+describe("Select focus ring — home page", () => {
+  const src = read("../app/page.tsx");
+  it("filter-by-language select has amber focus ring", () => {
+    assertSelectHasFocusRing(src, 'aria-label="Filter by language"');
+  });
+});
+
+describe("Select focus ring — reader page", () => {
+  const src = read("../app/reader/[bookId]/page.tsx");
+  it("reader translation language select (desktop) has amber focus ring", () => {
+    assertSelectHasFocusRing(src, 'id="reader-trans-lang"');
+  });
+  it("reader translation language select (mobile) has amber focus ring", () => {
+    // Mobile select uses aria-label="Translation language" in the slide-up panel
+    const mobileIdx = src.indexOf('aria-label="Translation language"', src.indexOf("md:hidden fixed bottom-0"));
+    expect(mobileIdx).toBeGreaterThan(-1);
+    const window = src.slice(mobileIdx, mobileIdx + 300);
+    expect(window).toContain("focus:outline-none");
+    expect(window).toContain("focus:ring-2");
+    expect(window).toContain("focus:ring-amber-400");
+  });
+});
+
+describe("Select focus ring — QueueTab", () => {
+  const src = read("../components/QueueTab.tsx");
+  it("preview language select has amber focus ring", () => {
+    assertSelectHasFocusRing(src, 'aria-label="Preview language"');
+  });
+});

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -483,7 +483,7 @@ export default function BooksPage() {
                   aria-label="Translation language"
                   value={newLangInput[b.id] ?? "zh"}
                   onChange={(e) => setNewLangInput({ ...newLangInput, [b.id]: e.target.value })}
-                  className="text-xs rounded border border-amber-300 px-1.5 py-0.5 shrink-0 bg-white"
+                  className="text-xs rounded border border-amber-300 px-1.5 py-0.5 shrink-0 bg-white focus:outline-none focus:ring-2 focus:ring-amber-400"
                   title="Pick a language to queue for translation"
                 >
                   {QUEUE_LANG_OPTIONS.map((o) => (

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -591,7 +591,7 @@ export default function Home() {
                 <div className="flex gap-2">
                   <select
                     aria-label="Filter by language"
-                    className="rounded-lg border border-amber-300 bg-white px-3 py-2.5 text-sm text-ink flex-1 sm:flex-none"
+                    className="rounded-lg border border-amber-300 bg-white px-3 py-2.5 text-sm text-ink flex-1 sm:flex-none focus:outline-none focus:ring-2 focus:ring-amber-400"
                     value={lang}
                     onChange={(e) => setLang(e.target.value)}
                   >

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2022,7 +2022,7 @@ export default function ReaderPage() {
                       <label htmlFor="reader-trans-lang" className="block text-xs text-amber-700 mb-1">Target language</label>
                       <select
                         id="reader-trans-lang"
-                        className="w-full text-sm rounded-lg border border-amber-300 px-3 py-2 text-ink bg-white"
+                        className="w-full text-sm rounded-lg border border-amber-300 px-3 py-2 text-ink bg-white focus:outline-none focus:ring-2 focus:ring-amber-400"
                         value={translationLang}
                         onChange={(e) => {
                           setTranslationLang(e.target.value);
@@ -2239,7 +2239,7 @@ export default function ReaderPage() {
             <div className="bg-white/95 backdrop-blur border-t border-amber-200 px-3 py-2 flex items-center gap-2 animate-slide-up">
               <select
                 aria-label="Translation language"
-                className="text-xs rounded border border-amber-300 px-2 py-2 text-ink bg-white flex-1 min-h-[44px] md:min-h-0"
+                className="text-xs rounded border border-amber-300 px-2 py-2 text-ink bg-white flex-1 min-h-[44px] md:min-h-0 focus:outline-none focus:ring-2 focus:ring-amber-400"
                 value={translationLang}
                 onChange={(e) => setTranslationLang(e.target.value)}
               >

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -756,7 +756,7 @@ export default function QueueTab({ adminFetch }: Props) {
             aria-label="Preview language"
             value={dryRunLang}
             onChange={(e) => { setDryRunLang(e.target.value); setDryRunResult(null); setPlanResult(null); }}
-            className="rounded border border-amber-300 px-2 py-1 text-sm bg-white"
+            className="rounded border border-amber-300 px-2 py-1 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-amber-400"
           >
             {[
               { code: "zh", label: "Chinese (zh)" },


### PR DESCRIPTION
## What

Five `<select>` elements were missing the app-standard amber focus ring (`focus:outline-none focus:ring-2 focus:ring-amber-400`), causing keyboard users to see inconsistent browser-default focus rings instead of the amber style used everywhere else in the UI.

**Affected locations:**
- `src/app/admin/books/page.tsx` — Translation language select
- `src/app/page.tsx` — Filter by language select
- `src/app/reader/[bookId]/page.tsx` — Target language select (desktop panel)
- `src/app/reader/[bookId]/page.tsx` — Translation language select (mobile slide-up panel)
- `src/components/QueueTab.tsx` — Preview language select

## Why

WCAG 2.4.7 Focus Visible — browser-default focus rings vary per OS/browser and may not meet the 3:1 contrast ratio against the amber border background. The profile page's selects already use `focus:ring-2 focus:ring-amber-400` as the correct pattern; this brings all other selects in line.

## Test plan

- Added `SelectFocusRing.test.ts` — 5 static-analysis assertions (one per fixed select), confirming presence of `focus:outline-none`, `focus:ring-2`, `focus:ring-amber-400`
- Updated `AdminBooksAriaLabels.test.ts` look-back window from 350 → 400 chars (the added classes pushed `aria-label` just past the old window boundary)
- All 3590 frontend tests pass

Closes #2233
