### PR TITLE
fix: show 'Clear all filters' CTA when both tag and search filters active

### DIFF
--- a/frontend/src/__tests__/VocabFilterDeadend.test.ts
+++ b/frontend/src/__tests__/VocabFilterDeadend.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression #2389: vocabulary empty-state must show "Clear all filters" CTA
+ * when both a tag filter and a search term are active simultaneously.
+ * Previously only one CTA was shown (tag filter took precedence), leaving
+ * users in a dead-end if clearing the tag still returned zero results.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8"
+);
+
+describe("Vocabulary page empty-state filter dead-end (issue #2389)", () => {
+  it("handles both selectedTag and search active: source references both conditions", () => {
+    // The empty-state block should contain logic for both-active case
+    const emptyStateBlock = src.slice(
+      src.indexOf("filtered.length === 0"),
+      src.indexOf("filtered.length === 0") + 2000
+    );
+    // Must have a branch that handles selectedTag && search both truthy
+    expect(emptyStateBlock).toMatch(/selectedTag.*&&.*search|search.*&&.*selectedTag/);
+  });
+
+  it("shows 'Clear all filters' text when both filters are active", () => {
+    expect(src).toContain("Clear all filters");
+  });
+
+  it("clears both tag and search in the combined handler", () => {
+    // The combined clear handler must call setSelectedTag(null) and setSearch("")
+    const clearAllIdx = src.indexOf("Clear all filters");
+    expect(clearAllIdx).toBeGreaterThan(-1);
+    const surrounding = src.slice(Math.max(0, clearAllIdx - 500), clearAllIdx + 200);
+    expect(surrounding).toContain("setSelectedTag(null)");
+    expect(surrounding).toContain('setSearch("")');
+  });
+
+  it("still shows single 'Clear tag filter' when only tag is active", () => {
+    expect(src).toContain("Clear tag filter");
+  });
+
+  it("still shows single 'Clear search' when only search is active", () => {
+    expect(src).toContain("Clear search");
+  });
+});

--- a/frontend/src/__tests__/VocabFilteredEmptyState.test.ts
+++ b/frontend/src/__tests__/VocabFilteredEmptyState.test.ts
@@ -16,7 +16,7 @@ const src = readFileSync(
  * the condition and capturing up to the opening of the items section.
  */
 const filteredEmptyBlock =
-  src.match(/filtered\.length === 0[\s\S]{0,2500}space-y-8/)?.[0] ?? "";
+  src.match(/filtered\.length === 0[\s\S]{0,3500}space-y-8/)?.[0] ?? "";
 
 describe("Vocabulary filtered empty state (closes #1923)", () => {
   it("filtered empty block is found in source", () => {

--- a/frontend/src/__tests__/VocabularyPage.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.test.tsx
@@ -19,7 +19,7 @@ jest.mock("next/navigation", () => ({
 
 jest.mock("@/lib/api", () => ({
   getVocabulary: jest.fn(),
-  deleteVocabularyWord: jest.fn(),
+  deleteVocabularyWord: jest.fn().mockResolvedValue(undefined),
   exportVocabularyToObsidian: jest.fn(),
   getWordDefinition: jest.fn(),
   listVocabularyTags: jest.fn().mockResolvedValue([]),

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -611,7 +611,19 @@ function VocabularyPageContent() {
         ) : filtered.length === 0 ? (
           <div className="text-center text-stone-600 mt-16 flex flex-col items-center gap-2">
             <EmptyVocabIcon className="w-14 h-14 text-amber-300" aria-hidden="true" />
-            {selectedTag ? (
+            {selectedTag && search ? (
+              <>
+                <p className="font-serif text-lg text-stone-600 mt-1">No words match &ldquo;{search}&rdquo; in tag &ldquo;{selectedTag}&rdquo;</p>
+                <p className="text-sm">Try clearing the search or the tag filter.</p>
+                <button
+                  type="button"
+                  onClick={() => { setSelectedTag(null); setSearch(""); }}
+                  className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
+                >
+                  Clear all filters
+                </button>
+              </>
+            ) : selectedTag ? (
               <>
                 <p className="font-serif text-lg text-stone-600 mt-1">No words tagged &ldquo;{selectedTag}&rdquo;</p>
                 <p className="text-sm">This tag has no vocabulary words yet.</p>


### PR DESCRIPTION
## What changed

Fixed a dead-end UX state in the vocabulary page empty state. When both a tag filter and a search term are active simultaneously and yield zero results, the previous code only showed one "clear" CTA (tag filter took precedence via `if selectedTag`). Clearing the tag could still leave zero results if the search term was restrictive, with no escape button shown.

**Change:** Added a new `selectedTag && search` branch that shows a "Clear all filters" button resetting both simultaneously. The single-filter branches are unchanged.

## Why

Users could get stuck: clear tag → still zero results → no button to clear search. The combined-active case needs its own CTA.

## Test plan

- [x] New regression test `VocabFilterDeadend.test.ts` (5 assertions): verifies `Clear all filters` text exists, both setters are called, single-filter branches still present
- [x] Updated capture window in existing `VocabFilteredEmptyState.test.ts` (regex `{0,2500}` → `{0,3500}`) — the block grew due to the new branch
- [x] Full frontend suite: 3813 tests pass

Closes #2389
