### PR TITLE
fix: show error state with retry in vocabulary DefinitionSheet on fetch failure (closes #2417)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -446,6 +446,7 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-30 | InsightChat: API error responses now render as a distinct red alert bubble (role="alert", AlertCircleIcon) instead of appearing as normal AI assistant messages (closes #2408) | components/InsightChat.tsx | #2409 |
 | 2026-04-30 | QuickHighlightPanel: added error state — save/delete failures now show inline role="alert" message ("Save failed — tap a colour to retry") instead of silently resetting the panel (closes #2410) | components/QuickHighlightPanel.tsx | #2411 |
 | 2026-04-30 | Reader annotations sidebar: replaced silent empty state on getAnnotations failure with "Couldn't load annotations" error state + Retry button — prevents misleading "No annotations yet" (closes #2414) | app/reader/[bookId]/page.tsx | #2415 |
+| 2026-04-30 | Vocabulary DefinitionSheet: replaced silent .catch() on getWordDefinition failure with error state — shows "Couldn't load definition" + Retry button instead of misleading "No definition found." (closes #2417) | app/vocabulary/page.tsx | #2418 |
 
 ---
 

--- a/frontend/src/__tests__/VocabDefinitionSheetErrorState.test.tsx
+++ b/frontend/src/__tests__/VocabDefinitionSheetErrorState.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Regression test for issue #2417 — DefinitionSheet must show an error state
+ * with Retry on fetch failure instead of the misleading "No definition found."
+ */
+import fs from "fs";
+import path from "path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "../app/vocabulary/page.tsx"),
+  "utf-8",
+);
+
+// Locate the DefinitionSheet component body (ends at the next top-level function)
+const dsStart = SOURCE.indexOf("function DefinitionSheet(");
+const dsEnd = SOURCE.indexOf("\nfunction ", dsStart + 1);
+const DS = SOURCE.slice(dsStart, dsEnd === -1 ? SOURCE.length : dsEnd);
+
+describe("DefinitionSheet — error state (issue #2417)", () => {
+  it("declares an error state variable", () => {
+    expect(DS).toMatch(/const\s+\[.*[Ee]rror.*,\s*set.*[Ee]rror.*\]\s*=\s*useState\s*\(\s*false\s*\)/);
+  });
+
+  it("sets error state to true in the catch block", () => {
+    // Catch should call an error setter, not be empty
+    expect(DS).toMatch(/\.catch\s*\([^)]*\)\s*=>\s*[^)]*[Ee]rror[^)]*\(\s*true\s*\)/);
+  });
+
+  it("resets error state to false before retrying", () => {
+    expect(DS).toMatch(/set[A-Za-z]*[Ee]rror[A-Za-z]*\s*\(\s*false\s*\)/);
+  });
+
+  it("renders a retry button when in error state", () => {
+    expect(DS).toMatch(/[Rr]etry/);
+  });
+
+  it("renders an error message distinct from 'No definition found'", () => {
+    // Matches "Couldn&apos;t load" or "Couldn't load" or "Failed to load" etc.
+    expect(DS).toMatch(/Couldn(?:&apos;|')t load|[Ff]ailed to load|[Ee]rror loading/);
+  });
+});

--- a/frontend/src/__tests__/VocabularyPage.coverage2.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.coverage2.test.tsx
@@ -155,7 +155,7 @@ describe("VocabularyPage — DefinitionSheet mousedown outside (lines 59-62)", (
 // ── Line 46: getWordDefinition catch callback ────────────────────────────────
 
 describe("VocabularyPage — DefinitionSheet getWordDefinition error (line 46)", () => {
-  it("silently catches getWordDefinition rejection and stops loading", async () => {
+  it("shows error state with Retry on getWordDefinition rejection", async () => {
     mockGetWordDefinition.mockRejectedValue(new Error("Network error"));
 
     render(<VocabularyPage />);
@@ -164,10 +164,12 @@ describe("VocabularyPage — DefinitionSheet getWordDefinition error (line 46)",
 
     await userEvent.click(screen.getByRole("button", { name: "ephemeral" }));
 
-    // After rejection, loading stops and "No definition found" shows
+    // After rejection, error state renders instead of misleading "No definition found"
     await waitFor(() =>
-      expect(screen.getByText(/No definition found/i)).toBeInTheDocument()
+      expect(screen.getByText(/Couldn't load definition/i)).toBeInTheDocument()
     );
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    expect(screen.queryByText(/No definition found/i)).not.toBeInTheDocument();
   });
 
   it("opens DefinitionSheet with lang=null (lang ?? undefined becomes undefined)", async () => {

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -114,16 +114,21 @@ interface DefinitionSheetProps {
 function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
   const [def, setDef] = useState<WordDefinition | null>(null);
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState(false);
+  const [retryTick, setRetryTick] = useState(0);
   const ref = useRef<HTMLDivElement>(null);
   useFocusTrap(ref);
   useScrollLock(true);
 
   useEffect(() => {
+    setFetchError(false);
+    setLoading(true);
+    setDef(null);
     getWordDefinition(word, lang ?? undefined)
       .then(setDef)
-      .catch(() => {})
+      .catch(() => setFetchError(true))
       .finally(() => setLoading(false));
-  }, [word, lang]);
+  }, [word, lang, retryTick]);
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) { if (e.key === "Escape") onClose(); }
@@ -189,7 +194,19 @@ function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
             </div>
           )}
 
-          {!loading && (!def || def.definitions.length === 0) && (
+          {!loading && fetchError && (
+            <div role="status" className="flex flex-col items-center gap-2 py-2 text-center">
+              <p className="text-sm text-stone-500">Couldn&apos;t load definition.</p>
+              <button
+                onClick={() => setRetryTick((t) => t + 1)}
+                className="text-xs px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+              >
+                Retry
+              </button>
+            </div>
+          )}
+
+          {!loading && !fetchError && (!def || def.definitions.length === 0) && (
             <p className="text-sm text-stone-600 italic">No definition found.</p>
           )}
 


### PR DESCRIPTION
## What changed

`DefinitionSheet` in `vocabulary/page.tsx` had a silent `.catch(() => {})` on `getWordDefinition`. When the API call failed, the spinner would clear and the component rendered **"No definition found."** — the same message shown when Wiktionary genuinely has no entry for the word. Users had no way to tell if the lookup failed or simply returned no results, and there was no retry option.

This PR adds:
- `fetchError` boolean state + `retryTick` counter
- On failure: renders **"Couldn't load definition."** with a **Retry** button
- On success with empty results: still shows "No definition found." (unchanged behaviour)
- `setFetchError(false)` / `setLoading(true)` / `setDef(null)` reset before each attempt (including retries)

## Why

Silent fetch failures leave users confused — they may think a word has no definition when it's actually a network error.

## Test plan

- New: `VocabDefinitionSheetErrorState.test.tsx` — 5 source-level assertions verifying error state declaration, catch handler, reset, Retry button, and distinct error message
- Updated: `VocabularyPage.coverage2.test.tsx` — updated existing test that expected old silent-fail behaviour to assert the new error UI
- Full frontend suite: 3863 tests passing

Closes #2417
