### PR TITLE
fix: show Wiktionary fallback link when no vocabulary definition found (closes #2477)

### DIFF
--- a/frontend/src/__tests__/VocabNoDefinitionFallbackLink.test.tsx
+++ b/frontend/src/__tests__/VocabNoDefinitionFallbackLink.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Regression test for #2477: DefinitionSheet must show a Wiktionary fallback
+ * link when no definitions are found, so the user has a next step instead of
+ * a dead-end "No definition found." message.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { backendToken: "token123" } }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getVocabulary: jest.fn(),
+  deleteVocabularyWord: jest.fn(),
+  exportVocabularyToObsidian: jest.fn(),
+  getWordDefinition: jest.fn(),
+  listVocabularyTags: jest.fn().mockResolvedValue([]),
+  getVocabularyWordTags: jest.fn().mockResolvedValue([]),
+  addVocabularyWordTag: jest.fn().mockResolvedValue({ tag: "" }),
+  removeVocabularyWordTag: jest.fn().mockResolvedValue(undefined),
+  ApiError: class ApiError extends Error { status = 500; },
+}));
+
+import * as api from "@/lib/api";
+import VocabularyPage from "@/app/vocabulary/page";
+
+const mockGetVocabulary = api.getVocabulary as jest.MockedFunction<typeof api.getVocabulary>;
+const mockGetWordDefinition = api.getWordDefinition as jest.MockedFunction<typeof api.getWordDefinition>;
+
+const SAMPLE_WORDS = [
+  {
+    id: 1,
+    word: "ephemeral",
+    lemma: "ephemeral",
+    language: "en",
+    occurrences: [{ book_id: 1, book_title: "Moby Dick", chapter_index: 0, sentence_text: "The ephemeral whale." }],
+  },
+];
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetVocabulary.mockResolvedValue(SAMPLE_WORDS);
+});
+
+describe("DefinitionSheet — no-definition fallback link (closes #2477)", () => {
+  it("shows a Wiktionary link when the API returns empty definitions array", async () => {
+    mockGetWordDefinition.mockResolvedValue({
+      lemma: "ephemeral",
+      language: "en",
+      definitions: [],
+      url: "https://en.wiktionary.org/wiki/ephemeral",
+    });
+
+    render(<VocabularyPage />);
+    await flushPromises();
+    await screen.findByText("ephemeral");
+
+    await userEvent.click(screen.getByRole("button", { name: "ephemeral" }));
+
+    await waitFor(() => expect(screen.getByText(/No definition found/i)).toBeInTheDocument());
+
+    // Must render a fallback Wiktionary link — not a dead end
+    const link = screen.getByRole("link", { name: /Search Wiktionary/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", expect.stringContaining("wiktionary.org/wiki/ephemeral"));
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("constructs a Wiktionary URL from word when def is null", async () => {
+    // Simulate API resolving with null (backend returned nothing)
+    mockGetWordDefinition.mockResolvedValue(null as any);
+
+    render(<VocabularyPage />);
+    await flushPromises();
+    await screen.findByText("ephemeral");
+
+    await userEvent.click(screen.getByRole("button", { name: "ephemeral" }));
+
+    await waitFor(() => expect(screen.getByText(/No definition found/i)).toBeInTheDocument());
+
+    const link = screen.getByRole("link", { name: /Search Wiktionary/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", expect.stringContaining("wiktionary.org/wiki/ephemeral"));
+  });
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -208,7 +208,17 @@ function DefinitionSheet({ word, lang, onClose }: DefinitionSheetProps) {
           )}
 
           {!loading && !fetchError && (!def || def.definitions.length === 0) && (
-            <p className="text-sm text-stone-600 italic">No definition found.</p>
+            <div className="space-y-2">
+              <p className="text-sm text-stone-600 italic">No definition found.</p>
+              <a
+                href={def?.url ?? `https://en.wiktionary.org/wiki/${encodeURIComponent(word)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block text-xs text-amber-700 hover:text-amber-800 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
+              >
+                Search Wiktionary <ArrowUpRightIcon className="w-3 h-3 inline" aria-hidden="true" /><span className="sr-only"> (opens in new tab)</span>
+              </a>
+            </div>
           )}
 
           {def && def.definitions.length > 0 && (


### PR DESCRIPTION
## What changed

When the Wiktionary lookup returns no definitions for a word, `DefinitionSheet` previously showed only:

> *No definition found.*

with no action the user could take. Now it renders a **"Search Wiktionary"** link below that message, constructed from `def.url` when available or `https://en.wiktionary.org/wiki/<word>` as a fallback. The link opens in a new tab with a `sr-only` "(opens in new tab)" label for screen readers.

## Why

Dead-end states break the user's flow. A vocabulary user who gets no definition should have a one-click path to look the word up directly rather than being abandoned.

## Files changed

- `frontend/src/app/vocabulary/page.tsx` — added Wiktionary fallback link in the no-definition branch of `DefinitionSheet`
- `frontend/src/__tests__/VocabNoDefinitionFallbackLink.test.tsx` — two regression tests: empty-definitions case and null-def case

## Test plan

- [x] `VocabNoDefinitionFallbackLink.test.tsx` — both cases pass
- [x] Existing `VocabularyPage.definition.test.tsx` suite unchanged (4002 total tests pass)
- [x] Backend tests: 1941 passed

Closes #2477

## Docs follow-up

N/A — minor UX fix, no new interaction pattern to document.
