### PR TITLE
fix: add lang to reader sidebar annotation sentence_text for WCAG 3.1.2 (closes #2271)

### DIFF
--- a/frontend/src/__tests__/ReaderSidebarAnnotationLang.test.ts
+++ b/frontend/src/__tests__/ReaderSidebarAnnotationLang.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Regression for #2271 — sidebar annotation sentence_text must carry a lang
+ * attribute for foreign-language books (WCAG 3.1.2 Language of Parts, Level AA).
+ *
+ * The sidebar container does NOT inherit lang={bookLanguage} from the reader
+ * scroll area, so the annotation <p> tag must carry its own lang attribute.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf-8"
+);
+
+describe("Reader sidebar annotation sentence_text lang attribute (closes #2271)", () => {
+  it("renderCard annotation <p> tag has lang from bookLanguage", () => {
+    // renderCard is the IIFE inside the Notes tab — find the unique class string for the annotation <p>
+    const anchor = src.indexOf('"text-xs italic leading-relaxed line-clamp-3 flex-1"');
+    expect(anchor).toBeGreaterThan(-1);
+    // lang= should appear on the same tag — check 60 chars before the className anchor
+    const before = src.slice(Math.max(0, anchor - 60), anchor);
+    expect(before).toMatch(/lang=\{bookLanguage/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1805,7 +1805,7 @@ export default function ReaderPage() {
                     }}
                   >
                     <div className="flex items-start justify-between gap-2">
-                      <p className="text-xs italic leading-relaxed line-clamp-3 flex-1">
+                      <p lang={bookLanguage} className="text-xs italic leading-relaxed line-clamp-3 flex-1">
                         &ldquo;{ann.sentence_text}&rdquo;
                       </p>
                       <button


### PR DESCRIPTION
## What changed

`frontend/src/app/reader/[bookId]/page.tsx` — added `lang={bookLanguage}` to the annotation `<p>` tag inside `renderCard` in the reader sidebar Notes tab.

## Why

The reader's main scroll area carries `lang={bookLanguage}` (line 1390), but the sidebar panel is a separate DOM subtree and does **not** inherit that attribute. The annotation snippet (`ann.sentence_text`) is raw book text that can be in any language. Without a `lang` attribute, screen readers fall back to the page's default `lang="en"` and mispronounce foreign-language text — a WCAG 3.1.2 Language of Parts (Level AA) violation.

`bookLanguage` is already in scope in the component (defaults to `"en"` when the book has no language metadata), so the fix is a single attribute addition.

## Test plan

- `frontend/src/__tests__/ReaderSidebarAnnotationLang.test.ts` — static assertion that the `<p>` tag with the unique class `"text-xs italic leading-relaxed line-clamp-3 flex-1"` carries `lang={bookLanguage}`.
- Full frontend suite: 601 suites / 3632 tests pass.

Closes #2271

- [ ] Docs updated (if applicable)
