### PR TITLE
fix: add aria-label to TTS idle Read button (closes #2609)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -245,7 +245,10 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-04-29 | 11.47 | Flashcard feedback question word span missing lang — added lang={currentCard.language} to word span in grade prompt — WCAG 3.1.2 fix — closes #2289 | ✅ Done |
 | 2026-05-01 | 12.1 | SentenceReader note-dot button aria-controls + note card id; InsightChat ContextChip/MsgContextBlock useId + aria-controls; AnnotationsSidebar toggle aria-haspopup="dialog" — WAI-ARIA disclosure/dialog pattern — closes #2563 (PR #2564) | ✅ Done |
 | 2026-05-01 | 12.2 | VocabWordTooltip, WordLookup, WordActionDrawer, decks add-word picker, reader chat sheet dialogs: added aria-describedby — WAI-ARIA dialog description for screen-reader context on focus — closes #2565 (PR #2566) | ✅ Done |
-| 2026-05-01 | 12.3 | Vocabulary page rapid-delete silently swallowed backend errors — added deleteErrorMsg state + visible red error banner with 5 s auto-dismiss; both handleDelete commit-path and onDone toast-expiry path now surface errors — closes #2603 | 🔄 In progress |
+| 2026-05-01 | 12.3 | Vocabulary page rapid-delete silently swallowed backend errors — added deleteErrorMsg state + visible red error banner with 5 s auto-dismiss; both handleDelete commit-path and onDone toast-expiry path now surface errors — closes #2603 (PR #2604) | ✅ Done |
+| 2026-05-01 | 12.4 | Decks page (deleteDeck), deck detail page (removeDeckMember), notes page (deleteAnnotation + deleteInsight) — all 8 UndoToast commit paths had bare .catch(() => {}) silent errors — added error banner state to each — closes #2605 (PR #2606) | ✅ Done |
+| 2026-05-01 | 12.5 | Upload chapter review dead-end — user removing all chapters saw disabled confirm button with no explanation; added empty-state <li> with "at least one chapter needed" message and escape link — closes #2607 (PR #2608) | ✅ Done |
+| 2026-05-01 | 12.6 | TTSControls idle Read button had no accessible name — WCAG 4.1.2 violation; screen readers announced "Read, dimmed" with no context; added aria-label="Read aloud — loading chapter text" — closes #2609 (PR #2610) | 🔄 In progress |
 
 ---
 

--- a/frontend/src/__tests__/TTSIdleAriaLabel2609.test.ts
+++ b/frontend/src/__tests__/TTSIdleAriaLabel2609.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression test for #2609:
+ * TTSControls idle Read button has no accessible name explaining why it's disabled.
+ * Screen readers announced "Read, dimmed, button" with no context on why it cannot activate.
+ *
+ * Fix: the disabled idle button must carry an aria-label or title attribute so
+ * assistive technologies communicate its state (WCAG 4.1.2 Name, Role, Value).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../components/TTSControls.tsx"),
+  "utf8",
+);
+
+describe("TTSControls idle Read button accessible name (closes #2609)", () => {
+  it("disabled idle Read button has an aria-label attribute", () => {
+    // Find the disabled idle fallback button block (not loading/playing/paused/error).
+    // It must have both `disabled` and `aria-label` within the same button element.
+    const disabledButtonMatch = src.match(
+      /<button[\s\S]{0,600}?disabled[\s\S]{0,600}?aria-label="[^"]*"[\s\S]{0,300}?>[\s\S]{0,200}?Read[\s\S]{0,50}?<\/button>/,
+    );
+    expect(disabledButtonMatch).not.toBeNull();
+  });
+
+  it("disabled idle Read button aria-label is non-empty and descriptive", () => {
+    // The label must convey why the button is inactive — not just "Read".
+    // Find aria-label on a disabled button that renders "Read" text — must mention loading/unavailable.
+    const match = src.match(
+      /<button\s[^>]*disabled[^>]*aria-label="([^"]+)"[^>]*>[\s\S]{0,200}?Read[\s\S]{0,50}?<\/button>/,
+    );
+    const altMatch = src.match(
+      /<button\s[^>]*aria-label="([^"]+)"[^>]*disabled[^>]*>[\s\S]{0,200}?Read[\s\S]{0,50}?<\/button>/,
+    );
+    const block = match || altMatch;
+    expect(block).not.toBeNull();
+    expect(block![1] ?? block![0]).toMatch(/loading|unavailable|preparing|no text/i);
+  });
+});

--- a/frontend/src/components/TTSControls.tsx
+++ b/frontend/src/components/TTSControls.tsx
@@ -447,6 +447,7 @@ export default function TTSControls({
         ) : (
           <button
             disabled
+            aria-label="Read aloud — loading chapter text"
             className="rounded-lg bg-amber-100 text-amber-400 px-4 py-2.5 md:py-1.5 text-sm cursor-not-allowed min-h-[44px] md:min-h-0 flex items-center gap-1.5"
           >
             <PlayIcon className="w-3.5 h-3.5" aria-hidden="true" />


### PR DESCRIPTION
## What changed

Added `aria-label="Read aloud — loading chapter text"` to the disabled idle `Read` button in `TTSControls.tsx`.

## Why

The fallback disabled button (rendered when `status === "idle"` — before chapter audio is ready) had no accessible name beyond the visible "Read" text. Screen readers announced it as "Read, dimmed, button" with no explanation of why it cannot activate. WCAG 4.1.2 (Name, Role, Value) requires disabled controls to have an accessible name that communicates their state.

## Test plan

- Added `TTSIdleAriaLabel2609.test.ts` — two static source tests:
  1. Confirms the disabled idle button carries an `aria-label` attribute
  2. Confirms the label is descriptive (references "loading")
- All 4245 frontend tests pass

Closes #2609
