### PR TITLE
fix: show error state when flashcards deck selector fetch fails (closes #2439)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -458,6 +458,7 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-30 | Notes/[bookId]: annotation edit save failure now shows inline "Couldn't save — try again." error below Save/Cancel buttons instead of silently keeping edit open (closes #2433) | app/notes/[bookId]/page.tsx | #2434 |
 | 2026-04-30 | Profile page: getMe() failure no longer silently shows key-input form to users who already have a Gemini key — shows "Couldn't load key status" + Retry instead (closes #2435) | app/profile/page.tsx | #2436 |
 | 2026-04-30 | Profile page: listDecks() failure now shows "Couldn't load study decks" + Retry in the decks section instead of silently hiding it (closes #2437) | app/profile/page.tsx | #2438 |
+| 2026-04-30 | Flashcards page: listDecks() failure now shows "Couldn't load decks" + Retry instead of silently removing the deck selector (closes #2439) | app/vocabulary/flashcards/page.tsx | #2440 |
 
 ---
 

--- a/frontend/src/__tests__/FlashcardsDecksFetchError.test.ts
+++ b/frontend/src/__tests__/FlashcardsDecksFetchError.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Source-level regression tests for flashcards page deck selector fetch-error state (issue #2439).
+ */
+import fs from "fs";
+import path from "path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "../app/vocabulary/flashcards/page.tsx"),
+  "utf8"
+);
+
+describe("Flashcards page — deck selector fetch-error state (issue #2439)", () => {
+  it("declares decksFetchError state", () => {
+    expect(SOURCE).toMatch(/decksFetchError/);
+  });
+
+  it("declares decksRetryTick state", () => {
+    expect(SOURCE).toMatch(/decksRetryTick/);
+  });
+
+  it("sets decksFetchError true in listDecks catch block", () => {
+    const fetchIdx = SOURCE.indexOf("listDecks()");
+    expect(fetchIdx).toBeGreaterThan(-1);
+    const snippet = SOURCE.slice(fetchIdx, fetchIdx + 600);
+    expect(snippet).toMatch(/setDecksFetchError\(true\)/);
+  });
+
+  it("includes decksRetryTick in the useEffect dependency array", () => {
+    expect(SOURCE).toMatch(/decksRetryTick\]/);
+  });
+
+  it("renders error UI with Retry button when deck fetch fails", () => {
+    expect(SOURCE).toMatch(/decksFetchError.*Couldn.*t load/s);
+  });
+});

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -55,6 +55,8 @@ export default function FlashcardsPage() {
   const [submitting, setSubmitting] = useState(false);
   const [done, setDone] = useState(false);
   const [decks, setDecks] = useState<DeckSummary[]>([]);
+  const [decksFetchError, setDecksFetchError] = useState(false);
+  const [decksRetryTick, setDecksRetryTick] = useState(0);
   // Initialize from localStorage synchronously so loadData fires once with the saved deck,
   // avoiding a second setLoading(true) cycle that would briefly hide the deck selector.
   const [selectedDeckId, setSelectedDeckId] = useState<number | undefined>(() => readLastDeckId());
@@ -87,6 +89,7 @@ export default function FlashcardsPage() {
   useEffect(() => {
     if (status !== "authenticated") return;
     let alive = true;
+    setDecksFetchError(false);
     listDecks()
       .then((d) => {
         if (!alive) return;
@@ -98,11 +101,11 @@ export default function FlashcardsPage() {
           setSelectedDeckId(undefined);
         }
       })
-      .catch(() => {});
+      .catch(() => { if (alive) setDecksFetchError(true); });
     return () => {
       alive = false;
     };
-  }, [status]);
+  }, [status, decksRetryTick]);
 
   // Update page title (WCAG 2.4.2)
   useEffect(() => {
@@ -190,7 +193,18 @@ export default function FlashcardsPage() {
         </div>
 
         {/* Deck selector */}
-        {decks.length > 0 && (
+        {decksFetchError && (
+          <div role="status" className="flex items-center justify-between rounded-lg border border-amber-100 bg-white px-3 py-2">
+            <p className="text-xs text-stone-500">Couldn&apos;t load decks.</p>
+            <button
+              onClick={() => setDecksRetryTick((t) => t + 1)}
+              className="text-xs px-2 py-1 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+        {!decksFetchError && decks.length > 0 && (
           <div className="flex items-center gap-2">
             <label
               htmlFor="flashcards-deck-select"


### PR DESCRIPTION
## What changed

When `listDecks()` fails on the flashcards page, the deck filter area now shows **"Couldn't load decks."** with a Retry button instead of silently hiding the selector. Previously the `.catch(() => {})` swallowed the error, `decks` stayed `[]`, and the selector never rendered — users studying specific decks had no way to know filtering was unavailable due to a network error.

**Changes:**
- Added `decksFetchError` + `decksRetryTick` states
- `useEffect` clears error on each attempt, sets it on catch
- `decksRetryTick` added to `useEffect` dep array; Retry button increments it
- Render: `decksFetchError → error+Retry | decks.length > 0 → selector | else → nothing`

## Why

Users who regularly filter flashcard review to a specific deck (e.g., "French verbs" only) rely on the deck selector being visible. When `listDecks()` fails silently, the entire filter control disappears — they fall back to "All decks" unknowingly. This is the same silent-disappear pattern fixed in the profile Study decks section (#2437/#2438).

## Test plan

- [x] 5 source-level regression tests in `FlashcardsDecksFetchError.test.ts`: state declarations, error set on catch (600-char window), retry tick in deps, error message render
- [x] Full frontend suite: 3915 tests pass

Closes #2439
