### PR TITLE
fix: show error state with retry on Obsidian settings fetch failure (closes #2424)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -451,6 +451,7 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-30 | ReadingStats: replaced silent null return on fetch failure with error state — shows "Couldn't load reading stats" message and Retry button (closes #2412) | components/ReadingStats.tsx | #2413 |
 | 2026-04-30 | Reader vocab sidebar: replaced silent .catch() on getVocabulary failure with error state — shows "Couldn't load vocabulary" + Retry button instead of misleading "No vocabulary saved yet" (closes #2421) | app/reader/[bookId]/page.tsx | #2422 |
 | 2026-04-30 | Upload page: replaced silent getUploadQuota() failure with "Couldn't load quota" error state + Retry button — prevents misleading active upload zone when user may be at limit (closes #2423) | app/upload/page.tsx | #2425 |
+| 2026-04-30 | Profile Obsidian settings: replaced silent .catch() on getObsidianSettings failure with error state — shows "Couldn't load Obsidian settings" + Retry button inside accordion so user knows load failed (closes #2424) | app/profile/page.tsx | — |
 
 ---
 

--- a/frontend/src/__tests__/ProfileObsidianFetchError.test.ts
+++ b/frontend/src/__tests__/ProfileObsidianFetchError.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Source-level regression tests for profile page Obsidian settings fetch error (issue #2424).
+ */
+import fs from "fs";
+import path from "path";
+
+const SOURCE_PATH = path.resolve(__dirname, "../app/profile/page.tsx");
+const SOURCE = fs.readFileSync(SOURCE_PATH, "utf8");
+
+describe("Profile page — Obsidian settings fetch error state (issue #2424)", () => {
+  it("declares obsidianFetchError state", () => {
+    expect(SOURCE).toMatch(/obsidianFetchError/);
+  });
+
+  it("declares obsidianRetryTick state", () => {
+    expect(SOURCE).toMatch(/obsidianRetryTick/);
+  });
+
+  it("sets obsidianFetchError on getObsidianSettings rejection (no silent swallow)", () => {
+    // Find the Load Obsidian settings useEffect block
+    const effectStart = SOURCE.indexOf("// Load Obsidian settings");
+    expect(effectStart).toBeGreaterThan(0);
+    const effectEnd = SOURCE.indexOf("}, [session?.backendToken", effectStart);
+    const effectBlock = SOURCE.slice(effectStart, effectEnd + 80);
+    expect(effectBlock).toMatch(/setObsidianFetchError\s*\(\s*true\s*\)/);
+  });
+
+  it("renders error UI with retry when obsidianFetchError is true", () => {
+    expect(SOURCE).toMatch(/Couldn(?:&apos;|')t load|[Ff]ailed to load|[Ee]rror loading/);
+    expect(SOURCE).toMatch(/setObsidianRetryTick/);
+  });
+
+  it("obsidianRetryTick is included in the getObsidianSettings useEffect dependency array", () => {
+    const effectStart = SOURCE.indexOf("// Load Obsidian settings");
+    expect(effectStart).toBeGreaterThan(0);
+    const depsStart = SOURCE.indexOf("}, [session?.backendToken", effectStart);
+    const depsStr = SOURCE.slice(depsStart, depsStart + 80);
+    expect(depsStr).toMatch(/obsidianRetryTick/);
+  });
+});

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -39,6 +39,8 @@ export default function ProfilePage() {
   const [obsidianSaving, setObsidianSaving] = useState(false);
   const [obsidianMsg, setObsidianMsg] = useState<{ text: string; ok: boolean } | null>(null);
   const obsidianMsgTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [obsidianFetchError, setObsidianFetchError] = useState(false);
+  const [obsidianRetryTick, setObsidianRetryTick] = useState(0);
 
   // ── Preferences state ──────────────────────────────────────────────────────
   const [settings, setSettings] = useState<AppSettings>({
@@ -104,12 +106,13 @@ export default function ProfilePage() {
   // Load Obsidian settings
   useEffect(() => {
     if (!session?.backendToken) return;
+    setObsidianFetchError(false);
     getObsidianSettings().then((s) => {
       setObsidianRepo(s.obsidian_repo ?? "");
       setObsidianPath(s.obsidian_path ?? "All Notes/002 Literature Notes/000 Books");
       setHasObsidianToken(s.has_github_token ?? false);
-    }).catch(() => {});
-  }, [session?.backendToken]);
+    }).catch(() => setObsidianFetchError(true));
+  }, [session?.backendToken, obsidianRetryTick]);
 
   useEffect(() => {
     setSettings(getSettings());
@@ -379,6 +382,17 @@ export default function ProfilePage() {
           {/* Collapsible body */}
           {obsidianOpen && (
             <div id="obsidian-export-panel" role="region" aria-label="Obsidian export settings" className="px-6 pb-6 space-y-4 border-t border-amber-100">
+              {obsidianFetchError && (
+                <div role="status" className="flex items-center justify-between pt-4">
+                  <p className="text-sm text-stone-500">Couldn&apos;t load Obsidian settings.</p>
+                  <button
+                    onClick={() => setObsidianRetryTick((t) => t + 1)}
+                    className="text-xs px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+                  >
+                    Retry
+                  </button>
+                </div>
+              )}
               <div className="pt-4">
                 <div className="flex items-center justify-between mb-1">
                   <label htmlFor="obsidian-token" className="block text-sm font-medium text-ink">


### PR DESCRIPTION
## What changed

`profile/page.tsx` previously swallowed `getObsidianSettings()` fetch failures silently — the accordion body stayed blank with no user signal and no recovery path.

This PR adds `obsidianFetchError` + `obsidianRetryTick` states. On rejection the error flag flips and renders a "Couldn't load Obsidian settings" message with a **Retry** button inside the collapsible accordion body. Clicking Retry increments the tick, re-triggering the `useEffect`.

## Why

Users who hit a transient auth/network error while expanding the Obsidian accordion would see an empty form with no explanation — indistinguishable from "no settings configured". The error state makes the failure visible and recoverable without a full page reload.

## Test plan

5 source-level tests in `frontend/src/__tests__/ProfileObsidianFetchError.test.ts`:
- `obsidianFetchError` state declared
- `obsidianRetryTick` state declared
- `.catch()` sets `obsidianFetchError`
- Error UI with Retry button present in source
- `obsidianRetryTick` in useEffect dependency array

Closes #2424

## Docs follow-up
Changelog row added to `docs/design-improvement-plan.md`.
