### PR TITLE
ux: add aria-labelledby to DeckCard article for screen reader navigation (closes #2545)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -566,3 +566,4 @@ WCAG 2.1.1 (Keyboard) and 4.1.2 (Name, Role, Value) fixes for keyboard-only and 
 | 2026-04-30 | Search results sections: added aria-label={title} to ResultsSection <section> — exposes Annotations, Vocabulary, Chapters result groups as role="region" landmarks (P3) | app/search/page.tsx | #2539 |
 | 2026-04-30 | Profile Obsidian Export section: added aria-label="Obsidian Export" — missed in #2533 sweep, section was role="generic" and invisible to landmark navigation (P3) | app/profile/page.tsx | #2541 |
 | 2026-05-01 | CollapseHeading disclosure buttons: added aria-controls prop referencing controlled region id — WAI-ARIA disclosure pattern for AT programmatic navigation (P3) | app/notes/[bookId]/page.tsx | #2543 |
+| 2026-05-01 | DeckCard article: added aria-labelledby={`deck-name-${deck.id}`} and id on <h2> — multiple unnamed article landmarks on decks page made distinguishable for screen reader navigation (P3) | components/DeckCard.tsx | #2545 |

--- a/frontend/src/__tests__/DeckCardArticleAriaLabelledBy2545.test.ts
+++ b/frontend/src/__tests__/DeckCardArticleAriaLabelledBy2545.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Regression tests for #2545:
+ * DeckCard <article> elements must have aria-labelledby referencing the deck
+ * name heading so screen readers can identify individual cards when navigating
+ * by article landmark.
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "..", "components/DeckCard.tsx"),
+  "utf-8"
+);
+
+describe("DeckCard article has aria-labelledby (closes #2545)", () => {
+  it("article element has aria-labelledby attribute", () => {
+    expect(src).toContain("aria-labelledby=");
+  });
+
+  it("aria-labelledby references a deck-name id", () => {
+    expect(src).toMatch(/aria-labelledby=\{[^}]*deck-name/);
+  });
+
+  it("h2 has matching id attribute keyed by deck.id", () => {
+    expect(src).toMatch(/id=\{[^}]*deck-name[^}]*deck\.id/);
+  });
+});

--- a/frontend/src/components/DeckCard.tsx
+++ b/frontend/src/components/DeckCard.tsx
@@ -17,7 +17,7 @@ export default function DeckCard({ deck, href, onClick, onDelete }: DeckCardProp
     <>
       <div className="flex items-center gap-2 flex-wrap">
         <DeckIcon className="w-4 h-4 text-amber-600 shrink-0" />
-        <h2 className="font-serif font-semibold text-ink text-base truncate" title={deck.name}>
+        <h2 id={`deck-name-${deck.id}`} className="font-serif font-semibold text-ink text-base truncate" title={deck.name}>
           {deck.name}
         </h2>
         <span
@@ -53,6 +53,7 @@ export default function DeckCard({ deck, href, onClick, onDelete }: DeckCardProp
   return (
     <article
       data-testid={`deck-card-${deck.id}`}
+      aria-labelledby={`deck-name-${deck.id}`}
       className="rounded-xl border border-amber-100 bg-white p-4 transition-all duration-200 hover:-translate-y-0.5"
     >
       <div className="flex items-start justify-between gap-3">


### PR DESCRIPTION
## What changed

`DeckCard.tsx` renders each deck as an `<article>`. Multiple deck cards appear on the decks page, but the `<article>` elements had no accessible name — screen readers navigating by article landmark would announce each as "article" with no way to differentiate between decks.

Changes:
1. Added `id={`deck-name-${deck.id}`}` to the `<h2>` inside `cardContent`
2. Added `aria-labelledby={`deck-name-${deck.id}`}` to the `<article>` element

The id is keyed by `deck.id` so it remains unique across all cards on the page. The `<h2>` appears in all three render paths (href, onClick, static div), so `aria-labelledby` always resolves.

## Why

WAI-ARIA: when multiple elements with the same role appear on a page, each should have a distinct accessible name so users navigating by landmark can identify them. Without `aria-labelledby`, VoiceOver/NVDA article navigation announces each deck card as "article" — users can't tell which deck is which without entering and reading the card content.

## Test plan

- New regression test `DeckCardArticleAriaLabelledBy2545.test.ts`: 3 tests verifying `aria-labelledby=` on article, pattern referencing `deck-name`, and matching `id` on `<h2>`
- Full frontend suite: 728 suites, 4111 tests passed
- Full backend suite: 1941 passed, 1 skipped

Closes #2545
