### PR TITLE
ux: add tabIndex={0} to activity-log and definition scroll containers (closes #2513)

### DIFF
--- a/frontend/src/__tests__/ScrollTabIndexRegression2513.test.ts
+++ b/frontend/src/__tests__/ScrollTabIndexRegression2513.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression tests for #2513:
+ * Display-only scrollable containers in QueueTab (activity log),
+ * SeedPopularButton (recent events log), and VocabWordTooltip (definition body)
+ * must have tabIndex={0} so keyboard users can focus and scroll them.
+ * (WCAG 2.1.1 Keyboard, Level A)
+ *
+ * Static source-code analysis: cheaper than a full render and pinpoints
+ * the exact pattern that must not regress.
+ */
+import fs from "fs";
+import path from "path";
+
+const queueTabSrc = fs.readFileSync(
+  path.resolve(__dirname, "../components/QueueTab.tsx"),
+  "utf-8",
+);
+
+const seedButtonSrc = fs.readFileSync(
+  path.resolve(__dirname, "../components/SeedPopularButton.tsx"),
+  "utf-8",
+);
+
+const vocabTooltipSrc = fs.readFileSync(
+  path.resolve(__dirname, "../components/VocabWordTooltip.tsx"),
+  "utf-8",
+);
+
+describe("Scrollable display-only containers — WCAG 2.1.1 (closes #2513)", () => {
+  it("QueueTab activity-log ul has tabIndex={0}", () => {
+    const regex =
+      /max-h-60[^>]*overflow-y-auto[^>]*tabIndex=\{0\}|tabIndex=\{0\}[^>]*max-h-60[^>]*overflow-y-auto/;
+    expect(queueTabSrc).toMatch(regex);
+  });
+
+  it("SeedPopularButton recent-events ul has tabIndex={0}", () => {
+    const regex =
+      /max-h-40[^>]*overflow-y-auto[^>]*tabIndex=\{0\}|tabIndex=\{0\}[^>]*max-h-40[^>]*overflow-y-auto/;
+    expect(seedButtonSrc).toMatch(regex);
+  });
+
+  it("VocabWordTooltip definition body div has tabIndex={0}", () => {
+    const regex =
+      /max-h-40[^>]*overflow-y-auto[^>]*tabIndex=\{0\}|tabIndex=\{0\}[^>]*max-h-40[^>]*overflow-y-auto/;
+    expect(vocabTooltipSrc).toMatch(regex);
+  });
+});

--- a/frontend/src/components/QueueTab.tsx
+++ b/frontend/src/components/QueueTab.tsx
@@ -685,7 +685,7 @@ export default function QueueTab({ adminFetch }: Props) {
             <summary className="text-xs text-amber-700 cursor-pointer rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1">
               Activity log ({s.log.length})
             </summary>
-            <ul role="list" className="mt-1 text-xs space-y-1 max-h-60 overflow-y-auto list-none p-0 m-0">
+            <ul role="list" tabIndex={0} className="mt-1 text-xs space-y-1 max-h-60 overflow-y-auto list-none p-0 m-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded">
               {s.log
                 .slice()
                 .reverse()

--- a/frontend/src/components/SeedPopularButton.tsx
+++ b/frontend/src/components/SeedPopularButton.tsx
@@ -261,7 +261,7 @@ export default function SeedPopularButton({ adminFetch, onComplete }: Props) {
               <summary className="text-xs text-amber-700 cursor-pointer rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1">
                 Recent events ({state.log.length})
               </summary>
-              <ul role="list" className="mt-1 text-xs space-y-0.5 max-h-40 overflow-y-auto list-none p-0 m-0">
+              <ul role="list" tabIndex={0} className="mt-1 text-xs space-y-0.5 max-h-40 overflow-y-auto list-none p-0 m-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded">
                 {state.log.slice().reverse().map((entry, i) => (
                   <li
                     key={i}

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -89,7 +89,7 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
       </div>
 
       {/* Body */}
-      <div className="px-3 py-2.5 max-h-40 overflow-y-auto">
+      <div tabIndex={0} className="px-3 py-2.5 max-h-40 overflow-y-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-inset rounded">
         {loading && (
           <div className="flex items-center gap-2 text-amber-700 text-xs py-1" role="status">
             <span className="w-3 h-3 border-2 border-amber-300 border-t-amber-700 rounded-full animate-spin shrink-0" aria-hidden="true" />


### PR DESCRIPTION
## What changed

Added `tabIndex={0}` and a focus-visible ring to three display-only scrollable containers that were unreachable by keyboard (WCAG 2.1.1 Keyboard, Level A):

| File | Element | Max-height |
|---|---|---|
| `QueueTab.tsx` | Activity-log `<ul>` inside `<details>` | `max-h-60` |
| `SeedPopularButton.tsx` | Recent-events `<ul>` inside `<details>` | `max-h-40` |
| `VocabWordTooltip.tsx` | Definition body `<div>` | `max-h-40` |

## Why

These containers can overflow their `max-height` but had no way for keyboard-only users to scroll the hidden content. The pattern matches the exact violation fixed in #2511 (merged in #2512), now caught in three more places.

The `VocabWordTooltip` case is user-facing: readers who look up a word definition mid-reading couldn't scroll through longer definitions with a keyboard.

## Test plan

- New `ScrollTabIndexRegression2513.test.ts` (static source analysis) — 3 tests, one per container — all pass
- Full frontend suite: 4042 tests pass

Closes #2513
