### PR TITLE
fix: surface backend errors on vocabulary word deletion (closes #2603)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -245,6 +245,7 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.47 | Flashcard feedback question word span missing lang — added lang={currentCard.language} to word span in grade prompt — WCAG 3.1.2 fix — closes #2289 | ✅ Done |
 | 2026-05-01 | 12.1 | SentenceReader note-dot button aria-controls + note card id; InsightChat ContextChip/MsgContextBlock useId + aria-controls; AnnotationsSidebar toggle aria-haspopup="dialog" — WAI-ARIA disclosure/dialog pattern — closes #2563 (PR #2564) | ✅ Done |
 | 2026-05-01 | 12.2 | VocabWordTooltip, WordLookup, WordActionDrawer, decks add-word picker, reader chat sheet dialogs: added aria-describedby — WAI-ARIA dialog description for screen-reader context on focus — closes #2565 (PR #2566) | ✅ Done |
+| 2026-05-01 | 12.3 | Vocabulary page rapid-delete silently swallowed backend errors — added deleteErrorMsg state + visible red error banner with 5 s auto-dismiss; both handleDelete commit-path and onDone toast-expiry path now surface errors — closes #2603 | 🔄 In progress |
 
 ---
 

--- a/frontend/src/__tests__/VocabRapidDeleteError2603.test.tsx
+++ b/frontend/src/__tests__/VocabRapidDeleteError2603.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Regression test for #2603:
+ * Rapid vocabulary deletion silently swallows backend errors.
+ *
+ * When a user deletes word A then deletes word B before the undo toast expires,
+ * word A is committed to the backend via deleteVocabularyWord. If that call
+ * fails, the user gets no feedback while the word appears deleted in the UI.
+ *
+ * Fix: catch the rejection and surface an error toast.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { backendToken: "token123" } }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+jest.mock("@/lib/api", () => ({
+  getVocabulary: jest.fn(),
+  deleteVocabularyWord: jest.fn(),
+  exportVocabularyToObsidian: jest.fn(),
+  getWordDefinition: jest.fn(),
+  listVocabularyTags: jest.fn().mockResolvedValue([]),
+  getVocabularyWordTags: jest.fn().mockResolvedValue([]),
+  addVocabularyWordTag: jest.fn().mockResolvedValue({ tag: "" }),
+  removeVocabularyWordTag: jest.fn().mockResolvedValue(undefined),
+  ApiError: class ApiError extends Error {
+    status = 500;
+  },
+}));
+
+import * as api from "@/lib/api";
+import VocabularyPage from "@/app/vocabulary/page";
+
+const mockGetVocabulary = api.getVocabulary as jest.MockedFunction<
+  typeof api.getVocabulary
+>;
+const mockDeleteVocabularyWord =
+  api.deleteVocabularyWord as jest.MockedFunction<
+    typeof api.deleteVocabularyWord
+  >;
+
+const WORDS = [
+  {
+    id: 1,
+    word: "ephemeral",
+    occurrences: [
+      { book_id: 1, book_title: "Moby Dick", chapter_index: 0, sentence_text: "x" },
+    ],
+  },
+  {
+    id: 2,
+    word: "ardent",
+    occurrences: [
+      { book_id: 1, book_title: "Moby Dick", chapter_index: 0, sentence_text: "y" },
+    ],
+  },
+];
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetVocabulary.mockResolvedValue(WORDS);
+});
+
+test("rapid delete: backend failure surfaced as visible error feedback", async () => {
+  // The first delete is committed when a second delete fires (or toast expires).
+  // If the backend rejects, the user must see an error message — not silence.
+  mockDeleteVocabularyWord.mockRejectedValue(new Error("Network error"));
+
+  render(<VocabularyPage />);
+  await screen.findByText("ephemeral");
+
+  // Delete word A
+  await userEvent.click(screen.getByTestId("delete-ephemeral"));
+  expect(screen.queryByText("ephemeral")).not.toBeInTheDocument();
+
+  // Delete word B while toast is still showing — this commits word A to the backend
+  await userEvent.click(screen.getByTestId("delete-ardent"));
+
+  // Give the rejected promise time to resolve
+  await flushPromises();
+
+  // An error message must be visible to the user (not silent)
+  await waitFor(() => {
+    const errorMsg = screen.queryByText(/failed|error|could not/i);
+    expect(errorMsg).toBeInTheDocument();
+  });
+});
+
+test("source: onDone handler does not silently swallow deleteVocabularyWord errors", () => {
+  // Statically verify that onDone does NOT use a bare .catch(() => {}) silencer.
+  // The handler must propagate or show an error when the backend call fails.
+  const src = require("fs").readFileSync(
+    require("path").join(__dirname, "../app/vocabulary/page.tsx"),
+    "utf8",
+  );
+  const onDoneIdx = src.indexOf("onDone={() =>");
+  expect(onDoneIdx).not.toBe(-1);
+  // The onDone block must NOT contain a bare .catch(() => {}) that silences errors
+  const block = src.slice(onDoneIdx, onDoneIdx + 200);
+  // A bare catch with empty body is the bug pattern
+  expect(block).not.toMatch(/\.catch\(\(\)\s*=>\s*\{\s*\}\)/);
+});

--- a/frontend/src/app/vocabulary/page.tsx
+++ b/frontend/src/app/vocabulary/page.tsx
@@ -260,6 +260,7 @@ function VocabularyPageContent() {
   const [exportMsg, setExportMsg] = useState<string | null>(null);
   const [exporting, setExporting] = useState(false);
   const [deletedWordToast, setDeletedWordToast] = useState<VocabularyWord | null>(null);
+  const [deleteErrorMsg, setDeleteErrorMsg] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [sortMode, setSortMode] = useState<SortMode>("alpha");
   const [activeWord, setActiveWord] = useState<{ word: string; lang: string | null } | null>(null);
@@ -357,7 +358,11 @@ function VocabularyPageContent() {
 
   function handleDelete(form: VocabularyWord) {
     if (deletedWordToast) {
-      deleteVocabularyWord(deletedWordToast.word).catch(() => {});
+      const wordBeingCommitted = deletedWordToast.word;
+      deleteVocabularyWord(wordBeingCommitted).catch(() => {
+        setDeleteErrorMsg(`Could not remove "${wordBeingCommitted}" — please try again`);
+        setTimeout(() => setDeleteErrorMsg(null), 5000);
+      });
       setDeletedWordToast(null);
     }
     setWords((prev) => prev.filter((w) => w.word !== form.word));
@@ -523,6 +528,11 @@ function VocabularyPageContent() {
             ) : (
               <span className="text-red-600">{exportMsg}</span>
             )}
+          </div>
+        )}
+        {deleteErrorMsg && (
+          <div className="border border-red-200 bg-red-50 rounded-xl px-4 py-3 text-sm text-red-700 mt-2">
+            {deleteErrorMsg}
           </div>
         )}
       </div>
@@ -730,7 +740,11 @@ function VocabularyPageContent() {
             setDeletedWordToast(null);
           }}
           onDone={() => {
-            deleteVocabularyWord(deletedWordToast.word).catch(() => {});
+            const word = deletedWordToast.word;
+            deleteVocabularyWord(word).catch(() => {
+              setDeleteErrorMsg(`Could not remove "${word}" — please try again`);
+              setTimeout(() => setDeleteErrorMsg(null), 5000);
+            });
             setDeletedWordToast(null);
           }}
         />


### PR DESCRIPTION
## What changed

`vocabulary/page.tsx` — rapid-delete and toast-expiry both call `deleteVocabularyWord` but previously silenced failures with `.catch(() => {})`. When the backend is unreachable or returns an error, the word appears deleted in the UI but survives in the database (re-appears on reload) with no user feedback.

Fix:
- `handleDelete` (commit-previous-on-second-delete path): catch rejects → `setDeleteErrorMsg("Could not remove \"<word>\" — please try again")`
- `UndoToast.onDone` (commit-on-expiry path): same catch → same error banner
- Added `deleteErrorMsg` state rendered as a red banner in the existing `role="status"` live region; auto-dismisses after 5 s

## Why

WCAG 3.3.1 / interaction quality: users performing an irreversible action must know when it fails. A silent `.catch(() => {})` on a delete is a data-integrity risk.

## Test plan

- [x] New test `VocabRapidDeleteError2603.test.tsx` (2 tests): rapid-delete path shows error, static source check that `onDone` no longer has bare `.catch(() => {})` — both failed before the fix, both pass after
- [x] Full frontend suite: 4233 tests pass
- [x] Full backend suite: 1941 passed, 1 skipped

Closes #2603

- [ ] Docs updated (design-improvement-plan.md Change Log — included in this PR)
