### PR TITLE
fix: add lang to AnnotationsSidebar and reader notes-expand panel for WCAG 3.1.2 (closes #2275)

### DIFF
--- a/frontend/src/__tests__/AnnotationsSidebarLang.test.ts
+++ b/frontend/src/__tests__/AnnotationsSidebarLang.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Static source analysis: AnnotationsSidebar sentence_text and reader notes-expand panel
+ * both carry lang attribute — WCAG 3.1.2 Language of Parts (closes #2275)
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const SRC_ROOT = path.resolve(__dirname, "..");
+const sidebarSrc = fs.readFileSync(
+  path.join(SRC_ROOT, "components/AnnotationsSidebar.tsx"),
+  "utf8"
+);
+const readerSrc = fs.readFileSync(
+  path.join(SRC_ROOT, "app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("AnnotationsSidebar WCAG 3.1.2 lang (issue #2275)", () => {
+  it("AnnotationsSidebar Props interface includes bookLanguage", () => {
+    const ifaceIdx = sidebarSrc.indexOf("interface Props");
+    expect(ifaceIdx).toBeGreaterThan(-1);
+    const block = sidebarSrc.slice(ifaceIdx, ifaceIdx + 600);
+    expect(block).toMatch(/bookLanguage\??\s*:/);
+  });
+
+  it("AnnotationsSidebar sentence_text <p> has lang={bookLanguage}", () => {
+    // Anchor on the unique className string for the sentence preview paragraph
+    const anchor = sidebarSrc.indexOf('"text-xs italic leading-relaxed line-clamp-3 flex-1"');
+    expect(anchor).toBeGreaterThan(-1);
+    const before = sidebarSrc.slice(Math.max(0, anchor - 80), anchor);
+    expect(before).toMatch(/lang=\{bookLanguage/);
+  });
+});
+
+describe("Reader notes-expand panel WCAG 3.1.2 lang (issue #2275)", () => {
+  it("notes-expand panel sentence_text div has lang={bookLanguage}", () => {
+    // Anchor on the unique className string for the notes-expand item
+    const anchor = readerSrc.indexOf('"text-ink line-clamp-2"');
+    expect(anchor).toBeGreaterThan(-1);
+    const before = readerSrc.slice(Math.max(0, anchor - 80), anchor);
+    expect(before).toMatch(/lang=\{bookLanguage/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2293,7 +2293,7 @@ export default function ReaderPage() {
                       }}
                       className="w-full text-left px-3 py-2 min-h-[44px] md:min-h-0 flex flex-col justify-center rounded-lg border border-amber-200 bg-amber-50 text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                     >
-                      <div className="text-ink line-clamp-2">{ann.sentence_text}</div>
+                      <div lang={bookLanguage} className="text-ink line-clamp-2">{ann.sentence_text}</div>
                       {ann.note_text && (
                         <div className="text-stone-600 mt-0.5 line-clamp-1 italic">{ann.note_text}</div>
                       )}

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -29,9 +29,11 @@ interface Props {
   loading?: boolean;
   /** When provided, "View all notes" links to /notes/{bookId} instead of /notes */
   bookId?: number;
+  /** BCP 47 language tag for the book — used to mark sentence_text lang (WCAG 3.1.2) */
+  bookLanguage?: string;
 }
 
-export default function AnnotationsSidebar({ annotations, totalCount, onJump, onEdit, loading, bookId }: Props) {
+export default function AnnotationsSidebar({ annotations, totalCount, onJump, onEdit, loading, bookId, bookLanguage }: Props) {
   const [open, setOpen] = useState(false);
   const drawerRef = useRef<HTMLDivElement>(null);
   useFocusTrap(drawerRef, open);
@@ -142,7 +144,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
                         onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onJump(ann); setOpen(false); } }}
                       >
                         <div className="flex items-start justify-between gap-2">
-                          <p className="text-xs italic leading-relaxed line-clamp-3 flex-1">
+                          <p lang={bookLanguage ?? undefined} className="text-xs italic leading-relaxed line-clamp-3 flex-1">
                             &ldquo;{ann.sentence_text}&rdquo;
                           </p>
                           <div className="flex items-center gap-1 shrink-0 mt-0.5">


### PR DESCRIPTION
## What changed

- **`AnnotationsSidebar.tsx`**: Added `bookLanguage?: string` prop and applied `lang={bookLanguage ?? undefined}` to the `<p>` that renders `ann.sentence_text` (the original book sentence where the annotation was placed)
- **`reader/[bookId]/page.tsx`**: Added `lang={bookLanguage}` to the `<div>` rendering `ann.sentence_text` in the bottom-bar notes-expand panel (line 2296)

## Why

Two locations were rendering foreign-language book text (`ann.sentence_text`) without a `lang` attribute, violating WCAG 3.1.2 Language of Parts (Level AA). Screen readers select the pronunciation engine based on the `lang` attribute; without it, a German sentence gets English phonetics.

The reader desktop sidebar fix (line 1808) landed in PR #2272. This PR covers the two remaining locations missed by that fix.

## Test plan

- [ ] Static source assertion: `AnnotationsSidebar` Props includes `bookLanguage?`
- [ ] Static source assertion: sentence_text `<p>` in `AnnotationsSidebar` has `lang={bookLanguage ?? undefined}`
- [ ] Static source assertion: notes-expand panel `<div>` in reader page has `lang={bookLanguage}`
- [ ] Full frontend suite: 3637 tests pass

Closes #2275
