### PR TITLE
fix: add title tooltip to DeckCard description for truncated text (closes #2308)

### DIFF
--- a/frontend/src/__tests__/DeckCardDescriptionTitle.test.ts
+++ b/frontend/src/__tests__/DeckCardDescriptionTitle.test.ts
@@ -1,0 +1,22 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/DeckCard.tsx"),
+  "utf8"
+);
+
+describe("DeckCard — description title attribute", () => {
+  it("description paragraph has a title attribute for truncated text", () => {
+    const anchor = src.indexOf("line-clamp-2");
+    expect(anchor).toBeGreaterThan(-1);
+    const window = src.slice(anchor, anchor + 100);
+    expect(window).toContain("title=");
+  });
+
+  it("description does not use static className without title", () => {
+    const anchor = src.indexOf("line-clamp-2");
+    const window = src.slice(anchor, anchor + 100);
+    expect(window).not.toMatch(/className="[^"]*line-clamp-2[^"]*">[^<]/);
+  });
+});

--- a/frontend/src/components/DeckCard.tsx
+++ b/frontend/src/components/DeckCard.tsx
@@ -26,7 +26,7 @@ export default function DeckCard({ deck, onClick, onDelete }: DeckCardProps) {
         </span>
       </div>
       {deck.description && (
-        <p className="text-sm text-stone-600 mt-1.5 line-clamp-2">{deck.description}</p>
+        <p className="text-sm text-stone-600 mt-1.5 line-clamp-2" title={deck.description}>{deck.description}</p>
       )}
       <div className="mt-3 flex items-center gap-3 text-xs text-stone-600">
         <span>


### PR DESCRIPTION
## What changed

`DeckCard.tsx` line 29: added `title={deck.description}` to the description paragraph that was already using `line-clamp-2`.

## Why

When a user creates a deck with a long description, the text is silently clipped after 2 lines with no way to see the full content on hover. The deck name at line 18 already sets `title={deck.name}` for the same reason — this brings the description into parity.

Closes #2308

## Test plan

- [x] `DeckCardDescriptionTitle.test.ts` — 2 new tests: description paragraph has `title=`, does not use static `className` without `title`
- [x] Full frontend suite: 3677 tests pass
