### PR TITLE
fix: include book title in continue-reading link aria-label (closes #2577)

### DIFF
--- a/frontend/src/__tests__/ContinueReadingAriaLabel2577.test.ts
+++ b/frontend/src/__tests__/ContinueReadingAriaLabel2577.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Regression test for #2577:
+ * "Continue reading" home card must include the book title in its aria-label
+ * so screen readers convey which book the link opens (WCAG 2.4.4).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/page.tsx"),
+  "utf8",
+);
+
+describe("Continue reading link includes book title in aria-label (closes #2577)", () => {
+  it("aria-label on continue-reading link includes book title interpolation", () => {
+    const idx = src.indexOf("Continue Reading");
+    expect(idx).not.toBe(-1);
+    // Look within 800 chars for the Link's aria-label
+    const block = src.slice(idx, idx + 800);
+    // Must interpolate the book title, not just be a static string
+    expect(block).toMatch(/aria-label=\{`Continue reading \$\{/);
+  });
+
+  it("aria-label references recentBooks[0].title", () => {
+    const idx = src.indexOf("Continue Reading");
+    expect(idx).not.toBe(-1);
+    const block = src.slice(idx, idx + 800);
+    expect(block).toContain("recentBooks[0].title");
+  });
+});

--- a/frontend/src/__tests__/ContinueReadingFocusVisible.test.ts
+++ b/frontend/src/__tests__/ContinueReadingFocusVisible.test.ts
@@ -12,7 +12,8 @@ const homePage = fs.readFileSync(
 
 describe("Home page Continue Reading focus-visible", () => {
   it("Continue Reading button has focus-visible ring + lift", () => {
-    const idx = homePage.indexOf('aria-label="Continue reading"');
+    // aria-label is now dynamic: `Continue reading ${recentBooks[0].title}`
+    const idx = homePage.indexOf("Continue Reading");
     expect(idx).toBeGreaterThan(0);
     const block = homePage.slice(idx, idx + 800);
     expect(block).toContain("focus-visible:-translate-y-0.5");
@@ -21,7 +22,7 @@ describe("Home page Continue Reading focus-visible", () => {
   });
 
   it("Continue Reading button has onFocus/onBlur handlers", () => {
-    const idx = homePage.indexOf('aria-label="Continue reading"');
+    const idx = homePage.indexOf("Continue Reading");
     const block = homePage.slice(idx, idx + 1500);
     expect(block).toMatch(/onFocus=/);
     expect(block).toMatch(/onBlur=/);

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -324,7 +324,7 @@ export default function Home() {
                 </h2>
                 <Link
                   href={`/reader/${recentBooks[0].id}`}
-                  aria-label="Continue reading"
+                  aria-label={`Continue reading ${recentBooks[0].title}`}
                   className="w-full text-left rounded-xl border border-amber-200 bg-white p-3 flex items-center gap-3 hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 transition-all duration-200"
                   style={{ boxShadow: "var(--shadow-card)" }}
                   onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.boxShadow = "var(--shadow-card-hover)"; }}


### PR DESCRIPTION
## What changed
The "Continue Reading" card on the home page used a static `aria-label="Continue reading"` — screen reader users had no way to know which book the link would open. Changed to `aria-label={`Continue reading ${recentBooks[0].title}`}` so the book title is announced on focus.

## Why
Closes #2577. WCAG 2.4.4 Link Purpose (Level A) requires that the purpose of a link be determinable from its accessible name alone. The popular-books section already used the book title in its labels; the continue-reading card was inconsistent.

## Test plan
- New `ContinueReadingAriaLabel2577.test.ts`: verifies the aria-label is a template literal that includes `recentBooks[0].title`
- Updated `ContinueReadingFocusVisible.test.ts`: changed its anchor string from the old static label to the heading text "Continue Reading" (no behaviour change — test now survives the label being dynamic)
- All 4165 frontend tests pass

## Docs follow-up
- [ ] N/A — no design change
