### PR TITLE
fix: add focus-visible ring to search page Library back link (closes #2350)

### DIFF
--- a/frontend/src/__tests__/SearchPageBackLinkFocusRing.test.ts
+++ b/frontend/src/__tests__/SearchPageBackLinkFocusRing.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Regression test for #2350: search page "Library" back link was missing
+ * focus-visible ring (WCAG 2.4.7).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/search/page.tsx"),
+  "utf8",
+);
+
+describe("Search page back link focus ring (closes #2350)", () => {
+  it("Library back link (ArrowLeftIcon + Library text) has focus-visible:ring-amber-400", () => {
+    // Anchor on the ArrowLeftIcon inside the back link — unique to the header nav link
+    const idx = src.indexOf('ArrowLeftIcon className="w-3.5 h-3.5 mr-1 inline"');
+    expect(idx).toBeGreaterThan(-1);
+    // Look backward into the containing <Link> element for focus ring
+    const window = src.slice(Math.max(0, idx - 250), idx + 30);
+    expect(window).toContain("focus-visible:ring-amber-400");
+  });
+
+  it("Library back link has focus:outline-none", () => {
+    const idx = src.indexOf('ArrowLeftIcon className="w-3.5 h-3.5 mr-1 inline"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 250), idx + 30);
+    expect(window).toContain("focus:outline-none");
+  });
+});

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -211,7 +211,7 @@ export default function SearchPage() {
       <div className="flex items-center gap-4 mb-6">
         <Link
           href="/"
-          className="text-amber-700 hover:text-amber-900 text-sm font-medium shrink-0 min-h-[44px] md:min-h-0 flex items-center"
+          className="text-amber-700 hover:text-amber-900 text-sm font-medium shrink-0 min-h-[44px] md:min-h-0 flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
         >
           <ArrowLeftIcon className="w-3.5 h-3.5 mr-1 inline" aria-hidden="true" />Library
         </Link>


### PR DESCRIPTION
## What changed

Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded` to the "Library" back link in the search page header (`app/search/page.tsx`).

## Why

The back link had `min-h-[44px]` (indicating it's a primary interactive element) but was missing a keyboard focus ring — a WCAG 2.4.7 violation. All equivalent back links across notes, profile, vocabulary, and import pages were updated in prior cycles; this one was missed.

## Test plan

- [x] `SearchPageBackLinkFocusRing.test.ts` — 2 static-analysis tests confirming focus ring classes on the header back link
- [x] Full frontend suite: 3743 tests passing

Closes #2350
