### PR TITLE
ux: pause UndoToast timer on hover/focus; increase duration 3s→5s (closes #2509)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -548,3 +548,4 @@ WCAG 2.1.1 (Keyboard) and 4.1.2 (Name, Role, Value) fixes for keyboard-only and 
 | 2026-04-30 | Upload chapter word-count pill: added AlertCircleIcon when word count < 100 or > 8000; color alone is insufficient per WCAG 1.4.1 | app/upload/[bookId]/chapters/page.tsx | #2503 |
 | 2026-04-30 | Reading stats heatmap legend: added title + aria-label to each swatch (0, 1–2, 3–5, 6–10, 11+) so colorblind users can identify intensity levels (WCAG 1.4.1) | components/ReadingStats.tsx | #2505 |
 | 2026-04-30 | Flashcard card-to-card transition: flipButtonRef + useEffect focus-move on currentIndex change; prevents focus loss when grade buttons unmount between cards (WCAG 2.4.3) | app/vocabulary/flashcards/page.tsx | #2507 |
+| 2026-04-30 | UndoToast: increased auto-dismiss from 3 s → 5 s; timer now pauses on mouseenter/focusin and resumes on mouseleave/focusout — WCAG 2.2.1 Timing Adjustable (Level A) | components/UndoToast.tsx | #2509 |

--- a/frontend/src/__tests__/UndoToast.test.tsx
+++ b/frontend/src/__tests__/UndoToast.test.tsx
@@ -26,13 +26,13 @@ describe("UndoToast", () => {
     await waitFor(() => expect(onDone).toHaveBeenCalledTimes(1), { timeout: 500 });
   });
 
-  it("auto-dismisses after 3 seconds by calling onDone", async () => {
+  it("auto-dismisses after 5 seconds by calling onDone", async () => {
     jest.useFakeTimers();
     const onDone = jest.fn();
     render(<UndoToast message="Highlight deleted" onUndo={jest.fn()} onDone={onDone} />);
 
     await act(async () => {
-      jest.advanceTimersByTime(3300);
+      jest.advanceTimersByTime(5300);
     });
 
     expect(onDone).toHaveBeenCalledTimes(1);
@@ -45,7 +45,7 @@ describe("UndoToast", () => {
     render(<UndoToast message="Highlight deleted" onUndo={onUndo} onDone={onDone} />);
 
     await act(async () => {
-      jest.advanceTimersByTime(3300);
+      jest.advanceTimersByTime(5300);
     });
 
     expect(onUndo).not.toHaveBeenCalled();

--- a/frontend/src/__tests__/UndoToastTimingPause.test.tsx
+++ b/frontend/src/__tests__/UndoToastTimingPause.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * Regression test for #2509:
+ * UndoToast must pause its auto-dismiss timer when the toast receives keyboard
+ * focus or mouse hover so keyboard users have enough time to click "Undo"
+ * (WCAG 2.2.1 Timing Adjustable, Level A).
+ */
+import React from "react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UndoToast from "@/components/UndoToast";
+
+describe("UndoToast timing — closes #2509", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it("calls onDone after the base duration when not interacted with", () => {
+    const onDone = jest.fn();
+    const onUndo = jest.fn();
+    render(<UndoToast message="Word removed" onUndo={onUndo} onDone={onDone} />);
+
+    // Should NOT be called yet
+    act(() => { jest.advanceTimersByTime(4999); });
+    expect(onDone).not.toHaveBeenCalled();
+
+    // Should be called after full 5 s + 300 ms fade
+    act(() => { jest.advanceTimersByTime(1 + 300); });
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("pauses auto-dismiss while the toast has keyboard focus", async () => {
+    const onDone = jest.fn();
+    render(<UndoToast message="Word removed" onUndo={jest.fn()} onDone={onDone} />);
+
+    // Focus the Undo button — timer should freeze
+    const undoBtn = screen.getByRole("button", { name: /undo/i });
+    act(() => { undoBtn.focus(); });
+
+    // Advance well past the base duration — onDone must NOT fire
+    act(() => { jest.advanceTimersByTime(10000); });
+    expect(onDone).not.toHaveBeenCalled();
+
+    // Blur — timer should restart and onDone fires after base duration + fade
+    act(() => { undoBtn.blur(); });
+    act(() => { jest.advanceTimersByTime(5000 + 300); });
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("pauses auto-dismiss while the mouse is over the toast", async () => {
+    const onDone = jest.fn();
+    render(<UndoToast message="Word removed" onUndo={jest.fn()} onDone={onDone} />);
+
+    const toast = screen.getByRole("status");
+
+    // Simulate mouseenter via React synthetic event
+    act(() => { fireEvent.mouseEnter(toast); });
+    act(() => { jest.advanceTimersByTime(10000); });
+    expect(onDone).not.toHaveBeenCalled();
+
+    // Simulate mouseleave — timer restarts
+    act(() => { fireEvent.mouseLeave(toast); });
+    act(() => { jest.advanceTimersByTime(5000 + 300); });
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onUndo immediately when Undo button is clicked", async () => {
+    const onUndo = jest.fn();
+    const onDone = jest.fn();
+    render(<UndoToast message="Word removed" onUndo={onUndo} onDone={onDone} />);
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(screen.getByRole("button", { name: /undo/i }));
+
+    expect(onUndo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/UndoToast.tsx
+++ b/frontend/src/components/UndoToast.tsx
@@ -1,7 +1,9 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
-const DURATION_MS = 3000;
+// WCAG 2.2.1: 5 s gives keyboard users enough time to reach the Undo button.
+// The timer also pauses while the toast is hovered or focused (see handlers below).
+const DURATION_MS = 5000;
 
 interface Props {
   message: string;
@@ -11,14 +13,35 @@ interface Props {
 
 export default function UndoToast({ message, onUndo, onDone }: Props) {
   const [visible, setVisible] = useState(true);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pausedRef = useRef(false);
 
-  useEffect(() => {
-    const timer = setTimeout(() => {
+  const startTimer = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
       setVisible(false);
       setTimeout(onDone, 300);
     }, DURATION_MS);
-    return () => clearTimeout(timer);
   }, [onDone]);
+
+  useEffect(() => {
+    startTimer();
+    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+  }, [startTimer]);
+
+  function pause() {
+    if (!pausedRef.current) {
+      pausedRef.current = true;
+      if (timerRef.current) clearTimeout(timerRef.current);
+    }
+  }
+
+  function resume() {
+    if (pausedRef.current) {
+      pausedRef.current = false;
+      startTimer();
+    }
+  }
 
   function handleUndo() {
     setVisible(false);
@@ -31,6 +54,10 @@ export default function UndoToast({ message, onUndo, onDone }: Props) {
       role="status"
       aria-live="polite"
       aria-atomic="true"
+      onMouseEnter={pause}
+      onMouseLeave={resume}
+      onFocus={pause}
+      onBlur={resume}
       className={`fixed bottom-6 left-1/2 -translate-x-1/2 z-50 bg-stone-800 text-white rounded-xl shadow-xl px-4 py-3 text-sm flex items-center gap-3 transition-all duration-300 ${
         visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
       }`}


### PR DESCRIPTION
## What changed

`UndoToast` auto-dismissed after 3 seconds with no way to pause, extend, or turn off the timer. This is a WCAG 2.2.1 (Timing Adjustable, Level A) failure: a keyboard user who triggers "delete" must Tab from their current position to the fixed-position "Undo" button — 3 seconds is often not enough.

**Changes:**
- `DURATION_MS` increased from 3 000 ms → 5 000 ms (more breathing room by default)
- Auto-dismiss timer pauses on `mouseenter` / `focusin` and restarts on `mouseleave` / `focusout` — once a keyboard user focuses inside the toast, the timer is frozen indefinitely until they leave

## Why

WCAG 2.2.1 Success Criterion requires that time limits be turn-offable, adjustable, or extendable (with at least 20 seconds of extension). None of the exceptions (real-time, essential, 20-hour) apply to a deletion undo toast. The pause-on-focus pattern satisfies the "extend with a simple action" path.

## Test plan

- [x] `UndoToastTimingPause.test.tsx` — 4 new tests covering: base-duration dismissal at 5 s, focus-pauses-timer, mouseenter-pauses-timer, Undo-click works
- [x] `UndoToast.test.tsx` — updated timing from 3 300 ms → 5 300 ms to match new duration
- [x] Full frontend suite: 4037 tests pass
