### PR TITLE
fix: add title tooltip to vocabulary occurrence buttons for truncated sentence context (closes #2316)

### DIFF
--- a/frontend/src/__tests__/VocabOccurrenceTitleTooltip.test.ts
+++ b/frontend/src/__tests__/VocabOccurrenceTitleTooltip.test.ts
@@ -1,0 +1,17 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Vocabulary occurrence button title tooltip for truncated sentence context", () => {
+  it("occurrence button has title attribute near line-clamp-2 span", () => {
+    const anchor = src.indexOf("line-clamp-2\">&ldquo;{occ.sentence_text}");
+    expect(anchor).toBeGreaterThan(-1);
+    // title= appears on the button element before the span with line-clamp-2 (onClick handler spans ~1300 chars between them)
+    const window = src.slice(anchor - 1400, anchor + 50);
+    expect(window).toContain("title={occ.sentence_text}");
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1975,6 +1975,7 @@ export default function ReaderPage() {
                               {relevantOccs.map((occ, i) => (
                                 <button
                                   key={i}
+                                  title={occ.sentence_text}
                                   onClick={() => {
                                     if (occ.chapter_index !== chapterIndex) {
                                       goToChapter(occ.chapter_index);


### PR DESCRIPTION
## What changed

Added `title={occ.sentence_text}` to each vocabulary occurrence `<button>` in the reader sidebar. The sentence context inside the button uses `line-clamp-2`, which truncates long sentences with an ellipsis; without a `title`, mouse users cannot hover to read the full sentence.

## Why

Completes the title-tooltip sweep across all truncated-text surfaces in the reader. Vocabulary occurrences are one of the most-used reading features — users jump to word context via these buttons frequently.

## Test plan

- `VocabOccurrenceTitleTooltip.test.ts`: static analysis confirms `title={occ.sentence_text}` appears on the button element containing the `line-clamp-2` span
- Full frontend suite: 3684 tests pass

Closes #2316
