### PR TITLE
fix: add lang to flashcard status counter word for WCAG 3.1.2 (closes #2273)

### DIFF
--- a/frontend/src/__tests__/FlashcardStatusLang.test.ts
+++ b/frontend/src/__tests__/FlashcardStatusLang.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Regression for #2273 — flashcard status counter must wrap the foreign word
+ * in a lang-attributed span (WCAG 3.1.2 Language of Parts, Level AA).
+ *
+ * The status counter is aria-live="polite" so screen readers announce the word.
+ * Without a lang attribute the pronunciation engine defaults to English.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/vocabulary/flashcards/page.tsx"),
+  "utf-8"
+);
+
+describe("Flashcard status counter lang attribute (closes #2273)", () => {
+  it("status counter uses JSX span with lang for the word, not a template literal", () => {
+    // Anchor: the unique aria-live status paragraph
+    const anchor = src.indexOf('role="status" aria-live="polite" aria-atomic="true"');
+    expect(anchor).toBeGreaterThan(-1);
+    // Look forward 300 chars to capture the counter content
+    const block = src.slice(anchor, anchor + 300);
+    // Must NOT have the bare template literal form
+    expect(block).not.toMatch(/`:\s*\$\{currentCard\.word\}`/);
+    // Must have a span with lang wrapping the word
+    expect(block).toMatch(/lang=\{currentCard\.language/);
+  });
+});

--- a/frontend/src/__tests__/FlashcardsCoverage.test.tsx
+++ b/frontend/src/__tests__/FlashcardsCoverage.test.tsx
@@ -81,14 +81,14 @@ test("grading first card of two advances to second card instead of showing done"
   mockStats.mockResolvedValue(STATS);
 
   render(<FlashcardsPage />);
-  await waitFor(() => screen.getByText("ephemeral"));
+  await waitFor(() => screen.getAllByText("ephemeral")[0]);
 
   // Flip and grade first card
   await userEvent.click(screen.getByText("Show answer"));
   await userEvent.click(screen.getByRole("button", { name: /Good/i }));
 
   // Should advance to second card, not show "All done"
-  await waitFor(() => screen.getByText("stoic"));
+  await waitFor(() => screen.getAllByText("stoic")[0]);
   expect(screen.queryByText(/all done for today/i)).not.toBeInTheDocument();
   // Now on card index 1 → "2 of 2 remaining"
   expect(screen.getByText(/2 of 2 remaining/i)).toBeInTheDocument();
@@ -99,7 +99,7 @@ test("card counter shows correct position after advancing", async () => {
   mockStats.mockResolvedValue(STATS);
 
   render(<FlashcardsPage />);
-  await waitFor(() => screen.getByText("ephemeral"));
+  await waitFor(() => screen.getAllByText("ephemeral")[0]);
 
   // Initially shows card 1 of 2
   expect(screen.getByRole("status", { name: "" })).toBeInTheDocument();
@@ -110,7 +110,7 @@ test("card counter shows correct position after advancing", async () => {
   await userEvent.click(screen.getByRole("button", { name: /Again/i }));
 
   // Now showing card 2 of 2
-  await waitFor(() => screen.getByText("stoic"));
+  await waitFor(() => screen.getAllByText("stoic")[0]);
   expect(screen.getByText(/2 of 2 remaining/)).toBeInTheDocument();
 });
 
@@ -211,7 +211,7 @@ test("pressing Enter on card flips it to reveal answer side", async () => {
   mockStats.mockResolvedValue(STATS);
 
   render(<FlashcardsPage />);
-  await waitFor(() => screen.getByText("ephemeral"));
+  await waitFor(() => screen.getAllByText("ephemeral")[0]);
 
   const card = screen.getByRole("button", { name: /press to reveal definition/i });
   card.focus();
@@ -227,7 +227,7 @@ test("pressing Space on card flips it to reveal answer side", async () => {
   mockStats.mockResolvedValue(STATS);
 
   render(<FlashcardsPage />);
-  await waitFor(() => screen.getByText("ephemeral"));
+  await waitFor(() => screen.getAllByText("ephemeral")[0]);
 
   const card = screen.getByRole("button", { name: /press to reveal definition/i });
   card.focus();
@@ -255,14 +255,14 @@ test("done state shows deck-specific message when a deck is selected", async () 
 
   render(<FlashcardsPage />);
   await flushPromises();
-  await screen.findByText("ephemeral");
+  await screen.findAllByText("ephemeral").then(els => els[0]);
 
   // Select a specific deck
   const select = await screen.findByRole("combobox", { name: /deck/i });
   await userEvent.selectOptions(select, "1");
 
   // Drain the reload
-  await waitFor(() => screen.getByText("ephemeral"));
+  await waitFor(() => screen.getAllByText("ephemeral")[0]);
 
   // Grade the card
   await userEvent.click(screen.getByText("Show answer"));

--- a/frontend/src/__tests__/FlashcardsCoverage2.test.tsx
+++ b/frontend/src/__tests__/FlashcardsCoverage2.test.tsx
@@ -65,7 +65,7 @@ beforeEach(() => {
 
 test("Back button calls router.push('/vocabulary') (line 149, #2003)", async () => {
   render(<FlashcardsPage />);
-  await waitFor(() => screen.getByText("ephemeral"));
+  await waitFor(() => screen.getAllByText("ephemeral")[0]);
 
   await userEvent.click(screen.getByRole("button", { name: /back to vocabulary/i }));
   expect(mockPush).toHaveBeenCalledWith("/vocabulary");
@@ -75,7 +75,7 @@ test("Back button calls router.push('/vocabulary') (line 149, #2003)", async () 
 
 test("clicking the card div directly toggles flipped state via onClick (line 251, #2003)", async () => {
   render(<FlashcardsPage />);
-  await waitFor(() => screen.getByText("ephemeral"));
+  await waitFor(() => screen.getAllByText("ephemeral")[0]);
 
   // Click the card div itself (not the "Show answer" button) to flip it via onClick
   const card = screen.getByRole("button", { name: /press to reveal definition/i });
@@ -89,7 +89,7 @@ test("clicking the card div directly toggles flipped state via onClick (line 251
 
 test("Enter keydown on card div invokes onKeyDown handler and flips card (line 251, #2003)", async () => {
   render(<FlashcardsPage />);
-  await waitFor(() => screen.getByText("ephemeral"));
+  await waitFor(() => screen.getAllByText("ephemeral")[0]);
 
   // Flip to the definition side first via "Show answer" button so the card is in flipped=true state
   await userEvent.click(screen.getByText("Show answer"));
@@ -106,7 +106,7 @@ test("Enter keydown on card div invokes onKeyDown handler and flips card (line 2
 
 test("Space keydown on card div invokes onKeyDown handler and flips card (line 251, #2003)", async () => {
   render(<FlashcardsPage />);
-  await waitFor(() => screen.getByText("ephemeral"));
+  await waitFor(() => screen.getAllByText("ephemeral")[0]);
 
   await userEvent.click(screen.getByText("Show answer"));
   await waitFor(() => screen.getByRole("button", { name: /Good/i }));
@@ -119,7 +119,7 @@ test("Space keydown on card div invokes onKeyDown handler and flips card (line 2
 
 test("non-activating key on card does not flip it (line 251 branch, #2003)", async () => {
   render(<FlashcardsPage />);
-  await waitFor(() => screen.getByText("ephemeral"));
+  await waitFor(() => screen.getAllByText("ephemeral")[0]);
 
   const card = screen.getByRole("button", { name: /press to reveal definition/i });
   fireEvent.keyDown(card, { key: "Tab" });
@@ -138,7 +138,7 @@ test("readLastDeckId returns undefined when localStorage.getItem throws (line 30
   });
 
   render(<FlashcardsPage />);
-  await waitFor(() => screen.getByText("ephemeral"));
+  await waitFor(() => screen.getAllByText("ephemeral")[0]);
 
   // getDueFlashcards should be called with undefined (no deck restored due to error)
   expect(mockGetDue).toHaveBeenCalledWith(undefined);

--- a/frontend/src/__tests__/FlashcardsPage.errorstate.test.tsx
+++ b/frontend/src/__tests__/FlashcardsPage.errorstate.test.tsx
@@ -75,7 +75,7 @@ test("Retry button re-fetches and shows cards on success", async () => {
   await user.click(retryBtn);
 
   await waitFor(() => {
-    expect(screen.getByText("Schadenfreude")).toBeInTheDocument();
+    expect(screen.getAllByText("Schadenfreude")[0]).toBeInTheDocument();
   });
   expect(screen.queryByRole("alert")).not.toBeInTheDocument();
 });

--- a/frontend/src/__tests__/FlashcardsPage.test.tsx
+++ b/frontend/src/__tests__/FlashcardsPage.test.tsx
@@ -68,8 +68,8 @@ test("renders card word on front face", async () => {
   mockGetDue.mockResolvedValue([SAMPLE_CARD]);
   mockStats.mockResolvedValue(ONE_DUE_STATS);
   render(<FlashcardsPage />);
-  await waitFor(() => screen.getByText("ephemeral"));
-  expect(screen.getByText("ephemeral")).toBeInTheDocument();
+  await waitFor(() => screen.getAllByText("ephemeral")[0]);
+  expect(screen.getAllByText("ephemeral")[0]).toBeInTheDocument();
   expect(screen.getByText("Show answer")).toBeInTheDocument();
 });
 
@@ -77,7 +77,7 @@ test("flipping card reveals grade buttons", async () => {
   mockGetDue.mockResolvedValue([SAMPLE_CARD]);
   mockStats.mockResolvedValue(ONE_DUE_STATS);
   render(<FlashcardsPage />);
-  await waitFor(() => screen.getByText("ephemeral"));
+  await waitFor(() => screen.getAllByText("ephemeral")[0]);
 
   await userEvent.click(screen.getByText("Show answer"));
   expect(screen.getByText("Again")).toBeInTheDocument();
@@ -99,7 +99,7 @@ test("grading a card calls reviewFlashcard and advances", async () => {
   mockStats.mockResolvedValueOnce(ONE_DUE_STATS).mockResolvedValue({ total: 1, due_today: 0, reviewed_today: 1 });
 
   render(<FlashcardsPage />);
-  await waitFor(() => screen.getByText("ephemeral"));
+  await waitFor(() => screen.getAllByText("ephemeral")[0]);
 
   await userEvent.click(screen.getByText("Show answer"));
   await userEvent.click(screen.getByText("Good"));
@@ -122,7 +122,7 @@ test("shows progress bar", async () => {
   mockGetDue.mockResolvedValue([SAMPLE_CARD]);
   mockStats.mockResolvedValue({ total: 1, due_today: 1, reviewed_today: 0 });
   render(<FlashcardsPage />);
-  await waitFor(() => screen.getByText("ephemeral"));
+  await waitFor(() => screen.getAllByText("ephemeral")[0]);
 
   expect(screen.getByText("0 / 1 today")).toBeInTheDocument();
 });

--- a/frontend/src/__tests__/FlashcardsShowAnswerHint.test.tsx
+++ b/frontend/src/__tests__/FlashcardsShowAnswerHint.test.tsx
@@ -47,7 +47,7 @@ beforeEach(() => {
 
 test("Show answer button displays a Space keyboard shortcut hint", async () => {
   render(<FlashcardsPage />);
-  await waitFor(() => screen.getByText("ephemeral"));
+  await waitFor(() => screen.getAllByText("ephemeral")[0]);
 
   const btn = screen.getByRole("button", { name: /show answer/i });
   expect(btn.textContent).toMatch(/space|enter|⎵/i);
@@ -55,7 +55,7 @@ test("Show answer button displays a Space keyboard shortcut hint", async () => {
 
 test("Show answer button aria-label includes keyboard shortcut context", async () => {
   render(<FlashcardsPage />);
-  await waitFor(() => screen.getByText("ephemeral"));
+  await waitFor(() => screen.getAllByText("ephemeral")[0]);
 
   const btn = screen.getByRole("button", { name: /show answer/i });
   // Either visible text or aria-label should mention Space/Enter

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -340,7 +340,7 @@ export default function FlashcardsPage() {
             {/* Card counter — role=status so screen readers announce position after grading */}
             <p role="status" aria-live="polite" aria-atomic="true" className="text-center text-xs text-stone-600">
               {currentIndex + 1} of {cards.length} remaining
-              {currentCard ? `: ${currentCard.word}` : ""}
+              {currentCard ? <>: <span lang={currentCard.language ?? undefined}>{currentCard.word}</span></> : ""}
             </p>
           </div>
         ) : null}


### PR DESCRIPTION
## What changed

`frontend/src/app/vocabulary/flashcards/page.tsx` — converts the template literal `: ${currentCard.word}` in the `role="status"` card-position counter to JSX, wrapping the word in `<span lang={currentCard.language ?? undefined}>`.

Updated 5 existing test files (`FlashcardsPage.test.tsx`, `FlashcardsCoverage.test.tsx`, `FlashcardsCoverage2.test.tsx`, `FlashcardsShowAnswerHint.test.tsx`, `FlashcardsPage.errorstate.test.tsx`) to use `getAllByText`/`findAllByText` since the word now appears in two DOM locations (card face + status counter).

## Why

The `role="status" aria-live="polite"` counter announces the current card's word to screen readers on each grade action. Before this fix the word appeared as a plain text node with no `lang` attribute — screen readers used the page's default `lang="en"` to pronounce foreign vocabulary (WCAG 3.1.2 Language of Parts, Level AA).

## Test plan

- `frontend/src/__tests__/FlashcardStatusLang.test.ts` — static assertion that the status counter uses `<span lang={currentCard.language ...}>` instead of a template literal.
- Full suite: 602 suites / 3634 tests pass.

Closes #2273

- [ ] Docs updated (if applicable)
