### PR TITLE
fix: add lang attribute to vocab word list for WCAG 3.1.2 compliance

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -222,7 +222,8 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.24 | title tooltips for reader header truncated book title h1 and authors p — closes #2237 (PR #2238) | ✅ Done |
 | 2026-04-29 | 11.25 | title tooltips for profile deck names, SeedPopularButton current title, QueueTab retry/error — closes #2239 (PR #2240) | ✅ Done |
 | 2026-04-29 | 11.26 | target=_blank links missing sr-only "(opens in new tab)" announcement for screen readers — closes #2241 (PR #2242) | ✅ Done |
-| 2026-04-29 | 11.27 | vocabulary filter sr-only live region conditionally rendered — WCAG 4.1.3 fix: always render container — closes #2243 | 🔄 In progress |
+| 2026-04-29 | 11.27 | vocabulary filter sr-only live region conditionally rendered — WCAG 4.1.3 fix: always render container — closes #2243 (PR #2244) | ✅ Done |
+| 2026-04-29 | 11.28 | vocabulary word list missing lang attribute on foreign words — WCAG 3.1.2 fix: add lang to lemma button and sentence spans — closes #2245 | 🔄 In progress |
 
 ---
 

--- a/frontend/src/__tests__/VocabLangAttribute.test.ts
+++ b/frontend/src/__tests__/VocabLangAttribute.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression for #2245 — vocabulary word list must add lang attribute on
+ * foreign-language words and context sentences so screen readers pronounce
+ * them correctly (WCAG 3.1.2 Language of Parts, Level AA).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/vocabulary/page.tsx"),
+  "utf-8"
+);
+
+describe("Vocabulary word list lang attribute (closes #2245)", () => {
+  it("lemma button has lang attribute from group.language", () => {
+    // The lemma word button should carry lang={group.language ?? undefined}
+    // so screen readers use correct pronunciation rules.
+    // Unique anchor: the lemma button is the one with the vocab flash handler.
+    const idx = src.indexOf("setActiveWord({ word: group.lemma");
+    expect(idx).toBeGreaterThan(-1);
+    // Look backward 150 chars for the button opening tag
+    const before = src.slice(Math.max(0, idx - 150), idx);
+    expect(before).toMatch(/lang=\{group\.language/);
+  });
+
+  it("context sentence span has lang attribute from group.language", () => {
+    // Each occurrence's sentence_text is rendered in the book's language;
+    // it must carry a lang attribute so AT switches pronunciation.
+    const idx = src.indexOf("occ.sentence_text");
+    expect(idx).toBeGreaterThan(-1);
+    // Check that somewhere near the sentence_text there is a lang attribute
+    const window = src.slice(Math.max(0, idx - 200), idx + 50);
+    expect(window).toMatch(/lang=\{group\.language/);
+  });
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -378,13 +378,14 @@ function VocabularyPageContent() {
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-2 flex-wrap">
             <button
+              lang={group.language ?? undefined}
               onClick={() => setActiveWord({ word: group.lemma, lang: group.language })}
               className="font-serif font-semibold text-ink text-base hover:text-amber-700 transition-colors text-left min-h-[44px] md:min-h-0 flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               {group.lemma}
             </button>
             {alternateForms.length > 0 && (
-              <span className="text-xs text-stone-600">
+              <span lang={group.language ?? undefined} className="text-xs text-stone-600">
                 ({alternateForms.map((f) => f.word).join(", ")})
               </span>
             )}
@@ -417,7 +418,7 @@ function VocabularyPageContent() {
             f.occurrences.map((occ, i) => (
               <div key={`${f.word}-${i}`} className="text-sm text-stone-600">
                 {f.word !== group.lemma && (
-                  <span className="text-xs text-amber-700 font-medium mr-1.5">{f.word}</span>
+                  <span lang={group.language ?? undefined} className="text-xs text-amber-700 font-medium mr-1.5">{f.word}</span>
                 )}
                 {occ.book_title ? (
                   <a
@@ -431,7 +432,7 @@ function VocabularyPageContent() {
                 )}{" "}
                 <span className="text-stone-600">{`Ch.${occ.chapter_index + 1}`}</span>
                 {" — "}
-                <span className="italic">&ldquo;{occ.sentence_text}&rdquo;</span>
+                <span lang={group.language ?? undefined} className="italic">&ldquo;{occ.sentence_text}&rdquo;</span>
               </div>
             ))
           )}


### PR DESCRIPTION
## What changed

Added `lang` attributes to foreign-language vocabulary words and context sentences on the vocabulary page so that screen readers use the correct pronunciation rules.

**Files changed:**
- `frontend/src/app/vocabulary/page.tsx` — `renderGroup()`: added `lang={group.language ?? undefined}` to:
  1. The lemma word button
  2. Alternate form spans
  3. The alternate form word span (inline form indicator)
  4. The context sentence `<span>` wrapping `occ.sentence_text`

## Why

WCAG 3.1.2 (Language of Parts) — Level AA — requires that the language of each passage or phrase in the content be programmatically determinable. Without a `lang` attribute, screen readers read German, Chinese, and Japanese vocabulary words using English phonemes, mispronouncing them entirely.

The `group.language` field already holds the BCP-47 code (e.g. `"de"`, `"zh"`, `"ja"`) from the Wiktionary lookup service — no backend change was needed.

## Test plan

- [x] `VocabLangAttribute.test.ts` — 2 new regression tests:
  1. Lemma button carries `lang={group.language ...}` attribute
  2. Context sentence span carries `lang={group.language ...}` attribute
- [x] All 3608 frontend tests pass (`--no-coverage --ci`)
- [x] Existing `VocabFilterLiveRegion.test.ts` suite still passes

Closes #2245

## Docs follow-up

Change Log row 11.28 added to `docs/design-improvement-plan.md` in this PR.

- [x] Docs updated (if applicable)
