### PR TITLE
fix: add lang attribute to reader scroll container for WCAG 3.1.2 compliance

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -224,7 +224,8 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.26 | target=_blank links missing sr-only "(opens in new tab)" announcement for screen readers — closes #2241 (PR #2242) | ✅ Done |
 | 2026-04-29 | 11.27 | vocabulary filter sr-only live region conditionally rendered — WCAG 4.1.3 fix: always render container — closes #2243 (PR #2244) | ✅ Done |
 | 2026-04-29 | 11.28 | vocabulary word list missing lang attribute on foreign words — WCAG 3.1.2 fix: add lang to lemma button and sentence spans — closes #2245 (PR #2246) | ✅ Done |
-| 2026-04-29 | 11.29 | reader vocab sidebar missing lang attribute on foreign words — WCAG 3.1.2 fix: add lang to lemma/form/sentence spans — closes #2247 | 🔄 In progress |
+| 2026-04-29 | 11.29 | reader vocab sidebar missing lang attribute on foreign words — WCAG 3.1.2 fix: add lang to lemma/form/sentence spans — closes #2247 (PR #2248) | ✅ Done |
+| 2026-04-29 | 11.30 | reader scroll container missing lang attribute for non-English books — WCAG 3.1.2 fix: add lang={bookLanguage} to reader-scroll div — closes #2249 | 🔄 In progress |
 
 ---
 

--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -223,7 +223,8 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.25 | title tooltips for profile deck names, SeedPopularButton current title, QueueTab retry/error — closes #2239 (PR #2240) | ✅ Done |
 | 2026-04-29 | 11.26 | target=_blank links missing sr-only "(opens in new tab)" announcement for screen readers — closes #2241 (PR #2242) | ✅ Done |
 | 2026-04-29 | 11.27 | vocabulary filter sr-only live region conditionally rendered — WCAG 4.1.3 fix: always render container — closes #2243 (PR #2244) | ✅ Done |
-| 2026-04-29 | 11.28 | vocabulary word list missing lang attribute on foreign words — WCAG 3.1.2 fix: add lang to lemma button and sentence spans — closes #2245 | 🔄 In progress |
+| 2026-04-29 | 11.28 | vocabulary word list missing lang attribute on foreign words — WCAG 3.1.2 fix: add lang to lemma button and sentence spans — closes #2245 (PR #2246) | ✅ Done |
+| 2026-04-29 | 11.29 | reader vocab sidebar missing lang attribute on foreign words — WCAG 3.1.2 fix: add lang to lemma/form/sentence spans — closes #2247 | 🔄 In progress |
 
 ---
 

--- a/frontend/src/__tests__/ReaderScrollContainerLang.test.ts
+++ b/frontend/src/__tests__/ReaderScrollContainerLang.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Regression for #2249 — the reader scroll container must carry a lang
+ * attribute derived from the book's language so screen readers use correct
+ * pronunciation for non-English books (WCAG 3.1.2 Language of Parts).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf-8"
+);
+
+describe("Reader scroll container lang attribute (closes #2249)", () => {
+  it("reader-scroll container has lang attribute from bookLanguage", () => {
+    // The id="reader-scroll" container must carry lang={bookLanguage}
+    const idx = src.indexOf('id="reader-scroll"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 300);
+    expect(window).toMatch(/lang=\{bookLanguage\}/);
+  });
+});

--- a/frontend/src/__tests__/ReaderVocabSidebarLang.test.ts
+++ b/frontend/src/__tests__/ReaderVocabSidebarLang.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Regression for #2247 — reader vocab sidebar must add lang attribute on
+ * foreign-language words and context sentences so screen readers pronounce
+ * them correctly (WCAG 3.1.2 Language of Parts, Level AA).
+ *
+ * Companion to VocabLangAttribute.test.ts which covers vocabulary/page.tsx.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf-8"
+);
+
+describe("Reader vocab sidebar lang attribute (closes #2247)", () => {
+  it("lemma word span has lang attribute from w.language", () => {
+    // The lemma span is "text-sm font-semibold text-ink" and renders {lemma}
+    const idx = src.indexOf('"text-sm font-semibold text-ink">{lemma}');
+    expect(idx).toBeGreaterThan(-1);
+    // Look backward 100 chars for lang attribute
+    const before = src.slice(Math.max(0, idx - 100), idx);
+    expect(before).toMatch(/lang=\{w\.language/);
+  });
+
+  it("context sentence span in vocab sidebar has lang attribute", () => {
+    // The occurrence sentence span is italic line-clamp-2 and renders occ.sentence_text
+    const idx = src.indexOf('"text-xs text-stone-600 italic line-clamp-2"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 60), idx + 150);
+    expect(window).toMatch(/lang=\{w\.language/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1962,9 +1962,9 @@ export default function ReaderPage() {
                                 onClick={() => router.push(`/vocabulary?word=${encodeURIComponent(w.word)}`)}
                                 className="w-full flex items-center justify-between gap-2 px-3 py-2 min-h-[44px] md:min-h-0 hover:bg-amber-100 transition-colors text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-inset"
                               >
-                                <span className="text-sm font-semibold text-ink">{lemma}</span>
+                                <span lang={w.language ?? undefined} className="text-sm font-semibold text-ink">{lemma}</span>
                                 {isForm && (
-                                  <span className="text-[10px] text-amber-700 shrink-0 italic">{w.word}</span>
+                                  <span lang={w.language ?? undefined} className="text-[10px] text-amber-700 shrink-0 italic">{w.word}</span>
                                 )}
                               </button>
                               {/* Context occurrences */}
@@ -1986,7 +1986,7 @@ export default function ReaderPage() {
                                   {vocabView === "book" && (
                                     <span className="text-[10px] text-stone-600 mr-1">Ch.{occ.chapter_index + 1}</span>
                                   )}
-                                  <span className="text-xs text-stone-600 italic line-clamp-2">&ldquo;{occ.sentence_text}&rdquo;</span>
+                                  <span lang={w.language ?? undefined} className="text-xs text-stone-600 italic line-clamp-2">&ldquo;{occ.sentence_text}&rdquo;</span>
                                 </button>
                               ))}
                             </div>

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1387,6 +1387,7 @@ export default function ReaderPage() {
         <div className="flex flex-col flex-1 overflow-hidden min-w-0">
           <div
             id="reader-scroll"
+            lang={bookLanguage}
             className="flex-1 overflow-y-auto px-4 py-4 md:px-8 md:py-8 pb-16 md:pb-8"
             onClick={handleReaderTap}
             onTouchStart={handleTouchStart}


### PR DESCRIPTION
## What changed

Added `lang={bookLanguage}` to the reader's main scroll container (`id="reader-scroll"`) so that screen readers use the correct pronunciation engine for the book's source language.

**File changed:** `frontend/src/app/reader/[bookId]/page.tsx`

`bookLanguage` is already computed from `meta?.languages[0] || "en"` and used throughout the component (TTS synthesis, translation language filtering, Wiktionary lookups). This change applies it to the content container so the language is programmatically determinable for the entire reading area.

Translated paragraphs already carry their own `lang={translationLang}` from SentenceReader, which correctly overrides the container language for translated content.

## Why

WCAG 3.1.2 (Language of Parts) — Level AA. For non-English books (German, French, Latin, etc. from Project Gutenberg), without a `lang` attribute on the scroll container, screen readers fall back to the page's default language (English) and mispronounce all book content. This is the broadest fix of the three WCAG 3.1.2 PRs this session — it covers all book content rather than just vocabulary sidebar items.

## Test plan

- [x] `ReaderScrollContainerLang.test.ts` — 1 regression test verifying `lang={bookLanguage}` is present on `id="reader-scroll"`
- [x] All 3611 frontend tests pass (`--no-coverage --ci`)

Closes #2249

## Docs follow-up

Change Log row 11.30 added to `docs/design-improvement-plan.md` in this PR.

- [x] Docs updated (if applicable)
