### PR TITLE
ux: increase VocabularyToast duration 2s→4s and pause on hover/focus (closes #2515)

### DIFF
--- a/frontend/src/__tests__/VocabularyToast.test.tsx
+++ b/frontend/src/__tests__/VocabularyToast.test.tsx
@@ -27,9 +27,9 @@ test("calls onDone after the timer fires", () => {
   // onDone not called before timers fire
   expect(onDone).not.toHaveBeenCalled();
 
-  // Advance past the 2000ms visibility timer
+  // Advance past the 4000ms visibility timer (#2515: was 2000ms)
   act(() => {
-    jest.advanceTimersByTime(2000);
+    jest.advanceTimersByTime(4000);
   });
 
   // Still not called — there is a 300ms fade-out delay after the first timer

--- a/frontend/src/__tests__/VocabularyToastTiming.test.tsx
+++ b/frontend/src/__tests__/VocabularyToastTiming.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Regression tests for #2515:
+ * VocabularyToast must auto-dismiss after 4 s (not 2 s) and pause
+ * the timer while hovered or focused (WCAG 2.2.1, Level A).
+ */
+import React from "react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import VocabularyToast from "@/components/VocabularyToast";
+
+beforeEach(() => jest.useFakeTimers());
+afterEach(() => {
+  jest.useRealTimers();
+  jest.clearAllMocks();
+});
+
+describe("VocabularyToast timing — closes #2515", () => {
+  it("calls onDone after 4 s when not interacted with", () => {
+    const onDone = jest.fn();
+    render(<VocabularyToast word="hallo" onDone={onDone} />);
+
+    act(() => { jest.advanceTimersByTime(3999); });
+    expect(onDone).not.toHaveBeenCalled();
+
+    act(() => { jest.advanceTimersByTime(4000 + 300 + 100); });
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT auto-dismiss while the mouse is over the toast", () => {
+    const onDone = jest.fn();
+    render(<VocabularyToast word="hallo" onDone={onDone} />);
+    const toast = screen.getByRole("status");
+
+    act(() => { fireEvent.mouseEnter(toast); });
+    act(() => { jest.advanceTimersByTime(20000); });
+    expect(onDone).not.toHaveBeenCalled();
+
+    act(() => { fireEvent.mouseLeave(toast); });
+    act(() => { jest.advanceTimersByTime(4000 + 300 + 100); });
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT auto-dismiss while the toast has keyboard focus", () => {
+    const onDone = jest.fn();
+    render(<VocabularyToast word="hallo" onDone={onDone} />);
+    const toast = screen.getByRole("status");
+
+    act(() => { fireEvent.focus(toast); });
+    act(() => { jest.advanceTimersByTime(20000); });
+    expect(onDone).not.toHaveBeenCalled();
+
+    act(() => { fireEvent.blur(toast); });
+    act(() => { jest.advanceTimersByTime(4000 + 300 + 100); });
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the saved word and a confirmation message", () => {
+    render(<VocabularyToast word="bonjour" onDone={jest.fn()} />);
+    expect(screen.getByText(/bonjour/)).toBeInTheDocument();
+    expect(screen.getByText(/saved to vocabulary/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/VocabularyToast.tsx
+++ b/frontend/src/components/VocabularyToast.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { CheckCircleIcon } from "@/components/Icons";
 
 interface Props {
@@ -8,27 +8,56 @@ interface Props {
   language?: string;
 }
 
+// WCAG 2.2.1: 4 s gives users enough time to read the confirmation.
+// The timer pauses while the toast is hovered or focused.
+const DURATION_MS = 4000;
+
 export default function VocabularyToast({ word, onDone, language }: Props) {
   const [visible, setVisible] = useState(true);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pausedRef = useRef(false);
 
-  useEffect(() => {
-    const timer = setTimeout(() => {
+  const startTimer = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
       setVisible(false);
       setTimeout(onDone, 300);
-    }, 2000);
-    return () => clearTimeout(timer);
+    }, DURATION_MS);
   }, [onDone]);
+
+  useEffect(() => {
+    startTimer();
+    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+  }, [startTimer]);
+
+  function pause() {
+    if (!pausedRef.current) {
+      pausedRef.current = true;
+      if (timerRef.current) clearTimeout(timerRef.current);
+    }
+  }
+
+  function resume() {
+    if (pausedRef.current) {
+      pausedRef.current = false;
+      startTimer();
+    }
+  }
 
   return (
     <div
       role="status"
       aria-live="polite"
       aria-atomic="true"
+      onMouseEnter={pause}
+      onMouseLeave={resume}
+      onFocus={pause}
+      onBlur={resume}
       className={`fixed bottom-6 right-6 z-50 bg-white border border-amber-300 shadow-lg rounded-xl px-4 py-3 text-sm font-medium text-ink transition-all duration-300 flex items-center gap-2.5 ${
         visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
       }`}
     >
-      <CheckCircleIcon className="w-4 h-4 text-emerald-600 shrink-0" />
+      <CheckCircleIcon className="w-4 h-4 text-emerald-600 shrink-0" aria-hidden="true" />
       <span><strong lang={language ?? undefined}>{word}</strong> saved to vocabulary</span>
     </div>
   );


### PR DESCRIPTION
## What changed

`VocabularyToast` now auto-dismisses after **4 s** (was 2 s) and pauses the timer while hovered or focused.

## Why

2 s violated WCAG 2.2.1 Timing Adjustable (Level A): no mechanism to turn off, adjust, or extend the time limit. The fix mirrors the pattern from PR #2510 (UndoToast 3 s → 5 s): a longer base duration plus `onMouseEnter/Leave` + `onFocus/Blur` handlers that freeze the countdown.

4 s was chosen over 5 s because VocabularyToast is informational (word-saved confirmation — no required action), while UndoToast offers an Undo action the user may want to reach.

## Test plan

- New `VocabularyToastTiming.test.tsx` — 4 tests covering: base auto-dismiss after 4 s, pause on mouse hover, pause on keyboard focus, word/message rendering — all pass
- Existing `VocabularyToast.test.tsx` — timer expectation updated from 2000 ms → 4000 ms — passes
- Full frontend suite: 4046 tests pass

Closes #2515
