### PR TITLE
fix: roving tabindex + arrow-key nav for SentenceActionPopup toolbar (closes #2468)

### DIFF
--- a/frontend/src/__tests__/ReaderComponentsFocusRing.test.ts
+++ b/frontend/src/__tests__/ReaderComponentsFocusRing.test.ts
@@ -30,7 +30,7 @@ describe("SentenceActionPopup focus rings (closes #2176)", () => {
   it("Note button has focus-visible ring with stone-800 offset", () => {
     const idx = sentencePopup.indexOf("onNote()");
     expect(idx).toBeGreaterThan(-1);
-    const window = sentencePopup.slice(idx, idx + 450);
+    const window = sentencePopup.slice(idx, idx + 650);
     expect(window).toContain("focus-visible:ring-amber-400");
     expect(window).toContain("ring-offset-stone-800");
   });

--- a/frontend/src/__tests__/SentenceActionPopupKeyboard.test.tsx
+++ b/frontend/src/__tests__/SentenceActionPopupKeyboard.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Regression test for #2468: SentenceActionPopup role="toolbar" must implement
+ * roving tabindex and arrow-key navigation per ARIA APG toolbar pattern.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import SentenceActionPopup from "@/components/SentenceActionPopup";
+
+const BASE_PROPS = {
+  sentenceText: "Call me Ishmael.",
+  position: { x: 200, y: 200 },
+  onRead: jest.fn(),
+  onNote: jest.fn(),
+  onChat: jest.fn(),
+  onClose: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("SentenceActionPopup toolbar — roving tabindex (closes #2468)", () => {
+  it("only the first (Read) button is in the tab sequence initially", () => {
+    render(<SentenceActionPopup {...BASE_PROPS} />);
+    const read = screen.getByRole("button", { name: /Read/i });
+    const note = screen.getByRole("button", { name: /Note/i });
+    const chat = screen.getByRole("button", { name: /Chat/i });
+    expect(read).toHaveAttribute("tabindex", "0");
+    expect(note).toHaveAttribute("tabindex", "-1");
+    expect(chat).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("ArrowRight moves focus from Read → Note", async () => {
+    const user = userEvent.setup();
+    render(<SentenceActionPopup {...BASE_PROPS} />);
+    const read = screen.getByRole("button", { name: /Read/i });
+    read.focus();
+    await user.keyboard("{ArrowRight}");
+    expect(screen.getByRole("button", { name: /Note/i })).toHaveFocus();
+  });
+
+  it("ArrowRight wraps from last item → first item", async () => {
+    const user = userEvent.setup();
+    render(<SentenceActionPopup {...BASE_PROPS} />);
+    const chat = screen.getByRole("button", { name: /Chat/i });
+    chat.focus();
+    await user.keyboard("{ArrowRight}");
+    expect(screen.getByRole("button", { name: /Read/i })).toHaveFocus();
+  });
+
+  it("ArrowLeft moves focus from Note → Read", async () => {
+    const user = userEvent.setup();
+    render(<SentenceActionPopup {...BASE_PROPS} />);
+    const note = screen.getByRole("button", { name: /Note/i });
+    note.focus();
+    await user.keyboard("{ArrowLeft}");
+    expect(screen.getByRole("button", { name: /Read/i })).toHaveFocus();
+  });
+
+  it("ArrowLeft wraps from first item → last item", async () => {
+    const user = userEvent.setup();
+    render(<SentenceActionPopup {...BASE_PROPS} />);
+    const read = screen.getByRole("button", { name: /Read/i });
+    read.focus();
+    await user.keyboard("{ArrowLeft}");
+    expect(screen.getByRole("button", { name: /Chat/i })).toHaveFocus();
+  });
+});

--- a/frontend/src/components/SentenceActionPopup.tsx
+++ b/frontend/src/components/SentenceActionPopup.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { SpeakerIcon, NoteIcon, ChatIcon } from "@/components/Icons";
 
 interface Props {
@@ -13,6 +13,22 @@ interface Props {
 
 export default function SentenceActionPopup({ sentenceText: _sentenceText, position, onRead, onNote, onChat, onClose }: Props) {
   const ref = useRef<HTMLDivElement>(null);
+  const toolbarRef = useRef<HTMLDivElement>(null);
+  const [focusedToolbarIdx, setFocusedToolbarIdx] = useState(0);
+
+  function handleToolbarKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
+    e.preventDefault();
+    const btns = Array.from(toolbarRef.current?.querySelectorAll<HTMLButtonElement>("button") ?? []);
+    if (btns.length === 0) return;
+    const cur = btns.indexOf(document.activeElement as HTMLButtonElement);
+    const base = cur >= 0 ? cur : focusedToolbarIdx;
+    const next = e.key === "ArrowRight"
+      ? (base + 1) % btns.length
+      : (base - 1 + btns.length) % btns.length;
+    setFocusedToolbarIdx(next);
+    btns[next].focus();
+  }
 
   useEffect(() => {
     ref.current?.querySelector<HTMLButtonElement>("button")?.focus();
@@ -45,36 +61,52 @@ export default function SentenceActionPopup({ sentenceText: _sentenceText, posit
   if (left + popupW > window.innerWidth - 8) left = window.innerWidth - popupW - 8;
   if (top < 8) top = position.y + 16;
 
+  const readIdx = 0;
+  const noteIdx = onNote ? 1 : -1;
+  const chatIdx = onChat ? (onNote ? 2 : 1) : -1;
+
   return (
     <div
       ref={ref}
-      role="toolbar"
-      aria-label="Sentence actions"
       style={{ left, top }}
-      className="fixed z-50 flex items-center gap-0.5 bg-stone-800 rounded-xl shadow-xl px-1 py-1 animate-fade-in"
+      className="fixed z-50 animate-fade-in"
     >
-      <button
-        onClick={() => { onRead(); onClose(); }}
-        className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 focus-visible:ring-offset-stone-800"
+      <div
+        ref={toolbarRef}
+        role="toolbar"
+        aria-label="Sentence actions"
+        onKeyDown={handleToolbarKeyDown}
+        className="flex items-center gap-0.5 bg-stone-800 rounded-xl shadow-xl px-1 py-1"
       >
-        <SpeakerIcon className="w-3.5 h-3.5 shrink-0" /> Read
-      </button>
-      {onNote && (
         <button
-          onClick={() => { onNote(); onClose(); }}
+          onClick={() => { setFocusedToolbarIdx(readIdx); onRead(); onClose(); }}
+          onFocus={() => setFocusedToolbarIdx(readIdx)}
+          tabIndex={focusedToolbarIdx === readIdx ? 0 : -1}
           className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 focus-visible:ring-offset-stone-800"
         >
-          <NoteIcon className="w-3.5 h-3.5 shrink-0" /> Note
+          <SpeakerIcon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" /> Read
         </button>
-      )}
-      {onChat && (
-        <button
-          onClick={() => { onChat(); onClose(); }}
-          className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 focus-visible:ring-offset-stone-800"
-        >
-          <ChatIcon className="w-3.5 h-3.5 shrink-0" /> Chat
-        </button>
-      )}
+        {onNote && (
+          <button
+            onClick={() => { setFocusedToolbarIdx(noteIdx); onNote(); onClose(); }}
+            onFocus={() => setFocusedToolbarIdx(noteIdx)}
+            tabIndex={focusedToolbarIdx === noteIdx ? 0 : -1}
+            className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 focus-visible:ring-offset-stone-800"
+          >
+            <NoteIcon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" /> Note
+          </button>
+        )}
+        {onChat && (
+          <button
+            onClick={() => { setFocusedToolbarIdx(chatIdx); onChat(); onClose(); }}
+            onFocus={() => setFocusedToolbarIdx(chatIdx)}
+            tabIndex={focusedToolbarIdx === chatIdx ? 0 : -1}
+            className="flex items-center gap-1 px-3 py-2 text-white text-xs font-medium rounded-lg hover:bg-stone-700 active:bg-stone-600 transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 focus-visible:ring-offset-stone-800"
+          >
+            <ChatIcon className="w-3.5 h-3.5 shrink-0" aria-hidden="true" /> Chat
+          </button>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## What changed

`SentenceActionPopup` declared `role="toolbar"` but all buttons had implicit `tabIndex=0`, so Tab visited each button individually — violating the ARIA APG toolbar keyboard interaction pattern.

Changes to `frontend/src/components/SentenceActionPopup.tsx`:
- Added `focusedToolbarIdx` state (roving tabindex)
- Added `handleToolbarKeyDown` with ArrowLeft/ArrowRight navigation and wrap-around
- Added `onKeyDown` + `ref` on the toolbar div
- Each button gets `tabIndex={focusedToolbarIdx === idx ? 0 : -1}` and `onFocus` sync

## Why

The ARIA APG toolbar pattern requires the toolbar to be a single Tab stop, with ArrowLeft/ArrowRight moving focus between items. Without this, keyboard users must Tab through every button in the popup — degrading the interaction for both keyboard and AT users (WCAG 4.1.2).

This completes the toolbar-keyboard series: AnnotationToolbar (#2459), SelectionToolbar + QuickHighlightPanel (#2461), and now SentenceActionPopup (#2468).

## Test plan

- New test: `src/__tests__/SentenceActionPopupKeyboard.test.tsx` — 5 tests covering initial tabIndex state, ArrowRight/Left navigation, and wrap-around in both directions
- Updated `ReaderComponentsFocusRing.test.ts` window width (450→650) to accommodate new props
- Full Jest suite: 3993 tests, all pass

Closes #2468
