### PR TITLE
fix: add aria-controls to reader mobile Notes button (closes #2559)

### DIFF
--- a/frontend/src/__tests__/ReaderNotesAriaControls2559.test.ts
+++ b/frontend/src/__tests__/ReaderNotesAriaControls2559.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Regression tests for #2559:
+ * Reader mobile Notes button uses aria-expanded without aria-controls.
+ * The revealed panel has no id, so AT cannot programmatically navigate
+ * to the revealed content after activating the button.
+ * Fix: add id="reader-mobile-notes-panel" to the panel and
+ * aria-controls="reader-mobile-notes-panel" to the Notes button.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Reader mobile Notes button has aria-controls (closes #2559)", () => {
+  it("notes expand panel has id=reader-mobile-notes-panel", () => {
+    expect(src).toContain('id="reader-mobile-notes-panel"');
+  });
+
+  it("Notes button has aria-controls referencing the panel id", () => {
+    expect(src).toContain('aria-controls="reader-mobile-notes-panel"');
+  });
+
+  it("aria-controls appears on the same button as aria-expanded={notesExpanded}", () => {
+    // Find the Notes button (has aria-expanded={notesExpanded})
+    const idx = src.indexOf("aria-expanded={notesExpanded}");
+    expect(idx).not.toBe(-1);
+    // Check within 300 chars around it for aria-controls
+    const context = src.slice(Math.max(0, idx - 300), idx + 100);
+    expect(context).toContain('aria-controls="reader-mobile-notes-panel"');
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2390,7 +2390,7 @@ export default function ReaderPage() {
 
           {/* Notes expand panel */}
           {session?.backendToken && notesExpanded && (
-            <div className="bg-white/95 backdrop-blur border-t border-amber-200 px-3 py-2 max-h-60 overflow-y-auto animate-slide-up">
+            <div id="reader-mobile-notes-panel" className="bg-white/95 backdrop-blur border-t border-amber-200 px-3 py-2 max-h-60 overflow-y-auto animate-slide-up">
               {annotations.length === 0 ? (
                 <div className="text-center text-stone-600 py-4 text-sm">
                   <NoteIcon className="w-6 h-6 mx-auto mb-1 opacity-40" />
@@ -2489,6 +2489,7 @@ export default function ReaderPage() {
               }`}
               aria-label={annotations.length > 0 ? `Notes (${annotations.length})` : "Notes"}
               aria-expanded={notesExpanded}
+              aria-controls="reader-mobile-notes-panel"
             >
               <NoteIcon className="w-5 h-5" />
               {annotations.length > 0 && (


### PR DESCRIPTION
## What changed

Added `id="reader-mobile-notes-panel"` to the notes expand panel and `aria-controls="reader-mobile-notes-panel"` to the Notes button in the mobile reader bottom toolbar (`frontend/src/app/reader/[bookId]/page.tsx`).

## Why

The Notes button used `aria-expanded` without `aria-controls`. Per WAI-ARIA, when a button uses `aria-expanded` to indicate a revealed region, it must include `aria-controls` referencing that region's `id` so screen reader users can programmatically navigate to the panel content after activating the button. Without this link, AT users know a panel opened (from `aria-expanded`) but cannot jump to it.

## Test plan

New regression test `ReaderNotesAriaControls2559.test.ts` verifies:
1. Notes expand panel has `id="reader-mobile-notes-panel"`
2. Notes button has `aria-controls="reader-mobile-notes-panel"`
3. `aria-controls` appears on the same element as `aria-expanded={notesExpanded}`

Full frontend suite: 4125 tests pass.

Closes #2559
