### PR TITLE
ux: fix orphan label in reader translation panel — use role=group for Display mode (closes #2547)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -567,3 +567,4 @@ WCAG 2.1.1 (Keyboard) and 4.1.2 (Name, Role, Value) fixes for keyboard-only and 
 | 2026-04-30 | Profile Obsidian Export section: added aria-label="Obsidian Export" — missed in #2533 sweep, section was role="generic" and invisible to landmark navigation (P3) | app/profile/page.tsx | #2541 |
 | 2026-05-01 | CollapseHeading disclosure buttons: added aria-controls prop referencing controlled region id — WAI-ARIA disclosure pattern for AT programmatic navigation (P3) | app/notes/[bookId]/page.tsx | #2543 |
 | 2026-05-01 | DeckCard article: added aria-labelledby={`deck-name-${deck.id}`} and id on <h2> — multiple unnamed article landmarks on decks page made distinguishable for screen reader navigation (P3) | components/DeckCard.tsx | #2545 |
+| 2026-05-01 | Reader translation Display mode: replaced orphan <label> with <p id> + role="group" aria-labelledby — WCAG 1.3.1 group label association for Inline/Side-by-side toggle (P3) | app/reader/[bookId]/page.tsx | #2547 |

--- a/frontend/src/__tests__/ReaderTranslationDisplayGroup2547.test.ts
+++ b/frontend/src/__tests__/ReaderTranslationDisplayGroup2547.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Regression tests for #2547:
+ * The "Display" mode toggle group in the reader translation sidebar
+ * must use role="group" + aria-labelledby rather than an orphan <label>
+ * without htmlFor (WCAG 1.3.1).
+ */
+import fs from "fs";
+import path from "path";
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "..", "app/reader/[bookId]/page.tsx"),
+  "utf-8"
+);
+
+describe("Reader translation Display group has group role and label (closes #2547)", () => {
+  it("Display toggle buttons are wrapped in role=group", () => {
+    expect(src).toMatch(/role="group"[^>]*aria-labelledby="reader-trans-display-label"|aria-labelledby="reader-trans-display-label"[^>]*role="group"/);
+  });
+
+  it("Group label element has the correct id", () => {
+    expect(src).toContain('id="reader-trans-display-label"');
+  });
+
+  it("No orphan <label> without htmlFor containing just 'Display'", () => {
+    // The old pattern: <label ...>Display</label> with no htmlFor
+    expect(src).not.toMatch(/<label(?![^>]*htmlFor)[^>]*>\s*Display\s*<\/label>/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2159,8 +2159,8 @@ export default function ReaderPage() {
 
                     {/* Display mode */}
                     <div className="mb-4">
-                      <label className="block text-xs text-amber-700 mb-1">Display</label>
-                      <div className="flex rounded-lg border border-amber-300 overflow-hidden">
+                      <p id="reader-trans-display-label" className="block text-xs text-amber-700 mb-1">Display</p>
+                      <div role="group" aria-labelledby="reader-trans-display-label" className="flex rounded-lg border border-amber-300 overflow-hidden">
                         <button
                           onClick={() => setDisplayMode("inline")}
                           aria-pressed={displayMode === "inline"}


### PR DESCRIPTION
## What changed

`app/reader/[bookId]/page.tsx` had an orphan `<label>Display</label>` (no `htmlFor`) wrapping the Inline / Side-by-side toggle buttons in the translation sidebar. The label had no programmatic association with any control, violating WCAG 1.3.1.

Changes:
1. Replaced `<label ...>Display</label>` with `<p id="reader-trans-display-label" ...>Display</p>` — avoids creating an orphan label element
2. Added `role="group"` and `aria-labelledby="reader-trans-display-label"` to the button group wrapper div

Before:
```tsx
<label className="...">Display</label>
<div className="flex ...">
  <button aria-pressed={...}>Inline</button>
  <button aria-pressed={...}>Side by side</button>
</div>
```

After:
```tsx
<p id="reader-trans-display-label" className="...">Display</p>
<div role="group" aria-labelledby="reader-trans-display-label" className="flex ...">
  <button aria-pressed={...}>Inline</button>
  <button aria-pressed={...}>Side by side</button>
</div>
```

## Why

WCAG 1.3.1 / 4.1.2: a group of related controls should have a programmatic group label. Without `role="group"` + `aria-labelledby`, screen readers navigating to the Inline/Side-by-side buttons have no context that these are display mode options. The orphan `<label>` (no `htmlFor`) doesn't associate with any control — browsers treat it as unlabeled, and ATs skip it for form navigation.

## Test plan

- New regression test `ReaderTranslationDisplayGroup2547.test.ts`: 3 tests verifying `role="group"` with `aria-labelledby`, matching `id` on the label element, and no orphan `<label>` matching the old pattern
- Full frontend suite: 729 suites, 4114 tests passed

Closes #2547
