### PR TITLE
fix: add Retry button to search error state (closes #2479)

### DIFF
--- a/frontend/src/__tests__/SearchPageErrorRetry.test.tsx
+++ b/frontend/src/__tests__/SearchPageErrorRetry.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * Regression test for #2479: search error state must include a Retry button
+ * so users can re-run the same query without having to retype it.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockSearchParams = { get: (k: string) => (k === "q" ? "hamlet" : null) };
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const mockSearchFn = jest.fn();
+jest.mock("@/lib/api", () => ({
+  searchInAppContent: (...args: unknown[]) => mockSearchFn(...args),
+}));
+
+import SearchPage from "@/app/search/page";
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  mockSearchFn.mockReset();
+});
+
+describe("search error state — retry button (closes #2479)", () => {
+  it("shows a Retry button inside the error alert", async () => {
+    mockSearchFn.mockRejectedValue(new Error("network error"));
+    render(<SearchPage />);
+    await flushPromises();
+
+    await screen.findByRole("alert");
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("clicking Retry re-runs the search and clears the error on success", async () => {
+    mockSearchFn
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockResolvedValueOnce({ query: "hamlet", total: 0, results: [] });
+
+    render(<SearchPage />);
+    await flushPromises();
+
+    await screen.findByRole("alert");
+
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    await flushPromises();
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+    expect(mockSearchFn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -107,6 +107,7 @@ function SearchResultsInner() {
   const [data, setData] = useState<InAppSearchResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [retryTick, setRetryTick] = useState(0);
 
   useEffect(() => {
     document.title = q.trim()
@@ -123,15 +124,10 @@ function SearchResultsInner() {
     setLoading(true);
     setError(null);
     searchInAppContent(q)
-      .then((d) => {
-        setData(d);
-        setLoading(false);
-      })
-      .catch((e) => {
-        setError(e?.message ?? "Search failed");
-        setLoading(false);
-      });
-  }, [q]);
+      .then((d) => { setData(d); })
+      .catch((e) => { setError(e?.message ?? "Search failed"); })
+      .finally(() => { setLoading(false); });
+  }, [q, retryTick]);
 
   const annotations = data?.results.filter((r): r is Extract<InAppSearchResult, { type: "annotation" }> => r.type === "annotation") ?? [];
   const vocabulary = data?.results.filter((r): r is Extract<InAppSearchResult, { type: "vocabulary" }> => r.type === "vocabulary") ?? [];
@@ -176,7 +172,13 @@ function SearchResultsInner() {
       {!loading && error && (
         <div role="alert" className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg px-4 py-3 flex items-center gap-2">
           <AlertCircleIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
-          <span>Error: {error}</span>
+          <span className="flex-1">Error: {error}</span>
+          <button
+            onClick={() => setRetryTick((t) => t + 1)}
+            className="text-xs px-3 py-1.5 rounded-lg border border-red-300 text-red-700 hover:bg-red-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 shrink-0"
+          >
+            Retry
+          </button>
         </div>
       )}
 


### PR DESCRIPTION
## What changed

When the in-app search API fails, the error banner previously showed only:

> Error: Search failed

with no way to recover except retyping the query. Now:

1. A **Retry** button appears inside the error banner — clicking it re-runs the same search without requiring any query change.
2. The search `useEffect` now uses `.finally(() => setLoading(false))` instead of manual `setLoading(false)` calls in both `.then()` and `.catch()`, preventing the spinner from getting stuck if state updates throw.

## Why

Dead-end error states break user flow. A user whose search failed due to a transient network error should be able to recover with one click, not by re-typing.

## Files changed

- `frontend/src/app/search/page.tsx` — added `retryTick` state, Retry button in error banner, `.finally()` cleanup
- `frontend/src/__tests__/SearchPageErrorRetry.test.tsx` — two regression tests: error state shows Retry button; clicking Retry re-runs the search and clears the error

## Test plan

- [x] `SearchPageErrorRetry.test.tsx` — both cases pass
- [x] Existing `SearchPage.errorstate.test.tsx` unchanged (all 4003 frontend tests pass)
- [x] Backend tests: 1941 passed

Closes #2479

## Docs follow-up

N/A — minor UX fix in an existing error state.
