### PR TITLE
fix: replace remaining router.push nav buttons with Link elements across all pages (closes #2451)

### DIFF
--- a/frontend/e2e/home.spec.ts
+++ b/frontend/e2e/home.spec.ts
@@ -64,8 +64,8 @@ test("clicking a library book navigates to reader page", async ({ page }) => {
 
   // Explicitly open the Home tab in case the session effect flipped to Discover
   await page.getByRole("tab", { name: "Home" }).click();
-  // The Continue Reading button at the top navigates directly to the reader
-  await page.getByRole("button", { name: "Continue reading" }).click();
+  // The Continue Reading link at the top navigates directly to the reader
+  await page.getByRole("link", { name: "Continue reading" }).click();
   await page.waitForURL(/\/reader\/1342/);
   expect(page.url()).toContain("/reader/1342");
 });

--- a/frontend/e2e/landing.spec.ts
+++ b/frontend/e2e/landing.spec.ts
@@ -38,7 +38,7 @@ test("unauthenticated visitor sees landing hero on discover tab", async ({ page 
   ).toBeVisible({ timeout: 5000 });
 
   // Sign-in CTA should be present
-  await expect(page.getByRole("button", { name: /Sign in free/i })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Sign in free/i })).toBeVisible();
 });
 
 test("authenticated user does not see landing hero", async ({ page }) => {

--- a/frontend/e2e/notes-page.spec.ts
+++ b/frontend/e2e/notes-page.spec.ts
@@ -40,7 +40,7 @@ test("notes page: empty state when there are no notes", async ({ page }) => {
   await page.goto("/notes/1342");
 
   await expect(page.getByText("No notes yet")).toBeVisible();
-  await expect(page.getByRole("button", { name: /Open reader/ })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Open reader/ })).toBeVisible();
 });
 
 test("notes page: renders book title and annotation sentence", async ({ page }) => {

--- a/frontend/src/__tests__/AdminBooksPage.branches.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.branches.test.tsx
@@ -333,10 +333,10 @@ describe("AdminBooksPage — expanded book with no translations cached", () => {
   });
 });
 
-// ── Additional: "Open" button navigates to reader ─────────────────────────────
+// ── Additional: "Open" link navigates to reader ──────────────────────────────
 
-describe("AdminBooksPage — Open button navigates to reader", () => {
-  it("navigates to /reader/:id when Open is clicked", async () => {
+describe("AdminBooksPage — Open link navigates to reader", () => {
+  it("Open reader link has href /reader/:id", async () => {
     mockAdminFetch
       .mockResolvedValueOnce(SAMPLE_BOOKS)
       .mockResolvedValueOnce(SAMPLE_TRANSLATIONS);
@@ -344,9 +344,7 @@ describe("AdminBooksPage — Open button navigates to reader", () => {
     render(<BooksPage />);
     await flushPromises();
 
-    const openBtn = await screen.findByRole("button", { name: /^Open reader for/i });
-    await userEvent.click(openBtn);
-
-    expect(mockPush).toHaveBeenCalledWith("/reader/1");
+    const openLink = await screen.findByRole("link", { name: /^Open reader for/i });
+    expect(openLink).toHaveAttribute("href", "/reader/1");
   });
 });

--- a/frontend/src/__tests__/AdminBooksPage.test.tsx
+++ b/frontend/src/__tests__/AdminBooksPage.test.tsx
@@ -129,16 +129,15 @@ describe("AdminBooksPage — loading and basic render", () => {
 });
 
 describe("AdminBooksPage — book actions", () => {
-  it("shows Open button that navigates to reader", async () => {
+  it("shows Open link that navigates to reader", async () => {
     mockAdminFetch
       .mockResolvedValueOnce(SAMPLE_BOOKS)
       .mockResolvedValueOnce(SAMPLE_TRANSLATIONS);
     render(<BooksPage />);
     await flushPromises();
 
-    const openBtns = await screen.findAllByRole("button", { name: /open/i });
-    await userEvent.click(openBtns[0]);
-    expect(mockPush).toHaveBeenCalledWith("/reader/1");
+    const openLinks = await screen.findAllByRole("link", { name: /open/i });
+    expect(openLinks[0]).toHaveAttribute("href", "/reader/1");
   });
 
   it("shows translation language pills for books with translations", async () => {

--- a/frontend/src/__tests__/AdminBooksTouchTargets.test.ts
+++ b/frontend/src/__tests__/AdminBooksTouchTargets.test.ts
@@ -31,10 +31,11 @@ describe("admin/books page touch targets (closes #867)", () => {
     expect(window).toContain("min-h-[44px]");
   });
 
-  it("Open reader button has min-h-[44px]", () => {
-    const idx = src.indexOf('router.push(`/reader/${b.id}`)');
+  it("Open reader link has min-h-[44px]", () => {
+    // Open reader is now a <Link href={`/reader/${b.id}`}> — anchor on aria-label
+    const idx = src.indexOf('aria-label={`Open reader for');
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(idx, idx + 200);
+    const window = src.slice(idx, idx + 300);
     expect(window).toContain("min-h-[44px]");
   });
 

--- a/frontend/src/__tests__/AdminUploadsCoverage.test.tsx
+++ b/frontend/src/__tests__/AdminUploadsCoverage.test.tsx
@@ -84,12 +84,11 @@ test("clicking Clear filter resets filter and reloads without user_id", async ()
   );
 });
 
-// ── Open button ───────────────────────────────────────────────────────────────
+// ── Open link ─────────────────────────────────────────────────────────────────
 
-test("clicking Open navigates to /reader/:book_id", async () => {
+test("Open link navigates to /reader/:book_id", async () => {
   await renderPage();
 
-  await userEvent.click(screen.getByRole("button", { name: /Open Dune/i }));
-
-  expect(mockPush).toHaveBeenCalledWith("/reader/42");
+  const link = screen.getByRole("link", { name: /Open Dune/i });
+  expect(link).toHaveAttribute("href", "/reader/42");
 });

--- a/frontend/src/__tests__/AdminUploadsTouchTargets.test.ts
+++ b/frontend/src/__tests__/AdminUploadsTouchTargets.test.ts
@@ -21,11 +21,11 @@ describe("admin/uploads page touch targets (closes #861)", () => {
     expect(window).toContain("min-h-[44px]");
   });
 
-  it("Open (row) button has min-h-[44px]", () => {
-    // anchor on the reader push inside onClick
-    const idx = src.indexOf("router.push(`/reader/");
+  it("Open (row) link has min-h-[44px]", () => {
+    // Open is now a <Link href={`/reader/${u.book_id}`}> — anchor on aria-label
+    const idx = src.indexOf("aria-label={`Open ");
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(idx, idx + 200);
+    const window = src.slice(idx, idx + 300);
     expect(window).toContain("min-h-[44px]");
   });
 });

--- a/frontend/src/__tests__/BookNotesPage.coverage2.test.tsx
+++ b/frontend/src/__tests__/BookNotesPage.coverage2.test.tsx
@@ -281,13 +281,13 @@ test("section view with book-level insight shows Book-level sub-heading", async 
   expect(screen.getByRole("button", { name: /Book-level/i })).toBeInTheDocument();
 });
 
-// ── "Open reader" button ───────────────────────────────────────────────────────
+// ── "Open reader" link ────────────────────────────────────────────────────────
 
-test("'Open reader' button on empty state navigates to reader", async () => {
+test("'Open reader' link on empty state navigates to reader", async () => {
   render(<BookNotesPage />);
   await waitFor(() => screen.getByText(/No notes yet/i));
-  fireEvent.click(screen.getByRole("button", { name: /Open reader/i }));
-  expect(mockPush).toHaveBeenCalledWith("/reader/10");
+  const link = screen.getByRole("link", { name: /Open reader/i });
+  expect(link).toHaveAttribute("href", "/reader/10");
 });
 
 // ── Nested collapse ────────────────────────────────────────────────────────────

--- a/frontend/src/__tests__/BookNotesPage.test.tsx
+++ b/frontend/src/__tests__/BookNotesPage.test.tsx
@@ -296,10 +296,10 @@ test("insight with context_text has reader link", async () => {
 
 // ── Navigation ─────────────────────────────────────────────────────────────────
 
-test("← Notes button navigates to /notes", async () => {
+test("← Notes link navigates to /notes", async () => {
   mockGetAnnotations.mockResolvedValue([]);
   render(<BookNotesPage />);
   await waitFor(() => screen.getByText(/No notes yet/i));
-  fireEvent.click(screen.getByRole("button", { name: /Notes/i }));
-  expect(mockPush).toHaveBeenCalledWith("/notes");
+  const link = screen.getByRole("link", { name: /Notes/i });
+  expect(link).toHaveAttribute("href", "/notes");
 });

--- a/frontend/src/__tests__/DeckDetailPage.errorstate.test.tsx
+++ b/frontend/src/__tests__/DeckDetailPage.errorstate.test.tsx
@@ -52,7 +52,7 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
-test("error state shows alert with Retry and Back-to-decks buttons", async () => {
+test("error state shows alert with Retry button and Back-to-decks link", async () => {
   mockGetDeck.mockRejectedValue(new Error("network error"));
   mockGetVocabulary.mockResolvedValue([]);
   render(<DeckDetailPage />);
@@ -60,7 +60,7 @@ test("error state shows alert with Retry and Back-to-decks buttons", async () =>
 
   expect(await screen.findByRole("alert")).toBeInTheDocument();
   expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: /back to decks/i })).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: /back to decks/i })).toBeInTheDocument();
 });
 
 test("Retry button re-fetches and shows deck on success", async () => {
@@ -82,15 +82,13 @@ test("Retry button re-fetches and shows deck on success", async () => {
   expect(screen.queryByRole("alert")).not.toBeInTheDocument();
 });
 
-test("Back-to-decks navigates away", async () => {
+test("Back-to-decks link has correct href", async () => {
   mockGetDeck.mockRejectedValue(new Error("fail"));
   mockGetVocabulary.mockResolvedValue([]);
   render(<DeckDetailPage />);
   await flushPromises();
 
   await screen.findByRole("alert");
-  const user = userEvent.setup();
-  await user.click(screen.getByRole("button", { name: /back to decks/i }));
-
-  expect(mockPush).toHaveBeenCalledWith("/decks");
+  const link = screen.getByRole("link", { name: /back to decks/i });
+  expect(link).toHaveAttribute("href", "/decks");
 });

--- a/frontend/src/__tests__/DeckDetailPageCoverage.test.tsx
+++ b/frontend/src/__tests__/DeckDetailPageCoverage.test.tsx
@@ -99,11 +99,11 @@ test("invalid deckId (NaN) renders error state without calling getDeck", async (
 
 // ── Back navigation ───────────────────────────────────────────────────────────
 
-test("Decks back button navigates to /decks", async () => {
+test("Decks back link navigates to /decks", async () => {
   render(<DeckDetailPage />);
   await waitFor(() => screen.getByText("laufen"));
-  await userEvent.click(screen.getByRole("button", { name: /decks/i }));
-  expect(mockPush).toHaveBeenCalledWith("/decks");
+  const link = screen.getByRole("link", { name: /decks/i });
+  expect(link).toHaveAttribute("href", "/decks");
 });
 
 // ── handleAdd error rollback ──────────────────────────────────────────────────
@@ -266,15 +266,15 @@ test("smart deck does not show Remove buttons", async () => {
   expect(screen.queryByRole("button", { name: /Remove/i })).not.toBeInTheDocument();
 });
 
-// ── Smart deck empty state — Back to decks button ─────────────────────────────
+// ── Smart deck empty state — Back to decks link ───────────────────────────────
 
-test("smart deck empty state Back to decks button navigates to /decks", async () => {
+test("smart deck empty state Back to decks link navigates to /decks", async () => {
   mockGetDeck.mockResolvedValue({ ...DECK, mode: "smart", members: [] });
   render(<DeckDetailPage />);
   await waitFor(() => screen.getByTestId("deck-detail-empty-state"));
 
-  await userEvent.click(screen.getByRole("button", { name: /back to decks/i }));
-  expect(mockPush).toHaveBeenCalledWith("/decks");
+  const link = screen.getByRole("link", { name: /back to decks/i });
+  expect(link).toHaveAttribute("href", "/decks");
 });
 
 // ── Error state retry ─────────────────────────────────────────────────────────
@@ -291,11 +291,11 @@ test("Retry button in error state re-fetches the deck", async () => {
 
 // ── Error state back to decks ─────────────────────────────────────────────────
 
-test("Back to decks button in error state navigates to /decks", async () => {
+test("Back to decks link in error state navigates to /decks", async () => {
   mockGetDeck.mockRejectedValueOnce(new Error("Network error"));
   render(<DeckDetailPage />);
   await waitFor(() => screen.getByText(/Could not load deck/i));
 
-  await userEvent.click(screen.getByRole("button", { name: /back to decks/i }));
-  expect(mockPush).toHaveBeenCalledWith("/decks");
+  const link = screen.getByRole("link", { name: /back to decks/i });
+  expect(link).toHaveAttribute("href", "/decks");
 });

--- a/frontend/src/__tests__/DecksNewPageCoverage.test.tsx
+++ b/frontend/src/__tests__/DecksNewPageCoverage.test.tsx
@@ -57,13 +57,14 @@ beforeEach(() => {
   mockPush.mockReset();
 });
 
-// ── header back button ─────────────────────────────────────────────────────────
+// ── header back link ───────────────────────────────────────────────────────────
 
-test("header back button navigates to /decks", async () => {
+test("header back link navigates to /decks", async () => {
   render(<DecksNewPage />);
-  const user = userEvent.setup();
-  await user.click(screen.getByRole("button", { name: /decks/i }));
-  expect(mockPush).toHaveBeenCalledWith("/decks");
+  // There are two links to /decks: header back and Cancel. Both are fine.
+  const links = screen.getAllByRole("link", { name: /decks/i });
+  expect(links.length).toBeGreaterThanOrEqual(1);
+  expect(links[0]).toHaveAttribute("href", "/decks");
 });
 
 // ── smart → manual mode toggle ─────────────────────────────────────────────────

--- a/frontend/src/__tests__/DecksNotesFocusRing.test.ts
+++ b/frontend/src/__tests__/DecksNotesFocusRing.test.ts
@@ -50,7 +50,8 @@ describe("decks/new page button focus rings (closes #2172)", () => {
 
 describe("notes page button focus rings (closes #2172)", () => {
   it("Library back button has focus-visible:ring-2 for WCAG 2.4.7", () => {
-    expect(notesPage).toMatch(/router\.push\("\/"\)[\s\S]{0,300}?focus-visible:ring-2|focus-visible:ring-2[\s\S]{0,300}?router\.push\("\/"\)/);
+    // Library back button is now a <Link href="/"> — match on href near focus-visible:ring-2
+    expect(notesPage).toMatch(/href="\/"\s*[\s\S]{0,300}?focus-visible:ring-2|focus-visible:ring-2[\s\S]{0,300}?href="\//);
   });
 
   it("notes page has at least 3 focus-visible:ring-2 instances", () => {

--- a/frontend/src/__tests__/DecksPage.test.tsx
+++ b/frontend/src/__tests__/DecksPage.test.tsx
@@ -60,10 +60,7 @@ test("renders an empty state with a New-deck CTA when the user has no decks", as
   expect(await screen.findByTestId("decks-empty-state")).toBeInTheDocument();
   const cta = screen.getByTestId("decks-empty-new-btn");
   expect(cta).toBeInTheDocument();
-
-  const user = userEvent.setup();
-  await user.click(cta);
-  expect(mockPush).toHaveBeenCalledWith("/decks/new");
+  expect(cta).toHaveAttribute("href", "/decks/new");
 });
 
 test("renders one DeckCard per deck returned from the API", async () => {
@@ -75,13 +72,12 @@ test("renders one DeckCard per deck returned from the API", async () => {
   expect(screen.getByTestId("deck-member-count-2")).toHaveTextContent("40");
 });
 
-test("'New deck' header button navigates to /decks/new", async () => {
+test("'New deck' header link navigates to /decks/new", async () => {
   mockListDecks.mockResolvedValue(SAMPLE_DECKS);
   render(<DecksPage />);
   await screen.findByText("German verbs");
-  const user = userEvent.setup();
-  await user.click(screen.getByTestId("decks-new-btn"));
-  expect(mockPush).toHaveBeenCalledWith("/decks/new");
+  const link = screen.getByTestId("decks-new-btn");
+  expect(link).toHaveAttribute("href", "/decks/new");
 });
 
 test("deleting a deck removes it from the list optimistically and shows UndoToast", async () => {

--- a/frontend/src/__tests__/DecksPageCoverage.test.tsx
+++ b/frontend/src/__tests__/DecksPageCoverage.test.tsx
@@ -21,15 +21,15 @@ jest.mock("@/lib/api", () => ({
   deleteDeck: jest.fn(),
 }));
 
-// DeckCard stub: renders deck name as a button (click → onClick) and a delete button
+// DeckCard stub: renders deck name as a link (href prop) and a delete button
 jest.mock("@/components/DeckCard", () => {
-  const DC = ({ deck, onClick, onDelete }: {
+  const DC = ({ deck, href, onDelete }: {
     deck: { id: number; name: string };
-    onClick: () => void;
+    href: string;
     onDelete: (id: number) => void;
   }) => (
     <div>
-      <button onClick={onClick}>{deck.name}</button>
+      <a href={href}>{deck.name}</a>
       <button data-testid={`deck-delete-${deck.id}`} onClick={() => onDelete(deck.id)}>
         Delete
       </button>
@@ -85,26 +85,26 @@ beforeEach(() => {
   mockDeleteDeck.mockResolvedValue(undefined);
 });
 
-// ── Back / Library button ─────────────────────────────────────────────────────
+// ── Back / Library link ───────────────────────────────────────────────────────
 
-test("back button navigates to /", async () => {
+test("back link navigates to /", async () => {
   mockListDecks.mockResolvedValue([DECK_A]);
   render(<DecksPage />);
   await waitFor(() => screen.getByText("German verbs"));
 
-  await userEvent.click(screen.getByRole("button", { name: /library/i }));
-  expect(mockPush).toHaveBeenCalledWith("/");
+  const link = screen.getByRole("link", { name: /library/i });
+  expect(link).toHaveAttribute("href", "/");
 });
 
-// ── DeckCard click → navigate to deck ────────────────────────────────────────
+// ── DeckCard link → navigate to deck ─────────────────────────────────────────
 
-test("clicking a deck card navigates to its detail page", async () => {
+test("deck card link navigates to its detail page", async () => {
   mockListDecks.mockResolvedValue([DECK_A]);
   render(<DecksPage />);
   await waitFor(() => screen.getByText("German verbs"));
 
-  await userEvent.click(screen.getByRole("button", { name: "German verbs" }));
-  expect(mockPush).toHaveBeenCalledWith("/decks/1");
+  const link = screen.getByRole("link", { name: "German verbs" });
+  expect(link).toHaveAttribute("href", "/decks/1");
 });
 
 // ── UndoToast onUndo — deck restored ─────────────────────────────────────────

--- a/frontend/src/__tests__/EmptyStateCta.test.ts
+++ b/frontend/src/__tests__/EmptyStateCta.test.ts
@@ -28,11 +28,11 @@ describe("EmptyStateCta", () => {
   });
 
   it("vocabulary empty state CTA navigates to home/library", () => {
-    // Empty state CTA should call router.push("/")
+    // Empty state CTA is now a <Link href="/"> — check for href="/" after the empty state text
     const idx = vocabPage.indexOf('No saved words yet');
     expect(idx).toBeGreaterThan(0);
     const after = vocabPage.slice(idx, idx + 1500);
-    expect(after).toMatch(/router\.push\("\/"\)/);
+    expect(after).toMatch(/href="\//);
   });
 
   it("notes overview empty state has a Browse books CTA button", () => {
@@ -41,10 +41,11 @@ describe("EmptyStateCta", () => {
   });
 
   it("notes overview empty state CTA navigates to home/library", () => {
+    // Empty state CTA is now a <Link href="/"> — check for href="/" after the empty state text
     const idx = notesOverviewPage.indexOf('No notes yet');
     expect(idx).toBeGreaterThan(0);
     const after = notesOverviewPage.slice(idx, idx + 1500);
-    expect(after).toMatch(/router\.push\("\/"\)/);
+    expect(after).toMatch(/href="\//);
   });
 
   it("search empty state has a Clear search CTA button", () => {

--- a/frontend/src/__tests__/HomePage.test.tsx
+++ b/frontend/src/__tests__/HomePage.test.tsx
@@ -137,20 +137,19 @@ describe("HomePage — initial render", () => {
     expect(screen.getByText(/Public domain classics with AI assistance/i)).toBeInTheDocument();
   });
 
-  it("shows Sign in button when unauthenticated", async () => {
+  it("shows Sign in link when unauthenticated", async () => {
     await renderHome();
-    // Both the header "Sign in" and the hero "Sign in free" buttons are present
-    // for unauthenticated visitors; check at least one navigates to /login.
-    const signInBtns = screen.getAllByRole("button", { name: /Sign in/i });
-    expect(signInBtns.length).toBeGreaterThanOrEqual(1);
+    // Both the header "Sign in" and the hero "Sign in free" links are present
+    // for unauthenticated visitors; check at least one points to /login.
+    const signInLinks = screen.getAllByRole("link", { name: /Sign in/i });
+    expect(signInLinks.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("navigates to /login when Sign in is clicked", async () => {
-    const user = userEvent.setup();
+  it("Sign in link navigates to /login", async () => {
     await renderHome();
-    // Click the header's "Sign in" button (exact text, not the hero's "Sign in free")
-    await user.click(screen.getByRole("button", { name: "Sign in" }));
-    expect(mockPush).toHaveBeenCalledWith("/login");
+    // Header "Sign in" link (exact text, not the hero's "Sign in free")
+    const signInLink = screen.getByRole("link", { name: "Sign in" });
+    expect(signInLink).toHaveAttribute("href", "/login");
   });
 
   it("shows Discover tab by default when library is empty", async () => {
@@ -177,9 +176,9 @@ describe("HomePage — signed-in state", () => {
     mockGetReadingProgress.mockResolvedValue([]);
   });
 
-  it("shows profile button instead of Sign in", async () => {
+  it("shows profile link instead of Sign in", async () => {
     await renderHome();
-    expect(screen.queryByRole("button", { name: /Sign in/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Sign in" })).not.toBeInTheDocument();
   });
 
   it("shows profile initial when no picture", async () => {
@@ -188,12 +187,10 @@ describe("HomePage — signed-in state", () => {
     expect(screen.getByText("A")).toBeInTheDocument();
   });
 
-  it("navigates to /profile when profile button is clicked", async () => {
-    const user = userEvent.setup();
+  it("profile link navigates to /profile", async () => {
     await renderHome();
-    const profileBtn = screen.getByTitle("Alice — Profile & Settings");
-    await user.click(profileBtn);
-    expect(mockPush).toHaveBeenCalledWith("/profile");
+    const profileLink = screen.getByTitle("Alice — Profile & Settings");
+    expect(profileLink).toHaveAttribute("href", "/profile");
   });
 
   it("shows 'Your Notes' tab when authenticated", async () => {
@@ -551,13 +548,11 @@ describe("HomePage — Home dashboard (UX-008)", () => {
     expect(screen.getAllByText("Moby Dick").length).toBeGreaterThan(1);
   });
 
-  it("clicking Continue Reading card navigates directly to reader", async () => {
-    const user = userEvent.setup();
+  it("Continue Reading card is a link to the reader", async () => {
     await renderHome();
-    // The Continue Reading button is the first interactive element with the book title
-    const continueBtn = screen.getByRole("button", { name: /Continue Reading/i });
-    await user.click(continueBtn);
-    expect(mockPush).toHaveBeenCalledWith("/reader/1");
+    // The Continue Reading card is now a <Link href="/reader/1">
+    const continueLink = screen.getByRole("link", { name: /Continue reading/i });
+    expect(continueLink).toHaveAttribute("href", "/reader/1");
   });
 
   it("shows stats strip with user progress when stats loaded", async () => {

--- a/frontend/src/__tests__/HomepageFocusRings.test.ts
+++ b/frontend/src/__tests__/HomepageFocusRings.test.ts
@@ -10,15 +10,15 @@ const src = fs.readFileSync(
 );
 
 describe("Homepage header buttons focus rings (closes #2193)", () => {
-  it("Sign in button (unauthenticated header) has focus ring", () => {
-    // Use router.push('/login') in header context
-    const idx = src.indexOf("router.push(\"/login\")");
+  it("Sign in link (unauthenticated header) has focus ring", () => {
+    // Sign in is now a <Link href="/login"> — anchor on href="/login"
+    const idx = src.indexOf('href="/login"');
     expect(idx).toBeGreaterThan(-1);
     const window = src.slice(idx, idx + 300);
     expect(window).toContain("focus-visible:ring-amber-400");
   });
 
-  it("Profile avatar button (overflow-hidden) has ring-inset", () => {
+  it("Profile avatar link (overflow-hidden) has ring-inset", () => {
     // className comes after aria-label — look forward from first "Profile & Settings"
     const idx = src.indexOf("Profile & Settings");
     expect(idx).toBeGreaterThan(-1);

--- a/frontend/src/__tests__/NotesBookIdTouchTargets.test.ts
+++ b/frontend/src/__tests__/NotesBookIdTouchTargets.test.ts
@@ -22,15 +22,15 @@ describe("notes/[bookId] page touch targets (closes #849)", () => {
     expect(window).toContain("min-h-[44px]");
   });
 
-  it("back to Notes header button has min-h-[44px]", () => {
-    // className comes after onClick — check a forward window
-    const idx = src.indexOf('router.push("/notes")');
+  it("back to Notes header link has min-h-[44px]", () => {
+    // back to Notes is now a <Link href="/notes"> — anchor on href="/notes"
+    const idx = src.indexOf('href="/notes"');
     expect(idx).toBeGreaterThan(-1);
     const window = src.slice(idx, idx + 200);
     expect(window).toContain("min-h-[44px]");
   });
 
-  it("empty-state Open reader button has min-h-[44px]", () => {
+  it("empty-state Open reader link has min-h-[44px]", () => {
     const idx = src.indexOf("Open reader");
     expect(idx).toBeGreaterThan(-1);
     const window = src.slice(Math.max(0, idx - 350), idx + 20);

--- a/frontend/src/__tests__/NotesPage.branches.test.tsx
+++ b/frontend/src/__tests__/NotesPage.branches.test.tsx
@@ -95,23 +95,23 @@ describe("NotesPage overview — book card sources", () => {
     await waitFor(() => expect(screen.getByText("Vocab Only Book")).toBeInTheDocument());
   });
 
-  it("navigates to /notes/[bookId] when book card is clicked", async () => {
+  it("book card is a link to /notes/[bookId]", async () => {
     mockGetAllAnnotations.mockResolvedValue([
       { id: 1, book_id: 55, chapter_index: 0, sentence_text: "s", note_text: "", color: "yellow",
         book_title: "Click Me", created_at: "2026-01-01T00:00:00" } as AnnotationWithBook,
     ]);
     render(<NotesPage />);
     await waitFor(() => screen.getByText("Click Me"));
-    await userEvent.click(screen.getByText("Click Me"));
-    expect(mockRouterPush).toHaveBeenCalledWith("/notes/55");
+    const link = screen.getByRole("link", { name: /Click Me/i });
+    expect(link).toHaveAttribute("href", "/notes/55");
   });
 
-  it("navigates to / when ← Library button is clicked", async () => {
+  it("← Library link navigates to /", async () => {
     mockUseSession.mockReturnValue({ data: { backendToken: "tok" }, status: "authenticated" });
     render(<NotesPage />);
     await flushPromises();
-    fireEvent.click(screen.getByRole("button", { name: /Library/i }));
-    expect(mockRouterPush).toHaveBeenCalledWith("/");
+    const link = screen.getByRole("link", { name: /Library/i });
+    expect(link).toHaveAttribute("href", "/");
   });
 });
 

--- a/frontend/src/__tests__/NotesPage.test.tsx
+++ b/frontend/src/__tests__/NotesPage.test.tsx
@@ -95,12 +95,12 @@ test("shows insight count badge on book card when insights exist", async () => {
   expect(countPill).toBeTruthy();
 });
 
-test("clicking a book card navigates to /notes/[bookId]", async () => {
+test("book card is a link to /notes/[bookId]", async () => {
   mockGetAllAnnotations.mockResolvedValue([makeAnnotation({ book_id: 42, book_title: "Test Book" })]);
   render(<NotesPage />);
   await waitFor(() => expect(screen.getByText("Test Book")).toBeInTheDocument());
-  await userEvent.click(screen.getByText("Test Book"));
-  expect(mockPush).toHaveBeenCalledWith("/notes/42");
+  const link = screen.getByRole("link", { name: /Test Book/i });
+  expect(link).toHaveAttribute("href", "/notes/42");
 });
 
 test("search filters book cards by title", async () => {

--- a/frontend/src/__tests__/NotesPageCoverage3.test.tsx
+++ b/frontend/src/__tests__/NotesPageCoverage3.test.tsx
@@ -39,17 +39,15 @@ beforeEach(() => {
   mockGetVocabulary.mockResolvedValue([]);
 });
 
-// ── "Browse books" button onClick (FN:184) ────────────────────────────────────
+// ── "Browse books" link (FN:184) ─────────────────────────────────────────────
 
-test("clicking 'Browse books' in empty state navigates to / via router.push", async () => {
+test("'Browse books' in empty state is a link to /", async () => {
   // All APIs return empty arrays → books.length === 0 → empty state shown
   render(<NotesPage />);
   await waitFor(() => flushPromises());
 
-  const browseBtn = await screen.findByRole("button", { name: /browse books/i });
-  await userEvent.click(browseBtn);
-
-  expect(mockPush).toHaveBeenCalledWith("/");
+  const browseLink = await screen.findByRole("link", { name: /browse books/i });
+  expect(browseLink).toHaveAttribute("href", "/");
 });
 
 // ── "Clear search" button onClick (FN:196) ────────────────────────────────────

--- a/frontend/src/__tests__/NotesUploadTouchTargets.test.ts
+++ b/frontend/src/__tests__/NotesUploadTouchTargets.test.ts
@@ -12,8 +12,8 @@ const uploadSrc = fs.readFileSync(
 
 describe("notes/page and upload/page touch targets (closes #860)", () => {
   it("notes Library back button has min-h-[44px]", () => {
-    // className comes after onClick in JSX — use forward window
-    const idx = notesSrc.indexOf('router.push("/")');
+    // Library back button is now a <Link href="/"> — anchor on href="/" near min-h-[44px]
+    const idx = notesSrc.indexOf('href="/"');
     expect(idx).toBeGreaterThan(-1);
     const window = notesSrc.slice(idx, idx + 200);
     expect(window).toContain("min-h-[44px]");

--- a/frontend/src/__tests__/ProfileFocusRing.test.ts
+++ b/frontend/src/__tests__/ProfileFocusRing.test.ts
@@ -8,7 +8,8 @@ const src = fs.readFileSync(
 
 describe("profile page button focus rings (closes #2170)", () => {
   it("back-to-Library button has focus-visible:ring-2 for WCAG 2.4.7", () => {
-    expect(src).toMatch(/router\.push\("\/"\)[\s\S]{0,200}?focus-visible:ring-2|focus-visible:ring-2[\s\S]{0,200}?router\.push\("\/"\)/);
+    // Library back button is now a <Link href="/"> — match on href="/" near focus-visible:ring-2
+    expect(src).toMatch(/href="\/"\s*[\s\S]{0,200}?focus-visible:ring-2|focus-visible:ring-2[\s\S]{0,200}?href="\//);
   });
 
   it("Sign out button has focus-visible:ring-2 for WCAG 2.4.7", () => {

--- a/frontend/src/__tests__/ProfilePage.coverage2.test.tsx
+++ b/frontend/src/__tests__/ProfilePage.coverage2.test.tsx
@@ -53,14 +53,14 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-// ── Line 136: "← Library" back button ────────────────────────────────────────
+// ── Line 136: "← Library" back link ─────────────────────────────────────────
 
-test("clicking ← Library navigates to /", async () => {
+test("← Library link navigates to /", async () => {
   render(<ProfilePage />);
   await act(async () => await flushPromises());
 
-  fireEvent.click(screen.getByRole("button", { name: /Library/i }));
-  expect(mockPush).toHaveBeenCalledWith("/");
+  const link = screen.getByRole("link", { name: /Library/i });
+  expect(link).toHaveAttribute("href", "/");
 });
 
 // ── Line 164: "Sign out" button ───────────────────────────────────────────────
@@ -73,19 +73,19 @@ test("clicking Sign out calls signOut with /login callback", async () => {
   expect(mockSignOut).toHaveBeenCalledWith({ callbackUrl: "/login" });
 });
 
-// ── Line 171: "Admin Panel" button ────────────────────────────────────────────
+// ── Line 171: "Admin Panel" link ─────────────────────────────────────────────
 
-test("clicking Admin Panel navigates to /admin", async () => {
+test("Admin Panel link navigates to /admin", async () => {
   const { getMe } = require("@/lib/api");
   getMe.mockResolvedValueOnce({ hasGeminiKey: false, role: "admin" });
 
   render(<ProfilePage />);
   await waitFor(() =>
-    expect(screen.getByRole("button", { name: /admin panel/i })).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /admin panel/i })).toBeInTheDocument()
   );
 
-  fireEvent.click(screen.getByRole("button", { name: /admin panel/i }));
-  expect(mockPush).toHaveBeenCalledWith("/admin");
+  const link = screen.getByRole("link", { name: /admin panel/i });
+  expect(link).toHaveAttribute("href", "/admin");
 });
 
 // ── Line 272: obsidianRepo onChange ──────────────────────────────────────────

--- a/frontend/src/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/__tests__/ProfilePage.test.tsx
@@ -209,19 +209,19 @@ describe("ProfilePage — preferences", () => {
 });
 
 describe("ProfilePage — admin visibility", () => {
-  it("does not show Admin Panel button for regular users", async () => {
+  it("does not show Admin Panel link for regular users", async () => {
     render(<ProfilePage />);
     await waitFor(() => screen.getByText(/Profile/i));
-    expect(screen.queryByRole("button", { name: /admin panel/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /admin panel/i })).not.toBeInTheDocument();
   });
 
-  it("shows Admin Panel button when user is admin", async () => {
+  it("shows Admin Panel link when user is admin", async () => {
     const { getMe } = require("@/lib/api");
     getMe.mockResolvedValueOnce({ hasGeminiKey: false, role: "admin" });
 
     render(<ProfilePage />);
     await waitFor(() =>
-      expect(screen.getByRole("button", { name: /admin panel/i })).toBeInTheDocument()
+      expect(screen.getByRole("link", { name: /admin panel/i })).toBeInTheDocument()
     );
   });
 });

--- a/frontend/src/__tests__/ReaderHeaderAria.test.ts
+++ b/frontend/src/__tests__/ReaderHeaderAria.test.ts
@@ -38,11 +38,11 @@ describe("Reader header buttons aria-label (closes #1015)", () => {
     expect(window).toContain("aria-label");
   });
 
-  it("Profile avatar button has aria-label", () => {
-    // Find the profile button (router.push("/profile") in header)
-    const idx = src.indexOf('router.push("/profile")');
+  it("Profile avatar link has aria-label", () => {
+    // Profile avatar is now a <Link href="/profile"> — anchor on href="/profile"
+    const idx = src.indexOf('href="/profile"');
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(Math.max(0, idx - 50), idx + 200);
+    const window = src.slice(idx, idx + 300);
     expect(window).toContain("aria-label");
   });
 });

--- a/frontend/src/__tests__/ReaderPage.branches2.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches2.test.tsx
@@ -1717,11 +1717,10 @@ describe("ReaderPage.branches2 — gemini key required banner navigation button"
       if (banner) expect(banner).toBeInTheDocument();
     }, { timeout: 2000 });
 
-    // Click the navigation button in the gemini key required banner
-    const addKeyBtn = screen.queryByText("Add your Gemini API key in Settings");
-    if (addKeyBtn) {
-      await userEvent.click(addKeyBtn);
-      expect(mockPush).toHaveBeenCalledWith("/profile");
+    // The "Add your Gemini API key in Settings" is now a Link to /profile
+    const addKeyLink = screen.queryByText("Add your Gemini API key in Settings");
+    if (addKeyLink) {
+      expect(addKeyLink.closest("a")).toHaveAttribute("href", "/profile");
     }
   });
 });

--- a/frontend/src/__tests__/ReaderPage.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.test.tsx
@@ -846,15 +846,14 @@ describe("ReaderPage — reading progress bar", () => {
   });
 });
 
-describe("ReaderPage — profile button", () => {
-  it("navigates to /profile when profile button is clicked", async () => {
+describe("ReaderPage — profile link", () => {
+  it("profile link navigates to /profile", async () => {
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
     render(<ReaderPage />);
     await flushPromises();
 
-    const profileBtn = await screen.findByTitle("TestUser");
-    await userEvent.click(profileBtn);
-    expect(mockPush).toHaveBeenCalledWith("/profile");
+    const profileLink = await screen.findByTitle("TestUser");
+    expect(profileLink).toHaveAttribute("href", "/profile");
   });
 });
 

--- a/frontend/src/__tests__/ReaderVocabLemmaProfileAvatarTouchTargets.test.ts
+++ b/frontend/src/__tests__/ReaderVocabLemmaProfileAvatarTouchTargets.test.ts
@@ -21,33 +21,34 @@ describe("reader vocab lemma header button touch target (closes #944)", () => {
   });
 });
 
-describe("reader profile avatar button touch target (closes #944)", () => {
-  it("reader header profile avatar button has min-w-[44px]", () => {
-    const idx = readerSrc.indexOf('router.push("/profile")');
+describe("reader profile avatar link touch target (closes #944)", () => {
+  it("reader header profile avatar link has min-w-[44px]", () => {
+    // Profile avatar is now a <Link href="/profile"> — anchor on href="/profile"
+    const idx = readerSrc.indexOf('href="/profile"');
     expect(idx).toBeGreaterThan(-1);
     const window = readerSrc.slice(idx, idx + 300);
     expect(window).toContain("min-w-[44px]");
   });
 
-  it("reader header profile avatar button has min-h-[44px]", () => {
-    const idx = readerSrc.indexOf('router.push("/profile")');
+  it("reader header profile avatar link has min-h-[44px]", () => {
+    const idx = readerSrc.indexOf('href="/profile"');
     expect(idx).toBeGreaterThan(-1);
     const window = readerSrc.slice(idx, idx + 300);
     expect(window).toContain("min-h-[44px]");
   });
 });
 
-describe("homepage profile avatar button touch target (closes #944)", () => {
-  it("homepage header profile avatar button has min-w-[44px]", () => {
-    // Find the profile button that navigates to /profile
-    const idx = homeSrc.indexOf('router.push("/profile")');
+describe("homepage profile avatar link touch target (closes #944)", () => {
+  it("homepage header profile avatar link has min-w-[44px]", () => {
+    // Profile avatar is now a <Link href="/profile"> — anchor on href="/profile"
+    const idx = homeSrc.indexOf('href="/profile"');
     expect(idx).toBeGreaterThan(-1);
     const window = homeSrc.slice(idx, idx + 300);
     expect(window).toContain("min-w-[44px]");
   });
 
-  it("homepage header profile avatar button has min-h-[44px]", () => {
-    const idx = homeSrc.indexOf('router.push("/profile")');
+  it("homepage header profile avatar link has min-h-[44px]", () => {
+    const idx = homeSrc.indexOf('href="/profile"');
     expect(idx).toBeGreaterThan(-1);
     const window = homeSrc.slice(idx, idx + 300);
     expect(window).toContain("min-h-[44px]");

--- a/frontend/src/__tests__/RemainingNavLinks.test.ts
+++ b/frontend/src/__tests__/RemainingNavLinks.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Source-level tests verifying that pure-navigation buttons have been replaced
+ * with semantic Link elements across the remaining pages (closes #2451).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+function readSrc(rel: string): string {
+  return fs.readFileSync(path.join(__dirname, "../app", rel), "utf8");
+}
+
+const profileSrc = readSrc("profile/page.tsx");
+const vocabSrc = readSrc("vocabulary/page.tsx");
+const notesListSrc = readSrc("notes/page.tsx");
+const notesBookSrc = readSrc("notes/[bookId]/page.tsx");
+const decksSrc = readSrc("decks/page.tsx");
+const decksNewSrc = readSrc("decks/new/page.tsx");
+const deckDetailSrc = readSrc("decks/[deckId]/page.tsx");
+const adminBooksSrc = readSrc("admin/books/page.tsx");
+const adminUploadsSrc = readSrc("admin/uploads/page.tsx");
+const homeSrc = readSrc("page.tsx");
+const readerSrc = readSrc("reader/[bookId]/page.tsx");
+
+describe("profile page nav links (closes #2451)", () => {
+  it("Library back button uses href=/ not router.push", () => {
+    expect(profileSrc).not.toMatch(/<button[^>]*onClick[^>]*router\.push\(["']\/["']\)/);
+    expect(profileSrc).toMatch(/href=["']\/["']/);
+  });
+
+  it("Admin Panel uses href=/admin not router.push", () => {
+    expect(profileSrc).not.toMatch(/<button[^>]*onClick[^>]*router\.push\(["']\/admin["']\)/);
+    expect(profileSrc).toMatch(/href=["']\/admin["']/);
+  });
+});
+
+describe("vocabulary page nav links (closes #2451)", () => {
+  it("Library back button uses href=/ not router.push", () => {
+    expect(vocabSrc).not.toMatch(/<button[^>]*onClick[^>]*router\.push\(["']\/["']\)/);
+    expect(vocabSrc).toMatch(/href=["']\/["']/);
+  });
+
+  it("Flashcards button uses href not router.push", () => {
+    expect(vocabSrc).not.toMatch(/<button[^>]*onClick[^>]*router\.push\(["']\/vocabulary\/flashcards["']\)/);
+    expect(vocabSrc).toMatch(/href=["']\/vocabulary\/flashcards["']/);
+  });
+});
+
+describe("notes list page nav links (closes #2451)", () => {
+  it("Library back button uses href=/ not router.push", () => {
+    expect(notesListSrc).not.toMatch(/<button[^>]*onClick[^>]*router\.push\(["']\/["']\)/);
+    expect(notesListSrc).toMatch(/href=["']\/["']/);
+  });
+
+  it("book card uses href not router.push", () => {
+    expect(notesListSrc).not.toMatch(/onClick.*router\.push.*notes\//);
+    expect(notesListSrc).toMatch(/href=.*\/notes\//);
+  });
+});
+
+describe("notes book page nav links (closes #2451)", () => {
+  it("Notes back button uses href=/notes not router.push", () => {
+    expect(notesBookSrc).not.toMatch(/<button[^>]*onClick[^>]*router\.push\(["']\/notes["']\)/);
+    expect(notesBookSrc).toMatch(/href=["']\/notes["']/);
+  });
+
+  it("Open reader button uses href not router.push", () => {
+    expect(notesBookSrc).not.toMatch(/<button[^>]*onClick.*router\.push.*\/reader\//);
+    expect(notesBookSrc).toMatch(/href=.*\/reader\//);
+  });
+});
+
+describe("decks page nav links (closes #2451)", () => {
+  it("Library back button uses href=/ not router.push", () => {
+    expect(decksSrc).not.toMatch(/<button[^>]*onClick[^>]*router\.push\(["']\/["']\)/);
+    expect(decksSrc).toMatch(/href=["']\/["']/);
+  });
+
+  it("New deck header button uses href=/decks/new not router.push", () => {
+    expect(decksSrc).not.toMatch(/<button[^>]*onClick[^>]*router\.push\(["']\/decks\/new["']\)/);
+    expect(decksSrc).toMatch(/href=["']\/decks\/new["']/);
+  });
+
+  it("DeckCard uses href prop not onClick with router.push", () => {
+    expect(decksSrc).not.toMatch(/onClick.*router\.push.*\/decks\//);
+    expect(decksSrc).toMatch(/href=.*\/decks\//);
+  });
+});
+
+describe("decks new page nav links (closes #2451)", () => {
+  it("Decks back button uses href=/decks not router.push", () => {
+    expect(decksNewSrc).not.toMatch(/<button[^>]*onClick[^>]*router\.push\(["']\/decks["']\)/);
+    expect(decksNewSrc).toMatch(/href=["']\/decks["']/);
+  });
+});
+
+describe("deck detail page nav links (closes #2451)", () => {
+  it("Decks back button in header uses href=/decks not router.push", () => {
+    const idx = decksNewSrc.indexOf('href="/decks"');
+    expect(idx).toBeGreaterThan(-1);
+  });
+
+  it("empty state Start reading uses href=/ (Link element)", () => {
+    // The empty-state "Start reading" CTA should be a Link (href="/"), not a button
+    // (The header button with conditional logic intentionally keeps router.push)
+    expect(deckDetailSrc).toMatch(/href=["']\/["'][\s\S]{0,400}Start reading/);
+  });
+});
+
+describe("admin books page nav links (closes #2451)", () => {
+  it("Open reader button uses href not router.push", () => {
+    expect(adminBooksSrc).not.toMatch(/<button[^>]*onClick.*router\.push.*\/reader\//);
+    expect(adminBooksSrc).toMatch(/href=.*\/reader\//);
+  });
+});
+
+describe("admin uploads page nav links (closes #2451)", () => {
+  it("Open button uses href not router.push", () => {
+    expect(adminUploadsSrc).not.toMatch(/<button[^>]*onClick.*router\.push.*\/reader\//);
+    expect(adminUploadsSrc).toMatch(/href=.*\/reader\//);
+  });
+});
+
+describe("home page nav links (closes #2451)", () => {
+  it("Sign in header button uses href=/login not router.push", () => {
+    const idx = homeSrc.indexOf('href="/login"');
+    expect(idx).toBeGreaterThan(-1);
+  });
+
+  it("Profile avatar uses href=/profile not router.push onClick", () => {
+    expect(homeSrc).not.toMatch(/<button[^>]*onClick[^>]*router\.push\(["']\/profile["']\)/);
+    expect(homeSrc).toMatch(/href=["']\/profile["']/);
+  });
+
+  it("Continue reading card uses href not router.push", () => {
+    expect(homeSrc).not.toMatch(/<button[^>]*Continue reading[\s\S]{0,100}router\.push/);
+    expect(homeSrc).toMatch(/href=.*\/reader\//);
+  });
+});
+
+describe("reader page profile avatar links (closes #2451)", () => {
+  it("Profile avatar in header uses href=/profile not router.push onClick", () => {
+    expect(readerSrc).not.toMatch(/<button[^>]*onClick[^>]*router\.push\(["']\/profile["']\)[\s\S]{0,300}rounded-full/);
+    expect(readerSrc).toMatch(/href=["']\/profile["']/);
+  });
+
+  it("Gemini key settings uses href=/profile not router.push", () => {
+    const idx = readerSrc.indexOf("Add your Gemini API key in Settings");
+    expect(idx).toBeGreaterThan(-1);
+    const context = readerSrc.slice(Math.max(0, idx - 200), idx + 50);
+    expect(context).not.toMatch(/onClick.*router\.push/);
+    expect(context).toMatch(/href=["']\/profile["']/);
+  });
+});

--- a/frontend/src/__tests__/VocabDeckNotesFocusRing.test.ts
+++ b/frontend/src/__tests__/VocabDeckNotesFocusRing.test.ts
@@ -24,7 +24,8 @@ const undoToast = fs.readFileSync(
 
 describe("vocabulary page button focus rings (closes #2174)", () => {
   it("Library back button has focus-visible:ring-2", () => {
-    expect(vocabPage).toMatch(/router\.push\("\/"\)[\s\S]{0,300}?focus-visible:ring-2|focus-visible:ring-2[\s\S]{0,300}?router\.push\("\/"\)/);
+    // Library back button is now a <Link href="/"> — match on href near focus-visible:ring-2
+    expect(vocabPage).toMatch(/href="\/"\s*[\s\S]{0,300}?focus-visible:ring-2|focus-visible:ring-2[\s\S]{0,300}?href="\//);
   });
 
   it("Flashcards button has focus-visible:ring-2", () => {
@@ -43,7 +44,8 @@ describe("vocabulary page button focus rings (closes #2174)", () => {
 
 describe("decks/[deckId] page button focus rings (closes #2174)", () => {
   it("Decks back button has focus-visible:ring-2", () => {
-    expect(deckDetailPage).toMatch(/router\.push\("\/decks"\)[\s\S]{0,300}?focus-visible:ring-2|focus-visible:ring-2[\s\S]{0,300}?router\.push\("\/decks"\)/);
+    // Decks back button is now a <Link href="/decks"> — match on href near focus-visible:ring-2
+    expect(deckDetailPage).toMatch(/href="\/decks"[\s\S]{0,300}?focus-visible:ring-2|focus-visible:ring-2[\s\S]{0,300}?href="\/decks"/);
   });
 
   it("deck detail page has at least 4 focus-visible:ring-2 instances", () => {

--- a/frontend/src/__tests__/VocabularyPage.branches.test.tsx
+++ b/frontend/src/__tests__/VocabularyPage.branches.test.tsx
@@ -66,17 +66,17 @@ beforeEach(() => {
   mockPush.mockReset();
 });
 
-// ── Line 72: router.push("/") ─────────────────────────────────────────────────
+// ── Library back link ─────────────────────────────────────────────────────────
 
 describe("VocabularyPage — Library back button (line 72)", () => {
-  it("navigates to '/' when ← Library button is clicked", async () => {
+  it("← Library link has href='/'", async () => {
     mockGetVocabulary.mockResolvedValue(MANY_WORDS);
     render(<VocabularyPage />);
     await flushPromises();
 
     await screen.findByText("apple");
-    await userEvent.click(screen.getByText("Library"));
-    expect(mockPush).toHaveBeenCalledWith("/");
+    const link = screen.getByRole("link", { name: /Library/i });
+    expect(link).toHaveAttribute("href", "/");
   });
 });
 

--- a/frontend/src/app/admin/books/page.tsx
+++ b/frontend/src/app/admin/books/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { adminFetch } from "@/lib/adminFetch";
 import SeedPopularButton from "@/components/SeedPopularButton";
 import { fuzzyMatchAny } from "@/lib/fuzzyMatch";
@@ -42,8 +42,6 @@ const QUEUE_LANG_OPTIONS = [
 ] as const;
 
 export default function BooksPage() {
-  const router = useRouter();
-
   useEffect(() => {
     document.title = "Admin: Books — Book Reader AI";
   }, []);
@@ -470,13 +468,13 @@ export default function BooksPage() {
                   )}
                 </div>
 
-                <button
-                  onClick={() => router.push(`/reader/${b.id}`)}
+                <Link
+                  href={`/reader/${b.id}`}
                   aria-label={`Open reader for ${b.title}`}
                   className="text-xs text-amber-700 hover:text-amber-800 shrink-0 min-h-[44px] md:min-h-0 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                 >
                   Open
-                </button>
+                </Link>
 
                 <select
                   aria-label="Translation language"

--- a/frontend/src/app/admin/uploads/page.tsx
+++ b/frontend/src/app/admin/uploads/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useCallback, useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { adminFetch } from "@/lib/adminFetch";
 import { AlertCircleIcon, CloseIcon, EmptyUploadIcon, RetryIcon } from "@/components/Icons";
 
@@ -29,7 +29,6 @@ function fmt_date(iso: string): string {
 }
 
 export default function UploadsPage() {
-  const router = useRouter();
   const [uploads, setUploads] = useState<UploadEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -168,13 +167,13 @@ export default function UploadsPage() {
                     </td>
                     <td className="px-4 py-2.5 text-stone-600 whitespace-nowrap">{fmt_date(u.uploaded_at)}</td>
                     <td className="px-4 py-2.5">
-                      <button
-                        onClick={() => router.push(`/reader/${u.book_id}`)}
+                      <Link
+                        href={`/reader/${u.book_id}`}
                         aria-label={`Open ${u.title}`}
                         className="text-xs text-amber-700 hover:text-amber-800 min-h-[44px] md:min-h-0 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                       >
                         Open
-                      </button>
+                      </Link>
                     </td>
                   </tr>
                 ))}

--- a/frontend/src/app/decks/[deckId]/page.tsx
+++ b/frontend/src/app/decks/[deckId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
 import { useSession } from "next-auth/react";
 import {
   DeckDetail,
@@ -130,12 +131,12 @@ export default function DeckDetailPage() {
   return (
     <main id="main-content" className="min-h-screen bg-parchment">
       <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
-        <button
-          onClick={() => router.push("/decks")}
+        <Link
+          href="/decks"
           className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] md:min-h-0 flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
         >
           <ArrowLeftIcon className="w-4 h-4 shrink-0" /> Decks
-        </button>
+        </Link>
         <div className="flex-1 min-w-0">
           <h1 className="font-serif font-bold text-ink truncate" title={deck?.name}>
             {deck?.name ?? "Deck"}
@@ -193,13 +194,12 @@ export default function DeckDetailPage() {
                 <RetryIcon className="w-4 h-4" aria-hidden="true" />
                 Retry
               </button>
-              <button
-                type="button"
-                onClick={() => router.push("/decks")}
-                className="px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg border border-amber-300 text-amber-700 text-sm hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
+              <Link
+                href="/decks"
+                className="px-4 py-2 min-h-[44px] md:min-h-0 rounded-lg border border-amber-300 text-amber-700 text-sm hover:bg-amber-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 inline-flex items-center"
               >
                 Back to decks
-              </button>
+              </Link>
             </div>
           </div>
         ) : (
@@ -229,13 +229,12 @@ export default function DeckDetailPage() {
                 {isManual ? (
                   vocab.length === 0 ? (
                     <>
-                      <button
-                        type="button"
-                        onClick={() => router.push("/")}
+                      <Link
+                        href="/"
                         className="mt-1 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
                       >
                         Start reading
-                      </button>
+                      </Link>
                     </>
                   ) : (
                     <button
@@ -248,14 +247,13 @@ export default function DeckDetailPage() {
                     </button>
                   )
                 ) : (
-                  <button
-                    type="button"
-                    onClick={() => router.push("/decks")}
+                  <Link
+                    href="/decks"
                     className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                   >
                     <ArrowLeftIcon className="w-4 h-4" />
                     Back to decks
-                  </button>
+                  </Link>
                 )}
               </div>
             ) : (

--- a/frontend/src/app/decks/new/page.tsx
+++ b/frontend/src/app/decks/new/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { FormEvent, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { ApiError, createDeck, DeckMode } from "@/lib/api";
 import { ArrowLeftIcon, DeckIcon } from "@/components/Icons";
 
@@ -74,12 +75,12 @@ export default function DecksNewPage() {
   return (
     <main id="main-content" className="min-h-screen bg-parchment">
       <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
-        <button
-          onClick={() => router.push("/decks")}
+        <Link
+          href="/decks"
           className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] md:min-h-0 flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
         >
           <ArrowLeftIcon className="w-4 h-4 shrink-0" /> Decks
-        </button>
+        </Link>
         <div className="flex-1 min-w-0">
           <h1 className="font-serif font-bold text-ink truncate">New deck</h1>
         </div>
@@ -300,13 +301,12 @@ export default function DecksNewPage() {
               <DeckIcon className="w-4 h-4" />
               {submitting ? "Creating…" : "Create deck"}
             </button>
-            <button
-              type="button"
-              onClick={() => router.push("/decks")}
-              className="text-sm text-amber-700 hover:text-amber-900 min-h-[44px] md:min-h-0 px-3 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
+            <Link
+              href="/decks"
+              className="text-sm text-amber-700 hover:text-amber-900 min-h-[44px] md:min-h-0 px-3 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 flex items-center"
             >
               Cancel
-            </button>
+            </Link>
           </div>
         </form>
       </div>

--- a/frontend/src/app/decks/page.tsx
+++ b/frontend/src/app/decks/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useCallback, useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { useSession } from "next-auth/react";
 import { DeckSummary, deleteDeck, listDecks } from "@/lib/api";
 import DeckCard from "@/components/DeckCard";
@@ -9,7 +9,6 @@ import { ArrowLeftIcon, DeckIcon, AlertCircleIcon, RetryIcon } from "@/component
 
 export default function DecksPage() {
   const { data: session } = useSession();
-  const router = useRouter();
   const [decks, setDecks] = useState<DeckSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState(false);
@@ -60,12 +59,12 @@ export default function DecksPage() {
   return (
     <main id="main-content" className="min-h-screen bg-parchment">
       <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
-        <button
-          onClick={() => router.push("/")}
+        <Link
+          href="/"
           className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] md:min-h-0 flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
         >
           <ArrowLeftIcon className="w-4 h-4 shrink-0" /> Library
-        </button>
+        </Link>
         <div className="flex-1 min-w-0">
           <h1 className="font-serif font-bold text-ink truncate">Decks</h1>
           {!loading && !fetchError && (
@@ -75,16 +74,15 @@ export default function DecksPage() {
           )}
         </div>
         {showNewDeckBtn && (
-          <button
-            type="button"
-            onClick={() => router.push("/decks/new")}
+          <Link
+            href="/decks/new"
             data-testid="decks-new-btn"
             aria-label="New deck"
             className="flex items-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <DeckIcon className="w-4 h-4" />
             <span className="hidden sm:inline">New deck</span>
-          </button>
+          </Link>
         )}
       </header>
 
@@ -123,15 +121,14 @@ export default function DecksPage() {
               Build focused review lists from your saved vocabulary. Start with a manual
               deck — pick a few words and study just them.
             </p>
-            <button
-              type="button"
-              onClick={() => router.push("/decks/new")}
+            <Link
+              href="/decks/new"
               data-testid="decks-empty-new-btn"
               className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
             >
               <DeckIcon className="w-4 h-4" />
               New deck
-            </button>
+            </Link>
           </div>
         ) : (
           <ul role="list" aria-label="Your decks" className="space-y-4 list-none p-0 m-0">
@@ -139,7 +136,7 @@ export default function DecksPage() {
               <li key={d.id}>
                 <DeckCard
                   deck={d}
-                  onClick={() => router.push(`/decks/${d.id}`)}
+                  href={`/decks/${d.id}`}
                   onDelete={handleDelete}
                 />
               </li>

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
 import { useSession } from "next-auth/react";
 import {
   getAnnotations,
@@ -686,12 +687,12 @@ export default function BookNotesPage() {
       {/* Sticky header */}
       <header className="sticky top-0 z-10 border-b border-amber-200 bg-white/80 backdrop-blur px-4 md:px-6 py-3">
         <div className="max-w-3xl mx-auto flex items-center gap-3 flex-wrap">
-          <button
-            onClick={() => router.push("/notes")}
+          <Link
+            href="/notes"
             className="text-amber-700 hover:text-amber-900 text-sm font-medium shrink-0 min-h-[44px] md:min-h-0 flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <ArrowLeftIcon className="w-3.5 h-3.5 mr-1 inline" aria-hidden="true" />Notes
-          </button>
+          </Link>
 
           <div className="flex-1 min-w-0">
             <p className="text-xs text-stone-600 truncate" title={`${annCount} annotations · ${insCount} insights · ${vocCount} words`}>
@@ -789,12 +790,12 @@ export default function BookNotesPage() {
             <EmptyNotesIcon className="w-16 h-16 mx-auto mb-3 text-amber-300" aria-hidden="true" />
             <p className="font-serif text-lg text-ink mb-1">No notes yet</p>
             <p className="text-sm">Annotate sentences, save AI insights, or add words to vocabulary while reading.</p>
-            <button
-              onClick={() => router.push(`/reader/${bookId}`)}
+            <Link
+              href={`/reader/${bookId}`}
               className="mt-4 px-5 py-2 min-h-[44px] md:min-h-0 rounded-lg bg-amber-700 text-white text-sm font-medium hover:bg-amber-800 inline-flex items-center gap-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
             >
               Open reader <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
-            </button>
+            </Link>
           </div>
         ) : (
           <div data-testid="notes-content">

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { useSession } from "next-auth/react";
 import { getAllAnnotations, getAllInsights, getVocabulary, AnnotationWithBook, BookInsightWithBook, VocabularyWord } from "@/lib/api";
 import { NoteIcon, InsightIcon, VocabIcon, EmptyNotesIcon, ArrowLeftIcon, ArrowRightIcon, WordIcon, AlertCircleIcon, RetryIcon } from "@/components/Icons";
@@ -111,12 +112,12 @@ export default function NotesOverviewPage() {
     <main id="main-content" className="min-h-screen bg-parchment">
       <header className="border-b border-amber-200 bg-white/60 backdrop-blur px-4 md:px-6 py-3 md:py-4 sticky top-0 z-10">
         <div className="max-w-3xl mx-auto flex items-center gap-4">
-          <button
-            onClick={() => router.push("/")}
+          <Link
+            href="/"
             className="text-amber-700 hover:text-amber-900 text-sm font-medium shrink-0 min-h-[44px] md:min-h-0 flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           >
             <ArrowLeftIcon className="w-3.5 h-3.5 mr-1 inline" aria-hidden="true" />Library
-          </button>
+          </Link>
           <div className="flex-1">
             <h1 className="text-xl font-serif font-bold text-ink">Your Notes</h1>
           </div>
@@ -177,13 +178,12 @@ export default function NotesOverviewPage() {
               <>
                 <p className="font-serif text-lg text-ink mb-1">No notes yet</p>
                 <p className="text-sm">Annotate sentences or save AI insights while reading.</p>
-                <button
-                  type="button"
-                  onClick={() => router.push("/")}
+                <Link
+                  href="/"
                   className="mt-5 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
                 >
                   Browse books <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
-                </button>
+                </Link>
               </>
             ) : (
               <>
@@ -203,13 +203,13 @@ export default function NotesOverviewPage() {
           <ul role="list" aria-label="Books with notes" className="space-y-3 list-none p-0 m-0">
             {filtered.map((book) => (
               <li key={book.bookId}>
-              <button
-                onClick={() => router.push(`/notes/${book.bookId}`)}
+              <Link
+                href={`/notes/${book.bookId}`}
                 style={{ boxShadow: "var(--shadow-card)" }}
-                onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card-hover)"; }}
-                onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card)"; }}
-                onFocus={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card-hover)"; }}
-                onBlur={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card)"; }}
+                onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.boxShadow = "var(--shadow-card-hover)"; }}
+                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.boxShadow = "var(--shadow-card)"; }}
+                onFocus={(e) => { (e.currentTarget as HTMLElement).style.boxShadow = "var(--shadow-card-hover)"; }}
+                onBlur={(e) => { (e.currentTarget as HTMLElement).style.boxShadow = "var(--shadow-card)"; }}
                 className="w-full text-left rounded-xl border border-amber-200 bg-white/80 px-5 py-4 hover:border-amber-400 transition-colors group focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
               >
                 <div className="flex items-start gap-3">
@@ -243,7 +243,7 @@ export default function NotesOverviewPage() {
                     <p className="text-amber-600 group-hover:text-amber-800 mt-0.5"><ArrowRightIcon className="w-5 h-5" aria-hidden="true" /></p>
                   </div>
                 </div>
-              </button>
+              </Link>
               </li>
             ))}
           </ul>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -193,15 +193,15 @@ export default function Home() {
           <div className="flex items-center gap-2">
             {status === "authenticated" ? <SearchBar /> : null}
             {status === "unauthenticated" ? (
-              <button
-                onClick={() => router.push("/login")}
-                className="rounded-lg border border-amber-300 px-4 py-2.5 md:py-1.5 text-sm font-medium text-amber-700 hover:bg-amber-50 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
+              <Link
+                href="/login"
+                className="rounded-lg border border-amber-300 px-4 py-2.5 md:py-1.5 text-sm font-medium text-amber-700 hover:bg-amber-50 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 flex items-center"
               >
                 Sign in
-              </button>
+              </Link>
             ) : (
-              <button
-                onClick={() => router.push("/profile")}
+              <Link
+                href="/profile"
                 title={`${session?.backendUser?.name ?? "Profile"} — Profile & Settings`}
                 aria-label={`${session?.backendUser?.name ?? "Profile"} — Profile & Settings`}
                 className="min-w-[44px] md:min-w-0 min-h-[44px] md:min-h-0 w-11 h-11 md:w-9 md:h-9 rounded-full overflow-hidden border border-amber-200 hover:border-amber-400 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-inset"
@@ -214,7 +214,7 @@ export default function Home() {
                     {session?.backendUser?.name?.[0] ?? "?"}
                   </span>
                 )}
-              </button>
+              </Link>
             )}
           </div>
         </div>
@@ -322,15 +322,15 @@ export default function Home() {
                 <h2 className="text-xs font-semibold uppercase tracking-widest text-stone-600 mb-2">
                   Continue Reading
                 </h2>
-                <button
+                <Link
+                  href={`/reader/${recentBooks[0].id}`}
                   aria-label="Continue reading"
-                  onClick={() => router.push(`/reader/${recentBooks[0].id}`)}
                   className="w-full text-left rounded-xl border border-amber-200 bg-white p-3 flex items-center gap-3 hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 transition-all duration-200"
                   style={{ boxShadow: "var(--shadow-card)" }}
-                  onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card-hover)"; }}
-                  onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card)"; }}
-                  onFocus={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card-hover)"; }}
-                  onBlur={(e) => { (e.currentTarget as HTMLButtonElement).style.boxShadow = "var(--shadow-card)"; }}
+                  onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.boxShadow = "var(--shadow-card-hover)"; }}
+                  onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.boxShadow = "var(--shadow-card)"; }}
+                  onFocus={(e) => { (e.currentTarget as HTMLElement).style.boxShadow = "var(--shadow-card-hover)"; }}
+                  onBlur={(e) => { (e.currentTarget as HTMLElement).style.boxShadow = "var(--shadow-card)"; }}
                 >
                   {recentBooks[0].cover ? (
                     // eslint-disable-next-line @next/next/no-img-element
@@ -348,7 +348,7 @@ export default function Home() {
                     </p>
                   </div>
                   <ArrowRightIcon className="w-4 h-4 text-amber-700 shrink-0" />
-                </button>
+                </Link>
               </section>
             )}
 
@@ -495,12 +495,12 @@ export default function Home() {
                     70,000+ free classics from Project Gutenberg — with AI translation, vocabulary building, and reading insights.
                   </p>
                   <div className="flex flex-col sm:flex-row gap-3 justify-center items-center">
-                    <button
-                      onClick={() => router.push("/login")}
-                      className="rounded-lg bg-amber-700 px-7 py-3 min-h-[44px] md:min-h-0 text-white font-semibold text-base hover:bg-amber-800 transition-colors shadow-sm min-w-[160px] focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
+                    <Link
+                      href="/login"
+                      className="rounded-lg bg-amber-700 px-7 py-3 min-h-[44px] md:min-h-0 text-white font-semibold text-base hover:bg-amber-800 transition-colors shadow-sm min-w-[160px] focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700 flex items-center justify-center"
                     >
                       Sign in free
-                    </button>
+                    </Link>
                     <button
                       onClick={() => document.getElementById("discover-search")?.scrollIntoView({ behavior: "smooth" })}
                       className="rounded-lg border border-amber-300 px-7 py-3 min-h-[44px] md:min-h-0 text-amber-800 font-medium text-base hover:bg-amber-50 transition-colors min-w-[160px] flex items-center justify-center gap-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -2,6 +2,7 @@
 import { useSession, signOut } from "next-auth/react";
 import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { saveGeminiKey, deleteGeminiKey, getMe, getObsidianSettings, saveObsidianSettings, listDecks, DeckSummary } from "@/lib/api";
 import { ArrowLeftIcon, CheckIcon, ChevronRightIcon, DeckIcon } from "@/components/Icons";
 import { getSettings, saveSettings, AppSettings } from "@/lib/settings";
@@ -210,12 +211,12 @@ export default function ProfilePage() {
     <main id="main-content" className="min-h-screen bg-parchment">
       {/* Header */}
       <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-6 py-4 flex items-center gap-4">
-        <button
-          onClick={() => router.push("/")}
+        <Link
+          href="/"
           className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] md:min-h-0 flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
         >
           <ArrowLeftIcon className="w-3.5 h-3.5 mr-1 inline" aria-hidden="true" />Library
-        </button>
+        </Link>
         <h1 className="font-serif font-bold text-ink">Profile &amp; Settings</h1>
       </header>
 
@@ -245,12 +246,12 @@ export default function ProfilePage() {
               Sign out
             </button>
             {isAdmin && (
-              <button
-                onClick={() => router.push("/admin")}
+              <Link
+                href="/admin"
                 className="text-sm text-amber-700 hover:text-amber-900 underline min-h-[44px] md:min-h-0 flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
               >
                 Admin Panel
-              </button>
+              </Link>
             )}
           </div>
         </section>

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback } from "react";
+import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
@@ -1343,8 +1344,8 @@ export default function ReaderPage() {
 
           {/* Profile / Sign-in — always rightmost */}
           {session?.backendToken ? (
-            <button
-              onClick={() => router.push("/profile")}
+            <Link
+              href="/profile"
               title={session.backendUser?.name ?? "Profile"}
               aria-label={session.backendUser?.name ?? "Profile"}
               className="shrink-0 min-w-[44px] min-h-[44px] md:min-w-0 md:min-h-0 w-10 h-10 md:w-8 md:h-8 rounded-full overflow-hidden border border-amber-300 hover:border-amber-500 transition-colors ml-auto md:ml-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
@@ -1357,7 +1358,7 @@ export default function ReaderPage() {
                   {session.backendUser?.name?.[0] ?? "?"}
                 </span>
               )}
-            </button>
+            </Link>
           ) : (
             <a
               href="/api/auth/signin"
@@ -1410,12 +1411,12 @@ export default function ReaderPage() {
         <div className="bg-amber-50 border-b border-amber-300 px-4 py-2 text-xs text-amber-800 flex items-center gap-2">
           <span>
             Translation requires a Gemini API key.{" "}
-            <button
-              onClick={() => router.push("/profile")}
+            <Link
+              href="/profile"
               className="underline font-medium hover:text-amber-900 rounded focus:outline-none focus-visible:ring-1 focus-visible:ring-amber-600"
             >
               Add your Gemini API key in Settings
-            </button>{" "}
+            </Link>{" "}
             to start translating.
           </span>
         </div>

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2,7 +2,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback } from "react";
 import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import Link from "next/link";
 import { useSession } from "next-auth/react";
 import { getBookChapters, deleteTranslationCache, synthesizeSpeech, getMe, getBookTranslationStatus, requestChapterTranslation, getChapterTranslation, getChapterQueueStatus, retryChapterTranslation, enqueueBookTranslation, saveReadingProgress, getAnnotations, createAnnotation, getVocabulary, saveVocabularyWord, exportVocabularyToObsidian, saveInsight, TranslationStatus, BookMeta, BookChapter, ApiError, Annotation, VocabularyWord, ChapterSource } from "@/lib/api";
 import { recordRecentBook, saveLastChapter, getLastChapter } from "@/lib/recentBooks";

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState, useMemo, useCallback, useRef, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
 import { useSession } from "next-auth/react";
 import {
   getVocabulary,
@@ -468,12 +469,12 @@ function VocabularyPageContent() {
   return (
     <main id="main-content" className="min-h-screen bg-parchment">
       <header className="border-b border-amber-200 bg-white/70 backdrop-blur px-4 md:px-6 py-3 md:py-4 flex items-center gap-3 md:gap-4">
-        <button
-          onClick={() => router.push("/")}
+        <Link
+          href="/"
           className="text-amber-700 hover:text-amber-900 text-sm min-h-[44px] md:min-h-0 flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
         >
           <ArrowLeftIcon className="w-4 h-4 shrink-0" /> Library
-        </button>
+        </Link>
         <div className="flex-1 min-w-0">
           <h1 className="font-serif font-bold text-ink truncate">Vocabulary</h1>
           {!loading && (
@@ -482,15 +483,15 @@ function VocabularyPageContent() {
             </p>
           )}
         </div>
-        <button
-          onClick={() => router.push("/vocabulary/flashcards")}
+        <Link
+          href="/vocabulary/flashcards"
           aria-label="Flashcards"
           className="flex items-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
           data-testid="flashcards-btn"
         >
           <FlashcardIcon className="w-4 h-4" />
           <span className="hidden sm:inline">Flashcards</span>
-        </button>
+        </Link>
         <button
           onClick={() => handleExport()}
           disabled={exporting || words.length === 0}
@@ -632,13 +633,12 @@ function VocabularyPageContent() {
             <EmptyVocabIcon className="w-14 h-14 text-amber-300" />
             <p className="font-serif text-lg text-stone-600 mt-1">No saved words yet.</p>
             <p className="text-sm">Double-click any word while reading to save it here.</p>
-            <button
-              type="button"
-              onClick={() => router.push("/")}
+            <Link
+              href="/"
               className="mt-4 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-amber-700 text-white hover:bg-amber-800 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
             >
               Browse books <ArrowRightIcon className="w-4 h-4" aria-hidden="true" />
-            </button>
+            </Link>
           </div>
         ) : filtered.length === 0 ? (
           <div className="text-center text-stone-600 mt-16 flex flex-col items-center gap-2">

--- a/frontend/src/components/DeckCard.tsx
+++ b/frontend/src/components/DeckCard.tsx
@@ -1,14 +1,16 @@
 "use client";
+import Link from "next/link";
 import type { DeckSummary } from "@/lib/api";
 import { DeckIcon, TrashIcon } from "@/components/Icons";
 
 interface DeckCardProps {
   deck: DeckSummary;
+  href?: string;
   onClick?: () => void;
   onDelete?: (id: number) => void | Promise<void>;
 }
 
-export default function DeckCard({ deck, onClick, onDelete }: DeckCardProps) {
+export default function DeckCard({ deck, href, onClick, onDelete }: DeckCardProps) {
   const modeLabel = deck.mode === "smart" ? "Smart" : "Manual";
 
   const cardContent = (
@@ -54,7 +56,16 @@ export default function DeckCard({ deck, onClick, onDelete }: DeckCardProps) {
       className="rounded-xl border border-amber-100 bg-white p-4 transition-all duration-200 hover:-translate-y-0.5"
     >
       <div className="flex items-start justify-between gap-3">
-        {onClick ? (
+        {href ? (
+          <Link
+            href={href}
+            aria-label={`Open deck ${deck.name}`}
+            data-testid={`deck-card-link-${deck.id}`}
+            className="min-w-0 flex-1 text-left hover:opacity-80 transition-opacity rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
+          >
+            {cardContent}
+          </Link>
+        ) : onClick ? (
           <button
             type="button"
             onClick={onClick}


### PR DESCRIPTION
## What changed

Replaced `<button onClick={() => router.push(...)}> ` navigation elements with semantic `<Link href="...">` across 11 pages and 1 component:

**Pages fixed:**
- `app/page.tsx` — Sign in header button, profile avatar, "Continue reading" card, "Sign in free" CTA
- `app/profile/page.tsx` — Library back button, Admin Panel link
- `app/vocabulary/page.tsx` — Library back button, Flashcards button, "Browse books" empty state CTA
- `app/notes/page.tsx` — Library back button, "Browse books" empty state CTA, book card navigation
- `app/notes/[bookId]/page.tsx` — Notes back button, "Open reader" empty state CTA
- `app/decks/page.tsx` — Library back button, New deck button (header + empty state)
- `app/decks/new/page.tsx` — Decks back button, Cancel button
- `app/decks/[deckId]/page.tsx` — Decks back button, "Back to decks" (error + smart deck empty state), "Start reading" CTA
- `app/admin/books/page.tsx` — "Open" reader button
- `app/admin/uploads/page.tsx` — "Open" reader button
- `app/reader/[bookId]/page.tsx` — Profile avatar button, Gemini key settings inline link

**Component fixed:**
- `components/DeckCard.tsx` — Added optional `href` prop; renders `<Link>` when provided, preserves `<button>` fallback for callers that still need onClick

**Intentionally preserved as `router.push`:**
- Auth guard redirects in `useEffect` (e.g. `router.replace("/login")`)
- Error state "Back to library" in reader page (contextual, not primary nav)
- Conditional button `vocab.length === 0 ? router.push("/") : setPickerOpen(true)` in deck detail header

## Why

`<button>` for pure page navigation is a semantic HTML bug:
- Prevents Ctrl+Click / middle-click to open in a new tab
- Screen readers announce as "button" not "link" (WCAG 4.1.2 violation)
- No href means the destination is invisible to search crawlers and assistive tech

## Test plan

- [x] `RemainingNavLinks.test.ts` — new source-level tests verifying all 11 pages use `href=` for navigation (not `router.push`)
- [x] 36 existing test files updated: `getByRole("button")` → `getByRole("link")`, `mockPush` assertions → `toHaveAttribute("href", ...)`
- [x] Full test suite: 3955 tests pass across 683 suites

Closes #2451
