### PR TITLE
fix: obsidian toast shows success messages in emerald, errors in red

### DIFF
--- a/frontend/src/__tests__/ObsidianToastSuccessColor.test.ts
+++ b/frontend/src/__tests__/ObsidianToastSuccessColor.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression test for #2346: reader obsidian toast must distinguish success
+ * from error messages. Before the fix, ALL non-URL messages (including
+ * "Insight saved to book notes") rendered in text-red-600 error styling.
+ *
+ * Fixed by changing obsidianToast state to { msg: string; ok: boolean } | null
+ * so the render branch can use .ok to choose success vs error styling.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Reader obsidian toast success/error color (closes #2346)", () => {
+  it("obsidianToast state is typed with ok flag, not plain string", () => {
+    // After fix: state is { msg: string; ok: boolean } | null
+    expect(src).toMatch(/obsidianToast.*\{.*ok.*boolean/s);
+  });
+
+  it("toast render uses .ok to choose emerald vs red styling", () => {
+    // Success messages → emerald; error messages → red
+    const idx = src.indexOf("obsidianToast.ok");
+    expect(idx).toBeGreaterThan(-1);
+    const section = src.slice(idx, idx + 300);
+    expect(section).toMatch(/text-emerald/);
+    expect(section).toMatch(/text-red-600/);
+  });
+
+  it("insight save sets ok:true for success", () => {
+    // Saved to book notes is a success — msg appears before ok in the object
+    expect(src).toMatch(/Insight saved to book notes[^}]*ok:\s*true/s);
+  });
+
+  it("insight save sets ok:false for failure", () => {
+    expect(src).toMatch(/Failed to save insight[^}]*ok:\s*false/s);
+  });
+});

--- a/frontend/src/__tests__/RemainingAnchorFocusRings.test.ts
+++ b/frontend/src/__tests__/RemainingAnchorFocusRings.test.ts
@@ -47,9 +47,9 @@ describe("Reader page remaining anchor focus rings (closes #2202)", () => {
   });
 
   it("Obsidian export URL link has focus ring", () => {
-    const idx = readerSrc.indexOf("href={obsidianToast}");
+    const idx = readerSrc.indexOf("href={obsidianToast.msg}");
     expect(idx).toBeGreaterThan(-1);
-    const window = readerSrc.slice(idx, idx + 240);
+    const window = readerSrc.slice(idx, idx + 280);
     expect(window).toContain("focus-visible:ring-amber-400");
   });
 

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -89,8 +89,8 @@ export default function ReaderPage() {
   // Vocabulary toast
   const [vocabToastWord, setVocabToastWord] = useState<string | null>(null);
 
-  // Obsidian export toast
-  const [obsidianToast, setObsidianToast] = useState<string | null>(null);
+  // Obsidian export toast — { msg: string; ok: boolean } distinguishes success from error
+  const [obsidianToast, setObsidianToast] = useState<{ msg: string; ok: boolean } | null>(null);
 
   // Annotation delete undo toast
   const [deletedAnnotationToast, setDeletedAnnotationToast] = useState<Annotation | null>(null);
@@ -831,10 +831,10 @@ export default function ReaderPage() {
   async function handleObsidianExport() {
     try {
       const { urls } = await exportVocabularyToObsidian(Number(bookId));
-      setObsidianToast(urls[0] || "Exported successfully");
+      setObsidianToast({ msg: urls[0] || "Exported successfully", ok: true });
       setTimeout(() => setObsidianToast(null), 6000);
     } catch (e) {
-      setObsidianToast(e instanceof Error ? e.message : "Export failed");
+      setObsidianToast({ msg: e instanceof Error ? e.message : "Export failed", ok: false });
       setTimeout(() => setObsidianToast(null), 4000);
     }
   }
@@ -1657,25 +1657,27 @@ export default function ReaderPage() {
 
           {/* aria-live-obsidian-toast-mirror: always-present so AT announces (WCAG 4.1.3) */}
           <span aria-live="polite" aria-atomic="true" className="sr-only">
-            {obsidianToast ? (obsidianToast.startsWith("http") ? `Exported to ${obsidianToast}` : obsidianToast) : ""}
+            {obsidianToast ? (obsidianToast.msg.startsWith("http") ? `Exported to ${obsidianToast.msg}` : obsidianToast.msg) : ""}
           </span>
           {/* Obsidian export toast — visual only, conditionally mounted */}
           {obsidianToast && (
             <div className="fixed bottom-6 right-6 z-50 bg-white border border-amber-300 shadow-lg rounded-xl px-5 py-3 text-sm text-ink max-w-xs">
-              {obsidianToast.startsWith("http") ? (
+              {obsidianToast.msg.startsWith("http") ? (
                 <>
                   Exported!{" "}
                   <a
-                    href={obsidianToast}
+                    href={obsidianToast.msg}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-amber-700 underline break-all focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
                   >
-                    {obsidianToast}<span className="sr-only"> (opens in new tab)</span>
+                    {obsidianToast.msg}<span className="sr-only"> (opens in new tab)</span>
                   </a>
                 </>
+              ) : obsidianToast.ok ? (
+                <span className="text-emerald-700">{obsidianToast.msg}</span>
               ) : (
-                <span className="text-red-600">{obsidianToast}</span>
+                <span className="text-red-600">{obsidianToast.msg}</span>
               )}
             </div>
           )}
@@ -1761,8 +1763,8 @@ export default function ReaderPage() {
                   chapterIndex={chapterIndex}
                   onSaveInsight={session?.backendToken ? (question, answer, context) => {
                     saveInsight({ book_id: Number(bookId), chapter_index: chapterIndex, question, answer, context_text: context })
-                      .then(() => setObsidianToast("Insight saved to book notes"))
-                      .catch(() => setObsidianToast("Failed to save insight"))
+                      .then(() => setObsidianToast({ msg: "Insight saved to book notes", ok: true }))
+                      .catch(() => setObsidianToast({ msg: "Failed to save insight", ok: false }))
                       .finally(() => setTimeout(() => setObsidianToast(null), 3000));
                   } : undefined}
                 />
@@ -2230,8 +2232,8 @@ export default function ReaderPage() {
               chapterIndex={chapterIndex}
               onSaveInsight={session?.backendToken ? (question, answer, context) => {
                 saveInsight({ book_id: Number(bookId), chapter_index: chapterIndex, question, answer, context_text: context })
-                  .then(() => setObsidianToast("Insight saved to book notes"))
-                  .catch(() => setObsidianToast("Failed to save insight"))
+                  .then(() => setObsidianToast({ msg: "Insight saved to book notes", ok: true }))
+                  .catch(() => setObsidianToast({ msg: "Failed to save insight", ok: false }))
                   .finally(() => setTimeout(() => setObsidianToast(null), 3000));
               } : undefined}
             />


### PR DESCRIPTION
## What changed

`src/app/reader/[bookId]/page.tsx`: changed the `obsidianToast` state from `string | null` to `{ msg: string; ok: boolean } | null` so the render can distinguish success from error messages.

**Before:** every non-URL message rendered in `text-red-600` error styling:
```
"Insight saved to book notes"  → <span class="text-red-600">  ❌ wrong
"Exported successfully"        → <span class="text-red-600">  ❌ wrong
"Export failed"                → <span class="text-red-600">  ✓ correct
```

**After:** `.ok` flag drives the color:
```
{ msg: "Insight saved…", ok: true  } → <span class="text-emerald-700">  ✓
{ msg: "Exported successfully", ok: true  } → <span class="text-emerald-700">  ✓
{ msg: "Export failed",        ok: false } → <span class="text-red-600">     ✓
```

Updated all 4 `setObsidianToast` call sites:
- Obsidian export success → `{ msg: urls[0] || "Exported successfully", ok: true }`
- Obsidian export error → `{ msg: e.message || "Export failed", ok: false }`
- Insight save success → `{ msg: "Insight saved to book notes", ok: true }` (×2 locations)
- Insight save failure → `{ msg: "Failed to save insight", ok: false }` (×2 locations)

Also updated the always-present `aria-live` mirror and the `<a href>` to use `.msg`.

## Why

The `obsidianToast` variable was reused for both Obsidian export results and insight-save confirmations. The render only checked `startsWith("http")` to decide style — anything else was rendered in red. "Insight saved to book notes" and "Exported successfully" are success states that should not appear in error red.

## Test plan

- [x] `src/__tests__/ObsidianToastSuccessColor.test.ts` — 4 static-analysis tests verifying the `{ msg, ok }` shape and per-type color
- [x] `src/__tests__/RemainingAnchorFocusRings.test.ts` — updated anchor from `href={obsidianToast}` to `href={obsidianToast.msg}`, extended window to 280 chars
- [x] Full frontend test suite: 3734 tests pass

Closes #2346
