### PR TITLE
fix: add lang attribute to search VocabularyCard word for WCAG 3.1.2 (closes #2263)

### DIFF
--- a/backend/services/search.py
+++ b/backend/services/search.py
@@ -97,7 +97,7 @@ async def search_content(
         if "vocabulary" in scope:
             async with db.execute(
                 """
-                SELECT v.word, wo.id AS occurrence_id, wo.book_id,
+                SELECT v.word, v.language, wo.id AS occurrence_id, wo.book_id,
                        b.title AS book_title, wo.chapter_index,
                        snippet(word_occurrences_fts, 0, '<b>', '</b>', '…', 20) AS snippet
                 FROM word_occurrences_fts
@@ -114,6 +114,7 @@ async def search_content(
                     results.append({
                         "type": "vocabulary",
                         "word": row["word"],
+                        "language": row["language"],
                         "occurrence_id": row["occurrence_id"],
                         "book_id": row["book_id"],
                         "book_title": row["book_title"] or "",

--- a/backend/tests/test_router_search.py
+++ b/backend/tests/test_router_search.py
@@ -418,3 +418,19 @@ async def test_search_content_limit_above_max_clamped(tmp_db, test_user):
     from services.search import MAX_LIMIT
     result = await search_content(test_user["id"], "anythingxyz", limit=MAX_LIMIT + 100)
     assert result["total"] == 0  # no data; confirmed no crash on oversized limit
+
+
+async def test_search_vocabulary_result_includes_language(client, test_user):
+    """Vocabulary search results must include language field for WCAG 3.1.2 (#2263)."""
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        await _seed_vocab_occurrence(db, test_user["id"], "Heimweh", 7777, 0,
+                                     "filled with Heimweh")
+        await db.commit()
+
+    res = await client.get("/api/search?q=Heimweh")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["total"] == 1
+    hit = data["results"][0]
+    assert hit["type"] == "vocabulary"
+    assert "language" in hit

--- a/frontend/src/__tests__/SearchVocabLang.test.ts
+++ b/frontend/src/__tests__/SearchVocabLang.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Regression for #2263 — search page VocabularyCard must add lang attribute
+ * on the word div and the InAppSearchResult vocabulary type must include a
+ * language field (WCAG 3.1.2 Language of Parts, Level AA).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const page = readFileSync(
+  join(__dirname, "../app/search/page.tsx"),
+  "utf-8"
+);
+
+const api = readFileSync(
+  join(__dirname, "../lib/api.ts"),
+  "utf-8"
+);
+
+describe("Search page vocabulary lang attribute (closes #2263)", () => {
+  it("InAppSearchResult vocabulary type includes language field", () => {
+    const idx = api.indexOf('type: "vocabulary"');
+    expect(idx).toBeGreaterThan(-1);
+    const block = api.slice(idx, idx + 200);
+    expect(block).toMatch(/language\??\s*:/);
+  });
+
+  it("VocabularyCard word div has lang attribute from r.language", () => {
+    // Anchor on the unique content {r.word} inside VocabularyCard and look back
+    const idx = page.indexOf(">{r.word}</div>");
+    expect(idx).toBeGreaterThan(-1);
+    const before = page.slice(Math.max(0, idx - 60), idx);
+    expect(before).toMatch(/lang=\{r\.language/);
+  });
+});

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -49,7 +49,7 @@ function VocabularyCard({ r }: { r: Extract<InAppSearchResult, { type: "vocabula
       style={{ boxShadow: "var(--shadow-card)" }}
     >
       <div className="flex items-baseline justify-between gap-2 mb-1">
-        <div className="font-serif text-base text-ink">{r.word}</div>
+        <div className="font-serif text-base text-ink" lang={r.language ?? undefined}>{r.word}</div>
         <div className="text-xs text-stone-600">Vocabulary · Ch.&nbsp;{r.chapter_index + 1}</div>
       </div>
       <SnippetHtml snippet={r.snippet} />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -92,6 +92,7 @@ export type InAppSearchResult =
   | {
       type: "vocabulary";
       word: string;
+      language?: string;
       occurrence_id: number;
       book_id: number;
       book_title: string;


### PR DESCRIPTION
## What changed

Added WCAG 3.1.2 Language of Parts compliance to the in-app search vocabulary results:

**Backend (`backend/services/search.py`):**
- Added `v.language` to the vocabulary scope `SELECT` and to the result dict

**Frontend (`frontend/src/lib/api.ts`):**
- Added `language?: string` to the `vocabulary` variant of `InAppSearchResult`

**Frontend (`frontend/src/app/search/page.tsx`):**
- Added `lang={r.language ?? undefined}` to the word `<div>` in `VocabularyCard`

## Why

WCAG 3.1.2 (Language of Parts, Level AA): saved vocabulary words in search results are in the book's source language (e.g. Chinese, German). Without `lang`, screen readers mispronounce them using English phonemes. The `language` field was already stored in the `vocabulary` table but not exposed through the search endpoint.

## Test plan

- New `frontend/src/__tests__/SearchVocabLang.test.ts`:
  - `InAppSearchResult` vocabulary type includes `language` field
  - `VocabularyCard` word div has `lang={r.language` in 60-char backward window from `{r.word}`
- New backend test `test_search_vocabulary_result_includes_language` verifies `language` key in `/api/search` vocabulary results
- Full frontend suite: 3623 tests pass
- Search tests: 31 pass

Closes #2263

- [ ] Docs updated (if applicable)
