### PR TITLE
fix: always-present live regions for home + admin search counts (WCAG 4.1.3)

### DIFF
--- a/frontend/src/__tests__/SearchLiveRegions.test.ts
+++ b/frontend/src/__tests__/SearchLiveRegions.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Regression tests for #2340: home page and admin books search live regions
+ * must use the always-present pattern (WCAG 4.1.3) so screen readers announce
+ * result counts when search completes.
+ *
+ * Broken pattern: {condition && <div role="status">} — conditionally mounts
+ * the live region alongside its content; NVDA/Chrome won't announce it.
+ *
+ * Fixed pattern: always-present container with content that changes.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const homeSrc = fs.readFileSync(path.join(__dirname, "../app/page.tsx"), "utf8");
+const adminBooksSrc = fs.readFileSync(path.join(__dirname, "../app/admin/books/page.tsx"), "utf8");
+
+// ── Home page Discover search ──────────────────────────────────────────────────
+
+describe("Home page search live region — WCAG 4.1.3 (closes #2340)", () => {
+  it("search result live region is not conditionally mounted on searching state", () => {
+    // The broken pattern: {!searching && searchedQuery && !searchError && (<div role="status"...}
+    expect(homeSrc).not.toMatch(
+      /\{!searching\s*&&\s*searchedQuery\s*&&\s*!searchError\s*&&\s*\(/
+    );
+  });
+
+  it("search result live region uses always-present pattern near the results area", () => {
+    // Anchor on the comment that sits right above the live region
+    const idx = homeSrc.indexOf("always-present so AT announces updates (WCAG 4.1.3)");
+    expect(idx).toBeGreaterThan(-1);
+    // The always-present live region should appear within 300 chars of the comment
+    const section = homeSrc.slice(idx, idx + 300);
+    expect(section).toMatch(/role="status"/);
+    expect(section).toMatch(/aria-live="polite"/);
+  });
+
+  it("home search live region content uses ternary for empty state", () => {
+    const idx = homeSrc.indexOf("always-present so AT announces updates (WCAG 4.1.3)");
+    const section = homeSrc.slice(idx, idx + 400);
+    // Content is conditional on state (ternary), not container mounting
+    expect(section).toMatch(/searchedQuery.*\?/s);
+  });
+});
+
+// ── Admin books search ─────────────────────────────────────────────────────────
+
+describe("Admin books search live region — WCAG 4.1.3 (closes #2340)", () => {
+  it("search count live region is not conditionally mounted on searchQuery", () => {
+    // The broken pattern: {searchQuery && (<span role="status" aria-live...}
+    expect(adminBooksSrc).not.toMatch(
+      /\{searchQuery\s*&&\s*\(\s*\n?\s*<span\s[^>]*role="status"/
+    );
+  });
+
+  it("admin books search live region uses always-present pattern", () => {
+    const idx = adminBooksSrc.indexOf('aria-label="Filter books"');
+    expect(idx).toBeGreaterThan(-1);
+    const section = adminBooksSrc.slice(idx, idx + 400);
+    expect(section).toMatch(/aria-live="polite"/);
+  });
+
+  it("admin books search count uses ternary for empty state", () => {
+    const idx = adminBooksSrc.indexOf('aria-label="Filter books"');
+    const section = adminBooksSrc.slice(idx, idx + 400);
+    // The content should be conditional (ternary), not the container
+    expect(section).toMatch(/searchQuery\s*\?/);
+  });
+});

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -347,14 +347,11 @@ export default function BooksPage() {
           className="flex-1 rounded-lg border border-amber-300 px-3 py-2 text-sm placeholder:text-stone-600 focus:outline-none focus:ring-2 focus:ring-amber-400"
           aria-label="Filter books"
         />
-        {searchQuery && (
-          <span role="status" aria-live="polite" aria-atomic="true" className="text-xs text-stone-600">
-            {books.filter((b) =>
-              fuzzyMatchAny(searchQuery, [b.title, ...(b.authors || []), b.id]),
-            ).length}{" "}
-            / {books.length}
-          </span>
-        )}
+        <span aria-live="polite" aria-atomic="true" className="text-xs text-stone-600">
+          {searchQuery ? `${books.filter((b) =>
+            fuzzyMatchAny(searchQuery, [b.title, ...(b.authors || []), b.id]),
+          ).length} / ${books.length}` : ""}
+        </span>
       </div>
 
       <ul role="list" aria-label="Books" className="bg-white rounded-xl border border-amber-200 divide-y divide-amber-100 overflow-hidden list-none p-0 m-0">

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -637,14 +637,14 @@ export default function Home() {
                 </div>
               )}
 
-              {/* Visually-hidden live region: announces search result count to screen readers */}
-              {!searching && searchedQuery && !searchError && (
-                <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
-                  {searchResults.length > 0
+              {/* Visually-hidden live region: always-present so AT announces updates (WCAG 4.1.3) */}
+              <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+                {!searching && searchedQuery && !searchError
+                  ? searchResults.length > 0
                     ? `Found ${searchResults.length} book${searchResults.length === 1 ? "" : "s"} for ${searchedQuery}.`
-                    : `Search complete. No results for ${searchedQuery}.`}
-                </div>
-              )}
+                    : `Search complete. No results for ${searchedQuery}.`
+                  : ""}
+              </div>
 
               {searching && (
                 <div role="status" aria-label="Loading search results">


### PR DESCRIPTION
## What changed

Fixed two conditional-mount live regions that violated WCAG 4.1.3 (Status Messages). Screen readers (NVDA/JAWS/VoiceOver) won't announce content injected into a newly-mounted live region — the region must already be present in the DOM when the content changes.

**Home page (`src/app/page.tsx`):**
- Was: `{!searching && searchedQuery && !searchError && (<div role="status"...>)}`
- Now: always-present `<div role="status" aria-live="polite">` with ternary content

**Admin books page (`src/app/admin/books/page.tsx`):**
- Was: `{searchQuery && (<span role="status" aria-live...>count</span>)}`
- Now: always-present `<span aria-live="polite">` with ternary content (no `role="status"` to avoid conflict with the existing toast `role="status"` element on the page)

## Why

The broken pattern causes NVDA/Chrome to silently skip the announcement — the AT has no chance to register the live region before content appears inside it. The fix ensures the container exists from first render so updates are always announced.

## Test plan

- [x] `frontend/src/__tests__/SearchLiveRegions.test.ts` — 6 static-analysis tests covering both pages (already passing in the test suite)
- [x] Full frontend test suite: 3721 tests pass
- [x] Manual verification: home page search and admin books filter both use always-present containers

Closes #2340
