### PR TITLE
fix: add title tooltips to reader annotation cards for truncated text (closes #2310)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -414,6 +414,16 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 ---
 
 
+## Wave 17 — Dialog ARIA, Title Tooltips, and Truncation UX (2026-04-29)
+
+| Date | Change | File(s) | PR |
+|------|--------|---------|----|
+| 2026-04-29 | WordLookup popup: added role="dialog", aria-label, close button with CloseIcon (closes #2306) | WordLookup.tsx | #2307 |
+| 2026-04-29 | DeckCard description: added title={deck.description} for truncated text tooltip (closes #2308) | DeckCard.tsx | #2309 |
+| 2026-04-29 | Reader annotation cards: added title tooltip on desktop sidebar role=button and mobile bottom-sheet button for truncated sentence/note text (closes #2310) | reader/[bookId]/page.tsx | #2310 |
+
+---
+
 ## #364 — Mobile sub-sentence selection (design note, 2026-04-27)
 
 **Status:** Shipped. Design note merged in #1671; implementation drops the touch `preventDefault` per Approach B.

--- a/frontend/src/__tests__/AnnotationCardTitleTooltip.test.ts
+++ b/frontend/src/__tests__/AnnotationCardTitleTooltip.test.ts
@@ -1,0 +1,27 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Annotation card title tooltip for truncated text", () => {
+  it("desktop sidebar annotation card (role=button) has title attribute near line-clamp-3", () => {
+    // Find the role="button" annotation card in the sidebar
+    const roleButtonIdx = src.indexOf('aria-label={`Jump to annotation:');
+    expect(roleButtonIdx).toBeGreaterThan(-1);
+    // Check within 200 chars of the aria-label for a title attribute
+    const window = src.slice(roleButtonIdx - 50, roleButtonIdx + 300);
+    expect(window).toContain("title=");
+  });
+
+  it("mobile bottom sheet annotation button has title attribute near line-clamp-2", () => {
+    // Use lastIndexOf to get the mobile bottom sheet list (last occurrence of the label)
+    const listIdx = src.lastIndexOf('aria-label="Annotations"');
+    expect(listIdx).toBeGreaterThan(-1);
+    // The button in this list should have a title attribute within 900 chars
+    const window = src.slice(listIdx, listIdx + 900);
+    expect(window).toContain("title=");
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1781,6 +1781,7 @@ export default function ReaderPage() {
                     role="button"
                     tabIndex={0}
                     aria-label={`Jump to annotation: ${ann.sentence_text.slice(0, 60)}`}
+                    title={ann.note_text ? `${ann.sentence_text} — ${ann.note_text}` : ann.sentence_text}
                     className={`rounded-lg border px-3 py-2.5 cursor-pointer hover:opacity-80 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 ${colorBadge[ann.color] ?? colorBadge.yellow}`}
                     onClick={() => {
                       if (ann.chapter_index !== chapterIndex) {
@@ -2293,6 +2294,7 @@ export default function ReaderPage() {
                         }
                         setNotesExpanded(false);
                       }}
+                      title={ann.note_text ? `${ann.sentence_text} — ${ann.note_text}` : ann.sentence_text}
                       className="w-full text-left px-3 py-2 min-h-[44px] md:min-h-0 flex flex-col justify-center rounded-lg border border-amber-200 bg-amber-50 text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                     >
                       <div lang={bookLanguage} className="text-ink line-clamp-2">{ann.sentence_text}</div>


### PR DESCRIPTION
## What changed

Added `title` tooltip attributes to truncated annotation card text in the reader:

- **Desktop sidebar** (`renderCard` function, ~line 1780): `role="button"` card now has `title={sentence + note}` so hovering reveals full annotation text that is clamped to 3 lines.
- **Mobile bottom sheet** (~line 2285): `<button>` now has `title={sentence + note}` so hovering reveals full annotation sentence (clamped to 2 lines) and note (clamped to 1 line).
- **docs/design-improvement-plan.md**: Added Wave 17 section logging PRs #2307, #2309, and #2310.

## Why

The note text was clamped to a single line with no way for mouse users to preview the full content before navigating. This follows the same tooltip pattern already used on DeckCard name (`h2 title={deck.name}`) and profile deck buttons (`title={d.name}`).

## Test plan

- New static-analysis test `AnnotationCardTitleTooltip.test.ts` asserts both the sidebar card and the bottom-sheet button have `title=` attributes.
- Full frontend suite: 3683 tests pass.
