### PR TITLE
fix: surface error banner when add-word fails in deck detail page (closes #2614)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -249,7 +249,8 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-05-01 | 12.4 | Decks page (deleteDeck), deck detail page (removeDeckMember), notes page (deleteAnnotation + deleteInsight) — all 8 UndoToast commit paths had bare .catch(() => {}) silent errors — added error banner state to each — closes #2605 (PR #2606) | ✅ Done |
 | 2026-05-01 | 12.5 | Upload chapter review dead-end — user removing all chapters saw disabled confirm button with no explanation; added empty-state <li> with "at least one chapter needed" message and escape link — closes #2607 (PR #2608) | ✅ Done |
 | 2026-05-01 | 12.6 | TTSControls idle Read button had no accessible name — WCAG 4.1.2 violation; screen readers announced "Read, dimmed" with no context; added aria-label="Read aloud — loading chapter text" — closes #2609 (PR #2610) | ✅ Done |
-| 2026-05-01 | 12.7 | Reader annotation undo-restore silently swallowed createAnnotation errors — user clicked Undo and believed annotation was restored but it was permanently lost on failure; added annotationUndoError state + role="alert" banner — closes #2611 (PR #2612) | 🔄 In progress |
+| 2026-05-01 | 12.7 | Reader annotation undo-restore silently swallowed createAnnotation errors — user clicked Undo and believed annotation was restored but it was permanently lost on failure; added annotationUndoError state + role="alert" banner — closes #2611 (PR #2612) | ✅ Done |
+| 2026-05-01 | 12.8 | Deck detail add-word silently rolled back on API failure with no user feedback — user saw word appear then disappear with no explanation; added addMemberErrorMsg state + role="alert" banner — closes #2614 | 🔄 In progress |
 
 ---
 

--- a/frontend/src/__tests__/DeckAddWordError2614.test.ts
+++ b/frontend/src/__tests__/DeckAddWordError2614.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Regression: /decks/[deckId] handleAdd should surface an error banner
+ * when addDeckMember API call fails, not silently roll back.
+ * Closes #2614
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("Deck detail page — add-word failure UX (#2614)", () => {
+  const src = read("src/app/decks/[deckId]/page.tsx");
+
+  it("declares an addMemberErrorMsg state for add failures", () => {
+    expect(src).toMatch(/addMemberErrorMsg/);
+  });
+
+  it("handleAdd catch block sets an error message (not just silent rollback)", () => {
+    const handleAddStart = src.indexOf("const handleAdd");
+    expect(handleAddStart).toBeGreaterThan(-1);
+    const handleAddEnd = src.indexOf("\n  );", handleAddStart) + 5;
+    const handleAddBody = src.slice(handleAddStart, handleAddEnd);
+    // Must have a catch that calls setAddMemberErrorMsg, not just silent rollback
+    expect(handleAddBody).toMatch(/setAddMemberErrorMsg/);
+  });
+
+  it("add failure error banner renders with role=alert", () => {
+    // The banner for add errors must use role="alert" for screen readers
+    const addErrorBannerMatch = src.match(
+      /addMemberErrorMsg[\s\S]{0,200}?role=["']alert["']|role=["']alert["'][\s\S]{0,200}?addMemberErrorMsg/,
+    );
+    expect(addErrorBannerMatch).not.toBeNull();
+  });
+});

--- a/frontend/src/app/decks/[deckId]/page.tsx
+++ b/frontend/src/app/decks/[deckId]/page.tsx
@@ -35,6 +35,7 @@ export default function DeckDetailPage() {
   const [error, setError] = useState(false);
   const [removedToast, setRemovedToast] = useState<VocabularyWord | null>(null);
   const [removeMemberErrorMsg, setRemoveMemberErrorMsg] = useState<string | null>(null);
+  const [addMemberErrorMsg, setAddMemberErrorMsg] = useState<string | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
 
   useEffect(() => {
@@ -127,6 +128,8 @@ export default function DeckDetailPage() {
             ? { ...prev, members: prev.members.filter((id) => id !== vocabularyId) }
             : prev,
         );
+        setAddMemberErrorMsg("Could not add word to deck — please try again");
+        setTimeout(() => setAddMemberErrorMsg(null), 5000);
       });
     },
     [deckId],
@@ -323,6 +326,12 @@ export default function DeckDetailPage() {
       {removeMemberErrorMsg && (
         <div role="alert" aria-live="assertive" className="fixed bottom-20 left-1/2 -translate-x-1/2 z-50 bg-red-50 border border-red-200 rounded-xl px-4 py-3 text-sm text-red-700 shadow-md">
           {removeMemberErrorMsg}
+        </div>
+      )}
+
+      {addMemberErrorMsg && (
+        <div role="alert" aria-live="assertive" className="fixed bottom-32 left-1/2 -translate-x-1/2 z-50 bg-red-50 border border-red-200 rounded-xl px-4 py-3 text-sm text-red-700 shadow-md">
+          {addMemberErrorMsg}
         </div>
       )}
 


### PR DESCRIPTION
## What changed

When a user adds a word to a deck from the word picker and the `addDeckMember` API call fails, the word was silently removed from the optimistic UI with no explanation. The user sees the word appear briefly then disappear — no toast, no banner, no feedback.

Added `addMemberErrorMsg` state and a `role="alert" aria-live="assertive"` error banner, mirroring the existing `removeMemberErrorMsg` pattern already present in the same component.

## Why

Silent optimistic rollback is a UX bug: users can't tell whether their action succeeded or failed, and may retry repeatedly or assume data loss with no path to recovery.

## Files

- `frontend/src/app/decks/[deckId]/page.tsx` — added `addMemberErrorMsg` state; updated `handleAdd` catch to set error message with 5s auto-dismiss; added error banner in JSX
- `frontend/src/__tests__/DeckAddWordError2614.test.ts` — 3 static regression tests verifying state declared, catch surfaces error, banner uses `role="alert"`

## Test plan

- [x] `DeckAddWordError2614` regression test: 3/3 pass
- [x] Full frontend suite: 760 suites / 4250 tests pass

Closes #2614

- [ ] Docs updated (if applicable)
