### PR TITLE
fix: add Books CTA to admin audio empty state (closes #2572)

### DIFF
--- a/frontend/src/__tests__/AdminAudioEmptyCta2572.test.ts
+++ b/frontend/src/__tests__/AdminAudioEmptyCta2572.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Regression test for #2572:
+ * Admin audio empty state must include a CTA linking to /admin/books.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/admin/audio/page.tsx"),
+  "utf8",
+);
+
+describe("Admin audio empty state has CTA (closes #2572)", () => {
+  it("empty state contains a link to /admin/books", () => {
+    const emptyIdx = src.indexOf("No audio cached");
+    expect(emptyIdx).not.toBe(-1);
+    const context = src.slice(emptyIdx, emptyIdx + 300);
+    expect(context).toContain("/admin/books");
+  });
+
+  it("empty state CTA is an anchor or Link element", () => {
+    const emptyIdx = src.indexOf("No audio cached");
+    const context = src.slice(emptyIdx, emptyIdx + 300);
+    expect(context).toMatch(/<a |href=/);
+  });
+});

--- a/frontend/src/app/admin/audio/page.tsx
+++ b/frontend/src/app/admin/audio/page.tsx
@@ -112,7 +112,11 @@ export default function AudioPage() {
         </li>
       ))}
       {audio.length === 0 && (
-        <li className="px-4 py-8 text-center text-amber-700 text-sm">No audio cached.</li>
+        <li className="px-4 py-8 text-center text-amber-700 text-sm">
+          No audio cached.{" "}
+          <a href="/admin/books" className="underline hover:text-amber-900">Go to Books</a>
+          {" "}to generate audio.
+        </li>
       )}
     </ul>
     </div>


### PR DESCRIPTION
## What changed

`src/app/admin/audio/page.tsx` empty state showed only "No audio cached." — no guidance on what to do next. Added an inline "Go to Books" link pointing to `/admin/books` where audio generation is triggered.

## Why

The error state on the same page provides a Retry button, but the empty state left admins with no path forward. First-time admins wouldn't know they need to visit the Books admin page to trigger audio generation.

## Test plan

- New regression test `AdminAudioEmptyCta2572.test.ts` — verifies the empty state contains a `/admin/books` link
- Full frontend suite: 4157 tests pass

Closes #2572
