### PR TITLE
chore: mark stale design-improvement-plan entries as done

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -238,11 +238,11 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.40 | Flashcard status counter word in template literal missing lang — converted to JSX span with lang attribute — WCAG 3.1.2 fix — closes #2273 (PR #2274) | ✅ Done |
 | 2026-04-29 | 11.41 | AnnotationsSidebar sentence_text and reader notes-expand panel missing lang — added bookLanguage prop to AnnotationsSidebar + lang on both elements — WCAG 3.1.2 fix — closes #2275 (PR #2276) | ✅ Done |
 | 2026-04-29 | 11.42 | WordLookup selected word missing lang — added bookLanguage prop to WordLookup + lang on word heading — WCAG 3.1.2 fix — closes #2279 (PR #2280) | ✅ Done |
-| 2026-04-29 | 11.43 | VocabularyToast word text missing lang — added lang={language} to word span in VocabularyToast — WCAG 3.1.2 fix — closes #2281 (PR #2282) | 🔄 In progress |
+| 2026-04-29 | 11.43 | VocabularyToast word text missing lang — added lang={language} to word span in VocabularyToast — WCAG 3.1.2 fix — closes #2281 (PR #2282) | ✅ Done |
 | 2026-04-29 | 11.44 | AnnotationToolbar quoted sentence missing lang — added bookLanguage prop to AnnotationToolbar + lang on quoted paragraph — WCAG 3.1.2 fix — closes #2283 (PR #2284) | ✅ Done |
 | 2026-04-29 | 11.45 | Gutenberg search empty state missing CTA — added Clear search button that resets query + searchedQuery + results — closes #2285 (PR #2286) | ✅ Done |
-| 2026-04-29 | 11.46 | InsightChat ContextChip and MsgContextBlock quoted text missing lang — added bookLanguage prop to both sub-components + lang on quoted spans — WCAG 3.1.2 fix — closes #2287 (PR #2288) | 🔄 In progress |
-| 2026-04-29 | 11.47 | Flashcard feedback question word span missing lang — added lang={currentCard.language} to word span in grade prompt — WCAG 3.1.2 fix — closes #2289 | 🔄 In progress |
+| 2026-04-29 | 11.46 | InsightChat ContextChip and MsgContextBlock quoted text missing lang — added bookLanguage prop to both sub-components + lang on quoted spans — WCAG 3.1.2 fix — closes #2287 (PR #2288) | ✅ Done |
+| 2026-04-29 | 11.47 | Flashcard feedback question word span missing lang — added lang={currentCard.language} to word span in grade prompt — WCAG 3.1.2 fix — closes #2289 | ✅ Done |
 | 2026-05-01 | 12.1 | SentenceReader note-dot button aria-controls + note card id; InsightChat ContextChip/MsgContextBlock useId + aria-controls; AnnotationsSidebar toggle aria-haspopup="dialog" — WAI-ARIA disclosure/dialog pattern — closes #2563 (PR #2564) | ✅ Done |
 | 2026-05-01 | 12.2 | VocabWordTooltip, WordLookup, WordActionDrawer, decks add-word picker, reader chat sheet dialogs: added aria-describedby — WAI-ARIA dialog description for screen-reader context on focus — closes #2565 (PR #2566) | ✅ Done |
 


### PR DESCRIPTION
## What changed
Mark three stale "🔄 In progress" rows in `docs/design-improvement-plan.md` as "✅ Done":
- **11.43** — VocabularyToast lang fix (PR #2282, merged)
- **11.46** — InsightChat ContextChip/MsgContextBlock lang fix (PR #2288, merged)
- **11.47** — Flashcard feedback word span lang fix (issue #2289, closed)

## Why
These entries were left with an in-progress marker after their PRs merged, making the change log inaccurate.

## Test plan
- [x] No logic changes — docs-only fix
- [x] Full frontend (4231) and backend (1941) test suites pass

- [ ] Docs updated (design-improvement-plan.md — this IS the docs fix)
