### PR TITLE
fix: add N and W shortcut entries to all three keyboard shortcuts panels (closes #2594)

### DIFF
--- a/frontend/src/__tests__/ShortcutsPanelEntries2594.test.ts
+++ b/frontend/src/__tests__/ShortcutsPanelEntries2594.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Regression test for #2594:
+ * All three keyboard shortcuts panels (focus-mode overlay, desktop dropdown,
+ * mobile dropdown) must include both the N (sentence-select) and W (word-select)
+ * mode entries. Uses static source analysis.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+/** Extract a shortcut list array from the source near a given anchor string. */
+function extractShortcutBlock(anchor: string): string {
+  const idx = src.indexOf(anchor);
+  if (idx === -1) return "";
+  // Grab up to 1500 chars around the anchor to capture the list array
+  return src.slice(idx, idx + 1500);
+}
+
+describe("Reader keyboard shortcuts panels completeness (closes #2594)", () => {
+  describe("Focus-mode overlay panel (focus-hotkeys-panel)", () => {
+    const block = extractShortcutBlock('id="focus-hotkeys-panel"');
+
+    it("lists the N key for sentence selection mode", () => {
+      expect(block).toMatch(/["']N["']/);
+      expect(block).toMatch(/[Ss]entence/);
+    });
+
+    it("lists the W key for word selection mode", () => {
+      expect(block).toMatch(/["']W["']/);
+      expect(block).toMatch(/[Ww]ord/);
+    });
+  });
+
+  describe("Desktop dropdown panel (shortcuts-panel)", () => {
+    const block = extractShortcutBlock('id="shortcuts-panel"');
+
+    it("lists the N key for sentence selection mode", () => {
+      expect(block).toMatch(/["']N["']/);
+      expect(block).toMatch(/[Ss]entence/);
+    });
+
+    it("lists the W key for word selection mode", () => {
+      expect(block).toMatch(/["']W["']/);
+      expect(block).toMatch(/[Ww]ord/);
+    });
+  });
+
+  describe("Mobile dropdown panel (shortcuts-panel-mobile)", () => {
+    const block = extractShortcutBlock('id="shortcuts-panel-mobile"');
+
+    it("lists the N key for sentence selection mode", () => {
+      expect(block).toMatch(/["']N["']/);
+      expect(block).toMatch(/[Ss]entence/);
+    });
+
+    it("lists the W key for word selection mode", () => {
+      expect(block).toMatch(/["']W["']/);
+      expect(block).toMatch(/[Ww]ord/);
+    });
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -1124,6 +1124,7 @@ export default function ReaderPage() {
               { keys: ["F"], label: "Toggle focus mode" },
               { keys: ["?"], label: "Show this panel" },
               { keys: ["N"], label: "Sentence selection mode" },
+              { keys: ["W"], label: "Word mode (in N mode)" },
               { keys: ["Esc"], label: "Close panels" },
             ].map(({ keys, label }) => (
               <div key={label} className="flex items-center justify-between gap-2">
@@ -1459,7 +1460,8 @@ export default function ReaderPage() {
                     { keys: ["F"], label: "Toggle focus mode" },
                     { keys: ["?"], label: "Show this panel" },
                     { keys: ["N"], label: "Sentence selection mode" },
-              { keys: ["Esc"], label: "Close panels" },
+                    { keys: ["W"], label: "Word mode (in N mode)" },
+                    { keys: ["Esc"], label: "Close panels" },
                   ].map(({ keys, label }) => (
                     <div key={label} className="flex items-center justify-between gap-2">
                       <span className="text-xs text-stone-600">{label}</span>
@@ -2716,6 +2718,8 @@ export default function ReaderPage() {
                       { keys: ["←", "→"], label: "Previous / Next chapter" },
                       { keys: ["F"], label: "Toggle focus mode" },
                       { keys: ["?"], label: "Show this panel" },
+                      { keys: ["N"], label: "Sentence selection mode" },
+                      { keys: ["W"], label: "Word mode (in N mode)" },
                       { keys: ["Esc"], label: "Close panels" },
                     ].map(({ keys, label }) => (
                       <div key={label} className="flex items-center justify-between gap-2">


### PR DESCRIPTION
## What changed

All three keyboard shortcuts help panels in the reader were missing entries for the `N` and `W` keyboard modes shipped in recent PRs.

| Panel | Before | After |
|---|---|---|
| Focus-mode overlay (`focus-hotkeys-panel`) | Lists N, missing W | Lists N + W |
| Desktop dropdown (`shortcuts-panel`) | Lists N, missing W | Lists N + W |
| Mobile dropdown (`shortcuts-panel-mobile`) | Missing both N and W | Lists N + W |

Added to all three:
- `W` → "Word mode (in N mode)" — keyboard word-lookup mode shipped in #2593
- `N` → "Sentence selection mode" — added to mobile panel (was already in desktop/focus panels)

## Why

The shortcuts help panel is the primary discovery surface for keyboard power users. #2586 shipped sentence-select (N) and #2593 shipped word-select (W), but neither PR updated the mobile panel, and neither added W to any panel. Users pressing `?` for help would not learn these modes existed.

## Test plan

- New regression test: `frontend/src/__tests__/ShortcutsPanelEntries2594.test.ts` (6 tests)
  - Verifies each of the 3 panels contains `"N"` + "Sentence" text
  - Verifies each of the 3 panels contains `"W"` + "Word" text
- Full frontend suite: 4204 tests pass
- Full backend suite: 1941 tests pass

Closes #2594
