### PR TITLE
fix: show error state on profile Gemini key status fetch failure (closes #2435)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -457,7 +457,7 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-30 | Vocabulary page tag filter: replaced silent listVocabularyTags() failure with inline "Couldn't load tags" error + Retry — filter strip no longer silently disappears (closes #2431) | app/vocabulary/page.tsx | #2432 |
 | 2026-04-30 | Notes/[bookId]: annotation edit save failure now shows inline "Couldn't save — try again." error below Save/Cancel buttons instead of silently keeping edit open (closes #2433) | app/notes/[bookId]/page.tsx | #2434 |
 | 2026-04-30 | Profile page: getMe() failure no longer silently shows key-input form to users who already have a Gemini key — shows "Couldn't load key status" + Retry instead (closes #2435) | app/profile/page.tsx | #2436 |
-| 2026-04-30 | Profile page: listDecks() failure now shows "Couldn't load study decks" + Retry in the decks section instead of silently hiding it (closes #2437) | app/profile/page.tsx | — |
+| 2026-04-30 | Profile page: listDecks() failure now shows "Couldn't load study decks" + Retry in the decks section instead of silently hiding it (closes #2437) | app/profile/page.tsx | #2438 |
 
 ---
 

--- a/frontend/src/__tests__/ProfileGeminiKeyFetchError.test.ts
+++ b/frontend/src/__tests__/ProfileGeminiKeyFetchError.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Source-level regression tests for profile page Gemini key fetch-error state (issue #2435).
+ */
+import fs from "fs";
+import path from "path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "../app/profile/page.tsx"),
+  "utf8"
+);
+
+describe("Profile page — Gemini key fetch-error state (issue #2435)", () => {
+  it("declares geminiKeyFetchError state", () => {
+    expect(SOURCE).toMatch(/geminiKeyFetchError/);
+  });
+
+  it("declares geminiKeyRetryTick state", () => {
+    expect(SOURCE).toMatch(/geminiKeyRetryTick/);
+  });
+
+  it("sets geminiKeyFetchError true in getMe catch block", () => {
+    const fetchIdx = SOURCE.indexOf("getMe()");
+    expect(fetchIdx).toBeGreaterThan(-1);
+    const snippet = SOURCE.slice(fetchIdx, fetchIdx + 300);
+    expect(snippet).toMatch(/setGeminiKeyFetchError\(true\)/);
+  });
+
+  it("clears geminiKeyFetchError before the fetch attempt", () => {
+    const fetchIdx = SOURCE.indexOf("getMe()");
+    const snippet = SOURCE.slice(Math.max(0, fetchIdx - 100), fetchIdx + 300);
+    expect(snippet).toMatch(/setGeminiKeyFetchError\(false\)/);
+  });
+
+  it("includes geminiKeyRetryTick in the useEffect dependency array", () => {
+    expect(SOURCE).toMatch(/geminiKeyRetryTick\]/);
+  });
+
+  it("renders error UI with Retry button when key fetch fails", () => {
+    expect(SOURCE).toMatch(/geminiKeyFetchError.*Couldn.*t load/s);
+  });
+});

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -25,6 +25,8 @@ export default function ProfilePage() {
   const [keyInput, setKeyInput] = useState("");
   const [hasKey, setHasKey] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
+  const [geminiKeyFetchError, setGeminiKeyFetchError] = useState(false);
+  const [geminiKeyRetryTick, setGeminiKeyRetryTick] = useState(0);
   const [savingKey, setSavingKey] = useState(false);
   const [removingKey, setRemovingKey] = useState(false);
   const [keyMessage, setKeyMessage] = useState<{ text: string; ok: boolean } | null>(null);
@@ -100,11 +102,12 @@ export default function ProfilePage() {
 
   // Fetch live key status from backend (session JWT can be stale after key changes)
   useEffect(() => {
+    setGeminiKeyFetchError(false);
     getMe().then((me) => {
       setHasKey(me.hasGeminiKey);
       setIsAdmin(me.role === "admin");
-    }).catch(() => {});
-  }, [session?.backendToken]);
+    }).catch(() => setGeminiKeyFetchError(true));
+  }, [session?.backendToken, geminiKeyRetryTick]);
 
   // Load Obsidian settings
   useEffect(() => {
@@ -327,7 +330,17 @@ export default function ProfilePage() {
             generous (1M tokens/day).
           </p>
 
-          {hasKey ? (
+          {geminiKeyFetchError ? (
+            <div role="status" className="flex items-center justify-between rounded-xl border border-amber-100 bg-white px-4 py-3">
+              <p className="text-sm text-stone-500">Couldn&apos;t load key status.</p>
+              <button
+                onClick={() => setGeminiKeyRetryTick((t) => t + 1)}
+                className="text-xs px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+              >
+                Retry
+              </button>
+            </div>
+          ) : hasKey ? (
             <div className="space-y-3">
               <div className="flex items-center gap-2 text-sm text-emerald-700 bg-emerald-50 border border-emerald-200 rounded-lg px-4 py-3">
                 <CheckIcon aria-hidden="true" className="w-4 h-4 shrink-0" />


### PR DESCRIPTION
## What changed

When `getMe()` rejects on the profile page, the Gemini key section no longer silently shows the API key input form — which falsely implies the user has no key configured. Instead it now shows an inline **"Couldn't load key status."** message with a Retry button.

**Changes:**
- Added `geminiKeyFetchError` + `geminiKeyRetryTick` states
- `useEffect` clears the error on each attempt and sets it on catch
- `geminiKeyRetryTick` added to the `useEffect` dependency array so the Retry button re-triggers the fetch
- Render: `geminiKeyFetchError → error+Retry | hasKey → key-active | else → key-input`

## Why

`hasKey` starts as `false`. If `getMe()` fails silently (network blip, stale token), users who already have a Gemini key see the "Enter your API key" input form — an actively misleading state that could cause them to re-enter their key unnecessarily or think their configuration was lost. This is the same silent-failure pattern fixed across the app in the audit sweep starting with #2412.

## Test plan

- [x] 6 source-level regression tests in `ProfileGeminiKeyFetchError.test.ts` covering: state declarations, error set on catch, error cleared on attempt, retry tick in deps, error message render
- [x] Full frontend suite: 3906 tests pass

Closes #2435
