### PR TITLE
fix: correct N-key docs — sentence-select mode, not Notes sidebar toggle

### DIFF
--- a/docs/tutorials/annotations.md
+++ b/docs/tutorials/annotations.md
@@ -37,7 +37,7 @@ Click a highlighted sentence to re-open the toolbar. The same color swatches app
 
 ## View all annotations in the sidebar
 
-Open the **Notes** tab in the reader sidebar (click the **Notes** button in the right toolbar, or press **N**). All highlights and notes for the current chapter appear here, in reading order.
+Open the **Notes** tab in the reader sidebar by clicking the **Notes** button in the right toolbar (desktop) or the notepad icon in the mobile bottom bar. All highlights and notes for the current chapter appear here, in reading order.
 
 Switch chapters to see annotations from other parts of the book.
 
@@ -49,8 +49,16 @@ Go to [Notes](/notes) in the main navigation. This page lists every book you hav
 
 From the Notes page, click **Export** to download your annotations as a JSON file. You can also configure Obsidian export in your profile to push annotations directly to your Obsidian vault — see [Export vocabulary to Obsidian](obsidian-export.md) for setup instructions.
 
+## Keyboard shortcuts
+
+| Key | Action |
+|---|---|
+| `N` | Enter sentence-selection mode — navigate sentences with `J`/`K` or `↑`/`↓`, then press `Enter` to open the annotation toolbar for that sentence |
+| `W` | Switch to word-selection mode while in sentence-selection mode — navigate words with `H`/`L` or `←`/`→`, press `Enter` to look up a word |
+| `Escape` | Exit sentence or word selection mode |
+
 ## Tips
 
 - **Color coding:** use different colors to tag annotations by type (e.g. yellow for vocabulary, blue for plot, green for favorite passages).
 - **Inline reading:** the small dot next to an annotated sentence lets you read your note without leaving the text flow — hover (desktop) or tap (mobile) to expand it.
-- **Keyboard shortcut:** press **N** in the reader to toggle the Notes sidebar.
+- **Keyboard users:** press `N` to enter sentence-selection mode. Navigate to a sentence with `J`/`K`, then press `Enter` to annotate it without using the mouse.

--- a/docs/tutorials/focus-mode.md
+++ b/docs/tutorials/focus-mode.md
@@ -44,6 +44,8 @@ When paragraph focus is on and you hover a paragraph, the HUD shows a **Read par
 | `→` | Next chapter |
 | `Space` | Play / pause TTS |
 | `?` | Show all keyboard shortcuts |
+| `N` | Enter sentence-selection mode — navigate sentences with `J`/`K`, press `Enter` to annotate |
+| `W` | Switch to word-selection mode within sentence-selection — navigate words with `H`/`L`, press `Enter` to look up |
 
 ## Tips
 

--- a/frontend/src/__tests__/AnnotationsTutorialNKey2596.test.ts
+++ b/frontend/src/__tests__/AnnotationsTutorialNKey2596.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Regression test for #2596:
+ * The annotations tutorial must NOT say pressing N toggles the Notes sidebar
+ * (N now activates sentence-selection mode, shipped in #2586).
+ * The focus-mode tutorial must include N and W in its keyboard shortcuts table.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const annotationsMd = fs.readFileSync(
+  path.join(__dirname, "../../../docs/tutorials/annotations.md"),
+  "utf8",
+);
+
+const focusModeMd = fs.readFileSync(
+  path.join(__dirname, "../../../docs/tutorials/focus-mode.md"),
+  "utf8",
+);
+
+describe("Annotations tutorial keyboard shortcut accuracy (closes #2596)", () => {
+  it("does NOT claim N toggles the Notes sidebar", () => {
+    // The old incorrect tip said: "press N in the reader to toggle the Notes sidebar"
+    expect(annotationsMd).not.toMatch(/[Nn]\b.*[Nn]otes sidebar/);
+    expect(annotationsMd).not.toMatch(/toggle.*[Nn]otes.*sidebar.*N\b/i);
+  });
+
+  it("mentions sentence-selection mode for the N key", () => {
+    // The doc should explain N enters sentence-select mode
+    expect(annotationsMd).toMatch(/[Ss]entence.{0,30}select|sentence.{0,30}mode/i);
+    expect(annotationsMd).toMatch(/\bN\b/);
+  });
+});
+
+describe("Focus-mode tutorial keyboard shortcuts completeness (closes #2596)", () => {
+  it("includes the N key for sentence-selection mode", () => {
+    expect(focusModeMd).toMatch(/\bN\b/);
+    expect(focusModeMd).toMatch(/[Ss]entence/);
+  });
+
+  it("includes the W key for word mode", () => {
+    expect(focusModeMd).toMatch(/\bW\b/);
+    expect(focusModeMd).toMatch(/[Ww]ord/);
+  });
+});


### PR DESCRIPTION
## What changed

- **`docs/tutorials/annotations.md`**: removed the incorrect claim that pressing `N` toggles the Notes sidebar. Added a new `## Keyboard shortcuts` table documenting N (sentence-selection mode), W (word-selection mode), and Esc. Updated the Tips section to correctly describe the keyboard annotation flow.
- **`docs/tutorials/focus-mode.md`**: added N and W rows to the keyboard shortcuts table so the focus-mode docs are consistent with the reader's actual behaviour.
- **`frontend/src/__tests__/AnnotationsTutorialNKey2596.test.ts`**: static regression tests (4) that read both markdown files and assert the correct content — prevents the wrong N-key description from being re-introduced.

## Why

The N key was repurposed in #2586/#2593 to enter sentence-selection mode, but `annotations.md` still said "press N in the reader to toggle the Notes sidebar." `focus-mode.md` was also missing N and W from its shortcuts table. Both docs would mislead users expecting the old behaviour.

## Test plan

- [x] 4 new regression tests pass: `AnnotationsTutorialNKey2596.test.ts`
- [x] Full frontend suite: 4222 tests pass
- [x] Full backend suite: 1941 tests pass

Closes #2596
