### PR TITLE
fix: always render vocab filter aria-live region for reliable first-keystroke announcement

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -221,7 +221,8 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.23 | title tooltips for truncated deck name (DeckCard h2, deck-detail h1) and book title (notes list) — closes #2235 (PR #2236) | ✅ Done |
 | 2026-04-29 | 11.24 | title tooltips for reader header truncated book title h1 and authors p — closes #2237 (PR #2238) | ✅ Done |
 | 2026-04-29 | 11.25 | title tooltips for profile deck names, SeedPopularButton current title, QueueTab retry/error — closes #2239 (PR #2240) | ✅ Done |
-| 2026-04-29 | 11.26 | target=_blank links missing sr-only "(opens in new tab)" announcement for screen readers — closes #2241 | 🔄 In progress |
+| 2026-04-29 | 11.26 | target=_blank links missing sr-only "(opens in new tab)" announcement for screen readers — closes #2241 (PR #2242) | ✅ Done |
+| 2026-04-29 | 11.27 | vocabulary filter sr-only live region conditionally rendered — WCAG 4.1.3 fix: always render container — closes #2243 | 🔄 In progress |
 
 ---
 

--- a/frontend/src/__tests__/VocabFilterLiveRegion.test.ts
+++ b/frontend/src/__tests__/VocabFilterLiveRegion.test.ts
@@ -2,6 +2,10 @@
  * Regression for #1850 — vocabulary filter must announce result count via
  * an sr-only aria-live region so screen readers know when filtering changes
  * the word list (WCAG 4.1.3).
+ *
+ * Regression for #2243 — live region must be unconditionally rendered so that
+ * aria-live fires on the *first* filter keystroke (newly-inserted live regions
+ * are not reliably announced by NVDA/Firefox).
  */
 import { readFileSync } from "fs";
 import { join } from "path";
@@ -11,7 +15,7 @@ const src = readFileSync(
   "utf-8"
 );
 
-describe("Vocabulary filter live region (closes #1850)", () => {
+describe("Vocabulary filter live region (closes #1850, #2243)", () => {
   it("has an sr-only aria-live region for filter result announcements", () => {
     // The filter live region is a div with both aria-live and className="sr-only"
     const idx = src.indexOf('aria-live="polite" aria-atomic="true" className="sr-only"');
@@ -27,5 +31,19 @@ describe("Vocabulary filter live region (closes #1850)", () => {
     const window = src.slice(Math.max(0, idx - 100), idx + 300);
     // Should reference filtered length or a word count variable
     expect(window).toMatch(/filtered\.length|filterCount|wordCount/);
+  });
+
+  it("live region is always rendered (not wrapped in a conditional)", () => {
+    // The element must not be inside a conditional expression like {condition && <div ...>}
+    // so that it is present in the DOM before the user activates filtering.
+    // Correct: <div role="status" ...>{condition ? content : ""}</div>
+    // Wrong:   {condition && <div role="status" ...>content</div>}
+    const idx = src.indexOf('aria-live="polite" aria-atomic="true" className="sr-only"');
+    expect(idx).toBeGreaterThan(-1);
+
+    // Look backward 200 chars for "&&" immediately before the opening <div
+    const before = src.slice(Math.max(0, idx - 200), idx);
+    // The pattern "{(search || selectedTag) && (" indicates conditional rendering
+    expect(before).not.toMatch(/\(search.*selectedTag.*&&\s*\(?\s*$/);
   });
 });

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -503,12 +503,10 @@ function VocabularyPageContent() {
         )}
       </div>
 
-      {/* Visually-hidden live region: announces filter result counts to screen readers */}
-      {(search || selectedTag) && (
-        <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
-          {`${filtered.length} word${filtered.length === 1 ? "" : "s"} found.`}
-        </div>
-      )}
+      {/* Visually-hidden live region: always in DOM so aria-live fires on first filter keystroke */}
+      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+        {(search || selectedTag) ? `${filtered.length} word${filtered.length === 1 ? "" : "s"} found.` : ""}
+      </div>
 
       <div className="max-w-2xl mx-auto px-4 md:px-6 py-6 md:py-8">
         {words.length > 5 && (


### PR DESCRIPTION
## What changed

The vocabulary filter `aria-live` status region was conditionally rendered — it only appeared in the DOM when a filter was active. Newly-inserted `aria-live` elements are not reliably announced by NVDA/Firefox (and similar AT bugs exist in JAWS + Chrome). The first filter keystroke was therefore silently dropping the "N words found" announcement.

The fix makes the container unconditionally rendered with empty content when no filter is active, exactly matching the ARIA authoring practices pattern for live regions.

```tsx
// Before — conditional rendering (misses first-keystroke announcement)
{(search || selectedTag) && (
  <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
    {`${filtered.length} word${filtered.length === 1 ? "" : "s"} found.`}
  </div>
)}

// After — always rendered (reliable first-keystroke announcement)
<div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
  {(search || selectedTag) ? `${filtered.length} word${filtered.length === 1 ? "" : "s"} found.` : ""}
</div>
```

## Why

WCAG 4.1.3 (Status Messages): screen-reader users must be informed when the word list changes in response to filtering. Without a reliably-present live region, the first announcement (and potentially more) is lost.

Reported as #2243, complements the #1850 fix that added the live region initially.

## Test plan

- [x] `VocabFilterLiveRegion.test.ts` — 3 regression tests pass:
  1. `aria-live` region exists
  2. Region references `filtered.length`
  3. Region is **not** wrapped in a conditional (new test for #2243)
- [x] All 3606 frontend tests pass (`--no-coverage --ci`)

Closes #2243

## Docs follow-up

Change Log row 11.27 added to `docs/design-improvement-plan.md` in this PR.

- [ ] Docs updated (if applicable) ✅
