### PR TITLE
chore: mark design-improvement-plan entry 12.8 as done (PR #2615 merged)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -250,7 +250,7 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-05-01 | 12.5 | Upload chapter review dead-end — user removing all chapters saw disabled confirm button with no explanation; added empty-state <li> with "at least one chapter needed" message and escape link — closes #2607 (PR #2608) | ✅ Done |
 | 2026-05-01 | 12.6 | TTSControls idle Read button had no accessible name — WCAG 4.1.2 violation; screen readers announced "Read, dimmed" with no context; added aria-label="Read aloud — loading chapter text" — closes #2609 (PR #2610) | ✅ Done |
 | 2026-05-01 | 12.7 | Reader annotation undo-restore silently swallowed createAnnotation errors — user clicked Undo and believed annotation was restored but it was permanently lost on failure; added annotationUndoError state + role="alert" banner — closes #2611 (PR #2612) | ✅ Done |
-| 2026-05-01 | 12.8 | Deck detail add-word silently rolled back on API failure with no user feedback — user saw word appear then disappear with no explanation; added addMemberErrorMsg state + role="alert" banner — closes #2614 | 🔄 In progress |
+| 2026-05-01 | 12.8 | Deck detail add-word silently rolled back on API failure with no user feedback — user saw word appear then disappear with no explanation; added addMemberErrorMsg state + role="alert" banner — closes #2614 (PR #2615) | ✅ Done |
 
 ---
 


### PR DESCRIPTION
## What changed

Marks `docs/design-improvement-plan.md` entry 12.8 as ✅ Done now that PR #2615 has merged.

## Why

Entry 12.8 was left at "🔄 In progress" after PR #2615 merged. This keeps the design change log accurate.

## Test plan

- [x] Docs-only change — no code modified
- [x] Full frontend suite: 760 suites / 4250 tests pass

- [ ] Docs updated (if applicable) — this IS the docs update
