### PR TITLE
fix: add aria-label to reader translation toggle checkbox (closes #2358)

### DIFF
--- a/frontend/src/__tests__/ReaderTranslationToggleLabel.test.ts
+++ b/frontend/src/__tests__/ReaderTranslationToggleLabel.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Regression test for #2358: translation toggle checkbox in the reader sidebar
+ * was missing an accessible name — screen readers announced "Disabled, checkbox"
+ * with no indication of which feature was being toggled.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Reader sidebar translation toggle accessible name (closes #2358)", () => {
+  it("translation toggle checkbox has aria-label", () => {
+    const idx = src.indexOf("translationEnabled");
+    expect(idx).toBeGreaterThan(-1);
+    // Find the checkbox in the translate tab toggle area
+    const toggleArea = src.indexOf("Enable/disable toggle");
+    expect(toggleArea).toBeGreaterThan(-1);
+    const window = src.slice(toggleArea, toggleArea + 900);
+    expect(window).toContain('aria-label="Enable translation"');
+  });
+
+  it("aria-label is on the sr-only checkbox, not just the outer label", () => {
+    // Find the translation toggle section and look for the sr-only checkbox there
+    const toggleIdx = src.indexOf("Enable/disable toggle");
+    expect(toggleIdx).toBeGreaterThan(-1);
+    // Within the toggle section (600 chars), find the sr-only checkbox
+    const toggleSection = src.slice(toggleIdx, toggleIdx + 900);
+    const srOnlyIdx = toggleSection.indexOf('className="sr-only"');
+    expect(srOnlyIdx).toBeGreaterThan(-1);
+    // Look for aria-label within 200 chars of the sr-only class in this section
+    const vicinity = toggleSection.slice(Math.max(0, srOnlyIdx - 50), srOnlyIdx + 200);
+    expect(vicinity).toContain('aria-label="Enable translation"');
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2022,6 +2022,7 @@ export default function ReaderPage() {
                       <input
                         type="checkbox"
                         className="sr-only"
+                        aria-label="Enable translation"
                         checked={translationEnabled}
                         onChange={(e) => { setTranslationEnabled(e.target.checked); saveSettings({ translationEnabled: e.target.checked }); }}
                       />


### PR DESCRIPTION
## What changed
Added `aria-label="Enable translation"` to the sr-only checkbox inside the custom toggle switch in the reader sidebar's Translate tab.

## Why
The checkbox used a `<label>` wrapper whose only text content was the dynamic "Enabled" / "Disabled" state. Screen readers announced the control as "Disabled, checkbox" with no indication of which feature was being toggled — a WCAG 1.3.1 / 4.1.2 violation (form control missing an accessible name).

## Test plan
- New static test `ReaderTranslationToggleLabel.test.ts` verifies `aria-label="Enable translation"` is present on the sr-only checkbox inside the toggle area
- All 3757 frontend tests pass

Closes #2358

## Docs follow-up
None — internal accessibility attribute, no user-visible copy change.
