### PR TITLE
fix: add lang attribute to VocabWordTooltip and WordActionDrawer for WCAG 3.1.2 (closes #2257)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -229,7 +229,8 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.31 | notes page missing lang attribute on annotation and vocab occurrence sentences — WCAG 3.1.2 fix — closes #2251 (PR #2252) | ✅ Done |
 | 2026-04-29 | 11.32 | decks word list and picker missing lang attribute on foreign vocabulary words — WCAG 3.1.2 fix — closes #2255 (PR #2256) | ✅ Done |
 | 2026-04-29 | 11.33 | VocabWordTooltip and WordActionDrawer missing lang attribute on displayed word — WCAG 3.1.2 fix — closes #2257 (PR #2259) | ✅ Done |
-| 2026-04-29 | 11.34 | flashcard review page missing lang attribute + backend language field in due API — WCAG 3.1.2 fix — closes #2258 | 🔄 In progress |
+| 2026-04-29 | 11.34 | flashcard review page missing lang attribute + backend language field in due API — WCAG 3.1.2 fix — closes #2258 (PR #2260) | ✅ Done |
+| 2026-04-29 | 11.35 | DefinitionSheet missing lang attribute on word and lemma spans — WCAG 3.1.2 fix — closes #2261 (PR #2262) | 🔄 In progress |
 
 ---
 

--- a/frontend/src/__tests__/WordPopupLang.test.ts
+++ b/frontend/src/__tests__/WordPopupLang.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Regression for #2257 — word popup components (VocabWordTooltip and
+ * WordActionDrawer) must add lang attribute on the displayed word so screen
+ * readers pronounce foreign-language vocabulary correctly
+ * (WCAG 3.1.2 Language of Parts, Level AA).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const tooltip = readFileSync(
+  join(__dirname, "../components/VocabWordTooltip.tsx"),
+  "utf-8"
+);
+
+const drawer = readFileSync(
+  join(__dirname, "../components/WordActionDrawer.tsx"),
+  "utf-8"
+);
+
+describe("Word popup components lang attribute (closes #2257)", () => {
+  it("VocabWordTooltip word span has lang attribute from lang prop", () => {
+    // The word span has id="vocab-tooltip-title"; use id= prefix to skip aria-labelledby
+    const idx = tooltip.indexOf('id="vocab-tooltip-title"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = tooltip.slice(idx, idx + 120);
+    expect(window).toMatch(/lang=\{lang/);
+  });
+
+  it("WordActionDrawer word span has lang attribute from language prop", () => {
+    // The word is rendered in font-serif font-bold text-xl span
+    const idx = drawer.indexOf('"font-serif font-bold text-ink text-xl"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = drawer.slice(idx, idx + 80);
+    expect(window).toMatch(/lang=\{language/);
+  });
+});

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -81,7 +81,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
     >
       {/* Header */}
       <div className="flex items-center justify-between px-3 pt-2.5 pb-1.5 border-b border-amber-100">
-        <span id="vocab-tooltip-title" className="font-semibold text-ink text-sm">{word}</span>
+        <span id="vocab-tooltip-title" lang={lang ?? undefined} className="font-semibold text-ink text-sm">{word}</span>
         <button onClick={onClose} aria-label="Close word definition" className="text-stone-600 hover:text-stone-700 p-0.5 rounded transition-colors min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"><CloseIcon className="w-3.5 h-3.5" /></button>
       </div>
 

--- a/frontend/src/components/WordActionDrawer.tsx
+++ b/frontend/src/components/WordActionDrawer.tsx
@@ -148,7 +148,7 @@ export default function WordActionDrawer({
         <div className="px-5 pb-5 space-y-3">
           {/* Word + phonetic */}
           <div className="flex items-baseline gap-2">
-            <span className="font-serif font-bold text-ink text-xl">{action.word}</span>
+            <span className="font-serif font-bold text-ink text-xl" lang={language ?? undefined}>{action.word}</span>
             {result?.phonetic && (
               <span className="text-sm text-amber-700">{result.phonetic}</span>
             )}


### PR DESCRIPTION
## What changed

Added `lang` attribute to two popup/drawer components that display foreign-language vocabulary words:

- **`VocabWordTooltip.tsx`**: added `lang={lang ?? undefined}` to the word title span (`id="vocab-tooltip-title"`)
- **`WordActionDrawer.tsx`**: added `lang={language ?? undefined}` to the word heading span

Both components already received the language code as a prop from their callers; only the attribute on the rendered element was missing.

## Why

WCAG 3.1.2 Language of Parts (Level AA) requires that text in a language different from the page language has a programmatically determinable language identifier. Screen readers use the `lang` attribute to select the correct voice/pronunciation engine. Without it, a Chinese or German word gets pronounced using English phonemes.

## Test plan

- New `frontend/src/__tests__/WordPopupLang.test.ts` with 2 static-analysis assertions:
  - `VocabWordTooltip`: checks `lang={lang` appears within 120 chars after `id="vocab-tooltip-title"`
  - `WordActionDrawer`: checks `lang={language` appears within 80 chars after the font class
- Full frontend suite: 3616 tests pass
- Full backend suite: 2015 tests pass

Closes #2257

- [ ] Docs updated (if applicable)
