### PR TITLE
fix: show error state with retry in vocab tag filter on fetch failure (closes #2431)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -453,7 +453,8 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-30 | Upload page: replaced silent getUploadQuota() failure with "Couldn't load quota" error state + Retry button — prevents misleading active upload zone when user may be at limit (closes #2423) | app/upload/page.tsx | #2425 |
 | 2026-04-30 | Profile Obsidian settings: replaced silent .catch() on getObsidianSettings failure with error state — shows "Couldn't load Obsidian settings" + Retry button inside accordion so user knows load failed (closes #2424) | app/profile/page.tsx | #2428 |
 | 2026-04-30 | TagEditor: replaced silent .catch() on initial tag fetch with loadFailed state — shows Retry button instead of misleading empty tag list (closes #2426) | components/TagEditor.tsx | #2427 |
-| 2026-04-30 | Home page stats panel: replaced silent getUserStats() failure with inline "Couldn't load stats" error + Retry — panel no longer disappears invisibly on network error (closes #2429) | app/page.tsx | — |
+| 2026-04-30 | Home page stats panel: replaced silent getUserStats() failure with inline "Couldn't load stats" error + Retry — panel no longer disappears invisibly on network error (closes #2429) | app/page.tsx | #2430 |
+| 2026-04-30 | Vocabulary page tag filter: replaced silent listVocabularyTags() failure with inline "Couldn't load tags" error + Retry — filter strip no longer silently disappears (closes #2431) | app/vocabulary/page.tsx | — |
 
 ---
 

--- a/frontend/src/__tests__/VocabTagsFetchError.test.ts
+++ b/frontend/src/__tests__/VocabTagsFetchError.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Source-level regression tests for vocabulary page tag filter fetch-error state (issue #2431).
+ */
+import fs from "fs";
+import path from "path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8"
+);
+
+describe("Vocabulary page — tag filter fetch-error state (issue #2431)", () => {
+  it("declares tagsFetchError state", () => {
+    expect(SOURCE).toMatch(/tagsFetchError/);
+  });
+
+  it("declares tagsRetryTick state", () => {
+    expect(SOURCE).toMatch(/tagsRetryTick/);
+  });
+
+  it("sets tagsFetchError on listVocabularyTags rejection", () => {
+    const fetchIdx = SOURCE.indexOf("listVocabularyTags()");
+    expect(fetchIdx).toBeGreaterThan(-1);
+    const snippet = SOURCE.slice(fetchIdx, fetchIdx + 200);
+    expect(snippet).toMatch(/setTagsFetchError\(true\)/);
+  });
+
+  it("renders error UI with Retry button when fetch fails", () => {
+    expect(SOURCE).toMatch(/tagsFetchError.*Couldn.*t load tags/s);
+  });
+
+  it("includes tagsRetryTick in the useEffect dependency array", () => {
+    const depsIdx = SOURCE.indexOf("tagsRetryTick]");
+    expect(depsIdx).toBeGreaterThan(-1);
+  });
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -253,6 +253,8 @@ function VocabularyPageContent() {
   const [sortMode, setSortMode] = useState<SortMode>("alpha");
   const [activeWord, setActiveWord] = useState<{ word: string; lang: string | null } | null>(null);
   const [allTags, setAllTags] = useState<VocabTagSummary[]>([]);
+  const [tagsFetchError, setTagsFetchError] = useState(false);
+  const [tagsRetryTick, setTagsRetryTick] = useState(0);
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
   const [tagsByVocabId, setTagsByVocabId] = useState<Record<number, string[]>>({});
   const highlightRef = useRef<HTMLDivElement>(null);
@@ -276,10 +278,11 @@ function VocabularyPageContent() {
   }, [session?.backendToken]);
 
   useEffect(() => {
+    setTagsFetchError(false);
     listVocabularyTags()
       .then(setAllTags)
-      .catch(() => {});
-  }, [session?.backendToken]);
+      .catch(() => setTagsFetchError(true));
+  }, [session?.backendToken, tagsRetryTick]);
 
   useEffect(() => {
     if (!selectedTag || words.length === 0) return;
@@ -546,7 +549,19 @@ function VocabularyPageContent() {
           </div>
         )}
 
-        {!loading && words.length > 0 && allTags.length > 0 && (
+        {!loading && words.length > 0 && tagsFetchError && (
+          <div role="status" className="mb-6 flex items-center justify-between rounded-xl border border-amber-100 bg-white px-4 py-3">
+            <p className="text-sm text-stone-500">Couldn&apos;t load tags.</p>
+            <button
+              onClick={() => setTagsRetryTick((t) => t + 1)}
+              className="text-xs px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
+        {!loading && words.length > 0 && !tagsFetchError && allTags.length > 0 && (
           <div
             data-testid="tag-filter-bar"
             role="group"


### PR DESCRIPTION
## What changed

`app/vocabulary/page.tsx` called `listVocabularyTags()` with a silent `.catch(() => {})`. On failure `allTags` stays `[]` and the tag filter strip is silently hidden (it only renders when `allTags.length > 0`). Users who organize words with tags lose the ability to filter their vocabulary with no explanation.

This PR adds `tagsFetchError` + `tagsRetryTick` states. On rejection an inline "Couldn't load tags." message with a **Retry** button appears where the filter normally would. Clicking Retry increments the tick, re-triggering the useEffect.

## Why

The tag filter is a core vocabulary organization feature. A transient network error silently removing it leaves users confused about whether tags exist or why filtering isn't available.

## Test plan

5 source-level tests in `frontend/src/__tests__/VocabTagsFetchError.test.ts`:
- `tagsFetchError` state declared
- `tagsRetryTick` state declared
- `.catch()` sets `tagsFetchError`
- Error UI with Retry present in source
- `tagsRetryTick` in useEffect dependency array

All 3895 frontend tests pass.

Closes #2431
