### PR TITLE
fix: always-present search live region in notes/page.tsx (closes #2338)

### DIFF
--- a/frontend/src/__tests__/NotesSearchLiveRegion.test.ts
+++ b/frontend/src/__tests__/NotesSearchLiveRegion.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Regression test for #2338: notes/page.tsx search filter live region must use
+ * the always-present pattern (WCAG 4.1.3) so screen readers announce result counts.
+ *
+ * The broken pattern: {search.trim() && !loading && <div role="status">...}
+ * AT only announces updates to already-present live regions, not newly-inserted ones.
+ *
+ * The fix: always-present container with content that changes.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(path.join(__dirname, "../app/notes/page.tsx"), "utf8");
+
+describe("notes/page.tsx search live region — WCAG 4.1.3 (closes #2338)", () => {
+  it("search result live region is always-present (not conditionally mounted)", () => {
+    // Must NOT use the broken conditional-mount pattern
+    expect(src).not.toMatch(/\{search\.trim\(\)\s*&&\s*!loading\s*&&\s*\(/);
+  });
+
+  it("search result live region uses the ?? '' always-present pattern", () => {
+    // Find the always-present live region near the search area
+    const idx = src.indexOf("aria-label=\"Search notes by book\"");
+    expect(idx).toBeGreaterThan(-1);
+    // The always-present pattern should appear in the 600 chars after the search input
+    const section = src.slice(idx, idx + 600);
+    expect(section).toMatch(/role="status"/);
+    expect(section).toMatch(/aria-live="polite"/);
+  });
+
+  it("live region content uses nullish-coalescing empty string for empty state", () => {
+    // Look for the ?? "" pattern near the search filter live region
+    const idx = src.indexOf("\"Search notes by book\"");
+    expect(idx).toBeGreaterThan(-1);
+    const section = src.slice(idx, idx + 600);
+    expect(section).toMatch(/\?\s*`\$\{filtered|: ""/);
+  });
+});

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -146,12 +146,10 @@ export default function NotesOverviewPage() {
           onChange={(e) => setSearch(e.target.value)}
         />
 
-        {/* Visually-hidden live region: announces filter result counts to screen readers */}
-        {search.trim() && !loading && (
-          <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
-            {`${filtered.length} book${filtered.length === 1 ? "" : "s"} found.`}
-          </div>
-        )}
+        {/* Visually-hidden live region: always-present so AT announces updates (WCAG 4.1.3) */}
+        <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+          {search.trim() && !loading ? `${filtered.length} book${filtered.length === 1 ? "" : "s"} found.` : ""}
+        </div>
 
         {loading ? (
           <div role="status" aria-label="Loading notes" className="flex justify-center py-20">


### PR DESCRIPTION
## What changed

`frontend/src/app/notes/page.tsx`: The search filter live region used a conditional mount pattern:

```tsx
{search.trim() && !loading && (
  <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
    {`${filtered.length} book${filtered.length === 1 ? "" : "s"} found.`}
  </div>
)}
```

Changed to the always-present pattern (same fix as #1886 for notes/[bookId]):

```tsx
<div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
  {search.trim() && !loading ? `${filtered.length} book${filtered.length === 1 ? "" : "s"} found.` : ""}
</div>
```

## Why

WCAG 4.1.3 — Status Messages: NVDA on Chrome (and some other AT) only announce updates to live regions that were **already present** in the DOM. When the container is conditionally inserted alongside its content, those AT stay silent and blind users get no feedback that the search filter worked.

## Test plan

- [x] New regression test `NotesSearchLiveRegion.test.ts` (3 tests): verifies the conditional-mount pattern is gone and the always-present pattern is in place
- [x] Full Jest suite: 632 suites / 3715 tests — all green

Closes #2338

[ ] Docs updated (if applicable)
