### PR TITLE
chore: update design-improvement-plan entries 12.6–12.7

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -248,7 +248,8 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-05-01 | 12.3 | Vocabulary page rapid-delete silently swallowed backend errors — added deleteErrorMsg state + visible red error banner with 5 s auto-dismiss; both handleDelete commit-path and onDone toast-expiry path now surface errors — closes #2603 (PR #2604) | ✅ Done |
 | 2026-05-01 | 12.4 | Decks page (deleteDeck), deck detail page (removeDeckMember), notes page (deleteAnnotation + deleteInsight) — all 8 UndoToast commit paths had bare .catch(() => {}) silent errors — added error banner state to each — closes #2605 (PR #2606) | ✅ Done |
 | 2026-05-01 | 12.5 | Upload chapter review dead-end — user removing all chapters saw disabled confirm button with no explanation; added empty-state <li> with "at least one chapter needed" message and escape link — closes #2607 (PR #2608) | ✅ Done |
-| 2026-05-01 | 12.6 | TTSControls idle Read button had no accessible name — WCAG 4.1.2 violation; screen readers announced "Read, dimmed" with no context; added aria-label="Read aloud — loading chapter text" — closes #2609 (PR #2610) | 🔄 In progress |
+| 2026-05-01 | 12.6 | TTSControls idle Read button had no accessible name — WCAG 4.1.2 violation; screen readers announced "Read, dimmed" with no context; added aria-label="Read aloud — loading chapter text" — closes #2609 (PR #2610) | ✅ Done |
+| 2026-05-01 | 12.7 | Reader annotation undo-restore silently swallowed createAnnotation errors — user clicked Undo and believed annotation was restored but it was permanently lost on failure; added annotationUndoError state + role="alert" banner — closes #2611 (PR #2612) | 🔄 In progress |
 
 ---
 


### PR DESCRIPTION
Updates entries 12.6 (TTS idle button aria-label, #2609/#2610 merged) to Done and adds entry 12.7 (reader annotation undo error, #2611/#2612 in progress).