### PR TITLE
fix: announce chapter title to screen readers on chapter navigation (closes #2370)

### DIFF
--- a/frontend/src/__tests__/ReaderChapterNavAnnounce.test.ts
+++ b/frontend/src/__tests__/ReaderChapterNavAnnounce.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Regression test for #2370: reader chapter navigation must announce the new
+ * chapter title to screen readers via an aria-live region.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Reader chapter nav aria-live announcement (closes #2370)", () => {
+  it("page contains an sr-only aria-live element for chapter announcements", () => {
+    const idx = src.indexOf('id="chapter-announce"');
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(idx, idx + 300);
+    expect(block).toMatch(/aria-live="polite"/);
+    expect(block).toMatch(/sr-only/);
+  });
+
+  it("chapter announce element has aria-atomic", () => {
+    const idx = src.indexOf("chapter-announce");
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(idx, idx + 300);
+    expect(block).toMatch(/aria-atomic/);
+  });
+
+  it("chapter announce element renders chapters[chapterIndex] title", () => {
+    const idx = src.indexOf("chapter-announce");
+    const block = src.slice(idx, idx + 400);
+    expect(block).toMatch(/chapters\[chapterIndex\]/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1381,6 +1381,19 @@ export default function ReaderPage() {
         </div>
       )}
 
+      {/* Screen-reader announcement for chapter navigation (WCAG 4.1.3) */}
+      <span
+        id="chapter-announce"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {chapters[chapterIndex]
+          ? `Chapter ${chapterIndex + 1}${chapters[chapterIndex].title ? `: ${chapters[chapterIndex].title}` : ""}`
+          : ""}
+      </span>
+
       {/* ── Body ────────────────────────────────────────────────────────── */}
       <div className="flex flex-1 overflow-hidden">
         {/* Reader */}


### PR DESCRIPTION
## What changed

`reader/[bookId]/page.tsx` — added a `sr-only` `aria-live="polite"` region (`id="chapter-announce"`) that renders:

```
Chapter N: Title
```

This element is always present in the DOM and updates whenever `chapterIndex` changes, so screen readers announce the new chapter title after the user activates "Previous chapter", "Next chapter", or selects a chapter from the chapter picker. Previously the chapter title span was a purely visual element with no live region, giving screen reader users no positional context after navigation.

## Why

WCAG 4.1.3 (Status Messages, Level AA) — changes of context (new chapter loaded) should be announced without requiring a focus change. A keyboard user navigating a long book chapter by chapter had no way to know which chapter they'd arrived at without tabbing to find the title.

Closes #2370.

## Test plan

- [x] `ReaderChapterNavAnnounce.test.ts` — 3 static tests:
  - `id="chapter-announce"` element exists
  - Element has `aria-live="polite"` and `sr-only`
  - Element has `aria-atomic` attribute
  - Element references `chapters[chapterIndex]`
- [x] Full suite: 3772 tests pass

## Docs follow-up

No docs update needed — this is an invisible accessibility fix.
