### PR TITLE
fix: show error state with retry in home stats panel on fetch failure (closes #2429)

### DIFF
--- a/frontend/src/__tests__/DisclosureAriaControls.test.ts
+++ b/frontend/src/__tests__/DisclosureAriaControls.test.ts
@@ -24,7 +24,7 @@ describe("Disclosure button aria-controls (closes #2081)", () => {
     it("aria-controls and id appear near aria-expanded statsExpanded usage", () => {
       const idx = homeSrc.indexOf('aria-expanded={statsExpanded}');
       expect(idx).toBeGreaterThan(-1);
-      const window = homeSrc.slice(idx, idx + 3000);
+      const window = homeSrc.slice(idx, idx + 4000);
       expect(window).toContain('aria-controls="stats-activity-panel"');
       expect(window).toContain('id="stats-activity-panel"');
     });

--- a/frontend/src/__tests__/HomeStatsErrorState.test.ts
+++ b/frontend/src/__tests__/HomeStatsErrorState.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Source-level regression tests for home page stats fetch-error state (issue #2429).
+ * The page is too large to mount with RTL, so we verify the pattern via source inspection.
+ */
+import fs from "fs";
+import path from "path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "../app/page.tsx"),
+  "utf8"
+);
+
+describe("Home page — stats fetch-error state (issue #2429)", () => {
+  it("declares userStatsFetchError state", () => {
+    expect(SOURCE).toMatch(/userStatsFetchError/);
+  });
+
+  it("declares userStatsRetryTick state", () => {
+    expect(SOURCE).toMatch(/userStatsRetryTick/);
+  });
+
+  it("sets userStatsFetchError on getUserStats rejection", () => {
+    const catchIdx = SOURCE.indexOf("getUserStats()");
+    expect(catchIdx).toBeGreaterThan(-1);
+    const snippet = SOURCE.slice(catchIdx, catchIdx + 200);
+    expect(snippet).toMatch(/setUserStatsFetchError\(true\)/);
+  });
+
+  it("renders error UI with Retry button when fetch fails", () => {
+    expect(SOURCE).toMatch(/userStatsFetchError.*Couldn.*t load stats/s);
+  });
+
+  it("includes userStatsRetryTick in the useEffect dependency array", () => {
+    expect(SOURCE).toMatch(/userStatsRetryTick/);
+    const depsIdx = SOURCE.indexOf("userStatsRetryTick]");
+    expect(depsIdx).toBeGreaterThan(-1);
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -53,6 +53,8 @@ export default function Home() {
   // ── Library / Home state ──
   const [recentBooks, setRecentBooks] = useState<RecentBook[]>([]);
   const [userStats, setUserStats] = useState<UserStats | null>(null);
+  const [userStatsFetchError, setUserStatsFetchError] = useState(false);
+  const [userStatsRetryTick, setUserStatsRetryTick] = useState(0);
   const [statsExpanded, setStatsExpanded] = useState(false);
   const [removedBookToast, setRemovedBookToast] = useState<RecentBook | null>(null);
 
@@ -77,7 +79,8 @@ export default function Home() {
     getMe().then((me) => {
       setIsAdmin(me.role === "admin");
     }).catch(() => {});
-    getUserStats().then(setUserStats).catch(() => {});
+    setUserStatsFetchError(false);
+    getUserStats().then(setUserStats).catch(() => setUserStatsFetchError(true));
     getReadingProgress().then((entries) => {
       const local = getRecentBooks();
       let changed = false;
@@ -96,7 +99,7 @@ export default function Home() {
         setRecentBooks(merged);
       }
     }).catch(() => {});
-  }, [status]);
+  }, [status, userStatsRetryTick]);
 
   // ── Discover state ──
   const [query, setQuery] = useState("");
@@ -349,7 +352,7 @@ export default function Home() {
             )}
 
             {/* Stats strip */}
-            {status === "authenticated" && userStats && (
+            {status === "authenticated" && (userStats || userStatsFetchError) && (
               <section>
                 <div className="flex items-center gap-2 mb-3">
                   <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-600 flex-1">
@@ -365,44 +368,58 @@ export default function Home() {
                   </button>
                 </div>
 
-                <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-                  {userStats.streak > 0 && (
-                    <div className="bg-white rounded-xl border border-amber-100 px-4 py-3 flex items-center gap-3">
-                      <FireIcon className="w-5 h-5 text-amber-600 shrink-0" />
-                      <div>
-                        <p className="text-lg font-bold text-amber-900 leading-none">{userStats.streak}</p>
-                        <p className="text-[10px] text-stone-600 mt-0.5">day streak</p>
+                {userStatsFetchError ? (
+                  <div role="status" className="flex items-center justify-between rounded-xl border border-amber-100 bg-white px-4 py-3">
+                    <p className="text-sm text-stone-500">Couldn&apos;t load stats.</p>
+                    <button
+                      onClick={() => setUserStatsRetryTick((t) => t + 1)}
+                      className="text-xs px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+                    >
+                      Retry
+                    </button>
+                  </div>
+                ) : (
+                  <>
+                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                      {userStats!.streak > 0 && (
+                        <div className="bg-white rounded-xl border border-amber-100 px-4 py-3 flex items-center gap-3">
+                          <FireIcon className="w-5 h-5 text-amber-600 shrink-0" />
+                          <div>
+                            <p className="text-lg font-bold text-amber-900 leading-none">{userStats!.streak}</p>
+                            <p className="text-[10px] text-stone-600 mt-0.5">day streak</p>
+                          </div>
+                        </div>
+                      )}
+                      <div className="bg-white rounded-xl border border-amber-100 px-4 py-3 flex items-center gap-3">
+                        <BookOpenIcon className="w-5 h-5 text-amber-600 shrink-0" />
+                        <div>
+                          <p className="text-lg font-bold text-stone-800 leading-none">{userStats!.totals.books_started}</p>
+                          <p className="text-[10px] text-stone-600 mt-0.5">books started</p>
+                        </div>
+                      </div>
+                      <div className="bg-white rounded-xl border border-amber-100 px-4 py-3 flex items-center gap-3">
+                        <VocabIcon className="w-5 h-5 text-amber-600 shrink-0" />
+                        <div>
+                          <p className="text-lg font-bold text-stone-800 leading-none">{userStats!.totals.vocabulary_words}</p>
+                          <p className="text-[10px] text-stone-600 mt-0.5">words saved</p>
+                        </div>
+                      </div>
+                      <div className="bg-white rounded-xl border border-amber-100 px-4 py-3 flex items-center gap-3">
+                        <NoteIcon className="w-5 h-5 text-amber-600 shrink-0" />
+                        <div>
+                          <p className="text-lg font-bold text-stone-800 leading-none">{userStats!.totals.annotations}</p>
+                          <p className="text-[10px] text-stone-600 mt-0.5">annotations</p>
+                        </div>
                       </div>
                     </div>
-                  )}
-                  <div className="bg-white rounded-xl border border-amber-100 px-4 py-3 flex items-center gap-3">
-                    <BookOpenIcon className="w-5 h-5 text-amber-600 shrink-0" />
-                    <div>
-                      <p className="text-lg font-bold text-stone-800 leading-none">{userStats.totals.books_started}</p>
-                      <p className="text-[10px] text-stone-600 mt-0.5">books started</p>
-                    </div>
-                  </div>
-                  <div className="bg-white rounded-xl border border-amber-100 px-4 py-3 flex items-center gap-3">
-                    <VocabIcon className="w-5 h-5 text-amber-600 shrink-0" />
-                    <div>
-                      <p className="text-lg font-bold text-stone-800 leading-none">{userStats.totals.vocabulary_words}</p>
-                      <p className="text-[10px] text-stone-600 mt-0.5">words saved</p>
-                    </div>
-                  </div>
-                  <div className="bg-white rounded-xl border border-amber-100 px-4 py-3 flex items-center gap-3">
-                    <NoteIcon className="w-5 h-5 text-amber-600 shrink-0" />
-                    <div>
-                      <p className="text-lg font-bold text-stone-800 leading-none">{userStats.totals.annotations}</p>
-                      <p className="text-[10px] text-stone-600 mt-0.5">annotations</p>
-                    </div>
-                  </div>
-                </div>
 
-                {/* Collapsible full activity view */}
-                {statsExpanded && (
-                  <div id="stats-activity-panel" className="mt-4">
-                    <ReadingStats active heatmapOnly />
-                  </div>
+                    {/* Collapsible full activity view */}
+                    {statsExpanded && (
+                      <div id="stats-activity-panel" className="mt-4">
+                        <ReadingStats active heatmapOnly />
+                      </div>
+                    )}
+                  </>
                 )}
               </section>
             )}


### PR DESCRIPTION
## What changed

`app/page.tsx` called `getUserStats()` with a silent `.catch(() => {})`. On failure the `userStats` state stays `null`, and the entire "Your Progress" stats panel (streak, books started, vocabulary words, annotations) disappears from the home page with no explanation or recovery path.

This PR adds `userStatsFetchError` + `userStatsRetryTick` states. On rejection the panel shows "Couldn't load stats." with a **Retry** button inline where the stats normally appear. Clicking Retry increments the tick, re-triggering the useEffect. The section header ("Your Progress") stays visible so the user understands what failed.

Also widens the `DisclosureAriaControls` test window from 3000 → 4000 chars to accommodate the new error-state code added between the disclosure button and the collapsible panel.

## Why

Returning users see their streak and reading stats as the first thing on the home page. A network hiccup (auth expiry, backend restart) caused the entire stats section to silently vanish — indistinguishable from "no data." The error state makes the failure visible and recoverable.

## Test plan

5 source-level tests in `frontend/src/__tests__/HomeStatsErrorState.test.ts`:
- `userStatsFetchError` state declared
- `userStatsRetryTick` state declared
- `.catch()` sets `userStatsFetchError`
- Error UI with Retry button present in source
- `userStatsRetryTick` in useEffect dependency array

All 3891 frontend tests pass.

Closes #2429
