### PR TITLE
fix: add role=status to QueueTab section-header spinners (closes #2362)

### DIFF
--- a/frontend/src/__tests__/QueueTabSpinnerStatus.test.ts
+++ b/frontend/src/__tests__/QueueTabSpinnerStatus.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Regression test for #2362: QueueTab section-header spinners (loadingCost,
+ * loadingItems) were missing role="status" — screen readers got no
+ * announcement when those sections were fetching data.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/QueueTab.tsx"),
+  "utf8",
+);
+
+describe("QueueTab header spinner role=status (closes #2362)", () => {
+  it('loadingCost spinner is wrapped in role="status"', () => {
+    const idx = src.indexOf("loadingCost && (");
+    expect(idx).toBeGreaterThan(-1);
+    const vicinity = src.slice(idx, idx + 200);
+    expect(vicinity).toMatch(/role="status"/);
+  });
+
+  it('loadingItems header spinner is wrapped in role="status"', () => {
+    // The items-header spinner uses the fixed-width slot comment as anchor
+    const idx = src.indexOf("Spinner slot has fixed width");
+    expect(idx).toBeGreaterThan(-1);
+    const vicinity = src.slice(idx, idx + 400);
+    expect(vicinity).toMatch(/role="status"/);
+  });
+});

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -1221,7 +1221,11 @@ export default function QueueTab({ adminFetch }: Props) {
             <div className="flex items-baseline justify-between flex-wrap gap-2">
               <h3 className="font-medium text-ink flex items-center gap-2">
                 Cost estimate (to drain queue)
-                {loadingCost && <Spinner />}
+                {loadingCost && (
+                  <span role="status" aria-label="Refreshing cost estimate">
+                    <Spinner />
+                  </span>
+                )}
               </h3>
               <span className="text-[11px] text-stone-600">
                 {cost.pending_items} pending across {cost.pending_books} book
@@ -1328,7 +1332,7 @@ export default function QueueTab({ adminFetch }: Props) {
               doesn't reflow and shift the filter pills. */}
           <span className="font-medium flex items-center gap-1.5">
             Items
-            <span className="inline-block w-3 h-3 align-middle">
+            <span className="inline-block w-3 h-3 align-middle" role="status" aria-label={loadingItems ? "Loading items" : ""}>
               {loadingItems && <Spinner />}
             </span>
           </span>


### PR DESCRIPTION
## What changed

Added `role="status"` to two section-header spinners in `QueueTab.tsx` that lacked accessible loading announcements:

1. **Cost estimate header** (`loadingCost`): wrapped the `<Spinner />` in `<span role="status" aria-label="Refreshing cost estimate">` so screen readers announce when the cost panel is refreshing.
2. **Items header** (`loadingItems`): added `role="status"` and a conditional `aria-label` to the existing fixed-width slot span so AT users know items are loading.

All other `animate-spin` occurrences in the codebase already have `role="status"` wrappers or are inside buttons (exempt — button label + `disabled` convey state).

## Why

WCAG 4.1.3 (Status Messages): status changes must be programmatically determinable without focus. These spinners were `aria-hidden="true"` with no live-region wrapper — screen readers received no signal that content was loading.

## Test plan

- New: `QueueTabSpinnerStatus.test.ts` — 2 static tests verifying `role="status"` appears near each header spinner
- Full frontend suite: 3760 tests pass

Closes #2362
