### PR TITLE
ux: add title tooltips to truncated deck/book names (closes #2235)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -218,9 +218,9 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.20 | focus-visible ring on reader Gemini reminder banner "Add your free Gemini API key" button — closes #2229 (PR #2230) | ✅ Done |
 | 2026-04-29 | 11.21 | upload dropzone role=button missing aria-disabled when quota full or uploading — closes #2231 (PR #2232) | ✅ Done |
 | 2026-04-29 | 11.22 | select elements missing amber focus ring across admin/books, home, reader, QueueTab — closes #2233 (PR #2234) | ✅ Done |
-| 2026-04-29 | 11.23 | title tooltips for truncated deck name (DeckCard h2, deck-detail h1) and book title (notes list) — closes #2235 (PR #2236) | 🔄 In progress |
+| 2026-04-29 | 11.23 | title tooltips for truncated deck name (DeckCard h2, deck-detail h1) and book title (notes list) — closes #2235 (PR #2236) | ✅ Done |
 | 2026-04-29 | 11.24 | title tooltips for reader header truncated book title h1 and authors p — closes #2237 (PR #2238) | ✅ Done |
-| 2026-04-29 | 11.25 | title tooltips for profile deck names, SeedPopularButton current title, QueueTab retry/error — closes #2239 (PR #2240) | 🔄 In progress |
+| 2026-04-29 | 11.25 | title tooltips for profile deck names, SeedPopularButton current title, QueueTab retry/error — closes #2239 (PR #2240) | ✅ Done |
 
 ---
 

--- a/frontend/src/__tests__/TruncatedTitleTooltips.test.ts
+++ b/frontend/src/__tests__/TruncatedTitleTooltips.test.ts
@@ -1,5 +1,5 @@
 /**
- * Regression tests for #2212: truncated book title/author <p> elements must
+ * Regression tests for #2212, #2235, #2237, #2239: truncated book/deck title elements must
  * have title attributes so sighted mouse users can hover to read the full text.
  */
 import * as fs from "fs";
@@ -27,6 +27,18 @@ const seedSrc = fs.readFileSync(
 );
 const queueTabSrc = fs.readFileSync(
   path.join(__dirname, "../components/QueueTab.tsx"),
+  "utf8"
+);
+const notesSrc = fs.readFileSync(
+  path.join(__dirname, "../app/notes/page.tsx"),
+  "utf8"
+);
+const deckDetailSrc = fs.readFileSync(
+  path.join(__dirname, "../app/decks/[deckId]/page.tsx"),
+  "utf8"
+);
+const deckCardSrc = fs.readFileSync(
+  path.join(__dirname, "../components/DeckCard.tsx"),
   "utf8"
 );
 
@@ -66,6 +78,33 @@ describe("Truncated title tooltip coverage — reader header (closes #2237)", ()
   it("reader header authors paragraph has title attribute", () => {
     const idx = readerSrc.indexOf('text-amber-700 truncate" title={meta.authors.join(", ")}');
     expect(idx).toBeGreaterThan(-1);
+  });
+});
+
+describe("Truncated title tooltip coverage — notes page (closes #2235)", () => {
+  it("book title in notes list has title attribute", () => {
+    const idx = notesSrc.indexOf("book.title");
+    expect(idx).toBeGreaterThan(-1);
+    const window = notesSrc.slice(Math.max(0, idx - 200), idx + 50);
+    expect(window).toContain("title=");
+  });
+});
+
+describe("Truncated title tooltip coverage — deck detail page (closes #2235)", () => {
+  it("deck name h1 has title attribute", () => {
+    const idx = deckDetailSrc.indexOf("deck?.name");
+    expect(idx).toBeGreaterThan(-1);
+    const window = deckDetailSrc.slice(Math.max(0, idx - 200), idx + 50);
+    expect(window).toContain("title=");
+  });
+});
+
+describe("Truncated title tooltip coverage — DeckCard (closes #2235)", () => {
+  it("deck name in card heading has title attribute", () => {
+    const idx = deckCardSrc.indexOf("deck.name");
+    expect(idx).toBeGreaterThan(-1);
+    const window = deckCardSrc.slice(Math.max(0, idx - 150), idx + 50);
+    expect(window).toContain("title=");
   });
 });
 

--- a/frontend/src/app/decks/[deckId]/page.tsx
+++ b/frontend/src/app/decks/[deckId]/page.tsx
@@ -136,7 +136,7 @@ export default function DeckDetailPage() {
           <ArrowLeftIcon className="w-4 h-4 shrink-0" /> Decks
         </button>
         <div className="flex-1 min-w-0">
-          <h1 className="font-serif font-bold text-ink truncate">
+          <h1 className="font-serif font-bold text-ink truncate" title={deck?.name}>
             {deck?.name ?? "Deck"}
           </h1>
           {deck && (

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -211,7 +211,7 @@ export default function NotesOverviewPage() {
               >
                 <div className="flex items-start gap-3">
                   <div className="flex-1 min-w-0">
-                    <p className="font-serif font-semibold text-ink text-base leading-snug group-hover:text-amber-900 transition-colors truncate">
+                    <p className="font-serif font-semibold text-ink text-base leading-snug group-hover:text-amber-900 transition-colors truncate" title={book.title}>
                       {book.title}
                     </p>
                     <div className="flex flex-wrap gap-2 mt-1.5">

--- a/frontend/src/components/DeckCard.tsx
+++ b/frontend/src/components/DeckCard.tsx
@@ -15,7 +15,7 @@ export default function DeckCard({ deck, onClick, onDelete }: DeckCardProps) {
     <>
       <div className="flex items-center gap-2 flex-wrap">
         <DeckIcon className="w-4 h-4 text-amber-600 shrink-0" />
-        <h2 className="font-serif font-semibold text-ink text-base truncate">
+        <h2 className="font-serif font-semibold text-ink text-base truncate" title={deck.name}>
           {deck.name}
         </h2>
         <span


### PR DESCRIPTION
## What

Three `class=truncate` text elements were missing `title=` attributes, leaving users no way to read the full text on hover when names are long:

- `src/app/notes/page.tsx` — book title `<p>` in the notes index list
- `src/app/decks/[deckId]/page.tsx` — deck name `<h1>` in the page header
- `src/components/DeckCard.tsx` — deck name `<h2>` in the deck card

## Why

PR #2213 (closes #2212) established the pattern of adding `title={fullText}` to truncated elements on the home page and BookCard. These three locations were missed in that sweep.

## Test plan

- Extended `TruncatedTitleTooltips.test.ts` with 3 new static-analysis assertions (one per fixed element), matching the existing test pattern
- All 3593 frontend tests pass

Closes #2235
