### PR TITLE
ux: make QueueTab display-only scroll containers keyboard-accessible (closes #2511)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -549,3 +549,4 @@ WCAG 2.1.1 (Keyboard) and 4.1.2 (Name, Role, Value) fixes for keyboard-only and 
 | 2026-04-30 | Reading stats heatmap legend: added title + aria-label to each swatch (0, 1–2, 3–5, 6–10, 11+) so colorblind users can identify intensity levels (WCAG 1.4.1) | components/ReadingStats.tsx | #2505 |
 | 2026-04-30 | Flashcard card-to-card transition: flipButtonRef + useEffect focus-move on currentIndex change; prevents focus loss when grade buttons unmount between cards (WCAG 2.4.3) | app/vocabulary/flashcards/page.tsx | #2507 |
 | 2026-04-30 | UndoToast: increased auto-dismiss from 3 s → 5 s; timer now pauses on mouseenter/focusin and resumes on mouseleave/focusout — WCAG 2.2.1 Timing Adjustable (Level A) | components/UndoToast.tsx | #2509 |
+| 2026-04-30 | QueueTab display-only scroll containers: added tabIndex={0} + focus ring to books-to-translate table wrapper and dry-run preview wrapper — WCAG 2.1.1 Keyboard (Level A) | components/QueueTab.tsx | #2511 |

--- a/frontend/src/__tests__/QueueTabScrollKeyboard.test.ts
+++ b/frontend/src/__tests__/QueueTabScrollKeyboard.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Regression test for #2511:
+ * Scrollable display-only containers in QueueTab must have tabIndex={0} so
+ * keyboard users can focus them and scroll with arrow/page keys
+ * (WCAG 2.1.1 Keyboard, Level A).
+ *
+ * Static source-code analysis: cheaper than a full render and pinpoints
+ * the exact pattern that must not regress.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "../components/QueueTab.tsx"),
+  "utf-8",
+);
+
+describe("QueueTab scrollable containers — WCAG 2.1.1 (closes #2511)", () => {
+  it('books-to-translate table scroll wrapper has tabIndex={0}', () => {
+    // The wrapper containing the <table aria-label="Books to translate">
+    // must be keyboard-focusable.
+    const tableWrapperRegex =
+      /max-h-40[^>]*overflow-y-auto[^>]*tabIndex=\{0\}|tabIndex=\{0\}[^>]*max-h-40[^>]*overflow-y-auto/;
+    expect(src).toMatch(tableWrapperRegex);
+  });
+
+  it('dry-run preview scroll wrapper has tabIndex={0}', () => {
+    // The wrapper showing the translated paragraph previews.
+    const previewWrapperRegex =
+      /max-h-64[^>]*overflow-y-auto[^>]*tabIndex=\{0\}|tabIndex=\{0\}[^>]*max-h-64[^>]*overflow-y-auto/;
+    expect(src).toMatch(previewWrapperRegex);
+  });
+});

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -811,7 +811,7 @@ export default function QueueTab({ adminFetch }: Props) {
               {" · "}~<strong>{planResult.estimated_days_at_rpd} days</strong> at RPD
             </p>
             {planResult.books.length > 0 && (
-              <div className="max-h-40 overflow-y-auto border border-amber-100 rounded text-xs">
+              <div tabIndex={0} className="max-h-40 overflow-y-auto border border-amber-100 rounded text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1">
                 <table className="w-full" aria-label="Books to translate">
                   <thead className="bg-amber-50">
                     <tr>
@@ -839,7 +839,7 @@ export default function QueueTab({ adminFetch }: Props) {
               Preview: <strong>{dryRunResult.preview_book_title || "book"}</strong>
               {" · "}{dryRunResult.total_chapters} chapters total across {dryRunResult.total_books} book(s)
             </p>
-            <div className="space-y-3 max-h-64 overflow-y-auto bg-amber-50/50 rounded-lg p-3">
+            <div tabIndex={0} className="space-y-3 max-h-64 overflow-y-auto bg-amber-50/50 rounded-lg p-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1">
               {Object.entries(dryRunResult.preview).map(([idx, paragraphs]) => (
                 <div key={idx} className="text-sm font-serif">
                   <div className="text-xs text-amber-700 mb-1">Chapter {Number(idx) + 1}</div>


### PR DESCRIPTION
## What changed

Two display-only scrollable containers in `QueueTab.tsx` were missing `tabIndex={0}`:

1. **Books-to-translate table wrapper** (`max-h-40 overflow-y-auto`): contains a `<table>` with book/chapter counts but no interactive children. Overflowed rows were unreachable by keyboard.
2. **Dry-run preview wrapper** (`max-h-64 overflow-y-auto`): contains translated paragraph previews (text only). Overflowed content was unreachable by keyboard.

Both containers now have `tabIndex={0}` and `focus-visible:ring-2` so keyboard users can Tab into them and scroll with arrow/page keys.

## Why

WCAG 2.1.1 (Keyboard, Level A): all content must be operable via keyboard. Scrollable containers with no interactive children need `tabIndex={0}` to allow keyboard scrolling.

## Test plan

- [x] `QueueTabScrollKeyboard.test.ts` — static source analysis verifies both wrappers carry `tabIndex={0}` (2 new tests)
- [x] Full frontend suite: 4039 tests pass
