### PR TITLE
fix: add live character counters to deck form name and description inputs

### DIFF
--- a/frontend/src/__tests__/DeckFormCharCounter.test.ts
+++ b/frontend/src/__tests__/DeckFormCharCounter.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Regression #2391: deck form name and description inputs must display
+ * live character counters so users know when they're approaching maxLength.
+ * Previously both fields had silent maxLength with no feedback.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "../app/decks/new/page.tsx"),
+  "utf8"
+);
+
+describe("Deck form character counters (issue #2391)", () => {
+  it("name input still has maxLength={80}", () => {
+    expect(src).toContain("maxLength={80}");
+  });
+
+  it("description textarea still has maxLength={500}", () => {
+    expect(src).toContain("maxLength={500}");
+  });
+
+  it("shows a character counter for the name field", () => {
+    // Counter should reference name.length and 80
+    expect(src).toMatch(/name\.length.*80|80.*name\.length/);
+  });
+
+  it("shows a character counter for the description field", () => {
+    // Counter should reference description.length and 500
+    expect(src).toMatch(/description\.length.*500|500.*description\.length/);
+  });
+
+  it("counter uses aria-live for screen reader announcements", () => {
+    expect(src).toContain('aria-live');
+  });
+
+  it("counter turns red near the limit", () => {
+    // Should have conditional red color class when near limit
+    expect(src).toMatch(/text-red-[456]00.*name\.length|name\.length.*text-red-[456]00/s);
+  });
+});

--- a/frontend/src/app/decks/new/page.tsx
+++ b/frontend/src/app/decks/new/page.tsx
@@ -103,10 +103,17 @@ export default function DecksNewPage() {
               maxLength={80}
               data-testid="deck-name-input"
               aria-invalid={!!error}
-              aria-describedby={error ? "deck-form-error" : undefined}
+              aria-describedby={error ? "deck-form-error" : "deck-name-counter"}
               className={`w-full rounded-xl border bg-white px-4 py-2.5 text-sm focus:outline-none focus:ring-2 placeholder:text-stone-600 ${error ? "border-red-400 focus:ring-red-400" : "border-amber-200 focus:ring-amber-400"}`}
               placeholder="e.g. German verbs"
             />
+            <p
+              id="deck-name-counter"
+              aria-live="polite"
+              className={`text-xs mt-1 text-right ${name.length >= 70 ? "text-red-500" : "text-stone-400"}`}
+            >
+              {name.length}/80
+            </p>
           </div>
 
           <div>
@@ -123,9 +130,17 @@ export default function DecksNewPage() {
               maxLength={500}
               rows={3}
               data-testid="deck-description-input"
+              aria-describedby="deck-description-counter"
               className="w-full rounded-xl border border-amber-200 bg-white px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 placeholder:text-stone-600"
               placeholder="What kind of words will go here?"
             />
+            <p
+              id="deck-description-counter"
+              aria-live="polite"
+              className={`text-xs mt-1 text-right ${description.length >= 490 ? "text-red-500" : "text-stone-400"}`}
+            >
+              {description.length}/500
+            </p>
           </div>
 
           <fieldset>


### PR DESCRIPTION
## What changed

Added live character counters beneath the deck name input (`maxLength={80}`) and description textarea (`maxLength={500}`) in the New Deck form.

- Counter shows `X/limit` right-aligned below each field
- Turns red at ≥70/80 chars (name) and ≥490/500 chars (description)
- Uses `aria-live="polite"` for screen reader announcements
- Input `aria-describedby` links to the counter element

## Why

Previously both fields silently stopped accepting characters at their limit with no user feedback — a clear usability gap (WCAG 3.3.1 in spirit).

## Test plan

- [x] New regression test `DeckFormCharCounter.test.ts` (6 assertions): verifies counters exist, aria-live present, red color class near limit
- [x] Full frontend suite: 3814 tests pass

Closes #2391
