### PR TITLE
ux: add aria-label to profile Obsidian Export section for landmark navigation (closes #2541)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -563,3 +563,4 @@ WCAG 2.1.1 (Keyboard) and 4.1.2 (Name, Role, Value) fixes for keyboard-only and 
 | 2026-04-30 | Profile page sections: added aria-labelledby to 4 sections and aria-label to 1 error-state section — exposes them as role="region" landmarks for screen reader landmark navigation (P3) | app/profile/page.tsx | #2533 |
 | 2026-04-30 | Home page sections: added aria-labelledby to 5 sections and aria-label to 1 conditional-heading section (Your Library) — exposes them as role="region" landmarks (P3) | app/page.tsx | #2535 |
 | 2026-04-30 | Notes book page sections: added aria-label to 5 sections (Annotations, AI Insights, Vocabulary, per-chapter, Book-level Insights) — landmark navigation for screen readers (P3) | app/notes/[bookId]/page.tsx | #2537 |
+| 2026-04-30 | Search results sections: added aria-label={title} to ResultsSection <section> — exposes Annotations, Vocabulary, Chapters result groups as role="region" landmarks (P3) | app/search/page.tsx | #2539 |

--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -564,3 +564,4 @@ WCAG 2.1.1 (Keyboard) and 4.1.2 (Name, Role, Value) fixes for keyboard-only and 
 | 2026-04-30 | Home page sections: added aria-labelledby to 5 sections and aria-label to 1 conditional-heading section (Your Library) — exposes them as role="region" landmarks (P3) | app/page.tsx | #2535 |
 | 2026-04-30 | Notes book page sections: added aria-label to 5 sections (Annotations, AI Insights, Vocabulary, per-chapter, Book-level Insights) — landmark navigation for screen readers (P3) | app/notes/[bookId]/page.tsx | #2537 |
 | 2026-04-30 | Search results sections: added aria-label={title} to ResultsSection <section> — exposes Annotations, Vocabulary, Chapters result groups as role="region" landmarks (P3) | app/search/page.tsx | #2539 |
+| 2026-04-30 | Profile Obsidian Export section: added aria-label="Obsidian Export" — missed in #2533 sweep, section was role="generic" and invisible to landmark navigation (P3) | app/profile/page.tsx | #2541 |

--- a/frontend/src/__tests__/ProfileObsidianSectionLandmark2541.test.ts
+++ b/frontend/src/__tests__/ProfileObsidianSectionLandmark2541.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Regression tests for #2541:
+ * profile/page.tsx Obsidian Export <section> must have aria-label so it
+ * exposes as role="region" for screen reader landmark navigation.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "..", "app/profile/page.tsx"),
+  "utf-8"
+);
+
+describe("Profile Obsidian Export section has aria-label for landmark navigation (closes #2541)", () => {
+  it('Obsidian Export section carries aria-label="Obsidian Export"', () => {
+    expect(src).toContain('aria-label="Obsidian Export"');
+  });
+
+  it("aria-label is on a <section> element (not an inner element)", () => {
+    const idx = src.indexOf('aria-label="Obsidian Export"');
+    expect(idx).not.toBe(-1);
+    // Look back up to 50 chars — the <section tag should appear immediately before the label
+    const context = src.slice(Math.max(0, idx - 50), idx);
+    expect(context).toMatch(/<section/);
+  });
+
+  it("Obsidian Export h2 button still has aria-controls pointing to the panel", () => {
+    expect(src).toContain('aria-controls="obsidian-export-panel"');
+  });
+});

--- a/frontend/src/__tests__/SearchResultsSectionLandmarks2539.test.ts
+++ b/frontend/src/__tests__/SearchResultsSectionLandmarks2539.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Regression tests for #2539:
+ * search/page.tsx ResultsSection <section> must have aria-label so it exposes
+ * as role="region" for screen reader landmark navigation.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "..", "app/search/page.tsx"),
+  "utf-8"
+);
+
+describe("Search results sections have aria-label for landmark navigation (closes #2539)", () => {
+  it("ResultsSection <section> carries aria-label={title}", () => {
+    expect(src).toContain('aria-label={title}');
+  });
+
+  it("aria-label={title} appears on the <section> element, not only on the <ul>", () => {
+    // There are two elements with aria-label={title}: the section and the ul.
+    // Verify the section appears before the ul (i.e., section gets the label first).
+    const sectionIdx = src.indexOf('<section');
+    const ulIdx = src.indexOf('<ul role="list" aria-label={title}');
+    // The section should come before the ul in the component
+    expect(sectionIdx).not.toBe(-1);
+    expect(ulIdx).not.toBe(-1);
+    // Check that the section between these two positions contains aria-label={title}
+    const sectionBlock = src.slice(sectionIdx, ulIdx);
+    expect(sectionBlock).toContain('aria-label={title}');
+  });
+
+  it("ResultsSection has an <h2> heading inside the section", () => {
+    // Ensure h2 is still present (label should complement heading, not replace it)
+    expect(src).toContain('<h2');
+  });
+});

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -384,7 +384,7 @@ export default function ProfilePage() {
         </section>
 
         {/* ── Obsidian Export Settings ────────────────────────────────────── */}
-        <section className="bg-white rounded-2xl border border-amber-100 overflow-hidden">
+        <section aria-label="Obsidian Export" className="bg-white rounded-2xl border border-amber-100 overflow-hidden">
           {/* Accordion header — WAI-ARIA: heading wraps button */}
           <h2 className="m-0">
             <button

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -86,7 +86,7 @@ function ResultCard({ r }: { r: InAppSearchResult }) {
 function ResultsSection({ title, items }: { title: string; items: InAppSearchResult[] }) {
   if (!items.length) return null;
   return (
-    <section className="space-y-3">
+    <section aria-label={title} className="space-y-3">
       <h2 className="text-sm uppercase tracking-wide text-stone-600">
         {title} · {items.length}
       </h2>


### PR DESCRIPTION
## What changed

`app/profile/page.tsx` had 7 `<section>` elements. Six were labeled in #2533 (PR #2534), but the Obsidian Export accordion section was missed:

```tsx
// Before (role="generic" — invisible to landmark navigation):
<section className="bg-white rounded-2xl border border-amber-100 overflow-hidden">

// After:
<section aria-label="Obsidian Export" className="bg-white rounded-2xl border border-amber-100 overflow-hidden">
```

The section uses a WAI-ARIA accordion pattern (`<h2>` wrapping `<button aria-expanded>`) so `aria-labelledby` can't point to a simple `id` on a heading — `aria-label` is the correct approach here.

## Why

WCAG 1.3.6 / ARIA: each `<section>` on a page must have an accessible name to expose as `role="region"`. Without it, the section is `role="generic"` — VoiceOver rotor and NVDA landmark browse can't navigate to "Obsidian Export" directly.

Same pattern as #2533 (profile sweep), #2535 (home), #2537 (notes), #2539 (search).

## Test plan

- New regression test `ProfileObsidianSectionLandmark2541.test.ts`: 3 tests verifying `aria-label="Obsidian Export"` is on the `<section>` and that `aria-controls` on the accordion button is still present
- Full frontend suite: 726 suites, 4104 tests passed

Closes #2541
