### PR TITLE
ux: restore focus to Show answer button on card-to-card transition (closes #2507)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -547,3 +547,4 @@ WCAG 2.1.1 (Keyboard) and 4.1.2 (Name, Role, Value) fixes for keyboard-only and 
 | 2026-04-30 | Flashcard done-state: tabIndex=-1 + useEffect focus-move on done=true; prevents focus loss when grade buttons unmount (WCAG 2.4.3) | app/vocabulary/flashcards/page.tsx | #2501 |
 | 2026-04-30 | Upload chapter word-count pill: added AlertCircleIcon when word count < 100 or > 8000; color alone is insufficient per WCAG 1.4.1 | app/upload/[bookId]/chapters/page.tsx | #2503 |
 | 2026-04-30 | Reading stats heatmap legend: added title + aria-label to each swatch (0, 1–2, 3–5, 6–10, 11+) so colorblind users can identify intensity levels (WCAG 1.4.1) | components/ReadingStats.tsx | #2505 |
+| 2026-04-30 | Flashcard card-to-card transition: flipButtonRef + useEffect focus-move on currentIndex change; prevents focus loss when grade buttons unmount between cards (WCAG 2.4.3) | app/vocabulary/flashcards/page.tsx | #2507 |

--- a/frontend/src/__tests__/FlashcardCardTransitionFocus.test.tsx
+++ b/frontend/src/__tests__/FlashcardCardTransitionFocus.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Regression test for #2507:
+ * When grading a flashcard (not the last one), the grade buttons unmount and the
+ * next card renders. Focus must move to the new card's "Show answer" button so
+ * keyboard users don't lose their position (WCAG 2.4.3 Focus Order).
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ status: "authenticated", data: { backendToken: "token" } }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getDueFlashcards: jest.fn(),
+  reviewFlashcard: jest.fn(),
+  getFlashcardStats: jest.fn(),
+  listDecks: jest.fn(() => Promise.resolve([])),
+}));
+
+import * as api from "@/lib/api";
+import FlashcardsPage from "@/app/vocabulary/flashcards/page";
+
+const mockGetDue = api.getDueFlashcards as jest.MockedFunction<typeof api.getDueFlashcards>;
+const mockReview = api.reviewFlashcard as jest.MockedFunction<typeof api.reviewFlashcard>;
+const mockStats = api.getFlashcardStats as jest.MockedFunction<typeof api.getFlashcardStats>;
+
+const CARD_A = {
+  vocabulary_id: 1,
+  word: "ephemeral",
+  due_date: "2026-04-30",
+  interval_days: 1,
+  ease_factor: 2.5,
+  repetitions: 0,
+  last_reviewed_at: null,
+  saved_at: "2026-04-28T10:00:00",
+};
+const CARD_B = {
+  vocabulary_id: 2,
+  word: "transient",
+  due_date: "2026-04-30",
+  interval_days: 1,
+  ease_factor: 2.5,
+  repetitions: 0,
+  last_reviewed_at: null,
+  saved_at: "2026-04-28T10:00:00",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockReview.mockResolvedValue({
+    vocabulary_id: 1,
+    interval_days: 1,
+    ease_factor: 2.36,
+    repetitions: 1,
+    next_due: "2026-05-01",
+  });
+  mockStats.mockResolvedValue({ total: 2, due_today: 2, reviewed_today: 0 });
+});
+
+describe("Flashcard card-to-card transition focus management (closes #2507)", () => {
+  it("moves focus to Show answer button after grading a non-last card", async () => {
+    mockGetDue.mockResolvedValue([CARD_A, CARD_B]);
+
+    render(<FlashcardsPage />);
+
+    // Wait for first card
+    await waitFor(() => screen.getAllByText("ephemeral")[0]);
+
+    // Flip the card
+    await userEvent.click(screen.getByRole("button", { name: /show answer/i }));
+
+    // Grade it — not the last card
+    await userEvent.click(screen.getByRole("button", { name: /good/i }));
+
+    // Second card should appear
+    await waitFor(() => screen.getAllByText("transient")[0]);
+
+    // Focus must be on the "Show answer" button for the next card
+    const showAnswerBtn = screen.getByRole("button", { name: /show answer/i });
+    expect(document.activeElement).toBe(showAnswerBtn);
+  });
+});

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -54,6 +54,7 @@ export default function FlashcardsPage() {
   const [submitting, setSubmitting] = useState(false);
   const [done, setDone] = useState(false);
   const doneContainerRef = useRef<HTMLDivElement>(null);
+  const flipButtonRef = useRef<HTMLButtonElement>(null);
   const [decks, setDecks] = useState<DeckSummary[]>([]);
   const [decksFetchError, setDecksFetchError] = useState(false);
   const [decksRetryTick, setDecksRetryTick] = useState(0);
@@ -118,6 +119,15 @@ export default function FlashcardsPage() {
   useEffect(() => {
     if (done) doneContainerRef.current?.focus();
   }, [done]);
+
+  // Move focus to the "Show answer" button when the card advances to the next card
+  // so keyboard users don't lose their position (WCAG 2.4.3 Focus Order, closes #2507)
+  useEffect(() => {
+    if (!done && cards.length > 0) flipButtonRef.current?.focus();
+  // currentIndex changing means a new card was loaded; cards.length guards against
+  // the initial render where no card exists yet.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentIndex]);
 
   const currentCard = cards[currentIndex] ?? null;
 
@@ -347,6 +357,7 @@ export default function FlashcardsPage() {
             {!flipped && (
               <div className="flex justify-center">
                 <button
+                  ref={flipButtonRef}
                   onClick={() => setFlipped(true)}
                   aria-label="Show answer (Space or Enter)"
                   className="px-6 py-3 bg-amber-700 text-white rounded-xl font-medium hover:bg-amber-800 transition-colors min-h-[44px] md:min-h-0 flex flex-col items-center gap-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"


### PR DESCRIPTION
## What changed

Added `flipButtonRef` on the "Show answer" button in `flashcards/page.tsx` and a `useEffect` that calls `flipButtonRef.current?.focus()` when `currentIndex` changes. This moves keyboard focus to the new card's flip button after each card-to-card transition.

## Why

When a user tabs to a grade button and activates it, the grade buttons unmount (because `flipped` becomes `false` for the next card) and focus falls to `<body>`. Keyboard and screen-reader users then have to Tab from the top of the page to resume reviewing.

The "done" state already handled this correctly with `doneContainerRef` (closes #2501). This PR applies the same WCAG 2.4.3 (Focus Order) fix to the mid-session card transition.

## Test plan

- [x] New regression test `FlashcardCardTransitionFocus.test.tsx`: grades a non-last card and asserts `document.activeElement === showAnswerBtn`
- [x] Existing `FlashcardDoneFocus` tests still pass — done-state focus unaffected
- [x] Full frontend suite: 4033/4033 pass

Closes #2507

## Docs follow-up

Design Change Log updated in `docs/design-improvement-plan.md`.
