### PR TITLE
fix: announce SelectionToolbar actions to screen readers on text selection (closes #2404)

### DIFF
--- a/frontend/src/__tests__/SelectionToolbar.test.tsx
+++ b/frontend/src/__tests__/SelectionToolbar.test.tsx
@@ -58,12 +58,12 @@ describe("SelectionToolbar", () => {
     jest.restoreAllMocks();
   });
 
-  it("renders nothing when there is no selection", () => {
-    const { container } = render(
+  it("renders no toolbar buttons when there is no selection", () => {
+    render(
       <SelectionToolbar onRead={jest.fn()} onHighlight={jest.fn()} />
     );
-    // Toolbar div not in document
-    expect(container.firstChild).toBeNull();
+    // No action buttons should be visible — only the sr-only live region remains
+    expect(document.querySelector('[role="toolbar"]')).not.toBeInTheDocument();
   });
 
   it("shows toolbar when text >= 2 chars is selected inside reader", () => {

--- a/frontend/src/__tests__/SelectionToolbarAnnouncement.test.ts
+++ b/frontend/src/__tests__/SelectionToolbarAnnouncement.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression test for issue #2404: SelectionToolbar appeared with no
+ * screen-reader announcement when text was selected via keyboard (WCAG 4.1.3).
+ *
+ * When the toolbar mounts (selection becomes truthy), an always-present
+ * sr-only aria-live="polite" region must announce the available actions so
+ * AT users know they can Tab to Read / Highlight / Note / Chat / Word buttons.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(process.cwd(), "src/components/SelectionToolbar.tsx"),
+  "utf8",
+);
+
+describe("SelectionToolbar keyboard accessibility announcement (issue #2404)", () => {
+  it("renders an aria-live=polite live region outside the conditional toolbar", () => {
+    // The component must NOT just return null — it must always render a live region
+    // (even when there is no selection) so AT can fire when content changes.
+    expect(src).toMatch(/aria-live="polite"/);
+    expect(src).toMatch(/sr-only/);
+  });
+
+  it("live region announces available actions when selection is active", () => {
+    // The announcement text must describe the actions available
+    expect(src).toMatch(/Tab.*action|action.*Tab|selection.*action|Tab.*Read|Read.*Highlight/i);
+  });
+
+  it("does not return null outright — always renders the live region", () => {
+    // Confirm we no longer have the bare "return null" pattern for no-selection state
+    // (it was `if (!selection) return null;` — now it should return a fragment)
+    expect(src).not.toMatch(/if \(!selection\) return null/);
+  });
+});

--- a/frontend/src/components/SelectionToolbar.tsx
+++ b/frontend/src/components/SelectionToolbar.tsx
@@ -97,7 +97,22 @@ export default function SelectionToolbar({ onRead, onHighlight, onNote, onChat, 
     };
   }, [selection]);
 
-  if (!selection) return null;
+  // Build action list for the screen-reader announcement
+  const actionLabels = [
+    onRead && "Read",
+    onHighlight && "Highlight",
+    onNote && "Note",
+    onChat && "Chat",
+    onVocab && "Look up word",
+  ].filter(Boolean).join(", ");
+
+  // Always render a live region so AT can announce when selection activates.
+  // When there is no selection, render just the sr-only live region (no visual toolbar).
+  if (!selection) {
+    return (
+      <span role="status" aria-live="polite" aria-atomic="true" className="sr-only" />
+    );
+  }
 
   const scrollEl = document.getElementById("reader-scroll");
   const scrollRect = scrollEl?.getBoundingClientRect();
@@ -127,6 +142,11 @@ export default function SelectionToolbar({ onRead, onHighlight, onNote, onChat, 
   const btnClass = "flex items-center gap-1.5 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-white/10 active:bg-white/20 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 focus-visible:ring-offset-stone-800";
 
   return (
+    <>
+      {/* Always-present live region: announces toolbar actions when selection activates (WCAG 4.1.3) */}
+      <span role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+        {`Text selected. Press Tab for actions: ${actionLabels}`}
+      </span>
     <div
       ref={toolbarRef}
       role="toolbar"
@@ -165,5 +185,6 @@ export default function SelectionToolbar({ onRead, onHighlight, onNote, onChat, 
         </button>
       )}
     </div>
+    </>
   );
 }


### PR DESCRIPTION
## What changed

`SelectionToolbar` now always renders a `role="status" aria-live="polite"` live region in the DOM, even when no text is selected. When a selection becomes active, the region announces "Text selected. Press Tab for actions: Read, Highlight, Note, Chat, Look up word" so keyboard and AT users know which actions are available.

Previously the component returned `null` (or only the toolbar) when there was no selection, which prevented screen readers from picking up the state change when selection became active — violating WCAG 4.1.3 (Status Messages).

## Why

Keyboard users who select text via Shift+Arrow have no way to discover the toolbar exists without a live announcement. The live region must be in the DOM *before* content changes for AT to fire — returning `null` silently dropped the announcement.

## Test plan

- `SelectionToolbarAnnouncement.test.ts` (new) — 3 source-level regex tests verifying: `aria-live="polite"` present, announcement text references Tab and actions, component no longer returns `null` for no-selection state
- `SelectionToolbar.test.tsx` (updated) — existing "renders nothing when no selection" test updated to check `role="toolbar"` is absent rather than `container.firstChild` is null (now the sr-only span is always present)
- Full frontend suite: 3840 tests pass

Closes #2404

## Docs follow-up
- [ ] Docs updated (if applicable)
