### PR TITLE
fix: show error state with retry in VocabWordTooltip on fetch failure (closes #2419)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -447,6 +447,7 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-30 | QuickHighlightPanel: added error state — save/delete failures now show inline role="alert" message ("Save failed — tap a colour to retry") instead of silently resetting the panel (closes #2410) | components/QuickHighlightPanel.tsx | #2411 |
 | 2026-04-30 | Reader annotations sidebar: replaced silent empty state on getAnnotations failure with "Couldn't load annotations" error state + Retry button — prevents misleading "No annotations yet" (closes #2414) | app/reader/[bookId]/page.tsx | #2415 |
 | 2026-04-30 | Vocabulary DefinitionSheet: replaced silent .catch() on getWordDefinition failure with error state — shows "Couldn't load definition" + Retry button instead of misleading "No definition found." (closes #2417) | app/vocabulary/page.tsx | #2418 |
+| 2026-04-30 | VocabWordTooltip (reader): replaced silent .catch() on getWordDefinition failure with error state — shows "Couldn't load definition" + Retry button instead of misleading "No definition found." in core reading flow (closes #2419) | components/VocabWordTooltip.tsx | #2420 |
 
 ---
 

--- a/frontend/src/__tests__/VocabWordTooltip.test.tsx
+++ b/frontend/src/__tests__/VocabWordTooltip.test.tsx
@@ -86,10 +86,12 @@ describe("VocabWordTooltip — rendering", () => {
     await waitFor(() => expect(screen.getByText(/No definition found/i)).toBeInTheDocument());
   });
 
-  it("shows 'No definition found' when API rejects", async () => {
+  it("shows error state with Retry when API rejects", async () => {
     mockGetWordDefinition.mockRejectedValue(new Error("network error"));
     render(<VocabWordTooltip {...BASE} />);
-    await waitFor(() => expect(screen.getByText(/No definition found/i)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/Couldn't load definition/i)).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    expect(screen.queryByText(/No definition found/i)).not.toBeInTheDocument();
   });
 
   it("shows Wiktionary link after load", async () => {

--- a/frontend/src/__tests__/VocabWordTooltipErrorState.test.tsx
+++ b/frontend/src/__tests__/VocabWordTooltipErrorState.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Regression test for issue #2419 — VocabWordTooltip must show an error state
+ * with Retry on getWordDefinition failure instead of misleading "No definition found."
+ */
+import React from "react";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("@/lib/api", () => ({
+  getWordDefinition: jest.fn(),
+}));
+
+jest.mock("@/lib/useFocusTrap", () => ({ useFocusTrap: jest.fn() }));
+
+import * as api from "@/lib/api";
+import VocabWordTooltip from "@/components/VocabWordTooltip";
+
+const mockGetWordDefinition = api.getWordDefinition as jest.MockedFunction<typeof api.getWordDefinition>;
+
+const RECT = {
+  left: 100, top: 100, right: 200, bottom: 120,
+  width: 100, height: 20, x: 100, y: 100, toJSON: () => {},
+} as DOMRect;
+
+const flushPromises = () => new Promise<void>((r) => setTimeout(r, 0));
+
+const defaultProps = {
+  word: "ephemeral",
+  lang: "en",
+  rect: RECT,
+  onClose: jest.fn(),
+  onSave: jest.fn(),
+};
+
+describe("VocabWordTooltip — error state (issue #2419)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("shows error state with Retry when getWordDefinition rejects", async () => {
+    mockGetWordDefinition.mockRejectedValue(new Error("Network error"));
+
+    render(<VocabWordTooltip {...defaultProps} />);
+    await act(async () => await flushPromises());
+
+    expect(screen.getByText(/Couldn't load definition/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    expect(screen.queryByText(/No definition found/i)).not.toBeInTheDocument();
+  });
+
+  it("retries fetch when Retry is clicked", async () => {
+    mockGetWordDefinition
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockResolvedValueOnce({
+        lemma: "ephemeral",
+        language: "en",
+        definitions: [{ pos: "adj", text: "short-lived" }],
+        url: "",
+      });
+
+    render(<VocabWordTooltip {...defaultProps} />);
+    await act(async () => await flushPromises());
+
+    const retryBtn = screen.getByRole("button", { name: /retry/i });
+    await userEvent.click(retryBtn);
+    await act(async () => await flushPromises());
+
+    await waitFor(() => expect(screen.getByText("short-lived")).toBeInTheDocument());
+    expect(mockGetWordDefinition).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows 'No definition found' (not error) when fetch succeeds with empty definitions", async () => {
+    mockGetWordDefinition.mockResolvedValue({
+      lemma: "ephemeral",
+      language: "en",
+      definitions: [],
+      url: "",
+    });
+
+    render(<VocabWordTooltip {...defaultProps} />);
+    await act(async () => await flushPromises());
+
+    expect(screen.getByText(/No definition found/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Couldn't load/i)).not.toBeInTheDocument();
+  });
+
+  it("shows definition content on successful fetch", async () => {
+    mockGetWordDefinition.mockResolvedValue({
+      lemma: "ephemeral",
+      language: "en",
+      definitions: [{ pos: "adj", text: "short-lived" }],
+      url: "https://en.wiktionary.org/wiki/ephemeral",
+    });
+
+    render(<VocabWordTooltip {...defaultProps} />);
+    await act(async () => await flushPromises());
+
+    expect(screen.getByText("short-lived")).toBeInTheDocument();
+    expect(screen.queryByText(/No definition found/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -15,19 +15,22 @@ interface Props {
 export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: Props) {
   const [def, setDef] = useState<WordDefinition | null>(null);
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState(false);
+  const [retryTick, setRetryTick] = useState(0);
   const [saved, setSaved] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   useFocusTrap(ref);
 
   useEffect(() => {
     setLoading(true);
+    setFetchError(false);
     setDef(null);
     setSaved(false);
     getWordDefinition(word, lang)
       .then(setDef)
-      .catch(() => {})
+      .catch(() => setFetchError(true))
       .finally(() => setLoading(false));
-  }, [word, lang]);
+  }, [word, lang, retryTick]);
 
   // Close on outside click
   useEffect(() => {
@@ -93,7 +96,18 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
             Looking up definition…
           </div>
         )}
-        {!loading && (!def || def.definitions.length === 0) && (
+        {!loading && fetchError && (
+          <div role="status" className="flex flex-col items-center gap-1.5 py-1 text-center">
+            <p className="text-xs text-stone-500">Couldn&apos;t load definition.</p>
+            <button
+              onClick={() => setRetryTick((t) => t + 1)}
+              className="text-xs px-2.5 py-1 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+        {!loading && !fetchError && (!def || def.definitions.length === 0) && (
           <p className="text-xs text-stone-600 italic">No definition found.</p>
         )}
         {!loading && def && def.definitions.length > 0 && (


### PR DESCRIPTION
## What changed

`VocabWordTooltip` in `components/VocabWordTooltip.tsx` had a silent `.catch(() => {})` on `getWordDefinition`. When the API call failed, the spinner cleared and the component showed **"No definition found."** — the same message shown when Wiktionary genuinely has no entry for the word.

This is the reading-flow version of the same pattern fixed in #2417 (vocabulary page `DefinitionSheet`). It is higher impact because it occurs when users tap words **while actively reading a book** — a core flow.

This PR adds:
- `fetchError` boolean state + `retryTick` counter  
- On failure: renders **"Couldn't load definition."** + a **Retry** button
- On success with empty definitions: unchanged "No definition found." message
- Resets `fetchError`, `loading`, and `def` before each attempt (including retries)

## Why

Silent failures in the reading flow leave users confused — they cannot tell whether the API failed or the word genuinely has no Wiktionary entry, and they have no way to recover without closing and reopening the tooltip.

## Test plan

- New: `VocabWordTooltipErrorState.test.tsx` — 4 RTL tests: error state on reject, retry re-fetches successfully, empty-result still shows "No definition found.", successful fetch shows content
- Updated: `VocabWordTooltip.test.tsx` — existing "shows 'No definition found' when API rejects" test updated to assert the new error UI instead
- Full frontend suite: 3862 tests passing

Closes #2419
