### PR TITLE
fix: use Link href='/' for deck zero-vocab 'Start reading' CTA (closes #2455)

### DIFF
--- a/frontend/src/__tests__/DeckStartReadingNavLink.test.ts
+++ b/frontend/src/__tests__/DeckStartReadingNavLink.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Regression test for #2455: deck page 'Start reading' button (zero-vocab state)
+ * must use a semantic Link href="/" not router.push("/").
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(process.cwd(), "src/app/decks/[deckId]/page.tsx"),
+  "utf8",
+);
+
+describe("decks/[deckId]/page — zero-vocab 'Start reading' nav (closes #2455)", () => {
+  it("does not use router.push('/') for the Start reading navigation", () => {
+    expect(src).not.toMatch(/vocab\.length\s*===?\s*0[^}]*router\.push\(["']\/["']\)/);
+  });
+
+  it("uses href='/' for the Start reading link when vocab is empty", () => {
+    expect(src).toMatch(/vocab\.length\s*===?\s*0[\s\S]{0,600}href=["']\/["']/);
+  });
+});

--- a/frontend/src/app/decks/[deckId]/page.tsx
+++ b/frontend/src/app/decks/[deckId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
 import {
@@ -26,7 +26,6 @@ import { useScrollLock } from "@/lib/useScrollLock";
 
 export default function DeckDetailPage() {
   const { data: session } = useSession();
-  const router = useRouter();
   const params = useParams<{ deckId: string }>();
   const deckId = Number(params?.deckId);
 
@@ -149,17 +148,29 @@ export default function DeckDetailPage() {
           )}
         </div>
         {deck && isManual && (
-          <button
-            type="button"
-            onClick={() => vocab.length === 0 ? router.push("/") : setPickerOpen(true)}
-            aria-label={vocab.length === 0 ? "No vocabulary saved yet — go to library" : "Add word to deck"}
-            title={vocab.length === 0 ? "No vocabulary saved yet — save words while reading" : candidateWords.length === 0 ? "All vocabulary words are already in this deck" : undefined}
-            disabled={vocab.length > 0 && candidateWords.length === 0}
-            className="flex items-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium transition-colors min-h-[44px] md:min-h-0 shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
-          >
-            <PlusIcon className="w-4 h-4" />
-            <span className="hidden sm:inline">{vocab.length === 0 ? "Start reading" : "Add word"}</span>
-          </button>
+          vocab.length === 0 ? (
+            <Link
+              href="/"
+              aria-label="No vocabulary saved yet — go to library"
+              title="No vocabulary saved yet — save words while reading"
+              className="flex items-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-sm font-medium transition-colors min-h-[44px] md:min-h-0 shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
+            >
+              <PlusIcon className="w-4 h-4" />
+              <span className="hidden sm:inline">Start reading</span>
+            </Link>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setPickerOpen(true)}
+              aria-label="Add word to deck"
+              title={candidateWords.length === 0 ? "All vocabulary words are already in this deck" : undefined}
+              disabled={candidateWords.length === 0}
+              className="flex items-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium transition-colors min-h-[44px] md:min-h-0 shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
+            >
+              <PlusIcon className="w-4 h-4" />
+              <span className="hidden sm:inline">Add word</span>
+            </button>
+          )
         )}
       </header>
 


### PR DESCRIPTION
## What changed

In `app/decks/[deckId]/page.tsx`, split the single conditional button into two semantically correct elements:

- **`vocab.length === 0`** → `<Link href="/">Start reading</Link>` — pure navigation to the library home; renders as `<a>` with correct role, right-click → "Open in new tab" works, browser history is correct
- **`vocab.length > 0`** → `<button onClick={() => setPickerOpen(true)}>Add word</button>` — opens the word-picker dialog (action, not navigation)

Also removes the now-unused `useRouter` import.

## Why

`<button onClick={router.push('/')}>` for pure navigation violates WCAG 4.1.2 — buttons must perform actions, not navigation. Screen readers announce the element as a button (expecting an action), not a link (expecting navigation), which misleads keyboard and AT users.

Closes #2455.

## Test plan

- New source-level test `DeckStartReadingNavLink.test.ts`:
  - Verifies `router.push('/')` is NOT used in the zero-vocab conditional
  - Verifies `href="/"` IS present within the zero-vocab conditional path
- All 3968 tests pass

## Docs follow-up

N/A — internal interaction pattern change.
