### PR TITLE
fix: roving tabindex + arrow-key nav for AnnotationToolbar color picker (closes #2459)

### DIFF
--- a/frontend/src/__tests__/AnnotationToolbarColorKeyboard.test.tsx
+++ b/frontend/src/__tests__/AnnotationToolbarColorKeyboard.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Regression test for #2459: AnnotationToolbar color picker (role="radiogroup")
+ * must implement roving tabindex + arrow-key navigation per ARIA APG.
+ *
+ * Before fix: all 4 color buttons are individually tabbable (tabIndex omitted = 0),
+ * no arrow-key handlers. After fix: only selected color is tabIndex=0, arrow keys
+ * move focus + selection within the group.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("@/lib/api", () => ({
+  createAnnotation: jest.fn(),
+  updateAnnotation: jest.fn(),
+  deleteAnnotation: jest.fn(),
+}));
+
+import AnnotationToolbar from "@/components/AnnotationToolbar";
+
+const BASE_PROPS = {
+  sentenceText: "It is a truth universally acknowledged.",
+  chapterIndex: 0,
+  bookId: 1,
+  onClose: jest.fn(),
+  onSaved: jest.fn(),
+  onDeleted: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("AnnotationToolbar color picker — roving tabindex (closes #2459)", () => {
+  it("only the selected (Yellow) color button is in the tab sequence initially", () => {
+    render(<AnnotationToolbar {...BASE_PROPS} />);
+    const yellow = screen.getByRole("radio", { name: "Yellow" });
+    const blue   = screen.getByRole("radio", { name: "Blue" });
+    const green  = screen.getByRole("radio", { name: "Green" });
+    const pink   = screen.getByRole("radio", { name: "Pink" });
+    expect(yellow).toHaveAttribute("tabindex", "0");
+    expect(blue).toHaveAttribute("tabindex", "-1");
+    expect(green).toHaveAttribute("tabindex", "-1");
+    expect(pink).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("ArrowRight moves focus and selection from Yellow → Blue", async () => {
+    const user = userEvent.setup();
+    render(<AnnotationToolbar {...BASE_PROPS} />);
+    const yellow = screen.getByRole("radio", { name: "Yellow" });
+    yellow.focus();
+    await user.keyboard("{ArrowRight}");
+    const blue = screen.getByRole("radio", { name: "Blue" });
+    expect(blue).toHaveFocus();
+    expect(blue).toHaveAttribute("aria-checked", "true");
+    expect(yellow).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("ArrowRight wraps from Pink → Yellow", async () => {
+    const user = userEvent.setup();
+    render(<AnnotationToolbar {...BASE_PROPS} />);
+    // Select Pink first by clicking it
+    await user.click(screen.getByRole("radio", { name: "Pink" }));
+    const pink = screen.getByRole("radio", { name: "Pink" });
+    pink.focus();
+    await user.keyboard("{ArrowRight}");
+    const yellow = screen.getByRole("radio", { name: "Yellow" });
+    expect(yellow).toHaveFocus();
+    expect(yellow).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("ArrowLeft moves focus and selection from Blue → Yellow", async () => {
+    const user = userEvent.setup();
+    render(<AnnotationToolbar {...BASE_PROPS} />);
+    await user.click(screen.getByRole("radio", { name: "Blue" }));
+    const blue = screen.getByRole("radio", { name: "Blue" });
+    blue.focus();
+    await user.keyboard("{ArrowLeft}");
+    const yellow = screen.getByRole("radio", { name: "Yellow" });
+    expect(yellow).toHaveFocus();
+    expect(yellow).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("ArrowLeft wraps from Yellow → Pink", async () => {
+    const user = userEvent.setup();
+    render(<AnnotationToolbar {...BASE_PROPS} />);
+    const yellow = screen.getByRole("radio", { name: "Yellow" });
+    yellow.focus();
+    await user.keyboard("{ArrowLeft}");
+    const pink = screen.getByRole("radio", { name: "Pink" });
+    expect(pink).toHaveFocus();
+    expect(pink).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("ArrowDown moves focus like ArrowRight", async () => {
+    const user = userEvent.setup();
+    render(<AnnotationToolbar {...BASE_PROPS} />);
+    const yellow = screen.getByRole("radio", { name: "Yellow" });
+    yellow.focus();
+    await user.keyboard("{ArrowDown}");
+    expect(screen.getByRole("radio", { name: "Blue" })).toHaveFocus();
+  });
+
+  it("ArrowUp moves focus like ArrowLeft", async () => {
+    const user = userEvent.setup();
+    render(<AnnotationToolbar {...BASE_PROPS} />);
+    const yellow = screen.getByRole("radio", { name: "Yellow" });
+    yellow.focus();
+    await user.keyboard("{ArrowUp}");
+    expect(screen.getByRole("radio", { name: "Pink" })).toHaveFocus();
+  });
+});

--- a/frontend/src/__tests__/AnnotationToolbarColorTouchTargets.test.ts
+++ b/frontend/src/__tests__/AnnotationToolbarColorTouchTargets.test.ts
@@ -10,21 +10,21 @@ describe("AnnotationToolbar color picker touch targets (closes #826)", () => {
   it("color button wrapper has min-h-[44px]", () => {
     const idx = src.indexOf("Highlight colour");
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(idx, idx + 600);
+    const window = src.slice(idx, idx + 900);
     expect(window).toContain("min-h-[44px]");
   });
 
   it("color button wrapper has min-w-[44px]", () => {
     const idx = src.indexOf("Highlight colour");
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(idx, idx + 600);
+    const window = src.slice(idx, idx + 900);
     expect(window).toContain("min-w-[44px]");
   });
 
   it("visual circle swatch stays w-8 h-8", () => {
     const idx = src.indexOf("Highlight colour");
     expect(idx).toBeGreaterThan(-1);
-    const window = src.slice(idx, idx + 1000);
+    const window = src.slice(idx, idx + 1200);
     expect(window).toContain("w-8 h-8");
   });
 });

--- a/frontend/src/components/AnnotationToolbar.tsx
+++ b/frontend/src/components/AnnotationToolbar.tsx
@@ -44,6 +44,22 @@ export default function AnnotationToolbar({
   const [error, setError] = useState<string | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const colorBtnRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  function handleColorKeyDown(e: React.KeyboardEvent, idx: number) {
+    let next = idx;
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+      e.preventDefault();
+      next = (idx + 1) % COLORS.length;
+    } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+      e.preventDefault();
+      next = (idx - 1 + COLORS.length) % COLORS.length;
+    } else {
+      return;
+    }
+    setColor(COLORS[next].key);
+    colorBtnRefs.current[next]?.focus();
+  }
   useFocusTrap(panelRef);
   useScrollLock(true);
 
@@ -146,13 +162,16 @@ export default function AnnotationToolbar({
           <div>
             <p className="text-xs text-stone-600 mb-2" aria-hidden="true">Highlight colour</p>
             <div role="radiogroup" aria-label="Highlight colour" className="flex items-center gap-0.5">
-              {COLORS.map((c) => (
+              {COLORS.map((c, idx) => (
                 <button
                   key={c.key}
+                  ref={(el) => { colorBtnRefs.current[idx] = el; }}
                   type="button"
                   role="radio"
                   title={c.label}
                   onClick={() => setColor(c.key)}
+                  onKeyDown={(e) => handleColorKeyDown(e, idx)}
+                  tabIndex={color === c.key ? 0 : -1}
                   aria-label={c.label}
                   aria-checked={color === c.key}
                   className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"


### PR DESCRIPTION
## What changed

Added roving tabindex and arrow-key navigation to the color picker in `AnnotationToolbar.tsx`.

**Before:** All 4 color buttons were individually tabbable (`tabIndex` unset → 0), with no keyboard navigation within the group.

**After:**
- Only the selected color button is in the tab sequence (`tabIndex={0}`); others are `tabIndex={-1}`
- `ArrowRight`/`ArrowDown` moves focus + selection to the next color (wraps around)
- `ArrowLeft`/`ArrowUp` moves focus + selection to the previous color (wraps around)
- Clicking a color still works as before

## Why

The color picker uses `role="radiogroup"` with `role="radio"` buttons — a custom ARIA widget. The [ARIA Authoring Practices Guide radiogroup pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radio/) requires roving tabindex and arrow-key navigation for custom radio widgets. Without this, keyboard-only users must Tab through all 4 colors individually, breaking the expected interaction model. Fixes WCAG 2.1.1 (Keyboard) — AA.

Note: the TTS gender and translation provider pickers in `profile/page.tsx` use native `<input type="radio">` and already get arrow-key navigation from the browser — no change needed there.

## Test plan

- New `AnnotationToolbarColorKeyboard.test.tsx` (7 tests): roving tabindex initial state, ArrowRight/Left/Up/Down with and without wrap-around
- Updated `AnnotationToolbarColorTouchTargets.test.ts`: widened source-window to accommodate new props
- All 3977 frontend tests pass

Closes #2459
