### PR TITLE
fix: keep 'Start reading now' visible after import done (closes #2567)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -243,6 +243,8 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.45 | Gutenberg search empty state missing CTA — added Clear search button that resets query + searchedQuery + results — closes #2285 (PR #2286) | ✅ Done |
 | 2026-04-29 | 11.46 | InsightChat ContextChip and MsgContextBlock quoted text missing lang — added bookLanguage prop to both sub-components + lang on quoted spans — WCAG 3.1.2 fix — closes #2287 (PR #2288) | 🔄 In progress |
 | 2026-04-29 | 11.47 | Flashcard feedback question word span missing lang — added lang={currentCard.language} to word span in grade prompt — WCAG 3.1.2 fix — closes #2289 | 🔄 In progress |
+| 2026-05-01 | 12.1 | SentenceReader note-dot button aria-controls + note card id; InsightChat ContextChip/MsgContextBlock useId + aria-controls; AnnotationsSidebar toggle aria-haspopup="dialog" — WAI-ARIA disclosure/dialog pattern — closes #2563 (PR #2564) | ✅ Done |
+| 2026-05-01 | 12.2 | VocabWordTooltip, WordLookup, WordActionDrawer, decks add-word picker, reader chat sheet dialogs: added aria-describedby — WAI-ARIA dialog description for screen-reader context on focus — closes #2565 (PR #2566) | ✅ Done |
 
 ---
 

--- a/frontend/src/__tests__/ImportPage.branches.test.tsx
+++ b/frontend/src/__tests__/ImportPage.branches.test.tsx
@@ -337,7 +337,7 @@ describe("ImportPage — canStartReading shows Start reading now button", () => 
     );
   });
 
-  it("hides 'Start reading now' after done event (redirect takes over)", async () => {
+  it("keeps 'Start reading now' visible after done event as manual escape hatch", async () => {
     jest.useFakeTimers();
     importBookStream.mockReturnValue(
       makeStream([
@@ -349,14 +349,14 @@ describe("ImportPage — canStartReading shows Start reading now button", () => 
     render(<BookImportPage />);
     await clickAndFlush(/start import/i);
 
-    // After done, redirect message shows and Start reading now is hidden
+    // After done, redirect message shows AND Start reading now remains visible
     await waitFor(() =>
       expect(screen.getByText(/Done — opening your book/i)).toBeInTheDocument()
     );
 
     expect(
       screen.queryByRole("button", { name: /Start reading now/i })
-    ).not.toBeInTheDocument();
+    ).toBeInTheDocument();
 
     jest.useRealTimers();
   });

--- a/frontend/src/__tests__/ImportSuccessCta2567.test.ts
+++ b/frontend/src/__tests__/ImportSuccessCta2567.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Regression test for #2567:
+ * "Start reading now" button must remain visible after isDone=true so the
+ * user has a manual escape hatch if the auto-redirect is slow or fails.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/import/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Import success page keeps 'Start reading' button after done (closes #2567)", () => {
+  it("Start reading button is NOT guarded by !isDone", () => {
+    // The old broken condition was: started && !isDone && canStartReading
+    expect(src).not.toContain("started && !isDone");
+  });
+
+  it("Start reading now button is inside a {started &&} block", () => {
+    const startReadingIdx = src.indexOf("Start reading now");
+    expect(startReadingIdx).not.toBe(-1);
+    const context = src.slice(Math.max(0, startReadingIdx - 600), startReadingIdx + 50);
+    expect(context).toContain("started &&");
+    expect(context).not.toContain("started && !isDone");
+  });
+
+  it("Cancel button is hidden when isDone", () => {
+    // After done, Cancel (which goes to home) should not show
+    expect(src).toContain("!isDone");
+    // !isDone should guard at minimum the Cancel button
+    const cancelIdx = src.indexOf("Cancel");
+    expect(cancelIdx).not.toBe(-1);
+    const context = src.slice(Math.max(0, cancelIdx - 500), cancelIdx + 50);
+    expect(context).toContain("!isDone");
+  });
+});

--- a/frontend/src/app/import/[bookId]/page.tsx
+++ b/frontend/src/app/import/[bookId]/page.tsx
@@ -315,7 +315,7 @@ export default function BookImportPage() {
             {isDone ? "Done — opening your book…" : ""}
           </p>
 
-          {started && !isDone && (
+          {started && (
             <div className="flex gap-2">
               {canStartReading && (
                 <button
@@ -325,12 +325,14 @@ export default function BookImportPage() {
                   Start reading now
                 </button>
               )}
-              <button
-                onClick={cancel}
-                className="rounded-lg border border-stone-300 text-stone-600 px-4 min-h-[44px] md:min-h-0 text-sm hover:bg-stone-50 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
-              >
-                Cancel
-              </button>
+              {!isDone && (
+                <button
+                  onClick={cancel}
+                  className="rounded-lg border border-stone-300 text-stone-600 px-4 min-h-[44px] md:min-h-0 text-sm hover:bg-stone-50 flex items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
+                >
+                  Cancel
+                </button>
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
## What changed

In `src/app/import/[bookId]/page.tsx`, the "Start reading now" button was conditionally rendered as `{started && !isDone && canStartReading}`. Once the import completed (`isDone=true`) the button disappeared, leaving users stranded if the 1200ms auto-redirect was slow or failed.

Changes:
- Removed `!isDone` guard from the "Start reading now" button — it now stays visible after import completes as a persistent escape hatch
- Moved `!isDone` guard to the Cancel button only (navigating home makes no sense once the book is ready)

## Why

If the router redirect is delayed or fails, users had no manual path to the reader. The "Done — opening your book…" message gave false confidence with no fallback.

## Test plan

- New regression test `ImportSuccessCta2567.test.ts` — verifies `started && !isDone` no longer gates the Start reading button, the button stays visible after done, and Cancel is hidden when done
- Updated `ImportPage.branches.test.tsx` — test renamed and assertion flipped to match new behavior
- Full frontend suite: 4155 tests pass

Closes #2567
