### PR TITLE
fix: show red border on TagEditor tag input when tag is invalid (closes #2302)

### DIFF
--- a/frontend/src/__tests__/TagEditorErrorBorder.test.ts
+++ b/frontend/src/__tests__/TagEditorErrorBorder.test.ts
@@ -1,0 +1,23 @@
+// Regression: tag input must show red border when error state is set (#2302)
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/TagEditor.tsx"),
+  "utf8"
+);
+
+describe("TagEditor — tag input error border", () => {
+  it("uses conditional border class on error", () => {
+    const anchor = src.indexOf("aria-invalid={!!error}");
+    expect(anchor).toBeGreaterThan(-1);
+    const window = src.slice(anchor, anchor + 350);
+    expect(window).toContain("border-red");
+  });
+
+  it("does not use static border-amber-300 alone on the tag input", () => {
+    const anchor = src.indexOf("aria-invalid={!!error}");
+    const window = src.slice(anchor, anchor + 350);
+    expect(window).not.toMatch(/className="[^"]*border border-amber-300[^"]*"/);
+  });
+});

--- a/frontend/src/components/TagEditor.tsx
+++ b/frontend/src/components/TagEditor.tsx
@@ -146,7 +146,7 @@ export default function TagEditor({
           aria-label="New tag"
           aria-invalid={!!error}
           aria-describedby={error ? `tag-editor-error-${vocabularyId}` : undefined}
-          className="rounded-full border border-amber-300 bg-white px-2 py-0.5 text-xs text-ink focus:outline-none focus:ring-2 focus:ring-amber-400 w-24 placeholder:text-stone-600"
+          className={`rounded-full border bg-white px-2 py-0.5 text-xs text-ink focus:outline-none focus:ring-2 w-24 placeholder:text-stone-600 ${error ? "border-red-400 focus:ring-red-400" : "border-amber-300 focus:ring-amber-400"}`}
           data-testid={`tag-input-${vocabularyId}`}
         />
       ) : (


### PR DESCRIPTION
## What changed

`frontend/src/components/TagEditor.tsx` line 149 — the new-tag input now applies a conditional red border (`border-red-400 focus:ring-red-400`) when the error state is set, instead of keeping the static amber border.

## Why

The input already had `aria-invalid={!!error}` and an accessible error message (`role="alert"`), but the border stayed amber on error. Users had no visual indication on the field itself that their tag was rejected.

## Test plan

- `TagEditorErrorBorder.test.ts` — static-analysis assertions verify the input carries conditional red-border styling
- All 3670 frontend tests pass
