### PR TITLE
fix: add title tooltips to QueueTab admin preset chain and cost model name (closes #2323)

### DIFF
--- a/frontend/src/__tests__/QueueTabAdminTitleTooltip.test.ts
+++ b/frontend/src/__tests__/QueueTabAdminTitleTooltip.test.ts
@@ -1,0 +1,24 @@
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/QueueTab.tsx"),
+  "utf8"
+);
+
+describe("QueueTab admin UI title tooltips for truncated text", () => {
+  it("preset chain div has title attribute", () => {
+    const anchor = src.indexOf('p.chain.join(" → ")');
+    expect(anchor).toBeGreaterThan(-1);
+    const window = src.slice(anchor - 100, anchor + 50);
+    expect(window).toContain('title={p.chain.join(" → ")}');
+  });
+
+  it("cost comparison model name div has title attribute", () => {
+    // Find the truncated model name div in the cost breakdown section
+    const anchor = src.indexOf("text-[11px] text-stone-600 font-mono truncate");
+    expect(anchor).toBeGreaterThan(-1);
+    const window = src.slice(anchor, anchor + 100);
+    expect(window).toContain("title={row.model}");
+  });
+});

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -1033,7 +1033,7 @@ export default function QueueTab({ adminFetch }: Props) {
                       <div className="text-[11px] text-stone-600 mt-1 leading-snug">
                         {p.description}
                       </div>
-                      <div className="text-xs font-mono text-stone-600 mt-1 truncate">
+                      <div className="text-xs font-mono text-stone-600 mt-1 truncate" title={p.chain.join(" → ")}>
                         {p.chain.join(" → ")}
                       </div>
                     </button>
@@ -1292,7 +1292,7 @@ export default function QueueTab({ adminFetch }: Props) {
                           : "border-amber-100"
                       }`}
                     >
-                      <div className="text-[11px] text-stone-600 font-mono truncate">
+                      <div className="text-[11px] text-stone-600 font-mono truncate" title={row.model}>
                         {row.model}
                       </div>
                       <div className="text-sm font-semibold text-ink">


### PR DESCRIPTION
## Summary

- `QueueTab.tsx` — preset chain `<div>` now has `title={p.chain.join(" → ")}` so admin users can hover to see the full pipeline chain when it overflows the container
- `QueueTab.tsx` — cost comparison model name `<div>` now has `title={row.model}` so long model names (e.g., `claude-opus-4-7-20251101`) are visible in full on hover

Both elements use `truncate` CSS and were silently clipping their content.

## Test plan

- [x] New test `QueueTabAdminTitleTooltip.test.ts` — 2 static-analysis tests, both passing
- [x] Full frontend suite: 3691 tests passing
- [x] Closes #2323
