### PR TITLE
fix: add lang to search result snippets for WCAG 3.1.2 (closes #2265)

### DIFF
--- a/backend/services/search.py
+++ b/backend/services/search.py
@@ -73,7 +73,8 @@ async def search_content(
                 """
                 SELECT a.id, a.book_id, b.title AS book_title, a.chapter_index,
                        a.note_text,
-                       snippet(annotations_fts, 0, '<b>', '</b>', '…', 20) AS snippet
+                       snippet(annotations_fts, 0, '<b>', '</b>', '…', 20) AS snippet,
+                       json_extract(b.languages, '$[0]') AS book_language
                 FROM annotations_fts
                 JOIN annotations a ON annotations_fts.rowid = a.id
                 LEFT JOIN books b ON a.book_id = b.id
@@ -92,6 +93,7 @@ async def search_content(
                         "chapter_index": row["chapter_index"],
                         "snippet": row["snippet"],
                         "note_text": row["note_text"],
+                        "book_language": row["book_language"],
                     })
 
         if "vocabulary" in scope:

--- a/backend/tests/test_router_search.py
+++ b/backend/tests/test_router_search.py
@@ -434,3 +434,29 @@ async def test_search_vocabulary_result_includes_language(client, test_user):
     hit = data["results"][0]
     assert hit["type"] == "vocabulary"
     assert "language" in hit
+
+
+@pytest.mark.asyncio
+async def test_search_annotation_result_includes_book_language(client, test_user):
+    """Annotation search results must include book_language field for WCAG 3.1.2 (#2265)."""
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        book_id = 8888
+        await db.execute(
+            "INSERT OR IGNORE INTO books (id, title, images, languages) VALUES (?, 'Faust', '[]', '[\"de\"]')",
+            (book_id,),
+        )
+        await db.execute(
+            """INSERT INTO annotations (user_id, book_id, chapter_index, sentence_text, note_text)
+               VALUES (?, ?, 0, 'Zwei Seelen wohnen in mir', '')""",
+            (test_user["id"], book_id),
+        )
+        await db.commit()
+
+    res = await client.get("/api/search?q=Seelen")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["total"] == 1
+    hit = data["results"][0]
+    assert hit["type"] == "annotation"
+    assert "book_language" in hit
+    assert hit["book_language"] == "de"

--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -231,6 +231,7 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.33 | VocabWordTooltip and WordActionDrawer missing lang attribute on displayed word — WCAG 3.1.2 fix — closes #2257 (PR #2259) | ✅ Done |
 | 2026-04-29 | 11.34 | flashcard review page missing lang attribute + backend language field in due API — WCAG 3.1.2 fix — closes #2258 (PR #2260) | ✅ Done |
 | 2026-04-29 | 11.35 | DefinitionSheet missing lang attribute on word and lemma spans — WCAG 3.1.2 fix — closes #2261 (PR #2262) | 🔄 In progress |
+| 2026-04-29 | 11.36 | Search result snippets (AnnotationCard + VocabularyCard) missing lang on foreign text — added book_language to annotation search results and lang wrappers around SnippetHtml — WCAG 3.1.2 fix — closes #2265 | 🔄 In progress |
 
 ---
 

--- a/frontend/src/__tests__/SearchSnippetLang.test.ts
+++ b/frontend/src/__tests__/SearchSnippetLang.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression for #2265 — search result snippet text must carry lang attributes
+ * on foreign-language content (WCAG 3.1.2 Language of Parts, Level AA).
+ *
+ * VocabularyCard: snippet wrapped with lang from r.language.
+ * AnnotationCard: snippet wrapped with lang from r.book_language (added to annotation results).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const page = readFileSync(
+  join(__dirname, "../app/search/page.tsx"),
+  "utf-8"
+);
+
+const api = readFileSync(
+  join(__dirname, "../lib/api.ts"),
+  "utf-8"
+);
+
+describe("Search result snippet lang attributes (closes #2265)", () => {
+  it("InAppSearchResult annotation type includes book_language field", () => {
+    const idx = api.indexOf('type: "annotation"');
+    expect(idx).toBeGreaterThan(-1);
+    const block = api.slice(idx, idx + 300);
+    expect(block).toMatch(/book_language\??\s*:/);
+  });
+
+  it("VocabularyCard SnippetHtml is wrapped with lang from r.language", () => {
+    // This exact string is unique to the VocabularyCard snippet wrapper
+    const idx = page.indexOf('lang={r.language ?? undefined}><SnippetHtml');
+    expect(idx).toBeGreaterThan(-1);
+  });
+
+  it("AnnotationCard SnippetHtml is wrapped with lang from r.book_language", () => {
+    // This exact string is unique to the AnnotationCard snippet wrapper
+    const idx = page.indexOf('lang={r.book_language ?? undefined}><SnippetHtml');
+    expect(idx).toBeGreaterThan(-1);
+  });
+});

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -32,7 +32,7 @@ function AnnotationCard({ r }: { r: Extract<InAppSearchResult, { type: "annotati
         <div className="font-serif text-base text-ink">{r.book_title || `Book #${r.book_id}`}</div>
         <div className="text-xs text-stone-600">Annotation · Ch.&nbsp;{r.chapter_index + 1}</div>
       </div>
-      <SnippetHtml snippet={r.snippet} />
+      <span lang={r.book_language ?? undefined}><SnippetHtml snippet={r.snippet} /></span>
       {r.note_text ? (
         <div className="mt-2 text-xs text-stone-600 italic">{r.note_text}</div>
       ) : null}
@@ -52,7 +52,7 @@ function VocabularyCard({ r }: { r: Extract<InAppSearchResult, { type: "vocabula
         <div className="font-serif text-base text-ink" lang={r.language ?? undefined}>{r.word}</div>
         <div className="text-xs text-stone-600">Vocabulary · Ch.&nbsp;{r.chapter_index + 1}</div>
       </div>
-      <SnippetHtml snippet={r.snippet} />
+      <span lang={r.language ?? undefined}><SnippetHtml snippet={r.snippet} /></span>
       <div className="mt-2 text-xs text-stone-600">in {r.book_title || `Book #${r.book_id}`}</div>
     </Link>
   );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -88,6 +88,7 @@ export type InAppSearchResult =
       chapter_index: number;
       snippet: string;
       note_text: string;
+      book_language?: string;
     }
   | {
       type: "vocabulary";


### PR DESCRIPTION
## What changed

Search result snippet text in AnnotationCard and VocabularyCard was rendered without `lang` attributes, meaning foreign-language context sentences (from German, French, Japanese, etc. books) were announced by screen readers using the wrong pronunciation engine — a WCAG 3.1.2 Language of Parts (Level AA) violation.

**Backend** (`backend/services/search.py`): annotation search query now extracts the book's primary language via `json_extract(b.languages, '$[0]') AS book_language` and includes it in each annotation result.

**API type** (`frontend/src/lib/api.ts`): `InAppSearchResult` annotation variant gains `book_language?: string`.

**Search page** (`frontend/src/app/search/page.tsx`):
- `AnnotationCard`: `<SnippetHtml>` wrapped in `<span lang={r.book_language ?? undefined}>`
- `VocabularyCard`: `<SnippetHtml>` wrapped in `<span lang={r.language ?? undefined}>`

## Why

WCAG 3.1.2 requires that any text in a language different from the page's default language carries a `lang` attribute. Search result snippets show raw book sentences; for non-English books these are foreign-language content without language markup.

## Test plan

- `frontend/src/__tests__/SearchSnippetLang.test.ts` — 3 static assertions
- `backend/tests/test_router_search.py::test_search_annotation_result_includes_book_language` — seeds a German book, asserts `book_language == "de"` in annotation result

Closes #2265

- [x] Docs updated (design-improvement-plan.md entry 11.36 added)
