### PR TITLE
fix: show error state with retry in reader annotations sidebar on fetch failure (closes #2414)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -445,6 +445,7 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-30 | AnnotationToolbar: close button disabled (opacity-40, cursor-not-allowed) and backdrop click no-op while save/delete in flight — prevents silent data loss risk (closes #2406) | components/AnnotationToolbar.tsx | #2407 |
 | 2026-04-30 | InsightChat: API error responses now render as a distinct red alert bubble (role="alert", AlertCircleIcon) instead of appearing as normal AI assistant messages (closes #2408) | components/InsightChat.tsx | #2409 |
 | 2026-04-30 | QuickHighlightPanel: added error state — save/delete failures now show inline role="alert" message ("Save failed — tap a colour to retry") instead of silently resetting the panel (closes #2410) | components/QuickHighlightPanel.tsx | #2411 |
+| 2026-04-30 | Reader annotations sidebar: replaced silent empty state on getAnnotations failure with "Couldn't load annotations" error state + Retry button — prevents misleading "No annotations yet" (closes #2414) | app/reader/[bookId]/page.tsx | #2415 |
 
 ---
 

--- a/frontend/src/__tests__/ReaderAnnotationsErrorState.test.ts
+++ b/frontend/src/__tests__/ReaderAnnotationsErrorState.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression tests for issue #2414:
+ * Reader annotations sidebar showed "No annotations yet" when getAnnotations fetch failed.
+ * Source-level assertions confirm the error state and retry path are wired.
+ */
+import * as path from "path";
+import * as fs from "fs";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Reader page — annotations error state (issue #2414)", () => {
+  it("declares annotationsError state", () => {
+    expect(src).toMatch(/annotationsError/);
+    expect(src).toMatch(/setAnnotationsError/);
+  });
+
+  it("catch block sets annotationsError instead of swallowing silently", () => {
+    // The old code was: .catch(() => {})
+    // New code must call setAnnotationsError(true) in the getAnnotations catch
+    const annotationsCatchSection = src.slice(
+      src.indexOf("getAnnotations("),
+      src.indexOf("getAnnotations(") + 300
+    );
+    expect(annotationsCatchSection).toMatch(/setAnnotationsError\s*\(\s*true\s*\)/);
+    expect(annotationsCatchSection).not.toMatch(/\.catch\s*\(\s*\(\s*\)\s*=>\s*\{\s*\}\s*\)/);
+  });
+
+  it("renders a distinct error message (not empty state) when annotationsError is true", () => {
+    // Should have a JSX branch checking annotationsError before the empty state
+    // and rendering error text with a Retry button
+    expect(src).toMatch(/annotationsError/);
+    // Error message should reference a retry or reload action
+    expect(src).toMatch(/Retry|retry|Couldn.t load|failed to load|couldn.t load/i);
+  });
+
+  it("error state renders role=\"status\" or role=\"alert\" (not the empty NoteIcon state)", () => {
+    // The error branch should use role="alert" or role="status" to announce the error
+    // The empty state uses NoteIcon with "No annotations yet"
+    // Verify both coexist (we didn't remove the empty state, just added the error branch first)
+    expect(src).toMatch(/No annotations yet/);
+    // And the error path is guarded separately from the empty state
+    const notesTabSection = src.slice(
+      src.lastIndexOf("sidebarTab === \"notes\""),
+      src.lastIndexOf("sidebarTab === \"notes\"") + 8000
+    );
+    expect(notesTabSection).toMatch(/annotationsError/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -71,6 +71,8 @@ export default function ReaderPage() {
   // Annotations
   const [annotations, setAnnotations] = useState<Annotation[]>([]);
   const [annotationsLoading, setAnnotationsLoading] = useState(false);
+  const [annotationsError, setAnnotationsError] = useState(false);
+  const [annotationsRetryTick, setAnnotationsRetryTick] = useState(0);
   const [notesExpanded, setNotesExpanded] = useState(false);
   const [annotationPanel, setAnnotationPanel] = useState<{
     sentenceText: string;
@@ -416,11 +418,12 @@ export default function ReaderPage() {
   useEffect(() => {
     if (!bookId || !session?.backendToken) return;
     setAnnotationsLoading(true);
+    setAnnotationsError(false);
     getAnnotations(Number(bookId))
       .then(setAnnotations)
-      .catch(() => {})
+      .catch(() => setAnnotationsError(true))
       .finally(() => setAnnotationsLoading(false));
-  }, [bookId, session?.backendToken]);
+  }, [bookId, session?.backendToken, annotationsRetryTick]);
 
   // Fetch vocabulary words for this book
   useEffect(() => {
@@ -1932,6 +1935,16 @@ export default function ReaderPage() {
                       <div className="flex justify-center mt-10" role="status" aria-label="Loading annotations">
                         <span className="sr-only">Loading annotations...</span>
                         <span className="w-5 h-5 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin" aria-hidden="true" />
+                      </div>
+                    ) : annotationsError ? (
+                      <div role="status" className="flex flex-col items-center gap-3 mt-10 text-center">
+                        <p className="text-sm text-stone-500">Couldn&apos;t load annotations.</p>
+                        <button
+                          onClick={() => setAnnotationsRetryTick((t) => t + 1)}
+                          className="text-xs px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+                        >
+                          Retry
+                        </button>
                       </div>
                     ) : filteredNotes.length === 0 ? (
                       <div className="text-center text-stone-600 mt-10 text-sm">


### PR DESCRIPTION
## What changed
`reader/[bookId]/page.tsx` used `.catch(() => {})` for `getAnnotations`. When the fetch failed, `annotationsLoading` went false and `annotations` stayed `[]` — the sidebar showed "No annotations yet" with the empty-state illustration, as if the user had no data.

Now:
- Adds `annotationsError` + `annotationsRetryTick` states
- catch sets `annotationsError(true)` and resets it on retry/reload
- The notes sidebar renders a "Couldn't load annotations" message with a **Retry** button (increments `annotationsRetryTick` to re-trigger the `useEffect`) — the misleading empty state only shows when `annotations` genuinely loaded as empty

## Why
A user with existing annotations opening their book saw their annotations "disappear" with no explanation or recovery path. This is one of the most confusing silent failures — the user's data looked gone but was actually just a transient fetch error.

## Test plan
- [x] New test file `ReaderAnnotationsErrorState.test.ts` (4 source-level tests):
  - `annotationsError`/`setAnnotationsError` declared
  - `catch` block calls `setAnnotationsError(true)` — not the old empty catch
  - Error path renders "Retry" / "Couldn't load" text
  - `annotationsError` check appears in the notes sidebar section
- [x] Full frontend suite: 3858 tests pass
- [x] Backend suite: passing

Closes #2414

## Docs follow-up
Design changelog updated in `docs/design-improvement-plan.md`.
