### PR TITLE
fix: hide admin action buttons when getMe() fails to prevent accidental self-delete (closes #2441)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -459,6 +459,7 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-30 | Profile page: getMe() failure no longer silently shows key-input form to users who already have a Gemini key — shows "Couldn't load key status" + Retry instead (closes #2435) | app/profile/page.tsx | #2436 |
 | 2026-04-30 | Profile page: listDecks() failure now shows "Couldn't load study decks" + Retry in the decks section instead of silently hiding it (closes #2437) | app/profile/page.tsx | #2438 |
 | 2026-04-30 | Flashcards page: listDecks() failure now shows "Couldn't load decks" + Retry instead of silently removing the deck selector (closes #2439) | app/vocabulary/flashcards/page.tsx | #2440 |
+| 2026-04-30 | Admin users page: getMe() failure no longer silently exposes own Revoke/Delete buttons — hides all action buttons and shows "Couldn't verify identity" + Retry (closes #2441) | app/admin/users/page.tsx | #2442 |
 
 ---
 

--- a/frontend/src/__tests__/AdminUsersGetMeError.test.ts
+++ b/frontend/src/__tests__/AdminUsersGetMeError.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Source-level regression tests for admin users page getMe() fetch-error state (issue #2441).
+ */
+import fs from "fs";
+import path from "path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "../app/admin/users/page.tsx"),
+  "utf8"
+);
+
+describe("Admin users page — getMe() fetch-error state (issue #2441)", () => {
+  it("declares myIdFetchFailed state", () => {
+    expect(SOURCE).toMatch(/myIdFetchFailed/);
+  });
+
+  it("sets myIdFetchFailed true in getMe catch block", () => {
+    const fetchIdx = SOURCE.indexOf("getMe()");
+    expect(fetchIdx).toBeGreaterThan(-1);
+    const snippet = SOURCE.slice(fetchIdx, fetchIdx + 300);
+    expect(snippet).toMatch(/setMyIdFetchFailed\(true\)/);
+  });
+
+  it("hides action buttons when myIdFetchFailed is true", () => {
+    expect(SOURCE).toMatch(/myIdFetchFailed/);
+    // Action buttons should be conditional on identity being known
+    expect(SOURCE).toMatch(/myIdFetchFailed.*Couldn/s);
+  });
+
+  it("renders a Retry button when identity fetch fails", () => {
+    expect(SOURCE).toMatch(/myIdFetchFailed.*Retry/s);
+  });
+
+  it("retries getMe on retry click", () => {
+    expect(SOURCE).toMatch(/myIdRetryTick/);
+  });
+});

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -17,14 +17,12 @@ interface User {
 export default function UsersPage() {
   const [users, setUsers] = useState<User[]>([]);
   const [myId, setMyId] = useState<number | null>(null);
+  const [myIdFetchFailed, setMyIdFetchFailed] = useState(false);
+  const [myIdRetryTick, setMyIdRetryTick] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [actError, setActError] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] = useState<number | null>(null);
-
-  useEffect(() => {
-    document.title = "Admin: Users — Book Reader AI";
-  }, []);
 
   useEffect(() => {
     document.title = "Admin: Users — Book Reader AI";
@@ -43,9 +41,12 @@ export default function UsersPage() {
   }, []);
 
   useEffect(() => {
-    getMe().then((me) => setMyId(me.id)).catch(() => {});
+    setMyIdFetchFailed(false);
+    getMe()
+      .then((me) => setMyId(me.id))
+      .catch(() => setMyIdFetchFailed(true));
     load();
-  }, [load]);
+  }, [load, myIdRetryTick]);
 
   async function act(fn: () => Promise<unknown>) {
     try {
@@ -92,6 +93,18 @@ export default function UsersPage() {
         </div>
       )}
 
+      {myIdFetchFailed && (
+        <div role="status" className="flex items-center justify-between rounded-lg border border-amber-100 bg-white px-3 py-2 mb-2">
+          <p className="text-xs text-stone-500">Couldn&apos;t verify your identity — action buttons hidden.</p>
+          <button
+            type="button"
+            onClick={() => setMyIdRetryTick((t) => t + 1)}
+            className="text-xs px-2 py-1 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+          >
+            Retry
+          </button>
+        </div>
+      )}
       <ul role="list" aria-label="Users" className="bg-white rounded-xl border border-amber-200 divide-y divide-amber-100 overflow-hidden list-none p-0 m-0">
         {users.map((u) => (
           <li key={u.id} className="px-4 py-3 flex items-center gap-3">
@@ -114,7 +127,7 @@ export default function UsersPage() {
               </div>
               <p className="text-xs text-stone-600 truncate" title={u.email}>{u.email}</p>
             </div>
-            {u.id !== myId && (
+            {!myIdFetchFailed && u.id !== myId && (
               <div className="flex gap-1 items-center">
                 <button
                   onClick={() =>
@@ -168,7 +181,7 @@ export default function UsersPage() {
                 )}
               </div>
             )}
-            {u.id === myId && <span className="text-xs text-stone-600">You</span>}
+            {!myIdFetchFailed && u.id === myId && <span className="text-xs text-stone-600">You</span>}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## What changed

`frontend/src/app/admin/users/page.tsx`: `getMe()` previously swallowed errors with `.catch(() => {})`, leaving `myId` as `null`. Since `u.id !== null` is always true, every user row showed Revoke/Delete buttons including the admin's own account — and the "You" label never appeared.

**Fix:**
- Added `myIdFetchFailed` (boolean) and `myIdRetryTick` (counter) states
- On catch: `setMyIdFetchFailed(true)` instead of silent no-op
- Before each fetch attempt: `setMyIdFetchFailed(false)`
- Added `myIdRetryTick` to `useEffect` dep array so Retry re-fetches
- Action buttons now only render when `!myIdFetchFailed && u.id !== myId`
- When identity unknown: shows "Couldn't verify your identity — action buttons hidden" banner with Retry

## Why

Prevents an admin from accidentally revoking or deleting their own account when the identity fetch fails transiently. The banner makes the degraded state visible rather than silently removing the safety guard.

## Test plan

- [x] `AdminUsersGetMeError.test.ts` — 5 source-level regression tests
- [x] Full frontend suite: 3921 tests pass
- [x] Full backend suite: passes

Closes #2441
