### PR TITLE
fix: move focus to first button when SentenceActionPopup opens (closes #2471)

### DIFF
--- a/frontend/src/__tests__/SentenceActionPopupFocusOnOpen.test.tsx
+++ b/frontend/src/__tests__/SentenceActionPopupFocusOnOpen.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * Regression test for #2471: SentenceActionPopup must move focus to the first
+ * toolbar button when it mounts, so keyboard users can reach it immediately
+ * without tabbing through the entire page (WCAG 2.4.3 Focus Order).
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import SentenceActionPopup from "@/components/SentenceActionPopup";
+
+const BASE_PROPS = {
+  sentenceText: "Call me Ishmael.",
+  position: { x: 200, y: 200 },
+  onRead: jest.fn(),
+  onNote: jest.fn(),
+  onChat: jest.fn(),
+  onClose: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("SentenceActionPopup focus-on-open (closes #2471)", () => {
+  it("Read button receives focus immediately when panel mounts", () => {
+    render(<SentenceActionPopup {...BASE_PROPS} />);
+    expect(screen.getByRole("button", { name: /Read/i })).toHaveFocus();
+  });
+
+  it("focus lands on first button even when optional buttons are absent", () => {
+    render(
+      <SentenceActionPopup
+        sentenceText="Hello."
+        position={{ x: 100, y: 100 }}
+        onRead={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+    expect(screen.getByRole("button", { name: /Read/i })).toHaveFocus();
+  });
+});

--- a/frontend/src/components/SentenceActionPopup.tsx
+++ b/frontend/src/components/SentenceActionPopup.tsx
@@ -15,6 +15,10 @@ export default function SentenceActionPopup({ sentenceText: _sentenceText, posit
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    ref.current?.querySelector<HTMLButtonElement>("button")?.focus();
+  }, []);
+
+  useEffect(() => {
     function handleKey(e: KeyboardEvent) {
       if (e.key === "Escape") onClose();
     }


### PR DESCRIPTION
## What changed

Added a mount-time `useEffect` to `SentenceActionPopup` that focuses the first toolbar button (Read) when the popup appears.

## Why

When the popup appears (triggered by a click on a sentence span), focus stayed on the body/span — a non-interactive element. Keyboard users had no way to reach the popup without tabbing through the entire page. WCAG 2.4.3 (Focus Order) requires focus to follow the user's intent; a popup should receive focus when it opens. This matches the pattern already used in `QuickHighlightPanel` (PR #2464).

## Test plan

- New test: `src/__tests__/SentenceActionPopupFocusOnOpen.test.tsx` — 2 tests
  - Read button receives focus when panel mounts (with all optional buttons)
  - Read button receives focus when only Read is present (no Note/Chat)
- Full Jest suite: 3993 tests, all pass

Closes #2471
