### PR TITLE
fix: add focus trap and auto-focus to WordLookup dialog (closes #2352)

### DIFF
--- a/frontend/src/__tests__/WordLookupFocusTrap.test.ts
+++ b/frontend/src/__tests__/WordLookupFocusTrap.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression tests for #2352: WordLookup dialog missing focus trap and
+ * auto-focus on open (WCAG 2.4.3 — Focus Order).
+ *
+ * Other dialogs (BookDetailModal, WordActionDrawer, AnnotationToolbar) all
+ * use useFocusTrap + tabIndex={-1} + dialogRef.current?.focus(). WordLookup
+ * was missing these patterns.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/WordLookup.tsx"),
+  "utf8",
+);
+
+describe("WordLookup dialog focus management (closes #2352)", () => {
+  it("imports useFocusTrap", () => {
+    expect(src).toContain("useFocusTrap");
+  });
+
+  it("dialog container has tabIndex={-1} for programmatic focus", () => {
+    const idx = src.indexOf('role="dialog"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 100), idx + 200);
+    expect(window).toContain("tabIndex={-1}");
+  });
+
+  it("dialog container has focus:outline-none", () => {
+    const idx = src.indexOf('role="dialog"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(Math.max(0, idx - 100), idx + 300);
+    expect(window).toContain("focus:outline-none");
+  });
+
+  it("calls useFocusTrap with the ref", () => {
+    expect(src).toMatch(/useFocusTrap\(ref\)/);
+  });
+
+  it("auto-focuses dialog on mount and restores focus on close", () => {
+    // The useEffect that moves focus should call ref.current?.focus()
+    expect(src).toContain("ref.current?.focus()");
+    // And restore previouslyFocused?.focus()
+    expect(src).toContain("previouslyFocused?.focus");
+  });
+});

--- a/frontend/src/components/WordLookup.tsx
+++ b/frontend/src/components/WordLookup.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
 import { CloseIcon } from "@/components/Icons";
+import { useFocusTrap } from "@/lib/useFocusTrap";
 
 interface Definition {
   partOfSpeech: string;
@@ -26,6 +27,7 @@ export default function WordLookup({ word, position, language, onClose }: Props)
   const [error, setError] = useState("");
   const ref = useRef<HTMLDivElement>(null);
   const lang = language?.split(/[-_]/)[0] ?? "en";
+  useFocusTrap(ref);
 
   useEffect(() => {
     setLoading(true);
@@ -72,6 +74,16 @@ export default function WordLookup({ word, position, language, onClose }: Props)
     return () => document.removeEventListener("keydown", handleKey);
   }, [onClose]);
 
+  // Move focus into dialog on open; restore to trigger on close
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    ref.current?.focus();
+    return () => {
+      previouslyFocused?.focus?.();
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Position the popup near the word, but keep it within viewport
   const isMobile = typeof window !== "undefined" && window.innerWidth < 640;
   const style: React.CSSProperties = isMobile
@@ -86,10 +98,12 @@ export default function WordLookup({ word, position, language, onClose }: Props)
   return (
     <div
       ref={ref}
+      tabIndex={-1}
       role="dialog"
+      aria-modal="true"
       aria-label={`Word definition: ${word}`}
       style={style}
-      className="relative sm:w-72 max-h-64 overflow-y-auto rounded-xl border border-amber-300 bg-white shadow-lg p-3 text-sm"
+      className="relative sm:w-72 max-h-64 overflow-y-auto rounded-xl border border-amber-300 bg-white shadow-lg p-3 text-sm focus:outline-none"
     >
       <button
         type="button"


### PR DESCRIPTION
## What changed

Added proper focus management to `WordLookup.tsx` — the popup dialog that appears when users tap/click a word in the reader:

1. **`useFocusTrap(ref)`** — Tab now cycles within the dialog instead of escaping to the page
2. **`tabIndex={-1}` + `aria-modal="true"`** on the dialog container — makes it programmatically focusable and signals to AT it's a modal
3. **Auto-focus `useEffect`** — focus moves into the dialog when it opens, and returns to the trigger element when it closes

## Why

Other dialogs in the codebase (`BookDetailModal`, `WordActionDrawer`, `AnnotationToolbar`) all implement this pattern. `WordLookup` was missing it — keyboard users and screen reader users couldn't interact with the popup because focus never moved into it (WCAG 2.4.3 — Focus Order).

## Test plan

- [x] `WordLookupFocusTrap.test.ts` — 5 static-analysis tests: `useFocusTrap` import, `tabIndex={-1}`, `focus:outline-none`, `useFocusTrap(ref)` call, auto-focus + restore pattern
- [x] Full frontend suite: 3746 tests passing

Closes #2352
