### PR TITLE
fix: show inline error on annotation edit save failure (closes #2433)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -454,7 +454,8 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-30 | Profile Obsidian settings: replaced silent .catch() on getObsidianSettings failure with error state — shows "Couldn't load Obsidian settings" + Retry button inside accordion so user knows load failed (closes #2424) | app/profile/page.tsx | #2428 |
 | 2026-04-30 | TagEditor: replaced silent .catch() on initial tag fetch with loadFailed state — shows Retry button instead of misleading empty tag list (closes #2426) | components/TagEditor.tsx | #2427 |
 | 2026-04-30 | Home page stats panel: replaced silent getUserStats() failure with inline "Couldn't load stats" error + Retry — panel no longer disappears invisibly on network error (closes #2429) | app/page.tsx | #2430 |
-| 2026-04-30 | Vocabulary page tag filter: replaced silent listVocabularyTags() failure with inline "Couldn't load tags" error + Retry — filter strip no longer silently disappears (closes #2431) | app/vocabulary/page.tsx | — |
+| 2026-04-30 | Vocabulary page tag filter: replaced silent listVocabularyTags() failure with inline "Couldn't load tags" error + Retry — filter strip no longer silently disappears (closes #2431) | app/vocabulary/page.tsx | #2432 |
+| 2026-04-30 | Notes/[bookId]: annotation edit save failure now shows inline "Couldn't save — try again." error below Save/Cancel buttons instead of silently keeping edit open (closes #2433) | app/notes/[bookId]/page.tsx | — |
 
 ---
 

--- a/frontend/src/__tests__/AnnotationEditSaveError.test.ts
+++ b/frontend/src/__tests__/AnnotationEditSaveError.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Source-level regression tests for annotation edit save-error state (issue #2433).
+ */
+import fs from "fs";
+import path from "path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "../app/notes/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Notes page — annotation edit save-error state (issue #2433)", () => {
+  it("declares editSaveError state", () => {
+    expect(SOURCE).toMatch(/editSaveError/);
+  });
+
+  it("sets editSaveError true in saveEdit catch block", () => {
+    const saveIdx = SOURCE.indexOf("async function saveEdit");
+    expect(saveIdx).toBeGreaterThan(-1);
+    const snippet = SOURCE.slice(saveIdx, saveIdx + 400);
+    expect(snippet).toMatch(/setEditSaveError\(true\)/);
+  });
+
+  it("clears editSaveError at the start of saveEdit", () => {
+    const saveIdx = SOURCE.indexOf("async function saveEdit");
+    const snippet = SOURCE.slice(saveIdx, saveIdx + 400);
+    expect(snippet).toMatch(/setEditSaveError\(false\)/);
+  });
+
+  it("passes saveError prop to AnnotationCard", () => {
+    expect(SOURCE).toMatch(/saveError=\{editSaveError\}/);
+  });
+
+  it("renders error message when saveError is true in AnnotationCard", () => {
+    expect(SOURCE).toMatch(/saveError.*Couldn.*t save/s);
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -73,6 +73,7 @@ function AnnotationCard({
   bookLanguage,
   isEditing,
   editNote,
+  saveError,
   onEdit,
   onEditChange,
   onSave,
@@ -86,6 +87,7 @@ function AnnotationCard({
   bookLanguage: string;
   isEditing: boolean;
   editNote: string;
+  saveError: boolean;
   onEdit: () => void;
   onEditChange: (v: string) => void;
   onSave: () => void;
@@ -126,6 +128,11 @@ function AnnotationCard({
               Cancel
             </button>
           </div>
+          {saveError && (
+            <p role="alert" className="text-xs text-red-600">
+              Couldn&apos;t save — try again.
+            </p>
+          )}
         </div>
       ) : (
         ann.note_text && (
@@ -278,6 +285,7 @@ export default function BookNotesPage() {
   // Inline edit
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editNote, setEditNote] = useState("");
+  const [editSaveError, setEditSaveError] = useState(false);
 
   // Delete loading sets (still used for notes opened mid-delete)
   const [deletingAnns, setDeletingAnns] = useState<Set<number>>(new Set());
@@ -370,17 +378,21 @@ export default function BookNotesPage() {
 
   // Edit handlers
   function startEdit(ann: Annotation) {
+    setEditSaveError(false);
     setEditingId(ann.id);
     setEditNote(ann.note_text);
   }
 
   async function saveEdit() {
     if (editingId === null) return;
+    setEditSaveError(false);
     try {
       const updated = await updateAnnotation(editingId, { note_text: editNote });
       setAnnotations((prev) => prev.map((a) => (a.id === editingId ? { ...a, note_text: updated.note_text } : a)));
       setEditingId(null);
-    } catch { /* keep edit open on failure */ }
+    } catch {
+      setEditSaveError(true);
+    }
   }
 
   function handleDeleteAnnotation(id: number) {
@@ -438,10 +450,11 @@ export default function BookNotesPage() {
           bookLanguage={bookLanguage}
           isEditing={editingId === ann.id}
           editNote={editNote}
+          saveError={editSaveError}
           onEdit={() => startEdit(ann)}
           onEditChange={setEditNote}
           onSave={saveEdit}
-          onCancel={() => setEditingId(null)}
+          onCancel={() => { setEditSaveError(false); setEditingId(null); }}
           onDelete={() => handleDeleteAnnotation(ann.id)}
           isDeleting={deletingAnns.has(ann.id)}
         />


### PR DESCRIPTION
## What changed

When `updateAnnotation` rejects during an annotation edit save in `notes/[bookId]/page.tsx`, the edit form now shows an inline error message — **"Couldn't save — try again."** — below the Save/Cancel buttons. Previously the catch block silently kept the edit open (`/* keep edit open on failure */`) with zero user feedback, leaving users unable to tell whether the save was pending, failed, or succeeded.

**Changes:**
- Added `editSaveError` state (cleared on attempt/success/cancel/new-edit)
- `saveEdit()` sets `editSaveError(true)` on catch; clears it on every attempt start
- `startEdit()` and cancel handler both clear the error
- `AnnotationCard` gains a `saveError` prop; renders a `role="alert"` error message when true

## Why

Silent save failures are a misleading dead-end: the user has edited a note, clicked Save, and receives no feedback. They may navigate away thinking the save is pending, losing their edit. This completes the silent-failure audit sweep started in #2412.

## Test plan

- [x] 5 source-level regression tests in `AnnotationEditSaveError.test.ts` covering: state declaration, error set on catch, error cleared on attempt, `saveError` prop wiring, error message render
- [x] Full frontend suite: 3900 tests pass
- [x] Backend failures (97) are pre-existing on `main`, unrelated to this frontend-only change

Closes #2433
