### PR TITLE
fix: show red border on deck name input when form has a validation error (closes #2299)

### DIFF
--- a/frontend/src/__tests__/DecksNewNameErrorBorder.test.ts
+++ b/frontend/src/__tests__/DecksNewNameErrorBorder.test.ts
@@ -1,0 +1,24 @@
+// Regression: deck name input must show red border when error state is set (#2299)
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/decks/new/page.tsx"),
+  "utf8"
+);
+
+describe("decks/new — deck name input error border", () => {
+  it("uses conditional border class on error", () => {
+    const anchor = src.indexOf("deck-name-input");
+    expect(anchor).toBeGreaterThan(-1);
+    const window = src.slice(anchor, anchor + 350);
+    expect(window).toContain("border-red");
+  });
+
+  it("does not use static border-amber-200 alone on name input", () => {
+    const anchor = src.indexOf("deck-name-input");
+    const window = src.slice(anchor, anchor + 350);
+    // Must not hardcode only the amber border; must be conditional
+    expect(window).not.toMatch(/className="[^"]*border border-amber-200[^"]*"/);
+  });
+});

--- a/frontend/src/app/decks/new/page.tsx
+++ b/frontend/src/app/decks/new/page.tsx
@@ -103,7 +103,7 @@ export default function DecksNewPage() {
               data-testid="deck-name-input"
               aria-invalid={!!error}
               aria-describedby={error ? "deck-form-error" : undefined}
-              className="w-full rounded-xl border border-amber-200 bg-white px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 placeholder:text-stone-600"
+              className={`w-full rounded-xl border bg-white px-4 py-2.5 text-sm focus:outline-none focus:ring-2 placeholder:text-stone-600 ${error ? "border-red-400 focus:ring-red-400" : "border-amber-200 focus:ring-amber-400"}`}
               placeholder="e.g. German verbs"
             />
           </div>


### PR DESCRIPTION
## What changed

`frontend/src/app/decks/new/page.tsx` line 106 — the deck name input now applies a conditional red border (`border-red-400 focus:ring-red-400`) when the form's error state is set, instead of keeping the static amber border.

## Why

The input already had `aria-invalid={!!error}` and an accessible error message (`id="deck-form-error" role="alert"`), but the border stayed amber on error. Users had no visual indication on the field itself that validation failed (e.g. empty deck name submitted).

## Test plan

- `DecksNewNameErrorBorder.test.ts` — static-analysis assertions verify the name input carries conditional red-border styling and no longer has a hardcoded static amber border
- All 3673 frontend tests pass
