### PR TITLE
fix: show error state when profile Study decks fetch fails (closes #2437)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -455,7 +455,9 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-30 | TagEditor: replaced silent .catch() on initial tag fetch with loadFailed state — shows Retry button instead of misleading empty tag list (closes #2426) | components/TagEditor.tsx | #2427 |
 | 2026-04-30 | Home page stats panel: replaced silent getUserStats() failure with inline "Couldn't load stats" error + Retry — panel no longer disappears invisibly on network error (closes #2429) | app/page.tsx | #2430 |
 | 2026-04-30 | Vocabulary page tag filter: replaced silent listVocabularyTags() failure with inline "Couldn't load tags" error + Retry — filter strip no longer silently disappears (closes #2431) | app/vocabulary/page.tsx | #2432 |
-| 2026-04-30 | Notes/[bookId]: annotation edit save failure now shows inline "Couldn't save — try again." error below Save/Cancel buttons instead of silently keeping edit open (closes #2433) | app/notes/[bookId]/page.tsx | — |
+| 2026-04-30 | Notes/[bookId]: annotation edit save failure now shows inline "Couldn't save — try again." error below Save/Cancel buttons instead of silently keeping edit open (closes #2433) | app/notes/[bookId]/page.tsx | #2434 |
+| 2026-04-30 | Profile page: getMe() failure no longer silently shows key-input form to users who already have a Gemini key — shows "Couldn't load key status" + Retry instead (closes #2435) | app/profile/page.tsx | #2436 |
+| 2026-04-30 | Profile page: listDecks() failure now shows "Couldn't load study decks" + Retry in the decks section instead of silently hiding it (closes #2437) | app/profile/page.tsx | — |
 
 ---
 

--- a/frontend/src/__tests__/ProfileDecksFetchError.test.ts
+++ b/frontend/src/__tests__/ProfileDecksFetchError.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Source-level regression tests for profile page Study decks fetch-error state (issue #2437).
+ */
+import fs from "fs";
+import path from "path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "../app/profile/page.tsx"),
+  "utf8"
+);
+
+describe("Profile page — Study decks fetch-error state (issue #2437)", () => {
+  it("declares decksFetchError state", () => {
+    expect(SOURCE).toMatch(/decksFetchError/);
+  });
+
+  it("declares decksRetryTick state", () => {
+    expect(SOURCE).toMatch(/decksRetryTick/);
+  });
+
+  it("sets decksFetchError true in listDecks catch block", () => {
+    const fetchIdx = SOURCE.indexOf("listDecks()");
+    expect(fetchIdx).toBeGreaterThan(-1);
+    const snippet = SOURCE.slice(fetchIdx, fetchIdx + 300);
+    expect(snippet).toMatch(/setDecksFetchError\(true\)/);
+  });
+
+  it("includes decksRetryTick in the useEffect dependency array", () => {
+    expect(SOURCE).toMatch(/decksRetryTick\]/);
+  });
+
+  it("renders error UI with Retry button when decks fetch fails", () => {
+    expect(SOURCE).toMatch(/decksFetchError.*Couldn.*t load/s);
+  });
+});

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -62,6 +62,8 @@ export default function ProfilePage() {
   // ── Study decks (decks with due cards today) ───────────────────────────────
   const [decks, setDecks] = useState<DeckSummary[]>([]);
   const [decksLoading, setDecksLoading] = useState(true);
+  const [decksFetchError, setDecksFetchError] = useState(false);
+  const [decksRetryTick, setDecksRetryTick] = useState(0);
 
   useEffect(() => {
     document.title = "Profile — Book Reader AI";
@@ -69,12 +71,13 @@ export default function ProfilePage() {
 
   useEffect(() => {
     let alive = true;
+    setDecksFetchError(false);
     listDecks()
       .then((d) => {
         if (alive) setDecks(d);
       })
       .catch(() => {
-        // Swallow — section just hides
+        if (alive) setDecksFetchError(true);
       })
       .finally(() => {
         if (alive) setDecksLoading(false);
@@ -82,7 +85,7 @@ export default function ProfilePage() {
     return () => {
       alive = false;
     };
-  }, []);
+  }, [decksRetryTick]);
 
   function gotoFlashcardsForDeck(deckId: number) {
     try {
@@ -250,7 +253,19 @@ export default function ProfilePage() {
         </section>
 
         {/* ── Study decks (due today) ──────────────────────────────────── */}
-        {decksLoading ? (
+        {decksFetchError ? (
+          <section className="bg-white rounded-2xl border border-amber-100 p-6">
+            <div role="status" className="flex items-center justify-between">
+              <p className="text-sm text-stone-500">Couldn&apos;t load study decks.</p>
+              <button
+                onClick={() => { setDecksLoading(true); setDecksRetryTick((t) => t + 1); }}
+                className="text-xs px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+              >
+                Retry
+              </button>
+            </div>
+          </section>
+        ) : decksLoading ? (
           <section
             role="status"
             aria-label="Loading study decks"


### PR DESCRIPTION
## What changed

When `listDecks()` fails on the profile page, the Study decks section now shows **"Couldn't load study decks."** with a Retry button instead of silently disappearing. Previously, the `.catch()` swallowed the error (`// Swallow — section just hides`), left `decks` as `[]`, and cleared the loading state — causing the entire section to vanish for users who have due flashcards.

**Changes:**
- Added `decksFetchError` + `decksRetryTick` states
- `useEffect` clears error on attempt, sets it on catch
- `decksRetryTick` added to `useEffect` dependency array; Retry button increments it and resets the loading state
- Render: `decksFetchError → error+Retry | decksLoading → skeleton | dueDecks.length > 0 → deck list | else → nothing`

## Why

Users who have study decks with due cards rely on the profile page to see their "Study decks" reminder and navigate to flashcard review. When `listDecks()` fails, the section silently disappears — they see nothing where they expected prompts, with no indication of failure. This continues the silent-failure audit sweep (#2412 series).

## Test plan

- [x] 5 source-level regression tests in `ProfileDecksFetchError.test.ts`: state declarations, error set on catch, retry tick in deps, error message render
- [x] Full frontend suite: 3910 tests pass

Closes #2437
