### PR TITLE
docs: update focus-mode tutorial with keyboard shortcuts HUD button

### DIFF
--- a/docs/tutorials/focus-mode.md
+++ b/docs/tutorials/focus-mode.md
@@ -11,13 +11,14 @@ Focus mode hides the reader's toolbars and sidebars so the only thing on screen 
 ## What changes in Focus mode
 
 - All toolbars, sidebars, and the header collapse and disappear.
-- A minimal HUD appears at the top center of the screen with: Previous chapter, current chapter title, Next chapter, Paragraph focus toggle, Typography settings, and an Exit focus mode button.
+- A minimal HUD appears at the top center of the screen with: Previous chapter, current chapter title, Next chapter, Paragraph focus toggle, Typography settings, Keyboard shortcuts, and an Exit focus mode button.
 - The text fills the full width of the reading area (respecting your content-width setting).
 
 ## Navigate in Focus mode
 
 - **Previous / Next chapter:** click the Prev and Next buttons in the HUD, or press **← →** arrow keys.
 - **Typography:** click **Aa** in the HUD to open the typography panel without exiting Focus mode.
+- **Keyboard shortcuts:** click the **⌨** (keyboard) button in the HUD, or press **?**, to open the shortcuts reference panel as a floating card. Click the button again or press **Esc** to close it.
 - **Exit:** press **F**, **Escape**, or click the **Focus** label button in the HUD.
 
 ## Paragraph focus


### PR DESCRIPTION
## What changed

Updated `docs/tutorials/focus-mode.md` to document the keyboard shortcuts HUD button added in PR #2382 (issue #2381).

Changes:
- Added "Keyboard shortcuts" to the HUD component list in the "What changes in Focus mode" section
- Added a navigation bullet: `**Keyboard shortcuts:** click the ⌨ button in the HUD, or press **?**, to open the shortcuts reference panel as a floating card`

## Why

The focus mode tutorial was missing documentation for the keyboard shortcuts button added to the HUD in #2381/#2382. Users wouldn't know the button existed or how to use it.

## Test plan

- [x] Frontend tests pass (653 suites, 3808 tests)
- [x] Docs-only change — no behavioral changes to test
- [x] Tutorial content matches actual HUD behavior (keyboard icon, `?` shortcut, Esc to close)

Closes #2387
