### PR TITLE
fix: add role=dialog and close button to WordLookup popup (closes #2306)

### DIFF
--- a/frontend/src/__tests__/WordLookupDialogAria.test.tsx
+++ b/frontend/src/__tests__/WordLookupDialogAria.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import WordLookup from "@/components/WordLookup";
+
+const DEFAULT_POSITION = { x: 200, y: 300 };
+
+beforeEach(() => {
+  global.fetch = jest.fn().mockReturnValue(new Promise(() => {}));
+});
+
+describe("WordLookup — dialog ARIA", () => {
+  it("has role=dialog on the popup container", () => {
+    render(
+      <WordLookup word="test" position={DEFAULT_POSITION} onClose={jest.fn()} />
+    );
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("aria-label on the dialog includes the word", () => {
+    render(
+      <WordLookup word="ephemeral" position={DEFAULT_POSITION} onClose={jest.fn()} />
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-label", expect.stringContaining("ephemeral"));
+  });
+
+  it("has a visible close button with aria-label", () => {
+    render(
+      <WordLookup word="test" position={DEFAULT_POSITION} onClose={jest.fn()} />
+    );
+    const closeBtn = screen.getByRole("button", { name: /close definition/i });
+    expect(closeBtn).toBeInTheDocument();
+  });
+
+  it("close button calls onClose", () => {
+    const onClose = jest.fn();
+    render(
+      <WordLookup word="test" position={DEFAULT_POSITION} onClose={onClose} />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /close definition/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/WordLookup.tsx
+++ b/frontend/src/components/WordLookup.tsx
@@ -100,14 +100,14 @@ export default function WordLookup({ word, position, language, onClose }: Props)
         <CloseIcon className="w-3.5 h-3.5" aria-hidden="true" />
       </button>
       {loading && (
-        <div className="flex items-center gap-2 text-amber-700" role="status">
+        <div className="flex items-center gap-2 text-amber-700 pr-6" role="status">
           <span className="w-3 h-3 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
           Looking up &ldquo;<span lang={lang}>{word}</span>&rdquo;...
         </div>
       )}
 
       {error && (
-        <p role="alert" className="text-amber-700 italic">{error} for &ldquo;<span lang={lang}>{word}</span>&rdquo;</p>
+        <p role="alert" className="text-amber-700 italic pr-6">{error} for &ldquo;<span lang={lang}>{word}</span>&rdquo;</p>
       )}
 
       {result && (

--- a/frontend/src/components/WordLookup.tsx
+++ b/frontend/src/components/WordLookup.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
+import { CloseIcon } from "@/components/Icons";
 
 interface Definition {
   partOfSpeech: string;
@@ -83,7 +84,21 @@ export default function WordLookup({ word, position, language, onClose }: Props)
       };
 
   return (
-    <div ref={ref} style={style} className="sm:w-72 max-h-64 overflow-y-auto rounded-xl border border-amber-300 bg-white shadow-lg p-3 text-sm">
+    <div
+      ref={ref}
+      role="dialog"
+      aria-label={`Word definition: ${word}`}
+      style={style}
+      className="relative sm:w-72 max-h-64 overflow-y-auto rounded-xl border border-amber-300 bg-white shadow-lg p-3 text-sm"
+    >
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close definition"
+        className="absolute top-1.5 right-1.5 rounded-full p-0.5 hover:bg-amber-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+      >
+        <CloseIcon className="w-3.5 h-3.5" aria-hidden="true" />
+      </button>
       {loading && (
         <div className="flex items-center gap-2 text-amber-700" role="status">
           <span className="w-3 h-3 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
@@ -97,7 +112,7 @@ export default function WordLookup({ word, position, language, onClose }: Props)
 
       {result && (
         <>
-          <div className="flex items-baseline gap-2 mb-2">
+          <div className="flex items-baseline gap-2 mb-2 pr-5">
             <span lang={lang} className="font-serif font-bold text-ink text-base">{result.word}</span>
             {result.phonetic && (
               <span className="text-xs text-amber-700">{result.phonetic}</span>


### PR DESCRIPTION
## What changed

- `WordLookup.tsx`: Added `role="dialog"` and `aria-label="Word definition: {word}"` to the popup container
- Added a visible close button (`aria-label="Close definition"`) in the top-right corner using `CloseIcon` from the icon system
- Added `position: relative` to the container to anchor the close button correctly
- Added `pr-5` padding-right to the word/phonetic row so the close button doesn't overlap content

## Why

The WordLookup popup acts as a dialog (closes on Escape + click-outside, contains interactive scrollable content) but had no ARIA dialog semantics. Screen reader users received no announcement when the popup opened and had no visible close affordance — keyboard-only users had to know about the undiscoverable Escape shortcut.

Closes #2306

## Test plan

- [x] `WordLookupDialogAria.test.tsx` — 4 new tests: `role="dialog"` present, `aria-label` contains the word, close button exists with correct label, close button fires `onClose`
- [x] Full frontend suite: 3677 tests pass
- [x] Existing WordLookup tests (Escape, click-outside, re-fetch, mobile layout) all continue to pass
