### PR TITLE
fix: keyboard-accessible annotated sentence spans in SentenceReader (closes #2553)

### DIFF
--- a/frontend/src/__tests__/AnnotatedSentenceKeyboard2553.test.ts
+++ b/frontend/src/__tests__/AnnotatedSentenceKeyboard2553.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression test for #2553:
+ * Annotated sentence spans in SentenceReader must be keyboard-reachable.
+ * A span that has a fullSegmentAnnotation must carry:
+ *   - tabIndex={0}
+ *   - role="button"
+ *   - an aria-label mentioning the annotation
+ *   - an onKeyDown handler (Enter/Space)
+ * This ensures keyboard users can navigate to and activate existing annotations
+ * (WCAG 2.1.1 Keyboard — Level A).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/SentenceReader.tsx"),
+  "utf8",
+);
+
+describe("SentenceReader annotated span keyboard accessibility (closes #2553)", () => {
+  it("annotated span receives tabIndex={0} when fullSegmentAnnotation exists", () => {
+    // The renderSeg function conditionally sets tabIndex.
+    // Look for the tabIndex={0} assignment tied to annotation presence.
+    const idx = src.indexOf("fullSegmentAnnotation");
+    expect(idx).not.toBe(-1);
+    // tabIndex may appear as tabIndex={0} or tabIndex={condition ? 0 : ...}
+    const block = src.slice(idx, idx + 3000);
+    expect(block).toMatch(/tabIndex=\{.*0/);
+  });
+
+  it("annotated span carries role button", () => {
+    const idx = src.indexOf("fullSegmentAnnotation");
+    const block = src.slice(idx, idx + 3000);
+    // role may be role="button" or role={expr ? "button" : ...}
+    expect(block).toMatch(/role=.*button/);
+  });
+
+  it("annotated span has aria-label referencing annotation", () => {
+    const idx = src.indexOf("fullSegmentAnnotation");
+    const block = src.slice(idx, idx + 3000);
+    expect(block).toMatch(/aria-label=/);
+  });
+
+  it("annotated span has onKeyDown handler for Enter/Space activation", () => {
+    const idx = src.indexOf("fullSegmentAnnotation");
+    const block = src.slice(idx, idx + 3000);
+    expect(block).toMatch(/onKeyDown=/);
+    // The handler should respond to Enter or Space
+    expect(block).toMatch(/Enter|Space|key\s*===\s*"Enter"|key\s*===\s*" "/);
+  });
+});

--- a/frontend/src/components/SentenceReader.tsx
+++ b/frontend/src/components/SentenceReader.tsx
@@ -758,12 +758,28 @@ export default function SentenceReader({
           // with a note" — multi-note rendering is a separate follow-up.
           const noteAnnotation = segAnns.find((a) => a.note_text);
           const flashClass = isJumpTarget ? "ring-2 ring-amber-400 bg-amber-50" : "";
+          // Keyboard accessibility for annotated segments (WCAG 2.1.1 / #2553):
+          // A span with an existing annotation is an interactive control — keyboard
+          // users must be able to focus it and activate it to edit or delete it.
+          const isAnnotationInteractive = !!(showAnnotations && fullSegmentAnnotation && onAnnotationClick);
           return (
             <span
               key={seg.flatIdx}
               ref={active ? (el) => { activeRef.current = el; } : undefined}
               data-seg={seg.flatIdx}
               data-jump-target={isJumpTarget ? "true" : undefined}
+              role={isAnnotationInteractive ? "button" : undefined}
+              tabIndex={isAnnotationInteractive ? 0 : undefined}
+              aria-label={isAnnotationInteractive ? `Annotated sentence: ${seg.text.slice(0, 80)}. Press Enter to edit.` : undefined}
+              onKeyDown={isAnnotationInteractive ? (e: React.KeyboardEvent<HTMLSpanElement>) => {
+                if (e.key !== "Enter" && e.key !== " ") return;
+                e.preventDefault();
+                const rect = (e.currentTarget as HTMLSpanElement).getBoundingClientRect();
+                onAnnotationClick!(fullSegmentAnnotation, {
+                  x: rect.left + rect.width / 2,
+                  y: rect.bottom,
+                });
+              } : undefined}
               onClick={(e) => {
                 if (disabled || !isSegmentLoaded(seg)) return;
                 // Ignore clicks that are the tail of a text-selection drag


### PR DESCRIPTION
## What changed

In `SentenceReader.tsx`, sentence spans that carry an existing annotation now receive keyboard-accessibility attributes when `onAnnotationClick` is provided:

- `role="button"` — exposes the span as an interactive control in the accessibility tree
- `tabIndex={0}` — places the annotated span in the natural Tab order
- `aria-label` — describes the sentence and the activation hint ("Press Enter to edit.")
- `onKeyDown` — handles Enter and Space to open QuickHighlightPanel (uses `getBoundingClientRect()` to get the position, matching the click-path)

Non-annotated spans are unchanged — their annotation and word-lookup paths are already keyboard-accessible via the SelectionToolbar (Shift+arrow text selection → toolbar auto-focuses for keyboard).

## Why

WCAG 2.1.1 Keyboard (Level A): all functionality must be operable through a keyboard interface. Annotated sentences had pointer-only `onClick` and no Tab stop, so keyboard users could not open the annotation editor on existing highlights.

## Test plan

- `AnnotatedSentenceKeyboard2553.test.ts`: static source assertions that verify `tabIndex`, `role="button"`, `aria-label`, and `onKeyDown` are present on annotated spans
- Full frontend suite: 4171 tests pass

Closes #2553

## Docs follow-up

The reader interaction design doc (`docs/reader-interaction-design.md`) could note this keyboard interaction. Filed as a documentation follow-up.
