### PR TITLE
docs: add text-selection and keyboard flow to annotations tutorial (closes #2499)

### DIFF
--- a/docs/tutorials/annotations.md
+++ b/docs/tutorials/annotations.md
@@ -4,9 +4,21 @@ The annotation system lets you mark up sentences while you read — add color-co
 
 ## Create a highlight
 
+There are two ways to open the action toolbar while reading:
+
+### Click a sentence (whole-sentence highlight)
+
 **On desktop:** click any sentence in the reader. A small toolbar appears beneath the selected sentence with color swatches (yellow, green, blue, pink, purple). Click a color to save a highlight.
 
 **On mobile:** long-press a sentence to open the same toolbar.
+
+### Select a phrase (partial text selection)
+
+Drag to select any span of text — a word, phrase, or passage — and a floating toolbar appears with actions: **Read**, **Highlight**, **Note**, **Chat**, and **Look up word**.
+
+**Keyboard:** use `Shift+Arrow` keys to extend the selection. The toolbar appears automatically, and focus moves to its first button. Navigate between buttons with `Arrow Left` / `Arrow Right`; press `Escape` to dismiss and return focus to where you were.
+
+---
 
 The highlight is saved automatically and synced to your account. Highlighted sentences appear color-coded the next time you open the chapter.
 

--- a/frontend/src/__tests__/AnnotationTutorialKeyboard.test.ts
+++ b/frontend/src/__tests__/AnnotationTutorialKeyboard.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Regression test for #2499:
+ * The annotations tutorial must document the text-selection and keyboard flow
+ * added in PR #2492 (Shift+Arrow to select, toolbar auto-focus, Escape to dismiss).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../../../docs/tutorials/annotations.md"),
+  "utf8",
+);
+
+describe("Annotations tutorial covers text-selection and keyboard flow (closes #2499)", () => {
+  it("mentions Shift+Arrow keyboard selection", () => {
+    expect(src).toMatch(/Shift\+Arrow|Shift \+ Arrow/i);
+  });
+
+  it("mentions Escape to dismiss the toolbar", () => {
+    expect(src).toMatch(/Escape/);
+  });
+
+  it("mentions the text selection / phrase selection workflow", () => {
+    expect(src).toMatch(/select.*phrase|phrase.*select|partial text selection|Select a phrase/i);
+  });
+
+  it("still covers the sentence-click workflow", () => {
+    expect(src).toMatch(/click any sentence/i);
+  });
+});


### PR DESCRIPTION
## What changed

Added documentation for two text-selection flows in `docs/tutorials/annotations.md`:

1. **Phrase selection (mouse)**: drag to select any span of text; the SelectionToolbar appears with Read, Highlight, Note, Chat, and Look up word actions.
2. **Keyboard selection**: `Shift+Arrow` to extend selection; toolbar auto-focuses its first button; Arrow Left/Right navigate between buttons; Escape dismisses and restores prior focus.

The tutorial previously only described the sentence-click (AnnotationToolbar) workflow. A reader using keyboard navigation or selecting partial text would not discover the SelectionToolbar on their own.

## Why

PR #2492 shipped the keyboard text-selection flow but the tutorial wasn't updated at that time. This is the docs follow-up.

## Test plan

- Static analysis test in `AnnotationTutorialKeyboard.test.ts` asserts the tutorial covers Shift+Arrow, Escape, phrase selection, and sentence-click
- All 4024 frontend tests pass

Closes #2499
