### PR TITLE
fix: add lang to WordLookup word display for WCAG 3.1.2 (closes #2279)

### DIFF
--- a/frontend/src/__tests__/WordLookup.test.tsx
+++ b/frontend/src/__tests__/WordLookup.test.tsx
@@ -62,7 +62,9 @@ describe("WordLookup rendering", () => {
         onClose={jest.fn()}
       />
     );
-    expect(screen.getByText(/Looking up.*serendipity/i)).toBeInTheDocument();
+    const status = screen.getByRole("status");
+    expect(status).toHaveTextContent(/Looking up/i);
+    expect(status).toHaveTextContent(/serendipity/i);
   });
 
   it("shows the word being looked up in loading message", () => {

--- a/frontend/src/__tests__/WordLookupLang.test.ts
+++ b/frontend/src/__tests__/WordLookupLang.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Static source analysis: WordLookup renders word and result.word with lang attribute
+ * for WCAG 3.1.2 Language of Parts (closes #2279)
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/WordLookup.tsx"),
+  "utf8"
+);
+
+describe("WordLookup WCAG 3.1.2 lang (issue #2279)", () => {
+  it("lang is computed at component scope (not only inside useEffect)", () => {
+    // Find first useEffect( call (not the import)
+    const useEffectCallIdx = src.indexOf("useEffect(");
+    const componentBody = src.slice(0, useEffectCallIdx > 0 ? useEffectCallIdx : src.length);
+    // lang must be computed somewhere before the first useEffect call
+    expect(componentBody).toMatch(/const lang\s*=/);
+  });
+
+  it("loading state renders word with lang attribute", () => {
+    const anchor = src.indexOf("Looking up");
+    expect(anchor).toBeGreaterThan(-1);
+    const block = src.slice(anchor, anchor + 120);
+    expect(block).toMatch(/lang=\{lang\}/);
+  });
+
+  it("error state renders word with lang attribute", () => {
+    const anchor = src.indexOf('role="alert"');
+    expect(anchor).toBeGreaterThan(-1);
+    const block = src.slice(anchor, anchor + 150);
+    expect(block).toMatch(/lang=\{lang\}/);
+  });
+
+  it("result heading renders result.word with lang attribute", () => {
+    const anchor = src.indexOf("result.word");
+    expect(anchor).toBeGreaterThan(-1);
+    const before = src.slice(Math.max(0, anchor - 80), anchor);
+    expect(before).toMatch(/lang=\{lang\}/);
+  });
+});

--- a/frontend/src/components/WordLookup.tsx
+++ b/frontend/src/components/WordLookup.tsx
@@ -24,13 +24,13 @@ export default function WordLookup({ word, position, language, onClose }: Props)
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const ref = useRef<HTMLDivElement>(null);
+  const lang = language?.split(/[-_]/)[0] ?? "en";
 
   useEffect(() => {
     setLoading(true);
     setError("");
     setResult(null);
 
-    const lang = language?.split(/[-_]/)[0] ?? "en";
     fetch(`https://api.dictionaryapi.dev/api/v2/entries/${lang}/${encodeURIComponent(word.toLowerCase())}`)
       .then((r) => {
         if (!r.ok) throw new Error("Not found");
@@ -87,18 +87,18 @@ export default function WordLookup({ word, position, language, onClose }: Props)
       {loading && (
         <div className="flex items-center gap-2 text-amber-700" role="status">
           <span className="w-3 h-3 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
-          Looking up &ldquo;{word}&rdquo;...
+          Looking up &ldquo;<span lang={lang}>{word}</span>&rdquo;...
         </div>
       )}
 
       {error && (
-        <p role="alert" className="text-amber-700 italic">{error} for &ldquo;{word}&rdquo;</p>
+        <p role="alert" className="text-amber-700 italic">{error} for &ldquo;<span lang={lang}>{word}</span>&rdquo;</p>
       )}
 
       {result && (
         <>
           <div className="flex items-baseline gap-2 mb-2">
-            <span className="font-serif font-bold text-ink text-base">{result.word}</span>
+            <span lang={lang} className="font-serif font-bold text-ink text-base">{result.word}</span>
             {result.phonetic && (
               <span className="text-xs text-amber-700">{result.phonetic}</span>
             )}


### PR DESCRIPTION
## What changed

- Moved `lang` computation to component scope in `WordLookup` (was only inside `useEffect`, making it inaccessible to JSX)
- Added `lang={lang}` to three locations where the word is rendered:
  1. Loading state: `Looking up "‹word›"...`
  2. Error state: `No definition found for "‹word›"`
  3. Result heading: the word returned by the dictionary API
- Updated `WordLookup.test.tsx`: loading-state test switched from `getByText(/Looking up.*word/i)` (fails when word is in a child `<span>`) to `getByRole("status")` + `toHaveTextContent` checks

## Why

WCAG 3.1.2 Language of Parts (Level AA): the word displayed in WordLookup is the original foreign-language text from the book. Without `lang`, screen readers apply English phonetics to German/French/Chinese etc. The `lang` variable was already computed from the `language` prop — it just wasn't applied to the rendered text.

## Test plan

- [ ] Static source: `lang` computed before first `useEffect(` call
- [ ] Static source: loading state has `lang={lang}` forward of "Looking up"
- [ ] Static source: error `role="alert"` element has `lang={lang}`
- [ ] Static source: `result.word` span has `lang={lang}` in backward window
- [ ] Full frontend suite: 3639 tests pass

Closes #2279
