### PR TITLE
chore(docs): require branching from origin/main, not another open PR's branch (closes #2222)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -506,7 +506,7 @@ Branch naming: `feat/`, `fix/`, `chore/`, `test/`, `design/`
 **Exact sequence every time — use the `/submit-pr` skill:**
 
 1. `git -C <repo> fetch origin main && git -C <repo> rebase origin/main`
-2. `git -C <repo> checkout -b <prefix>/description`
+2. `git -C <repo> checkout -b <prefix>/description` **off `origin/main`. Never branch from another open PR's branch.** If you need a change that depends on an unmerged PR, wait for that PR to merge — then rebase your new branch onto post-merge `origin/main`. Branching from another PR's branch causes squash-merge bundling: the second PR's commit message lands the first PR's content under a misleading title, breaking git-log archaeology and forcing the first PR to be closed-as-duplicate after the second merges. Verify before pushing: `git diff origin/main...HEAD` should show only the changes your PR description claims.
 3. Make commits; run the full test suite before submitting.
 4. **Check the in-flight PR limit.** If you already have 3 or more open PRs authored by you, stop here. Hold the branch locally until one of your PRs merges, then resume. See "Per-cycle priority (all code roles)".
 5. **Invoke the `/submit-pr` skill.** It handles push, PR creation (with `Closes #N` + appropriate label), auto-merge, and launches a background watcher that rebases on BEHIND and surfaces check failures until MERGED.


### PR DESCRIPTION
## What changed

Adds an explicit rule to `CLAUDE.md` step 2 of the "Branching and PR workflow" section:

> **Always branch from `origin/main`. Never from another open PR's branch.** If you need a change that depends on an unmerged PR, wait for that PR to merge — then rebase your new branch onto post-merge `origin/main`.

Also adds a verification line: `git diff origin/main...HEAD` should show only the changes the PR description claims.

## Why

Five squash-merge bundling incidents in this session, each predicted by PM ahead of time, each producing the same outcome:

| PR | Title | Bundled content (from another PR) |
|---|---|---|
| #2190 | "test: fix 4 reader static-analysis test window sizes" | 200 lines of #2188's reader-page focus rings |
| #2217 | "ux: lock body scroll when AnnotationToolbar modal is open" | 73 lines of #2215's lazy-img loading |
| #2221 | "ux: add focus-visible ring to summary disclosure elements" | 45 lines of #2219's error-page focus-ring test (resolved by rebase before merge) |
| #2248 | "ux: add lang attribute to reader vocab sidebar" | 39 lines of #2246's vocab-page lang content (resolved by rebase before merge) |
| #2250 | "ux: add lang attribute to reader scroll container" | 33 lines of #2248's reader-sidebar test (still pending) |

When the second PR squash-merges with the first PR's content bundled in, the commit message describes only the second PR's purpose. Future archaeologists searching git log for the first PR's content won't find it. Two of the five (#2188, #2215) had to be closed-as-duplicate after their content shipped under another title.

The implicit convention (step 1 fetches+rebases main, step 2 creates a new branch) failed because step 2 doesn't say *what to branch off*. This makes the rule explicit.

Closes #2222.

## Test plan

- [x] Docs-only change; backend pytest passes (2015 tests, 1 skipped)
- [x] No code touched; CI's path-scoping should skip frontend Jest and Verify Docker build
- [x] Branched from `origin/main` per the new rule (eating my own dog food)
