### PR TITLE
fix: add Go to Decks CTA to flashcard done state (closes #2575)

### DIFF
--- a/frontend/src/__tests__/FlashcardDoneCta2575.test.ts
+++ b/frontend/src/__tests__/FlashcardDoneCta2575.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Regression test for #2575:
+ * Flashcard done state must include a secondary CTA linking to /decks
+ * so users can immediately navigate to another deck without backtracking.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/vocabulary/flashcards/page.tsx"),
+  "utf8",
+);
+
+describe("Flashcard done state secondary CTA (closes #2575)", () => {
+  it("done state contains a link to /decks", () => {
+    const doneIdx = src.indexOf("All done for today");
+    expect(doneIdx).not.toBe(-1);
+    const doneBlock = src.slice(doneIdx, doneIdx + 600);
+    expect(doneBlock).toContain("/decks");
+  });
+
+  it("done state /decks link is an anchor or Link element", () => {
+    const doneIdx = src.indexOf("All done for today");
+    expect(doneIdx).not.toBe(-1);
+    const doneBlock = src.slice(doneIdx, doneIdx + 600);
+    // Either href="/decks" or href={`/decks`}
+    expect(doneBlock).toMatch(/href=["'`]\/decks["'`]/);
+  });
+
+  it("done state still retains Back to Vocabulary link", () => {
+    const doneIdx = src.indexOf("All done for today");
+    expect(doneIdx).not.toBe(-1);
+    const doneBlock = src.slice(doneIdx, doneIdx + 1000);
+    expect(doneBlock).toContain("/vocabulary");
+  });
+});

--- a/frontend/src/app/vocabulary/flashcards/page.tsx
+++ b/frontend/src/app/vocabulary/flashcards/page.tsx
@@ -290,12 +290,20 @@ export default function FlashcardsPage() {
                 ? `No more cards due in "${decks.find((d) => d.id === selectedDeckId)?.name ?? "this deck"}".`
                 : `You reviewed ${stats?.reviewed_today ?? 0} card${(stats?.reviewed_today ?? 0) !== 1 ? "s" : ""}. Come back tomorrow for more.`}
             </p>
-            <Link
-              href="/vocabulary"
-              className="mt-2 px-5 py-2.5 bg-amber-700 text-white rounded-lg font-medium hover:bg-amber-800 transition-colors min-h-[44px] md:min-h-0 inline-flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
-            >
-              Back to Vocabulary
-            </Link>
+            <div className="flex flex-wrap gap-3 justify-center">
+              <Link
+                href="/decks"
+                className="mt-2 px-5 py-2.5 bg-amber-700 text-white rounded-lg font-medium hover:bg-amber-800 transition-colors min-h-[44px] md:min-h-0 inline-flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-700"
+              >
+                Go to Decks
+              </Link>
+              <Link
+                href="/vocabulary"
+                className="mt-2 px-5 py-2.5 rounded-lg border border-amber-300 text-amber-900 font-medium hover:bg-amber-50 transition-colors min-h-[44px] md:min-h-0 inline-flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1"
+              >
+                Back to Vocabulary
+              </Link>
+            </div>
           </div>
         ) : !fetchError && currentCard ? (
           <div className="space-y-4">


### PR DESCRIPTION
## What changed
Added a primary "Go to Decks" CTA and demoted "Back to Vocabulary" to a secondary style in the flashcard done state. Users who finish reviewing a deck can now navigate directly to `/decks` to pick another deck without backtracking through the Vocabulary page.

## Why
Closes #2575. Previously the done state only offered "Back to Vocabulary" — forcing users to navigate Vocabulary → Decks manually to continue with another deck. The new primary CTA puts the most likely next action one tap away.

## Test plan
- New static-analysis test `FlashcardDoneCta2575.test.ts` asserts: (1) `/decks` link present in done block, (2) `href="/decks"` anchor exists, (3) `/vocabulary` link retained
- All 4161 frontend tests pass

## Docs follow-up
- [ ] Docs updated (N/A — internal navigation change)
