### PR TITLE
ux: raise character counter contrast in deck form to meet WCAG 1.4.3 (closes #2497)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -541,3 +541,5 @@ WCAG 2.1.1 (Keyboard) and 4.1.2 (Name, Role, Value) fixes for keyboard-only and 
 |------|--------|---------|----|
 | 2026-04-30 | SelectionToolbar: auto-focus first button on keyboard-driven text selection (Shift+Arrow); restore prior focus on close | components/SelectionToolbar.tsx | #2492 |
 | 2026-04-30 | TTS gender toggle: aria-label omits "Click to switch" when button is disabled (WCAG 4.1.2) | components/TTSControls.tsx | #2494 |
+| 2026-04-30 | QueueTab inline spinner: aria-label changed from empty string to undefined when not loading (WCAG 4.1.2) | components/QueueTab.tsx | #2496 |
+| 2026-04-30 | Deck form counters: text-stone-400 → text-stone-600 on parchment background; contrast 2.3:1 → 6.7:1 (WCAG 1.4.3) | app/decks/new/page.tsx | #2497 |

--- a/frontend/src/__tests__/DeckFormCounterContrast.test.ts
+++ b/frontend/src/__tests__/DeckFormCounterContrast.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Regression test for #2497:
+ * Character counters in the deck creation form must use text-stone-600 (not
+ * text-stone-400) to meet WCAG 1.4.3 AA contrast on the parchment background.
+ * text-stone-400 (#a8a29e) on parchment (#f5f0e8) ≈ 2.3:1 — fails AA.
+ * text-stone-600 (#57534e) on parchment (#f5f0e8) ≈ 6.7:1 — passes AA.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/decks/new/page.tsx"),
+  "utf8",
+);
+
+function blockAfterIdAttr(id: string): string {
+  // Find the <p id="<id>" ...> element (not the aria-describedby reference)
+  const marker = `id="${id}"`;
+  const idx = src.indexOf(marker);
+  expect(idx).toBeGreaterThan(-1);
+  return src.slice(idx, idx + 300);
+}
+
+describe("Deck form character counter contrast (closes #2497)", () => {
+  it("name counter does not use text-stone-400 in its idle class", () => {
+    const block = blockAfterIdAttr("deck-name-counter");
+    expect(block).not.toMatch(/text-stone-400/);
+  });
+
+  it("description counter does not use text-stone-400 in its idle class", () => {
+    const block = blockAfterIdAttr("deck-description-counter");
+    expect(block).not.toMatch(/text-stone-400/);
+  });
+
+  it("name counter uses text-stone-600 for passing contrast in its idle state", () => {
+    const block = blockAfterIdAttr("deck-name-counter");
+    expect(block).toMatch(/text-stone-600/);
+  });
+
+  it("description counter uses text-stone-600 for passing contrast in its idle state", () => {
+    const block = blockAfterIdAttr("deck-description-counter");
+    expect(block).toMatch(/text-stone-600/);
+  });
+});

--- a/frontend/src/app/decks/new/page.tsx
+++ b/frontend/src/app/decks/new/page.tsx
@@ -111,7 +111,7 @@ export default function DecksNewPage() {
             <p
               id="deck-name-counter"
               aria-live="polite"
-              className={`text-xs mt-1 text-right ${name.length >= 70 ? "text-red-500" : "text-stone-400"}`}
+              className={`text-xs mt-1 text-right ${name.length >= 70 ? "text-red-500" : "text-stone-600"}`}
             >
               {name.length}/80
             </p>
@@ -138,7 +138,7 @@ export default function DecksNewPage() {
             <p
               id="deck-description-counter"
               aria-live="polite"
-              className={`text-xs mt-1 text-right ${description.length >= 490 ? "text-red-500" : "text-stone-400"}`}
+              className={`text-xs mt-1 text-right ${description.length >= 490 ? "text-red-500" : "text-stone-600"}`}
             >
               {description.length}/500
             </p>


### PR DESCRIPTION
## What changed

Character counters in the deck creation form (`/decks/new`) used `text-stone-400` (`#a8a29e`) for their idle state, rendered on the `bg-parchment` (`#f5f0e8`) background. That combination yields a contrast ratio of approximately **2.3:1** — well below the WCAG 1.4.3 AA threshold of **4.5:1** for `text-xs` (12 px) text.

Changed idle colour to `text-stone-600` (`#57534e`) on both the name counter and the description counter. New contrast on parchment: **~6.7:1** — passes AA. Warning colour (`text-red-500`) is unchanged (already passes).

## Why

WCAG 1.4.3 (Contrast, Minimum) applies to all informational text. Character counters are not incidental — they tell users how much space they have remaining. The fix is minimal and consistent with `text-stone-600` already used for helper text in the same form.

## Test plan

- New static-analysis tests in `DeckFormCounterContrast.test.ts` assert that neither counter uses `text-stone-400` and both use `text-stone-600`
- Tests failed before the fix, pass after
- Full frontend suite: 4020/4020 pass
- Backend suite: no changes to backend

Closes #2497
