### PR TITLE
fix: show retry button in TagEditor on initial tag fetch failure (closes #2426)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -451,7 +451,9 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-30 | ReadingStats: replaced silent null return on fetch failure with error state — shows "Couldn't load reading stats" message and Retry button (closes #2412) | components/ReadingStats.tsx | #2413 |
 | 2026-04-30 | Reader vocab sidebar: replaced silent .catch() on getVocabulary failure with error state — shows "Couldn't load vocabulary" + Retry button instead of misleading "No vocabulary saved yet" (closes #2421) | app/reader/[bookId]/page.tsx | #2422 |
 | 2026-04-30 | Upload page: replaced silent getUploadQuota() failure with "Couldn't load quota" error state + Retry button — prevents misleading active upload zone when user may be at limit (closes #2423) | app/upload/page.tsx | #2425 |
-| 2026-04-30 | Profile Obsidian settings: replaced silent .catch() on getObsidianSettings failure with error state — shows "Couldn't load Obsidian settings" + Retry button inside accordion so user knows load failed (closes #2424) | app/profile/page.tsx | — |
+| 2026-04-30 | Profile Obsidian settings: replaced silent .catch() on getObsidianSettings failure with error state — shows "Couldn't load Obsidian settings" + Retry button inside accordion so user knows load failed (closes #2424) | app/profile/page.tsx | #2428 |
+| 2026-04-30 | TagEditor: replaced silent .catch() on initial tag fetch with loadFailed state — shows Retry button instead of misleading empty tag list (closes #2426) | components/TagEditor.tsx | #2427 |
+| 2026-04-30 | Home page stats panel: replaced silent getUserStats() failure with inline "Couldn't load stats" error + Retry — panel no longer disappears invisibly on network error (closes #2429) | app/page.tsx | — |
 
 ---
 

--- a/frontend/src/__tests__/TagEditorLoadError.test.tsx
+++ b/frontend/src/__tests__/TagEditorLoadError.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * RTL tests for TagEditor load-failure error state (issue #2426).
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockGetVocabularyWordTags = jest.fn();
+jest.mock("@/lib/api", () => ({
+  getVocabularyWordTags: (...args: any[]) => mockGetVocabularyWordTags(...args),
+  addVocabularyWordTag: jest.fn(),
+  removeVocabularyWordTag: jest.fn(),
+}));
+
+import TagEditor from "@/components/TagEditor";
+
+const BASE = { vocabularyId: 42, selectedTag: null };
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("TagEditor — load failure error state (issue #2426)", () => {
+  it("shows retry button when initial tag fetch rejects", async () => {
+    mockGetVocabularyWordTags.mockRejectedValue(new Error("network error"));
+    render(<TagEditor {...BASE} />);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument()
+    );
+  });
+
+  it("does NOT show '+ tag' button when fetch failed (error state is shown instead)", async () => {
+    mockGetVocabularyWordTags.mockRejectedValue(new Error("network error"));
+    render(<TagEditor {...BASE} />);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument()
+    );
+    expect(screen.queryByRole("button", { name: /add tag/i })).not.toBeInTheDocument();
+  });
+
+  it("retries the fetch and shows tags on success after clicking Retry", async () => {
+    mockGetVocabularyWordTags
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockResolvedValueOnce(["fiction", "german"]);
+    render(<TagEditor {...BASE} />);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument()
+    );
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    await waitFor(() =>
+      expect(screen.getByText("fiction")).toBeInTheDocument()
+    );
+    expect(screen.getByText("german")).toBeInTheDocument();
+  });
+
+  it("shows tags normally when fetch succeeds", async () => {
+    mockGetVocabularyWordTags.mockResolvedValue(["novel", "classic"]);
+    render(<TagEditor {...BASE} />);
+    await waitFor(() => expect(screen.getByText("novel")).toBeInTheDocument());
+    expect(screen.getByText("classic")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/TagEditor.tsx
+++ b/frontend/src/components/TagEditor.tsx
@@ -21,6 +21,7 @@ export default function TagEditor({
 }: TagEditorProps) {
   const [tags, setTags] = useState<string[]>(initialTags ?? []);
   const [loaded, setLoaded] = useState(initialTags !== undefined);
+  const [loadFailed, setLoadFailed] = useState(false);
   const [draft, setDraft] = useState("");
   const [adding, setAdding] = useState(false);
   const [busy, setBusy] = useState<string | null>(null);
@@ -31,13 +32,16 @@ export default function TagEditor({
   useEffect(() => {
     if (loaded) return;
     let alive = true;
+    setLoadFailed(false);
     getVocabularyWordTags(vocabularyId)
       .then((list) => {
         if (!alive) return;
         setTags(list);
         onTagsChange?.(list);
       })
-      .catch(() => {})
+      .catch(() => {
+        if (alive) setLoadFailed(true);
+      })
       .finally(() => {
         if (alive) setLoaded(true);
       });
@@ -133,7 +137,16 @@ export default function TagEditor({
         </span>
       ))}
 
-      {adding ? (
+      {loadFailed ? (
+        <button
+          type="button"
+          onClick={() => setLoaded(false)}
+          aria-label="Retry loading tags"
+          className="inline-flex items-center gap-0.5 rounded-full border border-dashed border-red-300 px-2 py-0.5 min-h-[44px] md:min-h-0 text-xs text-red-600 hover:bg-red-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"
+        >
+          Retry
+        </button>
+      ) : adding ? (
         <input
           ref={inputRef}
           type="text"


### PR DESCRIPTION
## What changed

`TagEditor` previously silently swallowed fetch failures in its `useEffect` — if `getVocabularyWordTags` rejected, the component stayed empty with no signal to the user and no way to recover.

This PR adds a `loadFailed` boolean state. On rejection, it flips to `true` and renders a **Retry** button in place of the `+ tag` button. Clicking Retry sets `loaded = false`, which re-triggers the `useEffect`, which resets `loadFailed` before attempting again — no separate retry counter needed.

## Why

Users who encounter a network hiccup while opening vocabulary cards would see an empty tag chip area indistinguishable from "no tags set." The error state makes the failure visible and recoverable.

## Test plan

- 4 RTL tests in `frontend/src/__tests__/TagEditorLoadError.test.tsx`:
  - Retry button appears when initial fetch rejects
  - `+ tag` button absent while in error state
  - Retry re-fetches and shows tags on success
  - Normal success path renders tags without Retry

Closes #2426

## Docs follow-up
Changelog row added to `docs/design-improvement-plan.md`.
