### PR TITLE
fix: always-present live region for import done message (WCAG 4.1.3)

### DIFF
--- a/frontend/src/__tests__/ImportDoneLiveRegion.test.ts
+++ b/frontend/src/__tests__/ImportDoneLiveRegion.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Regression test for #2342: the import page "Done" status message must use
+ * the always-present live region pattern (WCAG 4.1.3) so screen readers
+ * announce the completion message when isDone becomes true.
+ *
+ * Broken pattern: {isDone && <p role="status">Done…</p>}
+ * Fixed pattern: always-present <p role="status"> with ternary content
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/import/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Import page isDone live region — WCAG 4.1.3 (closes #2342)", () => {
+  it("done status message is not conditionally mounted on isDone", () => {
+    // Broken pattern: {isDone && (<p role="status"...)}
+    expect(src).not.toMatch(
+      /\{isDone\s*&&\s*\(?\s*\n?\s*<p\s[^>]*role="status"/,
+    );
+  });
+
+  it("always-present live region exists near the isDone usage", () => {
+    // The always-present container should be near the comment
+    const idx = src.indexOf("always-present so AT announces the done message");
+    expect(idx).toBeGreaterThan(-1);
+    const section = src.slice(idx, idx + 300);
+    expect(section).toMatch(/role="status"/);
+    expect(section).toMatch(/aria-live="polite"/);
+  });
+
+  it("done message content uses ternary, not conditional mount", () => {
+    const idx = src.indexOf("always-present so AT announces the done message");
+    const section = src.slice(idx, idx + 300);
+    expect(section).toMatch(/isDone\s*\?/);
+  });
+});

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -309,11 +309,10 @@ export default function BookImportPage() {
             </div>
           )}
 
-          {isDone && (
-            <p role="status" className="text-sm text-emerald-700 mb-4">
-              Done — opening your book…
-            </p>
-          )}
+          {/* always-present so AT announces the done message (WCAG 4.1.3) */}
+          <p role="status" aria-live="polite" aria-atomic="true" className="text-sm text-emerald-700 mb-4">
+            {isDone ? "Done — opening your book…" : ""}
+          </p>
 
           {started && !isDone && (
             <div className="flex gap-2">


### PR DESCRIPTION
## What changed

`src/app/import/[bookId]/page.tsx`: changed the `isDone` completion message from a conditionally-mounted `<p role="status">` to an always-present live region with ternary content.

**Before:**
```tsx
{isDone && (
  <p role="status" className="text-sm text-emerald-700 mb-4">
    Done — opening your book…
  </p>
)}
```

**After:**
```tsx
{/* always-present so AT announces the done message (WCAG 4.1.3) */}
<p role="status" aria-live="polite" aria-atomic="true" className="text-sm text-emerald-700 mb-4">
  {isDone ? "Done — opening your book…" : ""}
</p>
```

## Why

NVDA/JAWS/VoiceOver won't announce content injected into a newly-mounted live region — the region must already exist in the DOM before the content changes. When `isDone` became `true`, the old code injected a new `<p role="status">` alongside the content; AT never registered it. Since the page navigates away after 1200 ms, screen reader users received no "Done" feedback at all.

This follows the same always-present pattern established in #2340 (home + admin search) and #2339 (notes page).

## Test plan

- [x] `src/__tests__/ImportDoneLiveRegion.test.ts` — 3 static-analysis tests: confirms no conditional mount, confirms always-present container with correct ARIA attributes, confirms ternary content
- [x] Full frontend test suite: 3718 tests pass

Closes #2342
