### PR TITLE
fix: add sr-only new-tab announcement to export URL links (closes #2334)

### DIFF
--- a/frontend/src/__tests__/ExportUrlNewTabAnnouncement.test.ts
+++ b/frontend/src/__tests__/ExportUrlNewTabAnnouncement.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Regression tests for #2334: export URL links (vocabulary + reader Obsidian toast)
+ * must announce "(opens in new tab)" to screen-reader users.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+function read(rel: string) {
+  return fs.readFileSync(path.join(__dirname, rel), "utf8");
+}
+
+describe("export URL links announce new-tab to screen readers (closes #2334)", () => {
+  it("vocabulary page export URL link has sr-only new-tab announcement", () => {
+    const src = read("../app/vocabulary/page.tsx");
+    // The export result link renders a URL as visible text inside an <a target="_blank">
+    const idx = src.indexOf('target="_blank" rel="noopener noreferrer" className="text-amber-700 underline break-all');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 300);
+    expect(window).toMatch(/opens in new tab/);
+  });
+
+  it("reader page Obsidian export toast link has sr-only new-tab announcement", () => {
+    const src = read("../app/reader/[bookId]/page.tsx");
+    // The obsidian toast export link renders the URL as visible text inside <a target="_blank">
+    const idx = src.indexOf("obsidianToast.startsWith");
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 700);
+    expect(window).toMatch(/opens in new tab/);
+  });
+});

--- a/frontend/src/__tests__/VocabularyPage.branches.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.branches.test.tsx
@@ -171,7 +171,7 @@ describe("VocabularyPage — export message link branch", () => {
     await userEvent.click(screen.getByTestId("export-all-btn"));
 
     await waitFor(() => {
-      const link = screen.getByRole("link", { name: "https://example.com/note.md" });
+      const link = screen.getByRole("link", { name: /https:\/\/example\.com\/note\.md/ });
       expect(link).toBeInTheDocument();
       expect(link).toHaveAttribute("href", "https://example.com/note.md");
     });

--- a/frontend/src/__tests__/VocabularyPage.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.test.tsx
@@ -159,7 +159,7 @@ test("export shows URL link when export succeeds", async () => {
   await userEvent.click(exportBtn);
 
   await waitFor(() => {
-    const link = screen.getByRole("link", { name: "https://github.com/example/pr/1" });
+    const link = screen.getByRole("link", { name: /https:\/\/github\.com\/example\/pr\/1/ });
     expect(link).toHaveAttribute("href", "https://github.com/example/pr/1");
   });
 });

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1667,7 +1667,7 @@ export default function ReaderPage() {
                     rel="noopener noreferrer"
                     className="text-amber-700 underline break-all focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
                   >
-                    {obsidianToast}
+                    {obsidianToast}<span className="sr-only"> (opens in new tab)</span>
                   </a>
                 </>
               ) : (

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -496,7 +496,7 @@ function VocabularyPageContent() {
         {exportMsg && (
           <div className="border border-amber-300 bg-amber-50 rounded-xl px-4 py-3 text-sm text-ink">
             {exportMsg.startsWith("http") ? (
-              <>Exported! <a href={exportMsg} target="_blank" rel="noopener noreferrer" className="text-amber-700 underline break-all focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded">{exportMsg}</a></>
+              <>Exported! <a href={exportMsg} target="_blank" rel="noopener noreferrer" className="text-amber-700 underline break-all focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded">{exportMsg}<span className="sr-only"> (opens in new tab)</span></a></>
             ) : (
               <span className="text-red-600">{exportMsg}</span>
             )}


### PR DESCRIPTION
## What changed

Added `<span className="sr-only"> (opens in new tab)</span>` inside the export result link anchors in two places:

- `frontend/src/app/vocabulary/page.tsx` — Obsidian export URL link in the export status area
- `frontend/src/app/reader/[bookId]/page.tsx` — Obsidian export toast URL link

Both links render a dynamic URL as visible link text and open in a new tab via `target="_blank"`, but previously gave screen-reader users no indication that a new tab would open.

## Why

WCAG 2.4.4 (Link Purpose) and 3.2.2 (On Input) require that link behaviour unexpected by users (opening a new context) be announced. The pattern `<span className="sr-only"> (opens in new tab)</span>` is already established across VocabWordTooltip, BookDetailModal, vocabulary Wiktionary link, and the reader Gutenberg link — these two export links were the only remaining gaps.

## Test plan

- [x] New static-analysis tests in `ExportUrlNewTabAnnouncement.test.ts` assert both locations contain the sr-only text — confirmed failing before fix, passing after
- [x] Updated `VocabularyPage.test.tsx` and `VocabularyPage.branches.test.tsx` to use regex name matching (accessible name now includes "(opens in new tab)")
- [x] Full suite: 3708 tests pass (`npm test -- --no-coverage --ci`)

Closes #2334
