### PR TITLE
fix: center drag handle pill in bottom sheet drawers (closes #2377)

### DIFF
--- a/frontend/src/__tests__/BottomSheetDragHandle.test.ts
+++ b/frontend/src/__tests__/BottomSheetDragHandle.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Regression tests for bottom-sheet drag handle alignment (closes #2377).
+ *
+ * The drag handle pill must be centered in the drawer header. Using
+ * `justify-between` with `mx-auto` on a two-item flex row doesn't center
+ * anything — `justify-between` overrides `mx-auto`. The fix is a
+ * `justify-center` container with the close button positioned absolutely.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const wordDrawerSrc = fs.readFileSync(
+  path.join(__dirname, "../components/WordActionDrawer.tsx"),
+  "utf8",
+);
+
+const vocabPageSrc = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8",
+);
+
+describe("WordActionDrawer drag handle is centered (closes #2377)", () => {
+  it("drag handle container uses justify-center, not justify-between", () => {
+    // Find the block that contains the drag handle pill
+    const pillIdx = wordDrawerSrc.indexOf("bg-amber-200 rounded-full");
+    expect(pillIdx).toBeGreaterThan(-1);
+    // Look at the surrounding 200 chars for the container class
+    const block = wordDrawerSrc.slice(Math.max(0, pillIdx - 200), pillIdx + 50);
+    expect(block).toMatch(/justify-center/);
+    expect(block).not.toMatch(/justify-between/);
+  });
+
+  it("drag handle pill does NOT have mx-auto (which has no effect in justify-center)", () => {
+    const pillIdx = wordDrawerSrc.indexOf("bg-amber-200 rounded-full");
+    const pillLine = wordDrawerSrc.slice(pillIdx - 10, pillIdx + 60);
+    expect(pillLine).not.toMatch(/mx-auto/);
+  });
+
+  it("close button uses absolute positioning to stay right-aligned", () => {
+    const pillIdx = wordDrawerSrc.indexOf("bg-amber-200 rounded-full");
+    // Close button appears after the pill in the source
+    const block = wordDrawerSrc.slice(pillIdx, pillIdx + 400);
+    expect(block).toMatch(/absolute/);
+  });
+});
+
+describe("DefinitionSheet drag handle is centered (closes #2377)", () => {
+  it("drag handle container uses justify-center, not justify-between", () => {
+    const pillIdx = vocabPageSrc.indexOf("bg-amber-200 rounded-full");
+    expect(pillIdx).toBeGreaterThan(-1);
+    const block = vocabPageSrc.slice(Math.max(0, pillIdx - 200), pillIdx + 50);
+    expect(block).toMatch(/justify-center/);
+    expect(block).not.toMatch(/justify-between/);
+  });
+
+  it("drag handle pill does NOT have mx-auto", () => {
+    const pillIdx = vocabPageSrc.indexOf("bg-amber-200 rounded-full");
+    const pillLine = vocabPageSrc.slice(pillIdx - 10, pillIdx + 60);
+    expect(pillLine).not.toMatch(/mx-auto/);
+  });
+
+  it("close button uses absolute positioning to stay right-aligned", () => {
+    const pillIdx = vocabPageSrc.indexOf("bg-amber-200 rounded-full");
+    const block = vocabPageSrc.slice(pillIdx, pillIdx + 400);
+    expect(block).toMatch(/absolute/);
+  });
+});

--- a/frontend/src/__tests__/ReaderComponentsFocusRing.test.ts
+++ b/frontend/src/__tests__/ReaderComponentsFocusRing.test.ts
@@ -40,7 +40,7 @@ describe("WordActionDrawer focus rings (closes #2176)", () => {
   it("Close button has focus-visible ring", () => {
     const idx = wordDrawer.indexOf("Close word lookup");
     expect(idx).toBeGreaterThan(-1);
-    const window = wordDrawer.slice(idx, idx + 300);
+    const window = wordDrawer.slice(idx, idx + 400);
     expect(window).toContain("focus-visible:ring-amber-400");
   });
 

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -164,12 +164,12 @@ function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
         aria-label="Word definition"
         className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl border-t border-amber-200 max-h-[60vh] overflow-y-auto animate-slide-up focus:outline-none"
       >
-        <div className="flex items-center justify-between px-4 py-2 border-b border-amber-100">
-          <div className="w-10 h-1 bg-amber-200 rounded-full mx-auto" />
+        <div className="relative flex items-center justify-center px-4 py-2 border-b border-amber-100">
+          <div className="w-10 h-1 bg-amber-200 rounded-full" />
           <button
             onClick={onClose}
             aria-label="Close definition"
-            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-600 hover:text-ink hover:bg-amber-50 transition-colors -mr-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
+            className="absolute right-2 top-1/2 -translate-y-1/2 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-600 hover:text-ink hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <CloseIcon className="w-4 h-4" aria-hidden="true" />
           </button>

--- a/frontend/src/components/WordActionDrawer.tsx
+++ b/frontend/src/components/WordActionDrawer.tsx
@@ -136,12 +136,12 @@ export default function WordActionDrawer({
         className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl border-t border-amber-200 max-h-[60vh] overflow-y-auto safe-bottom animate-slide-up focus:outline-none"
       >
         {/* Drag handle + close button */}
-        <div className="flex items-center justify-between px-4 py-2">
-          <div className="w-10 h-1 bg-amber-200 rounded-full mx-auto" />
+        <div className="relative flex items-center justify-center px-4 py-2">
+          <div className="w-10 h-1 bg-amber-200 rounded-full" />
           <button
             onClick={onClose}
             aria-label="Close word lookup"
-            className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-600 hover:text-ink hover:bg-amber-50 transition-colors -mr-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
+            className="absolute right-2 top-1/2 -translate-y-1/2 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-lg text-stone-600 hover:text-ink hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <CloseIcon className="w-4 h-4" aria-hidden="true" />
           </button>


### PR DESCRIPTION
## What changed

Bottom-sheet drawers (`WordActionDrawer` and `DefinitionSheet` in the vocabulary page) had their drag handle pill left-aligned instead of centered.

**Root cause:** The header used `flex justify-between` with two children — the pill (with `mx-auto`) and the close button. With `justify-between`, the pill sits at the left edge and `mx-auto` has no effect. The intended centering was never achieved.

**Fix:** Changed both headers to `relative flex justify-center` and positioned the close button with `absolute right-2 top-1/2 -translate-y-1/2`. The drag handle pill is now truly centered; the close button remains right-aligned.

## Why

Mobile bottom-sheet convention places the drag handle pill centered at the top. The misalignment was cosmetically incorrect and looked like an unpolished UI.

## Test plan

- [x] New regression test `BottomSheetDragHandle.test.ts` (6 tests) verifies both components use `justify-center` containers and `absolute` close buttons
- [x] Updated `ReaderComponentsFocusRing.test.ts` — bumped window size from 300→400 chars for the close button assertion (className is longer after adding absolute positioning classes)
- [x] Full frontend suite: 3792 tests pass

## Docs follow-up

No doc changes needed — this is a visual CSS fix with no user-visible behaviour change.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
