### PR TITLE
fix: add focus ring to admin page inputs missing keyboard focus indicator (closes #2330)

### DIFF
--- a/frontend/src/__tests__/AdminInputFocusRing.test.ts
+++ b/frontend/src/__tests__/AdminInputFocusRing.test.ts
@@ -1,0 +1,34 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const adminBooksPath = path.join(__dirname, "../app/admin/books/page.tsx");
+const adminUploadsPath = path.join(__dirname, "../app/admin/uploads/page.tsx");
+
+const booksSrc = fs.readFileSync(adminBooksPath, "utf8");
+const uploadsSrc = fs.readFileSync(adminUploadsPath, "utf8");
+
+describe("Admin inputs have focus ring styles (WCAG 2.4.7)", () => {
+  it("admin/books import ID input has focus:ring-2", () => {
+    const idx = booksSrc.indexOf("Gutenberg Book ID to import");
+    const window = booksSrc.slice(idx, idx + 500);
+    expect(window).toMatch(/focus:ring-2/);
+  });
+
+  it("admin/books search filter input has focus:ring-2", () => {
+    const idx = booksSrc.indexOf("Filter books");
+    const window = booksSrc.slice(Math.max(0, idx - 400), idx + 100);
+    expect(window).toMatch(/focus:ring-2/);
+  });
+
+  it("admin/books chapter move input has focus:ring-2", () => {
+    const idx = booksSrc.indexOf("Move to chapter number");
+    const window = booksSrc.slice(idx, idx + 1200);
+    expect(window).toMatch(/focus:ring-2/);
+  });
+
+  it("admin/uploads user ID filter input has focus:ring-2", () => {
+    const idx = uploadsSrc.indexOf("User ID filter");
+    const window = uploadsSrc.slice(Math.max(0, idx - 400), idx + 100);
+    expect(window).toMatch(/focus:ring-2/);
+  });
+});

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -325,7 +325,7 @@ export default function BooksPage() {
           value={importId}
           onChange={(e) => setImportId(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && handleImport()}
-          className="flex-1 rounded-lg border border-amber-300 px-3 py-2 text-sm placeholder:text-stone-600"
+          className="flex-1 rounded-lg border border-amber-300 px-3 py-2 text-sm placeholder:text-stone-600 focus:outline-none focus:ring-2 focus:ring-amber-400"
         />
         <button
           onClick={handleImport}
@@ -344,7 +344,7 @@ export default function BooksPage() {
           placeholder="Search books by title, author, or ID…"
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="flex-1 rounded-lg border border-amber-300 px-3 py-2 text-sm placeholder:text-stone-600"
+          className="flex-1 rounded-lg border border-amber-300 px-3 py-2 text-sm placeholder:text-stone-600 focus:outline-none focus:ring-2 focus:ring-amber-400"
           aria-label="Filter books"
         />
         {searchQuery && (
@@ -625,7 +625,7 @@ export default function BooksPage() {
                                             onKeyDown={(e) => {
                                               if (e.key === "Enter") handleMove(t, moveInput[rowKey] ?? "");
                                             }}
-                                            className="w-14 rounded border border-amber-300 px-1 py-0.5 text-xs placeholder:text-stone-600"
+                                            className="w-14 rounded border border-amber-300 px-1 py-0.5 text-xs placeholder:text-stone-600 focus:outline-none focus:ring-2 focus:ring-amber-400"
                                             title="Reassign this translation to another chapter number (1-based)"
                                           />
                                           <button

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -107,7 +107,7 @@ export default function UploadsPage() {
           value={filterInput}
           onChange={(e) => setFilterInput(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && handleFilter()}
-          className="w-48 rounded-lg border border-amber-300 px-3 py-2 text-sm placeholder:text-stone-600"
+          className="w-48 rounded-lg border border-amber-300 px-3 py-2 text-sm placeholder:text-stone-600 focus:outline-none focus:ring-2 focus:ring-amber-400"
           aria-label="User ID filter"
           min={1}
         />


### PR DESCRIPTION
## What changed

Added `focus:outline-none focus:ring-2 focus:ring-amber-400` to four `<input>` elements in admin pages that were missing visible keyboard focus indicators:

- `app/admin/books/page.tsx` — Gutenberg Book ID import field, book search filter, chapter move-to field
- `app/admin/uploads/page.tsx` — user ID filter field

## Why

These inputs rendered with no visible focus ring when tabbed to, because the browser default outline was not explicitly set. Every other input in the codebase has this pattern — these were missed during initial implementation. Without a focus indicator, keyboard-only users cannot tell which field is active (WCAG 2.4.7 failure).

## Test plan

- Added `AdminInputFocusRing.test.ts` — 4 static analysis tests that assert each input's className contains `focus:ring-2`
- All 3702 frontend tests pass; 1941 backend tests pass
