### PR TITLE
fix: add role=status to Gemini-key-required reader banner (closes #2580)

### DIFF
--- a/frontend/src/__tests__/GeminiKeyBannerRoleStatus2580.test.ts
+++ b/frontend/src/__tests__/GeminiKeyBannerRoleStatus2580.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Regression test for #2580:
+ * The "Gemini key required" translation banner in the reader must carry
+ * role="status" so screen readers announce it (WCAG 4.1.3 / 4.1.2).
+ * The two sibling banners ("Translation queued", "Login required") already
+ * have role="status" — this test guards parity for the third one.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Reader Gemini-key-required banner has role=status (closes #2580)", () => {
+  it('banner div has role="status"', () => {
+    // Anchor on the unique banner text — not the condition string which appears
+    // earlier in the file as a setTranslationUsedProvider() argument.
+    const idx = src.indexOf("Gemini API key in Settings");
+    expect(idx).not.toBe(-1);
+    // Look behind 450 chars to find the opening div (div is ~416 chars before link text)
+    const block = src.slice(idx - 450, idx + 50);
+    expect(block).toMatch(/role="status"/);
+  });
+
+  it("banner text is present for context", () => {
+    expect(src).toContain("Gemini API key in Settings");
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1415,7 +1415,7 @@ export default function ReaderPage() {
 
       {/* Gemini key required notice — shown when logged in but no API key configured */}
       {translationEnabled && translationUsedProvider === "gemini key required" && (
-        <div className="bg-amber-50 border-b border-amber-300 px-4 py-2 text-xs text-amber-800 flex items-center gap-2">
+        <div role="status" className="bg-amber-50 border-b border-amber-300 px-4 py-2 text-xs text-amber-800 flex items-center gap-2">
           <span>
             Translation requires a Gemini API key.{" "}
             <Link


### PR DESCRIPTION
## What changed
Added `role="status"` to the "Gemini key required" translation banner in the reader page (`reader/[bookId]/page.tsx`).

## Why
The two sibling banners — "Translation queued" and "Login required" — already carry `role="status"` so screen readers announce them when they appear. The "Gemini key required" banner was missing it, meaning AT users would not hear the prompt telling them to add an API key. This violates WCAG 4.1.3 (Status Messages).

## Test plan
- New static regression test `GeminiKeyBannerRoleStatus2580.test.ts` verifies `role="status"` is present on the banner div.
- All 4167 frontend tests pass.

## Docs follow-up
N/A — single-attribute fix, no user-visible behaviour change beyond AT announcement.

Closes #2580
