### PR TITLE
fix: add aria-pressed to QuickHighlightPanel color picker buttons (closes #2356)

### DIFF
--- a/frontend/src/__tests__/QuickHighlightAriaPressed.test.ts
+++ b/frontend/src/__tests__/QuickHighlightAriaPressed.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Regression tests for #2356: QuickHighlightPanel color buttons were missing
+ * aria-pressed — screen readers could not identify which color was active.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/QuickHighlightPanel.tsx"),
+  "utf8",
+);
+
+describe("QuickHighlightPanel color button aria-pressed (closes #2356)", () => {
+  it("color buttons have aria-pressed attribute", () => {
+    // aria-pressed must be present in the color button block
+    expect(src).toContain("aria-pressed=");
+  });
+
+  it("aria-pressed reflects existingAnnotation color match", () => {
+    // The pressed state should be tied to whether this color matches
+    // the existing annotation's color
+    expect(src).toMatch(/aria-pressed=\{.*existingAnnotation.*color.*c\.key/);
+  });
+
+  it("aria-pressed is inside the COLORS.map loop near the color button", () => {
+    const mapStart = src.indexOf("COLORS.map(");
+    expect(mapStart).toBeGreaterThan(-1);
+    const mapBody = src.slice(mapStart, mapStart + 600);
+    expect(mapBody).toContain("aria-pressed=");
+  });
+});

--- a/frontend/src/__tests__/RemainingComponentsFocusRing.test.ts
+++ b/frontend/src/__tests__/RemainingComponentsFocusRing.test.ts
@@ -22,7 +22,7 @@ describe("QuickHighlightPanel button focus rings (closes #2183)", () => {
   it("color picker button has focus ring", () => {
     const idx = quickHighlightPanel.indexOf("onClick={() => handleColor");
     expect(idx).toBeGreaterThan(-1);
-    const window = quickHighlightPanel.slice(idx, idx + 300);
+    const window = quickHighlightPanel.slice(idx, idx + 400);
     expect(window).toContain("focus-visible:ring-amber-400");
   });
 

--- a/frontend/src/components/QuickHighlightPanel.tsx
+++ b/frontend/src/components/QuickHighlightPanel.tsx
@@ -113,6 +113,7 @@ export default function QuickHighlightPanel({
           onClick={() => handleColor(c.key)}
           disabled={busy}
           aria-label={c.label}
+          aria-pressed={existingAnnotation?.color === c.key}
           className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
         >
           <span


### PR DESCRIPTION
## What changed
Added `aria-pressed={existingAnnotation?.color === c.key}` to each color picker button in `QuickHighlightPanel.tsx`.

## Why
When a user opens the QuickHighlightPanel to change an existing annotation's color, the currently-applied color was indicated only visually (`scale-110` + colored border). Screen readers had no way to identify the active color, violating WCAG 4.1.2 (Name, Role, Value) — the pressed state of a toggle button must be exposed in the accessibility tree.

## Test plan
- `frontend/src/__tests__/QuickHighlightAriaPressed.test.ts` (3 new static tests):
  - `aria-pressed=` exists in the source
  - The value references `existingAnnotation?.color === c.key`
  - The attribute is inside the `COLORS.map()` loop
- `frontend/src/__tests__/RemainingComponentsFocusRing.test.ts`: existing test window widened from 300→400 chars to accommodate the new attribute line
- Full frontend suite: 3755 tests passed

Closes #2356
