### PR TITLE
ux: add title/aria-label to heatmap legend swatches for colorblind users (closes #2505)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -545,3 +545,5 @@ WCAG 2.1.1 (Keyboard) and 4.1.2 (Name, Role, Value) fixes for keyboard-only and 
 | 2026-04-30 | Deck form counters: text-stone-400 → text-stone-600 on parchment background; contrast 2.3:1 → 6.7:1 (WCAG 1.4.3) | app/decks/new/page.tsx | #2497 |
 | 2026-04-30 | Annotations tutorial: added "Select a phrase (partial text selection)" section with Shift+Arrow, Arrow Left/Right, Escape keyboard flow documentation | docs/tutorials/annotations.md | #2500 |
 | 2026-04-30 | Flashcard done-state: tabIndex=-1 + useEffect focus-move on done=true; prevents focus loss when grade buttons unmount (WCAG 2.4.3) | app/vocabulary/flashcards/page.tsx | #2501 |
+| 2026-04-30 | Upload chapter word-count pill: added AlertCircleIcon when word count < 100 or > 8000; color alone is insufficient per WCAG 1.4.1 | app/upload/[bookId]/chapters/page.tsx | #2503 |
+| 2026-04-30 | Reading stats heatmap legend: added title + aria-label to each swatch (0, 1–2, 3–5, 6–10, 11+) so colorblind users can identify intensity levels (WCAG 1.4.1) | components/ReadingStats.tsx | #2505 |

--- a/frontend/src/__tests__/ReadingStatsHeatmapLegend.test.ts
+++ b/frontend/src/__tests__/ReadingStatsHeatmapLegend.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Regression test for #2505:
+ * The reading stats heatmap legend must convey intensity levels through a
+ * non-color indicator in addition to color (WCAG 1.4.1 Use of Color).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/ReadingStats.tsx"),
+  "utf8",
+);
+
+describe("ReadingStats heatmap legend uses non-color indicators (closes #2505)", () => {
+  it("defines count-range labels for each intensity level", () => {
+    // The fix must define the 5 intensity count ranges (0, 1-2, 3-5, 6-10, 11+)
+    expect(src).toMatch(/11\+|≥\s*11|more than 10/i);
+  });
+
+  it("includes 1-2 or 1–2 label for second intensity bucket", () => {
+    expect(src).toMatch(/1[–-]2/);
+  });
+
+  it("applies title attributes to legend swatches for sighted colorblind users", () => {
+    // legend swatches must have title or aria-label so hover shows the count
+    const legendSection = src.match(/Legend[\s\S]{0,800}More/);
+    expect(legendSection).not.toBeNull();
+    expect(legendSection![0]).toMatch(/title|aria-label/i);
+  });
+});

--- a/frontend/src/components/ReadingStats.tsx
+++ b/frontend/src/components/ReadingStats.tsx
@@ -216,11 +216,17 @@ export default function ReadingStats({ active, heatmapOnly = false }: Props) {
           ))}
         </div>
 
-        {/* Legend */}
+        {/* Legend — each swatch has a title + aria-label so colorblind users can hover/AT for count range (WCAG 1.4.1) */}
         <div className="flex items-center gap-1 mt-2 justify-end">
           <span className="text-[9px] text-stone-600 mr-1">Less</span>
-          {["bg-stone-100", "bg-amber-200", "bg-amber-400", "bg-amber-600", "bg-amber-800"].map((c) => (
-            <div key={c} className={`w-3 h-3 rounded-[2px] ${c}`} />
+          {[
+            { bg: "bg-stone-100", label: "0 events" },
+            { bg: "bg-amber-200", label: "1–2 events" },
+            { bg: "bg-amber-400", label: "3–5 events" },
+            { bg: "bg-amber-600", label: "6–10 events" },
+            { bg: "bg-amber-800", label: "11+ events" },
+          ].map(({ bg, label }) => (
+            <div key={bg} title={label} aria-label={label} className={`w-3 h-3 rounded-[2px] ${bg}`} />
           ))}
           <span className="text-[9px] text-stone-600 ml-1">More</span>
         </div>


### PR DESCRIPTION
## What changed

Added `title` and `aria-label` attributes to each legend swatch in the reading activity heatmap, naming the count range it represents:

- `0 events` (stone-100)
- `1–2 events` (amber-200)
- `3–5 events` (amber-400)
- `6–10 events` (amber-600)
- `11+ events` (amber-800)

Previously the legend had five colored squares with only "Less" / "More" text — color was the sole indicator of intensity.

## Why

WCAG 1.4.1 (Use of Color) requires that color is not the only visual means of conveying information. Users with color vision deficiency (colorblindness) could see the squares but could not identify which color maps to which activity count. The `title` attribute makes the count range visible as a hover tooltip; the `aria-label` exposes it to AT.

## Test plan

- New static source test `ReadingStatsHeatmapLegend.test.ts` verifies:
  1. `11+` label exists for the highest intensity bucket
  2. `1–2` label exists for the second bucket
  3. Legend section contains `title` or `aria-label` attributes
- Full frontend test suite: 4032 tests pass

Closes #2505
