### PR TITLE
fix: replace alert() in retry-failed with inline toast (closes #2619)

### DIFF
--- a/docs/design-improvement-plan.md
+++ b/docs/design-improvement-plan.md
@@ -251,7 +251,8 @@ Second pass covered: vocabulary page, notes page, profile page, import page, Ann
 | 2026-05-01 | 12.6 | TTSControls idle Read button had no accessible name — WCAG 4.1.2 violation; screen readers announced "Read, dimmed" with no context; added aria-label="Read aloud — loading chapter text" — closes #2609 (PR #2610) | ✅ Done |
 | 2026-05-01 | 12.7 | Reader annotation undo-restore silently swallowed createAnnotation errors — user clicked Undo and believed annotation was restored but it was permanently lost on failure; added annotationUndoError state + role="alert" banner — closes #2611 (PR #2612) | ✅ Done |
 | 2026-05-01 | 12.8 | Deck detail add-word silently rolled back on API failure with no user feedback — user saw word appear then disappear with no explanation; added addMemberErrorMsg state + role="alert" banner — closes #2614 (PR #2615) | ✅ Done |
-| 2026-05-01 | 12.9 | Reader enqueue-all (Translate remaining) used blocking browser alert() for all feedback — replaced with inline enqueueToast state (role="status" for success, role="alert" for errors) with 5s auto-dismiss — closes #2617 | ✅ Done |
+| 2026-05-01 | 12.9 | Reader enqueue-all (Translate remaining) used blocking browser alert() for all feedback — replaced with inline enqueueToast state (role="status" for success, role="alert" for errors) with 5s auto-dismiss — closes #2617 (PR #2618) | ✅ Done |
+| 2026-05-01 | 12.10 | Reader retry-failed used blocking browser alert() on error — replaced with inline retryToast state (role="alert") with 5s auto-dismiss — closes #2619 | ✅ Done |
 
 ---
 

--- a/frontend/src/__tests__/ReaderPage.branches2.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches2.test.tsx
@@ -751,7 +751,6 @@ describe("ReaderPage.branches2 — handleRetryFailed error", () => {
     mockRetryChapterTranslation.mockRejectedValue(new Error("Retry server error"));
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
 
-    const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
     render(<ReaderPage />);
     await flushPromises();
 
@@ -768,14 +767,12 @@ describe("ReaderPage.branches2 — handleRetryFailed error", () => {
       await userEvent.click(retryBtn);
       await waitFor(() => {
         expect(mockRetryChapterTranslation).toHaveBeenCalled();
-        expect(alertMock).toHaveBeenCalledWith("Retry server error");
+        expect(screen.getByText("Retry server error")).toBeInTheDocument();
       });
     }
-
-    alertMock.mockRestore();
   });
 
-  it("shows 'Retry failed' alert when retryChapterTranslation throws non-Error", async () => {
+  it("shows 'Retry failed' toast when retryChapterTranslation throws non-Error", async () => {
     mockGetSettings.mockReturnValue({ ...DEFAULT_SETTINGS, translationEnabled: true });
     mockGetChapterTranslation.mockRejectedValue({ status: 404 });
     mockGetChapterQueueStatus.mockRejectedValue({ status: 404 });
@@ -783,7 +780,6 @@ describe("ReaderPage.branches2 — handleRetryFailed error", () => {
     mockRetryChapterTranslation.mockRejectedValue("non-error string");
     mockGetBookChapters.mockResolvedValue({ meta: SAMPLE_META, chapters: SAMPLE_CHAPTERS });
 
-    const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
     render(<ReaderPage />);
     await flushPromises();
 
@@ -799,11 +795,9 @@ describe("ReaderPage.branches2 — handleRetryFailed error", () => {
     if (retryBtn) {
       await userEvent.click(retryBtn);
       await waitFor(() => {
-        expect(alertMock).toHaveBeenCalledWith("Retry failed");
+        expect(screen.getByText("Retry failed")).toBeInTheDocument();
       });
     }
-
-    alertMock.mockRestore();
   });
 });
 

--- a/frontend/src/__tests__/ReaderPage.branches3.test.tsx
+++ b/frontend/src/__tests__/ReaderPage.branches3.test.tsx
@@ -784,8 +784,7 @@ describe("ReaderPage.branches3 — handleRetryFailed (lines 609-620)", () => {
 describe("ReaderPage.branches3 — handleRetryFailed catch (lines 614-615)", () => {
   afterEach(() => { jest.useRealTimers(); jest.restoreAllMocks(); });
 
-  it("shows alert when retryChapterTranslation throws (lines 614-615)", async () => {
-    const alertMock = jest.spyOn(window, "alert").mockImplementation(() => {});
+  it("shows toast when retryChapterTranslation throws (lines 614-615)", async () => {
     (mockGetSettings as jest.Mock).mockReturnValue({ ...DEFAULT_SETTINGS, translationEnabled: false });
     mockGetChapterTranslation.mockRejectedValue({ status: 404 });
     mockGetChapterQueueStatus.mockRejectedValue({ status: 404 });
@@ -824,7 +823,7 @@ describe("ReaderPage.branches3 — handleRetryFailed catch (lines 614-615)", () 
       .find((b) => /retry failed translation/i.test(b.textContent ?? "")) as HTMLElement;
     if (retryBtn) {
       await act(async () => { fireEvent.click(retryBtn); });
-      await waitFor(() => expect(alertMock).toHaveBeenCalledWith("retry service unavailable"));
+      await waitFor(() => expect(screen.getByText("retry service unavailable")).toBeInTheDocument());
     } else {
       expect(mockRequestChapterTranslation).toHaveBeenCalled();
     }

--- a/frontend/src/__tests__/ReaderRetryFailedAlertToToast2619.test.ts
+++ b/frontend/src/__tests__/ReaderRetryFailedAlertToToast2619.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression: handleRetryFailed must not use alert() for error feedback.
+ * Inline toast state replaces blocking browser dialog.
+ * Closes #2619
+ */
+import fs from "fs";
+import path from "path";
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(process.cwd(), rel), "utf8");
+}
+
+describe("Reader retry-failed alert → toast (#2619)", () => {
+  const src = read("src/app/reader/[bookId]/page.tsx");
+
+  it("handleRetryFailed does not call alert()", () => {
+    const fnStart = src.indexOf("async function handleRetryFailed");
+    expect(fnStart).toBeGreaterThan(-1);
+    const nextFn = src.indexOf("\n  async function ", fnStart + 1);
+    const fnBody = src.slice(fnStart, nextFn > 0 ? nextFn : fnStart + 2000);
+    expect(fnBody).not.toMatch(/\balert\s*\(/);
+  });
+
+  it("retry error is surfaced via a toast state (not alert)", () => {
+    // The function must set some error toast state in the catch block
+    const fnStart = src.indexOf("async function handleRetryFailed");
+    const nextFn = src.indexOf("\n  async function ", fnStart + 1);
+    const fnBody = src.slice(fnStart, nextFn > 0 ? nextFn : fnStart + 2000);
+    // Must call a setter for a toast state in the catch
+    expect(fnBody).toMatch(/set\w+Toast|setRetryError|setEnqueueToast/);
+  });
+
+  it("retry error banner uses role=alert for AT", () => {
+    // The banner for retry errors must use role="alert" for screen readers
+    const match = src.match(
+      /[Rr]etry[A-Za-z]*[Ee]rror|retryToast[\s\S]{0,400}?role=["']alert["']|role=["']alert["'][\s\S]{0,400}?[Rr]etry[A-Za-z]*[Ee]rror|role=["']alert["'][\s\S]{0,400}?retryToast/,
+    );
+    expect(match).not.toBeNull();
+  });
+});

--- a/frontend/src/app/reader/[bookId]/page.tsx
+++ b/frontend/src/app/reader/[bookId]/page.tsx
@@ -108,6 +108,9 @@ export default function ReaderPage() {
   const [deletedAnnotationToast, setDeletedAnnotationToast] = useState<Annotation | null>(null);
   const [annotationUndoError, setAnnotationUndoError] = useState<string | null>(null);
 
+  // Retry-failed error toast — replaces blocking alert()
+  const [retryToast, setRetryToast] = useState<string | null>(null);
+
   // Screen-reader announcement for annotation/highlight save success (WCAG 4.1.3)
   const [savedAnnotationMsg, setSavedAnnotationMsg] = useState("");
 
@@ -745,7 +748,8 @@ export default function ReaderPage() {
     try {
       await retryChapterTranslation(bid, chapterIndex, translationLang);
     } catch (e) {
-      alert(e instanceof Error ? e.message : "Retry failed");
+      setRetryToast(e instanceof Error ? e.message : "Retry failed");
+      setTimeout(() => setRetryToast(null), 5000);
       return;
     }
     translationCache.current.delete(cacheKey);
@@ -1892,6 +1896,13 @@ export default function ReaderPage() {
           {annotationUndoError && (
             <div role="alert" aria-live="assertive" className="fixed bottom-20 left-1/2 -translate-x-1/2 z-50 bg-red-50 border border-red-200 rounded-xl px-4 py-3 text-sm text-red-700 shadow-md">
               {annotationUndoError}
+            </div>
+          )}
+
+          {/* Retry-failed error toast — replaces blocking alert() (#2619) */}
+          {retryToast && (
+            <div role="alert" aria-live="assertive" className="fixed bottom-28 left-1/2 -translate-x-1/2 z-50 bg-red-50 border border-red-200 rounded-xl px-4 py-3 text-sm text-red-700 shadow-md">
+              {retryToast}
             </div>
           )}
 


### PR DESCRIPTION
## What changed

Replaced the blocking `alert()` in `handleRetryFailed` (reader page) with an inline `retryToast` state:
- Error path → `role="alert"` banner (red styling, assertive AT announcement)
- 5-second auto-dismiss via `setTimeout`
- New `retryToast` state variable alongside existing toast states

## Why

`handleRetryFailed` had one remaining `alert()` call after #2617 cleaned up `handleTranslateWholeBook`. Same anti-pattern: blocking browser dialog, no ARIA semantics, inconsistent OS styling across platforms.

## Test plan

- [x] New static regression test (`ReaderRetryFailedAlertToToast2619.test.ts`) — 3 checks: no `alert()` in function body, toast setter called in catch, banner has `role="alert"`
- [x] Updated 2 existing tests in `ReaderPage.branches2.test.tsx` and 1 in `ReaderPage.branches3.test.tsx` that previously mocked `window.alert` — now assert the error text appears in the DOM
- [x] Full frontend suite: 4256 tests pass (3 new)
- [x] Backend suite: 1941 passed

## Docs follow-up

Design improvement plan entry 12.10 added in this PR.
