### PR TITLE
fix: replace alert() in enqueue-all with inline toast (closes #2617)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -251,6 +251,7 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-05-01 | 12.6 | TTSControls idle Read button had no accessible name — WCAG 4.1.2 violation; screen readers announced "Read, dimmed" with no context; added aria-label="Read aloud — loading chapter text" — closes #2609 (PR #2610) | ✅ Done |
 | 2026-05-01 | 12.7 | Reader annotation undo-restore silently swallowed createAnnotation errors — user clicked Undo and believed annotation was restored but it was permanently lost on failure; added annotationUndoError state + role="alert" banner — closes #2611 (PR #2612) | ✅ Done |
 | 2026-05-01 | 12.8 | Deck detail add-word silently rolled back on API failure with no user feedback — user saw word appear then disappear with no explanation; added addMemberErrorMsg state + role="alert" banner — closes #2614 (PR #2615) | ✅ Done |
+| 2026-05-01 | 12.9 | Reader enqueue-all (Translate remaining) used blocking browser alert() for all feedback — replaced with inline enqueueToast state (role="status" for success, role="alert" for errors) with 5s auto-dismiss — closes #2617 | ✅ Done |
 
 ---
 

--- a/frontend/src/__tests__/ReaderEnqueueAlertToToast2617.test.ts
+++ b/frontend/src/__tests__/ReaderEnqueueAlertToToast2617.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression: handleEnqueueAll must not use alert() for feedback.
+ * Inline toast state replaces blocking browser dialog.
+ * Closes #2617
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("Reader enqueue-all alert → toast (#2617)", () => {
+  const src = read("src/app/reader/[bookId]/page.tsx");
+
+  it("handleTranslateWholeBook does not call alert()", () => {
+    const fnStart = src.indexOf("async function handleTranslateWholeBook");
+    expect(fnStart).toBeGreaterThan(-1);
+    // Find the end of the function by locating the next top-level async function after it
+    const nextFn = src.indexOf("\n  async function ", fnStart + 1);
+    const fnBody = src.slice(fnStart, nextFn > 0 ? nextFn : fnStart + 3000);
+    expect(fnBody).not.toMatch(/\balert\s*\(/);
+  });
+
+  it("declares an enqueueToast state variable for feedback", () => {
+    expect(src).toMatch(/enqueueToast/);
+  });
+
+  it("enqueueToast banner uses role=status or role=alert for AT", () => {
+    const match = src.match(
+      /enqueueToast[\s\S]{0,300}?role=["'](status|alert)["']|role=["'](status|alert)["'][\s\S]{0,300}?enqueueToast/,
+    );
+    expect(match).not.toBeNull();
+  });
+});

--- a/frontend/src/__tests__/ReaderPage.branches2.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches2.test.tsx
@@ -839,7 +839,6 @@ describe("ReaderPage.branches2 — translate whole book: enqueued=0 fresh=null",
     mockEnqueueBookTranslation.mockResolvedValue({ enqueued: 0 });
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
 
-    const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
     render(<ReaderPage />);
     await flushPromises();
 
@@ -855,12 +854,8 @@ describe("ReaderPage.branches2 — translate whole book: enqueued=0 fresh=null",
     await userEvent.click(screen.getByRole("button", { name: /translate remaining/i }));
 
     await waitFor(() => {
-      expect(alertMock).toHaveBeenCalledWith(
-        expect.stringMatching(/already translated or already queued/i),
-      );
+      expect(screen.getByText(/already translated or already queued/i)).toBeInTheDocument();
     });
-
-    alertMock.mockRestore();
   });
 });
 
@@ -884,7 +879,6 @@ describe("ReaderPage.branches2 — translate whole book: enqueued=0 failed>0", (
     mockEnqueueBookTranslation.mockResolvedValue({ enqueued: 0 });
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
 
-    const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
     render(<ReaderPage />);
     await flushPromises();
 
@@ -899,12 +893,8 @@ describe("ReaderPage.branches2 — translate whole book: enqueued=0 failed>0", (
     await userEvent.click(screen.getByRole("button", { name: /translate remaining/i }));
 
     await waitFor(() => {
-      expect(alertMock).toHaveBeenCalledWith(
-        expect.stringMatching(/previously failed/i),
-      );
+      expect(screen.getByText(/previously failed/i)).toBeInTheDocument();
     });
-
-    alertMock.mockRestore();
   });
 });
 
@@ -927,7 +917,6 @@ describe("ReaderPage.branches2 — translate whole book: enqueued=1 singular", (
     mockEnqueueBookTranslation.mockResolvedValue({ enqueued: 1 });
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
 
-    const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
     render(<ReaderPage />);
     await flushPromises();
 
@@ -941,12 +930,8 @@ describe("ReaderPage.branches2 — translate whole book: enqueued=1 singular", (
     await userEvent.click(screen.getByRole("button", { name: /translate remaining/i }));
 
     await waitFor(() => {
-      expect(alertMock).toHaveBeenCalledWith(
-        expect.stringMatching(/Queued 1 chapter for translation/),
-      );
+      expect(screen.getByText(/Queued 1 chapter for translation/)).toBeInTheDocument();
     });
-
-    alertMock.mockRestore();
   });
 });
 
@@ -987,7 +972,6 @@ describe("ReaderPage.branches2 — translate whole book: enqueued=0 queued=1 sin
     mockEnqueueBookTranslation.mockResolvedValue({ enqueued: 0 });
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
 
-    const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
     render(<ReaderPage />);
     await flushPromises();
 
@@ -1003,12 +987,8 @@ describe("ReaderPage.branches2 — translate whole book: enqueued=0 queued=1 sin
     await userEvent.click(screen.getByRole("button", { name: /translate remaining/i }));
 
     await waitFor(() => {
-      expect(alertMock).toHaveBeenCalledWith(
-        expect.stringMatching(/1 chapter is already in the queue/i),
-      );
+      expect(screen.getByText(/1 chapter is already in the queue/i)).toBeInTheDocument();
     });
-
-    alertMock.mockRestore();
   });
 });
 
@@ -1031,7 +1011,6 @@ describe("ReaderPage.branches2 — translate whole book: non-Error thrown", () =
     mockEnqueueBookTranslation.mockRejectedValue("raw error string");
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
 
-    const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
     render(<ReaderPage />);
     await flushPromises();
 
@@ -1045,10 +1024,8 @@ describe("ReaderPage.branches2 — translate whole book: non-Error thrown", () =
     await userEvent.click(screen.getByRole("button", { name: /translate remaining/i }));
 
     await waitFor(() => {
-      expect(alertMock).toHaveBeenCalledWith("Failed to queue book");
+      expect(screen.getByText("Failed to queue book")).toBeInTheDocument();
     });
-
-    alertMock.mockRestore();
   });
 });
 
@@ -2037,7 +2014,6 @@ describe("ReaderPage.branches2 — translate whole book: all already translated"
     mockEnqueueBookTranslation.mockResolvedValue({ enqueued: 0 });
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
 
-    const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
     render(<ReaderPage />);
     await flushPromises();
 
@@ -2052,12 +2028,8 @@ describe("ReaderPage.branches2 — translate whole book: all already translated"
     await userEvent.click(screen.getByRole("button", { name: /translate remaining/i }));
 
     await waitFor(() => {
-      expect(alertMock).toHaveBeenCalledWith(
-        expect.stringMatching(/All chapters are already translated\./),
-      );
+      expect(screen.getByText(/All chapters are already translated\./)).toBeInTheDocument();
     });
-
-    alertMock.mockRestore();
   });
 });
 
@@ -2240,7 +2212,6 @@ describe("ReaderPage.branches2 — translate whole book: enqueued=3 plural", () 
     mockEnqueueBookTranslation.mockResolvedValue({ enqueued: 3 });
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
 
-    const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
     render(<ReaderPage />);
     await flushPromises();
 
@@ -2254,12 +2225,8 @@ describe("ReaderPage.branches2 — translate whole book: enqueued=3 plural", () 
     await userEvent.click(screen.getByRole("button", { name: /translate remaining/i }));
 
     await waitFor(() => {
-      expect(alertMock).toHaveBeenCalledWith(
-        expect.stringMatching(/Queued 3 chapters for translation/),
-      );
+      expect(screen.getByText(/Queued 3 chapters for translation/)).toBeInTheDocument();
     });
-
-    alertMock.mockRestore();
   });
 });
 

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -101,6 +101,9 @@ export default function ReaderPage() {
   // Obsidian export toast — { msg: string; ok: boolean } distinguishes success from error
   const [obsidianToast, setObsidianToast] = useState<{ msg: string; ok: boolean } | null>(null);
 
+  // Enqueue-all feedback toast — replaces blocking alert()
+  const [enqueueToast, setEnqueueToast] = useState<{ msg: string; ok: boolean } | null>(null);
+
   // Annotation delete undo toast
   const [deletedAnnotationToast, setDeletedAnnotationToast] = useState<Annotation | null>(null);
   const [annotationUndoError, setAnnotationUndoError] = useState<string | null>(null);
@@ -722,9 +725,11 @@ export default function ReaderPage() {
       } else {
         msg = `All chapters are already translated or already queued.`;
       }
-      alert(msg);
+      setEnqueueToast({ msg, ok: true });
+      setTimeout(() => setEnqueueToast(null), 5000);
     } catch (e) {
-      alert(e instanceof Error ? e.message : "Failed to queue book");
+      setEnqueueToast({ msg: e instanceof Error ? e.message : "Failed to queue book", ok: false });
+      setTimeout(() => setEnqueueToast(null), 5000);
     } finally {
       setEnqueueingBook(false);
     }
@@ -1953,6 +1958,18 @@ export default function ReaderPage() {
               ) : (
                 <span className="text-red-600">{obsidianToast.msg}</span>
               )}
+            </div>
+          )}
+
+          {/* Enqueue-all toast — replaces blocking alert() (#2617) */}
+          {enqueueToast?.ok && (
+            <div role="status" aria-live="polite" className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 rounded-xl px-5 py-3 text-sm shadow-md max-w-sm text-center bg-emerald-50 border border-emerald-200 text-emerald-800">
+              {enqueueToast.msg}
+            </div>
+          )}
+          {enqueueToast && !enqueueToast.ok && (
+            <div role="alert" aria-live="assertive" className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 rounded-xl px-5 py-3 text-sm shadow-md max-w-sm text-center bg-red-50 border border-red-200 text-red-700">
+              {enqueueToast.msg}
             </div>
           )}
 


### PR DESCRIPTION
## What changed

Replaced both `alert()` calls in `handleTranslateWholeBook` (reader page) with an inline `enqueueToast` state that renders a short-lived banner:
- Success path → `role="status"` (polite AT announcement, green styling)
- Error path → `role="alert"` (assertive AT announcement, red styling)
- 5-second auto-dismiss via `setTimeout`

## Why

`alert()` blocks the browser main thread, renders as an OS-native dialog with inconsistent styling across platforms, and is inaccessible to assistive technology. The existing `obsidianToast` pattern was already the correct approach; this aligns the enqueue flow with it.

## Test plan

- [x] New static regression test (`ReaderEnqueueAlertToToast2617.test.ts`) — 3 checks: no `alert()` in function body, `enqueueToast` state declared, banner has `role="status"` or `role="alert"`
- [x] Updated 7 existing tests in `ReaderPage.branches2.test.tsx` that previously mocked `window.alert` — now assert the toast text appears in the DOM
- [x] Full frontend suite: 4253 tests pass
- [x] Backend suite: passes

## Docs follow-up

Design improvement plan entry 12.9 added in this PR.
