### PR TITLE
fix: accessible radio group labels on profile settings page (closes #2385)

### DIFF
--- a/frontend/src/__tests__/ProfileRadioGroupA11y.test.ts
+++ b/frontend/src/__tests__/ProfileRadioGroupA11y.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression test: profile page radio groups missing accessible group label (closes #2385).
+ *
+ * The TTS gender and translation-provider radio groups had no programmatic association
+ * between their visual heading label and the radio group container. Fix adds
+ * role="radiogroup" + aria-labelledby on each container, satisfying WCAG 1.3.1.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/profile/page.tsx"),
+  "utf8"
+);
+
+describe("Profile page radio group accessibility (closes #2385)", () => {
+  it("TTS gender container has role=radiogroup", () => {
+    const idx = src.indexOf("tts-gender-label");
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(Math.max(0, idx - 200), idx + 100);
+    expect(block).toContain('role="radiogroup"');
+  });
+
+  it("TTS gender heading has id=tts-gender-label", () => {
+    expect(src).toContain('id="tts-gender-label"');
+  });
+
+  it("TTS gender container has aria-labelledby=tts-gender-label", () => {
+    expect(src).toContain('aria-labelledby="tts-gender-label"');
+  });
+
+  it("Translation provider container has role=radiogroup", () => {
+    const idx = src.indexOf("translation-provider-label");
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(Math.max(0, idx - 200), idx + 100);
+    expect(block).toContain('role="radiogroup"');
+  });
+
+  it("Translation provider heading has id=translation-provider-label", () => {
+    expect(src).toContain('id="translation-provider-label"');
+  });
+
+  it("Translation provider container has aria-labelledby=translation-provider-label", () => {
+    expect(src).toContain('aria-labelledby="translation-provider-label"');
+  });
+});

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -516,8 +516,8 @@ export default function ProfilePage() {
           </div>
 
           {/* TTS voice gender */}
-          <div>
-            <label className="block text-sm font-medium text-ink mb-1.5">
+          <div role="radiogroup" aria-labelledby="tts-gender-label">
+            <label id="tts-gender-label" className="block text-sm font-medium text-ink mb-1.5">
               Text-to-speech voice
             </label>
             <p className="text-xs text-stone-600 mb-2">
@@ -548,8 +548,8 @@ export default function ProfilePage() {
           </div>
 
           {/* Translation provider */}
-          <div>
-            <label className="block text-sm font-medium text-ink mb-1.5">
+          <div role="radiogroup" aria-labelledby="translation-provider-label">
+            <label id="translation-provider-label" className="block text-sm font-medium text-ink mb-1.5">
               Translation provider
             </label>
             <div className="space-y-2">


### PR DESCRIPTION
## What changed

Added `role="radiogroup"` + `aria-labelledby` to the TTS gender and translation-provider radio group containers in `frontend/src/app/profile/page.tsx`. Added `id` attributes to the corresponding heading labels so screen readers can programmatically associate the group label with its radio buttons.

## Why

The radio groups used a bare `<label>` element as a visual heading with no `htmlFor` binding, and the container `<div>` had no group role. Screen readers in forms mode would announce the radio buttons without context about which group they belong to — a WCAG 1.3.1 (Info and Relationships) violation.

## Test plan

- 6 new source-level tests in `ProfileRadioGroupA11y.test.ts` verify `role="radiogroup"`, `aria-labelledby`, and `id` attributes on both groups
- Full suite: 3808 frontend + 1941 backend tests pass

Closes #2385
