### PR TITLE
fix: add title tooltips to notes page stats/export and SeedPopularButton log entries (closes #2325)

### DIFF
--- a/frontend/src/__tests__/NotesSeedTitleTooltips.test.ts
+++ b/frontend/src/__tests__/NotesSeedTitleTooltips.test.ts
@@ -1,0 +1,36 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const notesPageSrc = fs.readFileSync(
+  path.join(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf8"
+);
+const seedSrc = fs.readFileSync(
+  path.join(__dirname, "../components/SeedPopularButton.tsx"),
+  "utf8"
+);
+
+describe("Notes page title tooltips for truncated text", () => {
+  it("stats summary paragraph has title attribute", () => {
+    const anchor = notesPageSrc.indexOf("annotations · {insCount} insights");
+    expect(anchor).toBeGreaterThan(-1);
+    const window = notesPageSrc.slice(anchor - 200, anchor + 50);
+    expect(window).toContain("title={`${annCount} annotations");
+  });
+
+  it("export status message has title attribute", () => {
+    const anchor = notesPageSrc.indexOf('role="status"');
+    expect(anchor).toBeGreaterThan(-1);
+    const window = notesPageSrc.slice(anchor, anchor + 400);
+    expect(window).toContain("title={exportMsg || undefined}");
+  });
+});
+
+describe("SeedPopularButton log entry title tooltip for truncated text", () => {
+  it("log entry li has title attribute with book id and title", () => {
+    const anchor = seedSrc.indexOf("font-mono truncate");
+    expect(anchor).toBeGreaterThan(-1);
+    const window = seedSrc.slice(anchor - 200, anchor + 50);
+    expect(window).toContain("title={`#${entry.book_id}");
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -677,7 +677,7 @@ export default function BookNotesPage() {
           </button>
 
           <div className="flex-1 min-w-0">
-            <p className="text-xs text-stone-600 truncate">
+            <p className="text-xs text-stone-600 truncate" title={`${annCount} annotations · ${insCount} insights · ${vocCount} words`}>
               {annCount} annotations · {insCount} insights · {vocCount} words
             </p>
           </div>
@@ -726,6 +726,7 @@ export default function BookNotesPage() {
             role="status"
             aria-live="polite"
             aria-atomic="true"
+            title={exportMsg || undefined}
             className={`text-xs truncate px-3 py-1.5 rounded transition-all ${exportMsg ? "bg-amber-50 border border-amber-200 text-amber-800" : ""}`}
           >
             {exportMsg ?? ""}

--- a/frontend/src/components/SeedPopularButton.tsx
+++ b/frontend/src/components/SeedPopularButton.tsx
@@ -265,6 +265,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
                 {state.log.slice().reverse().map((entry, i) => (
                   <li
                     key={i}
+                    title={`#${entry.book_id} ${entry.title || ""}${entry.chars ? ` (${Math.round(entry.chars / 1000)}K)` : ""}${entry.error ? ` — ${entry.error}` : ""}`}
                     className={`font-mono truncate ${
                       entry.event === "failed" ? "text-red-600" : "text-stone-600"
                     }`}


### PR DESCRIPTION
## Summary

- `notes/[bookId]/page.tsx` — stats summary `<p>` (annotation/insight/word counts) now has `title=` so the full count string is visible on hover when the narrow header clips it
- `notes/[bookId]/page.tsx` — export status `<p role="status">` now has `title={exportMsg || undefined}` so long export messages aren't silently clipped
- `SeedPopularButton.tsx` — each log entry `<li>` now has `title=` showing full `#bookId title (XK) — error` text for truncated entries

## Test plan

- [x] New test `NotesSeedTitleTooltips.test.ts` — 3 static-analysis tests, all passing
- [x] Full frontend suite: 3691 tests passing
- [x] Closes #2325
