### PR TITLE
fix: add aria-valuetext to TTS position and speed sliders (closes #2400)

### DIFF
--- a/frontend/src/__tests__/TTSSliderAriaValuetext.test.ts
+++ b/frontend/src/__tests__/TTSSliderAriaValuetext.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression test for issue #2400: TTS sliders missing aria-valuetext.
+ * Screen readers announced raw floats ("152.3") instead of formatted values
+ * ("2:32" for position, "1.0×" for speed). WCAG 4.1.2 — Name, Role, Value.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(process.cwd(), "src/components/TTSControls.tsx"),
+  "utf8",
+);
+
+describe("TTSControls sliders — aria-valuetext (issue #2400)", () => {
+  it("playback position slider has aria-valuetext with formatted time", () => {
+    const posSlider = src.indexOf('aria-label="Playback position"');
+    expect(posSlider).toBeGreaterThan(0);
+    // Grab the surrounding input block (up to 300 chars back to include the whole tag)
+    const block = src.slice(Math.max(0, posSlider - 300), posSlider + 300);
+    expect(block).toMatch(/aria-valuetext/);
+    // Should reference formatTime, not a raw number
+    expect(block).toMatch(/formatTime/);
+  });
+
+  it("speed slider has aria-label", () => {
+    // The speed slider is at the second type="range"; confirm it has an aria-label
+    const first = src.indexOf('type="range"');
+    const second = src.indexOf('type="range"', first + 1);
+    expect(second).toBeGreaterThan(first);
+    const block = src.slice(second, second + 400);
+    expect(block).toMatch(/aria-label/);
+  });
+
+  it("speed slider has aria-valuetext with × suffix", () => {
+    const first = src.indexOf('type="range"');
+    const second = src.indexOf('type="range"', first + 1);
+    const block = src.slice(second, second + 400);
+    expect(block).toMatch(/aria-valuetext/);
+    // Should reference rate and the × symbol
+    expect(block).toMatch(/×/);
+  });
+});

--- a/frontend/src/components/TTSControls.tsx
+++ b/frontend/src/components/TTSControls.tsx
@@ -481,6 +481,7 @@ export default function TTSControls({
             onChange={(e) => seekTo(Number(e.target.value))}
             className="flex-1 accent-amber-700"
             aria-label="Playback position"
+            aria-valuetext={formatTime(globalCurrentTime)}
           />
           <span className="text-xs text-amber-700 tabular-nums w-10">
             {formatTime(globalDuration)}
@@ -498,6 +499,8 @@ export default function TTSControls({
           value={rate}
           onChange={(e) => changeRate(Number(e.target.value))}
           className="w-24 md:w-20 accent-amber-700"
+          aria-label="Playback speed"
+          aria-valuetext={`${rate.toFixed(1)}×`}
         />
         <span>{rate.toFixed(1)}×</span>
       </label>


### PR DESCRIPTION
## What changed

Added `aria-valuetext` to both range inputs in `TTSControls.tsx` and an explicit `aria-label` to the speed slider.

- **Playback position slider**: `aria-valuetext={formatTime(globalCurrentTime)}` — screen readers now announce "2:32" instead of "152.3"
- **Speed slider**: `aria-label="Playback speed"` + `aria-valuetext={`${rate.toFixed(1)}×`}` — screen readers now announce "1.0×" instead of "1.0"

## Why

WCAG 4.1.2 — Name, Role, Value requires that slider values be expressed in a form assistive technology can present meaningfully. Raw floats (seconds, unitless multipliers) are not meaningful to screen reader users.

## Test plan

- New regression tests in `TTSSliderAriaValuetext.test.ts` assert both sliders carry `aria-valuetext` referencing `formatTime` / the `×` symbol
- All 3833 Jest tests pass

Closes #2400
