### PR TITLE
fix: add lang to InsightChat ContextChip and MsgContextBlock for WCAG 3.1.2 (closes #2287)

### DIFF
--- a/frontend/src/__tests__/InsightChatContextChipLang.test.ts
+++ b/frontend/src/__tests__/InsightChatContextChipLang.test.ts
@@ -35,4 +35,19 @@ describe("InsightChat ContextChip WCAG 3.1.2 lang attribute", () => {
     const block = src.slice(anchor, anchor + 200);
     expect(block).toMatch(/bookLanguage=/);
   });
+
+  it("MsgContextBlock props include bookLanguage optional string", () => {
+    const anchor = src.indexOf("function MsgContextBlock(");
+    expect(anchor).toBeGreaterThan(-1);
+    const block = src.slice(anchor, anchor + 300);
+    expect(block).toMatch(/bookLanguage\?\s*:\s*string/);
+  });
+
+  it("MsgContextBlock quoted paragraph carries lang attribute", () => {
+    const anchor = src.indexOf("function MsgContextBlock(");
+    expect(anchor).toBeGreaterThan(-1);
+    // Find the paragraph within MsgContextBlock (body is ~600 chars to the <p>)
+    const body = src.slice(anchor, anchor + 700);
+    expect(body).toMatch(/lang=\{bookLanguage/);
+  });
 });

--- a/frontend/src/__tests__/InsightChatContextChipLang.test.ts
+++ b/frontend/src/__tests__/InsightChatContextChipLang.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Static-analysis tests for WCAG 3.1.2 lang attribute on InsightChat
+ * ContextChip quoted book text (issue #2287).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const SRC = path.resolve(__dirname, "../components/InsightChat.tsx");
+
+describe("InsightChat ContextChip WCAG 3.1.2 lang attribute", () => {
+  let src: string;
+
+  beforeAll(() => {
+    src = fs.readFileSync(SRC, "utf8");
+  });
+
+  it("ContextChip props include bookLanguage optional string", () => {
+    const anchor = src.indexOf("function ContextChip(");
+    expect(anchor).toBeGreaterThan(-1);
+    const block = src.slice(anchor, anchor + 300);
+    expect(block).toMatch(/bookLanguage\?\s*:\s*string/);
+  });
+
+  it("ContextChip quoted span carries lang attribute", () => {
+    const anchor = src.indexOf("italic leading-relaxed");
+    expect(anchor).toBeGreaterThan(-1);
+    // Look for lang= within 100 chars before the class (backward window)
+    const before = src.slice(Math.max(0, anchor - 100), anchor);
+    expect(before).toMatch(/lang=\{bookLanguage/);
+  });
+
+  it("ContextChip call site passes bookLanguage prop", () => {
+    const anchor = src.indexOf("<ContextChip");
+    expect(anchor).toBeGreaterThan(-1);
+    const block = src.slice(anchor, anchor + 200);
+    expect(block).toMatch(/bookLanguage=/);
+  });
+});

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -57,9 +57,11 @@ interface Props {
 // ── Context chip (expandable quote) ─────────────────────────────────────────
 function ContextChip({
   text,
+  bookLanguage,
   onRemove,
 }: {
   text: string;
+  bookLanguage?: string;
   onRemove?: () => void;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -70,7 +72,7 @@ function ContextChip({
       <div className="flex items-start gap-1.5">
         <PaperclipIcon className="w-3.5 h-3.5 shrink-0 mt-px text-amber-400" />
         <div className="flex-1 min-w-0">
-          <span className="italic leading-relaxed">
+          <span lang={bookLanguage ?? undefined} className="italic leading-relaxed">
             &ldquo;{shown}{!expanded && needsToggle ? "…" : ""}&rdquo;
           </span>
           {needsToggle && (
@@ -576,7 +578,7 @@ export default function InsightChat({
         {/* Context chip */}
         {contextText && (
           <div className="mb-2">
-            <ContextChip text={contextText} onRemove={() => setContextText("")} />
+            <ContextChip text={contextText} bookLanguage={bookLanguage} onRemove={() => setContextText("")} />
           </div>
         )}
 

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -481,6 +481,7 @@ export default function InsightChat({
                   <div className="max-w-[88%] w-full">
                     <MsgContextBlock
                       text={msg.context}
+                      bookLanguage={bookLanguage}
                       expanded={expandedMsgCtx.has(absIdx)}
                       onToggle={() =>
                         setExpandedMsgCtx((prev) => {
@@ -624,10 +625,12 @@ export default function InsightChat({
 // ── Message-level context block ───────────────────────────────────────────────
 function MsgContextBlock({
   text,
+  bookLanguage,
   expanded,
   onToggle,
 }: {
   text: string;
+  bookLanguage?: string;
   expanded: boolean;
   onToggle: () => void;
 }) {
@@ -636,7 +639,7 @@ function MsgContextBlock({
   return (
     <div className="flex items-start gap-1.5 rounded-lg bg-amber-50/80 border border-amber-100 px-2.5 py-1.5">
       <PaperclipIcon aria-hidden="true" className="w-3 h-3 text-amber-400 shrink-0 mt-px" />
-      <p className="text-xs text-amber-700 italic leading-relaxed flex-1">
+      <p lang={bookLanguage ?? undefined} className="text-xs text-amber-700 italic leading-relaxed flex-1">
         &ldquo;{shown}{!expanded && needsToggle ? "…" : ""}&rdquo;
         {needsToggle && (
           <button


### PR DESCRIPTION
## What changed

Added `bookLanguage?: string` prop to two sub-components in `InsightChat.tsx`:

1. **`ContextChip`** — the expandable quote chip in the input area. Applied `lang={bookLanguage ?? undefined}` to the `<span>` wrapping the quoted text.
2. **`MsgContextBlock`** — the context quote shown inline with user chat messages. Applied `lang={bookLanguage ?? undefined}` to the `<p>` wrapping the quoted text.

Both call sites now pass `bookLanguage` from the `InsightChat` props.

## Why

WCAG 3.1.2 (Language of Parts, Level AA): when a user selects book text from a foreign-language book and sends it as context in the chat, the quoted text is displayed without a `lang` attribute. Screen readers would use the UI language to pronounce it instead of the book's language.

## Test plan

- New static-analysis test `InsightChatContextChipLang.test.ts` (5 assertions): ContextChip has `bookLanguage?` in props, quoted span has `lang={bookLanguage}`, call site passes prop; MsgContextBlock has `bookLanguage?` in props, quoted `<p>` has `lang={bookLanguage}`
- Full Jest suite: 3652 tests pass

Closes #2287
