### PR TITLE
fix: replace router.push nav buttons with Link elements in home page tab bar (closes #2447)

### DIFF
--- a/frontend/src/__tests__/HomeNavLinks.test.ts
+++ b/frontend/src/__tests__/HomeNavLinks.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Regression tests for issue #2447 — home page nav bar items (Upload, Notes,
+ * Vocabulary, Admin) must be <Link> elements, not <button> with router.push,
+ * so they support Ctrl+Click / middle-click and announce as "link" to screen readers.
+ */
+import fs from "fs";
+import path from "path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "../app/page.tsx"),
+  "utf8"
+);
+
+describe("Home page nav bar — routing items must be Link elements (issue #2447)", () => {
+  it("Upload nav item uses Link href=/upload, not button+router.push", () => {
+    // Should NOT have button with router.push("/upload")
+    expect(SOURCE).not.toMatch(/router\.push\(["'`]\/upload["'`]\)/);
+    // Should have Link href="/upload"
+    expect(SOURCE).toMatch(/href=["'`]\/upload["'`]/);
+  });
+
+  it("Your Notes nav item uses Link href=/notes, not button+router.push", () => {
+    // The /notes route link should not be a router.push
+    expect(SOURCE).not.toMatch(/router\.push\(["'`]\/notes["'`]\)/);
+    expect(SOURCE).toMatch(/href=["'`]\/notes["'`]/);
+  });
+
+  it("Vocabulary nav item uses Link href=/vocabulary, not button+router.push", () => {
+    expect(SOURCE).not.toMatch(/router\.push\(["'`]\/vocabulary["'`]\)/);
+    expect(SOURCE).toMatch(/href=["'`]\/vocabulary["'`]/);
+  });
+
+  it("Admin nav item uses Link href=/admin, not button+router.push", () => {
+    expect(SOURCE).not.toMatch(/router\.push\(["'`]\/admin["'`]\)/);
+    expect(SOURCE).toMatch(/href=["'`]\/admin["'`]/);
+  });
+});

--- a/frontend/src/__tests__/HomePage.branches.test.tsx
+++ b/frontend/src/__tests__/HomePage.branches.test.tsx
@@ -337,21 +337,18 @@ describe("HomePage — getPopularBooks error (line 116)", () => {
 // ── Line 216: "Your Notes" tab navigates to /notes ───────────────────────────
 
 describe("HomePage — Your Notes tab (line 216)", () => {
-  it("navigates to /notes when Your Notes tab is clicked", async () => {
+  it("Your Notes link has href /notes", async () => {
     mockUseSession.mockReturnValue({
       data: { backendToken: "tok", backendUser: { id: 1, name: "User", picture: "" } },
       status: "authenticated",
     });
     mockGetReadingProgress.mockResolvedValue([]);
 
-    const user = userEvent.setup();
     render(<Home />);
     await act(flushPromises);
 
-    const notesTab = screen.getByRole("button", { name: "Your Notes" });
-    await user.click(notesTab);
-
-    expect(mockPush).toHaveBeenCalledWith("/notes");
+    const notesLink = screen.getByRole("link", { name: "Your Notes" });
+    expect(notesLink).toHaveAttribute("href", "/notes");
   });
 });
 

--- a/frontend/src/__tests__/HomePage.test.tsx
+++ b/frontend/src/__tests__/HomePage.test.tsx
@@ -198,19 +198,18 @@ describe("HomePage — signed-in state", () => {
 
   it("shows 'Your Notes' tab when authenticated", async () => {
     await renderHome();
-    expect(screen.getByRole("button", { name: "Your Notes" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Your Notes" })).toBeInTheDocument();
   });
 
   it("shows 'Your Word List' tab when authenticated", async () => {
     await renderHome();
-    expect(screen.getByRole("button", { name: "Your Word List" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Your Word List" })).toBeInTheDocument();
   });
 
   it("navigates to /vocabulary when 'Your Word List' is clicked", async () => {
-    const user = userEvent.setup();
     await renderHome();
-    await user.click(screen.getByRole("button", { name: "Your Word List" }));
-    expect(mockPush).toHaveBeenCalledWith("/vocabulary");
+    const link = screen.getByRole("link", { name: "Your Word List" });
+    expect(link).toHaveAttribute("href", "/vocabulary");
   });
 
   it("calls getMe and getReadingProgress on mount", async () => {
@@ -234,15 +233,13 @@ describe("HomePage — signed-in state", () => {
     expect(screen.queryByTestId("admin-tab")).not.toBeInTheDocument();
   });
 
-  it("clicking Admin tab navigates to /admin", async () => {
+  it("Admin tab has href /admin", async () => {
     mockGetMe.mockResolvedValue({ hasGeminiKey: true, role: "admin", approved: true });
-    const user = userEvent.setup();
     await renderHome();
     await waitFor(() => {
       expect(screen.queryByTestId("admin-tab")).toBeInTheDocument();
     });
-    await user.click(screen.getByTestId("admin-tab"));
-    expect(mockPush).toHaveBeenCalledWith("/admin");
+    expect(screen.getByTestId("admin-tab")).toHaveAttribute("href", "/admin");
   });
 });
 

--- a/frontend/src/__tests__/HomepageFocusRings.test.ts
+++ b/frontend/src/__tests__/HomepageFocusRings.test.ts
@@ -36,8 +36,8 @@ describe("Homepage tab bar focus rings (closes #2193)", () => {
     expect(window).toContain("focus-visible:ring-amber-400");
   });
 
-  it("Upload tab button has focus ring", () => {
-    const idx = src.indexOf("router.push(\"/upload\")");
+  it("Upload nav link has focus ring", () => {
+    const idx = src.indexOf("href=\"/upload\"");
     expect(idx).toBeGreaterThan(-1);
     const window = src.slice(idx, idx + 300);
     expect(window).toContain("focus-visible:ring-amber-400");

--- a/frontend/src/__tests__/HomepageNavCtaTouchTargets.test.ts
+++ b/frontend/src/__tests__/HomepageNavCtaTouchTargets.test.ts
@@ -18,12 +18,12 @@ describe("Home page tab-nav and CTA touch targets (closes #853)", () => {
     checkAround("setTab(key)");
   });
 
-  it("Upload tab button has min-h-[44px]", () => {
-    checkAround('router.push("/upload")');
+  it("Upload nav link has min-h-[44px]", () => {
+    checkAround('href="/upload"');
   });
 
-  it("Notes tab button has min-h-[44px]", () => {
-    checkAround('router.push("/notes")');
+  it("Notes nav link has min-h-[44px]", () => {
+    checkAround('href="/notes"');
   });
 
   it("Discover Books CTA has min-h-[44px]", () => {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -9,6 +9,7 @@ import ReadingStats from "@/components/ReadingStats";
 import { FireIcon, ArrowLeftIcon, ArrowRightIcon, BookOpenIcon, NoteIcon, InsightIcon, VocabIcon, BookCoverPlaceholderIcon, GlobeIcon, SummaryIcon, SpeakerIcon, GridViewIcon, ListViewIcon, SettingsIcon, SearchIcon, AlertCircleIcon, RetryIcon } from "@/components/Icons";
 import { SearchBar } from "@/components/SearchBar";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { useSession } from "next-auth/react";
 
 const FEATURED = [
@@ -265,39 +266,39 @@ export default function Home() {
           ))}
           </div>
           {status === "authenticated" && (
-            <button
-              onClick={() => router.push("/upload")}
+            <Link
+              href="/upload"
               className="px-5 py-3 min-h-[44px] md:min-h-0 text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               Upload
-            </button>
+            </Link>
           )}
           {status === "authenticated" && (
-            <button
-              onClick={() => router.push("/notes")}
+            <Link
+              href="/notes"
               className="px-5 py-3 min-h-[44px] md:min-h-0 text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               Your Notes
-            </button>
+            </Link>
           )}
           {status === "authenticated" && (
-            <button
-              onClick={() => router.push("/vocabulary")}
+            <Link
+              href="/vocabulary"
               className="px-5 py-3 min-h-[44px] md:min-h-0 text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               Your Word List
-            </button>
+            </Link>
           )}
-          {/* Admin tab — only visible to admin users */}
+          {/* Admin link — only visible to admin users */}
           {isAdmin && (
-            <button
-              onClick={() => router.push("/admin")}
+            <Link
+              href="/admin"
               data-testid="admin-tab"
               className="px-5 py-3 min-h-[44px] md:min-h-0 text-sm font-medium border-b-2 border-transparent text-amber-700 hover:text-amber-800 flex items-center gap-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
-              <SettingsIcon className="w-3.5 h-3.5" />
+              <SettingsIcon className="w-3.5 h-3.5" aria-hidden="true" />
               Admin
-            </button>
+            </Link>
           )}
         </div>
       </div>


### PR DESCRIPTION
## What changed

Home page tab bar navigation items (Upload, Your Notes, Your Word List, Admin) were implemented as `<button onClick={() => router.push(...)}>` elements. Replaced all four with `<Link href="...">` from Next.js.

## Why

- **Middle-click / Ctrl+Click was broken**: `<button>` elements don't support open-in-new-tab browser shortcuts — users lost a standard navigation affordance.
- **Wrong ARIA semantics**: Screen readers announce `<button>` as performing an in-page action. These items navigate to different pages, so they must be `<a>`/`<link>` so AT announces them as "link".
- The two Home/Discover items that switch tabs in-page remain `<button role="tab">` — those are correct as-is.

## Test plan

- Added `HomeNavLinks.test.ts` (4 source-level tests) asserting all four routing nav items use `href=` not `router.push`.
- Updated 4 existing test files (`HomePage.test.tsx`, `HomePage.branches.test.tsx`, `HomepageFocusRings.test.ts`, `HomepageNavCtaTouchTargets.test.ts`) to match the new Link element pattern.
- All 3934 frontend tests pass.

Closes #2447
