### PR TITLE
fix: add aria-invalid + aria-describedby to Obsidian form inputs (closes #2364)

### DIFF
--- a/frontend/src/__tests__/ProfileObsidianAriaInvalid.test.ts
+++ b/frontend/src/__tests__/ProfileObsidianAriaInvalid.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Regression test for #2364: Obsidian form inputs in profile/page.tsx were
+ * missing aria-invalid and aria-describedby — screen readers had no way to
+ * associate the error state with the field when focus returned to it.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/profile/page.tsx"),
+  "utf8",
+);
+
+describe("Profile Obsidian inputs aria-invalid (closes #2364)", () => {
+  it('obsidian-token input has aria-invalid', () => {
+    const idx = src.indexOf('id="obsidian-token"');
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(idx, idx + 400);
+    expect(block).toMatch(/aria-invalid/);
+  });
+
+  it('obsidian-repo input has aria-invalid', () => {
+    const idx = src.indexOf('id="obsidian-repo"');
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(idx, idx + 400);
+    expect(block).toMatch(/aria-invalid/);
+  });
+
+  it('obsidian-path input has aria-invalid', () => {
+    const idx = src.indexOf('id="obsidian-path"');
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(idx, idx + 400);
+    expect(block).toMatch(/aria-invalid/);
+  });
+
+  it('obsidian status message has an id for aria-describedby', () => {
+    expect(src).toMatch(/id="obsidian-msg"/);
+  });
+
+  it('obsidian-token input references obsidian-msg via aria-describedby', () => {
+    const idx = src.indexOf('id="obsidian-token"');
+    const block = src.slice(idx, idx + 600);
+    expect(block).toContain('aria-describedby="obsidian-msg"');
+  });
+});

--- a/frontend/src/__tests__/ProfileObsidianErrorBorder.test.ts
+++ b/frontend/src/__tests__/ProfileObsidianErrorBorder.test.ts
@@ -13,27 +13,27 @@ describe("ProfileObsidianErrorBorder", () => {
   it("Obsidian token input className references obsidianMsg", () => {
     const anchor = src.indexOf('id="obsidian-token"');
     expect(anchor).toBeGreaterThan(0);
-    const block = src.slice(anchor, anchor + 600);
+    const block = src.slice(anchor, anchor + 900);
     expect(block).toMatch(/obsidianMsg/);
   });
 
   it("Obsidian token input has red border class on error", () => {
     const anchor = src.indexOf('id="obsidian-token"');
-    const block = src.slice(anchor, anchor + 600);
+    const block = src.slice(anchor, anchor + 900);
     expect(block).toMatch(/border-red/);
   });
 
   it("Obsidian repo input has red border class on error", () => {
     const anchor = src.indexOf('id="obsidian-repo"');
     expect(anchor).toBeGreaterThan(0);
-    const block = src.slice(anchor, anchor + 600);
+    const block = src.slice(anchor, anchor + 900);
     expect(block).toMatch(/border-red/);
   });
 
   it("Obsidian path input has red border class on error", () => {
     const anchor = src.indexOf('id="obsidian-path"');
     expect(anchor).toBeGreaterThan(0);
-    const block = src.slice(anchor, anchor + 600);
+    const block = src.slice(anchor, anchor + 900);
     expect(block).toMatch(/border-red/);
   });
 });

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -401,6 +401,8 @@ export default function ProfilePage() {
                   placeholder={hasObsidianToken ? "Enter new token to replace existing" : "ghp_… (never shown back)"}
                   value={obsidianToken}
                   onChange={(e) => setObsidianToken(e.target.value)}
+                  aria-invalid={obsidianMsg?.ok === false || undefined}
+                  aria-describedby="obsidian-msg"
                   className={`w-full border rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 placeholder:text-stone-600 ${obsidianMsg?.ok === false ? "border-red-400 focus:ring-red-400" : "border-stone-300 focus:ring-amber-400"}`}
                 />
                 <p className="text-xs text-stone-600 mt-1">
@@ -418,6 +420,8 @@ export default function ProfilePage() {
                   placeholder="username/obsidian-notes"
                   value={obsidianRepo}
                   onChange={(e) => setObsidianRepo(e.target.value)}
+                  aria-invalid={obsidianMsg?.ok === false || undefined}
+                  aria-describedby="obsidian-msg"
                   className={`w-full border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 placeholder:text-stone-600 ${obsidianMsg?.ok === false ? "border-red-400 focus:ring-red-400" : "border-stone-300 focus:ring-amber-400"}`}
                 />
               </div>
@@ -432,6 +436,8 @@ export default function ProfilePage() {
                   placeholder="All Notes/002 Literature Notes/000 Books"
                   value={obsidianPath}
                   onChange={(e) => setObsidianPath(e.target.value)}
+                  aria-invalid={obsidianMsg?.ok === false || undefined}
+                  aria-describedby="obsidian-msg"
                   className={`w-full border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 placeholder:text-stone-600 ${obsidianMsg?.ok === false ? "border-red-400 focus:ring-red-400" : "border-stone-300 focus:ring-amber-400"}`}
                 />
               </div>
@@ -444,7 +450,7 @@ export default function ProfilePage() {
                 {obsidianSaving ? "Saving…" : "Save Obsidian settings"}
               </button>
 
-              <p role="status" aria-live="polite" aria-atomic="true" className={`text-sm ${obsidianMsg ? (obsidianMsg.ok ? "text-emerald-700" : "text-red-600") : ""}`}>
+              <p id="obsidian-msg" role="status" aria-live="polite" aria-atomic="true" className={`text-sm ${obsidianMsg ? (obsidianMsg.ok ? "text-emerald-700" : "text-red-600") : ""}`}>
                 {obsidianMsg?.text ?? ""}
               </p>
             </div>


### PR DESCRIPTION
## What changed

Three changes to `profile/page.tsx` (Obsidian settings section):

1. Added `id="obsidian-msg"` to the existing `<p role="status" aria-live="polite">` element.
2. Added `aria-invalid={obsidianMsg?.ok === false || undefined}` to the token, repo, and vault-path inputs.
3. Added `aria-describedby="obsidian-msg"` to all three inputs.

Also bumped the search window in the existing `ProfileObsidianErrorBorder.test.ts` from 600 → 900 chars to accommodate the two new attributes that now precede `className`.

## Why

WCAG 3.3.1 (Error Identification) and 4.1.2 (Name, Role, Value): inputs that can enter an invalid state must convey that state to assistive technology. The red border change was visual-only — screen readers had no signal the field was invalid when focus returned to it after the error was announced.

The Gemini key input on the same page already followed this pattern correctly; Obsidian inputs now match.

## Test plan

- New: `ProfileObsidianAriaInvalid.test.ts` — 5 static tests verifying `aria-invalid`, `aria-describedby`, and `id="obsidian-msg"` are present
- Existing: `ProfileObsidianErrorBorder.test.ts` — all 4 tests pass (window enlarged, no logic change)
- Full frontend suite: 3765 tests pass

Closes #2364
