### PR TITLE
fix: restore focus to trigger element when QuickHighlightPanel and SentenceActionPopup close (closes #2473)

### DIFF
--- a/frontend/src/__tests__/PopupFocusRestoreOnClose.test.tsx
+++ b/frontend/src/__tests__/PopupFocusRestoreOnClose.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Regression test for #2473: QuickHighlightPanel and SentenceActionPopup must
+ * restore focus to the previously-focused element when they unmount, so
+ * keyboard users do not lose their position in the document (WCAG 2.4.3).
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("@/lib/api", () => ({
+  createAnnotation: jest.fn(),
+  updateAnnotation: jest.fn(),
+  deleteAnnotation: jest.fn(),
+}));
+
+import { createAnnotation, updateAnnotation, deleteAnnotation } from "@/lib/api";
+import QuickHighlightPanel from "@/components/QuickHighlightPanel";
+import SentenceActionPopup from "@/components/SentenceActionPopup";
+
+const mockCreate = createAnnotation as jest.MockedFunction<typeof createAnnotation>;
+const mockUpdate = updateAnnotation as jest.MockedFunction<typeof updateAnnotation>;
+const mockDelete = deleteAnnotation as jest.MockedFunction<typeof deleteAnnotation>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCreate.mockResolvedValue({ id: 1, sentence_text: "Hello.", color: "yellow", book_id: 1, chapter_index: 0 } as never);
+  mockUpdate.mockResolvedValue({ id: 1, sentence_text: "Hello.", color: "blue", book_id: 1, chapter_index: 0 } as never);
+  mockDelete.mockResolvedValue(undefined as never);
+});
+
+describe("QuickHighlightPanel focus restoration (closes #2473)", () => {
+  it("restores focus to the previously-focused element when the panel unmounts", () => {
+    const trigger = document.createElement("button");
+    trigger.textContent = "Open panel";
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const onClose = jest.fn();
+    const { unmount } = render(
+      <QuickHighlightPanel
+        sentenceText="Hello."
+        chapterIndex={0}
+        bookId={1}
+        position={{ x: 200, y: 200 }}
+        onClose={onClose}
+        onSaved={jest.fn()}
+        onDeleted={jest.fn()}
+      />
+    );
+
+    // Panel should have moved focus into itself
+    expect(document.activeElement).not.toBe(trigger);
+
+    // When panel unmounts, focus should return to trigger
+    unmount();
+    expect(document.activeElement).toBe(trigger);
+
+    document.body.removeChild(trigger);
+  });
+});
+
+describe("SentenceActionPopup focus restoration (closes #2473)", () => {
+  it("restores focus to the previously-focused element when the popup unmounts", () => {
+    const trigger = document.createElement("button");
+    trigger.textContent = "Open popup";
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const { unmount } = render(
+      <SentenceActionPopup
+        sentenceText="Call me Ishmael."
+        position={{ x: 200, y: 200 }}
+        onRead={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    // Popup should have moved focus into itself
+    expect(document.activeElement).not.toBe(trigger);
+
+    // When popup unmounts, focus should return to trigger
+    unmount();
+    expect(document.activeElement).toBe(trigger);
+
+    document.body.removeChild(trigger);
+  });
+});

--- a/frontend/src/components/QuickHighlightPanel.tsx
+++ b/frontend/src/components/QuickHighlightPanel.tsx
@@ -56,7 +56,10 @@ export default function QuickHighlightPanel({
   }
 
   useEffect(() => {
+    const prev = document.activeElement as HTMLElement | null;
     toolbarRef.current?.querySelector<HTMLButtonElement>("button")?.focus();
+    return () => { prev?.focus?.(); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/frontend/src/components/SentenceActionPopup.tsx
+++ b/frontend/src/components/SentenceActionPopup.tsx
@@ -31,7 +31,10 @@ export default function SentenceActionPopup({ sentenceText: _sentenceText, posit
   }
 
   useEffect(() => {
+    const prev = document.activeElement as HTMLElement | null;
     ref.current?.querySelector<HTMLButtonElement>("button")?.focus();
+    return () => { prev?.focus?.(); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## What changed

`QuickHighlightPanel` and `SentenceActionPopup` both move focus into themselves on open, but did not return focus to the previously-focused element when unmounting. This left keyboard users stranded on `document.body` after pressing Escape or clicking an action button.

Fixed by capturing `document.activeElement` at mount time and restoring it in the `useEffect` cleanup, matching the existing pattern in `WordLookup` (src/components/WordLookup.tsx:77-85).

## Why

WCAG 2.4.3 Focus Order requires that when a dialog or popup closes, focus returns to the element that triggered it. Keyboard users who Tab-navigated to a sentence and opened a panel would lose their scroll position and reading context.

## Test plan

- [x] New test `PopupFocusRestoreOnClose.test.tsx` with 2 regression tests (one per component) — both confirmed failing before the fix, passing after
- [x] All 694 frontend test suites pass
- [x] Existing focus-ring and focus-on-open tests unaffected

Closes #2473
