### PR TITLE
fix: vocabulary word button — amber-700 base color for touch affordance (closes #2557)

### DIFF
--- a/frontend/src/__tests__/VocabWordButtonAffordance2557.test.ts
+++ b/frontend/src/__tests__/VocabWordButtonAffordance2557.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Regression tests for #2557:
+ * Vocabulary word button had no visual affordance on touch devices —
+ * `text-ink` (dark ink) with only `hover:text-amber-700` means touch users
+ * see static text with no indication the word is tappable.
+ * Fix: use `text-amber-700` as the base color so the word looks like a link
+ * on all devices.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/page.tsx"),
+  "utf8",
+);
+
+describe("Vocabulary word button has visual affordance on touch (closes #2557)", () => {
+  it("lemma button has text-amber-700 base color (not text-ink)", () => {
+    // Find the lemma button's className. It should start with text-amber-700
+    // so it's visible as interactive on touch devices without hover.
+    // The button has lang={group.language} and sets activeWord onClick.
+    const lemmaButtonIdx = src.indexOf("onClick={() => setActiveWord");
+    expect(lemmaButtonIdx).not.toBe(-1);
+    // className comes after onClick in source — look 400 chars after
+    const context = src.slice(lemmaButtonIdx, lemmaButtonIdx + 400);
+    expect(context).toContain("text-amber-700");
+    expect(context).not.toMatch(/\btext-ink\b[^"]*hover:text-amber-700/);
+  });
+
+  it("lemma button does not rely solely on hover for color change", () => {
+    // The pattern `text-ink ... hover:text-amber-700` (non-interactive base)
+    // should not exist on the word button in the vocabulary card.
+    const badPattern = /font-serif font-semibold text-ink[^"]*hover:text-amber-700/;
+    expect(src).not.toMatch(badPattern);
+  });
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -409,7 +409,7 @@ function VocabularyPageContent() {
             <button
               lang={group.language ?? undefined}
               onClick={() => setActiveWord({ word: group.lemma, lang: group.language })}
-              className="font-serif font-semibold text-ink text-base hover:text-amber-700 transition-colors text-left min-h-[44px] md:min-h-0 flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
+              className="font-serif font-semibold text-amber-700 hover:text-amber-900 text-base transition-colors text-left min-h-[44px] md:min-h-0 flex items-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
             >
               {group.lemma}
             </button>


### PR DESCRIPTION
## What changed

In `frontend/src/app/vocabulary/page.tsx`, the lemma word button in vocabulary cards changed from `text-ink hover:text-amber-700` to `text-amber-700 hover:text-amber-900`.

## Why

The previous styling gave the word the same color as surrounding static text (`text-ink`). The only affordance that the word was interactive was `hover:text-amber-700` — invisible on touch/mobile devices where hover doesn't exist. A touch user had no visual indication the word was tappable.

Using `text-amber-700` as the base color makes the word look link-like on all devices, consistent with the parchment/amber design language and the existing button `aria-label` approach.

## Test plan

- New regression test `VocabWordButtonAffordance2557.test.ts` verifies:
  1. The lemma button uses `text-amber-700` as the base color
  2. The `text-ink … hover:text-amber-700` (touch-invisible) pattern is absent
- Full frontend suite: 4122 tests pass

Closes #2557
