### PR TITLE
fix: shortcuts HUD button correctly toggles panel closed (closes #2383)

### DIFF
--- a/frontend/src/__tests__/ShortcutsHudToggle.test.ts
+++ b/frontend/src/__tests__/ShortcutsHudToggle.test.ts
@@ -1,0 +1,40 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("shortcuts HUD button toggle (closes #2383)", () => {
+  it("click-outside handler skips elements with data-shortcuts-trigger", () => {
+    // The handler must bail out when the event target is (or is inside)
+    // an element with data-shortcuts-trigger, so clicking the HUD button
+    // while the panel is open actually toggles it closed instead of
+    // re-opening via click event after mousedown fires setShowShortcuts(false).
+    const handlerIdx = src.indexOf("setShowShortcuts(false)");
+    expect(handlerIdx).toBeGreaterThan(-1);
+    const block = src.slice(Math.max(0, handlerIdx - 500), handlerIdx + 100);
+    expect(block).toContain("data-shortcuts-trigger");
+  });
+
+  it("header shortcuts button has data-shortcuts-trigger", () => {
+    // Find the header shortcuts button (inside the hidden md:block div)
+    const headerComment = src.indexOf("Keyboard shortcuts help");
+    expect(headerComment).toBeGreaterThan(-1);
+    const block = src.slice(headerComment, headerComment + 500);
+    expect(block).toContain("data-shortcuts-trigger");
+  });
+
+  it("focus mode HUD shortcuts button has data-shortcuts-trigger", () => {
+    // Find the HUD button in the focus mode pill
+    const hudComment = src.indexOf("Focus Mode HUD");
+    expect(hudComment).toBeGreaterThan(-1);
+    const headerComment = src.indexOf("── Header ──", hudComment);
+    const hudBlock = src.slice(hudComment, headerComment);
+    const btnIdx = hudBlock.indexOf('aria-label="Keyboard shortcuts"');
+    expect(btnIdx).toBeGreaterThan(-1);
+    const window = hudBlock.slice(btnIdx, btnIdx + 600);
+    expect(window).toContain("data-shortcuts-trigger");
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -314,6 +314,7 @@ export default function ReaderPage() {
   useEffect(() => {
     if (!showShortcuts) return;
     function handleClick(e: MouseEvent) {
+      if ((e.target as HTMLElement).closest("[data-shortcuts-trigger]")) return;
       if (shortcutsRef.current && !shortcutsRef.current.contains(e.target as Node)) {
         setShowShortcuts(false);
       }
@@ -952,7 +953,7 @@ export default function ReaderPage() {
             <span className="text-stone-400 mx-0.5" aria-hidden="true">|</span>
             <button
               onClick={() => setShowShortcuts((v) => !v)}
-              aria-label="Keyboard shortcuts" aria-expanded={showShortcuts} aria-controls="focus-hotkeys-panel" title="Keyboard shortcuts (?)"
+              aria-label="Keyboard shortcuts" aria-expanded={showShortcuts} aria-controls="focus-hotkeys-panel" title="Keyboard shortcuts (?)" data-shortcuts-trigger="true"
               className={`flex items-center justify-center w-7 h-7 rounded-full min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 ${
                 showShortcuts ? "bg-amber-100 text-amber-800" : "hover:bg-amber-50 text-stone-600"
               }`}
@@ -1294,6 +1295,7 @@ export default function ReaderPage() {
               aria-label="Keyboard shortcuts"
               aria-expanded={showShortcuts}
               aria-controls="shortcuts-panel"
+              data-shortcuts-trigger="true"
               className={`flex shrink-0 items-center justify-center w-7 h-7 min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 rounded-lg border text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 ${
                 showShortcuts
                   ? "bg-amber-100 border-amber-400 text-amber-800"


### PR DESCRIPTION
## What changed

- Added `data-shortcuts-trigger="true"` to both the header shortcuts button and the focus-mode HUD shortcuts button
- Updated the click-outside `mousedown` handler to bail out early when the click target is (or is inside) a `[data-shortcuts-trigger]` element

## Why

In focus mode, clicking the HUD keyboard icon button a second time (to close the panel) didn't work. The click-outside handler (from #2379) fires on `mousedown` and calls `setShowShortcuts(false)` because the HUD button is outside the `shortcutsRef` wrapper in the header. Then the `click` event fires and calls `setShowShortcuts(!v)` where `v` is now `false`, re-opening the panel immediately.

The header shortcuts button was not affected because it lives *inside* `shortcutsRef`, so the click-outside handler correctly skipped it. The HUD button (added in #2381) is outside `shortcutsRef`, so it wasn't excluded.

The fix marks all shortcuts-toggle buttons with `data-shortcuts-trigger` and guards the click-outside handler against them.

## Test plan

- New regression test: `ShortcutsHudToggle.test.ts` (3 tests)
  - Click-outside handler contains the `data-shortcuts-trigger` guard
  - Header shortcuts button has `data-shortcuts-trigger`
  - HUD shortcuts button has `data-shortcuts-trigger`
- Full suite: 3802 tests pass

Closes #2383
