### PR TITLE
fix: show error state with retry on upload quota fetch failure (closes #2423)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -449,6 +449,8 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-30 | Vocabulary DefinitionSheet: replaced silent .catch() on getWordDefinition failure with error state — shows "Couldn't load definition" + Retry button instead of misleading "No definition found." (closes #2417) | app/vocabulary/page.tsx | #2418 |
 | 2026-04-30 | VocabWordTooltip (reader): replaced silent .catch() on getWordDefinition failure with error state — shows "Couldn't load definition" + Retry button instead of misleading "No definition found." in core reading flow (closes #2419) | components/VocabWordTooltip.tsx | #2420 |
 | 2026-04-30 | ReadingStats: replaced silent null return on fetch failure with error state — shows "Couldn't load reading stats" message and Retry button (closes #2412) | components/ReadingStats.tsx | #2413 |
+| 2026-04-30 | Reader vocab sidebar: replaced silent .catch() on getVocabulary failure with error state — shows "Couldn't load vocabulary" + Retry button instead of misleading "No vocabulary saved yet" (closes #2421) | app/reader/[bookId]/page.tsx | #2422 |
+| 2026-04-30 | Upload page: replaced silent getUploadQuota() failure with "Couldn't load quota" error state + Retry button — prevents misleading active upload zone when user may be at limit (closes #2423) | app/upload/page.tsx | #2424 |
 
 ---
 

--- a/frontend/src/__tests__/UploadPageQuotaErrorState.test.ts
+++ b/frontend/src/__tests__/UploadPageQuotaErrorState.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Source-level regression tests for upload page quota fetch error state (issue #2423).
+ */
+import fs from "fs";
+import path from "path";
+
+const SOURCE_PATH = path.resolve(__dirname, "../app/upload/page.tsx");
+const SOURCE = fs.readFileSync(SOURCE_PATH, "utf8");
+
+describe("Upload page — quota fetch error state (issue #2423)", () => {
+  it("declares quotaFetchError state", () => {
+    expect(SOURCE).toMatch(/quotaFetchError/);
+  });
+
+  it("declares quotaRetryTick state", () => {
+    expect(SOURCE).toMatch(/quotaRetryTick/);
+  });
+
+  it("sets quotaFetchError on getUploadQuota rejection (no silent .catch(() => {}))", () => {
+    const effectStart = SOURCE.indexOf("getUploadQuota");
+    expect(effectStart).toBeGreaterThan(0);
+    const effectEnd = SOURCE.indexOf("}, [status", effectStart);
+    const effectBlock = SOURCE.slice(effectStart, effectEnd + 50);
+
+    expect(effectBlock).toMatch(/setQuotaFetchError\s*\(\s*true\s*\)/);
+  });
+
+  it("renders error UI with retry when quotaFetchError is true", () => {
+    expect(SOURCE).toMatch(/Couldn(?:&apos;|')t load quota|[Ff]ailed to load quota|[Cc]ouldn(?:&apos;|')t load/);
+    expect(SOURCE).toMatch(/setQuotaRetryTick/);
+  });
+
+  it("error branch appears before the quota bar render", () => {
+    const errorIdx = SOURCE.indexOf("quotaFetchError");
+    const quotaBarIdx = SOURCE.indexOf("quota !== null");
+    expect(errorIdx).toBeGreaterThan(0);
+    expect(quotaBarIdx).toBeGreaterThan(0);
+    expect(errorIdx).toBeLessThan(quotaBarIdx);
+  });
+});

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -15,14 +15,17 @@ export default function UploadPage() {
   }, []);
 
   const [quota, setQuota] = useState<UploadQuota | null>(null);
+  const [quotaFetchError, setQuotaFetchError] = useState(false);
+  const [quotaRetryTick, setQuotaRetryTick] = useState(0);
   const [dragging, setDragging] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (status !== "authenticated") return;
-    getUploadQuota().then(setQuota).catch(() => {});
-  }, [status]);
+    setQuotaFetchError(false);
+    getUploadQuota().then(setQuota).catch(() => setQuotaFetchError(true));
+  }, [status, quotaRetryTick]);
 
   const handleFile = useCallback(
     async (file: File) => {
@@ -114,6 +117,19 @@ export default function UploadPage() {
       </header>
 
       <div className="max-w-2xl mx-auto px-4 md:px-6 py-8 space-y-6">
+
+        {/* Quota error */}
+        {quotaFetchError && (
+          <div role="status" className="flex items-center justify-between rounded-xl border border-amber-100 bg-white p-4">
+            <p className="text-sm text-stone-500">Couldn&apos;t load quota.</p>
+            <button
+              onClick={() => setQuotaRetryTick((t) => t + 1)}
+              className="text-xs px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+            >
+              Retry
+            </button>
+          </div>
+        )}
 
         {/* Quota bar */}
         {quota !== null && (


### PR DESCRIPTION
## What changed

`getUploadQuota().catch(() => {})` silently discarded API errors, leaving `quota` as `null`. When null, the quota bar is hidden and `quotaFull` evaluates to `false` — so the upload drop zone appears fully active even when the user may be at their limit. If they attempt an upload, they get a confusing server error instead of a clear message.

Added `quotaFetchError` and `quotaRetryTick` states. The upload page now shows "Couldn't load quota" + Retry in place of the quota bar when the fetch fails, so users know the limit status is unavailable.

## Why

Closes #2423. Part of the silent-failure audit: annotations (#2415), DefinitionSheet (#2418), VocabWordTooltip (#2420), ReadingStats (#2413), vocab sidebar (#2422), and now upload quota.

## Test plan

- [x] New regression test: `frontend/src/__tests__/UploadPageQuotaErrorState.test.ts` — 5 source-level assertions covering error state declaration, retry mechanism, error branch placement before quota bar, and no silent `.catch()`
- [x] Full frontend suite: 3876 tests pass

## Docs follow-up

Design changelog row added to `docs/design-improvement-plan.md`.
