### PR TITLE
ux: add title tooltips to reader header truncated title and authors (closes #2237)

### DIFF
--- a/frontend/src/__tests__/TruncatedTitleTooltips.test.ts
+++ b/frontend/src/__tests__/TruncatedTitleTooltips.test.ts
@@ -13,6 +13,10 @@ const cardSrc = fs.readFileSync(
   path.join(__dirname, "../components/BookCard.tsx"),
   "utf8"
 );
+const readerSrc = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
 
 describe("Truncated title tooltip coverage (closes #2212)", () => {
   it("Popular Classics list-view book title has title attribute", () => {
@@ -37,6 +41,18 @@ describe("Truncated title tooltip coverage (closes #2212)", () => {
 
   it("BookCard author paragraph has title attribute", () => {
     const idx = cardSrc.indexOf('line-clamp-1" title={book.authors.join(", ")}');
+    expect(idx).toBeGreaterThan(-1);
+  });
+});
+
+describe("Truncated title tooltip coverage — reader header (closes #2237)", () => {
+  it("reader header h1 book title has title attribute", () => {
+    const idx = readerSrc.indexOf('truncate text-sm" title={meta.title}');
+    expect(idx).toBeGreaterThan(-1);
+  });
+
+  it("reader header authors paragraph has title attribute", () => {
+    const idx = readerSrc.indexOf('text-amber-700 truncate" title={meta.authors.join(", ")}');
     expect(idx).toBeGreaterThan(-1);
   });
 });

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -965,7 +965,7 @@ export default function ReaderPage() {
             {meta ? (
               <>
                 <div className="flex items-baseline gap-1.5 min-w-0">
-                  <h1 className="font-serif font-bold text-ink truncate text-sm">{meta.title}</h1>
+                  <h1 className="font-serif font-bold text-ink truncate text-sm" title={meta.title}>{meta.title}</h1>
                   {chapterSource === "upload" && (
                     <span
                       className="shrink-0 text-[10px] font-medium text-amber-700 bg-amber-100 border border-amber-200 rounded px-1 py-0.5 leading-none"
@@ -1001,7 +1001,7 @@ export default function ReaderPage() {
                     ><ArrowUpRightIcon className="w-3 h-3" aria-hidden="true" /></a>
                   )}
                 </div>
-                <p className="text-xs text-amber-700 truncate">{meta.authors.join(", ")}</p>
+                <p className="text-xs text-amber-700 truncate" title={meta.authors.join(", ")}>{meta.authors.join(", ")}</p>
               </>
             ) : (
               <div className="h-4 w-48 bg-amber-200 animate-pulse rounded" aria-hidden="true" />


### PR DESCRIPTION
## What

The reader page header displays truncated book title (`<h1>`) and authors (`<p>`) elements without `title=` attributes, so mouse users have no way to read the full text when names are long enough to be clipped.

- `src/app/reader/[bookId]/page.tsx` L968 — `<h1 class="… truncate">` → added `title={meta.title}`
- `src/app/reader/[bookId]/page.tsx` L1004 — `<p class="… truncate">` → added `title={meta.authors.join(", ")}`

## Why

Follows the pattern established in PR #2213 (closes #2212) for the home page and BookCard, and extended in PR #2236 (closes #2235) for notes and deck pages. Sighted mouse users need a hover tooltip to read truncated text — without it the content is effectively hidden.

## Test plan

- Added two assertions to `TruncatedTitleTooltips.test.ts` that confirm both truncated elements in the reader header carry a `title=` attribute
- Full frontend suite: 3592 tests pass
- Full backend suite: 1941 tests pass

Closes #2237
