### PR TITLE
fix: aria-controls on note-dot and context toggles; aria-haspopup on sidebar trigger (closes #2563)

### DIFF
--- a/frontend/src/__tests__/AriaControlsDialogHaspopup2563.test.ts
+++ b/frontend/src/__tests__/AriaControlsDialogHaspopup2563.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression tests for #2563:
+ * - SentenceReader note-dot button missing aria-controls + note card missing id
+ * - InsightChat ContextChip "more/less" toggle missing aria-controls
+ * - AnnotationsSidebar toggle button missing aria-haspopup="dialog"
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const sentenceReaderSrc = fs.readFileSync(
+  path.join(__dirname, "../components/SentenceReader.tsx"),
+  "utf8",
+);
+
+const insightChatSrc = fs.readFileSync(
+  path.join(__dirname, "../components/InsightChat.tsx"),
+  "utf8",
+);
+
+const annotationsSidebarSrc = fs.readFileSync(
+  path.join(__dirname, "../components/AnnotationsSidebar.tsx"),
+  "utf8",
+);
+
+describe("aria-controls and aria-haspopup for disclosure/dialog triggers (closes #2563)", () => {
+  describe("SentenceReader note-dot button", () => {
+    it("note-dot button has aria-controls referencing note-panel-${seg.flatIdx}", () => {
+      expect(sentenceReaderSrc).toContain('aria-controls={`note-panel-${seg.flatIdx}`}');
+    });
+
+    it("note card div has id matching note-panel-${...}", () => {
+      // The note card is rendered at the expandedNoteFlatIdx level
+      expect(sentenceReaderSrc).toContain('id={`note-panel-${expandedNoteFlatIdx}`}');
+    });
+
+    it("aria-controls appears on the same button as aria-expanded", () => {
+      const idx = sentenceReaderSrc.indexOf("aria-expanded={expandedNoteFlatIdx === seg.flatIdx}");
+      expect(idx).not.toBe(-1);
+      const context = sentenceReaderSrc.slice(Math.max(0, idx - 50), idx + 150);
+      expect(context).toContain('aria-controls={`note-panel-${seg.flatIdx}`}');
+    });
+  });
+
+  describe("InsightChat ContextChip toggle", () => {
+    it("ContextChip toggle button has aria-controls", () => {
+      expect(insightChatSrc).toContain('aria-controls={ctxId}');
+    });
+
+    it("ContextChip text span has dynamic id for aria-controls", () => {
+      expect(insightChatSrc).toContain('id={ctxId}');
+    });
+
+    it("ContextChip uses useId to generate stable id", () => {
+      expect(insightChatSrc).toContain('useId');
+    });
+  });
+
+  describe("AnnotationsSidebar toggle button", () => {
+    it("toggle button has aria-haspopup=dialog", () => {
+      expect(annotationsSidebarSrc).toContain('aria-haspopup="dialog"');
+    });
+
+    it("aria-haspopup appears near aria-expanded={open}", () => {
+      const idx = annotationsSidebarSrc.indexOf("aria-expanded={open}");
+      expect(idx).not.toBe(-1);
+      const context = annotationsSidebarSrc.slice(Math.max(0, idx - 100), idx + 100);
+      expect(context).toContain('aria-haspopup="dialog"');
+    });
+  });
+});

--- a/frontend/src/components/AnnotationsSidebar.tsx
+++ b/frontend/src/components/AnnotationsSidebar.tsx
@@ -72,6 +72,7 @@ export default function AnnotationsSidebar({ annotations, totalCount, onJump, on
       <button
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
+        aria-haspopup="dialog"
         aria-label="Toggle notes panel"
         title="Annotations"
         className="relative shrink-0 flex items-center gap-1.5 px-3 py-2 md:py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-50 text-xs font-medium transition-colors min-h-[44px] md:min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"

--- a/frontend/src/components/InsightChat.tsx
+++ b/frontend/src/components/InsightChat.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import {
@@ -65,6 +65,7 @@ function ContextChip({
   onRemove?: () => void;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const ctxId = useId();
   const needsToggle = text.length > CTX_COLLAPSE_AT;
   const shown = !needsToggle || expanded ? text : text.slice(0, CTX_COLLAPSE_AT);
   return (
@@ -72,7 +73,7 @@ function ContextChip({
       <div className="flex items-start gap-1.5">
         <PaperclipIcon className="w-3.5 h-3.5 shrink-0 mt-px text-amber-400" />
         <div className="flex-1 min-w-0">
-          <span lang={bookLanguage ?? undefined} className="italic leading-relaxed">
+          <span id={ctxId} lang={bookLanguage ?? undefined} className="italic leading-relaxed">
             &ldquo;{shown}{!expanded && needsToggle ? "…" : ""}&rdquo;
           </span>
           {needsToggle && (
@@ -81,6 +82,7 @@ function ContextChip({
               className="ml-1.5 text-amber-700 hover:text-amber-900 font-medium not-italic min-h-[44px] md:min-h-0 inline-flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
               aria-label="Toggle context"
               aria-expanded={expanded}
+              aria-controls={ctxId}
             >
               {expanded ? "less" : "more"}
             </button>
@@ -644,12 +646,13 @@ function MsgContextBlock({
   expanded: boolean;
   onToggle: () => void;
 }) {
+  const msgCtxId = useId();
   const needsToggle = text.length > CTX_COLLAPSE_AT;
   const shown = !needsToggle || expanded ? text : text.slice(0, CTX_COLLAPSE_AT);
   return (
     <div className="flex items-start gap-1.5 rounded-lg bg-amber-50/80 border border-amber-100 px-2.5 py-1.5">
       <PaperclipIcon aria-hidden="true" className="w-3 h-3 text-amber-400 shrink-0 mt-px" />
-      <p lang={bookLanguage ?? undefined} className="text-xs text-amber-700 italic leading-relaxed flex-1">
+      <p id={msgCtxId} lang={bookLanguage ?? undefined} className="text-xs text-amber-700 italic leading-relaxed flex-1">
         &ldquo;{shown}{!expanded && needsToggle ? "…" : ""}&rdquo;
         {needsToggle && (
           <button
@@ -657,6 +660,7 @@ function MsgContextBlock({
             className="ml-1.5 text-amber-700 hover:text-amber-900 font-medium not-italic min-h-[44px] md:min-h-0 inline-flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 rounded"
             aria-label="Toggle context"
             aria-expanded={expanded}
+            aria-controls={msgCtxId}
           >
             {expanded ? "less" : "more"}
           </button>

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -803,6 +803,7 @@ export default function SentenceReader({
                   className="inline-flex items-center justify-center ml-0.5 align-middle cursor-pointer min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0 -m-[19px] p-[19px] focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
                   aria-label={`Toggle note for: ${seg.text.slice(0, 60)}`}
                   aria-expanded={expandedNoteFlatIdx === seg.flatIdx}
+                  aria-controls={`note-panel-${seg.flatIdx}`}
                 >
                   <span className={`inline-block w-1.5 h-1.5 rounded-full ${NOTE_DOT_CLASS[noteAnnotation.color] ?? NOTE_DOT_CLASS.yellow}`} />
                 </button>
@@ -844,7 +845,7 @@ export default function SentenceReader({
               .find((a) => a.note_text) ?? null)
           : null;
         const noteCard = expandedAnn?.note_text ? (
-          <div className={`mt-1.5 text-xs rounded px-2.5 py-1.5 border ${NOTE_CARD_CLASS[expandedAnn.color] ?? NOTE_CARD_CLASS.yellow}`}>
+          <div id={`note-panel-${expandedNoteFlatIdx}`} className={`mt-1.5 text-xs rounded px-2.5 py-1.5 border ${NOTE_CARD_CLASS[expandedAnn.color] ?? NOTE_CARD_CLASS.yellow}`}>
             <p className="italic leading-relaxed">{expandedAnn.note_text}</p>
           </div>
         ) : null;


### PR DESCRIPTION
## What changed

Three accessibility fixes for disclosure/trigger buttons missing WAI-ARIA companion attributes:

**1. SentenceReader note-dot button** (`components/SentenceReader.tsx`)
- Added `aria-controls={`note-panel-${seg.flatIdx}`}` to the per-sentence note toggle button
- Added `id={`note-panel-${expandedNoteFlatIdx}`}` to the revealed note card `<div>`
- AT can now programmatically navigate from the toggle to the revealed note content

**2. InsightChat ContextChip and MsgContextBlock** (`components/InsightChat.tsx`)
- Added `useId()` import; generated `ctxId`/`msgCtxId` per component instance
- Added `id={ctxId}` / `id={msgCtxId}` to the text `<span>`/`<p>` that shows truncated context
- Added `aria-controls={ctxId}` / `aria-controls={msgCtxId}` to the "more/less" toggle button

**3. AnnotationsSidebar toggle button** (`components/AnnotationsSidebar.tsx`)
- Added `aria-haspopup="dialog"` alongside `aria-expanded={open}`
- Without this, AT treats the button as an inline disclosure widget; with it, AT knows the interaction opens a modal dialog and can prepare the user for focus moving into the dialog

## Why

WCAG 1.3.1 (Info and Relationships) + WAI-ARIA authoring practices:
- Buttons with `aria-expanded` should have `aria-controls` when they reveal a distinct region
- Dialog trigger buttons should declare `aria-haspopup="dialog"` so AT announces the nature of the interaction before activation

## Test plan

- [x] New regression test `AriaControlsDialogHaspopup2563.test.ts` — 8 assertions, all pass
- [x] Full frontend suite: 4140 tests pass

Closes #2563
