### PR TITLE
fix: replace router.push nav buttons with Link elements in admin layout and reader page (closes #2449)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -462,6 +462,7 @@ Systematic WCAG 2.1 AA pass covering loading states, dialog semantics, focus man
 | 2026-04-30 | Admin users page: getMe() failure no longer silently exposes own Revoke/Delete buttons — hides all action buttons and shows "Couldn't verify identity" + Retry (closes #2441) | app/admin/users/page.tsx | #2442 |
 | 2026-04-30 | Reader page: notifyAIUsed now uses strict `=== false` check so Gemini key reminder doesn't fire on transient getMe() failure when hasGeminiKey is null (closes #2443) | app/reader/[bookId]/page.tsx | #2444 |
 | 2026-04-30 | Reader page: added role="status" to translation queue and login-required banners so screen readers announce them (WCAG 4.1.3, closes #2445) | app/reader/[bookId]/page.tsx | #2446 |
+| 2026-04-30 | Home page nav bar: replaced router.push buttons with Link elements for Upload/Notes/Vocabulary/Admin so Ctrl+Click opens new tab and screen readers announce them as links (closes #2447) | app/page.tsx | #2448 |
 
 ---
 

--- a/frontend/e2e/vocab-sidebar.spec.ts
+++ b/frontend/e2e/vocab-sidebar.spec.ts
@@ -24,10 +24,10 @@ test("vocab sidebar chapter filter: default shows only chapter-0 word", async ({
   const vocabBtn = page.getByTitle("Vocabulary", { exact: true });
   await vocabBtn.click();
 
-  // Word card header buttons start with the lemma — "universal universally" for chapter-0 word
-  await expect(page.getByRole("button", { name: "universal universally" })).toBeVisible();
+  // Word card header links start with the lemma — "universal universally" for chapter-0 word
+  await expect(page.getByRole("link", { name: "universal universally" })).toBeVisible();
   // "acknowledged" word card (chapter 1) should be absent — its header is "acknowledge acknowledged"
-  await expect(page.getByRole("button", { name: "acknowledge acknowledged" })).not.toBeVisible();
+  await expect(page.getByRole("link", { name: "acknowledge acknowledged" })).not.toBeVisible();
 });
 
 test("vocab sidebar 'All chapters' toggle shows words from every chapter", async ({ page }) => {
@@ -40,8 +40,8 @@ test("vocab sidebar 'All chapters' toggle shows words from every chapter", async
   await page.getByRole("button", { name: "All chapters" }).click();
 
   // Both word cards should now be visible
-  await expect(page.getByRole("button", { name: "universal universally" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "acknowledge acknowledged" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "universal universally" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "acknowledge acknowledged" })).toBeVisible();
 });
 
 test("vocab sidebar: clicking an occurrence closes the sidebar", async ({ page }) => {

--- a/frontend/src/__tests__/AdminLayout.redirect.test.tsx
+++ b/frontend/src/__tests__/AdminLayout.redirect.test.tsx
@@ -56,15 +56,14 @@ test("renders authenticated layout with tabs when user is admin", async () => {
   mockGetMe.mockResolvedValue({ id: 1, email: "admin@x.com", role: "admin" });
   render(<AdminLayout><div>child content</div></AdminLayout>);
   await waitFor(() => screen.getByText("child content"));
-  expect(screen.getByRole("button", { name: /Library/i })).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: /Library/i })).toBeInTheDocument();
   expect(screen.getByRole("link", { name: "Users" })).toBeInTheDocument();
 });
 
-test("clicking Library button navigates to /", async () => {
+test("Library back link has href /", async () => {
   mockGetMe.mockResolvedValue({ id: 1, email: "admin@x.com", role: "admin" });
   render(<AdminLayout><div>child</div></AdminLayout>);
-  await waitFor(() => screen.getByRole("button", { name: /Library/i }));
-  fireEvent.click(screen.getByRole("button", { name: /Library/i }));
-  expect(mockPush).toHaveBeenCalledWith("/");
+  await waitFor(() => screen.getByRole("link", { name: /Library/i }));
+  expect(screen.getByRole("link", { name: /Library/i })).toHaveAttribute("href", "/");
 });
 

--- a/frontend/src/__tests__/AdminReaderNavLinks.test.ts
+++ b/frontend/src/__tests__/AdminReaderNavLinks.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Regression tests for issue #2449 — admin layout "Library" back button and
+ * reader "Library" back button / vocab "View all" button must be Link elements
+ * not buttons with router.push, so Ctrl+Click / middle-click works and screen
+ * readers announce them as links.
+ */
+import fs from "fs";
+import path from "path";
+
+const ADMIN_LAYOUT = fs.readFileSync(
+  path.resolve(__dirname, "../app/admin/layout.tsx"),
+  "utf8"
+);
+
+const READER = fs.readFileSync(
+  path.resolve(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8"
+);
+
+describe("Admin layout — Library back button must be a Link (issue #2449)", () => {
+  it("does not use router.push('/') for the Library back navigation", () => {
+    // The programmatic router.push('/') in useEffect redirect is acceptable;
+    // the interactive header button must NOT use router.push.
+    // We check that there is no button with router.push("/") in the JSX header area.
+    // The header button pattern was: <button onClick={() => router.push("/")} ...>Library
+    expect(ADMIN_LAYOUT).not.toMatch(/<button[^>]*onClick[^>]*router\.push\(["'`]\/["'`]\)/);
+  });
+
+  it("has href=/ for the Library back link", () => {
+    expect(ADMIN_LAYOUT).toMatch(/href=["'`]\/["'`]/);
+  });
+});
+
+describe("Reader page — Library back button must be a Link (issue #2449)", () => {
+  it("reader toolbar Library button uses Link href=/, not button+router.push", () => {
+    // Find the aria-label="Library" button context in the toolbar
+    const idx = READER.indexOf('aria-label="Library"');
+    expect(idx).toBeGreaterThan(-1);
+    // Within 200 chars before the aria-label, there should be no button element
+    // (because it's now a Link), and there should be href="/"
+    const before = READER.slice(Math.max(0, idx - 200), idx + 50);
+    expect(before).not.toMatch(/onClick.*router\.push/);
+    expect(before).toMatch(/href=["'`]\/["'`]/);
+  });
+});
+
+describe("Reader page — vocab 'View all' must be a Link (issue #2449)", () => {
+  it("vocab sidebar 'View all' uses Link href=/vocabulary, not button+router.push", () => {
+    const idx = READER.indexOf("View all");
+    expect(idx).toBeGreaterThan(-1);
+    const context = READER.slice(Math.max(0, idx - 300), idx + 50);
+    expect(context).not.toMatch(/onClick.*router\.push/);
+    expect(context).toMatch(/href=["'`]\/vocabulary["'`]/);
+  });
+});
+
+describe("Reader page — vocab word lemma link must be a Link (issue #2449)", () => {
+  it("vocab word lemma link uses Link with /vocabulary?word=, not button+router.push", () => {
+    // Find the vocab lemma navigation
+    const idx = READER.indexOf("/vocabulary?word=");
+    expect(idx).toBeGreaterThan(-1);
+    // The 200 chars before should not have button+onClick+router.push
+    const before = READER.slice(Math.max(0, idx - 200), idx + 80);
+    expect(before).not.toMatch(/onClick[^>]*router\.push/);
+    expect(before).toMatch(/href/);
+  });
+});

--- a/frontend/src/__tests__/ReaderHeaderAria.test.ts
+++ b/frontend/src/__tests__/ReaderHeaderAria.test.ts
@@ -8,17 +8,17 @@ const src = fs.readFileSync(
 
 describe("Reader header buttons aria-label (closes #1015)", () => {
   it("Library back button has aria-label", () => {
-    // Find the back-to-library button
-    const idx = src.indexOf('router.push("/")');
+    // Find the back-to-library Link (href="/")
+    const idx = src.indexOf('aria-label="Library"');
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(Math.max(0, idx - 200), idx + 50);
+    const window = src.slice(Math.max(0, idx - 50), idx + 200);
     expect(window).toContain("aria-label");
   });
 
   it("Library back button aria-label references Library", () => {
-    const idx = src.indexOf('router.push("/")');
+    const idx = src.indexOf('aria-label="Library"');
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(Math.max(0, idx - 200), idx + 50);
+    const window = src.slice(Math.max(0, idx - 50), idx + 200);
     expect(window).toMatch(/aria-label=.*[Ll]ibrary/);
   });
 

--- a/frontend/src/__tests__/ReaderMiscSmallButtonsTouchTargets.test.ts
+++ b/frontend/src/__tests__/ReaderMiscSmallButtonsTouchTargets.test.ts
@@ -33,6 +33,6 @@ describe("reader miscellaneous small button touch targets (closes #882)", () => 
   });
 
   it("Vocab sidebar View all button has min-h-[44px]", () => {
-    checkForward('router.push("/vocabulary")');
+    checkForward('href="/vocabulary"');
   });
 });

--- a/frontend/src/__tests__/ReaderPage.branches3.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches3.test.tsx
@@ -863,12 +863,11 @@ describe("ReaderPage.branches3 — vocab word heading click (line 1404)", () => 
     // Wait for the vocab word lemma heading to appear
     await waitFor(() => screen.getByText("ishmael2"));
 
-    // Find and click the vocab word heading button (line 1404)
-    const headingBtn = Array.from(document.querySelectorAll("button"))
-      .find((b) => b.textContent?.trim() === "ishmael2") as HTMLElement;
-    expect(headingBtn).toBeTruthy();
-    await userEvent.click(headingBtn);
-    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining("vocabulary"));
+    // Find the vocab word heading link (now a Link element, rendered as <a>)
+    const headingLink = Array.from(document.querySelectorAll("a"))
+      .find((a) => a.textContent?.trim() === "ishmael2") as HTMLAnchorElement;
+    expect(headingLink).toBeTruthy();
+    expect(headingLink.getAttribute("href")).toContain("vocabulary");
   });
 });
 

--- a/frontend/src/__tests__/ReaderPage.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.test.tsx
@@ -724,15 +724,13 @@ describe("ReaderPage — unauthenticated session", () => {
 });
 
 describe("ReaderPage — navigation from library button", () => {
-  it("back to library button calls router.push('/')", async () => {
+  it("Library header link has href /", async () => {
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
     render(<ReaderPage />);
     await flushPromises();
 
-    const libraryBtn = await screen.findByText("Library", { exact: false });
-    expect(libraryBtn.closest("button")).toBeTruthy();
-    await userEvent.click(libraryBtn.closest("button")!);
-    expect(mockPush).toHaveBeenCalledWith("/");
+    const libraryLink = await screen.findByRole("link", { name: /Library/i });
+    expect(libraryLink).toHaveAttribute("href", "/");
   });
 });
 
@@ -1142,7 +1140,7 @@ describe("ReaderPage — vocab sidebar content", () => {
     expect(await screen.findByText(/View all/)).toBeInTheDocument();
   });
 
-  it("'View all' navigates to /vocabulary", async () => {
+  it("'View all' links to /vocabulary", async () => {
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
     render(<ReaderPage />);
     await flushPromises();
@@ -1150,10 +1148,8 @@ describe("ReaderPage — vocab sidebar content", () => {
     const vocabBtn = await screen.findByTitle("Vocabulary");
     await userEvent.click(vocabBtn);
 
-    const viewAllBtn = await screen.findByText(/View all/);
-    await userEvent.click(viewAllBtn);
-
-    expect(mockPush).toHaveBeenCalledWith("/vocabulary");
+    const viewAllLink = await screen.findByRole("link", { name: /View all/i });
+    expect(viewAllLink).toHaveAttribute("href", "/vocabulary");
   });
 
   it("shows vocab count badge on Vocab button when words exist", async () => {

--- a/frontend/src/__tests__/ReaderPageUnicodeIcons.test.ts
+++ b/frontend/src/__tests__/ReaderPageUnicodeIcons.test.ts
@@ -41,7 +41,7 @@ describe("Reader page Unicode icon replacements", () => {
   });
 
   it("Library back button uses ArrowLeftIcon", () => {
-    expect(src).toMatch(/router\.push\("\/"\)[\s\S]{0,350}<ArrowLeftIcon/);
+    expect(src).toMatch(/aria-label="Library"[\s\S]{0,350}<ArrowLeftIcon/);
   });
 
   it("chapter navigation uses ArrowLeftIcon", () => {

--- a/frontend/src/__tests__/ReaderVocabLemmaProfileAvatarTouchTargets.test.ts
+++ b/frontend/src/__tests__/ReaderVocabLemmaProfileAvatarTouchTargets.test.ts
@@ -11,11 +11,11 @@ const homeSrc = fs.readFileSync(
 );
 
 describe("reader vocab lemma header button touch target (closes #944)", () => {
-  it("vocab lemma header button has min-h-[44px]", () => {
-    // Find the lemma header button that navigates to /vocabulary
-    const idx = readerSrc.indexOf('router.push(`/vocabulary?word=');
+  it("vocab lemma header link has min-h-[44px]", () => {
+    // Find the lemma header Link that navigates to /vocabulary?word=
+    const idx = readerSrc.indexOf('/vocabulary?word=');
     expect(idx).toBeGreaterThan(-1);
-    // className comes after onClick in the JSX
+    // className is nearby
     const window = readerSrc.slice(idx, idx + 300);
     expect(window).toContain("min-h-[44px]");
   });

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -75,9 +75,9 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   return (
     <main id="main-content" className="min-h-screen bg-parchment">
       <header className="border-b border-amber-200 bg-white/60 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
-        <button onClick={() => router.push("/")} className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] md:min-h-0 flex items-center gap-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1">
+        <Link href="/" className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] md:min-h-0 flex items-center gap-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1">
           <ArrowLeftIcon className="w-4 h-4" aria-hidden="true" /> Library
-        </button>
+        </Link>
         <h1 className="font-serif font-bold text-ink text-lg md:text-xl">Admin Panel</h1>
         <button onClick={loadStats} className="ml-auto text-sm text-amber-700 hover:text-amber-900 min-h-[44px] md:min-h-0 flex items-center gap-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1">
           <RetryIcon className="w-4 h-4" aria-hidden="true" /> Refresh

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
 import { useSession } from "next-auth/react";
 import { getBookChapters, deleteTranslationCache, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, getChapterTranslation, getChapterQueueStatus, retryChapterTranslation, enqueueBookTranslation, saveReadingProgress, getAnnotations, createAnnotation, getVocabulary, saveVocabularyWord, exportVocabularyToObsidian, saveInsight, TranslationStatus, BookMeta, BookChapter, ApiError, Annotation, VocabularyWord, ChapterSource } from "@/lib/api";
 import { recordRecentBook, saveLastChapter, getLastChapter } from "@/lib/recentBooks";
@@ -1011,13 +1012,13 @@ export default function ReaderPage() {
       } ${focusMode ? "" : "md:!max-h-none md:!opacity-100 md:!overflow-visible md:!border-b"}`}>
         {/* Row 1: nav + title + controls */}
         <div className="flex items-center gap-2 md:gap-3 px-3 md:px-4 py-2 md:py-3">
-          <button
-            onClick={() => router.push("/")}
+          <Link
+            href="/"
             aria-label="Library"
             className="text-amber-700 hover:text-amber-900 text-sm shrink-0 min-h-[44px] md:min-h-0 flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <ArrowLeftIcon className="w-4 h-4 shrink-0" aria-hidden="true" /><span className="hidden sm:inline ml-1">Library</span>
-          </button>
+          </Link>
 
           <div className="min-w-0 flex-1">
             {meta ? (
@@ -2036,9 +2037,9 @@ export default function ReaderPage() {
                       <span className="text-xs text-stone-600" aria-live="polite" aria-atomic="true">
                         {filteredVocab.length} word{filteredVocab.length !== 1 ? "s" : ""}
                       </span>
-                      <button onClick={() => router.push("/vocabulary")} className="text-xs text-amber-700 hover:text-amber-800 font-medium min-h-[44px] md:min-h-0 flex items-center gap-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1">
+                      <Link href="/vocabulary" className="text-xs text-amber-700 hover:text-amber-800 font-medium min-h-[44px] md:min-h-0 flex items-center gap-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1">
                         View all <ArrowRightIcon className="w-3 h-3 inline" aria-hidden="true" />
-                      </button>
+                      </Link>
                     </div>
                     {vocabFetchError ? (
                       <div role="status" className="flex flex-col items-center gap-2 mt-10 text-center">
@@ -2068,15 +2069,15 @@ export default function ReaderPage() {
                             <li key={w.id}>
                             <div className="rounded-lg bg-amber-50 border border-amber-200 overflow-hidden">
                               {/* Lemma header */}
-                              <button
-                                onClick={() => router.push(`/vocabulary?word=${encodeURIComponent(w.word)}`)}
+                              <Link
+                                href={`/vocabulary?word=${encodeURIComponent(w.word)}`}
                                 className="w-full flex items-center justify-between gap-2 px-3 py-2 min-h-[44px] md:min-h-0 hover:bg-amber-100 transition-colors text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-inset"
                               >
                                 <span lang={w.language ?? undefined} className="text-sm font-semibold text-ink">{lemma}</span>
                                 {isForm && (
                                   <span lang={w.language ?? undefined} className="text-[10px] text-amber-700 shrink-0 italic">{w.word}</span>
                                 )}
-                              </button>
+                              </Link>
                               {/* Context occurrences */}
                               {relevantOccs.map((occ, i) => (
                                 <button


### PR DESCRIPTION
## What changed

Replaced `<button onClick={() => router.push(...)}>` navigation elements with semantic `<Link href="...">` elements in:

- `frontend/src/app/admin/layout.tsx` — Library back button
- `frontend/src/app/reader/[bookId]/page.tsx` — Library header button, "View all" vocab button, vocab word lemma headings

Intentional programmatic redirects in `useEffect` (auth guards) and conditional navigation buttons remain as `router.push`.

## Why

Using `<button>` for pure page navigation is a semantic HTML bug:
- Prevents Ctrl+Click / middle-click to open in a new tab
- Screen readers announce these as "button" instead of "link"
- Violates WCAG 4.1.2 (Name, Role, Value)

## Test plan

- [x] `AdminReaderNavLinks.test.ts` — new source-level tests verifying admin layout and reader page use `href=` not `router.push` for navigation
- [x] `AdminLayout.redirect.test.tsx` — updated Library button tests to use `getByRole("link")` and `toHaveAttribute("href", "/")`
- [x] `ReaderHeaderAria.test.ts` — Library button anchor updated to `aria-label="Library"`
- [x] `ReaderMiscSmallButtonsTouchTargets.test.ts` — View all anchor updated to `href="/vocabulary"`
- [x] `ReaderPageUnicodeIcons.test.ts` — Library button pattern updated to `aria-label="Library"[\s\S]{0,350}<ArrowLeftIcon`
- [x] `ReaderPage.branches3.test.tsx` — vocab lemma heading test uses `querySelectorAll("a")` + href assertion
- [x] `ReaderPage.test.tsx` — Library and View all tests use `getByRole("link")` + `toHaveAttribute`
- [x] Full test suite: 3939 tests pass

Closes #2449
