### PR TITLE
fix: announce word addition via aria-live in deck add-word picker (closes #2398)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -438,6 +438,7 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-30 | Deck form: live character counters (X/80, X/500) with aria-live="polite" on name and description inputs — WCAG 3.3.1 spirit (closes #2391) | decks/new/page.tsx | #2392 |
 | 2026-04-30 | Deck detail page: distinguish zero-vocab state from all-in-deck state — show "Start reading" CTA with guidance when user has no vocabulary, instead of a silent disabled "Add word" button (closes #2394) | decks/[deckId]/page.tsx | #2394 |
 | 2026-04-30 | Profile Obsidian form: remove aria-invalid from all three fields on generic save error — WCAG 1.3.1 violation fixed; role="status" region (obsidian-msg) is the correct channel for form-level errors; aria-describedby links fields to it (closes #2396) | profile/page.tsx | #2396 |
+| 2026-04-30 | Deck add-word picker: aria-live status region announces each word addition to screen readers — WCAG 4.1.3 (closes #2398) | decks/[deckId]/page.tsx | #2398 |
 
 ---
 

--- a/frontend/src/__tests__/DeckPickerAddAnnouncement.test.ts
+++ b/frontend/src/__tests__/DeckPickerAddAnnouncement.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Regression test for issue #2398: AddWordPicker in the deck detail page
+ * did not announce word additions to screen readers (WCAG 4.1.3).
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("DeckDetailPage AddWordPicker — aria-live announcement on add (issue #2398)", () => {
+  const src = read("src/app/decks/[deckId]/page.tsx");
+
+  // Find the AddWordPicker function body (from its declaration to the next top-level function).
+  const pickerStart = src.indexOf("function AddWordPicker");
+  const afterPicker = src.indexOf("\nfunction ", pickerStart + 1);
+  const picker = afterPicker > 0 ? src.slice(pickerStart, afterPicker) : src.slice(pickerStart);
+
+  it("AddWordPicker tracks the last added word in state", () => {
+    // Must maintain local state for the last-added word name so it can populate the live region.
+    expect(picker).toMatch(/useState.*lastAdded|lastAdded.*useState|setLastAdded/);
+  });
+
+  it("AddWordPicker contains a role=status aria-live=polite region", () => {
+    expect(picker).toMatch(/role="status"/);
+    expect(picker).toMatch(/aria-live="polite"/);
+  });
+
+  it("live region text references the last added word", () => {
+    // The announcement should contain the word text, not just a generic message.
+    expect(picker).toMatch(/lastAdded/);
+  });
+});

--- a/frontend/src/app/decks/[deckId]/page.tsx
+++ b/frontend/src/app/decks/[deckId]/page.tsx
@@ -335,6 +335,7 @@ interface AddWordPickerProps {
 
 function AddWordPicker({ candidates, onClose, onAdd }: AddWordPickerProps) {
   const [query, setQuery] = useState("");
+  const [lastAdded, setLastAdded] = useState<string | null>(null);
   const closeRef = useRef<HTMLButtonElement | null>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
   useFocusTrap(dialogRef);
@@ -423,6 +424,7 @@ function AddWordPicker({ candidates, onClose, onAdd }: AddWordPickerProps) {
                     type="button"
                     onClick={() => {
                       onAdd(w.id);
+                      setLastAdded(w.word);
                     }}
                     aria-label={`Add ${w.word} to deck`}
                     title={w.word}
@@ -443,6 +445,10 @@ function AddWordPicker({ candidates, onClose, onAdd }: AddWordPickerProps) {
             </ul>
           )}
         </div>
+        {/* Screen-reader status region: announces each word addition (WCAG 4.1.3) */}
+        <span role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+          {lastAdded ? `"${lastAdded}" added to deck` : ""}
+        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
## What changed

Added a `role="status" aria-live="polite"` region inside the `AddWordPicker` dialog in `decks/[deckId]/page.tsx`. When the user clicks a word to add it to the deck, local `lastAdded` state is updated and the live region announces `"${word}" added to deck`.

## Why

**WCAG 4.1.3 (Status Messages):** When a word is added from the picker, it visually disappears from the list — but screen readers receive no announcement. Without a live region, keyboard and screen-reader users can only discover the addition by navigating the updated list (noticing the word is gone), not by hearing an immediate confirmation.

This mirrors the existing `UndoToast` pattern used for word *removal*, which already has `role="status" aria-live="polite"`.

## Test plan

- `DeckPickerAddAnnouncement.test.ts` — 3 new source-level assertions confirming:
  - `lastAdded` state exists in `AddWordPicker`
  - A `role="status" aria-live="polite"` region is present
  - The region references `lastAdded`
- Full suite: 3830 tests pass

## Docs follow-up

Change Log row added to `docs/design-improvement-plan.md`.

Closes #2398
