### PR TITLE
fix: add aria-label to vocabulary occurrence-count badge (closes #2465)

### DIFF
--- a/frontend/src/__tests__/VocabOccurrenceBadgeAriaLabel.test.ts
+++ b/frontend/src/__tests__/VocabOccurrenceBadgeAriaLabel.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Regression test for #2465: vocabulary occurrence-count badge must have
+ * aria-label so screen readers say "N occurrences" instead of ambiguous "N×".
+ */
+import fs from "fs";
+import path from "path";
+
+const vocabPage = fs.readFileSync(
+  path.resolve(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8",
+);
+
+describe("Vocabulary occurrence badge aria-label (closes #2465)", () => {
+  it("occurrence count badge has aria-label describing occurrences", () => {
+    const idx = vocabPage.indexOf("occurrenceCount}×");
+    expect(idx).toBeGreaterThan(-1);
+    const window = vocabPage.slice(Math.max(0, idx - 200), idx + 100);
+    expect(window).toMatch(/aria-label/);
+  });
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -413,7 +413,10 @@ function VocabularyPageContent() {
                 {group.language}
               </span>
             )}
-            <span className="text-xs text-stone-600 bg-stone-100 rounded-full px-2 py-0.5">
+            <span
+              aria-label={`${occurrenceCount} occurrence${occurrenceCount !== 1 ? "s" : ""}`}
+              className="text-xs text-stone-600 bg-stone-100 rounded-full px-2 py-0.5"
+            >
               {occurrenceCount}×
             </span>
           </div>


### PR DESCRIPTION
## What changed

Added `aria-label` to the occurrence-count badge in `app/vocabulary/page.tsx`:

```tsx
<span
  aria-label={`${occurrenceCount} occurrence${occurrenceCount !== 1 ? "s" : ""}`}
  className="text-xs text-stone-600 bg-stone-100 rounded-full px-2 py-0.5"
>
  {occurrenceCount}×
</span>
```

Screen readers now announce "3 occurrences" instead of "3 ×" / "3 times".

## Why

Closes #2465. The `×` (multiplication sign, U+00D7) is ambiguous across screen reader / browser combinations. Some ATs read it as "times", some as "×", leaving users without clear context. An explicit `aria-label` replaces the visual shorthand with plain English.

## Test plan

- [x] 1 new source-level test: `VocabOccurrenceBadgeAriaLabel.test.ts` — asserts `aria-label` is present within 200 chars of `{occurrenceCount}×`
- [x] 3988 / 3988 tests pass (`npm test -- --no-coverage --ci`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
