### PR TITLE
ux: add sr-only new-tab announcements to all target=_blank links (closes #2241)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -221,6 +221,7 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.23 | title tooltips for truncated deck name (DeckCard h2, deck-detail h1) and book title (notes list) — closes #2235 (PR #2236) | ✅ Done |
 | 2026-04-29 | 11.24 | title tooltips for reader header truncated book title h1 and authors p — closes #2237 (PR #2238) | ✅ Done |
 | 2026-04-29 | 11.25 | title tooltips for profile deck names, SeedPopularButton current title, QueueTab retry/error — closes #2239 (PR #2240) | ✅ Done |
+| 2026-04-29 | 11.26 | target=_blank links missing sr-only "(opens in new tab)" announcement for screen readers — closes #2241 | 🔄 In progress |
 
 ---
 

--- a/frontend/src/__tests__/AnchorFocusRings.test.ts
+++ b/frontend/src/__tests__/AnchorFocusRings.test.ts
@@ -58,18 +58,19 @@ describe("Vocabulary page anchor focus ring (closes #2200)", () => {
 
 describe("InsightChat Gemini API key anchor focus rings (closes #2200)", () => {
   it("Gemini key notice anchor (first) has focus ring", () => {
-    // First occurrence ends with Gemini API key</a>{" "}
-    const idx = chatSrc.indexOf('Gemini API key</a>{" "}');
+    // First occurrence: ends with sr-only new-tab span then </a>{" "}
+    const idx = chatSrc.indexOf('href="/profile" target="_blank"');
     expect(idx).toBeGreaterThan(-1);
-    const window = chatSrc.slice(Math.max(0, idx - 150), idx + 10);
+    const window = chatSrc.slice(Math.max(0, idx - 10), idx + 300);
     expect(window).toContain("focus-visible:ring-amber-400");
   });
 
   it("Gemini key chat-panel anchor (second) has focus ring", () => {
-    // Second occurrence ends with Gemini API key</a>.
-    const idx = chatSrc.indexOf("Gemini API key</a>.");
+    // Second occurrence: same href pattern, further in file
+    const first = chatSrc.indexOf('href="/profile" target="_blank"');
+    const idx = chatSrc.indexOf('href="/profile" target="_blank"', first + 1);
     expect(idx).toBeGreaterThan(-1);
-    const window = chatSrc.slice(Math.max(0, idx - 150), idx + 10);
+    const window = chatSrc.slice(Math.max(0, idx - 10), idx + 300);
     expect(window).toContain("focus-visible:ring-amber-400");
   });
 });

--- a/frontend/src/__tests__/NewTabAnnouncement2241.test.ts
+++ b/frontend/src/__tests__/NewTabAnnouncement2241.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Regression tests for #2241: target=_blank links must announce
+ * "(opens in new tab)" to screen-reader users via sr-only text or aria-label.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+function read(rel: string) {
+  return fs.readFileSync(path.join(__dirname, rel), "utf8");
+}
+
+function assertNewTabAnnouncement(src: string, linkText: string, contextSearch: string) {
+  const idx = src.indexOf(contextSearch);
+  expect(idx).toBeGreaterThan(-1);
+  const window = src.slice(Math.max(0, idx - 100), idx + 300);
+  const hasNewTabText = window.includes("opens in new tab") || window.includes("(opens in new tab)");
+  expect(hasNewTabText).toBe(true);
+}
+
+describe("target=_blank new-tab announcement for screen readers (closes #2241)", () => {
+  it("reader header Gutenberg link announces new tab", () => {
+    const src = read("../app/reader/[bookId]/page.tsx");
+    const idx = src.indexOf("gutenberg.org/ebooks/");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 50), idx + 600);
+    expect(window).toMatch(/opens in new tab/);
+  });
+
+  it("vocabulary page Wiktionary link announces new tab", () => {
+    const src = read("../app/vocabulary/page.tsx");
+    const idx = src.indexOf("View on Wiktionary");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 50), idx + 200);
+    expect(window).toMatch(/opens in new tab/);
+  });
+
+  it("profile page Google AI Studio link announces new tab", () => {
+    const src = read("../app/profile/page.tsx");
+    const idx = src.indexOf("Google AI Studio");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 50), idx + 200);
+    expect(window).toMatch(/opens in new tab/);
+  });
+
+  it("VocabWordTooltip Wiktionary link announces new tab", () => {
+    const src = read("../components/VocabWordTooltip.tsx");
+    const idx = src.indexOf("Wiktionary");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 50), idx + 200);
+    expect(window).toMatch(/opens in new tab/);
+  });
+
+  it("BookDetailModal Gutenberg link announces new tab", () => {
+    const src = read("../components/BookDetailModal.tsx");
+    const idx = src.indexOf("Project Gutenberg");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 50), idx + 200);
+    expect(window).toMatch(/opens in new tab/);
+  });
+
+  it("InsightChat profile links announce new tab", () => {
+    const src = read("../components/InsightChat.tsx");
+    const idx = src.indexOf('target="_blank"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 100), idx + 300);
+    expect(window).toMatch(/opens in new tab/);
+  });
+});

--- a/frontend/src/__tests__/VocabFilterLiveRegion.test.ts
+++ b/frontend/src/__tests__/VocabFilterLiveRegion.test.ts
@@ -13,21 +13,18 @@ const src = readFileSync(
 
 describe("Vocabulary filter live region (closes #1850)", () => {
   it("has an sr-only aria-live region for filter result announcements", () => {
-    // Must have a visually-hidden live region (not just the export status div)
-    // that announces filter results
-    expect(src).toContain("sr-only");
-    // That sr-only element must be inside or accompanied by aria-live
-    const srIdx = src.indexOf("sr-only");
-    const window = src.slice(Math.max(0, srIdx - 300), srIdx + 300);
+    // The filter live region is a div with both aria-live and className="sr-only"
+    const idx = src.indexOf('aria-live="polite" aria-atomic="true" className="sr-only"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 50), idx + 200);
     expect(window).toContain("aria-live");
   });
 
   it("filter announcement references filtered word count", () => {
     // The sr-only live region must include the filtered count
-    const srIdx = src.indexOf("sr-only");
-    expect(srIdx).toBeGreaterThan(-1);
-    // Find the aria-live region containing sr-only
-    const window = src.slice(Math.max(0, srIdx - 400), srIdx + 400);
+    const idx = src.indexOf('aria-live="polite" aria-atomic="true" className="sr-only"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 100), idx + 300);
     // Should reference filtered length or a word count variable
     expect(window).toMatch(/filtered\.length|filterCount|wordCount/);
   });

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -295,7 +295,7 @@ export default function ProfilePage() {
               rel="noopener noreferrer"
               className="text-amber-700 underline focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
             >
-              Google AI Studio
+              Google AI Studio<span className="sr-only"> (opens in new tab)</span>
             </a>{" "}
             for higher-quality translations, insights, chat, and TTS.
             Without a key, translations use Google Translate and TTS uses

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -997,7 +997,7 @@ export default function ReaderPage() {
                       rel="noopener noreferrer"
                       className="shrink-0 text-xs text-amber-700 hover:text-amber-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
                       title="View on Project Gutenberg"
-                      aria-label="View on Project Gutenberg"
+                      aria-label="View on Project Gutenberg (opens in new tab)"
                     ><ArrowUpRightIcon className="w-3 h-3" aria-hidden="true" /></a>
                   )}
                 </div>

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -208,7 +208,7 @@ function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
               rel="noopener noreferrer"
               className="inline-block text-xs text-amber-700 hover:text-amber-800 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
             >
-              View on Wiktionary <ArrowUpRightIcon className="w-3 h-3 inline" aria-hidden="true" />
+              View on Wiktionary <ArrowUpRightIcon className="w-3 h-3 inline" aria-hidden="true" /><span className="sr-only"> (opens in new tab)</span>
             </a>
           )}
         </div>

--- a/frontend/src/components/BookDetailModal.tsx
+++ b/frontend/src/components/BookDetailModal.tsx
@@ -156,7 +156,7 @@ export default function BookDetailModal({ book, recentBook, onClose, onRead }: P
             rel="noopener noreferrer"
             className="text-xs text-amber-700 hover:text-amber-800 hover:underline ml-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
           >
-            View on Project Gutenberg <ArrowUpRightIcon className="w-3 h-3 inline" aria-hidden="true" />
+            View on Project Gutenberg <ArrowUpRightIcon className="w-3 h-3 inline" aria-hidden="true" /><span className="sr-only"> (opens in new tab)</span>
           </a>
         </div>
       </div>

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -416,7 +416,7 @@ export default function InsightChat({
       {!hasGeminiKey && (
         <div className="px-3 py-2 bg-amber-50 border-b border-amber-100 text-xs text-amber-800">
           Insights require a{" "}
-          <a href="/profile" target="_blank" rel="noopener noreferrer" className="underline font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded">Gemini API key</a>{" "}
+          <a href="/profile" target="_blank" rel="noopener noreferrer" className="underline font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded">Gemini API key<span className="sr-only"> (opens in new tab)</span></a>{" "}
           — free from Google AI Studio.
         </div>
       )}
@@ -583,7 +583,7 @@ export default function InsightChat({
         {!hasGeminiKey && (
           <div className="bg-amber-50 border border-amber-100 rounded-lg px-3 py-2 mb-2 text-xs text-amber-800">
             Chat requires a{" "}
-            <a href="/profile" target="_blank" rel="noopener noreferrer" className="underline font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded">Gemini API key</a>.
+            <a href="/profile" target="_blank" rel="noopener noreferrer" className="underline font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded">Gemini API key<span className="sr-only"> (opens in new tab)</span></a>.
           </div>
         )}
 

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -124,7 +124,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
             rel="noopener noreferrer"
             className="text-[11px] text-amber-700 hover:text-amber-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
           >
-            Wiktionary <ArrowUpRightIcon className="w-3 h-3 inline" aria-hidden="true" />
+            Wiktionary <ArrowUpRightIcon className="w-3 h-3 inline" aria-hidden="true" /><span className="sr-only"> (opens in new tab)</span>
           </a>
         ) : <span />}
         <button


### PR DESCRIPTION
## What changed

All `target="_blank"` links in the frontend now announce "(opens in new tab)" to screen-reader users:

- `app/reader/[bookId]/page.tsx` — Gutenberg header link: updated `aria-label` to include "(opens in new tab)"
- `app/vocabulary/page.tsx` — "View on Wiktionary" link: added `<span class="sr-only"> (opens in new tab)</span>`
- `app/profile/page.tsx` — "Google AI Studio" link: added sr-only span
- `components/VocabWordTooltip.tsx` — Wiktionary footer link: added sr-only span
- `components/BookDetailModal.tsx` — "View on Project Gutenberg" link: added sr-only span
- `components/InsightChat.tsx` — both `/profile` links (×2): added sr-only span inside anchor

## Why

WCAG 2.1 G201: users should be warned before a new window or tab is opened. Sighted users see the `ArrowUpRightIcon` visual hint, but that icon is `aria-hidden="true"` so screen-reader users had no indication that clicking would open a new tab.

## Test plan

- New test file `NewTabAnnouncement2241.test.ts` — 6 static-analysis tests that assert `opens in new tab` appears in the window around each affected link
- Updated `AnchorFocusRings.test.ts` and `VocabFilterLiveRegion.test.ts` whose search strings were broken by the added `<span>` inside anchor tags
- `npm test` → 3605 tests pass ✅

Closes #2241

## Docs follow-up

Change Log entry added to `docs/design-improvement-plan.md` (11.26).
