### PR TITLE
fix: announce annotation and highlight saves to screen readers (closes #2402)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -439,6 +439,8 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-30 | Deck detail page: distinguish zero-vocab state from all-in-deck state — show "Start reading" CTA with guidance when user has no vocabulary, instead of a silent disabled "Add word" button (closes #2394) | decks/[deckId]/page.tsx | #2394 |
 | 2026-04-30 | Profile Obsidian form: remove aria-invalid from all three fields on generic save error — WCAG 1.3.1 violation fixed; role="status" region (obsidian-msg) is the correct channel for form-level errors; aria-describedby links fields to it (closes #2396) | profile/page.tsx | #2396 |
 | 2026-04-30 | Deck add-word picker: aria-live status region announces each word addition to screen readers — WCAG 4.1.3 (closes #2398) | decks/[deckId]/page.tsx | #2398 |
+| 2026-04-30 | TTS sliders: add aria-valuetext to playback position slider (formatted time, e.g. "2:32") and speed slider ("1.0×"); add aria-label to speed slider — WCAG 4.1.2 (closes #2400) | components/TTSControls.tsx | #2401 |
+| 2026-04-30 | Reader annotation/highlight save: sr-only role=status live region announces "Note saved" / "Highlight applied" after AnnotationToolbar or QuickHighlightPanel saves — WCAG 4.1.3 (closes #2402) | reader/[bookId]/page.tsx | #2403 |
 
 ---
 

--- a/frontend/src/__tests__/ReaderAnnotationSaveAnnouncement.test.ts
+++ b/frontend/src/__tests__/ReaderAnnotationSaveAnnouncement.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Regression test for issue #2402: reader page annotation and highlight saves
+ * had no screen-reader success announcement (WCAG 4.1.3).
+ *
+ * When a dialog/toolbar closes after a successful save, focus returns to the
+ * triggering element — screen readers hear nothing about the outcome. A
+ * sr-only role="status" live region must announce "Note saved" / "Highlight
+ * applied" so AT users get confirmation without requiring focus.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(process.cwd(), "src/app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Reader page annotation save announcements (issue #2402)", () => {
+  it("tracks a savedAnnotationMsg state variable", () => {
+    expect(src).toMatch(/savedAnnotationMsg|setSavedAnnotationMsg/);
+  });
+
+  it("has a sr-only role=status live region for annotation save feedback", () => {
+    // Must have an always-present live region (not conditional) so AT announces on first fire
+    expect(src).toMatch(/sr-only[\s\S]{0,200}role="status"[\s\S]{0,200}savedAnnotationMsg|role="status"[\s\S]{0,200}sr-only[\s\S]{0,200}savedAnnotationMsg/);
+  });
+
+  it("onSaved handler for AnnotationToolbar sets a save confirmation message", () => {
+    // The onSaved callback should call setSavedAnnotationMsg with a non-empty string
+    const annotationToolbarIdx = src.indexOf("AnnotationToolbar");
+    expect(annotationToolbarIdx).toBeGreaterThan(0);
+    // Find the nearest onSaved block after AnnotationToolbar
+    const onSavedIdx = src.indexOf("onSaved", annotationToolbarIdx);
+    expect(onSavedIdx).toBeGreaterThan(annotationToolbarIdx);
+    // Use 700 chars — the setAnnotations block is ~300 chars before setSavedAnnotationMsg
+    const block = src.slice(onSavedIdx, onSavedIdx + 700);
+    expect(block).toMatch(/setSavedAnnotationMsg/);
+  });
+
+  it("onSaved handler for QuickHighlightPanel sets a save confirmation message", () => {
+    const qhpIdx = src.indexOf("QuickHighlightPanel");
+    expect(qhpIdx).toBeGreaterThan(0);
+    const onSavedIdx = src.indexOf("onSaved", qhpIdx);
+    expect(onSavedIdx).toBeGreaterThan(qhpIdx);
+    const block = src.slice(onSavedIdx, onSavedIdx + 700);
+    expect(block).toMatch(/setSavedAnnotationMsg/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -95,6 +95,9 @@ export default function ReaderPage() {
   // Annotation delete undo toast
   const [deletedAnnotationToast, setDeletedAnnotationToast] = useState<Annotation | null>(null);
 
+  // Screen-reader announcement for annotation/highlight save success (WCAG 4.1.3)
+  const [savedAnnotationMsg, setSavedAnnotationMsg] = useState("");
+
   // TTS Read-button playback state — fed by TTSControls via callback props.
   const [ttsCurrentTime, setTtsCurrentTime] = useState(0);
   const [ttsDuration, setTtsDuration] = useState(0);
@@ -1626,6 +1629,8 @@ export default function ReaderPage() {
                   }
                   return [...prev, annotation];
                 });
+                setSavedAnnotationMsg(annotation.note_text ? "Note saved" : "Highlight saved");
+                setTimeout(() => setSavedAnnotationMsg(""), 2000);
               }}
               onDeleted={(id) => {
                 const ann = annotations.find((a) => a.id === id);
@@ -1654,6 +1659,8 @@ export default function ReaderPage() {
                   }
                   return [...prev, annotation];
                 });
+                setSavedAnnotationMsg("Highlight applied");
+                setTimeout(() => setSavedAnnotationMsg(""), 2000);
               }}
               onDeleted={(id) => {
                 const ann = annotations.find((a) => a.id === id);
@@ -1719,6 +1726,10 @@ export default function ReaderPage() {
           {/* aria-live-obsidian-toast-mirror: always-present so AT announces (WCAG 4.1.3) */}
           <span aria-live="polite" aria-atomic="true" className="sr-only">
             {obsidianToast ? (obsidianToast.msg.startsWith("http") ? `Exported to ${obsidianToast.msg}` : obsidianToast.msg) : ""}
+          </span>
+          {/* Annotation/highlight save confirmation for screen readers (WCAG 4.1.3) */}
+          <span role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+            {savedAnnotationMsg}
           </span>
           {/* Obsidian export toast — visual only, conditionally mounted */}
           {obsidianToast && (


### PR DESCRIPTION
## What changed

Added a screen-reader success announcement for annotation and highlight saves in the reader page.

- **New state**: `savedAnnotationMsg` tracks the current announcement text
- **AnnotationToolbar `onSaved`**: sets msg to `"Note saved"` (or `"Highlight saved"` for color-only changes), cleared after 2 s
- **QuickHighlightPanel `onSaved`**: sets msg to `"Highlight applied"`, cleared after 2 s
- **Always-present live region**: `<span role="status" aria-live="polite" aria-atomic="true" className="sr-only">{savedAnnotationMsg}</span>` placed alongside the existing obsidian toast mirror — always in the DOM so AT announces on first fire

No visual change — announcement only.

## Why

WCAG 4.1.3 — Status Messages: when a dialog/toolbar closes after a successful save, screen readers hear nothing. The deletion flow already had `UndoToast` (role=status) but the creation/update flow had no equivalent.

## Test plan

- New regression tests in `ReaderAnnotationSaveAnnouncement.test.ts`:
  - `savedAnnotationMsg` state variable present
  - `role="status"` sr-only live region references `savedAnnotationMsg`
  - Both `onSaved` handlers call `setSavedAnnotationMsg`
- All 3837 Jest tests pass

Closes #2402
