### PR TITLE
fix: add lang attribute to InsightCard context blockquote for WCAG 3.1.2 (closes #2267)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -231,7 +231,8 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.33 | VocabWordTooltip and WordActionDrawer missing lang attribute on displayed word — WCAG 3.1.2 fix — closes #2257 (PR #2259) | ✅ Done |
 | 2026-04-29 | 11.34 | flashcard review page missing lang attribute + backend language field in due API — WCAG 3.1.2 fix — closes #2258 (PR #2260) | ✅ Done |
 | 2026-04-29 | 11.35 | DefinitionSheet missing lang attribute on word and lemma spans — WCAG 3.1.2 fix — closes #2261 (PR #2262) | 🔄 In progress |
-| 2026-04-29 | 11.36 | Search result snippets (AnnotationCard + VocabularyCard) missing lang on foreign text — added book_language to annotation search results and lang wrappers around SnippetHtml — WCAG 3.1.2 fix — closes #2265 | 🔄 In progress |
+| 2026-04-29 | 11.36 | Search result snippets (AnnotationCard + VocabularyCard) missing lang on foreign text — backend book_language field + lang wrappers — WCAG 3.1.2 fix — closes #2265 (PR #2266) | ✅ Done |
+| 2026-04-29 | 11.37 | Notes InsightCard context blockquote missing lang attribute — added bookLanguage prop to InsightCard + lang on blockquote — WCAG 3.1.2 fix — closes #2267 | 🔄 In progress |
 
 ---
 

--- a/frontend/src/__tests__/NotesInsightLang.test.ts
+++ b/frontend/src/__tests__/NotesInsightLang.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Regression for #2267 — InsightCard context blockquote must carry a lang
+ * attribute for foreign-language book passages (WCAG 3.1.2 Language of Parts,
+ * Level AA).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf-8"
+);
+
+describe("Notes InsightCard context blockquote lang attribute (closes #2267)", () => {
+  it("InsightCard props interface includes bookLanguage", () => {
+    const idx = src.indexOf("function InsightCard(");
+    expect(idx).toBeGreaterThan(-1);
+    // Look 400 chars ahead to capture the Props block
+    const block = src.slice(idx, idx + 400);
+    expect(block).toMatch(/bookLanguage\??\s*:/);
+  });
+
+  it("InsightCard context blockquote has lang attribute from bookLanguage", () => {
+    // Anchor on the unique blockquote className in InsightCard and look backward for lang
+    const idx = src.indexOf('"border-l-4 border-amber-200 pl-4 italic text-stone-600 text-sm leading-relaxed"');
+    expect(idx).toBeGreaterThan(-1);
+    // lang= appears before className on the same tag — look back 60 chars
+    const before = src.slice(Math.max(0, idx - 60), idx);
+    expect(before).toMatch(/lang=\{bookLanguage/);
+  });
+
+  it("InsightCard call site passes bookLanguage prop", () => {
+    // The renderInsight function calls InsightCard
+    const idx = src.indexOf("function renderInsight");
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(idx, idx + 400);
+    expect(block).toMatch(/bookLanguage=\{bookLanguage\}/);
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -171,12 +171,14 @@ function InsightCard({
   bookId,
   onDelete,
   isDeleting,
+  bookLanguage,
 }: {
   ins: BookInsight;
   chapters: BookChapter[];
   bookId: number;
   onDelete: () => void;
   isDeleting: boolean;
+  bookLanguage?: string;
 }) {
   const readerHref = ins.chapter_index !== null
     ? `/reader/${bookId}?chapter=${ins.chapter_index}${ins.context_text ? `&sentence=${encodeURIComponent(ins.context_text)}` : ""}`
@@ -185,7 +187,7 @@ function InsightCard({
   return (
     <div className="my-3 space-y-1.5">
       {ins.context_text && (
-        <blockquote className="border-l-4 border-amber-200 pl-4 italic text-stone-600 text-sm leading-relaxed">
+        <blockquote lang={bookLanguage ?? undefined} className="border-l-4 border-amber-200 pl-4 italic text-stone-600 text-sm leading-relaxed">
           &ldquo;{truncate(ins.context_text, 200)}&rdquo;
         </blockquote>
       )}
@@ -451,6 +453,7 @@ export default function BookNotesPage() {
           bookId={bookId}
           onDelete={() => handleDeleteInsight(ins.id)}
           isDeleting={deletingIns.has(ins.id)}
+          bookLanguage={bookLanguage}
         />
       </li>
     );


### PR DESCRIPTION
## What changed

`InsightCard` in the notes page renders `ins.context_text` — the original book passage the AI insight is based on — in a `<blockquote>` without a `lang` attribute. For non-English books this is foreign-language text that screen readers mispronounce without a language hint (WCAG 3.1.2 Language of Parts, Level AA violation).

**Changes:**
- Added `bookLanguage?: string` prop to `InsightCard`
- Pass `bookLanguage={bookLanguage}` from `renderInsight` call site (bookLanguage is already derived from book metadata at line 336)
- Added `lang={bookLanguage ?? undefined}` to the `<blockquote>` element

## Why

WCAG 3.1.2 requires foreign-language text to carry a `lang` attribute. InsightCard context quotes come directly from book chapters; for foreign-language books these passages needed language attribution. `bookLanguage` was already available in the parent component but not threaded into InsightCard.

## Test plan

- `frontend/src/__tests__/NotesInsightLang.test.ts` — 3 static assertions:
  1. `InsightCard` props interface includes `bookLanguage`
  2. blockquote has `lang={bookLanguage` attribute
  3. call site passes `bookLanguage={bookLanguage}`

Closes #2267

- [x] Docs updated (design-improvement-plan.md entry 11.37 added)
