### PR TITLE
fix: add lang to Notes VocabRow word anchor for WCAG 3.1.2 (closes #2291)

### DIFF
--- a/frontend/src/__tests__/NotesVocabRowLang.test.ts
+++ b/frontend/src/__tests__/NotesVocabRowLang.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Static assertions: VocabRow word link carries lang attribute — WCAG 3.1.2
+ * Closes #2291
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(process.cwd(), "src/app/notes/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("NotesVocabRowLang", () => {
+  it("VocabRow component exists in source", () => {
+    expect(src).toContain("function VocabRow(");
+  });
+
+  it("VocabRow word anchor carries lang attribute", () => {
+    const anchor = src.indexOf("function VocabRow(");
+    expect(anchor).toBeGreaterThan(0);
+    // The <a> tag for the word should have lang before the closing > of the opening tag
+    const block = src.slice(anchor, anchor + 750);
+    expect(block).toMatch(/lang=\{bookLanguage/);
+  });
+
+  it("VocabRow word anchor lang uses null-coalescing pattern", () => {
+    const anchor = src.indexOf("function VocabRow(");
+    const block = src.slice(anchor, anchor + 750);
+    expect(block).toMatch(/lang=\{bookLanguage\s*\?\?\s*undefined\}/);
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -236,6 +236,7 @@ function VocabRow({
     <li className="flex gap-2 text-sm leading-relaxed before:content-['·'] before:text-amber-400 before:font-bold before:shrink-0">
       <span>
         <a
+          lang={bookLanguage ?? undefined}
           href={`/vocabulary?word=${encodeURIComponent(word)}`}
           className="font-semibold text-amber-700 hover:text-amber-900 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
         >


### PR DESCRIPTION
## What changed

In `frontend/src/app/notes/[bookId]/page.tsx`, the `VocabRow` component renders each saved vocabulary word as an anchor link. The `bookLanguage` prop was already threaded in and applied to the sentence-text span, but the word `<a>` tag itself was missing the attribute.

Added `lang={bookLanguage ?? undefined}` to the word anchor.

## Why

WCAG 3.1.2 (Language of Parts, Level AA): the vocabulary word is a foreign-language term and the `<a>` is the element a screen reader announces — the `lang` must be on the element, not only its sibling. Sentence-text span already had `lang`; this brings the word link into compliance.

## Test plan

- [ ] New test: `frontend/src/__tests__/NotesVocabRowLang.test.ts` (3 assertions)
- [ ] Full frontend suite: 3656 tests pass

Closes #2291
