### PR TITLE
fix: add Clear search CTA to Gutenberg search empty state (closes #2285)

### DIFF
--- a/frontend/src/__tests__/EmptyStateCta.test.ts
+++ b/frontend/src/__tests__/EmptyStateCta.test.ts
@@ -1,6 +1,6 @@
 /**
- * Static assertions: empty states in vocabulary and notes overview pages have CTA buttons.
- * Closes #1090
+ * Static assertions: empty states in vocabulary, notes overview, and home search
+ * pages have CTA buttons. Closes #1090, #2285
  */
 import fs from "fs";
 import path from "path";
@@ -12,6 +12,11 @@ const vocabPage = fs.readFileSync(
 
 const notesOverviewPage = fs.readFileSync(
   path.join(process.cwd(), "src/app/notes/page.tsx"),
+  "utf8",
+);
+
+const homePage = fs.readFileSync(
+  path.join(process.cwd(), "src/app/page.tsx"),
   "utf8",
 );
 
@@ -40,5 +45,20 @@ describe("EmptyStateCta", () => {
     expect(idx).toBeGreaterThan(0);
     const after = notesOverviewPage.slice(idx, idx + 1500);
     expect(after).toMatch(/router\.push\("\/"\)/);
+  });
+
+  it("search empty state has a Clear search CTA button", () => {
+    const idx = homePage.indexOf('No books found for');
+    expect(idx).toBeGreaterThan(-1);
+    const block = homePage.slice(idx, idx + 900);
+    expect(block).toMatch(/Clear search|clear search/);
+  });
+
+  it("search empty state CTA resets query state", () => {
+    const idx = homePage.indexOf('No books found for');
+    expect(idx).toBeGreaterThan(-1);
+    const block = homePage.slice(idx, idx + 900);
+    // The CTA should reset both the input query and the searched query
+    expect(block).toMatch(/setQuery\(""\)|setQuery\(''\)/);
   });
 });

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -676,6 +676,13 @@ export default function Home() {
                   <SearchIcon className="w-10 h-10 mx-auto mb-2 text-amber-400" aria-hidden="true" />
                   <p className="text-lg font-serif mb-1">No books found for &ldquo;{searchedQuery}&rdquo;</p>
                   <p className="text-sm text-amber-700">Try a different title, author, or language filter.</p>
+                  <button
+                    type="button"
+                    onClick={() => { setQuery(""); setSearchedQuery(""); setSearchResults([]); }}
+                    className="mt-4 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
+                  >
+                    Clear search
+                  </button>
                 </div>
               )}
             </section>


### PR DESCRIPTION
## What changed

Added a "Clear search" button to the Gutenberg search empty state (`frontend/src/app/page.tsx`). When a search returns no results, clicking the button resets `query`, `searchedQuery`, and `searchResults` to empty.

## Why

CLAUDE.md requires every empty state to have a primary CTA button. The search "no results" state had an icon, headline, and sub-text but no actionable next step — users had to manually delete their search text to start over.

## Test plan

- Extended `EmptyStateCta.test.ts` with 2 new assertions: the "No books found" block contains "Clear search" text and a `setQuery("")` call
- All 6 EmptyStateCta tests pass; full Jest suite: 3647 tests pass

Closes #2285
