### PR TITLE
fix: replace shadow-sm on card containers with --shadow-card CSS variable (closes #2328)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -424,6 +424,12 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-29 | AnnotationsSidebar annotation card: added title tooltip on role=button for truncated sentence/note text (closes #2312) | AnnotationsSidebar.tsx | #2313 |
 | 2026-04-29 | AnnotationToolbar sentence preview: added title={sentenceText} on line-clamp-2 paragraph (closes #2314) | AnnotationToolbar.tsx | #2315 |
 | 2026-04-29 | Vocabulary sidebar occurrence buttons: added title={occ.sentence_text} on buttons wrapping line-clamp-2 sentence context (closes #2316) | reader/[bookId]/page.tsx | #2317 |
+| 2026-04-29 | Deck word-list: added title={w.word} on member span and add-word picker button for truncated vocabulary words (closes #2318) | decks/[deckId]/page.tsx | #2319 |
+| 2026-04-29 | TTSControls loading preview: added title={loadingState.preview} on truncate paragraph (closes #2320) | TTSControls.tsx | #2322 |
+| 2026-04-30 | Import stage status messages: added title={s.message} on truncate paragraph during active stages (closes #2321) | import/[bookId]/page.tsx | #2324 |
+| 2026-04-30 | Notes page stats/export + SeedPopularButton log entries: title tooltips for truncated count summary, export message, and log list items (closes #2325) | notes/[bookId]/page.tsx, SeedPopularButton.tsx | #2326 |
+| 2026-04-30 | QueueTab admin: title tooltips for truncated preset chain div and cost comparison model name (closes #2323) | QueueTab.tsx | #2327 |
+| 2026-04-30 | Design system: replace hardcoded shadow-sm on card containers (import, login, notes) with --shadow-card CSS variable and hover handlers (closes #2328) | import/[bookId]/page.tsx, login/page.tsx, notes/page.tsx | #2328 |
 
 ---
 

--- a/frontend/src/__tests__/ShadowCardCssVar.test.ts
+++ b/frontend/src/__tests__/ShadowCardCssVar.test.ts
@@ -1,0 +1,34 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const importPageSrc = fs.readFileSync(
+  path.join(__dirname, "../app/import/[bookId]/page.tsx"),
+  "utf8"
+);
+const loginPageSrc = fs.readFileSync(
+  path.join(__dirname, "../app/login/page.tsx"),
+  "utf8"
+);
+const notesPageSrc = fs.readFileSync(
+  path.join(__dirname, "../app/notes/page.tsx"),
+  "utf8"
+);
+
+describe("Card containers use --shadow-card CSS variable instead of hardcoded shadow-sm", () => {
+  it("import page main card uses var(--shadow-card) inline style", () => {
+    expect(importPageSrc).toContain('var(--shadow-card)');
+    expect(importPageSrc).not.toMatch(/rounded-2xl[^"]*shadow-sm/);
+  });
+
+  it("login page card uses var(--shadow-card) inline style", () => {
+    expect(loginPageSrc).toContain('var(--shadow-card)');
+    // The white card container should not use shadow-sm (img and buttons may still use it)
+    expect(loginPageSrc).not.toMatch(/bg-white rounded-2xl[^"]*shadow-sm/);
+  });
+
+  it("notes page book list card uses var(--shadow-card) with hover handlers", () => {
+    expect(notesPageSrc).toContain('var(--shadow-card)');
+    expect(notesPageSrc).toContain('var(--shadow-card-hover)');
+    expect(notesPageSrc).not.toContain('hover:shadow-sm');
+  });
+});

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -177,7 +177,7 @@ export default function BookImportPage() {
   return (
     <main id="main-content" className="min-h-screen bg-parchment flex items-center justify-center px-4 py-8">
       <div className="w-full max-w-xl">
-        <div className="bg-white border border-amber-200 rounded-2xl shadow-sm p-8">
+        <div className="bg-white border border-amber-200 rounded-2xl p-8" style={{ boxShadow: "var(--shadow-card)" }}>
           <h1 className="font-serif text-2xl font-bold text-ink mb-1">
             Preparing your book
           </h1>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -23,7 +23,7 @@ function LoginForm() {
         </div>
 
         {/* Card */}
-        <div className="bg-white rounded-2xl shadow-sm border border-amber-100 p-8">
+        <div className="bg-white rounded-2xl border border-amber-100 p-8" style={{ boxShadow: "var(--shadow-card)" }}>
           <h2 className="font-serif text-xl font-semibold text-ink mb-1">Sign in</h2>
           <p className="text-sm text-stone-600 mb-8">
             Sign in to access your library and AI features.

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -207,7 +207,12 @@ export default function NotesOverviewPage() {
               <li key={book.bookId}>
               <button
                 onClick={() => router.push(`/notes/${book.bookId}`)}
-                className="w-full text-left rounded-xl border border-amber-200 bg-white/80 px-5 py-4 hover:border-amber-400 hover:shadow-sm transition-all group focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
+                style={{ boxShadow: "var(--shadow-card)" }}
+                onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card-hover)"; }}
+                onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card)"; }}
+                onFocus={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card-hover)"; }}
+                onBlur={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card)"; }}
+                className="w-full text-left rounded-xl border border-amber-200 bg-white/80 px-5 py-4 hover:border-amber-400 transition-colors group focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
               >
                 <div className="flex items-start gap-3">
                   <div className="flex-1 min-w-0">


### PR DESCRIPTION
## Summary

Replaces hardcoded `shadow-sm` on three card-level containers with the design system's `--shadow-card` CSS variable. Per CLAUDE.md: "Cards use `--shadow-card` CSS variable... Never hardcode `shadow-sm` / `shadow-md` directly on cards."

This also enables dark-mode shadow overrides defined in `globals.css` `:root[data-theme="dark"]`.

**Changes:**
- `import/[bookId]/page.tsx` — main white card: `shadow-sm` → `style={{ boxShadow: "var(--shadow-card)" }}`
- `login/page.tsx` — sign-in form card: same
- `notes/page.tsx` — book list link cards: `hover:shadow-sm` → `var(--shadow-card)` with onMouseEnter/Leave/Focus/Blur handlers (matching BookCard.tsx pattern)

## Test plan

- [x] New test `ShadowCardCssVar.test.ts` — 3 static-analysis tests verifying correct CSS var usage
- [x] Full frontend suite: 3693 tests passing
- [x] Closes #2328
