### PR TITLE
fix: show error state with retry button in ReadingStats on fetch failure (closes #2412)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -448,6 +448,7 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-30 | Reader annotations sidebar: replaced silent empty state on getAnnotations failure with "Couldn't load annotations" error state + Retry button — prevents misleading "No annotations yet" (closes #2414) | app/reader/[bookId]/page.tsx | #2415 |
 | 2026-04-30 | Vocabulary DefinitionSheet: replaced silent .catch() on getWordDefinition failure with error state — shows "Couldn't load definition" + Retry button instead of misleading "No definition found." (closes #2417) | app/vocabulary/page.tsx | #2418 |
 | 2026-04-30 | VocabWordTooltip (reader): replaced silent .catch() on getWordDefinition failure with error state — shows "Couldn't load definition" + Retry button instead of misleading "No definition found." in core reading flow (closes #2419) | components/VocabWordTooltip.tsx | #2420 |
+| 2026-04-30 | ReadingStats: replaced silent null return on fetch failure with error state — shows "Couldn't load reading stats" message and Retry button (closes #2412) | components/ReadingStats.tsx | #2413 |
 
 ---
 

--- a/frontend/src/__tests__/ReadingStatsErrorState.test.tsx
+++ b/frontend/src/__tests__/ReadingStatsErrorState.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Regression tests for issue #2412:
+ * ReadingStats silently returned null on fetch failure — no error state or retry button.
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import ReadingStats from "@/components/ReadingStats";
+
+const mockGetUserStats = jest.fn();
+
+jest.mock("@/lib/api", () => ({
+  getUserStats: (...args: unknown[]) => mockGetUserStats(...args),
+}));
+
+const HAPPY_STATS = {
+  streak: 3,
+  longest_streak: 7,
+  activity: [{ date: "2026-04-30", count: 2 }],
+  totals: { books_started: 5, vocabulary_words: 42, annotations: 11, insights: 3 },
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("ReadingStats — fetch failure (issue #2412)", () => {
+  it("renders an error message instead of returning null when getUserStats rejects", async () => {
+    mockGetUserStats.mockRejectedValue(new Error("Network error"));
+
+    render(<ReadingStats active={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toBeInTheDocument();
+      const status = screen.getByRole("status");
+      // Should NOT be the loading skeleton (which also has role="status" but has animate-pulse)
+      expect(status.className).not.toContain("animate-pulse");
+    });
+
+    // Should show an error message
+    expect(screen.getByText(/couldn't load|failed|error|try again/i)).toBeInTheDocument();
+  });
+
+  it("shows a retry button that re-fetches when clicked", async () => {
+    mockGetUserStats.mockRejectedValueOnce(new Error("Network error"));
+    mockGetUserStats.mockResolvedValueOnce(HAPPY_STATS);
+
+    render(<ReadingStats active={true} />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument()
+    );
+
+    // After successful retry, the stats content should appear
+    await waitFor(() =>
+      expect(screen.getAllByText(/reading streak|activity/i).length).toBeGreaterThan(0)
+    );
+
+    expect(mockGetUserStats).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders the happy path normally when stats load successfully", async () => {
+    mockGetUserStats.mockResolvedValue(HAPPY_STATS);
+
+    render(<ReadingStats active={true} />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/reading streak/i)).toBeInTheDocument()
+    );
+
+    expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
+  });
+
+  it("does not call getUserStats when active=false", async () => {
+    render(<ReadingStats active={false} />);
+    await act(async () => {});
+    expect(mockGetUserStats).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/ReadingStats.tsx
+++ b/frontend/src/components/ReadingStats.tsx
@@ -85,14 +85,18 @@ interface Props {
 export default function ReadingStats({ active, heatmapOnly = false }: Props) {
   const [stats, setStats] = useState<UserStats | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [retryTick, setRetryTick] = useState(0);
 
   useEffect(() => {
     if (!active) return;
+    setError(false);
+    setLoading(true);
     getUserStats()
       .then(setStats)
-      .catch(() => {})
+      .catch(() => setError(true))
       .finally(() => setLoading(false));
-  }, [active]);
+  }, [active, retryTick]);
 
   if (!active || (loading && !stats)) {
     return (
@@ -106,6 +110,20 @@ export default function ReadingStats({ active, heatmapOnly = false }: Props) {
           </div>
         )}
         <div className="h-28 bg-amber-50 rounded-xl border border-amber-100" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div role="status" className="flex flex-col items-center gap-3 py-8 text-center">
+        <p className="text-sm text-stone-500">Couldn&apos;t load reading stats.</p>
+        <button
+          onClick={() => setRetryTick((t) => t + 1)}
+          className="text-xs px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+        >
+          Retry
+        </button>
       </div>
     );
   }


### PR DESCRIPTION
## What changed
`ReadingStats` previously called `.catch(() => {})` when `getUserStats` failed. With `loading=false` and `stats=null`, the component hit `if (!stats) return null` — rendering a blank area with no explanation or recovery path.

Now:
- Adds an `error` state set in the catch block
- Adds a `retryTick` counter that re-triggers the `useEffect` when incremented
- Renders a "Couldn't load reading stats" message with a **Retry** button instead of returning `null`

## Why
Silent data-fetch failures leave users confused — they see the loading skeleton disappear and then nothing. A visible error with a retry path is the minimum expected UX for fetch failures on a core stats component (visible on home and profile pages).

## Test plan
- [x] New test file `ReadingStatsErrorState.test.tsx` (4 tests):
  - Error state renders `role="status"` (not `animate-pulse` skeleton) on rejection
  - Retry button re-fetches and resolves to stats on second call
  - Happy path renders normally (no retry button shown)
  - `getUserStats` not called when `active=false`
- [x] Full frontend suite: 3853 tests pass
- [x] Backend suite: passing

Closes #2412

## Docs follow-up
Design changelog updated in `docs/design-improvement-plan.md`.
