### PR TITLE
fix: add autoComplete=off and focus ring to API key / token password inputs (closes #2332)

### DIFF
--- a/frontend/src/__tests__/ApiKeyInputAutoComplete.test.ts
+++ b/frontend/src/__tests__/ApiKeyInputAutoComplete.test.ts
@@ -1,0 +1,31 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const profileSrc = fs.readFileSync(path.join(__dirname, "../app/profile/page.tsx"), "utf8");
+const queueTabSrc = fs.readFileSync(path.join(__dirname, "../components/QueueTab.tsx"), "utf8");
+
+describe("API key / token inputs have autoComplete=off and focus ring", () => {
+  it("profile Gemini API key input has autoComplete=off", () => {
+    const idx = profileSrc.indexOf('aria-label="Gemini API key"');
+    const window = profileSrc.slice(Math.max(0, idx - 50), idx + 400);
+    expect(window).toMatch(/autoComplete="off"/);
+  });
+
+  it("profile Obsidian token input has autoComplete=off", () => {
+    const idx = profileSrc.indexOf('id="obsidian-token"');
+    const window = profileSrc.slice(idx, idx + 300);
+    expect(window).toMatch(/autoComplete="off"/);
+  });
+
+  it("QueueTab admin Gemini API key input has autoComplete=off", () => {
+    const idx = queueTabSrc.indexOf("Gemini API key");
+    const window = queueTabSrc.slice(idx, idx + 600);
+    expect(window).toMatch(/autoComplete="off"/);
+  });
+
+  it("QueueTab admin Gemini API key input has focus:ring-2", () => {
+    const idx = queueTabSrc.indexOf("Gemini API key");
+    const window = queueTabSrc.slice(idx, idx + 600);
+    expect(window).toMatch(/focus:ring-2/);
+  });
+});

--- a/frontend/src/__tests__/QueueTabFormAria.test.ts
+++ b/frontend/src/__tests__/QueueTabFormAria.test.ts
@@ -19,7 +19,7 @@ describe("QueueTab service-settings inputs have accessible labels (closes #1030)
   it("Gemini API key input has aria-label", () => {
     const idx = src.indexOf('"•••• (leave empty to keep)"');
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(Math.max(0, idx - 300), idx + 100);
+    const window = src.slice(Math.max(0, idx - 500), idx + 100);
     expect(window).toMatch(/aria-label=/);
   });
 });

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -322,6 +322,7 @@ export default function ProfilePage() {
               <input
                 aria-label="Gemini API key"
                 type="password"
+                autoComplete="off"
                 placeholder="AIza…"
                 value={keyInput}
                 onChange={(e) => setKeyInput(e.target.value)}
@@ -396,6 +397,7 @@ export default function ProfilePage() {
                 <input
                   id="obsidian-token"
                   type="password"
+                  autoComplete="off"
                   placeholder={hasObsidianToken ? "Enter new token to replace existing" : "ghp_… (never shown back)"}
                   value={obsidianToken}
                   onChange={(e) => setObsidianToken(e.target.value)}

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -907,10 +907,11 @@ export default function QueueTab({ adminFetch }: Props) {
             <div className="flex gap-2">
               <input
                 type="password"
+                autoComplete="off"
                 aria-label="Gemini API key"
                 value={apiKey}
                 onChange={(e) => setApiKey(e.target.value)}
-                className="flex-1 rounded border border-amber-300 px-2 py-1 text-sm placeholder:text-stone-600"
+                className="flex-1 rounded border border-amber-300 px-2 py-1 text-sm placeholder:text-stone-600 focus:outline-none focus:ring-2 focus:ring-amber-400"
                 placeholder={settings?.has_api_key ? "•••• (leave empty to keep)" : "Paste key"}
               />
               <button


### PR DESCRIPTION
## What changed

- Added `autoComplete="off"` to three `type="password"` inputs used for API keys/tokens:
  - `app/profile/page.tsx` — Gemini API key and Obsidian GitHub token
  - `components/QueueTab.tsx` — Admin Gemini API key
- Added `focus:outline-none focus:ring-2 focus:ring-amber-400` to the QueueTab admin API key input (same focus ring gap as #2330)

## Why

Without `autoComplete="off"`, browsers offer to save API keys as login passwords and may autofill them from unrelated saved credentials — confusing and potentially incorrect behaviour. API key/token inputs should always opt out of password autofill.

The focus ring on the QueueTab input was also missing, leaving keyboard users with no visible focus indicator on that field (WCAG 2.4.7).

## Test plan

- Added `ApiKeyInputAutoComplete.test.ts` — 4 static analysis tests asserting `autoComplete="off"` and `focus:ring-2` on the affected inputs
- Updated window size in `QueueTabFormAria.test.ts` to accommodate the now-longer className
- All 3706 frontend tests pass; backend tests pass
