### PR TITLE
fix: add lang attribute to notes page passages for WCAG 3.1.2 compliance

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -226,6 +226,7 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.28 | vocabulary word list missing lang attribute on foreign words — WCAG 3.1.2 fix: add lang to lemma button and sentence spans — closes #2245 (PR #2246) | ✅ Done |
 | 2026-04-29 | 11.29 | reader vocab sidebar missing lang attribute on foreign words — WCAG 3.1.2 fix: add lang to lemma/form/sentence spans — closes #2247 (PR #2248) | ✅ Done |
 | 2026-04-29 | 11.30 | reader scroll container missing lang attribute for non-English books — WCAG 3.1.2 fix: add lang={bookLanguage} to reader-scroll div — closes #2249 (PR #2250) | ✅ Done |
+| 2026-04-29 | 11.31 | notes page missing lang attribute on annotation and vocab occurrence sentences — WCAG 3.1.2 fix — closes #2251 (PR #2252) | ✅ Done |
 
 ---
 

--- a/frontend/src/__tests__/NotesPageLang.test.ts
+++ b/frontend/src/__tests__/NotesPageLang.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Regression for #2251 — notes page must add lang attribute on foreign-language
+ * book passages (annotations and vocabulary occurrences) so screen readers
+ * pronounce them correctly (WCAG 3.1.2 Language of Parts, Level AA).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf-8"
+);
+
+describe("Notes page lang attribute on book passages (closes #2251)", () => {
+  it("AnnotationCard sentence paragraph has lang attribute", () => {
+    // The sentence is rendered in a <p className="italic..."> inside AnnotationCard
+    const idx = src.indexOf("ann.sentence_text");
+    expect(idx).toBeGreaterThan(-1);
+    // Look backward 100 chars from sentence_text for lang attribute
+    const before = src.slice(Math.max(0, idx - 150), idx);
+    expect(before).toMatch(/lang=\{bookLanguage\}/);
+  });
+
+  it("VocabItem occurrence sentence has lang attribute", () => {
+    // The occurrence sentence is rendered in an <a> inside VocabItem
+    const idx = src.indexOf("occurrence.sentence_text");
+    expect(idx).toBeGreaterThan(-1);
+    // Find the closest lang attribute before occurrence.sentence_text
+    const before = src.slice(Math.max(0, idx - 200), idx);
+    expect(before).toMatch(/lang=\{bookLanguage\}/);
+  });
+
+  it("bookLanguage is derived from meta.languages in the page", () => {
+    // The page must compute bookLanguage from meta
+    expect(src).toMatch(/bookLanguage.*=.*meta.*languages/);
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -70,6 +70,7 @@ function AnnotationCard({
   ann,
   chapters,
   bookId,
+  bookLanguage,
   isEditing,
   editNote,
   onEdit,
@@ -82,6 +83,7 @@ function AnnotationCard({
   ann: Annotation;
   chapters: BookChapter[];
   bookId: number;
+  bookLanguage: string;
   isEditing: boolean;
   editNote: string;
   onEdit: () => void;
@@ -96,7 +98,7 @@ function AnnotationCard({
       id={`annotation-${ann.id}`}
       className="border-l-4 border-amber-300 pl-4 my-3 scroll-mt-24"
     >
-      <p className="italic text-stone-600 leading-relaxed text-sm">
+      <p lang={bookLanguage} className="italic text-stone-600 leading-relaxed text-sm">
         &ldquo;{ann.sentence_text}&rdquo;
       </p>
 
@@ -219,12 +221,15 @@ function VocabRow({
   word,
   occurrence,
   chapters,
+  bookLanguage,
 }: {
   word: string;
   occurrence: { book_id: number; chapter_index: number; sentence_text: string };
   chapters: BookChapter[];
+  bookLanguage: string;
 }) {
-  const readerHref = `/reader/${occurrence.book_id}?chapter=${occurrence.chapter_index}&sentence=${encodeURIComponent(occurrence.sentence_text)}&word=${encodeURIComponent(word)}`;
+  const { book_id, chapter_index, sentence_text } = occurrence;
+  const readerHref = `/reader/${book_id}?chapter=${chapter_index}&sentence=${encodeURIComponent(sentence_text)}&word=${encodeURIComponent(word)}`;
   return (
     <li className="flex gap-2 text-sm leading-relaxed before:content-['·'] before:text-amber-400 before:font-bold before:shrink-0">
       <span>
@@ -234,13 +239,13 @@ function VocabRow({
         >
           {word}
         </a>{" "}
-        <span className="text-stone-600 text-xs">({chapterLabel(chapters, occurrence.chapter_index)})</span>
+        <span className="text-stone-600 text-xs">({chapterLabel(chapters, chapter_index)})</span>
         {" — "}
         <a
           href={readerHref}
           className="italic text-stone-600 hover:text-amber-700 hover:underline transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
         >
-          &ldquo;{truncate(occurrence.sentence_text, 90)}&rdquo;
+          <span lang={bookLanguage}>&ldquo;{truncate(occurrence.sentence_text, 90)}&rdquo;</span>
         </a>
       </span>
     </li>
@@ -328,6 +333,7 @@ export default function BookNotesPage() {
     return () => { document.title = "My Library — Book Reader AI"; };
   }, [meta]);
 
+  const bookLanguage = meta?.languages?.[0] ?? "en";
   const bookVocab = vocab.filter((v) => v.occurrences.some((o) => o.book_id === bookId));
 
   function toggleCollapse(key: string) {
@@ -422,6 +428,7 @@ export default function BookNotesPage() {
           ann={ann}
           chapters={chapters}
           bookId={bookId}
+          bookLanguage={bookLanguage}
           isEditing={editingId === ann.id}
           editNote={editNote}
           onEdit={() => startEdit(ann)}
@@ -567,6 +574,7 @@ export default function BookNotesPage() {
                         word={v.word}
                         occurrence={occ}
                         chapters={chapters}
+                        bookLanguage={bookLanguage}
                       />
                     ))
                 )}
@@ -622,7 +630,7 @@ export default function BookNotesPage() {
                       {chVoc.map((v) => {
                         const occ = v.occurrences.find((o) => o.book_id === bookId && o.chapter_index === ch);
                         return occ ? (
-                          <VocabRow key={v.word} word={v.word} occurrence={occ} chapters={chapters} />
+                          <VocabRow key={v.word} word={v.word} occurrence={occ} chapters={chapters} bookLanguage={bookLanguage} />
                         ) : null;
                       })}
                     </ul>


### PR DESCRIPTION
## What changed

Add `lang` attribute to foreign-language passages on the notes page so screen readers pronounce them in the correct language (WCAG 3.1.2 Language of Parts, Level AA).

- `AnnotationCard`: derive `bookLanguage` from `meta?.languages[0]` and pass it as a prop; apply `lang={bookLanguage}` to the annotation sentence `<p>`
- `VocabRow`: add `bookLanguage` prop; wrap the vocabulary occurrence sentence text in `<span lang={bookLanguage}>`

## Why

Issue #2251 — notes page was missing `lang` attributes on book-language passages (annotation sentences and vocabulary occurrence context sentences), causing screen readers to mispronounce foreign-language content.

## Test plan

- New regression test `NotesPageLang.test.ts` verifies:
  - `AnnotationCard` sentence `<p>` has `lang={bookLanguage}`
  - `VocabRow` occurrence sentence has `lang={bookLanguage}`
  - `bookLanguage` is derived from `meta.languages` in the page component
- Full Jest suite: 593 suites / 3614 tests passing

Closes #2251
