### PR TITLE
fix: add title tooltip to import stage status messages for truncated text (closes #2321)

### DIFF
--- a/frontend/src/__tests__/ImportStageMsgTitle.test.ts
+++ b/frontend/src/__tests__/ImportStageMsgTitle.test.ts
@@ -1,0 +1,16 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/import/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Import stage status message title tooltip", () => {
+  it("active stage message paragraph has title attribute near truncate class", () => {
+    const anchor = src.indexOf('s.message && s.status === "active"');
+    expect(anchor).toBeGreaterThan(-1);
+    const window = src.slice(anchor, anchor + 200);
+    expect(window).toContain("title={s.message}");
+  });
+});

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -277,7 +277,7 @@ export default function BookImportPage() {
                         </div>
                       )}
                     {s.message && s.status === "active" && (
-                      <p className="ml-7 mt-1 text-xs text-stone-600 truncate">
+                      <p className="ml-7 mt-1 text-xs text-stone-600 truncate" title={s.message}>
                         {s.message}
                       </p>
                     )}


### PR DESCRIPTION
## Summary

- Adds `title={s.message}` to the import stage status message `<p>` in `import/[bookId]/page.tsx`
- The element uses `truncate` CSS which clips long chapter/file path messages without any hover affordance
- Mouse users can now hover to see the full message text

## Test plan

- [x] New static-analysis test `ImportStageMsgTitle.test.ts` asserts the `title` attribute is present near the `truncate` paragraph
- [x] Full frontend test suite passes (3688 tests)
- [x] Closes #2321

## Docs follow-up

Design Change Log updated in previous PR for this wave (#2313).
