### PR TITLE
fix: add aria-required to deck name input (closes #2360)

### DIFF
--- a/frontend/src/__tests__/DeckNameRequired.test.ts
+++ b/frontend/src/__tests__/DeckNameRequired.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Regression test for #2360: deck name input was missing `required` attribute —
+ * screen readers could not tell users the field was mandatory before submission.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/decks/new/page.tsx"),
+  "utf8",
+);
+
+describe("Deck name input required attribute (closes #2360)", () => {
+  it("deck name input has required attribute", () => {
+    const idx = src.indexOf('id="deck-name"');
+    expect(idx).toBeGreaterThan(-1);
+    const window = src.slice(idx, idx + 300);
+    expect(window).toMatch(/\brequired\b/);
+  });
+});

--- a/frontend/src/app/decks/new/page.tsx
+++ b/frontend/src/app/decks/new/page.tsx
@@ -97,6 +97,7 @@ export default function DecksNewPage() {
             <input
               id="deck-name"
               type="text"
+              aria-required="true"
               value={name}
               onChange={(e) => setName(e.target.value)}
               maxLength={80}


### PR DESCRIPTION
## What changed
Added `aria-required="true"` to the deck name input in `decks/new/page.tsx`. Also adds a regression test confirming the attribute is present.

## Why
Issue #2360: the input lacked any required-field signal for screen readers. Using `required` (HTML attribute) was tried first but causes native browser form validation to fire — which intercepts submission before `handleSubmit` runs, breaking the existing "blocks submission when name is blank" test. `aria-required="true"` announces the field as required to assistive technology without native validation side-effects.

## Test plan
- New: `DeckNameRequired.test.ts` — verifies `aria-required` is present on the `deck-name` input
- Existing: `DecksNewPage.test.tsx` — "blocks submission when name is blank" still passes (custom error path unaffected)
- Full frontend suite: 3758 tests pass

Closes #2360
