### PR TITLE
fix: announce flashcard session-complete state to screen readers (closes #2467)

### DIFF
--- a/frontend/src/__tests__/FlashcardDoneStateAnnouncement.test.ts
+++ b/frontend/src/__tests__/FlashcardDoneStateAnnouncement.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Regression test for #2467: flashcard session-complete ("All done for today!")
+ * state must be wrapped in a live region so screen readers announce it when it
+ * appears (WCAG 4.1.3 Status Messages).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const src = readFileSync(
+  join(__dirname, "../app/vocabulary/flashcards/page.tsx"),
+  "utf-8"
+);
+
+describe("Flashcard done-state live region (closes #2467)", () => {
+  it("done-state container has role=status", () => {
+    const doneIdx = src.indexOf("All done for today!");
+    expect(doneIdx).toBeGreaterThan(-1);
+    // Within 300 chars before the text, the containing element must have role=status
+    const before = src.slice(Math.max(0, doneIdx - 300), doneIdx);
+    expect(before).toMatch(/role="status"/);
+  });
+
+  it("done-state container has aria-live=polite or role=status (not just visual heading)", () => {
+    const doneIdx = src.indexOf("All done for today!");
+    expect(doneIdx).toBeGreaterThan(-1);
+    const before = src.slice(Math.max(0, doneIdx - 300), doneIdx);
+    expect(before).toMatch(/role="status"|aria-live="polite"/);
+  });
+});

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -265,7 +265,7 @@ export default function FlashcardsPage() {
 
         {/* Done state */}
         {!fetchError && done ? (
-          <div className="flex flex-col items-center gap-4 py-16 text-center">
+          <div role="status" className="flex flex-col items-center gap-4 py-16 text-center">
             <CheckIcon className="w-12 h-12 text-green-500" />
             <h2 className="font-serif text-2xl text-ink">All done for today!</h2>
             <p className="text-sm text-stone-600">


### PR DESCRIPTION
## What changed

Added `role="status"` to the flashcard session-complete ("All done for today!") container in `app/vocabulary/flashcards/page.tsx`.

## Why

When the last card is graded and the done state appears, screen readers receive no announcement because the containing `<div>` is a plain element with no live region. WCAG 4.1.3 (Status Messages) requires that status changes conveyed visually are also communicated to AT without requiring focus. `role="status"` (implicit `aria-live="polite"`) satisfies this.

## Test plan

- New regression test: `src/__tests__/FlashcardDoneStateAnnouncement.test.ts`
  - Asserts `role="status"` is present on the container that holds "All done for today!"
- Full Jest suite: 3990 tests, all pass

Closes #2467
