### PR TITLE
fix: add lang attribute to decks word list and picker for WCAG 3.1.2 compliance

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -227,6 +227,7 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.29 | reader vocab sidebar missing lang attribute on foreign words — WCAG 3.1.2 fix: add lang to lemma/form/sentence spans — closes #2247 (PR #2248) | ✅ Done |
 | 2026-04-29 | 11.30 | reader scroll container missing lang attribute for non-English books — WCAG 3.1.2 fix: add lang={bookLanguage} to reader-scroll div — closes #2249 (PR #2250) | ✅ Done |
 | 2026-04-29 | 11.31 | notes page missing lang attribute on annotation and vocab occurrence sentences — WCAG 3.1.2 fix — closes #2251 (PR #2252) | ✅ Done |
+| 2026-04-29 | 11.32 | decks word list and picker missing lang attribute on foreign vocabulary words — WCAG 3.1.2 fix — closes #2255 (PR #2256) | ✅ Done |
 
 ---
 

--- a/frontend/src/__tests__/DecksWordLang.test.ts
+++ b/frontend/src/__tests__/DecksWordLang.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Regression for #2255 — decks word list and picker must add lang attribute on
+ * foreign-language vocabulary words so screen readers pronounce them correctly
+ * (WCAG 3.1.2 Language of Parts, Level AA).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/decks/[deckId]/page.tsx"),
+  "utf-8"
+);
+
+describe("Decks word lang attribute (closes #2255)", () => {
+  it("deck word list span has lang attribute from w.language", () => {
+    // The word span in the deck word list renders {w.word}
+    // The first occurrence of {w.word} should be inside a span with lang
+    const idx = src.indexOf('"font-serif text-ink truncate flex-1 min-w-0"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 100);
+    expect(window).toMatch(/lang=\{w\.language/);
+  });
+
+  it("vocab picker button span has lang attribute from w.language", () => {
+    // The picker button also renders {w.word} in a font-serif span
+    // There are two such spans; both must have lang
+    const first = src.indexOf('"font-serif text-ink truncate flex-1 min-w-0"');
+    const second = src.indexOf('"font-serif text-ink truncate flex-1 min-w-0"', first + 1);
+    expect(second).toBeGreaterThan(-1);
+    const window = src.slice(second, second + 100);
+    expect(window).toMatch(/lang=\{w\.language/);
+  });
+});

--- a/frontend/src/app/decks/[deckId]/page.tsx
+++ b/frontend/src/app/decks/[deckId]/page.tsx
@@ -255,7 +255,7 @@ export default function DeckDetailPage() {
                     key={w.id}
                     className="rounded-xl border border-amber-200 bg-white px-4 py-3 flex items-center justify-between gap-3"
                   >
-                    <span className="font-serif text-ink truncate flex-1 min-w-0">
+                    <span className="font-serif text-ink truncate flex-1 min-w-0" lang={w.language ?? undefined}>
                       {w.word}
                     </span>
                     {w.language && (
@@ -411,7 +411,7 @@ function AddWordPicker({ candidates, onClose, onAdd }: AddWordPickerProps) {
                     aria-label={`Add ${w.word} to deck`}
                     className="w-full flex items-center justify-between gap-3 rounded-lg border border-amber-200 bg-white px-3 py-2 text-left hover:border-amber-400 hover:bg-amber-50 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                   >
-                    <span className="font-serif text-ink truncate flex-1 min-w-0">
+                    <span className="font-serif text-ink truncate flex-1 min-w-0" lang={w.language ?? undefined}>
                       {w.word}
                     </span>
                     {w.language && (


### PR DESCRIPTION
## What changed

Add `lang` attribute to vocabulary word spans in the deck word list and vocab picker in `decks/[deckId]/page.tsx` so screen readers pronounce foreign-language words correctly (WCAG 3.1.2 Language of Parts, Level AA).

- Deck word list span (line ~258): `lang={w.language ?? undefined}` added
- Vocab picker button span (line ~414): same fix applied

## Why

Issue #2255 — `w.language` is already available in both rendering paths but was not being applied as a `lang` attribute. Part of the WCAG 3.1.2 fix series (#2245, #2247, #2249, #2251).

## Test plan

- New regression test `DecksWordLang.test.ts` verifies both word spans carry `lang={w.language...}`
- Full Jest suite: 593 suites / 3613 tests passing

Closes #2255
