### PR TITLE
ux: add warning icon to word-count pill for out-of-range chapters (closes #2503)

### DIFF
--- a/frontend/src/__tests__/UploadChapterWordWarnIcon.test.ts
+++ b/frontend/src/__tests__/UploadChapterWordWarnIcon.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Regression test for #2503:
+ * The word-count warning pill must include a non-color indicator (AlertCircleIcon)
+ * when a chapter's word count is outside the expected range (< 100 or > 8000).
+ * Color alone is insufficient per WCAG 1.4.1 (Use of Color).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/upload/[bookId]/chapters/page.tsx"),
+  "utf8",
+);
+
+describe("Upload chapter word-count warning pill has non-color indicator (closes #2503)", () => {
+  it("renders an AlertCircleIcon inside the word-count pill when wordWarn is true", () => {
+    // The fix must conditionally render AlertCircleIcon when wordWarn is true
+    expect(src).toMatch(/wordWarn.*AlertCircleIcon|AlertCircleIcon.*wordWarn/s);
+  });
+
+  it("applies inline-flex and gap classes to the pill span for icon alignment", () => {
+    // The span must use inline-flex so the icon and text align properly
+    expect(src).toMatch(/inline-flex.*items-center.*gap|gap.*items-center.*inline-flex/);
+  });
+
+  it("adds aria-hidden to the warning icon so it is decorative", () => {
+    // The icon is purely visual; the amber color + text still convey the warning
+    const iconSection = src.match(/wordWarn[\s\S]{0,200}AlertCircleIcon[\s\S]{0,100}/);
+    expect(iconSection).not.toBeNull();
+    expect(iconSection![0]).toMatch(/aria-hidden/);
+  });
+});

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -189,12 +189,13 @@ export default function ChapterEditorPage() {
                     />
                     <div className="flex items-center gap-2 mt-1">
                       <span
-                        className={`text-xs px-1.5 py-0.5 rounded font-mono ${
+                        className={`text-xs px-1.5 py-0.5 rounded font-mono inline-flex items-center gap-1 ${
                           wordWarn
                             ? "bg-amber-100 text-amber-700"
                             : "bg-stone-100 text-stone-600"
                         }`}
                       >
+                        {wordWarn && <AlertCircleIcon className="w-3 h-3 shrink-0" aria-hidden="true" />}
                         {ch.word_count.toLocaleString()} words
                       </span>
                     </div>


### PR DESCRIPTION
## What changed

Added `AlertCircleIcon` inside the word-count pill in the upload chapter review page when a chapter's word count is outside the expected range (< 100 or > 8000 words).

Previously the pill changed from stone to amber color — but color alone does not satisfy WCAG 1.4.1 (Use of Color). The warning is now conveyed by both color and a visible icon glyph.

## Why

WCAG 1.4.1 requires that color is not the only visual means of conveying information. Users with color vision deficiency could not distinguish warning chapters from normal ones.

## Test plan

- New static source analysis test `UploadChapterWordWarnIcon.test.ts` verifies:
  1. `AlertCircleIcon` is rendered conditionally when `wordWarn` is true
  2. The pill span uses `inline-flex items-center gap-1` for icon alignment
  3. The icon has `aria-hidden="true"` (decorative)
- Full frontend test suite: 4029 tests pass

Closes #2503
