### PR TITLE
fix: add lang attribute to ChapterCard snippet for WCAG 3.1.2 (closes #2269)

### DIFF
--- a/backend/services/search.py
+++ b/backend/services/search.py
@@ -129,7 +129,8 @@ async def search_content(
                 """
                 SELECT uc.id, uc.book_id, b.title AS book_title, uc.chapter_index,
                        uc.title AS chapter_title,
-                       snippet(user_chapters_fts, 1, '<b>', '</b>', '…', 30) AS snippet
+                       snippet(user_chapters_fts, 1, '<b>', '</b>', '…', 30) AS snippet,
+                       json_extract(b.languages, '$[0]') AS book_language
                 FROM user_chapters_fts
                 JOIN user_book_chapters uc ON user_chapters_fts.rowid = uc.id
                 JOIN books b ON uc.book_id = b.id
@@ -151,6 +152,7 @@ async def search_content(
                         "chapter_index": row["chapter_index"],
                         "chapter_title": row["chapter_title"],
                         "snippet": row["snippet"],
+                        "book_language": row["book_language"],
                     })
 
     return {"query": q, "results": results, "total": len(results)}

--- a/backend/tests/test_router_search.py
+++ b/backend/tests/test_router_search.py
@@ -460,3 +460,32 @@ async def test_search_annotation_result_includes_book_language(client, test_user
     assert hit["type"] == "annotation"
     assert "book_language" in hit
     assert hit["book_language"] == "de"
+
+
+@pytest.mark.asyncio
+async def test_search_chapter_result_includes_book_language(client, test_user):
+    """Chapter search results must include book_language field for WCAG 3.1.2 (#2269)."""
+    async with aiosqlite.connect(db_module.DB_PATH) as db:
+        book_id = 9111
+        await db.execute(
+            """INSERT OR REPLACE INTO books
+               (id, title, authors, languages, subjects, download_count,
+                cover, text, images, source, owner_user_id)
+               VALUES (?, 'Faust', '[]', '["de"]', '[]', 0, '', '', '[]', 'upload', ?)""",
+            (book_id, test_user["id"]),
+        )
+        await db.execute(
+            "INSERT OR REPLACE INTO user_book_chapters "
+            "(book_id, chapter_index, title, text, is_draft) VALUES (?, 0, 'Prolog', 'Habe nun Philosophie studiert', 0)",
+            (book_id,),
+        )
+        await db.commit()
+
+    res = await client.get("/api/search?q=Philosophie")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["total"] == 1
+    hit = data["results"][0]
+    assert hit["type"] == "chapter"
+    assert "book_language" in hit
+    assert hit["book_language"] == "de"

--- a/frontend/src/__tests__/SearchChapterLang.test.ts
+++ b/frontend/src/__tests__/SearchChapterLang.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Regression for #2269 — ChapterCard snippet must carry a lang attribute for
+ * foreign-language book chapters (WCAG 3.1.2 Language of Parts, Level AA).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const page = readFileSync(
+  join(__dirname, "../app/search/page.tsx"),
+  "utf-8"
+);
+
+const api = readFileSync(
+  join(__dirname, "../lib/api.ts"),
+  "utf-8"
+);
+
+describe("Search ChapterCard snippet lang attribute (closes #2269)", () => {
+  it("InAppSearchResult chapter type includes book_language field", () => {
+    const idx = api.indexOf('type: "chapter"');
+    expect(idx).toBeGreaterThan(-1);
+    const block = api.slice(idx, idx + 200);
+    expect(block).toMatch(/book_language\??\s*:/);
+  });
+
+  it("ChapterCard SnippetHtml is wrapped with lang from r.book_language", () => {
+    // ">Chapter</div>" is unique to ChapterCard (AnnotationCard: "Annotation · Ch.", VocabularyCard: "Vocabulary · Ch.")
+    const anchor = page.indexOf('"text-xs text-stone-600">Chapter</div>');
+    expect(anchor).toBeGreaterThan(-1);
+    // lang-wrapped snippet comes after the unique badge text
+    const after = page.slice(anchor, anchor + 200);
+    expect(after).toMatch(/lang=\{r\.book_language/);
+  });
+});

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -72,7 +72,7 @@ function ChapterCard({ r }: { r: Extract<InAppSearchResult, { type: "chapter" }>
         </div>
         <div className="text-xs text-stone-600">Chapter</div>
       </div>
-      <SnippetHtml snippet={r.snippet} />
+      <span lang={r.book_language ?? undefined}><SnippetHtml snippet={r.snippet} /></span>
     </Link>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -108,6 +108,7 @@ export type InAppSearchResult =
       chapter_index: number;
       chapter_title: string;
       snippet: string;
+      book_language?: string;
     };
 
 export interface InAppSearchResponse {


### PR DESCRIPTION
## What changed

- **Backend** (`backend/services/search.py`): added `json_extract(b.languages, '$[0]') AS book_language` to the chapter FTS5 query (the JOIN with `books b` was already present) and propagated the field into the result dict.
- **Frontend** (`frontend/src/lib/api.ts`): added `book_language?: string` to the `chapter` type in `InAppSearchResult`.
- **Frontend** (`frontend/src/app/search/page.tsx`): wrapped `<SnippetHtml>` in `<span lang={r.book_language ?? undefined}>` inside `ChapterCard` so screen readers use the correct pronunciation engine for foreign-language chapter text.

## Why

WCAG 3.1.2 (Language of Parts, Level AA) requires that text in a different language than the page language carries a `lang` attribute. The annotation and vocabulary search results received this fix in #2265/#2266. Chapter snippets — which are raw uploaded book text and can be in any language — were missed.

## Test plan

- `frontend/src/__tests__/SearchChapterLang.test.ts` — static assertions that `chapter` type has `book_language?` and `ChapterCard` wraps the snippet with `lang={r.book_language ?? undefined}`.
- `backend/tests/test_router_search.py::test_search_chapter_result_includes_book_language` — seeds a German-language upload, searches for a German word, asserts the hit carries `"book_language": "de"`.

Closes #2269

- [ ] Docs updated (if applicable)
