### PR TITLE
docs: log Wave 17 UX improvements in design-improvement-plan.md

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -433,6 +433,9 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-30 | Deck name input: aria-required="true" for screen reader required-field announcement without native validation side-effects (closes #2360) | decks/new/page.tsx | #2361 |
 | 2026-04-30 | QueueTab section-header spinners: role="status" wrappers on loadingCost and loadingItems inline Spinner components for WCAG 4.1.3 (closes #2362) | QueueTab.tsx | #2363 |
 | 2026-04-30 | Profile Obsidian inputs: aria-invalid + aria-describedby + id="obsidian-msg" on status paragraph matching Gemini key pattern (closes #2364) | profile/page.tsx | #2365 |
+| 2026-04-30 | Profile TTS gender + translation provider radio groups: role="radiogroup" + aria-labelledby — WCAG 1.3.1 (closes #2385) | profile/page.tsx | #2386 |
+| 2026-04-30 | Vocabulary empty-state: added "Clear all filters" CTA when both tag filter and search are active simultaneously — prevents dead-end with zero results (closes #2389) | vocabulary/page.tsx | #2390 |
+| 2026-04-30 | Deck form: live character counters (X/80, X/500) with aria-live="polite" on name and description inputs — WCAG 3.3.1 spirit (closes #2391) | decks/new/page.tsx | #2392 |
 
 ---
 


### PR DESCRIPTION
## What changed

Updated `docs/design-improvement-plan.md` Change Log with three UX improvements shipped on 2026-04-30:

- **#2386**: Profile TTS gender + translation provider radio groups — `role="radiogroup"` + `aria-labelledby` (WCAG 1.3.1)
- **#2390**: Vocabulary empty-state "Clear all filters" CTA when both tag and search are active simultaneously
- **#2392**: Deck form live character counters (X/80, X/500) with `aria-live="polite"`

## Why

Per-PR docs check: these are user-visible UX flow changes that belong in the design improvement log per the documentation policy.

## Test plan

- [x] Docs-only change — no code changes
- [x] Full frontend suite: 3814 tests pass

Closes #2385
