### PR TITLE
fix: add Wiktionary fallback link to WordLookup error state (closes #2482)

### DIFF
--- a/frontend/src/__tests__/WordLookupErrorFallbackLink.test.tsx
+++ b/frontend/src/__tests__/WordLookupErrorFallbackLink.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * Regression test for #2482: WordLookup must show a Wiktionary fallback link
+ * when the dictionary API returns no definition, so the popup is never a dead end.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import WordLookup from "@/components/WordLookup";
+
+const DEFAULT_POSITION = { x: 200, y: 300 };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("WordLookup — error fallback link (closes #2482)", () => {
+  it("shows a Wiktionary link when the API returns 404", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, json: jest.fn() });
+
+    render(
+      <WordLookup
+        word="xyzzy"
+        position={DEFAULT_POSITION}
+        language="en"
+        onClose={jest.fn()}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+
+    const link = screen.getByRole("link", { name: /Search Wiktionary/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", expect.stringContaining("wiktionary.org/wiki/xyzzy"));
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("constructs Wiktionary URL using the word prop when fetch rejects", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("network error"));
+
+    render(
+      <WordLookup
+        word="serendipity"
+        position={DEFAULT_POSITION}
+        language="en"
+        onClose={jest.fn()}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+
+    const link = screen.getByRole("link", { name: /Search Wiktionary/i });
+    expect(link).toHaveAttribute("href", expect.stringContaining("wiktionary.org/wiki/serendipity"));
+  });
+});

--- a/frontend/src/components/WordLookup.tsx
+++ b/frontend/src/components/WordLookup.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { CloseIcon } from "@/components/Icons";
+import { CloseIcon, ArrowUpRightIcon } from "@/components/Icons";
 import { useFocusTrap } from "@/lib/useFocusTrap";
 
 interface Definition {
@@ -121,7 +121,17 @@ export default function WordLookup({ word, position, language, onClose }: Props)
       )}
 
       {error && (
-        <p role="alert" className="text-amber-700 italic pr-6">{error} for &ldquo;<span lang={lang}>{word}</span>&rdquo;</p>
+        <div className="space-y-1.5 pr-6">
+          <p role="alert" className="text-amber-700 italic">{error} for &ldquo;<span lang={lang}>{word}</span>&rdquo;</p>
+          <a
+            href={`https://en.wiktionary.org/wiki/${encodeURIComponent(word)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block text-xs text-amber-700 hover:text-amber-800 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
+          >
+            Search Wiktionary <ArrowUpRightIcon className="w-3 h-3 inline" aria-hidden="true" /><span className="sr-only"> (opens in new tab)</span>
+          </a>
+        </div>
       )}
 
       {result && (


### PR DESCRIPTION
## What changed

`WordLookup.tsx` now renders a "Search Wiktionary" fallback link when the dictionary API returns no result, replacing the previous dead-end "No definition found" message.

## Why

When a user selects an obscure word or a word in an unsupported language in the reader, the popup showed only an error message with no actionable next step. This is the same dead-end pattern fixed for the vocabulary definition sheet in #2477/#2478.

## Test plan

- New regression test: `frontend/src/__tests__/WordLookupErrorFallbackLink.test.tsx`
  - Covers API 404 response → link appears with correct href/target/rel
  - Covers fetch network rejection → link URL constructed from word prop
- Full frontend suite: 4007 tests pass
