### PR TITLE
fix: auto-dismiss profile save success messages after 3s (closes #2368)

### DIFF
--- a/frontend/src/__tests__/ProfileSuccessMessageAutoDismiss.test.tsx
+++ b/frontend/src/__tests__/ProfileSuccessMessageAutoDismiss.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Regression test for #2368: profile page success messages (Gemini key save,
+ * Obsidian settings save) must auto-dismiss after 3 s. Error messages must stay.
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import ProfilePage from "@/app/profile/page";
+
+jest.mock("next-auth/react", () => ({
+  useSession: jest.fn().mockReturnValue({
+    data: { backendToken: "tok", backendUser: { name: "Test" } },
+  }),
+  signOut: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn().mockReturnValue({ push: jest.fn() }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  saveGeminiKey: jest.fn().mockResolvedValue({}),
+  deleteGeminiKey: jest.fn().mockResolvedValue({}),
+  getMe: jest.fn().mockResolvedValue({ hasGeminiKey: false, role: "user" }),
+  getObsidianSettings: jest.fn().mockResolvedValue({
+    obsidian_repo: "user/vault",
+    obsidian_path: "Notes/Books",
+  }),
+  saveObsidianSettings: jest.fn().mockResolvedValue({}),
+  listDecks: jest.fn().mockResolvedValue([]),
+  getUserStats: jest.fn().mockResolvedValue({
+    totals: { books_started: 0, vocabulary_words: 0, annotations: 0, insights: 0 },
+    streak: 0,
+    longest_streak: 0,
+    activity: [],
+  }),
+}));
+
+jest.mock("@/lib/settings", () => ({
+  getSettings: jest.fn().mockReturnValue({
+    insightLang: "en",
+    translationLang: "en",
+    translationEnabled: false,
+    ttsGender: "female",
+    chatFontSize: "xs",
+    translationProvider: "auto",
+    fontSize: "base",
+    theme: "light",
+  }),
+  saveSettings: jest.fn(),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+describe("ProfilePage success message auto-dismiss (closes #2368)", () => {
+  it("Gemini key success message disappears after 3 s", async () => {
+    render(<ProfilePage />);
+
+    const input = screen.getByPlaceholderText(/AIza/i);
+    fireEvent.change(input, { target: { value: "my-gemini-key" } });
+    fireEvent.click(screen.getByRole("button", { name: /save key/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Gemini API key saved/i)).toBeInTheDocument()
+    );
+
+    act(() => { jest.advanceTimersByTime(3000); });
+
+    expect(screen.queryByText(/Gemini API key saved/i)).not.toBeInTheDocument();
+  });
+
+  it("Gemini key error message stays visible after 3 s", async () => {
+    const { saveGeminiKey } = require("@/lib/api");
+    saveGeminiKey.mockRejectedValueOnce(new Error("Bad key"));
+
+    render(<ProfilePage />);
+
+    const input = screen.getByPlaceholderText(/AIza/i);
+    fireEvent.change(input, { target: { value: "bad-key" } });
+    fireEvent.click(screen.getByRole("button", { name: /save key/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Bad key/i)).toBeInTheDocument()
+    );
+
+    act(() => { jest.advanceTimersByTime(3000); });
+
+    expect(screen.getByText(/Bad key/i)).toBeInTheDocument();
+  });
+
+  it("Obsidian settings success message disappears after 3 s", async () => {
+    render(<ProfilePage />);
+
+    // Open the Obsidian accordion
+    const obsidianBtn = screen.getByRole("button", { name: /obsidian export/i });
+    fireEvent.click(obsidianBtn);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /save obsidian settings/i })).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /save obsidian settings/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Obsidian settings saved/i)).toBeInTheDocument()
+    );
+
+    act(() => { jest.advanceTimersByTime(3000); });
+
+    expect(screen.queryByText(/Obsidian settings saved/i)).not.toBeInTheDocument();
+  });
+
+  it("Obsidian settings error message stays visible after 3 s", async () => {
+    const { saveObsidianSettings } = require("@/lib/api");
+    saveObsidianSettings.mockRejectedValueOnce(new Error("Save failed"));
+
+    render(<ProfilePage />);
+
+    const obsidianBtn = screen.getByRole("button", { name: /obsidian export/i });
+    fireEvent.click(obsidianBtn);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /save obsidian settings/i })).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /save obsidian settings/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Save failed/i)).toBeInTheDocument()
+    );
+
+    act(() => { jest.advanceTimersByTime(3000); });
+
+    expect(screen.getByText(/Save failed/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useSession, signOut } from "next-auth/react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { saveGeminiKey, deleteGeminiKey, getMe, getObsidianSettings, saveObsidianSettings, listDecks, DeckSummary } from "@/lib/api";
 import { ArrowLeftIcon, CheckIcon, ChevronRightIcon, DeckIcon } from "@/components/Icons";
@@ -28,6 +28,7 @@ export default function ProfilePage() {
   const [savingKey, setSavingKey] = useState(false);
   const [removingKey, setRemovingKey] = useState(false);
   const [keyMessage, setKeyMessage] = useState<{ text: string; ok: boolean } | null>(null);
+  const keyMsgTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // ── Obsidian settings state ────────────────────────────────────────────────
   const [obsidianOpen, setObsidianOpen] = useState(false);
@@ -37,6 +38,7 @@ export default function ProfilePage() {
   const [obsidianPath, setObsidianPath] = useState("All Notes/002 Literature Notes/000 Books");
   const [obsidianSaving, setObsidianSaving] = useState(false);
   const [obsidianMsg, setObsidianMsg] = useState<{ text: string; ok: boolean } | null>(null);
+  const obsidianMsgTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // ── Preferences state ──────────────────────────────────────────────────────
   const [settings, setSettings] = useState<AppSettings>({
@@ -127,12 +129,14 @@ export default function ProfilePage() {
   async function handleSaveKey() {
     if (!keyInput.trim()) return;
     setSavingKey(true);
+    if (keyMsgTimerRef.current) clearTimeout(keyMsgTimerRef.current);
     setKeyMessage(null);
     try {
       await saveGeminiKey(keyInput.trim());
       setKeyInput("");
       setHasKey(true);
       setKeyMessage({ text: "Gemini API key saved. AI features now use your key.", ok: true });
+      keyMsgTimerRef.current = setTimeout(() => setKeyMessage(null), 3000);
     } catch (e: unknown) {
       setKeyMessage({ text: e instanceof Error ? e.message : "Failed to save key", ok: false });
     } finally {
@@ -142,6 +146,7 @@ export default function ProfilePage() {
 
   async function handleSaveObsidian() {
     setObsidianSaving(true);
+    if (obsidianMsgTimerRef.current) clearTimeout(obsidianMsgTimerRef.current);
     setObsidianMsg(null);
     try {
       await saveObsidianSettings({
@@ -152,6 +157,7 @@ export default function ProfilePage() {
       if (obsidianToken.trim()) setHasObsidianToken(true);
       setObsidianToken("");
       setObsidianMsg({ text: "Obsidian settings saved.", ok: true });
+      obsidianMsgTimerRef.current = setTimeout(() => setObsidianMsg(null), 3000);
     } catch (e: unknown) {
       setObsidianMsg({ text: e instanceof Error ? e.message : "Failed to save", ok: false });
     } finally {


### PR DESCRIPTION
## What changed

`profile/page.tsx` — `handleSaveKey` and `handleSaveObsidian` now clear their success messages after 3 seconds via `setTimeout`, matching the 2-second auto-dismiss already used by the preferences-saved banner.

- `useRef` timer IDs (`keyMsgTimerRef`, `obsidianMsgTimerRef`) clear any in-flight timer when a new save starts, preventing stale timeouts from clearing a fresh error message.
- Error messages (`ok: false`) are unaffected and remain visible until the user fixes the input or retries.

## Why

The preferences section already had auto-dismiss; the Gemini key and Obsidian sections did not. Persistent success banners add visual noise and make the form feel incomplete (no clear "done" moment).

Closes #2368.

## Test plan

- [x] `ProfileSuccessMessageAutoDismiss.test.tsx` — 4 new tests:
  - Gemini key success message disappears after 3 s (`jest.useFakeTimers`)
  - Gemini key error message stays after 3 s
  - Obsidian settings success message disappears after 3 s
  - Obsidian settings error message stays after 3 s
- [x] Full suite: 3769 tests pass
