### PR TITLE
fix: use Link href for import page Skip button navigation (closes #2457)

### DIFF
--- a/frontend/src/__tests__/ImportPage.branches.test.tsx
+++ b/frontend/src/__tests__/ImportPage.branches.test.tsx
@@ -309,15 +309,12 @@ describe("ImportPage — skipToReading (lines 213-216)", () => {
     expect(push).toHaveBeenCalledWith("/reader/42");
   });
 
-  it("Skip button before import start navigates to reader", async () => {
-    const { useRouter } = require("next/navigation");
-    const push = jest.fn();
-    useRouter.mockReturnValue({ push });
-
+  it("Skip link before import start points to reader URL", async () => {
     render(<BookImportPage />);
 
-    await clickAndFlush(/^Skip$/i);
-    expect(push).toHaveBeenCalledWith("/reader/42");
+    // "Skip" is now a semantic Link — check href rather than router.push
+    const skipLink = screen.getByRole("link", { name: /^Skip$/i });
+    expect(skipLink).toHaveAttribute("href", "/reader/42");
   });
 });
 

--- a/frontend/src/__tests__/ImportPage.coverage.test.tsx
+++ b/frontend/src/__tests__/ImportPage.coverage.test.tsx
@@ -255,17 +255,13 @@ describe("ImportPage — isDone auto-redirect", () => {
 // Line 263: "Skip" button before import starts — navigates to nextUrl
 // ─────────────────────────────────────────────────────────────────────────────
 describe("ImportPage — skip before import", () => {
-  it("Skip button navigates to reader URL without starting import", async () => {
-    const { useRouter } = require("next/navigation");
-    const push = jest.fn();
-    useRouter.mockReturnValue({ push });
-
+  it("Skip link points to reader URL without starting import", async () => {
     importBookStream.mockReturnValue(makeStream([]));
     render(<BookImportPage />);
 
-    // "Skip" is visible before import starts
-    fireEvent.click(screen.getByRole("button", { name: /^Skip$/i }));
-    expect(push).toHaveBeenCalledWith("/reader/42");
+    // "Skip" is a semantic Link rendered as <a> before import starts
+    const skipLink = screen.getByRole("link", { name: /^Skip$/i });
+    expect(skipLink).toHaveAttribute("href", "/reader/42");
     expect(importBookStream).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/__tests__/ImportSkipButtonNavLink.test.ts
+++ b/frontend/src/__tests__/ImportSkipButtonNavLink.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Regression test for #2457: import page 'Skip' button (pre-import state)
+ * must use a semantic Link href={nextUrl} not router.push(nextUrl).
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.join(process.cwd(), "src/app/import/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("import/[bookId]/page — 'Skip' nav button (closes #2457)", () => {
+  it("does not use router.push for the Skip navigation", () => {
+    expect(src).not.toMatch(/onClick=\{[^}]*router\.push\(nextUrl\)[^}]*\}[\s\S]{0,200}Skip/);
+  });
+
+  it("uses href={nextUrl} for the Skip link", () => {
+    expect(src).toMatch(/href=\{nextUrl\}[\s\S]{0,300}Skip/);
+  });
+});

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import {
   importBookStream,
@@ -200,12 +201,12 @@ export default function BookImportPage() {
                 >
                   Start import
                 </button>
-                <button
-                  onClick={() => router.push(nextUrl)}
+                <Link
+                  href={nextUrl}
                   className="rounded-lg border border-amber-300 text-amber-700 px-4 min-h-[44px] md:min-h-0 text-sm font-medium hover:bg-amber-50 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                 >
                   Skip
-                </button>
+                </Link>
               </div>
             </div>
           )}


### PR DESCRIPTION
## What changed

Converted the **Skip** button on `/import/[bookId]` (shown before import starts) from a `<button onClick={() => router.push(nextUrl)}>` to a semantic `<Link href={nextUrl}>`.

The other two buttons in that component — **Cancel** and **Start reading now** — call `abortRef.current?.abort()` as a side effect, so they correctly stay as `<button>` elements.

## Why

Using `<button>` for pure navigation violates WCAG 4.1.2 (name/role/value) and:
- Screen readers announce "button" instead of "link"
- Users cannot right-click → open in new tab
- Native browser back/forward semantics are lost

## Test plan

- New source-level regression test `ImportSkipButtonNavLink.test.ts` asserts `href={nextUrl}` and no `router.push`
- Updated `ImportPage.coverage.test.tsx` and `ImportPage.branches.test.tsx` to use `getByRole("link")` + `toHaveAttribute("href")` instead of button click + mockPush
- All 3970 frontend tests pass

Closes #2457
