### PR TITLE
fix: add aria-describedby to role=dialog elements (closes #2565)

### DIFF
--- a/frontend/src/__tests__/DialogAriaDescribedby2565.test.ts
+++ b/frontend/src/__tests__/DialogAriaDescribedby2565.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Regression tests for #2565:
+ * - VocabWordTooltip dialog missing aria-describedby
+ * - WordLookup dialog missing aria-describedby
+ * - WordActionDrawer dialog missing aria-describedby
+ * - Decks add-word picker dialog missing aria-describedby
+ * - Reader chat sheet dialog missing aria-describedby
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const vocabTooltipSrc = fs.readFileSync(
+  path.join(__dirname, "../components/VocabWordTooltip.tsx"),
+  "utf8",
+);
+
+const wordLookupSrc = fs.readFileSync(
+  path.join(__dirname, "../components/WordLookup.tsx"),
+  "utf8",
+);
+
+const wordActionDrawerSrc = fs.readFileSync(
+  path.join(__dirname, "../components/WordActionDrawer.tsx"),
+  "utf8",
+);
+
+const deckPageSrc = fs.readFileSync(
+  path.join(__dirname, "../app/decks/[deckId]/page.tsx"),
+  "utf8",
+);
+
+const readerPageSrc = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("role=dialog elements have aria-describedby (closes #2565)", () => {
+  describe("VocabWordTooltip", () => {
+    it("dialog has aria-describedby", () => {
+      expect(vocabTooltipSrc).toContain('aria-describedby="vocab-tooltip-desc"');
+    });
+
+    it("description element has matching id", () => {
+      expect(vocabTooltipSrc).toContain('id="vocab-tooltip-desc"');
+    });
+  });
+
+  describe("WordLookup", () => {
+    it("dialog has aria-describedby referencing a useId-generated id", () => {
+      expect(wordLookupSrc).toContain("aria-describedby={descId}");
+    });
+
+    it("uses useId to generate description id", () => {
+      expect(wordLookupSrc).toContain("useId");
+    });
+
+    it("description element has id={descId}", () => {
+      expect(wordLookupSrc).toContain("id={descId}");
+    });
+  });
+
+  describe("WordActionDrawer", () => {
+    it("dialog has aria-describedby referencing a useId-generated id", () => {
+      expect(wordActionDrawerSrc).toContain("aria-describedby={descId}");
+    });
+
+    it("uses useId to generate description id", () => {
+      expect(wordActionDrawerSrc).toContain("useId");
+    });
+
+    it("description element has id={descId}", () => {
+      expect(wordActionDrawerSrc).toContain("id={descId}");
+    });
+  });
+
+  describe("Decks add-word picker", () => {
+    it("dialog has aria-describedby", () => {
+      expect(deckPageSrc).toContain('aria-describedby="add-word-picker-desc"');
+    });
+
+    it("description element has matching id", () => {
+      expect(deckPageSrc).toContain('id="add-word-picker-desc"');
+    });
+  });
+
+  describe("Reader chat sheet", () => {
+    it("chat sheet dialog has aria-describedby", () => {
+      expect(readerPageSrc).toContain('aria-describedby="reader-chat-desc"');
+    });
+
+    it("description element has matching id", () => {
+      expect(readerPageSrc).toContain('id="reader-chat-desc"');
+    });
+  });
+});

--- a/frontend/src/app/decks/[deckId]/page.tsx
+++ b/frontend/src/app/decks/[deckId]/page.tsx
@@ -379,9 +379,11 @@ function AddWordPicker({ candidates, onClose, onAdd }: AddWordPickerProps) {
         role="dialog"
         aria-modal="true"
         aria-labelledby="add-word-picker-title"
+        aria-describedby="add-word-picker-desc"
         onClick={(e) => e.stopPropagation()}
         className="w-full md:max-w-md bg-parchment rounded-t-2xl md:rounded-2xl shadow-xl flex flex-col max-h-[80vh] animate-slide-up"
       >
+        <p id="add-word-picker-desc" className="sr-only">Select words to add to this deck</p>
         <div className="flex items-center gap-3 border-b border-amber-200 px-4 py-3">
           <h2
             id="add-word-picker-title"

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2318,7 +2318,8 @@ export default function ReaderPage() {
             onClick={() => { setSidebarOpen(false); setChatSheetText(null); }}
           />
           {/* Chat sheet (bottom half) */}
-          <div ref={chatSheetRef} tabIndex={-1} role="dialog" aria-modal="true" aria-label="Chat" className="h-[55vh] bg-parchment border-t border-amber-200 rounded-t-2xl shadow-2xl flex flex-col animate-slide-up safe-bottom focus:outline-none">
+          <div ref={chatSheetRef} tabIndex={-1} role="dialog" aria-modal="true" aria-label="Chat" aria-describedby="reader-chat-desc" className="h-[55vh] bg-parchment border-t border-amber-200 rounded-t-2xl shadow-2xl flex flex-col animate-slide-up safe-bottom focus:outline-none">
+            <span id="reader-chat-desc" className="sr-only">AI chat about the current passage</span>
             {/* Drag handle + close */}
             <div className="flex items-center justify-between px-4 py-2 border-b border-amber-200 shrink-0">
               <div className="w-10 h-1 bg-amber-200 rounded-full" />

--- a/frontend/src/components/VocabWordTooltip.tsx
+++ b/frontend/src/components/VocabWordTooltip.tsx
@@ -78,10 +78,12 @@ export default function VocabWordTooltip({ word, lang, rect, onClose, onSave }: 
       role="dialog"
       aria-modal="true"
       aria-labelledby="vocab-tooltip-title"
+      aria-describedby="vocab-tooltip-desc"
       tabIndex={-1}
       className="fixed z-50 w-72 rounded-xl border border-amber-200 bg-white shadow-xl overflow-hidden focus:outline-none"
       style={{ left, top }}
     >
+      <span id="vocab-tooltip-desc" className="sr-only">Word definition and vocabulary actions</span>
       {/* Header */}
       <div className="flex items-center justify-between px-3 pt-2.5 pb-1.5 border-b border-amber-100">
         <span id="vocab-tooltip-title" lang={lang ?? undefined} className="font-semibold text-ink text-sm">{word}</span>

--- a/frontend/src/components/WordActionDrawer.tsx
+++ b/frontend/src/components/WordActionDrawer.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { SpeakerIcon, SaveIcon, NoteIcon, CheckCircleIcon, CloseIcon, RetryIcon } from "@/components/Icons";
 import { useFocusTrap } from "@/lib/useFocusTrap";
 import { useScrollLock } from "@/lib/useScrollLock";
@@ -40,6 +40,7 @@ export default function WordActionDrawer({
   onSaveWord,
   onAnnotate,
 }: Props) {
+  const descId = useId();
   const [result, setResult] = useState<LookupResult | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -133,8 +134,10 @@ export default function WordActionDrawer({
         role="dialog"
         aria-modal="true"
         aria-label={`Word lookup: ${word}`}
+        aria-describedby={descId}
         className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl border-t border-amber-200 max-h-[60vh] overflow-y-auto safe-bottom animate-slide-up focus:outline-none"
       >
+        <span id={descId} className="sr-only">Word actions and definition lookup</span>
         {/* Drag handle + close button */}
         <div className="relative flex items-center justify-center px-4 py-2">
           <div className="w-10 h-1 bg-amber-200 rounded-full" />

--- a/frontend/src/components/WordLookup.tsx
+++ b/frontend/src/components/WordLookup.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { CloseIcon, ArrowUpRightIcon } from "@/components/Icons";
 import { useFocusTrap } from "@/lib/useFocusTrap";
 
@@ -22,6 +22,7 @@ interface Props {
 }
 
 export default function WordLookup({ word, position, language, onClose }: Props) {
+  const descId = useId();
   const [result, setResult] = useState<LookupResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -102,9 +103,11 @@ export default function WordLookup({ word, position, language, onClose }: Props)
       role="dialog"
       aria-modal="true"
       aria-label={`Word definition: ${word}`}
+      aria-describedby={descId}
       style={style}
       className="relative sm:w-72 max-h-64 overflow-y-auto rounded-xl border border-amber-300 bg-white shadow-lg p-3 text-sm focus:outline-none"
     >
+      <span id={descId} className="sr-only">Word definition lookup</span>
       <button
         type="button"
         onClick={onClose}


### PR DESCRIPTION
## What changed

Five `role="dialog"` elements were missing `aria-describedby`, violating the WAI-ARIA 1.1 recommendation that dialogs carry both a label (names the dialog) and a description (gives screen-reader users context about purpose before they interact).

Affected dialogs and fixes:
- **VocabWordTooltip** — added `aria-describedby="vocab-tooltip-desc"` + sr-only span "Word definition and vocabulary actions"
- **WordLookup** — added `useId`-based `descId`, `aria-describedby={descId}`, sr-only "Word definition lookup"
- **WordActionDrawer** — added `useId`-based `descId`, `aria-describedby={descId}`, sr-only "Word actions and definition lookup"
- **Decks add-word picker** — added `aria-describedby="add-word-picker-desc"` + sr-only "Select words to add to this deck"
- **Reader chat sheet** — added `aria-describedby="reader-chat-desc"` + sr-only "AI chat about the current passage"

## Why

Screen readers announce the dialog description immediately when focus moves into the dialog. Without it, users with assistive technology only hear the dialog's title/label and must tab through all contents to understand the dialog's purpose. This is a P2 WCAG 4.1.2 gap.

## Test plan

- New regression test `DialogAriaDescribedby2565.test.ts` — 12 assertions verifying `aria-describedby` and the corresponding `id` attributes are present in all five components
- Full frontend suite: 4152 tests pass

Closes #2565
