### PR TITLE
fix: add title tooltip to TTS loading preview for truncated sentence text (closes #2320)

### DIFF
--- a/frontend/src/__tests__/TTSLoadingPreviewTitle.test.ts
+++ b/frontend/src/__tests__/TTSLoadingPreviewTitle.test.ts
@@ -1,0 +1,16 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/TTSControls.tsx"),
+  "utf8"
+);
+
+describe("TTSControls loading preview title tooltip", () => {
+  it("loading preview paragraph has title attribute near truncate class", () => {
+    const anchor = src.indexOf("loadingState.preview}…");
+    expect(anchor).toBeGreaterThan(-1);
+    const window = src.slice(anchor - 150, anchor + 80);
+    expect(window).toContain("title={loadingState.preview}");
+  });
+});

--- a/frontend/src/components/TTSControls.tsx
+++ b/frontend/src/components/TTSControls.tsx
@@ -535,7 +535,7 @@ export default function TTSControls({
               aria-hidden="true"
             />
           </div>
-          <p className="text-xs text-stone-600 mt-1 italic truncate">
+          <p className="text-xs text-stone-600 mt-1 italic truncate" title={loadingState.preview}>
             &ldquo;{loadingState.preview}…&rdquo;
           </p>
         </div>


### PR DESCRIPTION
## What changed

Added `title={loadingState.preview}` to the loading preview `<p>` in `TTSControls.tsx`. The preview shows the sentence currently being synthesized with CSS `truncate`; long previews are clipped without a way to see the full text on hover.

## Why

Completes the title-tooltip sweep across all truncated user-facing text surfaces in the reader.

## Test plan

- `TTSLoadingPreviewTitle.test.ts`: static analysis confirms `title={loadingState.preview}` appears on the element with `truncate` near `loadingState.preview`
- Full frontend suite: all tests pass

Closes #2320
