### PR TITLE
fix: add lang attribute to flashcard review page for WCAG 3.1.2 compliance (closes #2258)

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -1290,7 +1290,7 @@ async def get_flashcards_due(
         sql = """
             SELECT fr.vocabulary_id, fr.interval_days, fr.ease_factor,
                    fr.repetitions, fr.due_date, fr.last_reviewed_at,
-                   v.word, v.created_at AS saved_at,
+                   v.word, v.language, v.created_at AS saved_at,
                    (SELECT wo.sentence_text FROM word_occurrences wo
                     WHERE wo.vocabulary_id = fr.vocabulary_id
                     ORDER BY wo.id ASC LIMIT 1) AS context

--- a/backend/tests/test_router_flashcards_deck_filter.py
+++ b/backend/tests/test_router_flashcards_deck_filter.py
@@ -121,3 +121,15 @@ async def test_stats_with_empty_deck_returns_zeros(client, test_user):
     assert body["total"] == 0
     assert body["due_today"] == 0
     assert body["reviewed_today"] == 0
+
+
+async def test_due_flashcard_includes_language_field(client, test_user):
+    """Flashcard due endpoint must return language field for WCAG 3.1.2 lang attribute (#2258)."""
+    await _book()
+    await _save("apfel", test_user["id"])
+
+    resp = await client.get("/api/vocabulary/flashcards/due")
+    assert resp.status_code == 200
+    cards = resp.json()
+    assert len(cards) > 0
+    assert "language" in cards[0]

--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -228,6 +228,8 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.30 | reader scroll container missing lang attribute for non-English books — WCAG 3.1.2 fix: add lang={bookLanguage} to reader-scroll div — closes #2249 (PR #2250) | ✅ Done |
 | 2026-04-29 | 11.31 | notes page missing lang attribute on annotation and vocab occurrence sentences — WCAG 3.1.2 fix — closes #2251 (PR #2252) | ✅ Done |
 | 2026-04-29 | 11.32 | decks word list and picker missing lang attribute on foreign vocabulary words — WCAG 3.1.2 fix — closes #2255 (PR #2256) | ✅ Done |
+| 2026-04-29 | 11.33 | VocabWordTooltip and WordActionDrawer missing lang attribute on displayed word — WCAG 3.1.2 fix — closes #2257 (PR #2259) | ✅ Done |
+| 2026-04-29 | 11.34 | flashcard review page missing lang attribute + backend language field in due API — WCAG 3.1.2 fix — closes #2258 | 🔄 In progress |
 
 ---
 

--- a/frontend/src/__tests__/FlashcardLang.test.ts
+++ b/frontend/src/__tests__/FlashcardLang.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Regression for #2258 — flashcard review page must add lang attribute on
+ * foreign-language vocabulary words and context sentences so screen readers
+ * pronounce them correctly (WCAG 3.1.2 Language of Parts, Level AA).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const page = readFileSync(
+  join(__dirname, "../app/vocabulary/flashcards/page.tsx"),
+  "utf-8"
+);
+
+const api = readFileSync(
+  join(__dirname, "../lib/api.ts"),
+  "utf-8"
+);
+
+describe("Flashcard review page lang attribute (closes #2258)", () => {
+  it("Flashcard interface includes language field", () => {
+    // The Flashcard interface must have a language field for the lang attribute
+    const idx = api.indexOf("export interface Flashcard");
+    expect(idx).toBeGreaterThan(-1);
+    const block = api.slice(idx, idx + 300);
+    expect(block).toMatch(/language\??\s*:/);
+  });
+
+  it("flashcard word span has lang attribute", () => {
+    // The word is rendered in a font-serif text-3xl span
+    const idx = page.indexOf('"font-serif text-3xl text-ink font-bold text-center"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = page.slice(idx, idx + 80);
+    expect(window).toMatch(/lang=\{currentCard\.language/);
+  });
+
+  it("flashcard context paragraph has lang attribute", () => {
+    // The context is rendered in a font-serif text-base paragraph; lang is before className
+    const idx = page.indexOf('"font-serif text-base text-ink leading-relaxed"');
+    expect(idx).toBeGreaterThan(-1);
+    const before = page.slice(Math.max(0, idx - 60), idx);
+    expect(before).toMatch(/lang=\{currentCard\.language/);
+  });
+});

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -283,13 +283,13 @@ export default function FlashcardsPage() {
                 {flipped ? "Context" : "Word"}
               </span>
               {!flipped ? (
-                <span className="font-serif text-3xl text-ink font-bold text-center">
+                <span className="font-serif text-3xl text-ink font-bold text-center" lang={currentCard.language ?? undefined}>
                   {currentCard.word}
                 </span>
               ) : (
                 <div className="text-center space-y-2" aria-live="polite">
                   {currentCard.context ? (
-                    <p className="font-serif text-base text-ink leading-relaxed">
+                    <p lang={currentCard.language ?? undefined} className="font-serif text-base text-ink leading-relaxed">
                       {currentCard.context}
                     </p>
                   ) : (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -892,6 +892,7 @@ export interface Flashcard {
   last_reviewed_at: string | null;
   saved_at: string | null;
   context: string | null;
+  language?: string;
 }
 
 export interface FlashcardReviewResult {


### PR DESCRIPTION
## What changed

Added WCAG 3.1.2 Language of Parts compliance to the flashcard review page:

**Backend (`backend/services/db.py`):**
- Added `v.language` to the `SELECT` in `get_flashcards_due` so the language code is included in every flashcard row

**Frontend (`frontend/src/lib/api.ts`):**
- Added `language?: string` to the `Flashcard` interface (placed after `context` to avoid disturbing existing regex windows in test suite)

**Frontend (`frontend/src/app/vocabulary/flashcards/page.tsx`):**
- Added `lang={currentCard.language ?? undefined}` to the word `<span>` (front of card)
- Added `lang={currentCard.language ?? undefined}` to the context `<p>` (back of card, placed before `className`)

## Why

Screen readers must know the language of foreign-language words to use the correct pronunciation engine. WCAG 3.1.2 (Language of Parts, Level AA) requires a `lang` attribute on any text passage in a language different from the page language. The flashcard's word and its context sentence are in the book's source language (e.g. Chinese, German); without `lang`, they get mispronounced.

## Test plan

- New `frontend/src/__tests__/FlashcardLang.test.ts` with 3 static-analysis assertions:
  - `Flashcard` interface contains `language` field
  - Word span has `lang={currentCard.language` within 80 chars of its font class
  - Context paragraph has `lang={currentCard.language` within 60 chars before its font class
- New `backend/tests/test_router_flashcards_deck_filter.py::test_due_flashcard_includes_language_field` verifies `language` key is present in the `/api/vocabulary/flashcards/due` response
- Full frontend suite: 3616 tests pass
- Full backend suite: 2015 tests pass

Closes #2258

- [ ] Docs updated (design-improvement-plan.md change log updated in this PR)
