### PR TITLE
fix: always-present aria-live mirrors for action toast notifications (WCAG 4.1.3)

### DIFF
--- a/frontend/src/__tests__/AdminBooksPage.coverage.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.coverage.test.tsx
@@ -157,7 +157,7 @@ describe("AdminBooksPage — import already_cached branch (line 111)", () => {
     await userEvent.click(screen.getByRole("button", { name: /import book/i }));
 
     await waitFor(() =>
-      expect(screen.getByRole("status")).toHaveTextContent(/already cached/i),
+      expect(screen.getAllByText(/already cached/i)[0]).toBeInTheDocument(),
     );
   });
 
@@ -248,7 +248,7 @@ describe("AdminBooksPage — handleRetranslate (lines 118-136)", () => {
       ),
     );
     await waitFor(() =>
-      expect(screen.getByRole("status")).toHaveTextContent(/paragraphs/i),
+      expect(screen.getAllByText(/paragraphs/i)[0]).toBeInTheDocument(),
     );
   });
 
@@ -450,7 +450,7 @@ describe("AdminBooksPage — retryFailedForLang (line 350)", () => {
       ),
     );
     await waitFor(() =>
-      expect(screen.getByRole("status")).toHaveTextContent(/Re-queued/i),
+      expect(screen.getAllByText(/Re-queued/i)[0]).toBeInTheDocument(),
     );
   });
 
@@ -570,7 +570,7 @@ describe("AdminBooksPage — bulk retranslate (lines 423-460)", () => {
       ),
     );
     await waitFor(() =>
-      expect(screen.getByRole("status")).toHaveTextContent(/chapters/i),
+      expect(screen.getAllByText(/chapters/i)[0]).toBeInTheDocument(),
     );
   });
 

--- a/frontend/src/__tests__/ExportUrlNewTabAnnouncement.test.ts
+++ b/frontend/src/__tests__/ExportUrlNewTabAnnouncement.test.ts
@@ -21,10 +21,11 @@ describe("export URL links announce new-tab to screen readers (closes #2334)", (
 
   it("reader page Obsidian export toast link has sr-only new-tab announcement", () => {
     const src = read("../app/reader/[bookId]/page.tsx");
-    // The obsidian toast export link renders the URL as visible text inside <a target="_blank">
-    const idx = src.indexOf("obsidianToast.startsWith");
+    // The obsidian visual toast export link renders the URL inside <a target="_blank">
+    // Anchor on the visual toast comment (after the always-present mirror)
+    const idx = src.indexOf("Obsidian export toast — visual only");
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(idx, idx + 700);
+    const window = src.slice(idx, idx + 1100);
     expect(window).toMatch(/opens in new tab/);
   });
 });

--- a/frontend/src/__tests__/ProfileObsidianFeedbackRole.test.ts
+++ b/frontend/src/__tests__/ProfileObsidianFeedbackRole.test.ts
@@ -40,11 +40,14 @@ describe("Profile page feedback messages have always-present live-region roles (
   });
 });
 
-describe("Reader obsidian toast has live-region role (closes #1255)", () => {
-  it("obsidianToast container has role=status", () => {
-    const idx = reader.indexOf("obsidianToast &&");
+describe("Reader obsidian toast has live-region role (closes #1255, updated #2344)", () => {
+  it("obsidianToast uses always-present aria-live mirror (split pattern, WCAG 4.1.3)", () => {
+    // #2344: visual toast is conditionally mounted for dismiss-button UX;
+    // announcement comes from the always-present sr-only mirror span
+    const idx = reader.indexOf("aria-live-obsidian-toast-mirror");
     expect(idx).toBeGreaterThan(-1);
     const region = reader.slice(idx, idx + 300);
-    expect(region).toContain('role="status"');
+    expect(region).toContain('aria-live="polite"');
+    expect(region).toContain('sr-only');
   });
 });

--- a/frontend/src/__tests__/QueueTab.branches2.test.tsx
+++ b/frontend/src/__tests__/QueueTab.branches2.test.tsx
@@ -297,9 +297,9 @@ describe("QueueTab.branches2 — clearAll with filter='all' (lines 325, 350)", (
         expect.objectContaining({ method: "DELETE" }),
       ),
     );
-    // Success shown as inline toast (role="status") instead of alert()
+    // Success shown as inline toast (aria-live mirror announces, visual div shows)
     await waitFor(() =>
-      expect(screen.getByRole("status")).toHaveTextContent(/5/),
+      expect(screen.getAllByText(/5/)[0]).toBeInTheDocument(),
     );
   });
 });

--- a/frontend/src/__tests__/ReaderPage.branches2.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches2.test.tsx
@@ -704,7 +704,7 @@ describe("ReaderPage.branches2 — Obsidian export toast variants", () => {
     await userEvent.click(exportBtn);
 
     await waitFor(() => {
-      expect(screen.getByText("Vault not found")).toBeInTheDocument();
+      expect(screen.getAllByText("Vault not found")[0]).toBeInTheDocument();
     });
   });
 
@@ -718,7 +718,7 @@ describe("ReaderPage.branches2 — Obsidian export toast variants", () => {
     await userEvent.click(exportBtn);
 
     await waitFor(() => {
-      expect(screen.getByText("Export failed")).toBeInTheDocument();
+      expect(screen.getAllByText("Export failed")[0]).toBeInTheDocument();
     });
   });
 
@@ -1079,7 +1079,7 @@ describe("ReaderPage.branches2 — onSaveInsight callback in InsightChat", () =>
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Insight saved to book notes")).toBeInTheDocument();
+      expect(screen.getAllByText("Insight saved to book notes")[0]).toBeInTheDocument();
     });
   });
 
@@ -1098,7 +1098,7 @@ describe("ReaderPage.branches2 — onSaveInsight callback in InsightChat", () =>
     await waitFor(() => expect(mockSaveInsight).toHaveBeenCalled());
 
     await waitFor(() => {
-      expect(screen.getByText("Failed to save insight")).toBeInTheDocument();
+      expect(screen.getAllByText("Failed to save insight")[0]).toBeInTheDocument();
     });
   });
 
@@ -2219,7 +2219,7 @@ describe("ReaderPage.branches2 — mobile chat onSaveInsight success", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Insight saved to book notes")).toBeInTheDocument();
+      expect(screen.getAllByText("Insight saved to book notes")[0]).toBeInTheDocument();
     });
   });
 });
@@ -2348,7 +2348,7 @@ describe("ReaderPage.branches2 — mobile onSaveInsight failure toast", () => {
     await userEvent.click(saveBtns[saveBtns.length - 1]);
 
     await waitFor(() => {
-      expect(screen.getByText("Failed to save insight")).toBeInTheDocument();
+      expect(screen.getAllByText("Failed to save insight")[0]).toBeInTheDocument();
     }, { timeout: 3000 });
   });
 });

--- a/frontend/src/__tests__/ToastLiveRegions.test.ts
+++ b/frontend/src/__tests__/ToastLiveRegions.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression tests for #2344: action toast notifications must use the
+ * always-present + conditionally-mounted split pattern (WCAG 4.1.3) so AT
+ * announces toast messages even though the visual container is conditional.
+ *
+ * Broken pattern: {toast && <div role="status">message + dismiss button</div>}
+ *   — AT never hears the announcement (live region injected with its content).
+ *
+ * Fixed pattern:
+ *   Always-present sr-only mirror  → <span aria-live="polite">{toast ?? ""}</span>
+ *   Conditional visual toast       → {toast && <div>message + dismiss button</div>}
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const adminBooksSrc = fs.readFileSync(
+  path.join(__dirname, "../app/admin/books/page.tsx"),
+  "utf8",
+);
+const queueTabSrc = fs.readFileSync(
+  path.join(__dirname, "../components/QueueTab.tsx"),
+  "utf8",
+);
+const readerSrc = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+// ── Admin books page toast ─────────────────────────────────────────────────
+
+describe("Admin books page toast live region — WCAG 4.1.3 (closes #2344)", () => {
+  it("toast container is not the sole role=status on the page (split pattern)", () => {
+    // Broken: {toast && (<div role="status"...)}
+    expect(adminBooksSrc).not.toMatch(
+      /\{toast\s*&&\s*\(?\s*\n?\s*<div\s[^>]*role="status"/,
+    );
+  });
+
+  it("always-present sr-only aria-live mirror exists for toast", () => {
+    const idx = adminBooksSrc.indexOf("aria-live-toast-mirror");
+    expect(idx).toBeGreaterThan(-1);
+    const section = adminBooksSrc.slice(idx, idx + 200);
+    expect(section).toMatch(/aria-live="polite"/);
+    expect(section).toMatch(/sr-only/);
+  });
+});
+
+// ── QueueTab toast ─────────────────────────────────────────────────────────
+
+describe("QueueTab toast live region — WCAG 4.1.3 (closes #2344)", () => {
+  it("toast container is not conditionally mounting a role=status", () => {
+    expect(queueTabSrc).not.toMatch(
+      /\{toast\s*&&\s*\(?\s*\n?\s*<div\s[^>]*role="status"/,
+    );
+  });
+
+  it("always-present sr-only aria-live mirror exists for toast", () => {
+    const idx = queueTabSrc.indexOf("aria-live-toast-mirror");
+    expect(idx).toBeGreaterThan(-1);
+    const section = queueTabSrc.slice(idx, idx + 200);
+    expect(section).toMatch(/aria-live="polite"/);
+    expect(section).toMatch(/sr-only/);
+  });
+});
+
+// ── Reader obsidian toast ──────────────────────────────────────────────────
+
+describe("Reader obsidian toast live region — WCAG 4.1.3 (closes #2344)", () => {
+  it("obsidianToast container is not conditionally mounting a role=status", () => {
+    expect(readerSrc).not.toMatch(
+      /\{obsidianToast\s*&&\s*\(?\s*\n?\s*<div\s[^>]*role="status"/,
+    );
+  });
+
+  it("always-present sr-only aria-live mirror exists for obsidianToast", () => {
+    const idx = readerSrc.indexOf("aria-live-obsidian-toast-mirror");
+    expect(idx).toBeGreaterThan(-1);
+    const section = readerSrc.slice(idx, idx + 200);
+    expect(section).toMatch(/aria-live="polite"/);
+    expect(section).toMatch(/sr-only/);
+  });
+});

--- a/frontend/src/__tests__/VocabFilterAriaLive.test.ts
+++ b/frontend/src/__tests__/VocabFilterAriaLive.test.ts
@@ -16,10 +16,12 @@ describe("Vocabulary filter word count aria-live (closes #2073)", () => {
   });
 
   it("aria-live and aria-atomic are near the word count", () => {
-    const idx = src.indexOf('aria-live="polite"');
-    expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(Math.max(0, idx - 100), idx + 200);
-    expect(window).toContain("filteredVocab.length");
+    // Anchor on filteredVocab.length to find the right live region
+    // (reader page may have multiple aria-live spans)
+    const vocabIdx = src.indexOf("filteredVocab.length");
+    expect(vocabIdx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, vocabIdx - 200), vocabIdx + 200);
+    expect(window).toContain('aria-live="polite"');
     expect(window).toContain('aria-atomic="true"');
   });
 });

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -304,8 +304,10 @@ export default function BooksPage() {
         </div>
       )}
 
+      {/* aria-live-toast-mirror: always-present so AT announces toast (WCAG 4.1.3) */}
+      <span aria-live="polite" aria-atomic="true" className="sr-only">{toast ?? ""}</span>
       {toast && (
-        <div role="status" className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 flex items-center justify-between gap-3">
+        <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 flex items-center justify-between gap-3">
           <span>{toast}</span>
           <button
             type="button"

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1655,9 +1655,13 @@ export default function ReaderPage() {
             />
           )}
 
-          {/* Obsidian export toast */}
+          {/* aria-live-obsidian-toast-mirror: always-present so AT announces (WCAG 4.1.3) */}
+          <span aria-live="polite" aria-atomic="true" className="sr-only">
+            {obsidianToast ? (obsidianToast.startsWith("http") ? `Exported to ${obsidianToast}` : obsidianToast) : ""}
+          </span>
+          {/* Obsidian export toast — visual only, conditionally mounted */}
           {obsidianToast && (
-            <div role="status" className="fixed bottom-6 right-6 z-50 bg-white border border-amber-300 shadow-lg rounded-xl px-5 py-3 text-sm text-ink max-w-xs">
+            <div className="fixed bottom-6 right-6 z-50 bg-white border border-amber-300 shadow-lg rounded-xl px-5 py-3 text-sm text-ink max-w-xs">
               {obsidianToast.startsWith("http") ? (
                 <>
                   Exported!{" "}

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -557,8 +557,10 @@ export default function QueueTab({ adminFetch }: Props) {
         </div>
       )}
 
+      {/* aria-live-toast-mirror: always-present so AT announces toast (WCAG 4.1.3) */}
+      <span aria-live="polite" aria-atomic="true" className="sr-only">{toast ?? ""}</span>
       {toast && (
-        <div role="status" className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 flex items-center justify-between gap-3">
+        <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 flex items-center justify-between gap-3">
           <span>{toast}</span>
           <button
             type="button"


### PR DESCRIPTION
## What changed

Three toast notification live regions across the app were conditionally mounting a `role="status"` element alongside their content — NVDA/JAWS/VoiceOver won't announce content that appears inside a newly-inserted live region.

These toasts also contained dismiss buttons, making a fully always-present container impractical (an orphaned dismiss button would be visible when no toast exists).

**Solution:** Split into two elements per toast:
1. An always-present `<span aria-live="polite" className="sr-only">` that echoes the toast text (WCAG 4.1.3 compliant announcement)
2. The existing visual toast container (conditionally mounted, for the dismiss-button UX)

**Files changed:**
- `app/admin/books/page.tsx` — action success toast (import cached, retranslate, retry, bulk ops)
- `components/QueueTab.tsx` — queue management success toast
- `app/reader/[bookId]/page.tsx` — Obsidian export toast (success URL + error messages + insight save)

**Tests updated** to reflect the split pattern:
- `ProfileObsidianFeedbackRole.test.ts` — updated to check mirror span, not visual toast `role="status"`
- `ExportUrlNewTabAnnouncement.test.ts` — updated anchor to visual toast section
- `VocabFilterAriaLive.test.ts` — updated to anchor on `filteredVocab.length`, not first `aria-live`
- `QueueTab.branches2.test.tsx`, `AdminBooksPage.coverage.test.tsx`, `ReaderPage.branches2.test.tsx` — updated `getByRole("status")` / `getByText()` calls that now find two elements (mirror + visual)

## Why

The split pattern separates the accessibility announcement (always-present, role-agnostic) from the visual toast (conditionally mounted for dismiss-button UX). This is consistent with the always-present pattern shipped in #2339, #2341, #2343.

## Test plan

- [x] `src/__tests__/ToastLiveRegions.test.ts` — 6 new static-analysis tests covering all three files
- [x] Full frontend test suite: 3727 tests pass
- [x] All pre-existing tests updated and passing

Closes #2344
