### PR TITLE
fix: add lang to AnnotationToolbar quoted sentence for WCAG 3.1.2 (closes #2283)

### DIFF
--- a/frontend/src/__tests__/AnnotationToolbarLang.test.ts
+++ b/frontend/src/__tests__/AnnotationToolbarLang.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Static-analysis tests for WCAG 3.1.2 lang attribute on AnnotationToolbar
+ * quoted sentence text (issue #2283).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const SRC = path.resolve(
+  __dirname,
+  "../components/AnnotationToolbar.tsx"
+);
+
+describe("AnnotationToolbar WCAG 3.1.2 lang attribute", () => {
+  let src: string;
+
+  beforeAll(() => {
+    src = fs.readFileSync(SRC, "utf8");
+  });
+
+  it("Props interface includes bookLanguage optional string", () => {
+    const anchor = src.indexOf("interface Props");
+    expect(anchor).toBeGreaterThan(-1);
+    const block = src.slice(anchor, anchor + 400);
+    expect(block).toMatch(/bookLanguage\?\s*:\s*string/);
+  });
+
+  it("quoted sentence paragraph carries lang attribute", () => {
+    const anchor = src.indexOf("sentenceText}");
+    expect(anchor).toBeGreaterThan(-1);
+    // Look for lang= in the 200 chars before the close of the paragraph
+    const block = src.slice(Math.max(0, anchor - 200), anchor + 20);
+    expect(block).toMatch(/lang=\{bookLanguage/);
+  });
+
+  it("bookLanguage is destructured from props", () => {
+    const anchor = src.indexOf("export default function AnnotationToolbar");
+    expect(anchor).toBeGreaterThan(-1);
+    const block = src.slice(anchor, anchor + 300);
+    expect(block).toMatch(/bookLanguage/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1548,6 +1548,7 @@ export default function ReaderPage() {
               sentenceText={annotationPanel.sentenceText}
               chapterIndex={annotationPanel.chapterIndex}
               bookId={Number(bookId)}
+              bookLanguage={bookLanguage}
               existingAnnotation={annotations.find(
                 (a) =>
                   a.sentence_text === annotationPanel.sentenceText &&

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -18,6 +18,7 @@ interface Props {
   sentenceText: string;
   chapterIndex: number;
   bookId: number;
+  bookLanguage?: string;
   existingAnnotation?: { id: number; note_text: string; color: string };
   onClose: () => void;
   onSaved: (annotation: Annotation) => void;
@@ -28,6 +29,7 @@ export default function AnnotationToolbar({
   sentenceText,
   chapterIndex,
   bookId,
+  bookLanguage,
   existingAnnotation,
   onClose,
   onSaved,
@@ -135,7 +137,7 @@ export default function AnnotationToolbar({
 
         <div className="px-5 pt-3 pb-5 space-y-4">
           {/* Quoted sentence */}
-          <p className="text-xs text-amber-700 font-serif italic line-clamp-2 leading-relaxed border-l-2 border-amber-300 pl-3">
+          <p lang={bookLanguage ?? undefined} className="text-xs text-amber-700 font-serif italic line-clamp-2 leading-relaxed border-l-2 border-amber-300 pl-3">
             {sentenceText}
           </p>
 


### PR DESCRIPTION
## What changed

Added `bookLanguage?: string` prop to `AnnotationToolbar` and applied `lang={bookLanguage ?? undefined}` to the quoted sentence `<p>` (line 138). Wired `bookLanguage={bookLanguage}` from the reader page call site.

## Why

WCAG 3.1.2 (Language of Parts, Level AA): screen readers must know the language of quoted source-text to pronounce it correctly. Without `lang`, the browser inherits the UI language instead of the book language.

## Test plan

- New static-analysis test `AnnotationToolbarLang.test.ts` (3 assertions): Props has `bookLanguage?`, `<p>` carries `lang={bookLanguage`, destructor includes `bookLanguage`
- Full Jest suite: 3645 tests pass

Closes #2283
