### PR TITLE
fix: add 44px touch targets to WordLookup close and WordActionDrawer retry buttons (closes #2348)

### DIFF
--- a/frontend/src/__tests__/WordLookupTouchTargets.test.ts
+++ b/frontend/src/__tests__/WordLookupTouchTargets.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Regression tests for #2348: WordLookup close button and WordActionDrawer
+ * retry button had touch targets below 44px on mobile (WCAG 2.5.5).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const lookupSrc = fs.readFileSync(
+  path.join(__dirname, "../components/WordLookup.tsx"),
+  "utf8",
+);
+const drawerSrc = fs.readFileSync(
+  path.join(__dirname, "../components/WordActionDrawer.tsx"),
+  "utf8",
+);
+
+describe("WordLookup close button touch target (closes #2348)", () => {
+  it("has min-h-[44px] for mobile touch target", () => {
+    const idx = lookupSrc.indexOf('aria-label="Close definition"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = lookupSrc.slice(idx, idx + 200);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("has md:min-h-0 to keep desktop compact", () => {
+    const idx = lookupSrc.indexOf('aria-label="Close definition"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = lookupSrc.slice(idx, idx + 200);
+    expect(window).toContain("md:min-h-0");
+  });
+
+  it("has min-w-[44px] for mobile touch target", () => {
+    const idx = lookupSrc.indexOf('aria-label="Close definition"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = lookupSrc.slice(idx, idx + 200);
+    expect(window).toContain("min-w-[44px]");
+  });
+
+  it("has flex items-center justify-center for proper sizing", () => {
+    const idx = lookupSrc.indexOf('aria-label="Close definition"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = lookupSrc.slice(idx, idx + 280);
+    expect(window).toContain("flex items-center justify-center");
+  });
+});
+
+describe("WordActionDrawer retry button touch target (closes #2348)", () => {
+  it("has min-h-[44px] for mobile touch target", () => {
+    const idx = drawerSrc.indexOf('aria-label="Retry dictionary lookup"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = drawerSrc.slice(idx, idx + 200);
+    expect(window).toContain("min-h-[44px]");
+  });
+
+  it("has md:min-h-0 to keep desktop compact", () => {
+    const idx = drawerSrc.indexOf('aria-label="Retry dictionary lookup"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = drawerSrc.slice(idx, idx + 200);
+    expect(window).toContain("md:min-h-0");
+  });
+
+  it("has min-w-[44px] for mobile touch target", () => {
+    const idx = drawerSrc.indexOf('aria-label="Retry dictionary lookup"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = drawerSrc.slice(idx, idx + 200);
+    expect(window).toContain("min-w-[44px]");
+  });
+});

--- a/frontend/src/components/WordActionDrawer.tsx
+++ b/frontend/src/components/WordActionDrawer.tsx
@@ -171,7 +171,7 @@ export default function WordActionDrawer({
                 type="button"
                 onClick={lookup}
                 aria-label="Retry dictionary lookup"
-                className="p-1 rounded hover:bg-amber-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
+                className="p-1 rounded hover:bg-amber-100 transition-colors min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
               >
                 <RetryIcon className="w-3.5 h-3.5 text-amber-700" aria-hidden="true" />
               </button>

--- a/frontend/src/components/WordLookup.tsx
+++ b/frontend/src/components/WordLookup.tsx
@@ -95,7 +95,7 @@ export default function WordLookup({ word, position, language, onClose }: Props)
         type="button"
         onClick={onClose}
         aria-label="Close definition"
-        className="absolute top-1.5 right-1.5 rounded-full p-0.5 hover:bg-amber-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+        className="absolute top-1.5 right-1.5 rounded-full p-0.5 hover:bg-amber-100 transition-colors min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
       >
         <CloseIcon className="w-3.5 h-3.5" aria-hidden="true" />
       </button>


### PR DESCRIPTION
## What changed

Added `min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center` to two icon-only buttons that had touch targets below the 44×44px mobile minimum (WCAG 2.5.5):

- **`WordLookup.tsx`** close button: was `p-0.5` (~16px) → now ≥44px on mobile
- **`WordActionDrawer.tsx`** retry-on-error button: was `p-1` (~24px) → now ≥44px on mobile

The `md:min-h-0 md:min-w-0` suffix keeps desktop chrome compact. This is the same pattern already used in `VocabWordTooltip.tsx`.

## Why

Both components render on mobile when users tap a word in the reader. The close and retry buttons were too small to reliably tap, making them effectively inaccessible on touch devices.

## Test plan

- [x] `WordLookupTouchTargets.test.ts` — 7 static-analysis tests confirming touch-target classes on both buttons
- [x] Full frontend suite: 3741 tests passing

Closes #2348
