### PR TITLE
fix: surface error on annotation undo-restore failure in reader (closes #2611)

### DIFF
--- a/frontend/src/__tests__/ReaderAnnotationUndoError2611.test.ts
+++ b/frontend/src/__tests__/ReaderAnnotationUndoError2611.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Regression test for #2611:
+ * Reader page annotation delete undo silently swallows createAnnotation errors.
+ * When "Undo" is clicked and the restore API call fails, the toast disappears
+ * with no feedback and the annotation is permanently lost.
+ *
+ * Fix: the onUndo handler must surface the error to the user, not silently drop it.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const BARE_CATCH = /\.catch\(\s*\(\s*\)\s*=>\s*\{\s*\}\s*\)/;
+
+const src = fs.readFileSync(
+  path.join(__dirname, "../app/reader/[bookId]/page.tsx"),
+  "utf8",
+);
+
+describe("Reader annotation undo error feedback (closes #2611)", () => {
+  it("createAnnotation in undo handler does not have a bare silent catch", () => {
+    // Use the JSX block comment as anchor (more precise than the state variable comment)
+    const undoSectionStart = src.indexOf("{/* Annotation delete undo toast */}");
+    const undoSectionEnd = src.indexOf("{/* Vocabulary save toast */}", undoSectionStart);
+    expect(undoSectionStart).not.toBe(-1);
+    const undoSection = src.slice(undoSectionStart, undoSectionEnd > 0 ? undoSectionEnd : undoSectionStart + 1500);
+    // The catch in this section must not be the silent no-op pattern
+    expect(undoSection).toMatch(/createAnnotation/);
+    expect(undoSection).not.toMatch(BARE_CATCH);
+  });
+
+  it("undo failure handler surfaces an error message to the user", () => {
+    const undoSectionStart = src.indexOf("{/* Annotation delete undo toast */}");
+    const undoSectionEnd = src.indexOf("{/* Vocabulary save toast */}", undoSectionStart);
+    const undoSection = src.slice(undoSectionStart, undoSectionEnd > 0 ? undoSectionEnd : undoSectionStart + 1500);
+    expect(undoSection).toMatch(/setAnnotationUndoError|setAnnotationError|setRestoreError|setUndoError/);
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -103,6 +103,7 @@ export default function ReaderPage() {
 
   // Annotation delete undo toast
   const [deletedAnnotationToast, setDeletedAnnotationToast] = useState<Annotation | null>(null);
+  const [annotationUndoError, setAnnotationUndoError] = useState<string | null>(null);
 
   // Screen-reader announcement for annotation/highlight save success (WCAG 4.1.3)
   const [savedAnnotationMsg, setSavedAnnotationMsg] = useState("");
@@ -1882,6 +1883,13 @@ export default function ReaderPage() {
             />
           )}
 
+          {/* Annotation undo error */}
+          {annotationUndoError && (
+            <div role="alert" aria-live="assertive" className="fixed bottom-20 left-1/2 -translate-x-1/2 z-50 bg-red-50 border border-red-200 rounded-xl px-4 py-3 text-sm text-red-700 shadow-md">
+              {annotationUndoError}
+            </div>
+          )}
+
           {/* Annotation delete undo toast */}
           {deletedAnnotationToast && (
             <UndoToast
@@ -1898,7 +1906,10 @@ export default function ReaderPage() {
                     color: ann.color,
                   }).then((restored) => {
                     setAnnotations((prev) => [...prev, restored]);
-                  }).catch(() => {});
+                  }).catch(() => {
+                    setAnnotationUndoError("Could not restore annotation — please try again");
+                    setTimeout(() => setAnnotationUndoError(null), 5000);
+                  });
                 }
               }}
               onDone={() => setDeletedAnnotationToast(null)}


### PR DESCRIPTION
## What changed

In `reader/[bookId]/page.tsx`, the annotation delete UndoToast `onUndo` handler called `createAnnotation(...).catch(() => {})` — the restore-on-undo API call silently swallowed failures.

Added:
- `annotationUndoError` state variable
- `.catch()` handler that sets the error message and auto-dismisses after 5 s
- `role="alert" aria-live="assertive"` error banner rendered above the undo toast

## Why

Same silent-error pattern fixed in #2605 (decks/notes pages) but present in the reader page's own annotation undo flow. If the restore API call failed, the toast disappeared and the user believed their annotation was restored — it was actually permanently lost with no feedback.

## Test plan

- Added `ReaderAnnotationUndoError2611.test.ts` — two static source tests:
  1. Confirms the `createAnnotation` catch in the undo section is not a bare no-op
  2. Confirms the catch handler sets an error state variable
- All 4247 frontend tests pass

Closes #2611
