### PR TITLE
fix: move focus to done-state container when flashcard session completes (closes #2501)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -543,3 +543,5 @@ WCAG 2.1.1 (Keyboard) and 4.1.2 (Name, Role, Value) fixes for keyboard-only and 
 | 2026-04-30 | TTS gender toggle: aria-label omits "Click to switch" when button is disabled (WCAG 4.1.2) | components/TTSControls.tsx | #2494 |
 | 2026-04-30 | QueueTab inline spinner: aria-label changed from empty string to undefined when not loading (WCAG 4.1.2) | components/QueueTab.tsx | #2496 |
 | 2026-04-30 | Deck form counters: text-stone-400 → text-stone-600 on parchment background; contrast 2.3:1 → 6.7:1 (WCAG 1.4.3) | app/decks/new/page.tsx | #2497 |
+| 2026-04-30 | Annotations tutorial: added "Select a phrase (partial text selection)" section with Shift+Arrow, Arrow Left/Right, Escape keyboard flow documentation | docs/tutorials/annotations.md | #2500 |
+| 2026-04-30 | Flashcard done-state: tabIndex=-1 + useEffect focus-move on done=true; prevents focus loss when grade buttons unmount (WCAG 2.4.3) | app/vocabulary/flashcards/page.tsx | #2501 |

--- a/frontend/src/__tests__/FlashcardDoneFocus.test.tsx
+++ b/frontend/src/__tests__/FlashcardDoneFocus.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Regression test for #2501:
+ * When the last flashcard is graded and the "All done for today!" state appears,
+ * focus must move into that container so keyboard/screen-reader users don't lose
+ * their position (WCAG 2.4.3 Focus Order).
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ status: "authenticated", data: { backendToken: "token" } }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getDueFlashcards: jest.fn(),
+  reviewFlashcard: jest.fn(),
+  getFlashcardStats: jest.fn(),
+  listDecks: jest.fn(() => Promise.resolve([])),
+}));
+
+import * as api from "@/lib/api";
+import FlashcardsPage from "@/app/vocabulary/flashcards/page";
+
+const mockGetDue = api.getDueFlashcards as jest.MockedFunction<typeof api.getDueFlashcards>;
+const mockReview = api.reviewFlashcard as jest.MockedFunction<typeof api.reviewFlashcard>;
+const mockStats = api.getFlashcardStats as jest.MockedFunction<typeof api.getFlashcardStats>;
+
+const CARD = {
+  vocabulary_id: 42,
+  word: "ephemeral",
+  due_date: "2026-04-30",
+  interval_days: 1,
+  ease_factor: 2.5,
+  repetitions: 0,
+  last_reviewed_at: null,
+  saved_at: "2026-04-28T10:00:00",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockReview.mockResolvedValue({
+    vocabulary_id: 42,
+    interval_days: 1,
+    ease_factor: 2.36,
+    repetitions: 1,
+    next_due: "2026-05-01",
+  });
+});
+
+describe("Flashcard done-state focus management (closes #2501)", () => {
+  it("moves focus to the done-state container after grading the last card", async () => {
+    mockGetDue.mockResolvedValue([CARD]);
+    mockStats
+      .mockResolvedValueOnce({ total: 1, due_today: 1, reviewed_today: 0 })
+      .mockResolvedValue({ total: 1, due_today: 0, reviewed_today: 1 });
+
+    render(<FlashcardsPage />);
+
+    // Wait for card to render
+    await waitFor(() => screen.getAllByText("ephemeral")[0]);
+
+    // Flip the card
+    await userEvent.click(screen.getByText("Show answer"));
+
+    // Grade it "Good" — this is the last card
+    await userEvent.click(screen.getByText("Good"));
+
+    // Done state should appear
+    await waitFor(() => screen.getByText("All done for today!"));
+
+    // Focus must be inside the done-state container (not body or a removed button)
+    const doneContainer = screen.getByText("All done for today!").closest("[tabindex]");
+    expect(doneContainer).not.toBeNull();
+    expect(document.activeElement).toBe(doneContainer);
+  });
+
+  it("done-state container is focusable (tabIndex=-1)", async () => {
+    mockGetDue.mockResolvedValue([]);
+    mockStats.mockResolvedValue({ total: 0, due_today: 0, reviewed_today: 0 });
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => screen.getByText("All done for today!"));
+
+    const heading = screen.getByText("All done for today!");
+    // The heading should be inside a tabIndex=-1 container
+    const container = heading.closest("[tabindex='-1']");
+    expect(container).not.toBeNull();
+  });
+});

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
 import {
@@ -53,6 +53,7 @@ export default function FlashcardsPage() {
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [done, setDone] = useState(false);
+  const doneContainerRef = useRef<HTMLDivElement>(null);
   const [decks, setDecks] = useState<DeckSummary[]>([]);
   const [decksFetchError, setDecksFetchError] = useState(false);
   const [decksRetryTick, setDecksRetryTick] = useState(0);
@@ -111,6 +112,12 @@ export default function FlashcardsPage() {
     document.title = "Flashcards — Book Reader AI";
     return () => { document.title = "Vocabulary — Book Reader AI"; };
   }, []);
+
+  // Move focus to done-state container so keyboard/screen-reader users don't lose
+  // their position when grade buttons unmount (WCAG 2.4.3 Focus Order, closes #2501)
+  useEffect(() => {
+    if (done) doneContainerRef.current?.focus();
+  }, [done]);
 
   const currentCard = cards[currentIndex] ?? null;
 
@@ -265,7 +272,7 @@ export default function FlashcardsPage() {
 
         {/* Done state */}
         {!fetchError && done ? (
-          <div role="status" className="flex flex-col items-center gap-4 py-16 text-center">
+          <div ref={doneContainerRef} role="status" tabIndex={-1} className="flex flex-col items-center gap-4 py-16 text-center focus:outline-none">
             <CheckIcon className="w-12 h-12 text-green-500" />
             <h2 className="font-serif text-2xl text-ink">All done for today!</h2>
             <p className="text-sm text-stone-600">


### PR DESCRIPTION
## What changed

When a user grades the last flashcard and the "All done for today!" state appears, focus was dropped to `<body>` because the grade buttons unmounted without any focus management. Keyboard and screen-reader users lost their position (WCAG 2.4.3 Focus Order).

**Fix:**
- Added `useRef` (`doneContainerRef`) on the done-state `<div>`
- Added `useEffect` that calls `doneContainerRef.current?.focus()` when `done` becomes `true`
- Added `tabIndex={-1}` so the div is programmatically focusable without entering the tab order
- Added `focus:outline-none` since the focus is intentional/programmatic

## Why

Without explicit focus management, after grading the last card:
- Keyboard users had no focused element; Tab would jump unpredictably
- Screen readers would not announce the "All done for today!" state

## Test plan

- [x] New regression tests in `FlashcardDoneFocus.test.tsx`:
  1. After grading the last card, `document.activeElement` is the done-state container
  2. The done-state container has `tabIndex="-1"` (is programmatically focusable)
- [x] All 4026 frontend tests pass
- [x] Backend tests pass

Closes #2501
