### PR TITLE
ux: add title tooltips to profile deck names, SeedPopularButton, and QueueTab errors (closes #2239)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -217,7 +217,10 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.19 | fix admin Retry button touch target: min-h-[36px] → min-h-[44px] md:min-h-0 in uploads and books admin pages — closes #2227 (PR #2228) | ✅ Done |
 | 2026-04-29 | 11.20 | focus-visible ring on reader Gemini reminder banner "Add your free Gemini API key" button — closes #2229 (PR #2230) | ✅ Done |
 | 2026-04-29 | 11.21 | upload dropzone role=button missing aria-disabled when quota full or uploading — closes #2231 (PR #2232) | ✅ Done |
-| 2026-04-29 | 11.22 | select elements missing amber focus ring across admin/books, home, reader, QueueTab — closes #2233 | 🔄 In progress |
+| 2026-04-29 | 11.22 | select elements missing amber focus ring across admin/books, home, reader, QueueTab — closes #2233 (PR #2234) | ✅ Done |
+| 2026-04-29 | 11.23 | title tooltips for truncated deck name (DeckCard h2, deck-detail h1) and book title (notes list) — closes #2235 (PR #2236) | 🔄 In progress |
+| 2026-04-29 | 11.24 | title tooltips for reader header truncated book title h1 and authors p — closes #2237 (PR #2238) | ✅ Done |
+| 2026-04-29 | 11.25 | title tooltips for profile deck names, SeedPopularButton current title, QueueTab retry/error — closes #2239 (PR #2240) | 🔄 In progress |
 
 ---
 

--- a/frontend/src/__tests__/ErrorRoleAlert1256.test.ts
+++ b/frontend/src/__tests__/ErrorRoleAlert1256.test.ts
@@ -18,7 +18,8 @@ describe("role=alert on dynamic error containers (closes #1256)", () => {
     const src = read("../components/QueueTab.tsx");
     const idx = src.indexOf("Last error:");
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(Math.max(0, idx - 100), idx + 50);
+    // look back 150 chars: title= attribute before closing > can extend the line
+    const window = src.slice(Math.max(0, idx - 150), idx + 50);
     expect(window).toMatch(/role="alert"/);
   });
 

--- a/frontend/src/__tests__/TruncatedTitleTooltips.test.ts
+++ b/frontend/src/__tests__/TruncatedTitleTooltips.test.ts
@@ -17,6 +17,18 @@ const readerSrc = fs.readFileSync(
   path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
   "utf8"
 );
+const profileSrc = fs.readFileSync(
+  path.join(__dirname, "../app/profile/page.tsx"),
+  "utf8"
+);
+const seedSrc = fs.readFileSync(
+  path.join(__dirname, "../components/SeedPopularButton.tsx"),
+  "utf8"
+);
+const queueTabSrc = fs.readFileSync(
+  path.join(__dirname, "../components/QueueTab.tsx"),
+  "utf8"
+);
 
 describe("Truncated title tooltip coverage (closes #2212)", () => {
   it("Popular Classics list-view book title has title attribute", () => {
@@ -53,6 +65,32 @@ describe("Truncated title tooltip coverage — reader header (closes #2237)", ()
 
   it("reader header authors paragraph has title attribute", () => {
     const idx = readerSrc.indexOf('text-amber-700 truncate" title={meta.authors.join(", ")}');
+    expect(idx).toBeGreaterThan(-1);
+  });
+});
+
+describe("Truncated title tooltip coverage — profile/SeedPopularButton/QueueTab (closes #2239)", () => {
+  it("profile Study Today deck button has title attribute for deck name", () => {
+    const idx = profileSrc.indexOf("title={d.name}");
+    expect(idx).toBeGreaterThan(-1);
+    const window = profileSrc.slice(Math.max(0, idx - 200), idx + 60);
+    expect(window).toContain("gotoFlashcardsForDeck");
+  });
+
+  it("SeedPopularButton current book title paragraph has title attribute", () => {
+    const idx = seedSrc.indexOf("title={state.current_book_title}");
+    expect(idx).toBeGreaterThan(-1);
+    const window = seedSrc.slice(Math.max(0, idx - 150), idx + 50);
+    expect(window).toContain("truncate");
+  });
+
+  it("QueueTab retry reason div has title attribute", () => {
+    const idx = queueTabSrc.indexOf('title={s.retry_reason}');
+    expect(idx).toBeGreaterThan(-1);
+  });
+
+  it("QueueTab last error div has title attribute", () => {
+    const idx = queueTabSrc.indexOf('title={s.last_error}');
     expect(idx).toBeGreaterThan(-1);
   });
 });

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -263,6 +263,7 @@ export default function ProfilePage() {
                     type="button"
                     onClick={() => gotoFlashcardsForDeck(d.id)}
                     aria-label={`Review ${d.due_today} due card${d.due_today !== 1 ? "s" : ""} in ${d.name}`}
+                    title={d.name}
                     className="w-full flex items-center gap-3 rounded-xl border border-amber-200 bg-white px-4 py-2 hover:border-amber-400 hover:bg-amber-50 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                   >
                     <DeckIcon className="w-4 h-4 text-amber-700 shrink-0" />

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -666,14 +666,14 @@ export default function QueueTab({ adminFetch }: Props) {
                 : ""}
             </div>
             {s.retry_reason && (
-              <div className="truncate">{s.retry_reason}</div>
+              <div className="truncate" title={s.retry_reason}>{s.retry_reason}</div>
             )}
           </div>
         ) : null}
 
         {/* Hard error — only shown once retries are exhausted. */}
         {s?.last_error && !(s.retry_attempt && s.retry_attempt > 0) && (
-          <div role="alert" className="text-xs text-red-600 bg-red-50 rounded px-2 py-1 truncate">
+          <div role="alert" className="text-xs text-red-600 bg-red-50 rounded px-2 py-1 truncate" title={s.last_error}>
             Last error: {s.last_error}
           </div>
         )}

--- a/frontend/src/components/SeedPopularButton.tsx
+++ b/frontend/src/components/SeedPopularButton.tsx
@@ -242,7 +242,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
           )}
 
           {running && state.current_book_title && (
-            <p className="text-xs text-amber-700 truncate flex items-center gap-1">
+            <p className="text-xs text-amber-700 truncate flex items-center gap-1" title={state.current_book_title}>
               <ChevronDownIcon className="w-3.5 h-3.5 shrink-0" />
               <span className="truncate">{state.current_book_title}</span>
             </p>


### PR DESCRIPTION
## What

Three more truncated dynamic text elements were missing `title=` attributes, leaving mouse users unable to hover to read the full content:

1. **Profile page** `src/app/profile/page.tsx` — deck name `{d.name}` in the "Study Today" deck button gets clipped for long names; added `title={d.name}` to the `<button>`.
2. **SeedPopularButton** `src/components/SeedPopularButton.tsx` — `{state.current_book_title}` in the "currently downloading" `<p>` was truncated; added `title={state.current_book_title}` to the `<p>`.
3. **QueueTab** `src/components/QueueTab.tsx` — retry reason and last-error `<div>` elements both had `truncate` but no tooltip; added `title={s.retry_reason}` and `title={s.last_error}` respectively.

Also expanded the `ErrorRoleAlert1256` test's lookback window from 100 → 150 chars to account for the `title=` attribute lengthening the `<div>` opening tag.

## Why

Follows the pattern from PR #2213 (#2212), PR #2236 (#2235), and PR #2238 (#2237). Sighted mouse users need a hover tooltip to read truncated dynamic text — without `title=`, content is silently hidden.

## Test plan

- Extended `TruncatedTitleTooltips.test.ts` with 4 new static-analysis assertions (profile deck name, SeedPopularButton title, QueueTab retry reason, QueueTab last error)
- Full frontend suite: 3596 tests pass (includes reader-header tests from #2238)

Closes #2239
