### PR TITLE
ux: make gender toggle aria-label conditional on loading state (closes #2493)

### DIFF
--- a/frontend/src/__tests__/TTSControlsGenderAriaDisabled.test.ts
+++ b/frontend/src/__tests__/TTSControlsGenderAriaDisabled.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Regression test for #2493:
+ * The TTS gender toggle button's aria-label must not say "Click to switch"
+ * when the button is disabled (status === "loading") — WCAG 4.1.2.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/TTSControls.tsx"),
+  "utf8",
+);
+
+describe("TTSControls gender toggle disabled aria-label (closes #2493)", () => {
+  it("aria-label line is conditional — references loading/disabled state inside the expression", () => {
+    // Extract just the aria-label line for the gender toggle button.
+    // The fix makes "Click to switch" conditional, so the aria-label expression
+    // itself must contain a reference to "loading" or "disabled" state.
+    const toggleIdx = src.indexOf("onClick={toggleGender}");
+    expect(toggleIdx).toBeGreaterThan(-1);
+    const toggleBlock = src.slice(toggleIdx, toggleIdx + 600);
+
+    const ariaLabelLine = toggleBlock
+      .split("\n")
+      .find((line) => line.includes("aria-label="));
+    expect(ariaLabelLine).toBeDefined();
+    // The aria-label value must conditionally include "Click to switch"
+    // based on the loading/disabled state — so "loading" must appear on the same line.
+    expect(ariaLabelLine).toMatch(/loading/);
+  });
+
+  it("gender toggle button still has an aria-label that identifies the voice", () => {
+    const toggleSection = src.slice(
+      src.indexOf("onClick={toggleGender}"),
+      src.indexOf("onClick={toggleGender}") + 600,
+    );
+    expect(toggleSection).toMatch(/aria-label=.*[Vv]oice/);
+  });
+});

--- a/frontend/src/components/TTSControls.tsx
+++ b/frontend/src/components/TTSControls.tsx
@@ -459,7 +459,7 @@ export default function TTSControls({
       <button
         onClick={toggleGender}
         title={`Voice: ${gender}. Click to switch.`}
-        aria-label={`Voice: ${gender === "female" ? "Female" : "Male"}. Click to switch.`}
+        aria-label={`Voice: ${gender === "female" ? "Female" : "Male"}${status !== "loading" ? ". Click to switch" : ""}`}
         className="text-xs px-3 py-2 md:px-2 md:py-1 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 transition-colors min-h-[44px] md:min-h-0 font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
         disabled={status === "loading"}
       >


### PR DESCRIPTION
## What changed

The TTS gender toggle button's `aria-label` now omits "Click to switch" when the button is disabled (i.e., when `status === "loading"`).

**Before:** `Voice: Female. Click to switch.` (even when button is disabled)
**After:** `Voice: Female` (when loading) / `Voice: Female. Click to switch` (when active)

## Why

Closes #2493. WCAG 4.1.2 (Name, Role, Value, Level A): the accessible name of a disabled control must not describe an action the user cannot currently perform. A screen-reader user hearing "Click to switch" on a disabled button gets misleading information.

## Test plan

- `TTSControlsGenderAriaDisabled.test.ts` (new) — static analysis confirms the aria-label expression contains a `loading`-based guard on the "Click to switch" phrase, and that the voice identifier is preserved in all states.
- All 10 existing TTS test suites (79 tests) pass.
- Full frontend suite: 4014/4014 passing after rebasing onto main (which includes the merged #2491 commit).

## Docs follow-up

N/A — no user-visible documentation needed for this fix.
