### PR TITLE
fix: add role=status to reader translation queue and login-required banners (WCAG 4.1.3) (closes #2445)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -461,6 +461,7 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-30 | Flashcards page: listDecks() failure now shows "Couldn't load decks" + Retry instead of silently removing the deck selector (closes #2439) | app/vocabulary/flashcards/page.tsx | #2440 |
 | 2026-04-30 | Admin users page: getMe() failure no longer silently exposes own Revoke/Delete buttons — hides all action buttons and shows "Couldn't verify identity" + Retry (closes #2441) | app/admin/users/page.tsx | #2442 |
 | 2026-04-30 | Reader page: notifyAIUsed now uses strict `=== false` check so Gemini key reminder doesn't fire on transient getMe() failure when hasGeminiKey is null (closes #2443) | app/reader/[bookId]/page.tsx | #2444 |
+| 2026-04-30 | Reader page: added role="status" to translation queue and login-required banners so screen readers announce them (WCAG 4.1.3, closes #2445) | app/reader/[bookId]/page.tsx | #2446 |
 
 ---
 

--- a/frontend/src/__tests__/ReaderBannerRoleStatus.test.ts
+++ b/frontend/src/__tests__/ReaderBannerRoleStatus.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Source-level regression tests for reader translation queue and login-required
+ * banners missing role="status" (issue #2445 — WCAG 4.1.3).
+ */
+import fs from "fs";
+import path from "path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Reader page — dynamic banners must have role=status (issue #2445)", () => {
+  it("translation queue banner has role=status", () => {
+    // Find the translation queue banner region
+    const idx = SOURCE.indexOf("Translation queued");
+    expect(idx).toBeGreaterThan(-1);
+    // role="status" must appear within 350 chars before the text
+    const context = SOURCE.slice(Math.max(0, idx - 350), idx + 50);
+    expect(context).toMatch(/role="status"/);
+  });
+
+  it("login required banner has role=status", () => {
+    const idx = SOURCE.indexOf("login required");
+    expect(idx).toBeGreaterThan(-1);
+    // Find the rendered banner text (not the state value comparison)
+    const loginBannerIdx = SOURCE.indexOf("Translation requires an account");
+    expect(loginBannerIdx).toBeGreaterThan(-1);
+    const context = SOURCE.slice(Math.max(0, loginBannerIdx - 200), loginBannerIdx + 50);
+    expect(context).toMatch(/role="status"/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1381,7 +1381,7 @@ export default function ReaderPage() {
         translationLoading &&
         translationUsedProvider &&
         translationUsedProvider.startsWith("queue") && (
-          <div className="bg-sky-50 border-b border-sky-200 px-4 py-2 text-xs text-sky-800 flex items-center gap-2">
+          <div role="status" className="bg-sky-50 border-b border-sky-200 px-4 py-2 text-xs text-sky-800 flex items-center gap-2">
             <span className="inline-block w-1.5 h-1.5 bg-sky-500 rounded-full animate-pulse" aria-hidden="true" />
             <span>
               <strong>Translation queued</strong> — {translationUsedProvider}.
@@ -1393,7 +1393,7 @@ export default function ReaderPage() {
 
       {/* Login required notice — shown when translation is not cached and user is not logged in */}
       {translationEnabled && translationUsedProvider === "login required" && (
-        <div className="bg-amber-50 border-b border-amber-300 px-4 py-2 text-xs text-amber-800 flex items-center gap-2">
+        <div role="status" className="bg-amber-50 border-b border-amber-300 px-4 py-2 text-xs text-amber-800 flex items-center gap-2">
           <span>
             Translation requires an account.{" "}
             <a href="/api/auth/signin" className="underline font-medium hover:text-amber-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded">


### PR DESCRIPTION
## What changed

`frontend/src/app/reader/[bookId]/page.tsx`: added `role="status"` to two dynamically-shown notification banners:

1. **Translation queue banner** — appears when a chapter is queued for background translation
2. **Login required banner** — appears when translation is blocked for unauthenticated users

Both banners appear and disappear as `translationLoading` / `translationUsedProvider` state changes — exactly the scenario WCAG 4.1.3 (Status Messages) requires `role="status"` for. Without it, screen readers using JAWS/NVDA/VoiceOver never announce these banners.

## Why

WCAG 4.1.3 compliance: status messages that are injected dynamically must be in a live region (`role="status"` or `aria-live`) so assistive technologies announce them without requiring focus to move to the element.

## Test plan

- [x] `ReaderBannerRoleStatus.test.ts` — 2 source-level tests verifying `role="status"` on both banners
- [x] Full frontend suite: 3928 tests pass
- [x] Full backend suite: passes

Closes #2445
