### PR TITLE
fix: show empty-state in chapter review when all chapters removed (closes #2607)

### DIFF
--- a/frontend/src/__tests__/ChapterReviewEmptyState2607.test.ts
+++ b/frontend/src/__tests__/ChapterReviewEmptyState2607.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Regression test for #2607:
+ * upload/[bookId]/chapters page shows no feedback when the user removes all chapters.
+ * The "Confirm & Start Reading" button silently disables with no message explaining why,
+ * leaving the user in a dead-end state.
+ *
+ * Fix: render an empty-state message in the chapter list when chapters.length === 0.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/upload/[bookId]/chapters/page.tsx"),
+  "utf8",
+);
+
+describe("Chapter review empty state (closes #2607)", () => {
+  it("renders an explanatory message when chapters list is empty", () => {
+    // The source must contain a message that appears when chapters.length === 0
+    // to prevent a dead-end state where the confirm button is disabled with no explanation.
+    expect(src).toMatch(/chapters\.length\s*===?\s*0.*(?:at least|no chapters|removed all)/is);
+  });
+
+  it("empty-state message is inside or near the chapter list area", () => {
+    // The empty state must be co-located with the chapter list, not just in a hidden error block.
+    // Check that there is a message that renders when chapters array is empty.
+    const listIdx = src.indexOf('role="list"');
+    expect(listIdx).not.toBe(-1);
+    const surroundingBlock = src.slice(listIdx, listIdx + 800);
+    // Should have a conditional block showing message when no chapters
+    expect(surroundingBlock).toMatch(/chapters\.length\s*===?\s*0|chapters\.length\s*<\s*1/);
+  });
+});

--- a/frontend/src/app/upload/[bookId]/chapters/page.tsx
+++ b/frontend/src/app/upload/[bookId]/chapters/page.tsx
@@ -161,6 +161,15 @@ export default function ChapterEditorPage() {
       <div className="flex-1 max-w-5xl mx-auto w-full px-4 md:px-6 py-4 grid grid-cols-1 md:grid-cols-2 gap-4 min-h-0">
         {/* Left: chapter list */}
         <ul role="list" aria-label="Chapters" className="overflow-y-auto space-y-2 pr-1 list-none p-0 m-0">
+          {chapters.length === 0 && (
+            <li className="flex flex-col items-center justify-center py-12 text-center gap-2">
+              <p className="text-sm font-medium text-ink">No chapters remaining</p>
+              <p className="text-xs text-stone-500">At least one chapter is needed to continue.</p>
+              <Link href="/upload" className="mt-2 text-sm text-amber-700 underline underline-offset-2 hover:text-amber-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 rounded">
+                ← Upload a different file
+              </Link>
+            </li>
+          )}
           {chapters.map((ch, i) => {
             const wordWarn = ch.word_count > 8000 || ch.word_count < 100;
             return (


### PR DESCRIPTION
## What changed

`app/upload/[bookId]/chapters/page.tsx` — when a user removes every chapter from the review list, the "Confirm & Start Reading" button silently disables (opacity-50) with no explanation. This left users in a dead-end: no message, no CTA, only a greyed-out button.

Fix: add an empty-state `<li>` in the chapter list that renders when `chapters.length === 0`, explaining at least one chapter is needed and offering a "← Upload a different file" escape link back to `/upload`.

## Why

WCAG 3.3.2 / interaction quality: disabled controls must have a visible explanation for why they're disabled. A dead-end with no guidance is a blocking UX failure for the upload flow.

## Test plan

- [x] New test `ChapterReviewEmptyState2607.test.ts` (2 tests): verifies source has a `chapters.length === 0` branch inside the chapter list area and an explanatory message — both failed before fix, both pass after
- [x] Full frontend suite: 4243 tests pass
- [x] Full backend suite: 1941 passed, 1 skipped

Closes #2607

- [ ] Docs updated (n/a — no tutorial covers the chapter review page in detail)
