### PR TITLE
fix: add title tooltip to AnnotationToolbar sentence preview for truncated text (closes #2314)

### DIFF
--- a/frontend/src/__tests__/AnnotationToolbarSentenceTitle.test.ts
+++ b/frontend/src/__tests__/AnnotationToolbarSentenceTitle.test.ts
@@ -1,0 +1,17 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/AnnotationToolbar.tsx"),
+  "utf8"
+);
+
+describe("AnnotationToolbar quoted sentence title tooltip", () => {
+  it("sentence paragraph has a title attribute near line-clamp-2", () => {
+    const anchor = src.indexOf("line-clamp-2");
+    expect(anchor).toBeGreaterThan(-1);
+    // title= appears on the same element, before the className containing line-clamp-2
+    const window = src.slice(anchor - 120, anchor + 80);
+    expect(window).toContain("title=");
+  });
+});

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -137,7 +137,7 @@ export default function AnnotationToolbar({
 
         <div className="px-5 pt-3 pb-5 space-y-4">
           {/* Quoted sentence */}
-          <p lang={bookLanguage ?? undefined} className="text-xs text-amber-700 font-serif italic line-clamp-2 leading-relaxed border-l-2 border-amber-300 pl-3">
+          <p lang={bookLanguage ?? undefined} title={sentenceText} className="text-xs text-amber-700 font-serif italic line-clamp-2 leading-relaxed border-l-2 border-amber-300 pl-3">
             {sentenceText}
           </p>
 


### PR DESCRIPTION
## What changed

Added `title={sentenceText}` to the quoted sentence `<p>` in `AnnotationToolbar.tsx`. The sentence preview has `line-clamp-2` which truncates long sentences with an ellipsis; without a `title` attribute, mouse users cannot see the full text on hover.

## Why

Completes the title-tooltip sweep across all annotation UI surfaces:
- PR #2309 — DeckCard description truncation
- PR #2311 — Reader page annotation cards (desktop + mobile)
- PR #2313 — AnnotationsSidebar annotation cards
- This PR — AnnotationToolbar sentence preview (closes #2314)

## Test plan

- `AnnotationToolbarSentenceTitle.test.ts`: static analysis confirms `title=` appears on the element with `line-clamp-2` in `AnnotationToolbar.tsx`
- Full frontend suite: 3684 tests pass

Closes #2314
