### PR TITLE
fix: show red border on Obsidian settings inputs when save fails (closes #2296)

### DIFF
--- a/frontend/src/__tests__/ProfileObsidianErrorBorder.test.ts
+++ b/frontend/src/__tests__/ProfileObsidianErrorBorder.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Static assertions: Profile Obsidian inputs show red border on save failure — closes #2296
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(process.cwd(), "src/app/profile/page.tsx"),
+  "utf8",
+);
+
+describe("ProfileObsidianErrorBorder", () => {
+  it("Obsidian token input className references obsidianMsg", () => {
+    const anchor = src.indexOf('id="obsidian-token"');
+    expect(anchor).toBeGreaterThan(0);
+    const block = src.slice(anchor, anchor + 600);
+    expect(block).toMatch(/obsidianMsg/);
+  });
+
+  it("Obsidian token input has red border class on error", () => {
+    const anchor = src.indexOf('id="obsidian-token"');
+    const block = src.slice(anchor, anchor + 600);
+    expect(block).toMatch(/border-red/);
+  });
+
+  it("Obsidian repo input has red border class on error", () => {
+    const anchor = src.indexOf('id="obsidian-repo"');
+    expect(anchor).toBeGreaterThan(0);
+    const block = src.slice(anchor, anchor + 600);
+    expect(block).toMatch(/border-red/);
+  });
+
+  it("Obsidian path input has red border class on error", () => {
+    const anchor = src.indexOf('id="obsidian-path"');
+    expect(anchor).toBeGreaterThan(0);
+    const block = src.slice(anchor, anchor + 600);
+    expect(block).toMatch(/border-red/);
+  });
+});

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -399,7 +399,7 @@ export default function ProfilePage() {
                   placeholder={hasObsidianToken ? "Enter new token to replace existing" : "ghp_… (never shown back)"}
                   value={obsidianToken}
                   onChange={(e) => setObsidianToken(e.target.value)}
-                  className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-amber-400 placeholder:text-stone-600"
+                  className={`w-full border rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 placeholder:text-stone-600 ${obsidianMsg?.ok === false ? "border-red-400 focus:ring-red-400" : "border-stone-300 focus:ring-amber-400"}`}
                 />
                 <p className="text-xs text-stone-600 mt-1">
                   Requires <code>contents:write</code> permission on your vault repo.
@@ -416,7 +416,7 @@ export default function ProfilePage() {
                   placeholder="username/obsidian-notes"
                   value={obsidianRepo}
                   onChange={(e) => setObsidianRepo(e.target.value)}
-                  className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 placeholder:text-stone-600"
+                  className={`w-full border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 placeholder:text-stone-600 ${obsidianMsg?.ok === false ? "border-red-400 focus:ring-red-400" : "border-stone-300 focus:ring-amber-400"}`}
                 />
               </div>
 
@@ -430,7 +430,7 @@ export default function ProfilePage() {
                   placeholder="All Notes/002 Literature Notes/000 Books"
                   value={obsidianPath}
                   onChange={(e) => setObsidianPath(e.target.value)}
-                  className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 placeholder:text-stone-600"
+                  className={`w-full border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 placeholder:text-stone-600 ${obsidianMsg?.ok === false ? "border-red-400 focus:ring-red-400" : "border-stone-300 focus:ring-amber-400"}`}
                 />
               </div>
 


### PR DESCRIPTION
## What changed

`frontend/src/app/profile/page.tsx` — Obsidian settings inputs (token, repo path, export path) now apply a conditional red border (`border-red-400 focus:ring-red-400`) when the Obsidian save call returns an error, matching the same pattern used for the Gemini key input (#2295).

## Why

Users had no visual feedback indicating which inputs were invalid on save failure. The error message text appeared but the input borders stayed amber, making it unclear which field to correct.

## Test plan

- `ProfileObsidianErrorBorder.test.ts` — static-analysis assertions verify all three inputs carry the conditional red-border class
- All 3668 frontend tests pass
