### PR TITLE
fix: add lang to VocabularyToast word for WCAG 3.1.2 (closes #2281)

### DIFF
--- a/frontend/src/__tests__/VocabularyToastLang.test.ts
+++ b/frontend/src/__tests__/VocabularyToastLang.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Static source analysis: VocabularyToast renders word with lang attribute
+ * for WCAG 3.1.2 Language of Parts (closes #2281)
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const toastSrc = fs.readFileSync(
+  path.join(__dirname, "../components/VocabularyToast.tsx"),
+  "utf8"
+);
+const readerSrc = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("VocabularyToast WCAG 3.1.2 lang (issue #2281)", () => {
+  it("VocabularyToast Props interface includes language", () => {
+    const ifaceIdx = toastSrc.indexOf("interface Props");
+    expect(ifaceIdx).toBeGreaterThan(-1);
+    const block = toastSrc.slice(ifaceIdx, ifaceIdx + 150);
+    expect(block).toMatch(/language\??\s*:/);
+  });
+
+  it("word in toast has lang attribute", () => {
+    // Anchor: unique "saved to vocabulary" text
+    const anchor = toastSrc.indexOf("saved to vocabulary");
+    expect(anchor).toBeGreaterThan(-1);
+    const before = toastSrc.slice(Math.max(0, anchor - 120), anchor);
+    expect(before).toMatch(/lang=\{language/);
+  });
+
+  it("reader page passes bookLanguage to VocabularyToast", () => {
+    const anchor = readerSrc.indexOf("<VocabularyToast");
+    expect(anchor).toBeGreaterThan(-1);
+    const block = readerSrc.slice(anchor, anchor + 150);
+    expect(block).toMatch(/language=\{bookLanguage\}/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1651,6 +1651,7 @@ export default function ReaderPage() {
             <VocabularyToast
               word={vocabToastWord}
               onDone={() => setVocabToastWord(null)}
+              language={bookLanguage}
             />
           )}
 

--- a/frontend/src/components/VocabularyToast.tsx
+++ b/frontend/src/components/VocabularyToast.tsx
@@ -5,9 +5,10 @@ import { CheckCircleIcon } from "@/components/Icons";
 interface Props {
   word: string;
   onDone: () => void;
+  language?: string;
 }
 
-export default function VocabularyToast({ word, onDone }: Props) {
+export default function VocabularyToast({ word, onDone, language }: Props) {
   const [visible, setVisible] = useState(true);
 
   useEffect(() => {
@@ -28,7 +29,7 @@ export default function VocabularyToast({ word, onDone }: Props) {
       }`}
     >
       <CheckCircleIcon className="w-4 h-4 text-emerald-600 shrink-0" />
-      <span><strong>{word}</strong> saved to vocabulary</span>
+      <span><strong lang={language ?? undefined}>{word}</strong> saved to vocabulary</span>
     </div>
   );
 }


### PR DESCRIPTION
## What changed

- Added `language?: string` prop to `VocabularyToast` and applied `lang={language ?? undefined}` to the `<strong>` element that renders the saved word
- Pass `bookLanguage` from `reader/[bookId]/page.tsx` to `<VocabularyToast>`

## Why

WCAG 3.1.2 Language of Parts (Level AA): the word displayed in the "saved to vocabulary" toast is foreign-language text. Without `lang`, screen readers apply English phonetics.

## Test plan

- [ ] Props includes `language?`
- [ ] `<strong>` element has `lang={language ?? undefined}` before "saved to vocabulary"
- [ ] Reader page passes `language={bookLanguage}` to `<VocabularyToast>`
- [ ] Full frontend suite: 3641 tests pass

Closes #2281
