### PR TITLE
ux: add aria-controls to CollapseHeading disclosure buttons (closes #2543)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -565,3 +565,4 @@ WCAG 2.1.1 (Keyboard) and 4.1.2 (Name, Role, Value) fixes for keyboard-only and 
 | 2026-04-30 | Notes book page sections: added aria-label to 5 sections (Annotations, AI Insights, Vocabulary, per-chapter, Book-level Insights) — landmark navigation for screen readers (P3) | app/notes/[bookId]/page.tsx | #2537 |
 | 2026-04-30 | Search results sections: added aria-label={title} to ResultsSection <section> — exposes Annotations, Vocabulary, Chapters result groups as role="region" landmarks (P3) | app/search/page.tsx | #2539 |
 | 2026-04-30 | Profile Obsidian Export section: added aria-label="Obsidian Export" — missed in #2533 sweep, section was role="generic" and invisible to landmark navigation (P3) | app/profile/page.tsx | #2541 |
+| 2026-05-01 | CollapseHeading disclosure buttons: added aria-controls prop referencing controlled region id — WAI-ARIA disclosure pattern for AT programmatic navigation (P3) | app/notes/[bookId]/page.tsx | #2543 |

--- a/frontend/src/__tests__/CollapseHeadingAriaControls2543.test.ts
+++ b/frontend/src/__tests__/CollapseHeadingAriaControls2543.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Regression tests for #2543:
+ * CollapseHeading disclosure buttons in notes/[bookId]/page.tsx must have
+ * aria-controls referencing the id of the controlled content region.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "..", "app/notes/[bookId]/page.tsx"),
+  "utf-8"
+);
+
+describe("CollapseHeading disclosure buttons have aria-controls (closes #2543)", () => {
+  it("CollapseHeading component button has aria-controls attribute", () => {
+    // The button inside CollapseHeading must reference its controlled region
+    expect(src).toContain("aria-controls=");
+  });
+
+  it("CollapseHeading component accepts and passes a controlsId prop", () => {
+    // The component definition should include controlsId in its props
+    expect(src).toMatch(/controlsId[?]?\s*:/);
+  });
+
+  it("Top-level Annotations disclosure has aria-controls", () => {
+    // The CollapseHeading for "Annotations" should pass a controlsId
+    const annIdx = src.indexOf('"Annotations"');
+    expect(annIdx).not.toBe(-1);
+    // Look ahead for controlsId prop in the nearby CollapseHeading
+    const context = src.slice(annIdx, annIdx + 300);
+    expect(context).toContain("controlsId=");
+  });
+
+  it("Controlled content divs/uls have matching id attributes", () => {
+    // Content regions controlled by CollapseHeading must have id attributes
+    // Look for id="collapse- pattern or similar
+    expect(src).toMatch(/id="collapse-/);
+  });
+});

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -33,12 +33,14 @@ function CollapseHeading({
   isCollapsed,
   onToggle,
   level = 2,
+  controlsId,
 }: {
   label: string;
   count?: number;
   isCollapsed: boolean;
   onToggle: () => void;
   level?: 2 | 3;
+  controlsId?: string;
 }) {
   const Tag = `h${level}` as "h2" | "h3";
   return (
@@ -46,6 +48,7 @@ function CollapseHeading({
       <button
         onClick={onToggle}
         aria-expanded={!isCollapsed}
+        aria-controls={controlsId}
         className={`w-full flex items-center gap-2 text-left group min-h-[44px] md:min-h-0 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-inset ${
           level === 2 ? "pb-1.5 border-b border-amber-200" : ""
         }`}
@@ -504,9 +507,10 @@ export default function BookNotesPage() {
               count={annCount}
               isCollapsed={collapsed.has("ann")}
               onToggle={() => toggleCollapse("ann")}
+              controlsId="collapse-ann"
             />
             {!collapsed.has("ann") && (
-              <div>
+              <div id="collapse-ann">
                 {annChapters.map((ch) => (
                   <div key={ch}>
                     <CollapseHeading
@@ -515,9 +519,10 @@ export default function BookNotesPage() {
                       isCollapsed={collapsed.has(`ann-ch-${ch}`)}
                       onToggle={() => toggleCollapse(`ann-ch-${ch}`)}
                       level={3}
+                      controlsId={`collapse-ann-ch-${ch}`}
                     />
                     {!collapsed.has(`ann-ch-${ch}`) && (
-                      <ul role="list" aria-label="Annotations" className="pl-2 list-none p-0 m-0">
+                      <ul role="list" id={`collapse-ann-ch-${ch}`} aria-label="Annotations" className="pl-2 list-none p-0 m-0">
                         {byChapterAnn.get(ch)!.map(renderAnnotation)}
                       </ul>
                     )}
@@ -536,9 +541,10 @@ export default function BookNotesPage() {
               count={insCount}
               isCollapsed={collapsed.has("insights")}
               onToggle={() => toggleCollapse("insights")}
+              controlsId="collapse-insights"
             />
             {!collapsed.has("insights") && (
-              <div>
+              <div id="collapse-insights">
                 {bookLevelIns.length > 0 && (
                   <div>
                     <CollapseHeading
@@ -547,9 +553,10 @@ export default function BookNotesPage() {
                       isCollapsed={collapsed.has("ins-book")}
                       onToggle={() => toggleCollapse("ins-book")}
                       level={3}
+                      controlsId="collapse-ins-book"
                     />
                     {!collapsed.has("ins-book") && (
-                      <ul role="list" aria-label="Insights" className="pl-2 list-none p-0 m-0">
+                      <ul role="list" id="collapse-ins-book" aria-label="Insights" className="pl-2 list-none p-0 m-0">
                         {bookLevelIns.map(renderInsight)}
                       </ul>
                     )}
@@ -563,9 +570,10 @@ export default function BookNotesPage() {
                       isCollapsed={collapsed.has(`ins-ch-${ch}`)}
                       onToggle={() => toggleCollapse(`ins-ch-${ch}`)}
                       level={3}
+                      controlsId={`collapse-ins-ch-${ch}`}
                     />
                     {!collapsed.has(`ins-ch-${ch}`) && (
-                      <ul role="list" aria-label="Insights" className="pl-2 list-none p-0 m-0">
+                      <ul role="list" id={`collapse-ins-ch-${ch}`} aria-label="Insights" className="pl-2 list-none p-0 m-0">
                         {byChapterIns.get(ch)!.map(renderInsight)}
                       </ul>
                     )}
@@ -584,9 +592,10 @@ export default function BookNotesPage() {
               count={vocCount}
               isCollapsed={collapsed.has("vocab")}
               onToggle={() => toggleCollapse("vocab")}
+              controlsId="collapse-vocab"
             />
             {!collapsed.has("vocab") && (
-              <ul role="list" className="my-2 ml-4 space-y-1 list-none">
+              <ul role="list" id="collapse-vocab" className="my-2 ml-4 space-y-1 list-none">
                 {bookVocab.map((v) =>
                   v.occurrences
                     .filter((o) => o.book_id === bookId)
@@ -634,9 +643,10 @@ export default function BookNotesPage() {
                 count={total}
                 isCollapsed={collapsed.has(key)}
                 onToggle={() => toggleCollapse(key)}
+                controlsId={`collapse-${key}`}
               />
               {!collapsed.has(key) && (
-                <div className="pl-2 space-y-1">
+                <div id={`collapse-${key}`} className="pl-2 space-y-1">
                   {chAnns.length > 0 && (
                     <ul role="list" aria-label="Annotations" className="list-none p-0 m-0">
                       {chAnns.map(renderAnnotation)}
@@ -670,9 +680,10 @@ export default function BookNotesPage() {
               count={bookLevelIns.length}
               isCollapsed={collapsed.has("ch-book")}
               onToggle={() => toggleCollapse("ch-book")}
+              controlsId="collapse-ch-book"
             />
             {!collapsed.has("ch-book") && (
-              <ul role="list" aria-label="Insights" className="pl-2 list-none p-0 m-0">
+              <ul role="list" id="collapse-ch-book" aria-label="Insights" className="pl-2 list-none p-0 m-0">
                 {bookLevelIns.map(renderInsight)}
               </ul>
             )}


### PR DESCRIPTION
## What changed

`app/notes/[bookId]/page.tsx` uses a `CollapseHeading` component for all disclosure buttons (Annotations, AI Insights, Vocabulary, per-chapter headings). The buttons had `aria-expanded` but no `aria-controls`, so assistive technologies couldn't programmatically navigate from the button to the region it controls.

Changes:
1. Added `controlsId?: string` prop to `CollapseHeading`
2. Added `aria-controls={controlsId}` to the disclosure button
3. Passed `controlsId` from every call site (8 usages across category view + chapter view)
4. Added matching `id` attributes to every controlled div/ul

Key associations:

| Disclosure button | controlsId | Controlled element |
|---|---|---|
| Annotations (h2) | `collapse-ann` | `<div id="collapse-ann">` |
| per-chapter annotations (h3) | `collapse-ann-ch-N` | `<ul id="collapse-ann-ch-N">` |
| AI Insights (h2) | `collapse-insights` | `<div id="collapse-insights">` |
| Book-level insights (h3) | `collapse-ins-book` | `<ul id="collapse-ins-book">` |
| per-chapter insights (h3) | `collapse-ins-ch-N` | `<ul id="collapse-ins-ch-N">` |
| Vocabulary (h2) | `collapse-vocab` | `<ul id="collapse-vocab">` |
| per-chapter (chapter view, h2) | `collapse-ch-N` | `<div id="collapse-ch-N">` |
| Book-level Insights (chapter view, h2) | `collapse-ch-book` | `<ul id="collapse-ch-book">` |

## Why

WAI-ARIA Authoring Practices for disclosure widgets: the button controlling a collapsible region should use `aria-controls` to reference the controlled element's `id`. Without it, AT users can only reach the region by navigation order — they can't jump directly from the button to the content. This is especially important in the notes page where headings are above collapsed content.

## Test plan

- New regression test `CollapseHeadingAriaControls2543.test.ts`: 4 tests verifying `aria-controls`, `controlsId` prop acceptance, per-section wiring, and `id="collapse-*"` on controlled elements
- Full frontend suite: 727 suites, 4108 tests passed

Closes #2543
