### PR TITLE
fix: move focus to first button when QuickHighlightPanel opens (closes #2463)

### DIFF
--- a/frontend/src/__tests__/QuickHighlightToolbarKeyboard.test.tsx
+++ b/frontend/src/__tests__/QuickHighlightToolbarKeyboard.test.tsx
@@ -1,6 +1,6 @@
 /**
- * Regression test for #2461: QuickHighlightPanel role="toolbar" must implement
- * roving tabindex and arrow-key navigation per ARIA APG toolbar pattern.
+ * Regression tests for #2461 (roving tabindex + arrow-key nav) and
+ * #2463 (focus moves to first button on open).
  */
 import React from "react";
 import { render, screen } from "@testing-library/react";
@@ -27,6 +27,13 @@ const BASE_PROPS = {
 
 beforeEach(() => {
   jest.clearAllMocks();
+});
+
+describe("QuickHighlightPanel focus-on-open (closes #2463)", () => {
+  it("Yellow button receives focus immediately when panel mounts", () => {
+    render(<QuickHighlightPanel {...BASE_PROPS} />);
+    expect(screen.getByRole("button", { name: "Yellow" })).toHaveFocus();
+  });
 });
 
 describe("QuickHighlightPanel toolbar — roving tabindex (closes #2461)", () => {

--- a/frontend/src/components/QuickHighlightPanel.tsx
+++ b/frontend/src/components/QuickHighlightPanel.tsx
@@ -56,6 +56,10 @@ export default function QuickHighlightPanel({
   }
 
   useEffect(() => {
+    toolbarRef.current?.querySelector<HTMLButtonElement>("button")?.focus();
+  }, []);
+
+  useEffect(() => {
     function handleClick(e: MouseEvent) {
       if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
         onClose();


### PR DESCRIPTION
## What changed

Added a `useEffect(() => { toolbarRef.current?.querySelector<HTMLButtonElement>("button")?.focus(); }, [])` to `QuickHighlightPanel.tsx` so focus moves to the Yellow button immediately when the panel mounts.

Also updated `QuickHighlightToolbarKeyboard.test.tsx` to cover this (one new test: "Yellow button receives focus immediately when panel mounts").

## Why

Closes #2463. When `QuickHighlightPanel` appeared (after clicking an annotated span or from the selection toolbar), focus stayed on the triggering element — typically a non-focusable `<span>`. Keyboard users had no indication the panel was open and no way to reach it without Tab-traversing through intervening elements.

`AnnotationToolbar` (full note editor) already calls `textareaRef.current?.focus()` on mount; this PR applies the same pattern to the colour-only quick panel.

## Test plan

- [x] 1 new test: `QuickHighlightPanel focus-on-open` — `Yellow button receives focus immediately when panel mounts`
- [x] 3988 / 3988 tests pass (`npm test -- --no-coverage --ci`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
