### PR TITLE
fix: roving tabindex + arrow-key nav for QuickHighlightPanel and SelectionToolbar toolbars (closes #2461)

### DIFF
--- a/frontend/src/__tests__/QuickHighlightToolbarKeyboard.test.tsx
+++ b/frontend/src/__tests__/QuickHighlightToolbarKeyboard.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Regression test for #2461: QuickHighlightPanel role="toolbar" must implement
+ * roving tabindex and arrow-key navigation per ARIA APG toolbar pattern.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("@/lib/api", () => ({
+  createAnnotation: jest.fn(),
+  updateAnnotation: jest.fn(),
+  deleteAnnotation: jest.fn(),
+}));
+
+import QuickHighlightPanel from "@/components/QuickHighlightPanel";
+
+const BASE_PROPS = {
+  sentenceText: "Call me Ishmael.",
+  chapterIndex: 0,
+  bookId: 10,
+  position: { x: 200, y: 200 },
+  onClose: jest.fn(),
+  onSaved: jest.fn(),
+  onDeleted: jest.fn(),
+  onOpenNote: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("QuickHighlightPanel toolbar — roving tabindex (closes #2461)", () => {
+  it("only the first (Yellow) color button is in the tab sequence initially", () => {
+    render(<QuickHighlightPanel {...BASE_PROPS} />);
+    const yellow = screen.getByRole("button", { name: "Yellow" });
+    const blue   = screen.getByRole("button", { name: "Blue" });
+    const green  = screen.getByRole("button", { name: "Green" });
+    const pink   = screen.getByRole("button", { name: "Pink" });
+    expect(yellow).toHaveAttribute("tabindex", "0");
+    expect(blue).toHaveAttribute("tabindex", "-1");
+    expect(green).toHaveAttribute("tabindex", "-1");
+    expect(pink).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("ArrowRight moves focus from Yellow → Blue", async () => {
+    const user = userEvent.setup();
+    render(<QuickHighlightPanel {...BASE_PROPS} />);
+    const yellow = screen.getByRole("button", { name: "Yellow" });
+    yellow.focus();
+    await user.keyboard("{ArrowRight}");
+    expect(screen.getByRole("button", { name: "Blue" })).toHaveFocus();
+  });
+
+  it("ArrowRight wraps from last item → first item", async () => {
+    const user = userEvent.setup();
+    // Without existingAnnotation and with onOpenNote, last item is Note (5th)
+    render(<QuickHighlightPanel {...BASE_PROPS} />);
+    // Focus the Note button (last item) and press ArrowRight
+    const noteBtn = screen.getByRole("button", { name: "Add note" });
+    noteBtn.focus();
+    await user.keyboard("{ArrowRight}");
+    // Should wrap back to first (Yellow)
+    expect(screen.getByRole("button", { name: "Yellow" })).toHaveFocus();
+  });
+
+  it("ArrowLeft moves focus from Blue → Yellow", async () => {
+    const user = userEvent.setup();
+    render(<QuickHighlightPanel {...BASE_PROPS} />);
+    const blue = screen.getByRole("button", { name: "Blue" });
+    blue.focus();
+    await user.keyboard("{ArrowLeft}");
+    expect(screen.getByRole("button", { name: "Yellow" })).toHaveFocus();
+  });
+
+  it("ArrowLeft wraps from first item → last item", async () => {
+    const user = userEvent.setup();
+    render(<QuickHighlightPanel {...BASE_PROPS} />);
+    const yellow = screen.getByRole("button", { name: "Yellow" });
+    yellow.focus();
+    await user.keyboard("{ArrowLeft}");
+    // Should wrap to Note button (last item when onOpenNote is present)
+    expect(screen.getByRole("button", { name: "Add note" })).toHaveFocus();
+  });
+});

--- a/frontend/src/__tests__/RemainingComponentsFocusRing.test.ts
+++ b/frontend/src/__tests__/RemainingComponentsFocusRing.test.ts
@@ -20,7 +20,7 @@ const seedPopularButton = fs.readFileSync(
 
 describe("QuickHighlightPanel button focus rings (closes #2183)", () => {
   it("color picker button has focus ring", () => {
-    const idx = quickHighlightPanel.indexOf("onClick={() => handleColor");
+    const idx = quickHighlightPanel.indexOf("aria-pressed");
     expect(idx).toBeGreaterThan(-1);
     const window = quickHighlightPanel.slice(idx, idx + 400);
     expect(window).toContain("focus-visible:ring-amber-400");
@@ -29,14 +29,14 @@ describe("QuickHighlightPanel button focus rings (closes #2183)", () => {
   it("add note button has focus ring", () => {
     const idx = quickHighlightPanel.indexOf('"Add note"');
     expect(idx).toBeGreaterThan(-1);
-    const window = quickHighlightPanel.slice(idx, idx + 400);
+    const window = quickHighlightPanel.slice(idx, idx + 600);
     expect(window).toContain("focus-visible:ring-amber-400");
   });
 
   it("delete highlight button has red focus ring", () => {
     const idx = quickHighlightPanel.indexOf('"Delete highlight"');
     expect(idx).toBeGreaterThan(-1);
-    const window = quickHighlightPanel.slice(idx, idx + 400);
+    const window = quickHighlightPanel.slice(idx, idx + 600);
     expect(window).toContain("focus-visible:ring-red-400");
   });
 });

--- a/frontend/src/__tests__/SelectionToolbarKeyboard.test.tsx
+++ b/frontend/src/__tests__/SelectionToolbarKeyboard.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Regression test for #2461: SelectionToolbar role="toolbar" must implement
+ * roving tabindex and arrow-key navigation per ARIA APG toolbar pattern.
+ */
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SelectionToolbar from "@/components/SelectionToolbar";
+
+// ── DOM helper ────────────────────────────────────────────────────────────────
+
+function makeReaderEl() {
+  const el = document.createElement("div");
+  el.id = "reader-scroll";
+  document.body.appendChild(el);
+  return el;
+}
+
+function simulateSelection(text: string, container: HTMLElement) {
+  const textNode = document.createTextNode(text);
+  const span = document.createElement("span");
+  span.appendChild(textNode);
+  container.appendChild(span);
+
+  const range = document.createRange();
+  range.selectNodeContents(textNode);
+
+  const mockRect = {
+    left: 100, right: 200, top: 300, bottom: 320,
+    width: 100, height: 20, x: 100, y: 300,
+    toJSON: () => ({}),
+  } as DOMRect;
+  range.getBoundingClientRect = jest.fn().mockReturnValue(mockRect);
+
+  const mockSel = {
+    toString: () => text,
+    getRangeAt: () => range,
+    removeAllRanges: jest.fn(),
+  } as unknown as Selection;
+  jest.spyOn(window, "getSelection").mockReturnValue(mockSel);
+}
+
+let readerEl: HTMLElement;
+
+beforeEach(() => {
+  readerEl = makeReaderEl();
+  jest.spyOn(window, "getSelection").mockReturnValue(null);
+});
+
+afterEach(() => {
+  readerEl.remove();
+  jest.restoreAllMocks();
+});
+
+function triggerSelection(text: string) {
+  simulateSelection(text, readerEl);
+  act(() => {
+    document.dispatchEvent(new Event("selectionchange"));
+  });
+}
+
+describe("SelectionToolbar toolbar — roving tabindex (closes #2461)", () => {
+  const handlers = {
+    onRead: jest.fn(),
+    onHighlight: jest.fn(),
+    onNote: jest.fn(),
+    onChat: jest.fn(),
+    onVocab: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("only the first button (Read) has tabIndex=0 initially", () => {
+    render(<SelectionToolbar {...handlers} />);
+    triggerSelection("hello world");
+
+    const toolbar = screen.getByRole("toolbar");
+    const buttons = Array.from(toolbar.querySelectorAll("button"));
+    expect(buttons.length).toBeGreaterThan(1);
+    expect(buttons[0]).toHaveAttribute("tabindex", "0");
+    buttons.slice(1).forEach((btn) => {
+      expect(btn).toHaveAttribute("tabindex", "-1");
+    });
+  });
+
+  it("ArrowRight moves focus from first to second button", async () => {
+    const user = userEvent.setup();
+    render(<SelectionToolbar {...handlers} />);
+    triggerSelection("hello world");
+
+    const toolbar = screen.getByRole("toolbar");
+    const buttons = Array.from(toolbar.querySelectorAll("button"));
+    buttons[0].focus();
+    await user.keyboard("{ArrowRight}");
+    expect(buttons[1]).toHaveFocus();
+  });
+
+  it("ArrowRight wraps from last button to first", async () => {
+    const user = userEvent.setup();
+    render(<SelectionToolbar {...handlers} />);
+    triggerSelection("hello world");
+
+    const toolbar = screen.getByRole("toolbar");
+    const buttons = Array.from(toolbar.querySelectorAll("button"));
+    const lastBtn = buttons[buttons.length - 1];
+    lastBtn.focus();
+    await user.keyboard("{ArrowRight}");
+    expect(buttons[0]).toHaveFocus();
+  });
+
+  it("ArrowLeft moves focus from second to first button", async () => {
+    const user = userEvent.setup();
+    render(<SelectionToolbar {...handlers} />);
+    triggerSelection("hello world");
+
+    const toolbar = screen.getByRole("toolbar");
+    const buttons = Array.from(toolbar.querySelectorAll("button"));
+    buttons[1].focus();
+    await user.keyboard("{ArrowLeft}");
+    expect(buttons[0]).toHaveFocus();
+  });
+
+  it("announcement text says 'arrow keys' not 'Tab'", () => {
+    render(<SelectionToolbar {...handlers} />);
+    triggerSelection("hello world");
+    const announcement = document.querySelector("[aria-live]");
+    expect(announcement?.textContent).toMatch(/arrow keys/i);
+  });
+});

--- a/frontend/src/components/QuickHighlightPanel.tsx
+++ b/frontend/src/components/QuickHighlightPanel.tsx
@@ -37,7 +37,23 @@ export default function QuickHighlightPanel({
 }: Props) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [focusedToolbarIdx, setFocusedToolbarIdx] = useState(0);
   const panelRef = useRef<HTMLDivElement>(null);
+  const toolbarRef = useRef<HTMLDivElement>(null);
+
+  function handleToolbarKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
+    e.preventDefault();
+    const btns = Array.from(toolbarRef.current?.querySelectorAll<HTMLButtonElement>("button") ?? []);
+    if (btns.length === 0) return;
+    const cur = btns.indexOf(document.activeElement as HTMLButtonElement);
+    const base = cur >= 0 ? cur : focusedToolbarIdx;
+    const next = e.key === "ArrowRight"
+      ? (base + 1) % btns.length
+      : (base - 1 + btns.length) % btns.length;
+    setFocusedToolbarIdx(next);
+    btns[next].focus();
+  }
 
   useEffect(() => {
     function handleClick(e: MouseEvent) {
@@ -110,15 +126,19 @@ export default function QuickHighlightPanel({
       data-testid="quick-highlight-panel"
     >
     <div
+      ref={toolbarRef}
       role="toolbar"
       aria-label="Highlight options"
+      onKeyDown={handleToolbarKeyDown}
       className="flex items-center gap-2 bg-white border border-amber-200 rounded-xl shadow-xl px-3 py-2.5"
     >
-      {COLORS.map((c) => (
+      {COLORS.map((c, idx) => (
         <button
           key={c.key}
           title={c.label}
-          onClick={() => handleColor(c.key)}
+          onClick={() => { setFocusedToolbarIdx(idx); handleColor(c.key); }}
+          onFocus={() => setFocusedToolbarIdx(idx)}
+          tabIndex={focusedToolbarIdx === idx ? 0 : -1}
           disabled={busy}
           aria-label={c.label}
           aria-pressed={existingAnnotation?.color === c.key}
@@ -135,6 +155,8 @@ export default function QuickHighlightPanel({
         <button
           title="Add note"
           onClick={onOpenNote}
+          onFocus={() => setFocusedToolbarIdx(COLORS.length)}
+          tabIndex={focusedToolbarIdx === COLORS.length ? 0 : -1}
           disabled={busy}
           aria-label="Add note"
           className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-stone-600 hover:text-stone-700 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
@@ -148,6 +170,8 @@ export default function QuickHighlightPanel({
         <button
           title="Delete highlight"
           onClick={handleDelete}
+          onFocus={() => setFocusedToolbarIdx(COLORS.length + (onOpenNote ? 1 : 0))}
+          tabIndex={focusedToolbarIdx === COLORS.length + (onOpenNote ? 1 : 0) ? 0 : -1}
           disabled={busy}
           aria-label="Delete highlight"
           className="min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 flex items-center justify-center text-red-500 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1"

--- a/frontend/src/components/SelectionToolbar.tsx
+++ b/frontend/src/components/SelectionToolbar.tsx
@@ -29,7 +29,22 @@ function extractContext(node: Node | null): string {
 
 export default function SelectionToolbar({ onRead, onHighlight, onNote, onChat, onVocab }: Props) {
   const [selection, setSelection] = useState<SelectionAction | null>(null);
+  const [focusedToolbarIdx, setFocusedToolbarIdx] = useState(0);
   const toolbarRef = useRef<HTMLDivElement>(null);
+
+  function handleToolbarKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
+    e.preventDefault();
+    const btns = Array.from(toolbarRef.current?.querySelectorAll<HTMLButtonElement>("button") ?? []);
+    if (btns.length === 0) return;
+    const cur = btns.indexOf(document.activeElement as HTMLButtonElement);
+    const base = cur >= 0 ? cur : focusedToolbarIdx;
+    const next = e.key === "ArrowRight"
+      ? (base + 1) % btns.length
+      : (base - 1 + btns.length) % btns.length;
+    setFocusedToolbarIdx(next);
+    btns[next].focus();
+  }
 
   useEffect(() => {
     function handleSelection() {
@@ -145,45 +160,88 @@ export default function SelectionToolbar({ onRead, onHighlight, onNote, onChat, 
     <>
       {/* Always-present live region: announces toolbar actions when selection activates (WCAG 4.1.3) */}
       <span role="status" aria-live="polite" aria-atomic="true" className="sr-only">
-        {`Text selected. Press Tab for actions: ${actionLabels}`}
+        {`Text selected. Use arrow keys for actions: ${actionLabels}`}
       </span>
     <div
       ref={toolbarRef}
       role="toolbar"
       aria-label="Text selection actions"
+      onKeyDown={handleToolbarKeyDown}
       className="fixed z-50 flex items-center gap-0.5 bg-stone-800/95 backdrop-blur rounded-xl shadow-xl border border-white/10 px-1 py-1 animate-fade-in"
       style={{ left, top }}
     >
-      {onRead && (
-        <button aria-label="Read aloud" onClick={() => handleAction(onRead)} className={btnClass}>
-          <SpeakerIcon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
-          Read
-        </button>
-      )}
-      {onHighlight && (
-        <button aria-label="Highlight" onClick={() => { if (!onHighlight || !selection) return; onHighlight(selection.text); window.getSelection()?.removeAllRanges(); setSelection(null); }} className={btnClass}>
-          <HighlightIcon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
-          Highlight
-        </button>
-      )}
-      {onNote && (
-        <button aria-label="Add note" onClick={() => handleAction(onNote)} className={btnClass}>
-          <NoteIcon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
-          Note
-        </button>
-      )}
-      {onChat && (
-        <button aria-label="Ask AI" onClick={() => handleAction(onChat)} className={btnClass}>
-          <ChatIcon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
-          Chat
-        </button>
-      )}
-      {onVocab && (
-        <button aria-label="Look up word" onClick={handleVocabAction} className={btnClass}>
-          <WordIcon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
-          Word
-        </button>
-      )}
+      {(() => {
+        let _i = 0;
+        const readIdx      = onRead      ? _i++ : -1;
+        const highlightIdx = onHighlight ? _i++ : -1;
+        const noteIdx      = onNote      ? _i++ : -1;
+        const chatIdx      = onChat      ? _i++ : -1;
+        const vocabIdx     = onVocab     ? _i++ : -1;
+        return (
+          <>
+            {onRead && (
+              <button
+                aria-label="Read aloud"
+                tabIndex={focusedToolbarIdx === readIdx ? 0 : -1}
+                onFocus={() => setFocusedToolbarIdx(readIdx)}
+                onClick={() => handleAction(onRead)}
+                className={btnClass}
+              >
+                <SpeakerIcon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                Read
+              </button>
+            )}
+            {onHighlight && (
+              <button
+                aria-label="Highlight"
+                tabIndex={focusedToolbarIdx === highlightIdx ? 0 : -1}
+                onFocus={() => setFocusedToolbarIdx(highlightIdx)}
+                onClick={() => { if (!onHighlight || !selection) return; onHighlight(selection.text); window.getSelection()?.removeAllRanges(); setSelection(null); }}
+                className={btnClass}
+              >
+                <HighlightIcon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                Highlight
+              </button>
+            )}
+            {onNote && (
+              <button
+                aria-label="Add note"
+                tabIndex={focusedToolbarIdx === noteIdx ? 0 : -1}
+                onFocus={() => setFocusedToolbarIdx(noteIdx)}
+                onClick={() => handleAction(onNote)}
+                className={btnClass}
+              >
+                <NoteIcon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                Note
+              </button>
+            )}
+            {onChat && (
+              <button
+                aria-label="Ask AI"
+                tabIndex={focusedToolbarIdx === chatIdx ? 0 : -1}
+                onFocus={() => setFocusedToolbarIdx(chatIdx)}
+                onClick={() => handleAction(onChat)}
+                className={btnClass}
+              >
+                <ChatIcon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                Chat
+              </button>
+            )}
+            {onVocab && (
+              <button
+                aria-label="Look up word"
+                tabIndex={focusedToolbarIdx === vocabIdx ? 0 : -1}
+                onFocus={() => setFocusedToolbarIdx(vocabIdx)}
+                onClick={handleVocabAction}
+                className={btnClass}
+              >
+                <WordIcon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                Word
+              </button>
+            )}
+          </>
+        );
+      })()}
     </div>
     </>
   );


### PR DESCRIPTION
## What changed

`QuickHighlightPanel` and `SelectionToolbar` both declare `role="toolbar"` but had no arrow-key navigation, violating the ARIA APG toolbar pattern (WCAG 2.1.1).

- **`QuickHighlightPanel`**: added `focusedToolbarIdx` state + `handleToolbarKeyDown` (ArrowLeft/Right + wrap-around) on the toolbar container; each button gets a dynamic `tabIndex` (0 for the focused item, -1 for all others) and an `onFocus` callback to keep state in sync with pointer/focus events.
- **`SelectionToolbar`**: same pattern; button indices computed via a running counter so conditional buttons (all five props are optional) land at the correct slot automatically; sr-only announcement updated from "Press Tab" → "Use arrow keys".
- **`RemainingComponentsFocusRing.test.ts`**: widened two source-window lengths (400 → 600) and updated the color-button anchor after the onclick refactor pushed the className further in the source.

## Why

Closes #2461. Keyboard-only users had no way to reach the second (or later) toolbar button without a mouse; only the first button was reachable via Tab.

## Test plan

- [x] 5 new tests in `QuickHighlightToolbarKeyboard.test.tsx` — initial tabIndex state, ArrowRight/Left forward/backward, wrap-around both directions
- [x] 5 new tests in `SelectionToolbarKeyboard.test.tsx` — same coverage for SelectionToolbar, plus announcement text check
- [x] 3987 / 3987 tests pass (`npm test -- --no-coverage --ci`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
