### PR TITLE
fix: add keyboard shortcuts button to mobile reader bottom bar (closes #2573)

### DIFF
--- a/frontend/src/__tests__/MobileShortcutsHelp2573.test.ts
+++ b/frontend/src/__tests__/MobileShortcutsHelp2573.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Regression test for #2573:
+ * The keyboard shortcuts help button was exclusively wrapped in `hidden md:block`,
+ * making it invisible on mobile. Mobile users could not discover keyboard shortcuts.
+ *
+ * Fix: add a keyboard shortcuts button to the mobile bottom bar, toggling a
+ * panel anchored above the bar (opens upward).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+// Anchor: the mobile bottom toolbar section comment is unique
+const mobileToolbarIdx = src.indexOf("Mobile floating bottom toolbar");
+// Anchor: the "Main bottom bar" sub-comment is inside the toolbar
+const mainBarIdx = src.indexOf("Main bottom bar");
+
+describe("Mobile keyboard shortcuts help (closes #2573)", () => {
+  it("mobile floating toolbar section is present", () => {
+    expect(mobileToolbarIdx).not.toBe(-1);
+    expect(mainBarIdx).not.toBe(-1);
+  });
+
+  it("mobile bottom bar contains a keyboard shortcuts button", () => {
+    // Slice from "Main bottom bar" until end of file — the bar content is all in there
+    const barBlock = src.slice(mainBarIdx);
+    expect(barBlock).toMatch(/aria-label="Keyboard shortcuts"/);
+  });
+
+  it("mobile shortcuts panel exists inside the mobile toolbar section", () => {
+    const mobileBlock = src.slice(mobileToolbarIdx);
+    // shortcuts-panel-mobile id, or "Keyboard Shortcuts" heading inside mobile section
+    expect(mobileBlock).toMatch(/shortcuts-panel-mobile|id="shortcuts-panel-mobile"/);
+  });
+
+  it("mobile shortcuts button is inside the mobile toolbar (not just desktop nav)", () => {
+    // The mobile toolbar starts at mobileToolbarIdx; find a shortcuts button after that point
+    const mobileBlock = src.slice(mobileToolbarIdx);
+    expect(mobileBlock).toMatch(/aria-label="Keyboard shortcuts"/);
+    // Ensure the button found is NOT wrapped in hidden md:block within the mobile block
+    const btnIdx = mobileBlock.indexOf('aria-label="Keyboard shortcuts"');
+    const surrounding = mobileBlock.slice(Math.max(0, btnIdx - 300), btnIdx + 10);
+    expect(surrounding).not.toContain("hidden md:block");
+  });
+});

--- a/frontend/src/__tests__/ReaderPage.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.test.tsx
@@ -1265,7 +1265,7 @@ describe("ReaderPage — keyboard shortcuts panel", () => {
     fireEvent.keyDown(document, { key: "?" });
 
     await waitFor(() => {
-      expect(screen.getByText("Keyboard Shortcuts")).toBeInTheDocument();
+      expect(screen.getAllByText("Keyboard Shortcuts").length).toBeGreaterThanOrEqual(1);
     });
   });
 
@@ -1276,7 +1276,7 @@ describe("ReaderPage — keyboard shortcuts panel", () => {
     await screen.findByTestId("reader-chapter-heading");
 
     fireEvent.keyDown(document, { key: "?" });
-    await waitFor(() => expect(screen.getByText("Keyboard Shortcuts")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getAllByText("Keyboard Shortcuts").length).toBeGreaterThanOrEqual(1));
 
     fireEvent.keyDown(document, { key: "Escape" });
     await waitFor(() => expect(screen.queryByText("Keyboard Shortcuts")).not.toBeInTheDocument());
@@ -1288,7 +1288,7 @@ describe("ReaderPage — keyboard shortcuts panel", () => {
     await flushPromises();
     await screen.findByTestId("reader-chapter-heading");
 
-    expect(screen.getByRole("button", { name: "Keyboard shortcuts" })).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Keyboard shortcuts" }).length).toBeGreaterThanOrEqual(1);
   });
 });
 

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -2524,6 +2524,43 @@ export default function ReaderPage() {
               )}
             </button>
 
+            <div className="relative">
+              <button
+                onClick={() => setShowShortcuts((v) => !v)}
+                aria-label="Keyboard shortcuts"
+                aria-expanded={showShortcuts}
+                aria-controls="shortcuts-panel-mobile"
+                className={`h-11 w-11 flex items-center justify-center rounded-lg border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 ${
+                  showShortcuts
+                    ? "bg-amber-700 text-white border-amber-700"
+                    : "text-amber-700 bg-amber-50 border-amber-200"
+                }`}
+              ><KeyboardIcon className="w-5 h-5" /></button>
+              {showShortcuts && (
+                <div id="shortcuts-panel-mobile" role="region" aria-label="Keyboard shortcuts" className="absolute bottom-full right-0 mb-2 w-56 bg-white border border-amber-200 rounded-xl shadow-lg z-50 p-3 animate-slide-up">
+                  <p className="text-[10px] font-semibold uppercase tracking-widest text-stone-600 mb-2">Keyboard Shortcuts</p>
+                  <div className="space-y-1.5">
+                    {[
+                      { keys: ["Space"], label: "Play / Pause TTS" },
+                      { keys: ["←", "→"], label: "Previous / Next chapter" },
+                      { keys: ["F"], label: "Toggle focus mode" },
+                      { keys: ["?"], label: "Show this panel" },
+                      { keys: ["Esc"], label: "Close panels" },
+                    ].map(({ keys, label }) => (
+                      <div key={label} className="flex items-center justify-between gap-2">
+                        <span className="text-xs text-stone-600">{label}</span>
+                        <div className="flex items-center gap-1 shrink-0">
+                          {keys.map((k) => (
+                            <kbd key={k} className="inline-flex items-center justify-center min-w-[22px] h-5 px-1 rounded border border-stone-200 bg-stone-50 text-[10px] font-mono text-stone-600">{k}</kbd>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+
             <button
               onClick={() => setSidebarOpen((v) => !v)}
               className={`h-11 w-11 flex items-center justify-center rounded-lg border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-1 ${


### PR DESCRIPTION
## What changed

Added a `KeyboardIcon` button to the mobile floating bottom toolbar (the `md:hidden` bar at the bottom of the reader page). The button reuses the existing `showShortcuts` state and toggles a keyboard shortcuts panel that anchors `bottom-full` (opens upward above the bar), matching the desktop panel's content exactly.

## Why

The existing shortcuts help button was wrapped in `hidden md:block`, making it invisible on screens narrower than 768px. Mobile users had no way to discover the keyboard shortcuts the reader supports (Space, ←/→, F, ?, Esc).

## Test plan

- New regression test `MobileShortcutsHelp2573.test.ts` (4 static-analysis tests):
  - Mobile toolbar section contains a `"Keyboard shortcuts"` button
  - `shortcuts-panel-mobile` id exists inside the mobile toolbar section
  - The mobile shortcuts button is not gated by `hidden md:block`
- Updated `ReaderPage.test.tsx`: changed `getByText`/`getByRole` to `getAllByText`/`getAllByRole` since both panels render simultaneously when `showShortcuts` is true
- Full frontend suite: 4175 tests pass

Closes #2573
