### PR TITLE
fix: visible status strip for sentence-selection keyboard mode (closes #2588)

### DIFF
--- a/frontend/src/__tests__/SentenceSelectionModeVisualIndicator2588.test.ts
+++ b/frontend/src/__tests__/SentenceSelectionModeVisualIndicator2588.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Regression test for #2588:
+ * Sentence-selection mode must show a visible status strip for sighted keyboard users.
+ * Screen readers already receive the sr-only live region (#2584); this test verifies
+ * the visible counterpart.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const readerSrc = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Sentence-selection mode visual indicator (closes #2588)", () => {
+  it("renders a visible status strip (not sr-only) when sentenceSelectMode is true", () => {
+    // Find the sentenceSelectMode conditional block in JSX
+    const modeIdx = readerSrc.indexOf("sentenceSelectMode &&");
+    expect(modeIdx).not.toBe(-1);
+    const modeBlock = readerSrc.slice(modeIdx, modeIdx + 2000);
+    // Must have a non-sr-only visible element showing the mode status
+    // (sr-only alone is not enough for sighted keyboard users)
+    expect(modeBlock).toMatch(/sentence-select-indicator|data-testid="sentence-select-status"|sentence.*select.*indicator/i);
+  });
+
+  it("visible strip contains navigation hints (J/K and Esc)", () => {
+    const modeIdx = readerSrc.indexOf("sentenceSelectMode &&");
+    expect(modeIdx).not.toBe(-1);
+    const modeBlock = readerSrc.slice(modeIdx, modeIdx + 2000);
+    // Must show key hints so sighted users know how to use and exit the mode
+    expect(modeBlock).toMatch(/J.*K|navigate|arrow/i);
+    expect(modeBlock).toMatch(/Esc|exit/i);
+  });
+
+  it("visible strip has role=status for screen readers (no duplication of announcement)", () => {
+    const modeIdx = readerSrc.indexOf("sentenceSelectMode &&");
+    expect(modeIdx).not.toBe(-1);
+    const modeBlock = readerSrc.slice(modeIdx, modeIdx + 2000);
+    expect(modeBlock).toMatch(/role="status"/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1529,11 +1529,26 @@ export default function ReaderPage() {
 
       {/* ── Body ────────────────────────────────────────────────────────── */}
       <div className="flex flex-1 overflow-hidden">
-        {/* Sentence-selection mode status (WCAG 4.1.3 — live region so screen readers announce mode) */}
+        {/* Sentence-selection mode status — sr-only live region for screen readers (WCAG 4.1.3)
+            + visible strip for sighted keyboard users (closes #2588) */}
         {sentenceSelectMode && (
-          <div role="status" aria-live="polite" className="sr-only">
-            Sentence selection mode active. Use J/K or arrow keys to navigate, Enter to annotate, N or Escape to exit.
-          </div>
+          <>
+            <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+              Sentence selection mode active. Use J/K or arrow keys to navigate, Enter to annotate, N or Escape to exit.
+            </div>
+            <div
+              data-testid="sentence-select-status"
+              className="sentence-select-indicator fixed bottom-20 md:bottom-4 left-1/2 -translate-x-1/2 z-40 flex items-center gap-3 px-4 py-2 bg-stone-800/90 text-white text-xs rounded-full shadow-lg backdrop-blur animate-fade-in pointer-events-none select-none"
+            >
+              <span className="font-medium text-amber-300">Sentence selection</span>
+              <span className="text-stone-400" aria-hidden="true">·</span>
+              <span><kbd className="font-mono">J</kbd>/<kbd className="font-mono">K</kbd> navigate</span>
+              <span className="text-stone-400" aria-hidden="true">·</span>
+              <span><kbd className="font-mono">Enter</kbd> annotate</span>
+              <span className="text-stone-400" aria-hidden="true">·</span>
+              <span><kbd className="font-mono">Esc</kbd> exit</span>
+            </div>
+          </>
         )}
         {/* Reader */}
         <div className="flex flex-col flex-1 overflow-hidden min-w-0">


### PR DESCRIPTION
## What changed

Added a visible status strip to the reader when sentence-selection keyboard mode is active (N key). Previously only screen readers received feedback via a `sr-only` live region; sighted keyboard users had no visual indication of what mode they were in or what keys to use.

The strip is a fixed pill at the bottom of the viewport showing:
- "Sentence selection" label (amber)
- J/K navigate · Enter annotate · Esc exit

The `sr-only` live region is retained alongside it so screen readers still get the WCAG 4.1.3 announcement.

## Why

Issue #2588: sighted keyboard users pressing N had no way to know they'd entered a mode, what keys to use, or how to exit.

## Test plan

- [x] 3 new static-analysis tests in `SentenceSelectionModeVisualIndicator2588.test.ts`
- [x] Separator dots given `aria-hidden="true"` to pass `ReaderContrast.test.ts`
- [x] Full frontend suite: 4194 tests pass

Closes #2588
