### PR TITLE
fix: remove blanket aria-invalid from Obsidian form fields on generic save error (closes #2396)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -437,6 +437,7 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-30 | Vocabulary empty-state: added "Clear all filters" CTA when both tag filter and search are active simultaneously — prevents dead-end with zero results (closes #2389) | vocabulary/page.tsx | #2390 |
 | 2026-04-30 | Deck form: live character counters (X/80, X/500) with aria-live="polite" on name and description inputs — WCAG 3.3.1 spirit (closes #2391) | decks/new/page.tsx | #2392 |
 | 2026-04-30 | Deck detail page: distinguish zero-vocab state from all-in-deck state — show "Start reading" CTA with guidance when user has no vocabulary, instead of a silent disabled "Add word" button (closes #2394) | decks/[deckId]/page.tsx | #2394 |
+| 2026-04-30 | Profile Obsidian form: remove aria-invalid from all three fields on generic save error — WCAG 1.3.1 violation fixed; role="status" region (obsidian-msg) is the correct channel for form-level errors; aria-describedby links fields to it (closes #2396) | profile/page.tsx | #2396 |
 
 ---
 

--- a/frontend/src/__tests__/ObsidianAriaInvalid.test.ts
+++ b/frontend/src/__tests__/ObsidianAriaInvalid.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression test for issue #2396: Obsidian form marks all three fields
+ * aria-invalid on a generic save error — a WCAG 1.3.1 violation.
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("ProfilePage — Obsidian form aria-invalid (issue #2396)", () => {
+  const src = read("src/app/profile/page.tsx");
+
+  it("does not scatter aria-invalid across all Obsidian fields for a generic error", () => {
+    // Count how many Obsidian input elements apply aria-invalid based on obsidianMsg
+    const matches = [
+      ...src.matchAll(/id="obsidian-(?:token|repo|path)"[\s\S]{0,400}?aria-invalid/g),
+    ];
+    // At most ONE field should carry aria-invalid — a generic network error should
+    // not mark every field invalid.
+    expect(matches.length).toBeLessThanOrEqual(1);
+  });
+
+  it("keeps role=status region as the primary error communication channel", () => {
+    // The obsidian-msg paragraph must have role=status so screen readers
+    // announce save errors without requiring aria-invalid on each field.
+    expect(src).toMatch(/id="obsidian-msg"[^>]*role="status"/);
+  });
+
+  it("keeps aria-describedby pointing to obsidian-msg on the repo field", () => {
+    // Fields may still reference the status region via aria-describedby.
+    expect(src).toMatch(/id="obsidian-repo"[\s\S]{0,300}?aria-describedby="obsidian-msg"/);
+  });
+});

--- a/frontend/src/__tests__/ProfileObsidianAriaInvalid.test.ts
+++ b/frontend/src/__tests__/ProfileObsidianAriaInvalid.test.ts
@@ -1,7 +1,12 @@
 /**
- * Regression test for #2364: Obsidian form inputs in profile/page.tsx were
- * missing aria-invalid and aria-describedby — screen readers had no way to
- * associate the error state with the field when focus returned to it.
+ * Regression test for #2396 (supersedes the aria-invalid assertions from #2364).
+ *
+ * #2364 added aria-invalid to all three Obsidian fields to associate error state.
+ * #2396 identified this as a WCAG 1.3.1 violation: aria-invalid must only appear
+ * on a field whose *value* is invalid.  A generic network/API save failure is not
+ * a per-field validation error.  The role="status" region (id="obsidian-msg") is
+ * the correct communication channel for form-level errors; aria-describedby links
+ * each field to that region so screen readers can still navigate to the message.
  */
 import * as fs from "fs";
 import * as path from "path";
@@ -11,34 +16,46 @@ const src = fs.readFileSync(
   "utf8",
 );
 
-describe("Profile Obsidian inputs aria-invalid (closes #2364)", () => {
-  it('obsidian-token input has aria-invalid', () => {
+describe("Profile Obsidian inputs — aria-invalid removed, aria-describedby kept (closes #2396)", () => {
+  it("obsidian-token input does NOT carry aria-invalid", () => {
     const idx = src.indexOf('id="obsidian-token"');
     expect(idx).toBeGreaterThan(-1);
     const block = src.slice(idx, idx + 400);
-    expect(block).toMatch(/aria-invalid/);
+    expect(block).not.toMatch(/aria-invalid/);
   });
 
-  it('obsidian-repo input has aria-invalid', () => {
+  it("obsidian-repo input does NOT carry aria-invalid", () => {
     const idx = src.indexOf('id="obsidian-repo"');
     expect(idx).toBeGreaterThan(-1);
     const block = src.slice(idx, idx + 400);
-    expect(block).toMatch(/aria-invalid/);
+    expect(block).not.toMatch(/aria-invalid/);
   });
 
-  it('obsidian-path input has aria-invalid', () => {
+  it("obsidian-path input does NOT carry aria-invalid", () => {
     const idx = src.indexOf('id="obsidian-path"');
     expect(idx).toBeGreaterThan(-1);
     const block = src.slice(idx, idx + 400);
-    expect(block).toMatch(/aria-invalid/);
+    expect(block).not.toMatch(/aria-invalid/);
   });
 
-  it('obsidian status message has an id for aria-describedby', () => {
+  it("obsidian status message has id=obsidian-msg for aria-describedby", () => {
     expect(src).toMatch(/id="obsidian-msg"/);
   });
 
-  it('obsidian-token input references obsidian-msg via aria-describedby', () => {
+  it("obsidian status message has role=status for screen reader announcement", () => {
+    const idx = src.indexOf('id="obsidian-msg"');
+    const block = src.slice(idx, idx + 200);
+    expect(block).toMatch(/role="status"/);
+  });
+
+  it("obsidian-token input references obsidian-msg via aria-describedby", () => {
     const idx = src.indexOf('id="obsidian-token"');
+    const block = src.slice(idx, idx + 600);
+    expect(block).toContain('aria-describedby="obsidian-msg"');
+  });
+
+  it("obsidian-repo input references obsidian-msg via aria-describedby", () => {
+    const idx = src.indexOf('id="obsidian-repo"');
     const block = src.slice(idx, idx + 600);
     expect(block).toContain('aria-describedby="obsidian-msg"');
   });

--- a/frontend/src/__tests__/ProfileObsidianErrorBorder.test.ts
+++ b/frontend/src/__tests__/ProfileObsidianErrorBorder.test.ts
@@ -1,5 +1,14 @@
 /**
- * Static assertions: Profile Obsidian inputs show red border on save failure — closes #2296
+ * Updated for #2396: per-field red borders removed from Obsidian inputs.
+ *
+ * Previously (#2296) each field conditionally toggled border-red-400 on save
+ * failure.  #2396 removes that because:
+ *   1. The error is form-level (network/API), not per-field — red borders
+ *      mislead users into thinking their input values are wrong.
+ *   2. The role="status" region (id="obsidian-msg") already communicates the
+ *      error with colour + text; duplicating it on every field is redundant.
+ *
+ * Fields now use unconditional border-stone-300 / focus:ring-amber-400.
  */
 import fs from "fs";
 import path from "path";
@@ -9,31 +18,32 @@ const src = fs.readFileSync(
   "utf8",
 );
 
-describe("ProfileObsidianErrorBorder", () => {
-  it("Obsidian token input className references obsidianMsg", () => {
+describe("ProfileObsidianErrorBorder (updated for #2396)", () => {
+  it("obsidian-token input uses static border classes, not conditional red on error", () => {
     const anchor = src.indexOf('id="obsidian-token"');
     expect(anchor).toBeGreaterThan(0);
     const block = src.slice(anchor, anchor + 900);
-    expect(block).toMatch(/obsidianMsg/);
+    expect(block).toMatch(/border-stone-300/);
+    expect(block).not.toMatch(/border-red/);
   });
 
-  it("Obsidian token input has red border class on error", () => {
-    const anchor = src.indexOf('id="obsidian-token"');
-    const block = src.slice(anchor, anchor + 900);
-    expect(block).toMatch(/border-red/);
-  });
-
-  it("Obsidian repo input has red border class on error", () => {
+  it("obsidian-repo input uses static border classes, not conditional red on error", () => {
     const anchor = src.indexOf('id="obsidian-repo"');
     expect(anchor).toBeGreaterThan(0);
     const block = src.slice(anchor, anchor + 900);
-    expect(block).toMatch(/border-red/);
+    expect(block).toMatch(/border-stone-300/);
+    expect(block).not.toMatch(/border-red/);
   });
 
-  it("Obsidian path input has red border class on error", () => {
+  it("obsidian-path input uses static border classes, not conditional red on error", () => {
     const anchor = src.indexOf('id="obsidian-path"');
     expect(anchor).toBeGreaterThan(0);
     const block = src.slice(anchor, anchor + 900);
-    expect(block).toMatch(/border-red/);
+    expect(block).toMatch(/border-stone-300/);
+    expect(block).not.toMatch(/border-red/);
+  });
+
+  it("error is still communicated via obsidian-msg status region", () => {
+    expect(src).toMatch(/id="obsidian-msg"[^>]*role="status"/);
   });
 });

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -407,9 +407,8 @@ export default function ProfilePage() {
                   placeholder={hasObsidianToken ? "Enter new token to replace existing" : "ghp_… (never shown back)"}
                   value={obsidianToken}
                   onChange={(e) => setObsidianToken(e.target.value)}
-                  aria-invalid={obsidianMsg?.ok === false || undefined}
                   aria-describedby="obsidian-msg"
-                  className={`w-full border rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 placeholder:text-stone-600 ${obsidianMsg?.ok === false ? "border-red-400 focus:ring-red-400" : "border-stone-300 focus:ring-amber-400"}`}
+                  className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-amber-400 placeholder:text-stone-600"
                 />
                 <p className="text-xs text-stone-600 mt-1">
                   Requires <code>contents:write</code> permission on your vault repo.
@@ -426,9 +425,8 @@ export default function ProfilePage() {
                   placeholder="username/obsidian-notes"
                   value={obsidianRepo}
                   onChange={(e) => setObsidianRepo(e.target.value)}
-                  aria-invalid={obsidianMsg?.ok === false || undefined}
                   aria-describedby="obsidian-msg"
-                  className={`w-full border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 placeholder:text-stone-600 ${obsidianMsg?.ok === false ? "border-red-400 focus:ring-red-400" : "border-stone-300 focus:ring-amber-400"}`}
+                  className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 placeholder:text-stone-600"
                 />
               </div>
 
@@ -442,9 +440,8 @@ export default function ProfilePage() {
                   placeholder="All Notes/002 Literature Notes/000 Books"
                   value={obsidianPath}
                   onChange={(e) => setObsidianPath(e.target.value)}
-                  aria-invalid={obsidianMsg?.ok === false || undefined}
                   aria-describedby="obsidian-msg"
-                  className={`w-full border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 placeholder:text-stone-600 ${obsidianMsg?.ok === false ? "border-red-400 focus:ring-red-400" : "border-stone-300 focus:ring-amber-400"}`}
+                  className="w-full border border-stone-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 placeholder:text-stone-600"
                 />
               </div>
 


### PR DESCRIPTION
## What changed

Removed `aria-invalid` from all three Obsidian export form fields (`obsidian-token`, `obsidian-repo`, `obsidian-path`) in `profile/page.tsx`. Also removed the conditional `border-red-400 / focus:ring-red-400` per-field error styling.

## Why

**WCAG 1.3.1 (Info and Relationships) violation.** `aria-invalid` must only appear on a field whose *value* is invalid. A generic network/API save failure is not a per-field validation error — every field was being marked invalid simultaneously even when the user entered perfectly valid data.

**Screen reader impact:** With the old code, when save failed, a screen reader user focusing into any of the three fields would hear it announced as "invalid". This falsely signals their input is wrong, not that a server error occurred.

**Fix:** The existing `role="status" aria-live="polite"` region (`id="obsidian-msg"`) already announces the save error correctly. Fields keep `aria-describedby="obsidian-msg"` so users can navigate to the message. No new machinery needed.

## Test plan

- `ObsidianAriaInvalid.test.ts` — new regression test confirming ≤1 field gets aria-invalid (now 0)
- `ProfileObsidianAriaInvalid.test.ts` — updated to assert fields do NOT have `aria-invalid` and DO have `aria-describedby`
- `ProfileObsidianErrorBorder.test.ts` — updated to assert static border classes (no red conditional)
- All 3827 frontend tests pass

## Docs follow-up

Change Log row added to `docs/design-improvement-plan.md`.

Closes #2396
