### PR TITLE
fix: add useScrollLock to AddWordPicker and vocabulary detail drawer (closes #2354)

### DIFF
--- a/frontend/src/__tests__/ModalScrollLock.test.ts
+++ b/frontend/src/__tests__/ModalScrollLock.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression tests for #2354: AddWordPicker (decks) and vocabulary word
+ * detail drawer were missing useScrollLock — body remained scrollable
+ * behind the modal while it was open.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const decksSrc = fs.readFileSync(
+  path.join(__dirname, "../app/decks/[deckId]/page.tsx"),
+  "utf8",
+);
+const vocabSrc = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8",
+);
+
+describe("AddWordPicker scroll lock (closes #2354)", () => {
+  it("imports useScrollLock", () => {
+    expect(decksSrc).toContain("useScrollLock");
+  });
+
+  it("calls useScrollLock inside AddWordPicker", () => {
+    const pickerStart = decksSrc.indexOf("function AddWordPicker(");
+    expect(pickerStart).toBeGreaterThan(-1);
+    const pickerBody = decksSrc.slice(pickerStart, pickerStart + 1000);
+    expect(pickerBody).toContain("useScrollLock(");
+  });
+});
+
+describe("Vocabulary word detail drawer scroll lock (closes #2354)", () => {
+  it("imports useScrollLock", () => {
+    expect(vocabSrc).toContain("useScrollLock");
+  });
+
+  it("calls useScrollLock in the word detail component", () => {
+    // The component that renders the bottom sheet drawer
+    expect(vocabSrc).toMatch(/useScrollLock\(true\)/);
+  });
+});

--- a/frontend/src/app/decks/[deckId]/page.tsx
+++ b/frontend/src/app/decks/[deckId]/page.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/Icons";
 import UndoToast from "@/components/UndoToast";
 import { useFocusTrap } from "@/lib/useFocusTrap";
+import { useScrollLock } from "@/lib/useScrollLock";
 
 export default function DeckDetailPage() {
   const { data: session } = useSession();
@@ -323,6 +324,7 @@ function AddWordPicker({ candidates, onClose, onAdd }: AddWordPickerProps) {
   const closeRef = useRef<HTMLButtonElement | null>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
   useFocusTrap(dialogRef);
+  useScrollLock(true);
 
   useEffect(() => {
     const prev = document.activeElement as HTMLElement | null;

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -16,6 +16,7 @@ import {
 import { EmptyVocabIcon, ArrowLeftIcon, ArrowRightIcon, FlashcardIcon, ArrowUpRightIcon, AlertCircleIcon, RetryIcon, CloseIcon } from "@/components/Icons";
 import TagEditor from "@/components/TagEditor";
 import { useFocusTrap } from "@/lib/useFocusTrap";
+import { useScrollLock } from "@/lib/useScrollLock";
 
 type SortMode = "alpha" | "language" | "book" | "recent";
 
@@ -114,6 +115,7 @@ function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
   const [loading, setLoading] = useState(true);
   const ref = useRef<HTMLDivElement>(null);
   useFocusTrap(ref);
+  useScrollLock(true);
 
   useEffect(() => {
     getWordDefinition(word, lang ?? undefined)


### PR DESCRIPTION
## What changed
`AddWordPicker` in `decks/[deckId]/page.tsx` and `DefinitionSheet` in `vocabulary/page.tsx` both render a modal overlay with a backdrop but did not call `useScrollLock` — the body remained scrollable behind the modal while it was open.

Added `import { useScrollLock } from "@/lib/useScrollLock"` and `useScrollLock(true)` to both components, immediately after `useFocusTrap`.

## Why
Both components have `role="dialog"` + `aria-modal="true"` and a full-screen backdrop, so the body scroll must be locked while they are open to avoid the double-scroll UX defect described in #2354.

## Test plan
- `frontend/src/__tests__/ModalScrollLock.test.ts` (4 new static tests):
  - `decks/[deckId]/page.tsx` imports `useScrollLock`
  - `AddWordPicker` function body calls `useScrollLock(`
  - `vocabulary/page.tsx` imports `useScrollLock`
  - `vocabulary/page.tsx` calls `useScrollLock(true)`
- Full frontend suite: 3747 tests passed
- Full backend suite: 1941 passed, 1 skipped

Closes #2354
