### PR TITLE
fix: surface backend errors on decks/notes delete operations (closes #2605)

### DIFF
--- a/frontend/src/__tests__/DecksNotesDeleteErrors2605.test.ts
+++ b/frontend/src/__tests__/DecksNotesDeleteErrors2605.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression test for #2605:
+ * decks/page.tsx, decks/[deckId]/page.tsx, and notes/[bookId]/page.tsx
+ * had the same silent .catch(() => {}) pattern as vocabulary (fixed in #2603).
+ *
+ * All commit paths in optimistic-delete/UndoToast flows must NOT silently
+ * swallow backend errors.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const srcDir = path.join(__dirname, "..");
+
+const decksPage = fs.readFileSync(
+  path.join(srcDir, "app/decks/page.tsx"),
+  "utf8",
+);
+const deckDetailPage = fs.readFileSync(
+  path.join(srcDir, "app/decks/[deckId]/page.tsx"),
+  "utf8",
+);
+const notesPage = fs.readFileSync(
+  path.join(srcDir, "app/notes/[bookId]/page.tsx"),
+  "utf8",
+);
+
+const BARE_CATCH = /\.catch\(\(\)\s*=>\s*\{\s*\}\)/;
+
+describe("decks/page.tsx — deck deletion error handling", () => {
+  it("handleDelete commit path does not bare-swallow errors", () => {
+    // Scan the handleDelete callback for the silent catch
+    const idx = decksPage.indexOf("handleDelete");
+    expect(idx).not.toBe(-1);
+    const block = decksPage.slice(idx, idx + 400);
+    expect(block).not.toMatch(BARE_CATCH);
+  });
+
+  it("UndoToast onDone for deck deletion does not bare-swallow errors", () => {
+    const undoIdx = decksPage.indexOf("<UndoToast");
+    expect(undoIdx).not.toBe(-1);
+    const block = decksPage.slice(undoIdx, undoIdx + 400);
+    expect(block).not.toMatch(BARE_CATCH);
+  });
+});
+
+describe("decks/[deckId]/page.tsx — deck member removal error handling", () => {
+  it("handleRemove commit path does not bare-swallow errors", () => {
+    const idx = deckDetailPage.indexOf("handleRemove");
+    expect(idx).not.toBe(-1);
+    const block = deckDetailPage.slice(idx, idx + 500);
+    expect(block).not.toMatch(BARE_CATCH);
+  });
+
+  it("UndoToast onDone for member removal does not bare-swallow errors", () => {
+    const undoIdx = deckDetailPage.indexOf("<UndoToast");
+    expect(undoIdx).not.toBe(-1);
+    const block = deckDetailPage.slice(undoIdx, undoIdx + 400);
+    expect(block).not.toMatch(BARE_CATCH);
+  });
+});
+
+describe("notes/[bookId]/page.tsx — annotation and insight deletion error handling", () => {
+  it("handleDeleteAnnotation commit path does not bare-swallow errors", () => {
+    const idx = notesPage.indexOf("handleDeleteAnnotation");
+    expect(idx).not.toBe(-1);
+    const block = notesPage.slice(idx, idx + 400);
+    expect(block).not.toMatch(BARE_CATCH);
+  });
+
+  it("handleDeleteInsight commit path does not bare-swallow errors", () => {
+    const idx = notesPage.indexOf("handleDeleteInsight");
+    expect(idx).not.toBe(-1);
+    const block = notesPage.slice(idx, idx + 400);
+    expect(block).not.toMatch(BARE_CATCH);
+  });
+
+  it("UndoToast onDone for annotation deletion does not bare-swallow errors", () => {
+    const annUndoIdx = notesPage.indexOf("Annotation deleted");
+    expect(annUndoIdx).not.toBe(-1);
+    const block = notesPage.slice(annUndoIdx, annUndoIdx + 400);
+    expect(block).not.toMatch(BARE_CATCH);
+  });
+
+  it("UndoToast onDone for insight deletion does not bare-swallow errors", () => {
+    const insUndoIdx = notesPage.indexOf("Insight deleted");
+    expect(insUndoIdx).not.toBe(-1);
+    const block = notesPage.slice(insUndoIdx, insUndoIdx + 400);
+    expect(block).not.toMatch(BARE_CATCH);
+  });
+});

--- a/frontend/src/app/decks/[deckId]/page.tsx
+++ b/frontend/src/app/decks/[deckId]/page.tsx
@@ -34,6 +34,7 @@ export default function DeckDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [removedToast, setRemovedToast] = useState<VocabularyWord | null>(null);
+  const [removeMemberErrorMsg, setRemoveMemberErrorMsg] = useState<string | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
 
   useEffect(() => {
@@ -100,7 +101,11 @@ export default function DeckDetailPage() {
         if (removed) {
           setRemovedToast((current) => {
             if (current) {
-              removeDeckMember(deckId, current.id).catch(() => {});
+              const wordBeingCommitted = current.word;
+              removeDeckMember(deckId, current.id).catch(() => {
+                setRemoveMemberErrorMsg(`Could not remove "${wordBeingCommitted}" — please try again`);
+                setTimeout(() => setRemoveMemberErrorMsg(null), 5000);
+              });
             }
             return removed;
           });
@@ -315,6 +320,12 @@ export default function DeckDetailPage() {
         />
       )}
 
+      {removeMemberErrorMsg && (
+        <div role="alert" aria-live="assertive" className="fixed bottom-20 left-1/2 -translate-x-1/2 z-50 bg-red-50 border border-red-200 rounded-xl px-4 py-3 text-sm text-red-700 shadow-md">
+          {removeMemberErrorMsg}
+        </div>
+      )}
+
       {removedToast && (
         <UndoToast
           message={`"${removedToast.word}" removed`}
@@ -327,7 +338,11 @@ export default function DeckDetailPage() {
             setRemovedToast(null);
           }}
           onDone={() => {
-            removeDeckMember(deckId, removedToast.id).catch(() => {});
+            const word = removedToast.word;
+            removeDeckMember(deckId, removedToast.id).catch(() => {
+              setRemoveMemberErrorMsg(`Could not remove "${word}" — please try again`);
+              setTimeout(() => setRemoveMemberErrorMsg(null), 5000);
+            });
             setRemovedToast(null);
           }}
         />

--- a/frontend/src/app/decks/page.tsx
+++ b/frontend/src/app/decks/page.tsx
@@ -13,6 +13,7 @@ export default function DecksPage() {
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState(false);
   const [removedDeckToast, setRemovedDeckToast] = useState<DeckSummary | null>(null);
+  const [deleteDeckErrorMsg, setDeleteDeckErrorMsg] = useState<string | null>(null);
 
   useEffect(() => {
     document.title = "Decks — Book Reader AI";
@@ -45,7 +46,11 @@ export default function DecksPage() {
         // If a previous toast is still showing, commit that delete immediately
         setRemovedDeckToast((current) => {
           if (current) {
-            deleteDeck(current.id).catch(() => {});
+            const deckName = current.name;
+            deleteDeck(current.id).catch(() => {
+              setDeleteDeckErrorMsg(`Could not delete "${deckName}" — please try again`);
+              setTimeout(() => setDeleteDeckErrorMsg(null), 5000);
+            });
           }
           return removed;
         });
@@ -145,6 +150,12 @@ export default function DecksPage() {
         )}
       </div>
 
+      {deleteDeckErrorMsg && (
+        <div role="alert" aria-live="assertive" className="fixed bottom-20 left-1/2 -translate-x-1/2 z-50 bg-red-50 border border-red-200 rounded-xl px-4 py-3 text-sm text-red-700 shadow-md">
+          {deleteDeckErrorMsg}
+        </div>
+      )}
+
       {removedDeckToast && (
         <UndoToast
           message={`"${removedDeckToast.name}" deleted`}
@@ -153,7 +164,11 @@ export default function DecksPage() {
             setRemovedDeckToast(null);
           }}
           onDone={() => {
-            deleteDeck(removedDeckToast.id).catch(() => {});
+            const deckName = removedDeckToast.name;
+            deleteDeck(removedDeckToast.id).catch(() => {
+              setDeleteDeckErrorMsg(`Could not delete "${deckName}" — please try again`);
+              setTimeout(() => setDeleteDeckErrorMsg(null), 5000);
+            });
             setRemovedDeckToast(null);
           }}
         />

--- a/frontend/src/app/notes/[bookId]/page.tsx
+++ b/frontend/src/app/notes/[bookId]/page.tsx
@@ -298,6 +298,7 @@ export default function BookNotesPage() {
   // Undo toast state
   const [deletedAnnToast, setDeletedAnnToast] = useState<Annotation | null>(null);
   const [deletedInsToast, setDeletedInsToast] = useState<BookInsight | null>(null);
+  const [deleteErrorMsg, setDeleteErrorMsg] = useState<string | null>(null);
 
   // Export
   const [exportMsg, setExportMsg] = useState<string | null>(null);
@@ -402,7 +403,10 @@ export default function BookNotesPage() {
   function handleDeleteAnnotation(id: number) {
     // If a previous toast is pending, commit that delete immediately
     if (deletedAnnToast) {
-      deleteAnnotation(deletedAnnToast.id).catch(() => {});
+      deleteAnnotation(deletedAnnToast.id).catch(() => {
+        setDeleteErrorMsg("Could not delete annotation — please try again");
+        setTimeout(() => setDeleteErrorMsg(null), 5000);
+      });
       setDeletedAnnToast(null);
     }
     const ann = annotations.find((a) => a.id === id);
@@ -414,7 +418,10 @@ export default function BookNotesPage() {
   function handleDeleteInsight(id: number) {
     // If a previous toast is pending, commit that delete immediately
     if (deletedInsToast) {
-      deleteInsight(deletedInsToast.id).catch(() => {});
+      deleteInsight(deletedInsToast.id).catch(() => {
+        setDeleteErrorMsg("Could not delete insight — please try again");
+        setTimeout(() => setDeleteErrorMsg(null), 5000);
+      });
       setDeletedInsToast(null);
     }
     const ins = insights.find((i) => i.id === id);
@@ -823,6 +830,12 @@ export default function BookNotesPage() {
         )}
       </div>
 
+      {deleteErrorMsg && (
+        <div role="alert" aria-live="assertive" className="fixed bottom-20 left-1/2 -translate-x-1/2 z-50 bg-red-50 border border-red-200 rounded-xl px-4 py-3 text-sm text-red-700 shadow-md">
+          {deleteErrorMsg}
+        </div>
+      )}
+
       {deletedAnnToast && (
         <UndoToast
           message="Annotation deleted"
@@ -831,7 +844,10 @@ export default function BookNotesPage() {
             setDeletedAnnToast(null);
           }}
           onDone={() => {
-            deleteAnnotation(deletedAnnToast.id).catch(() => {});
+            deleteAnnotation(deletedAnnToast.id).catch(() => {
+              setDeleteErrorMsg("Could not delete annotation — please try again");
+              setTimeout(() => setDeleteErrorMsg(null), 5000);
+            });
             setDeletedAnnToast(null);
           }}
         />
@@ -845,7 +861,10 @@ export default function BookNotesPage() {
             setDeletedInsToast(null);
           }}
           onDone={() => {
-            deleteInsight(deletedInsToast.id).catch(() => {});
+            deleteInsight(deletedInsToast.id).catch(() => {
+              setDeleteErrorMsg("Could not delete insight — please try again");
+              setTimeout(() => setDeleteErrorMsg(null), 5000);
+            });
             setDeletedInsToast(null);
           }}
         />


### PR DESCRIPTION
## What changed

Follow-up to #2603. The same `.catch(() => {})` silent-error pattern existed in three more pages with optimistic-delete/UndoToast flows:

**`app/decks/page.tsx`** — deck deletion
- Both the rapid-delete commit path and `UndoToast.onDone` now catch API failures and show a dismissing error banner

**`app/decks/[deckId]/page.tsx`** — deck member (word) removal
- Same two paths fixed for `removeDeckMember` calls

**`app/notes/[bookId]/page.tsx`** — annotation and insight deletion
- All four commit paths (`handleDeleteAnnotation`, `handleDeleteInsight`, and their respective `onDone` handlers) now surface a shared `deleteErrorMsg` state

Each page adds an `role="alert"` fixed banner that auto-dismisses after 5 s.

## Why

Same root cause as #2603: if the backend API fails, the item appears deleted in the UI but still exists in the database — it reappears on next page load with no feedback to the user.

## Test plan

- [x] New test `DecksNotesDeleteErrors2605.test.ts` (8 tests): static source checks that none of the 8 fixed locations still have bare `.catch(() => {})` — all 8 failed before fix, all 8 pass after
- [x] Full frontend suite: 4241 tests pass (includes #2603 tests merged from main)
- [x] Full backend suite: 1941 passed, 1 skipped

Closes #2605

- [ ] Docs updated (n/a — no user-visible behaviour doc needed for error surfacing)
